### PR TITLE
[SPARK-53482][SQL] MERGE INTO support nested case where source has less fields than target

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1695,10 +1695,10 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
               case UpdateStarAction(updateCondition) =>
                 // Use only source columns.  Missing columns in target will be handled in
                 // ResolveRowLevelCommandAssignments.
-                val assignments = targetTable.output.flatMap{ targetAttr =>
-                  sourceTable.output.find(
-                      sourceCol => conf.resolver(sourceCol.name, targetAttr.name))
-                    .map(Assignment(targetAttr, _))}
+                val sourceAttrs = DataTypeUtils.nestedAttributes(sourceTable.output)
+                val assignments = sourceAttrs.map{ sourceAttr =>
+                  Assignment(UnresolvedAttribute(sourceAttr.name),
+                    UnresolvedAttribute(sourceAttr.name))}
                 UpdateAction(
                   updateCondition.map(resolveExpressionByPlanChildren(_, m)),
                   // For UPDATE *, the value must be from source table.
@@ -1721,10 +1721,10 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
                   resolveExpressionByPlanOutput(_, m.sourceTable))
                 // Use only source columns.  Missing columns in target will be handled in
                 // ResolveRowLevelCommandAssignments.
-                val assignments = targetTable.output.flatMap{ targetAttr =>
-                  sourceTable.output.find(
-                      sourceCol => conf.resolver(sourceCol.name, targetAttr.name))
-                    .map(Assignment(targetAttr, _))}
+                val sourceAttrs = DataTypeUtils.nestedAttributes(sourceTable.output)
+                val assignments = sourceAttrs.map{ sourceAttr =>
+                  Assignment(UnresolvedAttribute(sourceAttr.name),
+                    UnresolvedAttribute(sourceAttr.name))}
                 InsertAction(
                   resolvedInsertCondition,
                   resolveAssignments(assignments, m, MergeResolvePolicy.SOURCE))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlignMergeAssignmentsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlignMergeAssignmentsSuite.scala
@@ -631,14 +631,6 @@ class AlignMergeAssignmentsSuite extends AlignAssignmentsSuiteBase {
         | INSERT (i, l, txt, txt) VALUES (src.i, src.l, src.txt, src.txt)
         |""".stripMargin,
       "Multiple assignments for 'txt'")
-
-    assertAnalysisException(
-      """MERGE INTO nested_struct_table t USING nested_struct_table src
-        |ON t.i = src.i
-        |WHEN NOT MATCHED THEN
-        | INSERT (s.n_i) VALUES (1)
-        |""".stripMargin,
-      "INSERT assignment keys cannot be nested fields: t.s.`n_i` = 1")
   }
 
   test("updates to nested structs in arrays") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support MERGE INTO where source has less fields than target.  This is already partially supported as part of: https://github.com/apache/spark/pull/51698, but only for top level fields.  This support it even for nested fields.

This patch does following:
- For MERGE INTO with `UPDATE *` and `INSERT *`, https://github.com/apache/spark/pull/51698 already changed it to expand the `*` to fields common to source and target table schema.  This change now expands it to UPDATE and INSERT for common flattened fields of source and target table schema.
- Previously INSERT did not allow specifying a leaf field.  I added this support, for this change to work.  The logic is similar to UPDATE


### Why are the changes needed?
For cases where source has less fields than target in MERGE INTO, it should behave more gracefully (inserting null values where source field does not exist).


### Does this PR introduce _any_ user-facing change?
No, only that this scenario used to fail and will now pass.


### How was this patch tested?
Add unit test to MergeIntoTableSuiteBase


### Was this patch authored or co-authored using generative AI tooling?
No
