### PR TITLE
[MINOR] Fix redundant brace in log

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -705,7 +705,7 @@ private[spark] class Client(
           // No configuration, so fall back to uploading local jar files.
           logWarning(
             log"Neither ${MDC(LogKeys.CONFIG, SPARK_JARS.key)} nor " +
-              log"${MDC(LogKeys.CONFIG2, SPARK_ARCHIVE.key)}} is set, falling back to uploading " +
+              log"${MDC(LogKeys.CONFIG2, SPARK_ARCHIVE.key)} is set, falling back to uploading " +
               log"libraries under SPARK_HOME.")
           val jarsDir = new File(YarnCommandBuilderUtils.findJarsDir(
             sparkConf.getenv("SPARK_HOME")))


### PR DESCRIPTION

### What changes were proposed in this pull request?
Remove redudant brace. Currently the log looks like this

> WARN Client: Neither spark.yarn.jars nor spark.yarn.archive} is set, falling back to uploading libraries under SPARK_HOME.

### Does this PR introduce _any_ user-facing change?
No

### Was this patch authored or co-authored using generative AI tooling?
No
