### PR TITLE
[SPARK-53461][PYTHON][DOCS] Clarify pie plot parameter `subplots`

### DIFF
--- a/python/pyspark/sql/plot/core.py
+++ b/python/pyspark/sql/plot/core.py
@@ -329,7 +329,7 @@ class PySparkPlotAccessor:
             Name of column to be used as the category labels for the pie plot.
         y : str, optional
             Name of the column to plot. If not provided, `subplots=True` must be passed at `kwargs`.
-        subplots : bool, default False, optional (passed via **kwargs)
+        subplots : bool, default False, optional (passed via `kwargs`)
             If True, create a separate subplot for each numeric column in the DataFrame.
         **kwargs
             Additional keyword arguments. See also `subplots` above.

--- a/python/pyspark/sql/plot/core.py
+++ b/python/pyspark/sql/plot/core.py
@@ -329,8 +329,10 @@ class PySparkPlotAccessor:
             Name of column to be used as the category labels for the pie plot.
         y : str, optional
             Name of the column to plot. If not provided, `subplots=True` must be passed at `kwargs`.
+        subplots : bool, default False, optional (passed via **kwargs)
+            If True, create a separate subplot for each numeric column in the DataFrame.
         **kwargs
-            Additional keyword arguments.
+            Additional keyword arguments. See also `subplots` above.
 
         Returns
         -------


### PR DESCRIPTION

### What changes were proposed in this pull request?
Clarify pie plot parameter `subplots`, document `subplots` via kwargs

### Why are the changes needed?
Otherwise, all generated subplots will share the same labels from the x column, which may not be obvious to users what `subplots` means

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests

### Was this patch authored or co-authored using generative AI tooling?
No
