### PR TITLE
[SPARK-53433][TESTS][FOLLOW-UP] Make the test compatible with PyArrow 15.0.0

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_udf_scalar.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf_scalar.py
@@ -525,14 +525,13 @@ class ScalarArrowUDFTestsMixin:
             pa.field("value", pa.binary(), nullable=False),
             pa.field("metadata", pa.binary(), nullable=False, metadata={b"variant": b"true"}),
         ]
-        variant_type = pa.struct(fields)
 
         @arrow_udf("variant")
         def scalar_f(v: pa.Array) -> pa.Array:
             assert isinstance(v, pa.Array)
             v = pa.array([bytes([12, i.as_py()]) for i in v], pa.binary())
             m = pa.array([bytes([1, 0, 0]) for i in v], pa.binary())
-            return pa.StructArray.from_arrays([v, m], type=variant_type)
+            return pa.StructArray.from_arrays([v, m], fields=fields)
 
         @arrow_udf("variant")
         def iter_f(it: Iterator[pa.Array]) -> Iterator[pa.Array]:
@@ -540,7 +539,7 @@ class ScalarArrowUDFTestsMixin:
                 assert isinstance(v, pa.Array)
                 v = pa.array([bytes([12, i.as_py()]) for i in v])
                 m = pa.array([bytes([1, 0, 0]) for i in v])
-                yield pa.StructArray.from_arrays([v, m], type=variant_type)
+                yield pa.StructArray.from_arrays([v, m], fields=fields)
 
         df = self.spark.range(0, 10)
         expected = [Row(l=i) for i in range(10)]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/52172 that makes the test compatible with PyArrow 0.15.

### Why are the changes needed?

Tests fail with PyArrow 0.15 https://github.com/apache/spark/actions/runs/17355567623/job/49268068508

`StructArray.from_arrays(..., type=...)` is available from PyArrow 15.0.0 (https://arrow.apache.org/docs/18.0/python/generated/pyarrow.StructArray.html#pyarrow.StructArray.from_arrays).

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.