### PR TITLE
[SPARK-53449][SQL] Simplify options for builtin Datasource Scan related classes

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionStateHelper.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionStateHelper.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.SparkSession
  * It also provides type annotations for IDEs to build indexes.
  */
 trait SessionStateHelper {
-  private def sessionState(sparkSession: SparkSession): SessionState = {
+  protected def sessionState(sparkSession: SparkSession): SessionState = {
     sparkSession.sessionState
   }
 
@@ -47,6 +47,10 @@ trait SessionStateHelper {
       sparkSession: SparkSession,
       options: Map[String, String]): Configuration = {
     sessionState(sparkSession).newHadoopConfWithOptions(options)
+  }
+
+  def getHadoopConf(sparkSession: SparkSession): Configuration = {
+    sessionState(sparkSession).newHadoopConf()
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Simplify interoperations between SQLConf and builtin Datasource Scan related classes, following
[SPARK-52704](https://issues.apache.org/jira/browse/SPARK-52704)
[SPARK-53415](https://issues.apache.org/jira/browse/SPARK-53415)

### Why are the changes needed?

- Reduce code duplication
- Restore type annotation for IDE

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
existing tests

### Was this patch authored or co-authored using generative AI tooling?
no


