### PR TITLE
[SPARK-53491][SS] Fix exponential formatting of inputRowsPerSecond and processedRowsPerSecond in progress metrics JSON

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/progress.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/progress.scala
@@ -331,8 +331,7 @@ private object SafeJsonSerializer {
 
   /** Convert BigDecimal to JValue while handling empty or infinite values */
   def safeDecimalToJValue(value: Double): JValue = {
-    if (value.isNaN || value.isInfinity) { JNothing } else {
-      JDecimal(BigDecimal(value).setScale(1, RoundingMode.HALF_UP))
-    }
+    if (value.isNaN || value.isInfinity) JNothing
+    else JDecimal(BigDecimal(value).setScale(1, RoundingMode.HALF_UP))
   }
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/progress.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/progress.scala
@@ -331,7 +331,9 @@ private object SafeJsonSerializer {
 
   /** Convert BigDecimal to JValue while handling empty or infinite values */
   def safeDecimalToJValue(value: Double): JValue = {
-    if (value.isNaN || value.isInfinity) JNothing
+    if (value.isNaN || value.isInfinity) {
+      JNothing
+    }
     else {
       val valueWithScale = BigDecimal(value).setScale(1, RoundingMode.HALF_UP)
       JDecimal(valueWithScale)

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/progress.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/progress.scala
@@ -317,6 +317,7 @@ private[sql] object SinkProgress {
 }
 
 private object SafeJsonSerializer {
+
   /** Convert Double to JValue while handling empty or infinite values */
   def safeDoubleToJValue(value: Double): JValue = {
     if (value.isNaN || value.isInfinity) JNothing else JDouble(value)

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/progress.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/progress.scala
@@ -331,12 +331,8 @@ private object SafeJsonSerializer {
 
   /** Convert BigDecimal to JValue while handling empty or infinite values */
   def safeDecimalToJValue(value: Double): JValue = {
-    if (value.isNaN || value.isInfinity) {
-      JNothing
-    }
-    else {
-      val valueWithScale = BigDecimal(value).setScale(1, RoundingMode.HALF_UP)
-      JDecimal(valueWithScale)
+    if (value.isNaN || value.isInfinity) { JNothing } else {
+      JDecimal(BigDecimal(value).setScale(1, RoundingMode.HALF_UP))
     }
   }
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/progress.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/progress.scala
@@ -22,6 +22,7 @@ import java.lang.{Long => JLong}
 import java.util.UUID
 
 import scala.jdk.CollectionConverters._
+import scala.math.BigDecimal.RoundingMode
 import scala.util.control.NonFatal
 
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
@@ -35,7 +36,7 @@ import org.json4s.jackson.JsonMethods._
 import org.apache.spark.annotation.Evolving
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
-import org.apache.spark.sql.streaming.SafeJsonSerializer.{safeDoubleToJValue, safeMapToJValue}
+import org.apache.spark.sql.streaming.SafeJsonSerializer.{safeDecimalToJValue, safeMapToJValue}
 import org.apache.spark.sql.streaming.SinkProgress.DEFAULT_NUM_OUTPUT_ROWS
 
 /**
@@ -183,8 +184,8 @@ class StreamingQueryProgress private[spark] (
       ("batchId" -> JInt(batchId)) ~
       ("batchDuration" -> JInt(batchDuration)) ~
       ("numInputRows" -> JInt(numInputRows)) ~
-      ("inputRowsPerSecond" -> safeDoubleToJValue(inputRowsPerSecond)) ~
-      ("processedRowsPerSecond" -> safeDoubleToJValue(processedRowsPerSecond)) ~
+      ("inputRowsPerSecond" -> safeDecimalToJValue(inputRowsPerSecond)) ~
+      ("processedRowsPerSecond" -> safeDecimalToJValue(processedRowsPerSecond)) ~
       ("durationMs" -> safeMapToJValue[JLong](durationMs, v => JInt(v.toLong))) ~
       ("eventTime" -> safeMapToJValue[String](eventTime, s => JString(s))) ~
       ("stateOperators" -> JArray(stateOperators.map(_.jsonValue).toList)) ~
@@ -255,8 +256,8 @@ class SourceProgress protected[spark] (
       ("endOffset" -> tryParse(endOffset)) ~
       ("latestOffset" -> tryParse(latestOffset)) ~
       ("numInputRows" -> JInt(numInputRows)) ~
-      ("inputRowsPerSecond" -> safeDoubleToJValue(inputRowsPerSecond)) ~
-      ("processedRowsPerSecond" -> safeDoubleToJValue(processedRowsPerSecond)) ~
+      ("inputRowsPerSecond" -> safeDecimalToJValue(inputRowsPerSecond)) ~
+      ("processedRowsPerSecond" -> safeDecimalToJValue(processedRowsPerSecond)) ~
       ("metrics" -> safeMapToJValue[String](metrics, s => JString(s)))
   }
 
@@ -316,6 +317,7 @@ private[sql] object SinkProgress {
 }
 
 private object SafeJsonSerializer {
+  /** Convert Double to JValue while handling empty or infinite values */
   def safeDoubleToJValue(value: Double): JValue = {
     if (value.isNaN || value.isInfinity) JNothing else JDouble(value)
   }
@@ -325,5 +327,14 @@ private object SafeJsonSerializer {
     if (map == null || map.isEmpty) return JNothing
     val keys = map.asScala.keySet.toSeq.sorted
     keys.map { k => k -> valueToJValue(map.get(k)): JObject }.reduce(_ ~ _)
+  }
+
+  /** Convert BigDecimal to JValue while handling empty or infinite values */
+  def safeDecimalToJValue(value: Double): JValue = {
+    if (value.isNaN || value.isInfinity) JNothing
+    else {
+      val valueWithScale = BigDecimal(value).setScale(1, RoundingMode.HALF_UP)
+      JDecimal(valueWithScale)
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryStatusAndProgressSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryStatusAndProgressSuite.scala
@@ -27,6 +27,7 @@ import scala.jdk.CollectionConverters._
 import org.json4s.jackson.JsonMethods._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.sql.Row
@@ -40,7 +41,7 @@ import org.apache.spark.sql.streaming.util.StreamManualClock
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.ArrayImplicits._
 
-class StreamingQueryStatusAndProgressSuite extends StreamTest with Eventually {
+class StreamingQueryStatusAndProgressSuite extends StreamTest with Eventually with Matchers {
   test("StreamingQueryProgress - prettyJson") {
     val json1 = testProgress1.prettyJson
     assertJson(
@@ -400,7 +401,7 @@ class StreamingQueryStatusAndProgressSuite extends StreamTest with Eventually {
     assert(data(0).getAs[Timestamp](0).equals(validValue))
   }
 
-  test("SPARK-53491: `inputRowsPerSecond` and  `processedRowsPerSecond` " +
+  test("SPARK-53491: inputRowsPerSecond and processedRowsPerSecond " +
     "should never be with scientific notation") {
     import testImplicits._
 
@@ -419,10 +420,8 @@ class StreamingQueryStatusAndProgressSuite extends StreamTest with Eventually {
 
       val progress = query.lastProgress.jsonValue
 
-      print(progress)
-
-      assert(!(progress \ "inputRowsPerSecond").values.toString.contains("E"))
-      assert(!(progress \ "processedRowsPerSecond").values.toString.contains("E"))
+      (progress \ "inputRowsPerSecond").values.toString should not include "E"
+      (progress \ "processedRowsPerSecond").values.toString should not include "E"
     } finally {
       query.stop()
       spark.streams.awaitAnyTermination(1000) // Waiting to allow cleaning all threads


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes an issue where `inputRowsPerSecond` and `processedRowsPerSecond` in streaming progress metrics JSON
were displayed in scientific notation (e.g., `1.9871777605776876E8`). The fix uses safe `Decimal` casting 
to ensure values are displayed in a more human-readable format.

### Results
Before change
```
{
  "id" : "9b512179-ea36-4b98-9d79-049d13813894",
  "runId" : "f85e2894-9582-493d-9b94-ce03e5490241",
  "name" : "TestFormatting",
  "timestamp" : "2025-09-04T10:57:02.897Z",
  "batchId" : 0,
  "batchDuration" : 1410,
  "numInputRows" : 900000,
  "inputRowsPerSecond" : 6.923076923076923E7,
  "processedRowsPerSecond" : 638297.8723404256,
  "durationMs" : {
    "addBatch" : 1101,
    "commitOffsets" : 157,
    "getBatch" : 0,
    "latestOffset" : 0,
    "queryPlanning" : 3,
    "triggerExecution" : 1410,
    "walCommit" : 149
  },
  "stateOperators" : [ ],
  "sources" : [ {
    "description" : "MemoryStream[value#133]",
    "startOffset" : null,
    "endOffset" : 0,
    "latestOffset" : null,
    "numInputRows" : 900000,
    "inputRowsPerSecond" : 6.923076923076923E7,
    "processedRowsPerSecond" : 638297.8723404256
  } ],
  "sink" : {
    "description" : "MemorySink",
    "numOutputRows" : 900000
  }
} 
```

After changes
```
{
  "id" : "03497c93-7ab7-4e14-ba5f-dadbfc8a4bf6",
  "runId" : "3933cdde-f99d-4a29-8bb8-d13bbb5df425",
  "name" : "TestFormatting",
  "timestamp" : "2025-09-04T15:50:45.500Z",
  "batchId" : 0,
  "batchDuration" : 1444,
  "numInputRows" : 900000,
  "inputRowsPerSecond" : 69230769.2,
  "processedRowsPerSecond" : 623268.7,
  "durationMs" : {
    "addBatch" : 1147,
    "commitOffsets" : 152,
    "getBatch" : 0,
    "latestOffset" : 0,
    "queryPlanning" : 3,
    "triggerExecution" : 1444,
    "walCommit" : 142
  },
  "stateOperators" : [ ],
  "sources" : [ {
    "description" : "MemoryStream[value#133]",
    "startOffset" : null,
    "endOffset" : 0,
    "latestOffset" : null,
    "numInputRows" : 900000,
    "inputRowsPerSecond" : 69230769.2,
    "processedRowsPerSecond" : 623268.7
  } ],
  "sink" : {
    "description" : "MemorySink",
    "numOutputRows" : 900000
  }
}
```

### Why are the changes needed?
Improves the readability of Spark Structured Streaming progress metrics JSON.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Run this Maven test:
```
./build/mvn -pl sql/core,sql/api \
-am test \
-DwildcardSuites=org.apache.spark.sql.streaming.StreamingQueryStatusAndProgressSuite \
-DwildcardTestName="SPARK-53491"
```
Results:
```
Run completed in 10 seconds, 680 milliseconds.
Total number of tests run: 12
Suites: completed 2, aborted 0
Tests: succeeded 12, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
```

### Was this patch authored or co-authored using generative AI tooling?
No
