### PR TITLE
[SPARK-53460][BUILD] Upgrade `analyticsaccelerator-s3` to 1.3.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -9,7 +9,7 @@ aliyun-java-sdk-core/4.5.10//aliyun-java-sdk-core-4.5.10.jar
 aliyun-java-sdk-kms/2.11.0//aliyun-java-sdk-kms-2.11.0.jar
 aliyun-java-sdk-ram/3.1.0//aliyun-java-sdk-ram-3.1.0.jar
 aliyun-sdk-oss/3.13.2//aliyun-sdk-oss-3.13.2.jar
-analyticsaccelerator-s3/1.2.1//analyticsaccelerator-s3-1.2.1.jar
+analyticsaccelerator-s3/1.3.0//analyticsaccelerator-s3-1.3.0.jar
 antlr-runtime/3.5.2//antlr-runtime-3.5.2.jar
 antlr4-runtime/4.13.1//antlr4-runtime-4.13.1.jar
 aopalliance-repackaged/3.0.6//aopalliance-repackaged-3.0.6.jar

--- a/hadoop-cloud/pom.xml
+++ b/hadoop-cloud/pom.xml
@@ -105,6 +105,12 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>software.amazon.s3.analyticsaccelerator</groupId>
+      <artifactId>analyticsaccelerator-s3</artifactId>
+      <version>${analyticsaccelerator-s3.version}</version>
+      <scope>${hadoop.deps.scope}</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.cloud.bigdataoss</groupId>
       <artifactId>gcs-connector</artifactId>
       <version>${gcs-connector.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,7 @@
     <aws.kinesis.producer.version>0.12.8</aws.kinesis.producer.version>
     <!-- Do not use 3.0.0: https://github.com/GoogleCloudDataproc/hadoop-connectors/issues/1114 -->
     <gcs-connector.version>hadoop3-2.2.28</gcs-connector.version>
+    <analyticsaccelerator-s3.version>1.3.0</analyticsaccelerator-s3.version>
     <!--  org.apache.httpcomponents/httpclient-->
     <commons.httpclient.version>4.5.14</commons.httpclient.version>
     <commons.httpcore.version>4.4.16</commons.httpcore.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `analyticsaccelerator-s3` to 1.3.0.

### Why are the changes needed?

To use the latest improvements and bug fixes for Apache Spark 4.1.0.
- https://github.com/awslabs/analytics-accelerator-s3/releases/tag/v1.3.0
  - https://github.com/awslabs/analytics-accelerator-s3/pull/345
  - https://github.com/awslabs/analytics-accelerator-s3/pull/338
  - https://github.com/awslabs/analytics-accelerator-s3/pull/321
  - https://github.com/awslabs/analytics-accelerator-s3/pull/342

### Does this PR introduce _any_ user-facing change?

No, this was a new library which is not released yet.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.