### PR TITLE
[SPARK-51739][PYTHON][FOLLOW-UP] Disable spark.sql.execution.arrow.pyspark.validateSchema.enabled by default

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -22,10 +22,6 @@ license: |
 * Table of contents
 {:toc}
 
-## Upgrading from Spark SQL 4.0 to 4.1
-
-- Since Spark 4.1, `mapInPandas` and `mapInArrow` enforces strict validation of the result against the schema. The column names must exactly match and types must match with compatible nullability. To restore the previous behavior, set `spark.sql.execution.arrow.pyspark.validateSchema.enabled` to `false`.
-
 ## Upgrading from Spark SQL 3.5 to 4.0
 
 - Since Spark 4.0, `spark.sql.ansi.enabled` is on by default. To restore the previous behavior, set `spark.sql.ansi.enabled` to `false` or `SPARK_ANSI_SQL_MODE` to `false`.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3961,7 +3961,7 @@ object SQLConf {
         "and DataSource against the expected schema to ensure that they are compatible.")
       .version("4.1.0")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val PYTHON_UDF_ARROW_ENABLED =
     buildConf("spark.sql.execution.pythonUDF.arrow.enabled")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/50531 that disables spark.sql.execution.arrow.pyspark.validateSchema.enabled by default

### Why are the changes needed?

To avoid breaking changes. Some analysis has to be proceeded first.

### Does this PR introduce _any_ user-facing change?

It actually prevents the user-facing change.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.