### PR TITLE
[SPARK-53483][SQL] Support disable code-gen for sort merge join other than FULL OUTER and Existence

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3029,7 +3029,7 @@ object SQLConf {
       .createWithDefault(true)
 
   val ENABLE_SORT_MERGE_JOIN_CODEGEN =
-    buildConf("spark.sql.codegen.join.SortMergeJoin.enabled")
+    buildConf("spark.sql.codegen.join.sortMergeJoin.enabled")
       .internal()
       .doc("When true, enables code-gen for sort merge join other than FULL OUTER and Existence.")
       .version("4.1.0")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3028,6 +3028,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val ENABLE_SORT_MERGE_JOIN_CODEGEN =
+    buildConf("spark.sql.codegen.join.SortMergeJoin.enabled")
+      .internal()
+      .doc("When true, enables code-gen for sort merge join other than FULL OUTER and Existence.")
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val MAX_NESTED_VIEW_DEPTH =
     buildConf("spark.sql.view.maxNestedViewDepth")
       .internal()
@@ -3605,7 +3613,7 @@ object SQLConf {
         "join operator")
       .version("2.2.1")
       .intConf
-      .createWithDefault(ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH)
+      .createWithDefault(4096)
 
   val SORT_MERGE_JOIN_EXEC_BUFFER_SPILL_THRESHOLD =
     buildConf("spark.sql.sortMergeJoinExec.buffer.spill.threshold")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -167,7 +167,7 @@ case class SortMergeJoinExec(
   override def supportCodegen: Boolean = joinType match {
     case FullOuter => conf.getConf(SQLConf.ENABLE_FULL_OUTER_SORT_MERGE_JOIN_CODEGEN)
     case _: ExistenceJoin => conf.getConf(SQLConf.ENABLE_EXISTENCE_SORT_MERGE_JOIN_CODEGEN)
-    case _ => true
+    case _ => conf.getConf(SQLConf.ENABLE_SORT_MERGE_JOIN_CODEGEN)
   }
 
   override def inputRDDs(): Seq[RDD[InternalRow]] = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support disable code-gen for sort merge join other than FULL OUTER and Existence. In addition, adjust the default value of spark.sql.sortMergeJoinExec.buffer.in.memory.threshold to be consistent with the BUFFER_IN_MEMORY_THRESHOLD of other operators, which is 4096.


### Why are the changes needed?
Avoid executor OOM when a single key matches too many rows in inner/left outer/ right outer sort merge join beccause of [currentRows](https://github.com/apache/spark/blob/e3133f4abf1cd5667abe5f0d05fa0af0df3033ae/sql/core/src/main/java/org/apache/spark/sql/execution/BufferedRowIterator.java#L34).
Before pr, we can only increase the executor memory. After pr, we can disable code-gen for sort merge join.

### Does this PR introduce _any_ user-facing change?
Yes, new configuration `spark.sql.codegen.join.sortMergeJoin.enabled`.


### How was this patch tested?
Local test, before pr will OOM, after pr run successfully.
```
    withSQLConf(SQLConf.ENABLE_SORT_MERGE_JOIN_CODEGEN.key -> "false",
      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
      val df1 = spark.range(1).map(_ => ("testkey", "testvalue1")).toDF("key", "value")
      val df2 = spark.range(50000000).map(_ => ("testkey", "testvalue2")).toDF("key", "value")
      df1.join(df2, Seq("key"), "left").show()
    }
```


### Was this patch authored or co-authored using generative AI tooling?
No.
