### PR TITLE
[SPARK-XXXX] Rocks db state store orphan removal protection

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -318,10 +318,9 @@ class RocksDBFileManager(
 
   /**
    * Find orphan files which are not tracked by zip files.
-   *
    * Both sst files and log files can be orphan files.
    * They are uploaded separately before the zip file of that version is uploaded.
-   * When a version's zip file is overwritten the referenced sst and log files become orphan.
+   * When the zip file of a version get overwritten, the referenced sst and log files become orphan.
    * Ensure sst and log files of any ongoing versions are not deleted.
    *
    * @param trackedFiles files tracked by metadata in versioned zip file

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -676,8 +676,8 @@ class RocksDBSuite extends AlsoTestWithChangelogCheckpointingEnabled with Shared
       // the orphan then the state will be corrupted.
       fileManagerB.deleteOldVersions(2)
 
-      // Passes, but behavior is incorrect. Both files should be protected to prevent corruption.
-      assert(sstCounts === Map("003" -> 1), sstCounts)
+      // Both files are protected to prevent corruption.
+      assert(sstCounts === Map("003" -> 2), sstCounts)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -655,7 +655,7 @@ class RocksDBSuite extends AlsoTestWithChangelogCheckpointingEnabled with Shared
       def sstCounts: Map[String, Int] = listFiles(sstDir)
         .map(_.getName.split("-").head)
         .groupBy(identity)
-        .mapValues(_.size)
+        .map { case (k, v) => k -> v.size }
 
       // Two copies of 003.sst exist.
       assert(sstCounts === Map("003" -> 2), sstCounts)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

This PR addresses the issue described in this spark dev mailing list thread: https://lists.apache.org/thread/27bg3gsd4czpd4o0ybvc2pxv6qhmpbfb 

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Include timestamps of all retained .zip files in the timestamp threshold used to detect orphaned files. This helps protect against state store corruption when multiple file managers are simultaneously running maintenance for the same partition.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To avoid state store corruption.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

A new test was added that goes over the problem.  The test is added in the first [commit](https://github.com/apache/spark/pull/52209/commits/4971e8625ad6463130049dd054229bb8c3c85087) in this PR. 


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
