### PR TITLE
[SPARK-53452][PYTHON] `from_arrow_type` should respect `valueContainsNull`

### DIFF
--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -321,9 +321,9 @@ def from_arrow_type(at: "pa.DataType", prefer_timestamp_ntz: bool = False) -> Da
         spark_type = ArrayType(from_arrow_type(at.value_type, prefer_timestamp_ntz))
     elif types.is_map(at):
         spark_type = MapType(
-            from_arrow_type(at.key_type, prefer_timestamp_ntz),
-            from_arrow_type(at.item_type, prefer_timestamp_ntz),
-            at.item_field.nullable,
+            keyType=from_arrow_type(at.key_type, prefer_timestamp_ntz),
+            valueType=from_arrow_type(at.item_type, prefer_timestamp_ntz),
+            valueContainsNull=at.item_field.nullable,
         )
     elif types.is_struct(at):
         if is_variant(at):

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -323,6 +323,7 @@ def from_arrow_type(at: "pa.DataType", prefer_timestamp_ntz: bool = False) -> Da
         spark_type = MapType(
             from_arrow_type(at.key_type, prefer_timestamp_ntz),
             from_arrow_type(at.item_type, prefer_timestamp_ntz),
+            at.item_field.nullable,
         )
     elif types.is_struct(at):
         if is_variant(at):

--- a/python/pyspark/sql/tests/arrow/test_arrow.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow.py
@@ -737,6 +737,18 @@ class ArrowTestsMixin:
         schema_rt = from_arrow_schema(arrow_schema, prefer_timestamp_ntz=True)
         self.assertEqual(self.schema, schema_rt)
 
+    def test_map_type_conversion_roundtrip(self):
+        from pyspark.sql.pandas.types import from_arrow_type, to_arrow_type
+
+        m1 = MapType(StringType(), IntegerType(), True)
+        m2 = MapType(StringType(), IntegerType(), False)
+
+        for t in [m1, m2]:
+            with self.subTest(map_type=t):
+                arrow_type = to_arrow_type(t)
+                t2 = from_arrow_type(arrow_type)
+                self.assertEqual(t, t2)
+
     def test_createDataFrame_with_ndarray(self):
         for arrow_enabled in [True, False]:
             with self.subTest(arrow_enabled=arrow_enabled):


### PR DESCRIPTION
### What changes were proposed in this pull request?
`from_arrow_type` should respect `valueContainsNull`:

```
In [4]: t = MapType(StringType(), IntegerType(), False)

In [5]: pt = to_arrow_type(t)

In [6]: pt
Out[6]: MapType(map<string, int32>)

In [7]: t2 = from_arrow_type(pt)

In [8]: t2
Out[8]: MapType(StringType(), IntegerType(), True)
```

### Why are the changes needed?
bug-fix


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
added test


### Was this patch authored or co-authored using generative AI tooling?
no