### PR TITLE
[SPARK-49386][CORE][SQL][FOLLOWUP] More accurate memory tracking for memory based spill threshold

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/sort/ShuffleExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/ShuffleExternalSorter.java
@@ -92,7 +92,7 @@ final class ShuffleExternalSorter extends MemoryConsumer implements ShuffleCheck
   /**
    * Force this sorter to spill when the in memory size in bytes is beyond this threshold.
    */
-  private final long sizeInBytesForSpillThreshold;
+  private final long sizeInBytesForSpillThreshold ;
 
   /** The buffer size to use when writing spills using DiskBlockObjectWriter */
   private final int fileBufferSizeBytes;

--- a/core/src/main/java/org/apache/spark/shuffle/sort/ShuffleExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/ShuffleExternalSorter.java
@@ -92,7 +92,7 @@ final class ShuffleExternalSorter extends MemoryConsumer implements ShuffleCheck
   /**
    * Force this sorter to spill when the in memory size in bytes is beyond this threshold.
    */
-  private final long sizeInBytesForSpillThreshold ;
+  private final long sizeInBytesForSpillThreshold;
 
   /** The buffer size to use when writing spills using DiskBlockObjectWriter */
   private final int fileBufferSizeBytes;

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1599,9 +1599,9 @@ package object config {
       .createWithDefault(Integer.MAX_VALUE)
 
   private[spark] val SHUFFLE_SPILL_MAX_SIZE_FORCE_SPILL_THRESHOLD =
-    ConfigBuilder("spark.shuffle.spill.maxRecordsSizeForSpillThreshold")
+    ConfigBuilder("spark.shuffle.spill.maxSizeInBytesForSpillThreshold")
       .internal()
-      .doc("The maximum size in memory before forcing the shuffle sorter to spill. " +
+      .doc("The maximum in memory size in bytes before forcing the shuffle sorter to spill. " +
         "By default it is Long.MAX_VALUE, which means we never force the sorter to spill, " +
         "until we reach some limitations, like the max page size limitation for the pointer " +
         "array in the sorter.")

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeKVExternalSorter.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeKVExternalSorter.java
@@ -61,9 +61,9 @@ public final class UnsafeKVExternalSorter {
       SerializerManager serializerManager,
       long pageSizeBytes,
       int numElementsForSpillThreshold,
-      long maxRecordsSizeForSpillThreshold) throws IOException {
+      long sizeInBytesForSpillThreshold) throws IOException {
     this(keySchema, valueSchema, blockManager, serializerManager, pageSizeBytes,
-      numElementsForSpillThreshold, maxRecordsSizeForSpillThreshold, null);
+      numElementsForSpillThreshold, sizeInBytesForSpillThreshold, null);
   }
 
   public UnsafeKVExternalSorter(
@@ -73,7 +73,7 @@ public final class UnsafeKVExternalSorter {
       SerializerManager serializerManager,
       long pageSizeBytes,
       int numElementsForSpillThreshold,
-      long maxRecordsSizeForSpillThreshold,
+      long sizeInBytesForSpillThreshold,
       @Nullable BytesToBytesMap map) throws IOException {
     this.keySchema = keySchema;
     this.valueSchema = valueSchema;
@@ -100,7 +100,7 @@ public final class UnsafeKVExternalSorter {
         (int) (long) SparkEnv.get().conf().get(package$.MODULE$.SHUFFLE_SORT_INIT_BUFFER_SIZE()),
         pageSizeBytes,
         numElementsForSpillThreshold,
-        maxRecordsSizeForSpillThreshold,
+        sizeInBytesForSpillThreshold,
         canUseRadixSort);
     } else {
       // During spilling, the pointer array in `BytesToBytesMap` will not be used, so we can borrow
@@ -168,7 +168,7 @@ public final class UnsafeKVExternalSorter {
         (int) (long) SparkEnv.get().conf().get(package$.MODULE$.SHUFFLE_SORT_INIT_BUFFER_SIZE()),
         pageSizeBytes,
         numElementsForSpillThreshold,
-        maxRecordsSizeForSpillThreshold,
+        sizeInBytesForSpillThreshold,
         inMemSorter,
         map.getTotalMemoryConsumption());
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArray.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArray.scala
@@ -34,12 +34,13 @@ import org.apache.spark.util.collection.unsafe.sort.{UnsafeExternalSorter, Unsaf
 
 /**
  * An append-only array for [[UnsafeRow]]s that strictly keeps content in an in-memory array
- * until [[numRowsInMemoryBufferThreshold]] is reached post which it will switch to a mode which
- * would flush to disk after [[numRowsSpillThreshold]] is met (or before if there is
- * excessive memory consumption). Setting these threshold involves following trade-offs:
+ * until [[numRowsInMemoryBufferThreshold]] or [[sizeInBytesInMemoryBufferThreshold]] is reached
+ * post which it will switch to a mode (backed by [[UnsafeExternalSorter]]) which would flush to
+ * disk after [[numRowsSpillThreshold]] is met (or before if there is excessive memory consumption).
+ * Setting these threshold involves following trade-offs:
  *
- * - If [[numRowsInMemoryBufferThreshold]] is too high, the in-memory array may occupy more memory
- *   than is available, resulting in OOM.
+ * - If [[numRowsInMemoryBufferThreshold]] and [[sizeInBytesInMemoryBufferThreshold]] are too high,
+ *   the in-memory array may occupy more memory than is available, resulting in OOM.
  * - If [[numRowsSpillThreshold]] is too low, data will be spilled frequently and lead to
  *   excessive disk writes. This may lead to a performance regression compared to the normal case
  *   of using an [[ArrayBuffer]] or [[Array]].

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArray.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArray.scala
@@ -131,7 +131,7 @@ class ExternalAppendOnlyUnsafeRowArray(
   def add(unsafeRow: UnsafeRow): Unit = {
     // Once spills, we will switch to UnsafeExternalSorter permanently.
     if (spillableArray == null && numRows < numRowsInMemoryBufferThreshold &&
-      inMemoryBufferSizeInBytes < sizeInBytesSpillThreshold) {
+      inMemoryBufferSizeInBytes < sizeInBytesInMemoryBufferThreshold) {
       inMemoryBuffer += unsafeRow.copy()
       inMemoryBufferSizeInBytes += unsafeRow.getSizeInBytes
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArray.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArray.scala
@@ -42,8 +42,8 @@ import org.apache.spark.util.collection.unsafe.sort.{UnsafeExternalSorter, Unsaf
  * - If [[numRowsInMemoryBufferThreshold]] and [[sizeInBytesInMemoryBufferThreshold]] are too high,
  *   the in-memory array may occupy more memory than is available, resulting in OOM.
  * - If [[numRowsSpillThreshold]] or [[sizeInBytesSpillThreshold]] is too low, data will be spilled
- *   frequently and lead to excessive disk writes. This may lead to a performance regression compared
- *   to the normal case of using an [[ArrayBuffer]] or [[Array]].
+ *   frequently and lead to excessive disk writes. This may lead to a performance regression
+ *   compared to the normal case of using an [[ArrayBuffer]] or [[Array]].
  */
 class ExternalAppendOnlyUnsafeRowArray(
     taskMemoryManager: TaskMemoryManager,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArray.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArray.scala
@@ -36,14 +36,14 @@ import org.apache.spark.util.collection.unsafe.sort.{UnsafeExternalSorter, Unsaf
  * An append-only array for [[UnsafeRow]]s that strictly keeps content in an in-memory array
  * until [[numRowsInMemoryBufferThreshold]] or [[sizeInBytesInMemoryBufferThreshold]] is reached
  * post which it will switch to a mode (backed by [[UnsafeExternalSorter]]) which would flush to
- * disk after [[numRowsSpillThreshold]] is met (or before if there is excessive memory consumption).
- * Setting these threshold involves following trade-offs:
+ * disk after [[numRowsSpillThreshold]] or [[sizeInBytesSpillThreshold]] is met (or before if there
+ * is excessive memory consumption). Setting these threshold involves following trade-offs:
  *
  * - If [[numRowsInMemoryBufferThreshold]] and [[sizeInBytesInMemoryBufferThreshold]] are too high,
  *   the in-memory array may occupy more memory than is available, resulting in OOM.
- * - If [[numRowsSpillThreshold]] is too low, data will be spilled frequently and lead to
- *   excessive disk writes. This may lead to a performance regression compared to the normal case
- *   of using an [[ArrayBuffer]] or [[Array]].
+ * - If [[numRowsSpillThreshold]] or [[sizeInBytesSpillThreshold]] is too low, data will be spilled
+ *   frequently and lead to excessive disk writes. This may lead to a performance regression compared
+ *   to the normal case of using an [[ArrayBuffer]] or [[Array]].
  */
 class ExternalAppendOnlyUnsafeRowArray(
     taskMemoryManager: TaskMemoryManager,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/UpdatingSessionsIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/UpdatingSessionsIterator.scala
@@ -44,7 +44,7 @@ class UpdatingSessionsIterator(
     inputSchema: Seq[Attribute],
     inMemoryThreshold: Int,
     spillThreshold: Int,
-    spillSizeThreshold: Long) extends Iterator[InternalRow] {
+    sizeInBytesSpillThreshold: Long) extends Iterator[InternalRow] {
 
   private val groupingWithoutSession: Seq[NamedExpression] =
     groupingExpressions.diff(Seq(sessionExpression))
@@ -151,8 +151,13 @@ class UpdatingSessionsIterator(
     currentKeys = groupingKey.copy()
     currentSession = sessionStruct.copy()
 
-    rowsForCurrentSession = new ExternalAppendOnlyUnsafeRowArray(inMemoryThreshold, spillThreshold,
-      spillSizeThreshold)
+    rowsForCurrentSession = new ExternalAppendOnlyUnsafeRowArray(
+      inMemoryThreshold,
+      // TODO: shall we have a new config to specify the max in-memory buffer size
+      //       of ExternalAppendOnlyUnsafeRowArray?
+      sizeInBytesSpillThreshold,
+      spillThreshold,
+      sizeInBytesSpillThreshold)
     rowsForCurrentSession.add(currentRow.asInstanceOf[UnsafeRow])
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/CartesianProductExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/CartesianProductExec.scala
@@ -37,12 +37,17 @@ class UnsafeCartesianRDD(
     right : RDD[UnsafeRow],
     inMemoryBufferThreshold: Int,
     spillThreshold: Int,
-    spillSizeThreshold: Long)
+    sizeInBytesSpillThreshold: Long)
   extends CartesianRDD[UnsafeRow, UnsafeRow](left.sparkContext, left, right) {
 
   override def compute(split: Partition, context: TaskContext): Iterator[(UnsafeRow, UnsafeRow)] = {
-    val rowArray = new ExternalAppendOnlyUnsafeRowArray(inMemoryBufferThreshold, spillThreshold,
-      spillSizeThreshold)
+    val rowArray = new ExternalAppendOnlyUnsafeRowArray(
+      inMemoryBufferThreshold,
+      // TODO: shall we have a new config to specify the max in-memory buffer size
+      //       of ExternalAppendOnlyUnsafeRowArray?
+      sizeInBytesSpillThreshold,
+      spillThreshold,
+      sizeInBytesSpillThreshold)
 
     val partition = split.asInstanceOf[CartesianPartition]
     rdd2.iterator(partition.s2, context).foreach(rowArray.add)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinEvaluatorFactory.scala
@@ -34,7 +34,7 @@ class SortMergeJoinEvaluatorFactory(
     output: Seq[Attribute],
     inMemoryThreshold: Int,
     spillThreshold: Int,
-    spillSizeThreshold: Long,
+    sizeInBytesSpillThreshold: Long,
     numOutputRows: SQLMetric,
     spillSize: SQLMetric,
     onlyBufferFirstMatchedRow: Boolean)
@@ -86,7 +86,7 @@ class SortMergeJoinEvaluatorFactory(
               RowIterator.fromScala(rightIter),
               inMemoryThreshold,
               spillThreshold,
-              spillSizeThreshold,
+              sizeInBytesSpillThreshold,
               spillSize,
               cleanupResources)
             private[this] val joinRow = new JoinedRow
@@ -132,7 +132,7 @@ class SortMergeJoinEvaluatorFactory(
             bufferedIter = RowIterator.fromScala(rightIter),
             inMemoryThreshold,
             spillThreshold,
-            spillSizeThreshold,
+            sizeInBytesSpillThreshold,
             spillSize,
             cleanupResources)
           val rightNullRow = new GenericInternalRow(right.output.length)
@@ -152,7 +152,7 @@ class SortMergeJoinEvaluatorFactory(
             bufferedIter = RowIterator.fromScala(leftIter),
             inMemoryThreshold,
             spillThreshold,
-            spillSizeThreshold,
+            sizeInBytesSpillThreshold,
             spillSize,
             cleanupResources)
           val leftNullRow = new GenericInternalRow(left.output.length)
@@ -189,7 +189,7 @@ class SortMergeJoinEvaluatorFactory(
               RowIterator.fromScala(rightIter),
               inMemoryThreshold,
               spillThreshold,
-              spillSizeThreshold,
+              sizeInBytesSpillThreshold,
               spillSize,
               cleanupResources,
               onlyBufferFirstMatchedRow)
@@ -227,7 +227,7 @@ class SortMergeJoinEvaluatorFactory(
               RowIterator.fromScala(rightIter),
               inMemoryThreshold,
               spillThreshold,
-              spillSizeThreshold,
+              sizeInBytesSpillThreshold,
               spillSize,
               cleanupResources,
               onlyBufferFirstMatchedRow)
@@ -272,7 +272,7 @@ class SortMergeJoinEvaluatorFactory(
               RowIterator.fromScala(rightIter),
               inMemoryThreshold,
               spillThreshold,
-              spillSizeThreshold,
+              sizeInBytesSpillThreshold,
               spillSize,
               cleanupResources,
               onlyBufferFirstMatchedRow)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -103,7 +103,7 @@ case class SortMergeJoinExec(
     conf.sortMergeJoinExecBufferSpillThreshold
   }
 
-  private def getSpillSizeThreshold: Long = {
+  private def getSizeInBytesSpillThreshold: Long = {
     conf.sortMergeJoinExecBufferSpillSizeThreshold
   }
 
@@ -125,7 +125,7 @@ case class SortMergeJoinExec(
     val numOutputRows = longMetric("numOutputRows")
     val spillSize = longMetric("spillSize")
     val spillThreshold = getSpillThreshold
-    val spillSizeThreshold = getSpillSizeThreshold
+    val sizeInBytesSpillThreshold = getSizeInBytesSpillThreshold
     val inMemoryThreshold = getInMemoryThreshold
     val evaluatorFactory = new SortMergeJoinEvaluatorFactory(
       leftKeys,
@@ -137,7 +137,7 @@ case class SortMergeJoinExec(
       output,
       inMemoryThreshold,
       spillThreshold,
-      spillSizeThreshold,
+      sizeInBytesSpillThreshold,
       numOutputRows,
       spillSize,
       onlyBufferFirstMatchedRow
@@ -228,12 +228,15 @@ case class SortMergeJoinExec(
     val clsName = classOf[ExternalAppendOnlyUnsafeRowArray].getName
 
     val spillThreshold = getSpillThreshold
-    val spillSizeThreshold = getSpillSizeThreshold
+    val sizeInBytesSpillThreshold = getSizeInBytesSpillThreshold
     val inMemoryThreshold = getInMemoryThreshold
 
     // Inline mutable state since not many join operations in a task
     val matches = ctx.addMutableState(clsName, "matches",
-      v => s"$v = new $clsName($inMemoryThreshold, $spillThreshold, ${spillSizeThreshold}L);",
+      // TODO: shall we have a new config to specify the max in-memory buffer size
+      //       of ExternalAppendOnlyUnsafeRowArray?
+      v => s"$v = new $clsName($inMemoryThreshold, ${sizeInBytesSpillThreshold}L, " +
+        s"$spillThreshold, ${sizeInBytesSpillThreshold}L);",
       forceInline = true)
     // Copy the streamed keys as class members so they could be used in next function call.
     val matchedKeyVars = copyKeys(ctx, streamedKeyVars)
@@ -1052,7 +1055,8 @@ case class SortMergeJoinExec(
  * @param inMemoryThreshold Threshold for number of rows guaranteed to be held in memory by
  *                          internal buffer
  * @param spillThreshold Threshold for number of rows to be spilled by internal buffer
- * @param spillSizeThreshold Threshold for size of rows to be spilled by internal buffer
+ * @param sizeInBytesSpillThreshold Threshold for size in bytes of rows to be spilled by
+ *                                  internal buffer
  * @param eagerCleanupResources the eager cleanup function to be invoked when no join row found
  * @param onlyBufferFirstMatch [[bufferMatchingRows]] should buffer only the first matching row
  */
@@ -1064,7 +1068,7 @@ private[joins] class SortMergeJoinScanner(
     bufferedIter: RowIterator,
     inMemoryThreshold: Int,
     spillThreshold: Int,
-    spillSizeThreshold: Long,
+    sizeInBytesSpillThreshold: Long,
     spillSize: SQLMetric,
     eagerCleanupResources: () => Unit,
     onlyBufferFirstMatch: Boolean = false) {
@@ -1079,7 +1083,13 @@ private[joins] class SortMergeJoinScanner(
   private[this] var matchJoinKey: InternalRow = _
   /** Buffered rows from the buffered side of the join. This is empty if there are no matches. */
   private[this] val bufferedMatches: ExternalAppendOnlyUnsafeRowArray =
-    new ExternalAppendOnlyUnsafeRowArray(inMemoryThreshold, spillThreshold, spillSizeThreshold)
+    new ExternalAppendOnlyUnsafeRowArray(
+      inMemoryThreshold,
+      // TODO: shall we have a new config to specify the max in-memory buffer size
+      //       of ExternalAppendOnlyUnsafeRowArray?
+      sizeInBytesSpillThreshold,
+      spillThreshold,
+      sizeInBytesSpillThreshold)
 
   // At the end of the task, update the task's spill size for buffered side.
   TaskContext.get().addTaskCompletionListener[Unit](_ => {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowAggregatePythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowAggregatePythonExec.scala
@@ -215,10 +215,10 @@ case class ArrowAggregatePythonExec(
       case Some(sessionExpression) =>
         val inMemoryThreshold = conf.windowExecBufferInMemoryThreshold
         val spillThreshold = conf.windowExecBufferSpillThreshold
-        val spillSizeThreshold = conf.windowExecBufferSpillSizeThreshold
+        val sizeInBytesSpillThreshold = conf.windowExecBufferSpillSizeThreshold
 
         new UpdatingSessionsIterator(iter, groupingWithoutSessionExpressions, sessionExpression,
-          child.output, inMemoryThreshold, spillThreshold, spillSizeThreshold)
+          child.output, inMemoryThreshold, spillThreshold, sizeInBytesSpillThreshold)
 
       case None => iter
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowWindowPythonEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowWindowPythonEvaluatorFactory.scala
@@ -149,7 +149,7 @@ class ArrowWindowPythonEvaluatorFactory(
 
     private val inMemoryThreshold = conf.windowExecBufferInMemoryThreshold
     private val spillThreshold = conf.windowExecBufferSpillThreshold
-    private val spillSizeThreshold = conf.windowExecBufferSpillSizeThreshold
+    private val sizeInBytesSpillThreshold = conf.windowExecBufferSpillSizeThreshold
     private val sessionLocalTimeZone = conf.sessionLocalTimeZone
     private val largeVarTypes = conf.arrowUseLargeVarTypes
 
@@ -288,8 +288,13 @@ class ArrowWindowPythonEvaluatorFactory(
 
         // Manage the current partition.
         val buffer: ExternalAppendOnlyUnsafeRowArray =
-          new ExternalAppendOnlyUnsafeRowArray(inMemoryThreshold, spillThreshold,
-            spillSizeThreshold)
+          new ExternalAppendOnlyUnsafeRowArray(
+            inMemoryThreshold,
+            // TODO: shall we have a new config to specify the max in-memory buffer size
+            //       of ExternalAppendOnlyUnsafeRowArray?
+            sizeInBytesSpillThreshold,
+            spillThreshold,
+            sizeInBytesSpillThreshold)
         var bufferIterator: Iterator[UnsafeRow] = _
 
         val indexRow =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowEvaluatorFactory.scala
@@ -45,7 +45,7 @@ class WindowEvaluatorFactory(
     private val factories = windowFrameExpressionFactoryPairs.map(_._2).toArray
     private val inMemoryThreshold = conf.windowExecBufferInMemoryThreshold
     private val spillThreshold = conf.windowExecBufferSpillThreshold
-    private val spillSizeThreshold = conf.windowExecBufferSpillSizeThreshold
+    private val sizeInBytesSpillThreshold = conf.windowExecBufferSpillSizeThreshold
 
     override def eval(
         partitionIndex: Int,
@@ -83,8 +83,13 @@ class WindowEvaluatorFactory(
 
         // Manage the current partition.
         val buffer: ExternalAppendOnlyUnsafeRowArray =
-          new ExternalAppendOnlyUnsafeRowArray(inMemoryThreshold, spillThreshold,
-            spillSizeThreshold)
+          new ExternalAppendOnlyUnsafeRowArray(
+            inMemoryThreshold,
+            // TODO: shall we have a new config to specify the max in-memory buffer size
+            //       of ExternalAppendOnlyUnsafeRowArray?
+            sizeInBytesSpillThreshold,
+            spillThreshold,
+            sizeInBytesSpillThreshold)
 
         var bufferIterator: Iterator[UnsafeRow] = _
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArrayBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArrayBenchmark.scala
@@ -107,6 +107,7 @@ object ExternalAppendOnlyUnsafeRowArrayBenchmark extends BenchmarkBase {
       for (_ <- 0L until iterations) {
         val array = new ExternalAppendOnlyUnsafeRowArray(
           ExternalAppendOnlyUnsafeRowArray.DefaultInitialSizeOfInMemoryBuffer,
+          Long.MaxValue,
           numSpillThreshold,
           Long.MaxValue)
 
@@ -172,7 +173,9 @@ object ExternalAppendOnlyUnsafeRowArrayBenchmark extends BenchmarkBase {
     benchmark.addCase("ExternalAppendOnlyUnsafeRowArray") { _: Int =>
       var sum = 0L
       for (_ <- 0L until iterations) {
-        val array = new ExternalAppendOnlyUnsafeRowArray(numSpillThreshold,
+        val array = new ExternalAppendOnlyUnsafeRowArray(
+          numSpillThreshold,
+          Long.MaxValue,
           numSpillThreshold,
           Long.MaxValue)
         rows.foreach(x => array.add(x))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArraySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArraySuite.scala
@@ -47,6 +47,7 @@ class ExternalAppendOnlyUnsafeRowArraySuite extends SparkFunSuite with LocalSpar
         1024,
         SparkEnv.get.memoryManager.pageSizeBytes,
         inMemoryThreshold,
+        Long.MaxValue,
         spillThreshold,
         Long.MaxValue)
       try f(array) finally {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is a followup of https://github.com/apache/spark/pull/47856 . It makes the memory tracking more accurate in several places:
1. In `ShuffleExternalSorter`/`UnsafeExternalSorter`, the memory is used by both the sorter itself, and its underlying in-memort sorter (for sorting shuffle partition ids). We need to add them up to calcuate the current memory usage.
2. In `ExternalAppendOnlyUnsafeRowArray`, the records are inserted to an in-memory buffer first. If the buffer gets too large (currently based on num records), we switch to `UnsafeExternalSorter`. The in-memory buffer also needs a memory based threshold

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  3. If you fix a bug, you can clarify why it is a bug.
-->
More accurate memory tracking results to better spill decisions

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, the feature is not released yet.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
existing tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no