### PR TITLE
[SPARK-53443][PYTHON] Update python to `SPDX-license`

### DIFF
--- a/python/packaging/classic/setup.py
+++ b/python/packaging/classic/setup.py
@@ -342,7 +342,7 @@ try:
             "pyspark.examples.src.main.python": ["*.py", "*/*.py"],
         },
         scripts=scripts,
-        license="http://www.apache.org/licenses/LICENSE-2.0",
+        license="Apache-2.0",
         # Don't forget to update python/docs/source/getting_started/install.rst
         # if you're updating the versions or dependencies.
         install_requires=["py4j==0.10.9.9"],
@@ -380,7 +380,6 @@ try:
         python_requires=">=3.10",
         classifiers=[
             "Development Status :: 5 - Production/Stable",
-            "License :: OSI Approved :: Apache Software License",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",

--- a/python/packaging/client/setup.py
+++ b/python/packaging/client/setup.py
@@ -202,7 +202,7 @@ try:
         url="https://github.com/apache/spark/tree/master/python",
         packages=connect_packages + test_packages,
         include_package_data=True,
-        license="http://www.apache.org/licenses/LICENSE-2.0",
+        license="Apache-2.0",
         # Don't forget to update python/docs/source/getting_started/install.rst
         # if you're updating the versions or dependencies.
         install_requires=[
@@ -217,7 +217,6 @@ try:
         python_requires=">=3.10",
         classifiers=[
             "Development Status :: 5 - Production/Stable",
-            "License :: OSI Approved :: Apache Software License",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",

--- a/python/packaging/connect/setup.py
+++ b/python/packaging/connect/setup.py
@@ -111,7 +111,7 @@ try:
         url="https://github.com/apache/spark/tree/master/python",
         packages=connect_packages,
         include_package_data=True,
-        license="http://www.apache.org/licenses/LICENSE-2.0",
+        license="Apache-2.0",
         # Don't forget to update python/docs/source/getting_started/install.rst
         # if you're updating the versions or dependencies.
         install_requires=[
@@ -127,7 +127,6 @@ try:
         python_requires=">=3.9",
         classifiers=[
             "Development Status :: 5 - Production/Stable",
-            "License :: OSI Approved :: Apache Software License",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
### What changes were proposed in this pull request?

update to the SPDX license https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license



### Why are the changes needed?

when we build pyspark we get an warning 

Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: Apache Software License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.

<img width="1040" height="632" alt="image" src="https://github.com/user-attachments/assets/dc09ae25-8fe0-4868-8d60-dd396d775591" />



With the PR 

<img width="1367" height="866" alt="image" src="https://github.com/user-attachments/assets/9220b3cd-74e5-4889-bb2e-929a2dd8245c" />

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass CI/CD test and check in the builds log to see if the deprecated warning is there.

### Was this patch authored or co-authored using generative AI tooling?
No.