### PR TITLE
[SPARK-53458][INFRA] Add daily dry-run release test GitHub Action jobs for Spark 4.0/3.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,10 @@ name: Release Apache Spark
 
 on:
   schedule:
+    # Dry-run schedule for `master`, `branch-4.0`, and `branch-3.5`
     - cron: '0 7 * * *'
+    - cron: '0 14 * * *'
+    - cron: '0 21 * * *'
   workflow_dispatch:
     inputs:
       branch:
@@ -109,14 +112,26 @@ jobs:
         )
       )
     steps:
+      - name: Set dry run branch
+        run: |
+          if [ "${{ inputs.branch != '' }}" ]; then
+            echo "GIT_BRANCH=${{ inputs.branch }}" >> $GITHUB_ENV
+          else
+            if [ "${{ github.event.schedule }}" == "0 14 * * *" ]; then
+              echo "GIT_BRANCH=branch-4.0" >> $GITHUB_ENV
+            elif [ "${{ github.event.schedule }}" == "0 21 * * *" ]; then
+              echo "GIT_BRANCH=branch-3.5" >> $GITHUB_ENV
+            else
+              echo "GIT_BRANCH=master" >> $GITHUB_ENV
+            fi
+          fi
       - name: Checkout Spark repository
         uses: actions/checkout@v4
         with:
           repository: apache/spark
-          ref: "${{ inputs.branch }}"
+          ref: "$GIT_BRANCH"
       - name: Release Apache Spark
         env:
-          GIT_BRANCH: "${{ inputs.branch }}"
           RELEASE_VERSION: "${{ inputs.release-version }}"
           SPARK_RC_COUNT: "${{ inputs.rc-count }}"
           IS_FINALIZE: "${{ inputs.finalize }}"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add daily dry-run release test GitHub Action jobs for Spark 4.0.x and 3.5.x.

### Why are the changes needed?

Like `master` branch, we had better have a test coverage for release processes including building `spark-rm` images for all live release branches.

https://github.com/apache/spark/actions/workflows/release.yml

This will help us to detect and recover any failures on release process as early as possible.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review because this is a daily job.

### Was this patch authored or co-authored using generative AI tooling?

No.