### PR TITLE
[SPARK-53441][PS] Bools `|`/`&`/`^` None should fail under ANSI

### DIFF
--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -237,6 +237,8 @@ class BooleanOps(DataTypeOps):
 
     def __and__(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
+        if right is None:
+            raise TypeError("AND can not be applied to given types.")
         if isinstance(right, IndexOpsMixin) and isinstance(right.dtype, extension_dtypes):
             return right.__and__(left)
         else:
@@ -256,6 +258,8 @@ class BooleanOps(DataTypeOps):
 
     def xor(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
+        if right is None:
+            raise TypeError("XOR can not be applied to given types.")
         if isinstance(right, IndexOpsMixin) and isinstance(right.dtype, extension_dtypes):
             return right ^ left
         elif _is_valid_for_logical_operator(right):
@@ -277,6 +281,8 @@ class BooleanOps(DataTypeOps):
 
     def __or__(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
+        if right is None:
+            raise TypeError("OR can not be applied to given types.")
         if isinstance(right, IndexOpsMixin) and isinstance(right.dtype, extension_dtypes):
             return right.__or__(left)
         else:

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -237,7 +237,11 @@ class BooleanOps(DataTypeOps):
 
     def __and__(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
-        if is_ansi_mode_enabled(left._internal.spark_frame.sparkSession) and right is None:
+        if (
+            is_ansi_mode_enabled(left._internal.spark_frame.sparkSession)
+            and self.dtype == bool
+            and right is None
+        ):
             raise TypeError("AND can not be applied to given types.")
         if isinstance(right, IndexOpsMixin) and isinstance(right.dtype, extension_dtypes):
             return right.__and__(left)
@@ -258,7 +262,11 @@ class BooleanOps(DataTypeOps):
 
     def xor(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
-        if is_ansi_mode_enabled(left._internal.spark_frame.sparkSession) and right is None:
+        if (
+            is_ansi_mode_enabled(left._internal.spark_frame.sparkSession)
+            and self.dtype == bool
+            and right is None
+        ):
             raise TypeError("XOR can not be applied to given types.")
         if isinstance(right, IndexOpsMixin) and isinstance(right.dtype, extension_dtypes):
             return right ^ left
@@ -281,7 +289,11 @@ class BooleanOps(DataTypeOps):
 
     def __or__(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
-        if is_ansi_mode_enabled(left._internal.spark_frame.sparkSession) and right is None:
+        if (
+            is_ansi_mode_enabled(left._internal.spark_frame.sparkSession)
+            and self.dtype == bool
+            and right is None
+        ):
             raise TypeError("OR can not be applied to given types.")
         if isinstance(right, IndexOpsMixin) and isinstance(right.dtype, extension_dtypes):
             return right.__or__(left)

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -237,7 +237,7 @@ class BooleanOps(DataTypeOps):
 
     def __and__(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
-        if right is None:
+        if is_ansi_mode_enabled(left._internal.spark_frame.sparkSession) and right is None:
             raise TypeError("AND can not be applied to given types.")
         if isinstance(right, IndexOpsMixin) and isinstance(right.dtype, extension_dtypes):
             return right.__and__(left)
@@ -258,7 +258,7 @@ class BooleanOps(DataTypeOps):
 
     def xor(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
-        if right is None:
+        if is_ansi_mode_enabled(left._internal.spark_frame.sparkSession) and right is None:
             raise TypeError("XOR can not be applied to given types.")
         if isinstance(right, IndexOpsMixin) and isinstance(right.dtype, extension_dtypes):
             return right ^ left
@@ -281,7 +281,7 @@ class BooleanOps(DataTypeOps):
 
     def __or__(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
-        if right is None:
+        if is_ansi_mode_enabled(left._internal.spark_frame.sparkSession) and right is None:
             raise TypeError("OR can not be applied to given types.")
         if isinstance(right, IndexOpsMixin) and isinstance(right.dtype, extension_dtypes):
             return right.__or__(left)

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -24,6 +24,7 @@ from pandas.api.types import CategoricalDtype
 
 from pyspark import pandas as ps
 from pyspark.pandas import option_context
+from pyspark.testing.utils import is_ansi_mode_test
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
 from pyspark.pandas.typedef.typehints import (
@@ -255,11 +256,15 @@ class BooleanOpsTestsMixin:
         self.assert_eq(pser & pser, psser & psser)
         self.assert_eq(pser & other_pser, psser & other_psser)
         self.assert_eq(other_pser & pser, other_psser & psser)
+        if is_ansi_mode_test:
+            self.assertRaises(TypeError, psser & None)
 
     def test_rand(self):
         pser, psser = self.pdf["bool"], self.psdf["bool"]
         self.assert_eq(True & pser, True & psser)
         self.assert_eq(False & pser, False & psser)
+        if is_ansi_mode_test:
+            self.assertRaises(TypeError, None & psser)
 
     def test_or(self):
         pdf, psdf = self.bool_pdf, self.bool_psdf
@@ -269,16 +274,18 @@ class BooleanOpsTestsMixin:
         self.assert_eq(pser | True, psser | True)
         self.assert_eq(pser | False, psser | False)
         self.assert_eq(pser | pser, psser | psser)
-        self.assert_eq(True | pser, True | psser)
-        self.assert_eq(False | pser, False | psser)
 
         self.assert_eq(pser | other_pser, psser | other_psser)
         self.assert_eq(other_pser | pser, other_psser | psser)
+        if is_ansi_mode_test:
+            self.assertRaises(TypeError, psser | None)
 
     def test_ror(self):
         pser, psser = self.pdf["bool"], self.psdf["bool"]
         self.assert_eq(True | pser, True | psser)
         self.assert_eq(False | pser, False | psser)
+        if is_ansi_mode_test:
+            self.assertRaises(TypeError, None | psser)
 
     def test_xor(self):
         pdf, psdf = self.bool_pdf, self.bool_psdf
@@ -293,6 +300,8 @@ class BooleanOpsTestsMixin:
 
         with self.assertRaisesRegex(TypeError, "XOR can not be applied to given types."):
             psser ^ "a"
+        if is_ansi_mode_test:
+            self.assertRaises(TypeError, psser ^ None)
 
         with option_context("compute.ops_on_diff_frames", True):
             pser, other_pser = self.pdf["bool"], self.integral_pdf["this"]
@@ -305,6 +314,8 @@ class BooleanOpsTestsMixin:
         self.assert_eq(True ^ pser, True ^ psser)
         self.assert_eq(False ^ pser, False ^ psser)
         self.assert_eq(1 ^ pser, 1 ^ psser)
+        if is_ansi_mode_test:
+            self.assertRaises(TypeError, None ^ psser)
 
     def test_isnull(self):
         self.assert_eq(self.pdf["bool"].isnull(), self.psdf["bool"].isnull())

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -721,8 +721,8 @@ class BooleanExtensionOpsTest(OpsTestBase):
 
     def test_rxor(self):
         pser, psser = self.boolean_pdf["this"], self.boolean_psdf["this"]
-        self.check_extension(True | pser, True | psser)
-        self.check_extension(False | pser, False | psser)
+        self.check_extension(True ^ pser, True ^ psser)
+        self.check_extension(False ^ pser, False ^ psser)
         with self.assertRaisesRegex(TypeError, "XOR can not be applied to given types."):
             1 ^ psser
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -257,14 +257,14 @@ class BooleanOpsTestsMixin:
         self.assert_eq(pser & other_pser, psser & other_psser)
         self.assert_eq(other_pser & pser, other_psser & psser)
         if is_ansi_mode_test:
-            self.assertRaises(TypeError, psser & None)
+            self.assertRaises(TypeError, lambda: psser & None)
 
     def test_rand(self):
         pser, psser = self.pdf["bool"], self.psdf["bool"]
         self.assert_eq(True & pser, True & psser)
         self.assert_eq(False & pser, False & psser)
         if is_ansi_mode_test:
-            self.assertRaises(TypeError, None & psser)
+            self.assertRaises(TypeError, lambda: None & psser)
 
     def test_or(self):
         pdf, psdf = self.bool_pdf, self.bool_psdf
@@ -278,14 +278,14 @@ class BooleanOpsTestsMixin:
         self.assert_eq(pser | other_pser, psser | other_psser)
         self.assert_eq(other_pser | pser, other_psser | psser)
         if is_ansi_mode_test:
-            self.assertRaises(TypeError, psser | None)
+            self.assertRaises(TypeError, lambda: psser | None)
 
     def test_ror(self):
         pser, psser = self.pdf["bool"], self.psdf["bool"]
         self.assert_eq(True | pser, True | psser)
         self.assert_eq(False | pser, False | psser)
         if is_ansi_mode_test:
-            self.assertRaises(TypeError, None | psser)
+            self.assertRaises(TypeError, lambda: None | psser)
 
     def test_xor(self):
         pdf, psdf = self.bool_pdf, self.bool_psdf
@@ -301,7 +301,7 @@ class BooleanOpsTestsMixin:
         with self.assertRaisesRegex(TypeError, "XOR can not be applied to given types."):
             psser ^ "a"
         if is_ansi_mode_test:
-            self.assertRaises(TypeError, psser ^ None)
+            self.assertRaises(TypeError, lambda: psser ^ None)
 
         with option_context("compute.ops_on_diff_frames", True):
             pser, other_pser = self.pdf["bool"], self.integral_pdf["this"]
@@ -315,7 +315,7 @@ class BooleanOpsTestsMixin:
         self.assert_eq(False ^ pser, False ^ psser)
         self.assert_eq(1 ^ pser, 1 ^ psser)
         if is_ansi_mode_test:
-            self.assertRaises(TypeError, None ^ psser)
+            self.assertRaises(TypeError, lambda: None ^ psser)
 
     def test_isnull(self):
         self.assert_eq(self.pdf["bool"].isnull(), self.psdf["bool"].isnull())


### PR DESCRIPTION
### What changes were proposed in this pull request?
Bools `|`/`&`/`^` None should fail under ANSI, following native pandas

For example,
```py
>>> pd.Series([True, False]) | None
Traceback (most recent call last):
...
TypeError: unsupported operand type(s) for |: 'bool' and 'NoneType'
```

but under ANSI
```py
>>> ps.Series([True, False]) | None
0    False                                                                      
1    False
dtype: bool
```

### Why are the changes needed?
Part of https://issues.apache.org/jira/browse/SPARK-53389

### Does this PR introduce _any_ user-facing change?
No, the feature hasn't been released yet.

Now bools `|`/`&`/`^` None fails under ANSI, e.g.

```py
>>> ps.Series([True, False]) | None
Traceback (most recent call last):
...
TypeError: OR can not be applied to given types.
```

### How was this patch tested?
Unit tests

Commands below passed:
```
 1027  SPARK_ANSI_SQL_MODE=true ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_boolean_ops BooleanOpsTests"
 1028  SPARK_ANSI_SQL_MODE=false ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_boolean_ops BooleanOpsTests"
```

### Was this patch authored or co-authored using generative AI tooling?
No
