### PR TITLE
[SPARK-53437][SQL] InterpretedUnsafeProjection shall setNull4Bytes for YearMonthIntervalType field

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala
@@ -268,7 +268,7 @@ object InterpretedUnsafeProjection {
             writer.setNull2Bytes(i)
           }
         }
-      case IntegerType | DateType | FloatType =>
+      case IntegerType | DateType | FloatType | _: YearMonthIntervalType =>
         (v, i) => {
           if (!v.isNullAt(i)) {
             unsafeWriter(v, i)


### PR DESCRIPTION
### What changes were proposed in this pull request?


InterpretedUnsafeProjection shall setNull4Bytes for a YearMonthIntervalType field instead of setNull8Bytes

### Why are the changes needed?

YearMonthIntervalType is 4-byte length

### Does this PR introduce _any_ user-facing change?
'No'.



### How was this patch tested?
Passing CI

### Was this patch authored or co-authored using generative AI tooling?
no