### PR TITLE
[SPARK-53486][ML][PYTHON] Avoid setting `weights_only=False` in torch model load

### DIFF
--- a/python/pyspark/ml/connect/classification.py
+++ b/python/pyspark/ml/connect/classification.py
@@ -381,11 +381,8 @@ class LogisticRegressionModel(
     def _load_core_model(self, path: str) -> None:
         import torch
 
-        with torch.serialization.safe_globals(
-            [torch.nn.modules.container.Sequential, torch.nn.modules.linear.Linear]
-        ):
-            lor_torch_model = torch.load(path, weights_only=True)
-            self.torch_model = lor_torch_model[0]
+        lor_torch_model = torch.load(path)
+        self.torch_model = lor_torch_model[0]
 
     def _get_extra_metadata(self) -> Dict[str, Any]:
         return {

--- a/python/pyspark/ml/connect/classification.py
+++ b/python/pyspark/ml/connect/classification.py
@@ -381,7 +381,7 @@ class LogisticRegressionModel(
     def _load_core_model(self, path: str) -> None:
         import torch
 
-        lor_torch_model = torch.load(path, weights_only=False)
+        lor_torch_model = torch.load(path, weights_only=True)
         self.torch_model = lor_torch_model[0]
 
     def _get_extra_metadata(self) -> Dict[str, Any]:

--- a/python/pyspark/ml/connect/classification.py
+++ b/python/pyspark/ml/connect/classification.py
@@ -381,8 +381,9 @@ class LogisticRegressionModel(
     def _load_core_model(self, path: str) -> None:
         import torch
 
-        lor_torch_model = torch.load(path, weights_only=True)
-        self.torch_model = lor_torch_model[0]
+        with torch.serialization.safe_globals([torch.nn.modules.container.Sequential]):
+            lor_torch_model = torch.load(path, weights_only=True)
+            self.torch_model = lor_torch_model[0]
 
     def _get_extra_metadata(self) -> Dict[str, Any]:
         return {

--- a/python/pyspark/ml/connect/classification.py
+++ b/python/pyspark/ml/connect/classification.py
@@ -381,7 +381,9 @@ class LogisticRegressionModel(
     def _load_core_model(self, path: str) -> None:
         import torch
 
-        with torch.serialization.safe_globals([torch.nn.modules.container.Sequential]):
+        with torch.serialization.safe_globals(
+            [torch.nn.modules.container.Sequential, torch.nn.modules.linear.Linear]
+        ):
             lor_torch_model = torch.load(path, weights_only=True)
             self.torch_model = lor_torch_model[0]
 

--- a/python/pyspark/ml/tests/connect/test_legacy_mode_classification.py
+++ b/python/pyspark/ml/tests/connect/test_legacy_mode_classification.py
@@ -134,7 +134,11 @@ class ClassificationTestsMixin:
             estimator = LORV2(maxIter=2, numTrainWorkers=2, learningRate=0.001)
             local_path = os.path.join(tmp_dir, "estimator")
             estimator.saveToLocal(local_path)
-            loaded_estimator = LORV2.loadFromLocal(local_path)
+
+            with torch.serialization.safe_globals(
+                [torch.nn.modules.container.Sequential, torch.nn.modules.linear.Linear]
+            ):
+                loaded_estimator = LORV2.loadFromLocal(local_path)
             assert loaded_estimator.uid == estimator.uid
             assert loaded_estimator.getOrDefault(loaded_estimator.maxIter) == 2
             assert loaded_estimator.getOrDefault(loaded_estimator.numTrainWorkers) == 2
@@ -144,7 +148,11 @@ class ClassificationTestsMixin:
             estimator2 = estimator.copy()
             estimator2.set(estimator2.maxIter, 10)
             estimator2.saveToLocal(local_path, overwrite=True)
-            loaded_estimator2 = LORV2.loadFromLocal(local_path)
+
+            with torch.serialization.safe_globals(
+                [torch.nn.modules.container.Sequential, torch.nn.modules.linear.Linear]
+            ):
+                loaded_estimator2 = LORV2.loadFromLocal(local_path)
             assert loaded_estimator2.getOrDefault(loaded_estimator2.maxIter) == 10
 
             fs_path = os.path.join(tmp_dir, "fs", "estimator")
@@ -198,7 +206,10 @@ class ClassificationTestsMixin:
                 rtol=1e-4,
             )
 
-            loaded_model = LORV2Model.loadFromLocal(local_model_path)
+            with torch.serialization.safe_globals(
+                [torch.nn.modules.container.Sequential, torch.nn.modules.linear.Linear]
+            ):
+                loaded_model = LORV2Model.loadFromLocal(local_model_path)
             assert loaded_model.numFeatures == 2
             assert loaded_model.numClasses == 2
             assert loaded_model.getOrDefault(loaded_model.maxIter) == 2

--- a/python/pyspark/ml/tests/connect/test_legacy_mode_classification.py
+++ b/python/pyspark/ml/tests/connect/test_legacy_mode_classification.py
@@ -136,7 +136,11 @@ class ClassificationTestsMixin:
             estimator.saveToLocal(local_path)
 
             with torch.serialization.safe_globals(
-                [torch.nn.modules.container.Sequential, torch.nn.modules.linear.Linear]
+                [
+                    torch.nn.modules.container.Sequential,
+                    torch.nn.modules.linear.Linear,
+                    torch.nn.modules.activation.Softmax,
+                ]
             ):
                 loaded_estimator = LORV2.loadFromLocal(local_path)
             assert loaded_estimator.uid == estimator.uid
@@ -150,7 +154,11 @@ class ClassificationTestsMixin:
             estimator2.saveToLocal(local_path, overwrite=True)
 
             with torch.serialization.safe_globals(
-                [torch.nn.modules.container.Sequential, torch.nn.modules.linear.Linear]
+                [
+                    torch.nn.modules.container.Sequential,
+                    torch.nn.modules.linear.Linear,
+                    torch.nn.modules.activation.Softmax,
+                ]
             ):
                 loaded_estimator2 = LORV2.loadFromLocal(local_path)
             assert loaded_estimator2.getOrDefault(loaded_estimator2.maxIter) == 10
@@ -207,7 +215,11 @@ class ClassificationTestsMixin:
             )
 
             with torch.serialization.safe_globals(
-                [torch.nn.modules.container.Sequential, torch.nn.modules.linear.Linear]
+                [
+                    torch.nn.modules.container.Sequential,
+                    torch.nn.modules.linear.Linear,
+                    torch.nn.modules.activation.Softmax,
+                ]
             ):
                 loaded_model = LORV2Model.loadFromLocal(local_model_path)
             assert loaded_model.numFeatures == 2

--- a/python/pyspark/ml/tests/connect/test_legacy_mode_classification.py
+++ b/python/pyspark/ml/tests/connect/test_legacy_mode_classification.py
@@ -140,6 +140,7 @@ class ClassificationTestsMixin:
                     torch.nn.modules.container.Sequential,
                     torch.nn.modules.linear.Linear,
                     torch.nn.modules.activation.Softmax,
+                    torch.nn.modules.container.Sequential,
                 ]
             ):
                 loaded_estimator = LORV2.loadFromLocal(local_path)
@@ -158,6 +159,7 @@ class ClassificationTestsMixin:
                     torch.nn.modules.container.Sequential,
                     torch.nn.modules.linear.Linear,
                     torch.nn.modules.activation.Softmax,
+                    torch.nn.modules.container.Sequential,
                 ]
             ):
                 loaded_estimator2 = LORV2.loadFromLocal(local_path)
@@ -219,6 +221,7 @@ class ClassificationTestsMixin:
                     torch.nn.modules.container.Sequential,
                     torch.nn.modules.linear.Linear,
                     torch.nn.modules.activation.Softmax,
+                    torch.nn.modules.container.Sequential,
                 ]
             ):
                 loaded_model = LORV2Model.loadFromLocal(local_model_path)

--- a/python/pyspark/ml/tests/connect/test_legacy_mode_classification.py
+++ b/python/pyspark/ml/tests/connect/test_legacy_mode_classification.py
@@ -198,10 +198,16 @@ class ClassificationTestsMixin:
             model.saveToLocal(local_model_path)
 
             # test saved torch model can be loaded by pytorch solely
-            lor_torch_model = torch.load(
-                os.path.join(local_model_path, "LogisticRegressionModel.torch"),
-                weights_only=False,
-            )
+            with torch.serialization.safe_globals(
+                [
+                    torch.nn.modules.container.Sequential,
+                    torch.nn.modules.linear.Linear,
+                    torch.nn.modules.activation.Softmax,
+                ]
+            ):
+                lor_torch_model = torch.load(
+                    os.path.join(local_model_path, "LogisticRegressionModel.torch")
+                )
 
             with torch.inference_mode():
                 torch_infer_result = lor_torch_model(

--- a/python/pyspark/ml/tests/connect/test_legacy_mode_classification.py
+++ b/python/pyspark/ml/tests/connect/test_legacy_mode_classification.py
@@ -140,7 +140,6 @@ class ClassificationTestsMixin:
                     torch.nn.modules.container.Sequential,
                     torch.nn.modules.linear.Linear,
                     torch.nn.modules.activation.Softmax,
-                    torch.nn.modules.container.Sequential,
                 ]
             ):
                 loaded_estimator = LORV2.loadFromLocal(local_path)
@@ -159,7 +158,6 @@ class ClassificationTestsMixin:
                     torch.nn.modules.container.Sequential,
                     torch.nn.modules.linear.Linear,
                     torch.nn.modules.activation.Softmax,
-                    torch.nn.modules.container.Sequential,
                 ]
             ):
                 loaded_estimator2 = LORV2.loadFromLocal(local_path)
@@ -221,7 +219,6 @@ class ClassificationTestsMixin:
                     torch.nn.modules.container.Sequential,
                     torch.nn.modules.linear.Linear,
                     torch.nn.modules.activation.Softmax,
-                    torch.nn.modules.container.Sequential,
                 ]
             ):
                 loaded_model = LORV2Model.loadFromLocal(local_model_path)
@@ -243,7 +240,15 @@ class ClassificationTestsMixin:
 
             fs_model_path = os.path.join(tmp_dir, "fs", "model")
             model.save(fs_model_path)
-            loaded_model = LORV2Model.load(fs_model_path)
+
+            with torch.serialization.safe_globals(
+                [
+                    torch.nn.modules.container.Sequential,
+                    torch.nn.modules.linear.Linear,
+                    torch.nn.modules.activation.Softmax,
+                ]
+            ):
+                loaded_model = LORV2Model.load(fs_model_path)
             assert loaded_model.numFeatures == 2
             assert loaded_model.numClasses == 2
             assert loaded_model.getOrDefault(loaded_model.maxIter) == 2

--- a/python/pyspark/ml/tests/connect/test_legacy_mode_pipeline.py
+++ b/python/pyspark/ml/tests/connect/test_legacy_mode_pipeline.py
@@ -45,6 +45,8 @@ class PipelineTestsMixin:
             )
 
     def test_pipeline(self):
+        import torch
+
         train_dataset = self.spark.createDataFrame(
             [
                 (1.0, [0.0, 5.0]),
@@ -94,43 +96,50 @@ class PipelineTestsMixin:
         self._check_result(local_transform_result2, expected_predictions, expected_probabilities)
 
         with tempfile.TemporaryDirectory(prefix="test_pipeline") as tmp_dir:
-            pipeline_local_path = os.path.join(tmp_dir, "pipeline")
-            pipeline.saveToLocal(pipeline_local_path)
-            loaded_pipeline = Pipeline.loadFromLocal(pipeline_local_path)
+            with torch.serialization.safe_globals(
+                [
+                    torch.nn.modules.container.Sequential,
+                    torch.nn.modules.linear.Linear,
+                    torch.nn.modules.activation.Softmax,
+                ]
+            ):
+                pipeline_local_path = os.path.join(tmp_dir, "pipeline")
+                pipeline.saveToLocal(pipeline_local_path)
+                loaded_pipeline = Pipeline.loadFromLocal(pipeline_local_path)
 
-            assert pipeline.uid == loaded_pipeline.uid
-            assert loaded_pipeline.getStages()[1].getMaxIter() == 200
+                assert pipeline.uid == loaded_pipeline.uid
+                assert loaded_pipeline.getStages()[1].getMaxIter() == 200
 
-            pipeline_model_local_path = os.path.join(tmp_dir, "pipeline_model")
-            model.saveToLocal(pipeline_model_local_path)
-            loaded_model = Pipeline.loadFromLocal(pipeline_model_local_path)
+                pipeline_model_local_path = os.path.join(tmp_dir, "pipeline_model")
+                model.saveToLocal(pipeline_model_local_path)
+                loaded_model = Pipeline.loadFromLocal(pipeline_model_local_path)
 
-            assert model.uid == loaded_model.uid
-            assert loaded_model.stages[1].getMaxIter() == 200
+                assert model.uid == loaded_model.uid
+                assert loaded_model.stages[1].getMaxIter() == 200
 
-            loaded_model_transform_result = loaded_model.transform(eval_dataset).toPandas()
-            self._check_result(
-                loaded_model_transform_result, expected_predictions, expected_probabilities
-            )
+                loaded_model_transform_result = loaded_model.transform(eval_dataset).toPandas()
+                self._check_result(
+                    loaded_model_transform_result, expected_predictions, expected_probabilities
+                )
 
-            pipeline2_local_path = os.path.join(tmp_dir, "pipeline2")
-            pipeline2.saveToLocal(pipeline2_local_path)
-            loaded_pipeline2 = Pipeline.loadFromLocal(pipeline2_local_path)
+                pipeline2_local_path = os.path.join(tmp_dir, "pipeline2")
+                pipeline2.saveToLocal(pipeline2_local_path)
+                loaded_pipeline2 = Pipeline.loadFromLocal(pipeline2_local_path)
 
-            assert pipeline2.uid == loaded_pipeline2.uid
-            assert loaded_pipeline2.getStages()[0].getStages()[1].getMaxIter() == 200
+                assert pipeline2.uid == loaded_pipeline2.uid
+                assert loaded_pipeline2.getStages()[0].getStages()[1].getMaxIter() == 200
 
-            pipeline2_model_local_path = os.path.join(tmp_dir, "pipeline2_model")
-            model2.saveToLocal(pipeline2_model_local_path)
-            loaded_model2 = Pipeline.loadFromLocal(pipeline2_model_local_path)
+                pipeline2_model_local_path = os.path.join(tmp_dir, "pipeline2_model")
+                model2.saveToLocal(pipeline2_model_local_path)
+                loaded_model2 = Pipeline.loadFromLocal(pipeline2_model_local_path)
 
-            assert model2.uid == loaded_model2.uid
-            assert loaded_model2.stages[0].stages[1].getMaxIter() == 200
+                assert model2.uid == loaded_model2.uid
+                assert loaded_model2.stages[0].stages[1].getMaxIter() == 200
 
-            loaded_model2_transform_result = loaded_model2.transform(eval_dataset).toPandas()
-            self._check_result(
-                loaded_model2_transform_result, expected_predictions, expected_probabilities
-            )
+                loaded_model2_transform_result = loaded_model2.transform(eval_dataset).toPandas()
+                self._check_result(
+                    loaded_model2_transform_result, expected_predictions, expected_probabilities
+                )
 
     @staticmethod
     def test_pipeline_copy():


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Avoid setting `weights_only=False` in torch model load.

By applying the default value of `weights_only`:
1, torch<2.6.0, the default value is false, no behavior change;
2, torch>=2.6.0, the default value is true, then the model load will require setting safe globals:
```
_pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint.
	(1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
	(2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
	WeightsUnpickler error: Unsupported global: GLOBAL torch.nn.modules.container.Sequential was not an allowed
global by default. Please use `torch.serialization.add_safe_globals([torch.nn.modules.container.Sequential])` or the `torch.serialization.safe_globals([torch.nn.modules.container.Sequential])` context manager to allowlist this global if you trust this class/function.
```

After this change, the behavior is the same as the pytorch


### Why are the changes needed?

> Loading un-trusted checkpoint with weights_only=False MUST never be done.

as per https://github.com/pytorch/pytorch/security



### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no