### PR TITLE
[SPARK-53472][DOCS] Fix jekyll-redirect-from template and generated html files

### DIFF
--- a/docs/_layouts/redirect.html
+++ b/docs/_layouts/redirect.html
@@ -19,10 +19,11 @@
 <html lang="en-US">
 <meta charset="utf-8">
 <title>Redirecting&hellip;</title>
-<link rel="canonical" href="{{ page.redirect.to }}.html">
-<script>location="{{ page.redirect.to }}.html"</script>
-<meta http-equiv="refresh" content="0; url={{ page.redirect.to }}.html">
+{% assign redirect_url = page.redirect.to | replace_first: '/', '' | prepend: rel_path_to_root | append: '.html' %}
+<link rel="canonical" href="{{ redirect_url }}">
+<script>location="{{ redirect_url }}"</script>
+<meta http-equiv="refresh" content="0; url={{ redirect_url }}">
 <meta name="robots" content="noindex">
 <h1>Redirecting&hellip;</h1>
-<a href="{{ page.redirect.to }}.html">Click here if you are not redirected.</a>
+<a href="{{ redirect_url }}">Click here if you are not redirected.</a>
 </html>


### PR DESCRIPTION
### Why are the changes needed?


`page.redirect.to` defaults to pages with the absolute site root. In this PR, we revise it to the docs relative.


### Does this PR introduce _any_ user-facing change?
doc fix

Check https://dist.apache.org/repos/dist/dev/spark/v4.0.1-rc1-docs/_site/ for https://dist.apache.org/repos/dist/dev/spark/v4.0.1-rc1-docs/_site/building-with-maven.html


### How was this patch tested?
build docs locally.


### Was this patch authored or co-authored using generative AI tooling?
no
