### PR TITLE
[SPARK-53464][K8S][INFRA] Update `setup-minikube` to v0.0.20

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1323,7 +1323,7 @@ jobs:
           sudo apt update
           sudo apt-get install r-base
       - name: Start Minikube
-        uses: medyagh/setup-minikube@v0.0.19
+        uses: medyagh/setup-minikube@v0.0.20
         with:
           kubernetes-version: "1.33.0"
           # Github Action limit cpu:2, memory: 6947MB, limit to 2U6G for better resource statistic


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `setup-minikube` to the latest version v0.0.20.

### Why are the changes needed?

Currently, we use `v0.0.19` (2025-01-22). We had better use the latest one.
- https://github.com/medyagh/setup-minikube/releases/tag/v0.0.20 (2025-07-08)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.