### PR TITLE
[SPARK-53490][CONNECT][SQL] Fix Protobuf conversion in observed metrics

### DIFF
--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
@@ -1749,6 +1749,42 @@ class ClientE2ETestSuite
     val nullRows = nullResult.filter(_.getAs[Long]("id") >= 5)
     assert(nullRows.forall(_.getAs[Int]("actual_p_id") == 0))
   }
+
+  test("SPARK-53490: struct type in observed metrics") {
+    val observation = Observation("struct")
+    spark
+      .range(10)
+      .observe(observation, struct(count(lit(1)).as("rows"), max("id").as("maxid")).as("struct"))
+      .collect()
+    val expectedSchema =
+      StructType(Seq(StructField("rows", LongType), StructField("maxid", LongType)))
+    val expectedValue = new GenericRowWithSchema(Array(10, 9), expectedSchema)
+    assert(observation.get.size === 1)
+    assert(observation.get.contains("struct"))
+    assert(observation.get("struct") === expectedValue)
+  }
+
+  test("SPARK-53490: array type in observed metrics") {
+    val observation = Observation("array")
+    spark
+      .range(10)
+      .observe(observation, array(count(lit(1))).as("array"))
+      .collect()
+    assert(observation.get.size === 1)
+    assert(observation.get.contains("array"))
+    assert(observation.get("array") === Array(10))
+  }
+
+  test("SPARK-53490: map type in observed metrics") {
+    val observation = Observation("map")
+    spark
+      .range(10)
+      .observe(observation, map(lit("count"), count(lit(1))).as("map"))
+      .collect()
+    assert(observation.get.size === 1)
+    assert(observation.get.contains("map"))
+    assert(observation.get("map") === Map("count" -> 10))
+  }
 }
 
 private[sql] case class ClassData(a: String, b: Int)

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkResult.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkResult.scala
@@ -383,7 +383,7 @@ private[sql] object SparkResult {
     (0 until metric.getKeysCount).foreach { i =>
       val key = metric.getKeys(i)
       val value = LiteralValueProtoConverter.toScalaValue(metric.getValues(i))
-      schema = schema.add(key, LiteralValueProtoConverter.toDataType(value.getClass))
+      schema = schema.add(key, LiteralValueProtoConverter.getDataType(metric.getValues(i)))
       values += value
     }
     new GenericRowWithSchema(values.result(), schema)

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/DataTypeProtoConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/DataTypeProtoConverter.scala
@@ -109,7 +109,7 @@ object DataTypeProtoConverter {
     ArrayType(toCatalystType(t.getElementType), t.getContainsNull)
   }
 
-  private def toCatalystStructType(t: proto.DataType.Struct): StructType = {
+  private[common] def toCatalystStructType(t: proto.DataType.Struct): StructType = {
     val fields = t.getFieldsList.asScala.toSeq.map { protoField =>
       val metadata = if (protoField.hasMetadata) {
         Metadata.fromJson(protoField.getMetadata)

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/LiteralExpressionProtoConverter.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/LiteralExpressionProtoConverter.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.connect.planner
 
 import org.apache.spark.connect.proto
 import org.apache.spark.sql.catalyst.{expressions, CatalystTypeConverters}
-import org.apache.spark.sql.connect.common.{DataTypeProtoConverter, InvalidPlanInput, LiteralValueProtoConverter}
+import org.apache.spark.sql.connect.common.{InvalidPlanInput, LiteralValueProtoConverter}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
@@ -32,107 +32,87 @@ object LiteralExpressionProtoConverter {
    *   Expression
    */
   def toCatalystExpression(lit: proto.Expression.Literal): expressions.Literal = {
+    val dataType = LiteralValueProtoConverter.getDataType(lit)
     lit.getLiteralTypeCase match {
       case proto.Expression.Literal.LiteralTypeCase.NULL =>
-        expressions.Literal(null, DataTypeProtoConverter.toCatalystType(lit.getNull))
+        expressions.Literal(null, dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.BINARY =>
-        expressions.Literal(lit.getBinary.toByteArray, BinaryType)
+        expressions.Literal(lit.getBinary.toByteArray, dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.BOOLEAN =>
-        expressions.Literal(lit.getBoolean, BooleanType)
+        expressions.Literal(lit.getBoolean, dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.BYTE =>
-        expressions.Literal(lit.getByte.toByte, ByteType)
+        expressions.Literal(lit.getByte.toByte, dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.SHORT =>
-        expressions.Literal(lit.getShort.toShort, ShortType)
+        expressions.Literal(lit.getShort.toShort, dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.INTEGER =>
-        expressions.Literal(lit.getInteger, IntegerType)
+        expressions.Literal(lit.getInteger, dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.LONG =>
-        expressions.Literal(lit.getLong, LongType)
+        expressions.Literal(lit.getLong, dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.FLOAT =>
-        expressions.Literal(lit.getFloat, FloatType)
+        expressions.Literal(lit.getFloat, dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.DOUBLE =>
-        expressions.Literal(lit.getDouble, DoubleType)
+        expressions.Literal(lit.getDouble, dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.DECIMAL =>
-        val decimal = Decimal.apply(lit.getDecimal.getValue)
-        var precision = decimal.precision
-        if (lit.getDecimal.hasPrecision) {
-          precision = math.max(precision, lit.getDecimal.getPrecision)
-        }
-        var scale = decimal.scale
-        if (lit.getDecimal.hasScale) {
-          scale = math.max(scale, lit.getDecimal.getScale)
-        }
-        expressions.Literal(decimal, DecimalType(math.max(precision, scale), scale))
+        expressions.Literal(Decimal.apply(lit.getDecimal.getValue), dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.STRING =>
-        expressions.Literal(UTF8String.fromString(lit.getString), StringType)
+        expressions.Literal(UTF8String.fromString(lit.getString), dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.DATE =>
-        expressions.Literal(lit.getDate, DateType)
+        expressions.Literal(lit.getDate, dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.TIMESTAMP =>
-        expressions.Literal(lit.getTimestamp, TimestampType)
+        expressions.Literal(lit.getTimestamp, dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.TIMESTAMP_NTZ =>
-        expressions.Literal(lit.getTimestampNtz, TimestampNTZType)
+        expressions.Literal(lit.getTimestampNtz, dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.CALENDAR_INTERVAL =>
         val interval = new CalendarInterval(
           lit.getCalendarInterval.getMonths,
           lit.getCalendarInterval.getDays,
           lit.getCalendarInterval.getMicroseconds)
-        expressions.Literal(interval, CalendarIntervalType)
+        expressions.Literal(interval, dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.YEAR_MONTH_INTERVAL =>
-        expressions.Literal(lit.getYearMonthInterval, YearMonthIntervalType())
+        expressions.Literal(lit.getYearMonthInterval, dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.DAY_TIME_INTERVAL =>
-        expressions.Literal(lit.getDayTimeInterval, DayTimeIntervalType())
+        expressions.Literal(lit.getDayTimeInterval, dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.TIME =>
         var precision = TimeType.DEFAULT_PRECISION
         if (lit.getTime.hasPrecision) {
           precision = lit.getTime.getPrecision
         }
-        expressions.Literal(lit.getTime.getNano, TimeType(precision))
+        expressions.Literal(lit.getTime.getNano, dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.ARRAY =>
         val arrayData = LiteralValueProtoConverter.toScalaArray(lit.getArray)
-        val dataType = DataTypeProtoConverter.toCatalystType(
-          proto.DataType.newBuilder
-            .setArray(LiteralValueProtoConverter.getProtoArrayType(lit.getArray))
-            .build())
         expressions.Literal.create(arrayData, dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.MAP =>
         val mapData = LiteralValueProtoConverter.toScalaMap(lit.getMap)
-        val dataType = DataTypeProtoConverter.toCatalystType(
-          proto.DataType.newBuilder
-            .setMap(LiteralValueProtoConverter.getProtoMapType(lit.getMap))
-            .build())
         expressions.Literal.create(mapData, dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.STRUCT =>
         val structData = LiteralValueProtoConverter.toScalaStruct(lit.getStruct)
-        val dataType = DataTypeProtoConverter.toCatalystType(
-          proto.DataType.newBuilder
-            .setStruct(LiteralValueProtoConverter.getProtoStructType(lit.getStruct))
-            .build())
         val convert = CatalystTypeConverters.createToCatalystConverter(dataType)
         expressions.Literal(convert(structData), dataType)
 
       case _ =>
         throw InvalidPlanInput(
-          s"Unsupported Literal Type: ${lit.getLiteralTypeCase.getNumber}" +
-            s"(${lit.getLiteralTypeCase.name})")
+          s"Unsupported Literal Type: ${lit.getLiteralTypeCase.name}" +
+            s"(${lit.getLiteralTypeCase.getNumber})")
     }
   }
 }

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/LiteralExpressionProtoConverterSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/LiteralExpressionProtoConverterSuite.scala
@@ -20,6 +20,8 @@ package org.apache.spark.sql.connect.planner
 import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
 
 import org.apache.spark.connect.proto
+import org.apache.spark.sql.catalyst.{expressions, CatalystTypeConverters}
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.connect.common.InvalidPlanInput
 import org.apache.spark.sql.connect.common.LiteralValueProtoConverter
 import org.apache.spark.sql.connect.common.LiteralValueProtoConverter.ToLiteralProtoOptions
@@ -51,7 +53,7 @@ class LiteralExpressionProtoConverterSuite extends AnyFunSuite { // scalastyle:i
     }
   }
 
-  Seq(
+  Seq[(Any, DataType)](
     (
       (1, "string", true),
       StructType(
@@ -76,7 +78,6 @@ class LiteralExpressionProtoConverterSuite extends AnyFunSuite { // scalastyle:i
             "b",
             StructType(Seq(StructField("c", IntegerType), StructField("d", IntegerType))))))),
     (Array(true, false, true), ArrayType(BooleanType)),
-    (Array(1.toByte, 2.toByte, 3.toByte), ArrayType(ByteType)),
     (Array(1.toShort, 2.toShort, 3.toShort), ArrayType(ShortType)),
     (Array(1, 2, 3), ArrayType(IntegerType)),
     (Array(1L, 2L, 3L), ArrayType(LongType)),
@@ -87,15 +88,16 @@ class LiteralExpressionProtoConverterSuite extends AnyFunSuite { // scalastyle:i
     (
       Array(Array(Array(Array(Array(Array(1, 2, 3)))))),
       ArrayType(ArrayType(ArrayType(ArrayType(ArrayType(ArrayType(IntegerType))))))),
-    (Array(Map(1 -> 2)), ArrayType(MapType(IntegerType, IntegerType))),
     (Map[String, String]("1" -> "2", "3" -> "4"), MapType(StringType, StringType)),
     (Map[String, Boolean]("1" -> true, "2" -> false), MapType(StringType, BooleanType)),
     (Map[Int, Int](), MapType(IntegerType, IntegerType)),
     (Map(1 -> 2, 3 -> 4, 5 -> 6), MapType(IntegerType, IntegerType))).zipWithIndex.foreach {
     case ((v, t), idx) =>
+      val convert = CatalystTypeConverters.createToCatalystConverter(t)
+      val expected = expressions.Literal(convert(v), t)
       test(s"complex proto value and catalyst value conversion #$idx") {
-        assertResult(v)(
-          LiteralValueProtoConverter.toScalaValue(
+        assertResult(expected)(
+          LiteralExpressionProtoConverter.toCatalystExpression(
             LiteralValueProtoConverter.toLiteralProtoWithOptions(
               v,
               Some(t),
@@ -103,8 +105,8 @@ class LiteralExpressionProtoConverterSuite extends AnyFunSuite { // scalastyle:i
       }
 
       test(s"complex proto value and catalyst value conversion #$idx - backward compatibility") {
-        assertResult(v)(
-          LiteralValueProtoConverter.toScalaValue(
+        assertResult(expected)(
+          LiteralExpressionProtoConverter.toCatalystExpression(
             LiteralValueProtoConverter.toLiteralProtoWithOptions(
               v,
               Some(t),
@@ -186,12 +188,12 @@ class LiteralExpressionProtoConverterSuite extends AnyFunSuite { // scalastyle:i
     val result = LiteralValueProtoConverter.toScalaStruct(structProto.getStruct)
     val resultType = LiteralValueProtoConverter.getProtoStructType(structProto.getStruct)
 
-    // Verify the result is a tuple with correct values
-    assert(result.isInstanceOf[Product])
-    val product = result.asInstanceOf[Product]
-    assert(product.productArity == 2)
-    assert(product.productElement(0) == 1)
-    assert(product.productElement(1) == "test")
+    // Verify the result is a GenericRowWithSchema with correct values
+    assert(result.isInstanceOf[GenericRowWithSchema])
+    val row = result.asInstanceOf[GenericRowWithSchema]
+    assert(row.length == 2)
+    assert(row.get(0) == 1)
+    assert(row.get(1) == "test")
 
     // Verify the returned struct type matches the original
     assert(resultType.getFieldsCount == 2)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR fixes a critical issue in the protobuf conversion of observed metrics in Spark Connect, specifically when dealing with complex data types like structs, arrays, and maps. The main changes include:
1. **Modified Observation class to store Row objects instead of Map[String, Any]**: Changed the internal promise type from `Promise[Map[String, Any]]` to `Promise[Row]` to preserve type information during protobuf serialization/deserialization.
2. **Enhanced protobuf conversion for complex types**: 
   - Added proper handling for struct types by creating `GenericRowWithSchema` objects instead of tuples
   - Added support for map type conversion in `LiteralValueProtoConverter`
   - Improved data type inference with a new `getDataType` method that properly handles all literal types
3. **Fixed observed metrics**: Modified the observed metrics processing to include data type information in the protobuf conversion, ensuring that complex types are properly serialized and deserialized.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The previous implementation had several issues:
1. **Data type loss**: Observed metrics were losing their original data types during Protobuf conversion, causing errors
2. **Struct handling problems**: The conversion logic didn't properly handle Row objects and struct types

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, this PR fixes a bug that was preventing users from successfully using observed metrics with complex data types (structs, arrays, maps) in Spark Connect. Users can now:
- Use `struct()` expressions in observed metrics and receive properly typed `GenericRowWithSchema` objects
- Use `array()` expressions in observed metrics and receive properly typed arrays
- Use `map()` expressions in observed metrics and receive properly typed maps

Previously, the code below would fail.
```scala
val observation = Observation("struct")
spark
  .range(10)
  .observe(observation, struct(count(lit(1)).as("rows"), max("id").as("maxid")).as("struct"))
  .collect()
observation.get
// Below is the error message:
"""
org.apache.spark.SparkUnsupportedOperationException: literal [10,9] not supported (yet).
org.apache.spark.sql.connect.common.LiteralValueProtoConverter$.toLiteralProtoBuilder(LiteralValueProtoConverter.scala:104)
org.apache.spark.sql.connect.common.LiteralValueProtoConverter$.toLiteralProto(LiteralValueProtoConverter.scala:203)
org.apache.spark.sql.connect.execution.SparkConnectPlanExecution$.$anonfun$createObservedMetricsResponse$2(SparkConnectPlanExecution.scala:571)
org.apache.spark.sql.connect.execution.SparkConnectPlanExecution$.$anonfun$createObservedMetricsResponse$2$adapted(SparkConnectPlanExecution.scala:570)
"""
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
`build/sbt "connect-client-jvm/testOnly *ClientE2ETestSuite -- -z SPARK-53490"`
`build/sbt "connect/testOnly *LiteralExpressionProtoConverterSuite"`

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Cursor 1.5.9
