### PR TITLE
[SPARK-53450] Nulls are filled unexpectedly after converting hive table scan to logical relation

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -347,7 +347,7 @@ private[hive] class HiveMetastoreCatalog(sparkSession: SparkSession) extends Log
     val inferenceMode = sparkSession.sessionState.conf.caseSensitiveInferenceMode
     val shouldInfer = (inferenceMode != NEVER_INFER) && !tableMeta.schemaPreservesCase
     if (shouldInfer) {
-      val tableName = relation.tableMeta.identifier.unquotedString
+      val tableName = tableMeta.identifier.unquotedString
       logInfo(log"Inferring case-sensitive schema for table ${MDC(TABLE_NAME, tableName)} " +
         log"(inference mode:  ${MDC(INFERENCE_MODE, inferenceMode)})})")
       val fileIndex = fileIndexOpt.getOrElse {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -36,6 +36,7 @@ import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetOptions}
+import org.apache.spark.sql.hive.HiveUtils.CONVERT_METASTORE_AS_NULLABLE
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.HiveCaseSensitiveInferenceMode._
 import org.apache.spark.sql.internal.SQLConf.PartitionOverwriteMode
@@ -338,14 +339,19 @@ private[hive] class HiveMetastoreCatalog(sparkSession: SparkSession) extends Log
       options: Map[String, String],
       fileFormat: FileFormat,
       fileIndexOpt: Option[FileIndex] = None): CatalogTable = {
+    val tableMeta = if (sparkSession.sessionState.conf.getConf(CONVERT_METASTORE_AS_NULLABLE)) {
+      relation.tableMeta.copy(schema = relation.tableMeta.schema.asNullable)
+    } else {
+      relation.tableMeta
+    }
     val inferenceMode = sparkSession.sessionState.conf.caseSensitiveInferenceMode
-    val shouldInfer = (inferenceMode != NEVER_INFER) && !relation.tableMeta.schemaPreservesCase
-    val tableName = relation.tableMeta.identifier.unquotedString
+    val shouldInfer = (inferenceMode != NEVER_INFER) && !tableMeta.schemaPreservesCase
     if (shouldInfer) {
+      val tableName = relation.tableMeta.identifier.unquotedString
       logInfo(log"Inferring case-sensitive schema for table ${MDC(TABLE_NAME, tableName)} " +
         log"(inference mode:  ${MDC(INFERENCE_MODE, inferenceMode)})})")
       val fileIndex = fileIndexOpt.getOrElse {
-        val rootPath = new Path(relation.tableMeta.location)
+        val rootPath = new Path(tableMeta.location)
         new InMemoryFileIndex(sparkSession, Seq(rootPath), options, None)
       }
 
@@ -354,23 +360,23 @@ private[hive] class HiveMetastoreCatalog(sparkSession: SparkSession) extends Log
           sparkSession,
           options,
           fileIndex.listFiles(Nil, Nil).flatMap(_.files).map(_.fileStatus))
-        .map(mergeWithMetastoreSchema(relation.tableMeta.dataSchema, _))
+        .map(mergeWithMetastoreSchema(tableMeta.dataSchema, _))
 
       inferredSchema match {
         case Some(dataSchema) =>
           if (inferenceMode == INFER_AND_SAVE) {
-            updateDataSchema(relation.tableMeta.identifier, dataSchema)
+            updateDataSchema(tableMeta.identifier, dataSchema)
           }
-          val newSchema = StructType(dataSchema ++ relation.tableMeta.partitionSchema)
-          relation.tableMeta.copy(schema = newSchema)
+          val newSchema = StructType(dataSchema ++ tableMeta.partitionSchema)
+          tableMeta.copy(schema = newSchema)
         case None =>
           logWarning(log"Unable to infer schema for table ${MDC(TABLE_NAME, tableName)} from " +
             log"file format ${MDC(FILE_FORMAT, fileFormat)} (inference mode: " +
             log"${MDC(INFERENCE_MODE, inferenceMode)}). Using metastore schema.")
-          relation.tableMeta
+          tableMeta
       }
     } else {
-      relation.tableMeta
+      tableMeta
     }
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -183,6 +183,16 @@ private[spark] object HiveUtils extends Logging {
     .booleanConf
     .createWithDefault(true)
 
+  val CONVERT_METASTORE_AS_NULLABLE = buildConf("spark.sql.hive.convertMetastoreAsNullable")
+    .doc("When set to true, apply nullable to the schema when Spark use datasource APIs instead " +
+      "of Hive serde to read/write Hive tables in Parquet or ORC formats. This flag is " +
+      "effective only if `convertMetastoreParquet` or `convertMetastoreOrc` is enabled " +
+      "respectively. It's recommended to set to true, when the nullability of table schema " +
+      "is inconsistent between the metastore and the data files.")
+    .version("4.1.0")
+    .booleanConf
+    .createWithDefault(false)
+
   val HIVE_METASTORE_SHARED_PREFIXES = buildStaticConf("spark.sql.hive.metastore.sharedPrefixes")
     .doc("A comma separated list of class prefixes that should be loaded using the classloader " +
       "that is shared between Spark SQL and a specific version of Hive. An example of classes " +


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR introduces a configuration `spark.sql.hive.convertMetastoreAsNullable` to set nullable to true for all fields while converting Hive parquet/orc tables to datasources to fix a data-correctness issue.

### Why are the changes needed?

Hive tables are generally schema-on-read, and those Spark-executed Hive DDLs are not always Hive compatible.

We have an online case that produces incorrect values while `convertMetastoreParquet=true`, for a null record, it sometimes returns 5, others 0, and no other values are witnessed yet.

I've tried 4 ways to read the table and data

1) convertMetastoreParquet=true, vectorized  -- negative
2) convertMetastoreParquet=true, row-based  -- negative
3) convertMetastoreParquet=false  -- positive
4) scan on the table path, partition path, or files -- positive


It turns out that the incorrect table schema led to wrong results.

So, in this PR, I added a new configuration to fall back on how Hive handles nullability blindly.  


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

Unfortunately, I've not yet figured out a reproducible unit test to cover this. So, I packed and tested online with our prod data

#### Before this PR
<img width="387" height="195" alt="image" src="https://github.com/user-attachments/assets/b89836c9-f0c2-4beb-8f19-903f761f212a" />

#### After this PR


<img width="387" height="192" alt="image" src="https://github.com/user-attachments/assets/6b305268-581f-4538-b60a-1d4ae5720fff" />

### Was this patch authored or co-authored using generative AI tooling?
no
