### PR TITLE
[MINOR][BUILD] Remove `preview` postfix in documentation.md when releasing

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -172,7 +172,7 @@ is_preview = bool(re.search(r'-preview\d*$', release_version))
 base_version = re.sub(r'-preview\d*$', '', release_version)
 
 stable_newline = f'  <li><a href="{{{{site.baseurl}}}}/docs/{release_version}/">Spark {release_version}</a></li>'
-preview_newline = f'  <li><a href="{{{{site.baseurl}}}}/docs/{release_version}/">Spark {release_version} preview</a></li>'
+preview_newline = f'  <li><a href="{{{{site.baseurl}}}}/docs/{release_version}/">Spark {release_version}</a></li>'
 
 inserted = False
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to remove `preview` postfix in `documentation.md` when releasing

### Why are the changes needed?

To be consistent. `preview` postfix is not needed, see https://github.com/apache/spark-website/blob/asf-site/documentation.md

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.