### PR TITLE
[SPARK-49933][SQL] Push WHEN NOT MATCHED BY SOURCE predicates to target

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.expressions.{Alias, And, Attribute, AttributeReference, Exists, Expression, IsNotNull, Literal, MetadataAttribute, MonotonicallyIncreasingID, OuterReference, PredicateHelper, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, Attribute, AttributeReference, Exists, Expression, IsNotNull, Literal, MetadataAttribute, MonotonicallyIncreasingID, Or, OuterReference, PredicateHelper, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.{FullOuter, Inner, JoinType, LeftAnti, LeftOuter, RightOuter}
@@ -174,16 +174,22 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
       readRelation, joinPlan, matchedActions, notMatchedActions,
       notMatchedBySourceActions, metadataAttrs, checkCardinality)
 
-    // predicates of the ON condition can be used to filter the target table (planning & runtime)
-    // only if there is no NOT MATCHED BY SOURCE clause
-    val (pushableCond, groupFilterCond) = if (notMatchedBySourceActions.isEmpty) {
-      if (groupFilterEnabled) {
-        (cond, Some(toGroupFilterCondition(relation, source, cond)))
-      } else {
-        (cond, None)
-      }
+    // predicates of the ON condition can be used to filter the target table only together with
+    // predicates of all NOT MATCHED BY SOURCE clauses, target rows that satisfy none of them
+    // match no action and are simply carried over, so such rows don't have to be read
+    // an unconditional NOT MATCHED BY SOURCE clause matches any target row and disables this
+    val pushableCond = if (notMatchedBySourceActions.exists(_.condition.isEmpty)) {
+      TrueLiteral
     } else {
-      (TrueLiteral, None)
+      (cond +: notMatchedBySourceActions.flatMap(_.condition)).reduce(Or)
+    }
+
+    // predicates of the ON condition can be used to filter the target table at runtime
+    // only if there is no NOT MATCHED BY SOURCE clause
+    val groupFilterCond = if (notMatchedBySourceActions.isEmpty && groupFilterEnabled) {
+      Some(toGroupFilterCondition(relation, source, cond))
+    } else {
+      None
     }
 
     // build a plan to replace read groups in the table

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedMergeIntoTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedMergeIntoTableSuite.scala
@@ -184,6 +184,91 @@ class GroupBasedMergeIntoTableSuite extends MergeIntoTableSuiteBase {
     }
   }
 
+  test("merge pushes conditional NOT MATCHED BY SOURCE predicates to target") {
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+        """{ "pk": 1, "salary": 100, "dep": "hr" }
+          |{ "pk": 2, "salary": 200, "dep": "software" }
+          |{ "pk": 3, "salary": 300, "dep": "finance" }
+          |""".stripMargin)
+
+      val sourceDF = Seq(1, 3, 6).toDF("pk")
+      sourceDF.createOrReplaceTempView("source")
+
+      // every NOT MATCHED BY SOURCE clause is conditional, so the ON condition and that clause's
+      // condition can be pushed to the target table as a disjunction; a target row satisfying
+      // neither is only carried over, so its group doesn't have to be read at all
+      val (cond, groupFilterCond) = executeAndKeepConditions {
+        sql(
+          s"""MERGE INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk AND t.dep IN ('hr', 'finance')
+             |WHEN MATCHED THEN
+             | UPDATE SET t.salary = t.salary + 1
+             |WHEN NOT MATCHED THEN
+             | INSERT (pk, salary, dep) VALUES (s.pk, 0, 'hr')
+             |WHEN NOT MATCHED BY SOURCE AND t.dep IN ('hr', 'finance') THEN
+             | DELETE
+             |""".stripMargin)
+      }
+
+      assert(cond.sql == "(t.dep IN ('hr', 'finance'))", s"unexpected pushable condition: $cond")
+      assert(groupFilterCond.isEmpty, "runtime group filtering must stay disabled")
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(1, 101, "hr"), // update
+          Row(2, 200, "software"), // unchanged, never read
+          Row(3, 301, "finance"), // update
+          Row(6, 0, "hr"))) // insert
+
+      // "software" can match neither the ON condition nor the NOT MATCHED BY SOURCE condition,
+      // so the pushed predicate keeps that group out of the scan and out of the rewrite
+      checkReplacedPartitions(Seq("hr", "finance"))
+    }
+  }
+
+  test("merge with unmatched ON condition pushes NOT MATCHED BY SOURCE predicates to target") {
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+        """{ "pk": 1, "salary": 100, "dep": "hr" }
+          |{ "pk": 2, "salary": 200, "dep": "software" }
+          |{ "pk": 3, "salary": 300, "dep": "finance" }
+          |""".stripMargin)
+
+      val sourceDF = Seq(5, 6).toDF("pk")
+      sourceDF.createOrReplaceTempView("source")
+
+      // this mirrors a "replace where" command: the ON condition never matches, so all source
+      // rows are inserted and target rows are deleted only where the NOT MATCHED BY SOURCE
+      // condition holds, which is exactly the predicate that ends up pushed to the target
+      val (cond, groupFilterCond) = executeAndKeepConditions {
+        sql(
+          s"""MERGE INTO $tableNameAsString t
+             |USING source s
+             |ON 1 = 0
+             |WHEN NOT MATCHED THEN
+             | INSERT (pk, salary, dep) VALUES (s.pk, 0, 'new')
+             |WHEN NOT MATCHED BY SOURCE AND t.dep IN ('hr', 'finance') THEN
+             | DELETE
+             |""".stripMargin)
+      }
+
+      assert(cond.sql == "(t.dep IN ('hr', 'finance'))", s"unexpected pushable condition: $cond")
+      assert(groupFilterCond.isEmpty, "runtime group filtering must stay disabled")
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(2, 200, "software"), // unchanged, never read
+          Row(5, 0, "new"), // insert
+          Row(6, 0, "new"))) // insert
+
+      checkReplacedPartitions(Seq("hr", "finance"))
+    }
+  }
+
   test("merge does not double plan table (group filter enabled)") {
     withSQLConf(SQLConf.RUNTIME_ROW_LEVEL_OPERATION_GROUP_FILTER_ENABLED.key -> "true") {
       withTempView("source") {


### PR DESCRIPTION
The catalyst `RewriteMergeIntoTable` rule makes a faulty assumption that the existence of `WHEN NOT MATCHED BY SOURCE` actions in a MERGE statement means the replace action will always have to do a full target table scan and makes it impossible to push any predicates down either during planning or runtime. While this is correct in case the merge contains a WhenNotMatchedBySource action w/o a filter condition, there is a place for predicate pushdown when **ALL** WhenNotMatchedBySource actions contain some filter condition.

### What changes were proposed in this pull request?

The PR changes the relevant rule to take WhenNotMatchedBySource predicate conditions into account in addition to the conditions coming from ON clause. The predicate to push down is now a disjunction between the condition from ON clause (which would have been pushed down had there not been a WhenNotMatchedBySource action) and all predicates coming from each WhenNotMatchedBySource action. If there is WhenNotMatchedBySource action w/o an explicit condition, it's treated as a TrueLiteral which will turn a disjunction into a TrueLiteral and effectively disable predicate pushdown.


### Why are the changes needed?
This is an issue that has been surfacing here and there because of the unacceptable performance implications of the current behavior. There is a similar [ticket](https://github.com/apache/iceberg/issues/11248) in iceberg caused by the overly strict implementation in the rule.

The use case that brought us to this issue is also Iceberg-related. Iceberg (unlike Delta) doesn't have a `replaceWhere` command that would do a row level operation to execute a partial overwrite even when data being overwritten is scattered across different files. Instead, one can do a MERGE query like the following that has the same semantic meaning:

```
MERGE INTO target_table as t
USING source as s
ON 1 = 0
WHEN NOT MATCHED THEN INSERT *
WHEN NOT MATCHED BY SOURCE AND [replaceWhereCondition] THEN DELETE
```

The problem with this query is that the predicate isn't being pushed down to the iceberg table when it's quite apparent that the first NOT MATCHED action has nothing to do with the existing target table and the second (NOT MATCHED BY SOURCE) action could only ever "touch" rows that satisfy [replaceWhereCondition]. The predicate pushed down to the table (after this PR) will be `(1 = 0) OR [replaceWhereCondition]`

### How was this patch tested?
I relied on existing tests that tested almost all iterations of the merge statement in various test files to make sure that there were no correctness issues. Please let me know in case there's a need to add a separate test that will test that predicate is actually being pushed down as well.

### Was this patch authored or co-authored using generative AI tooling?
No