### PR TITLE
[SPARK-53425][PYTHON][TESTS] Add more table argument tests for Arrow Python UDTFs

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_udtf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udtf.py
@@ -699,7 +699,7 @@ class ArrowUDTFTestsMixin:
         expected_df = self.spark.createDataFrame([(60, 180)], "computed_value int, multiplied int")
         assertDataFrameEqual(result_df, expected_df)
 
-    def test_arrow_udtf_with_named_arguments(self):
+    def test_arrow_udtf_with_named_arguments_scalar_only(self):
         @arrow_udtf(returnType="x int, y int, sum int")
         class NamedArgsUDTF:
             def eval(self, x: "pa.Array", y: "pa.Array") -> Iterator["pa.Table"]:
@@ -1410,6 +1410,241 @@ class ArrowUDTFTestsMixin:
             assert row.table_is_batch is True
             assert row.struct_is_array is True
 
+    @unittest.skip("SPARK-53387: Support PARTIITON BY with Arrow UDTF")
+    def test_arrow_udtf_table_partition_by_single_column(self):
+        @arrow_udtf(returnType="partition_key string, total_value bigint")
+        class PartitionSumUDTF:
+            def eval(self, table_data: "pa.RecordBatch") -> Iterator["pa.Table"]:
+                table = pa.table(table_data)
+                
+                # Each partition will have records with the same category
+                if table.num_rows > 0:
+                    category = table.column("category")[0].as_py()
+                    total = pa.compute.sum(table.column("value")).as_py()
+                    
+                    result_table = pa.table({
+                        "partition_key": pa.array([category], type=pa.string()),
+                        "total_value": pa.array([total], type=pa.int64())
+                    })
+                    yield result_table
+
+        self.spark.udtf.register("partition_sum_udtf", PartitionSumUDTF)
+        
+        # Create test data with categories
+        test_data = [
+            ("A", 10), ("A", 20), ("B", 30), ("B", 40), ("C", 50)
+        ]
+        test_df = self.spark.createDataFrame(test_data, "category string, value int")
+        test_df.createOrReplaceTempView("partition_test_data")
+
+
+        result_df = self.spark.sql("""
+            SELECT * FROM partition_sum_udtf(
+                TABLE(partition_test_data) PARTITION BY category
+            ) ORDER BY partition_key
+        """)
+        
+        expected_df = self.spark.createDataFrame([
+            ("A", 30), ("B", 70), ("C", 50)
+        ], "partition_key string, total_value bigint")
+        assertDataFrameEqual(result_df, expected_df)
+
+    @unittest.skip("SPARK-53387: Support PARTIITON BY with Arrow UDTF")
+    def test_arrow_udtf_table_partition_by_multiple_columns(self):
+        @arrow_udtf(returnType="dept string, status string, count_employees bigint")
+        class DeptStatusCountUDTF:
+            def eval(self, table_data: "pa.RecordBatch") -> Iterator["pa.Table"]:
+                table = pa.table(table_data)
+                
+                if table.num_rows > 0:
+                    dept = table.column("department")[0].as_py()
+                    status = table.column("status")[0].as_py()
+                    count = table.num_rows
+                    
+                    result_table = pa.table({
+                        "dept": pa.array([dept], type=pa.string()),
+                        "status": pa.array([status], type=pa.string()),
+                        "count_employees": pa.array([count], type=pa.int64())
+                    })
+                    yield result_table
+
+        self.spark.udtf.register("dept_status_count_udtf", DeptStatusCountUDTF)
+        
+        test_data = [
+            ("IT", "active"), ("IT", "active"), ("IT", "inactive"),
+            ("HR", "active"), ("HR", "inactive"), ("Finance", "active")
+        ]
+        test_df = self.spark.createDataFrame(test_data, "department string, status string")
+        test_df.createOrReplaceTempView("employee_data")
+        
+        result_df = self.spark.sql("""
+            SELECT * FROM dept_status_count_udtf(
+                TABLE(SELECT * FROM employee_data) 
+                PARTITION BY department, status
+            ) ORDER BY dept, status
+        """)
+        
+        expected_df = self.spark.createDataFrame([
+            ("Finance", "active", 1), ("HR", "active", 1), ("HR", "inactive", 1), ("IT", "active", 2), ("IT", "inactive", 1)
+        ], "dept string, status string, count_employees bigint")
+        assertDataFrameEqual(result_df, expected_df)
+
+    def test_arrow_udtf_with_scalar_first_table_second(self):
+        @arrow_udtf(returnType="filtered_id bigint")
+        class ScalarFirstTableSecondUDTF:
+            def eval(self, threshold: "pa.Array", table_data: "pa.RecordBatch") -> Iterator["pa.Table"]:
+                assert isinstance(
+                    threshold, pa.Array
+                ), f"Expected pa.Array for threshold, got {type(threshold)}"
+                assert isinstance(
+                    table_data, pa.RecordBatch
+                ), f"Expected pa.RecordBatch for table_data, got {type(table_data)}"
+
+                threshold_val = threshold[0].as_py()
+
+                # Convert record batch to table
+                table = pa.table(table_data)
+                id_column = table.column("id")
+                mask = pa.compute.greater(id_column, pa.scalar(threshold_val))
+                filtered_table = table.filter(mask)
+
+                if filtered_table.num_rows > 0:
+                    result_table = pa.table(
+                        {"filtered_id": filtered_table.column("id")}  # Keep original type
+                    )
+                    yield result_table
+
+        # Test with DataFrame API - scalar first, table second
+        input_df = self.spark.range(8)
+        result_df = ScalarFirstTableSecondUDTF(lit(4), input_df.asTable())
+        expected_df = self.spark.createDataFrame([(5,), (6,), (7,)], "filtered_id bigint")
+        assertDataFrameEqual(result_df, expected_df)
+
+        # Test SQL registration and usage
+        self.spark.udtf.register("test_scalar_first_table_second_udtf", ScalarFirstTableSecondUDTF)
+        sql_result_df = self.spark.sql(
+            "SELECT * FROM test_scalar_first_table_second_udtf(4, TABLE(SELECT id FROM range(0, 8)))"
+        )
+        assertDataFrameEqual(sql_result_df, expected_df)
+
+    def test_arrow_udtf_with_table_argument_in_middle(self):
+        """Test Arrow UDTF with table argument in the middle of multiple scalar arguments."""
+        @arrow_udtf(returnType="filtered_id bigint")
+        class TableInMiddleUDTF:
+            def eval(
+                self, 
+                min_threshold: "pa.Array", 
+                table_data: "pa.RecordBatch", 
+                max_threshold: "pa.Array"
+            ) -> Iterator["pa.Table"]:
+                assert isinstance(
+                    min_threshold, pa.Array
+                ), f"Expected pa.Array for min_threshold, got {type(min_threshold)}"
+                assert isinstance(
+                    table_data, pa.RecordBatch
+                ), f"Expected pa.RecordBatch for table_data, got {type(table_data)}"
+                assert isinstance(
+                    max_threshold, pa.Array
+                ), f"Expected pa.Array for max_threshold, got {type(max_threshold)}"
+
+                min_val = min_threshold[0].as_py()
+                max_val = max_threshold[0].as_py()
+
+                # Convert record batch to table
+                table = pa.table(table_data)
+                id_column = table.column("id")
+                
+                # Filter rows where min_val < id < max_val
+                mask = pa.compute.and_(
+                    pa.compute.greater(id_column, pa.scalar(min_val)),
+                    pa.compute.less(id_column, pa.scalar(max_val))
+                )
+                filtered_table = table.filter(mask)
+
+                if filtered_table.num_rows > 0:
+                    result_table = pa.table(
+                        {"filtered_id": filtered_table.column("id")}  # Keep original type
+                    )
+                    yield result_table
+
+        # Test with DataFrame API - scalar, table, scalar
+        input_df = self.spark.range(10)
+        result_df = TableInMiddleUDTF(lit(2), input_df.asTable(), lit(7))
+        expected_df = self.spark.createDataFrame([(3,), (4,), (5,), (6,)], "filtered_id bigint")
+        assertDataFrameEqual(result_df, expected_df)
+
+        # Test SQL registration and usage
+        self.spark.udtf.register("test_table_in_middle_udtf", TableInMiddleUDTF)
+        sql_result_df = self.spark.sql(
+            "SELECT * FROM test_table_in_middle_udtf(2, TABLE(SELECT id FROM range(0, 10)), 7)"
+        )
+        assertDataFrameEqual(sql_result_df, expected_df)
+
+    def test_arrow_udtf_with_named_arguments(self):
+        @arrow_udtf(returnType="result_id bigint, multiplier_used int")
+        class NamedArgsUDTF:
+            def eval(
+                self, 
+                table_data: "pa.RecordBatch", 
+                multiplier: "pa.Array"
+            ) -> Iterator["pa.Table"]:
+                assert isinstance(
+                    table_data, pa.RecordBatch
+                ), f"Expected pa.RecordBatch for table_data, got {type(table_data)}"
+                assert isinstance(
+                    multiplier, pa.Array
+                ), f"Expected pa.Array for multiplier, got {type(multiplier)}"
+
+                multiplier_val = multiplier[0].as_py()
+
+                # Convert record batch to table
+                table = pa.table(table_data)
+                id_column = table.column("id")
+                
+                # Multiply each id by the multiplier
+                multiplied_ids = pa.compute.multiply(id_column, pa.scalar(multiplier_val))
+                
+                result_table = pa.table({
+                    "result_id": multiplied_ids,
+                    "multiplier_used": pa.array([multiplier_val] * table.num_rows, type=pa.int32())
+                })
+                yield result_table
+
+        # Test with DataFrame API using named arguments
+        input_df = self.spark.range(3)  # [0, 1, 2]
+        result_df = NamedArgsUDTF(table_data=input_df.asTable(), multiplier=lit(5))
+        expected_df = self.spark.createDataFrame(
+            [(0, 5), (5, 5), (10, 5)], 
+            "result_id bigint, multiplier_used int"
+        )
+        assertDataFrameEqual(result_df, expected_df)
+
+        # Test with DataFrame API using different named argument order
+        result_df2 = NamedArgsUDTF(multiplier=lit(3), table_data=input_df.asTable())
+        expected_df2 = self.spark.createDataFrame(
+            [(0, 3), (3, 3), (6, 3)], 
+            "result_id bigint, multiplier_used int"
+        )
+        assertDataFrameEqual(result_df2, expected_df2)
+
+        # Test SQL registration and usage with named arguments
+        self.spark.udtf.register("test_named_args_udtf", NamedArgsUDTF)
+        
+        sql_result_df = self.spark.sql("""
+            SELECT * FROM test_named_args_udtf(
+                table_data => TABLE(SELECT id FROM range(0, 3)),
+                multiplier => 5
+            )
+        """)
+        assertDataFrameEqual(sql_result_df, expected_df)
+
+        sql_result_df2 = self.spark.sql("""
+            SELECT * FROM test_named_args_udtf(
+                multiplier => 5,
+                table_data => TABLE(SELECT id FROM range(0, 3))
+            )
+        """)
+        assertDataFrameEqual(sql_result_df2, expected_df2)
 
 class ArrowUDTFTests(ArrowUDTFTestsMixin, ReusedSQLTestCase):
     pass

--- a/python/pyspark/sql/tests/arrow/test_arrow_udtf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udtf.py
@@ -1611,28 +1611,30 @@ class ArrowUDTFTestsMixin:
                 yield result_table
 
         # Test with DataFrame API using named arguments
-        input_df = self.spark.range(3)  # [0, 1, 2]
-        result_df = NamedArgsUDTF(table_data=input_df.asTable(), multiplier=lit(5))
+        # TODO(SPARK-53426): Support named table argument with DataFrame API
+        # input_df = self.spark.range(3)  # [0, 1, 2]
+        # result_df = NamedArgsUDTF(table_data=input_df.asTable(), multiplier=lit(5))
         expected_df = self.spark.createDataFrame(
             [(0, 5), (5, 5), (10, 5)], 
             "result_id bigint, multiplier_used int"
         )
-        assertDataFrameEqual(result_df, expected_df)
+        # assertDataFrameEqual(result_df, expected_df)
 
         # Test with DataFrame API using different named argument order
-        result_df2 = NamedArgsUDTF(multiplier=lit(3), table_data=input_df.asTable())
+        # TODO(SPARK-53426): Support named table argument with DataFrame API
+        # result_df2 = NamedArgsUDTF(multiplier=lit(3), table_data=input_df.asTable())
         expected_df2 = self.spark.createDataFrame(
             [(0, 3), (3, 3), (6, 3)], 
             "result_id bigint, multiplier_used int"
         )
-        assertDataFrameEqual(result_df2, expected_df2)
+        # assertDataFrameEqual(result_df2, expected_df2)
 
         # Test SQL registration and usage with named arguments
         self.spark.udtf.register("test_named_args_udtf", NamedArgsUDTF)
         
         sql_result_df = self.spark.sql("""
             SELECT * FROM test_named_args_udtf(
-                table_data => TABLE(SELECT id FROM range(0, 3)),
+                table_data => TABLE(SELECT id FROM range(0, 3))
                 multiplier => 5
             )
         """)
@@ -1640,7 +1642,7 @@ class ArrowUDTFTestsMixin:
 
         sql_result_df2 = self.spark.sql("""
             SELECT * FROM test_named_args_udtf(
-                multiplier => 5,
+                multiplier => 3,
                 table_data => TABLE(SELECT id FROM range(0, 3))
             )
         """)

--- a/python/pyspark/sql/tests/arrow/test_arrow_udtf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udtf.py
@@ -1502,7 +1502,7 @@ class ArrowUDTFTestsMixin:
         result_df = self.spark.sql(
             """
             SELECT * FROM dept_status_count_udtf(
-                TABLE(SELECT * FROM employee_data) 
+                TABLE(SELECT * FROM employee_data)
                 PARTITION BY (department, status)
             ) ORDER BY dept, status
         """
@@ -1556,7 +1556,8 @@ class ArrowUDTFTestsMixin:
         # Test SQL registration and usage
         self.spark.udtf.register("test_scalar_first_table_second_udtf", ScalarFirstTableSecondUDTF)
         sql_result_df = self.spark.sql(
-            "SELECT * FROM test_scalar_first_table_second_udtf(4, TABLE(SELECT id FROM range(0, 8)))"
+            "SELECT * FROM test_scalar_first_table_second_udtf("
+            "4, TABLE(SELECT id FROM range(0, 8)))"
         )
         assertDataFrameEqual(sql_result_df, expected_df)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds more tests for various table argument support for Arrow Python UDTFs. 
It also exposed some existing issues that need to be fixed:
- [x] [SPARK-53387](https://issues.apache.org/jira/browse/SPARK-53387): Support PARTITION BY clause with Python Arrow UDTF
- [x] [SPARK-53426](https://issues.apache.org/jira/browse/SPARK-53426): Support named table argument with asTable() API

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To improve test coverage

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes