### PR TITLE
[SPARK-53442]Make PrometheusServlet compatible with OpenMetrics

### DIFF
--- a/core/src/test/scala/org/apache/spark/metrics/sink/PrometheusServletSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/sink/PrometheusServletSuite.scala
@@ -72,13 +72,13 @@ class PrometheusServletSuite extends SparkFunSuite with PrivateMethodTester {
   test("Counter should emit Prometheus counter") {
     val sink = createPrometheusServlet()
     val counter = new Counter
-    sink.registry.register("test.counter", counter)
+    sink.registry.register("counter1", counter)
     counter.inc(42)
 
     val snapshot = sink.getMetricsSnapshot()
 
-    assert(snapshot.contains("metrics_test_counter 42"))
-    assert(snapshot.contains("# TYPE metrics_test_counter counter"))
+    assert(snapshot.contains("metrics_counter1_total 42"))
+    assert(snapshot.contains("# TYPE metrics_counter1_total counter"))
   }
 
   test("Gauge should emit Prometheus gauge") {
@@ -86,11 +86,12 @@ class PrometheusServletSuite extends SparkFunSuite with PrivateMethodTester {
     val gauge = new Gauge[Double] {
       override def getValue: Double = 5.123
     }
-    sink.registry.register("test.gauge", gauge)
+    sink.registry.register("gauge1", gauge)
 
     val snapshot = sink.getMetricsSnapshot()
-    assert(snapshot.contains("metrics_test_gauge 5.123"))
-    assert(snapshot.contains("# TYPE metrics_test_gauge gauge"))
+    assert(snapshot.contains("metrics_gauge1 5.123"))
+    assert(snapshot.contains("# TYPE metrics_gauge1 gauge"))
+    validateNumericLinesFormat(snapshot)
   }
 
   test("Timer should emit summary and rates") {
@@ -103,14 +104,16 @@ class PrometheusServletSuite extends SparkFunSuite with PrivateMethodTester {
     val snapshot = sink.getMetricsSnapshot()
 
     // Summary
-    assert(snapshot.contains("metrics_test_timer_count 2"))
-    assert(snapshot.contains("metrics_test_timer_sum"))
-    assert(snapshot.contains("""metrics_test_timer{quantile="0.5"}"""))
+    assert(snapshot.contains("metrics_test_timer_duration_seconds_count 2"))
+    assert(snapshot.contains("metrics_test_timer_duration_seconds_sum"))
+    assert(snapshot.contains("""metrics_test_timer_duration_seconds{quantile="0.5"}"""))
 
     // Rate
     assert(snapshot.contains("metrics_test_timer_m1_rate"))
     assert(snapshot.contains("metrics_test_timer_m5_rate"))
     assert(snapshot.contains("metrics_test_timer_m15_rate"))
+
+    validateNumericLinesFormat(snapshot)
   }
 
   test("Histogram should emit summary") {
@@ -121,11 +124,12 @@ class PrometheusServletSuite extends SparkFunSuite with PrivateMethodTester {
     histogram.update(75)
     histogram.update(150)
 
-    val output = sink.getMetricsSnapshot()
+    val snapshot = sink.getMetricsSnapshot()
 
-    assert(output.contains("metrics_test_hist_count 3"))
-    assert(output.contains("metrics_test_hist_sum"))
-    assert(output.contains("""metrics_test_hist{quantile="0.5"}"""))
+    assert(snapshot.contains("metrics_test_hist_count 3"))
+    assert(snapshot.contains("metrics_test_hist_sum"))
+    assert(snapshot.contains("""metrics_test_hist{quantile="0.5"}"""))
+    validateNumericLinesFormat(snapshot)
   }
 
   test("Meter should emit count and rates") {
@@ -133,14 +137,24 @@ class PrometheusServletSuite extends SparkFunSuite with PrivateMethodTester {
     val meter = sink.registry.meter("test.meter")
     meter.mark(5)
 
-    val output = sink.getMetricsSnapshot()
+    val snapshot = sink.getMetricsSnapshot()
 
-    assert(output.contains("metrics_test_meter_count 5"))
-    assert(output.contains("metrics_test_meter_m1_rate"))
-    assert(output.contains("metrics_test_meter_m5_rate"))
-    assert(output.contains("metrics_test_meter_m15_rate"))
+    assert(snapshot.contains("metrics_test_meter_count_cumulative 5"))
+    assert(snapshot.contains("metrics_test_meter_m1_rate"))
+    assert(snapshot.contains("metrics_test_meter_m5_rate"))
+    assert(snapshot.contains("metrics_test_meter_m15_rate"))
+    validateNumericLinesFormat(snapshot)
   }
 
   private def createPrometheusServlet(): PrometheusServlet =
     new PrometheusServlet(new Properties, new MetricRegistry)
+
+  private def validateNumericLinesFormat(formattedOutput: String): Unit = {
+    val numericLinePattern = """^metrics_.*\s+([-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)$""".r
+    val lines = formattedOutput.linesIterator.filterNot(_.startsWith("#")).toList
+    lines.foreach {
+      case numericLinePattern(_, _) => // valid
+      case badLine => fail(s"Invalid metric value format: $badLine")
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes PrometheusServlet publish snapshot that's compatible with OpenMetrics

### Why are the changes needed?

Adopting OpenMetrics ensures our metrics output is forward-compatible with common observability tools, not only Prometheus, but also OpenTelemetry, Datadog and others.

### Does this PR introduce _any_ user-facing change?

This shall still be compatible witrh Prometheus, while adding more compatibility. No direct user facing changes otherwise.

### How was this patch tested?

CIs with added unit test

### Was this patch authored or co-authored using generative AI tooling?

No

