### PR TITLE
[SPARK-53399][SQL] Merge Python UDFs

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
@@ -44,7 +44,7 @@ trait AliasHelper {
     AttributeMap(aliasMap)
   }
 
-  protected def getAliasMap(exprs: Seq[NamedExpression]): AttributeMap[Alias] = {
+  protected def getAliasMap(exprs: Iterable[NamedExpression]): AttributeMap[Alias] = {
     // Create a map of Aliases to their values from the child projection.
     // e.g., 'SELECT a + b AS c, d ...' produces Map(c -> Alias(a + b, c)).
     AttributeMap(exprs.collect { case a: Alias => (a.toAttribute, a) })

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1170,9 +1170,7 @@ object CollapseProject extends Rule[LogicalPlan] with AliasHelper {
   }
 
   def apply(plan: LogicalPlan, alwaysInline: Boolean): LogicalPlan = {
-    val pythonUDFArrowFallbackOnUDT = conf.pythonUDFArrowFallbackOnUDT
-
-    traverse(plan, alwaysInline, Set.empty, pythonUDFArrowFallbackOnUDT)
+    traverse(plan, alwaysInline, Set.empty, conf.pythonUDFArrowFallbackOnUDT)
   }
 
   private def traverse(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1223,7 +1223,7 @@ object CollapseProject extends Rule[LogicalPlan] with AliasHelper {
             alwaysInline,
             newPythonUDFEvalTypesInUpperProjects,
             pythonUDFArrowFallbackOnUDT)
-          && canCollapseAggregate(p, agg) =>
+            && canCollapseAggregate(p, agg) =>
         agg.copy(aggregateExpressions = buildCleanedProjectList(
           p.projectList, agg.aggregateExpressions))
       case Project(l1, g @ GlobalLimit(_, limit @ LocalLimit(_, p2 @ Project(l2, _))))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1296,11 +1296,11 @@ object CollapseProject extends Rule[LogicalPlan] with AliasHelper {
     //    These include non-deterministic expressions or expensive ones that are referenced multiple
     //    times.
     // - `mustInlines` contains expressions with Python UDFs that must be inlined into the upper
-    //    node to avoid performance issues, or expressions with aggregate nodes.
+    //    node to avoid performance issues.
     // - `maybeInlines` contains expressions that might make sense to inline, such as expressions
     //    that are used only once, or are cheap to inline.
     //    But we need to take into account the side effect of adding new pass-through attributes to
-    //    the lover node, which can make the node much wider than it was originally.
+    //    the lower node, which can make the node much wider than it was originally.
     val neverInlines = ListBuffer.empty[NamedExpression]
     val mustInlines = ListBuffer.empty[NamedExpression]
     val maybeInlines = ListBuffer.empty[NamedExpression]


### PR DESCRIPTION
### What changes were proposed in this pull request?

Latest improvements to `CollapseProject` rule (like https://github.com/apache/spark/pull/33958) prevented duplicating expressive expressons, which brings considerable performance improvement in many cases.
But there is one particular case when it can introduce significant perfoamance degradation. Consider a query where the adjacent project nodes don't get collapsed because they contain expensive, multiple referenced expressions, but the nodes also contain Python UDF expressions that otherwise wouldn't prevent project node collapsion. E.g.:
```
Project a + a as a_plus_a, PythonUDF(...) as udf2, udf1
  Project <expensive calculation> as a, PythonUDF(...) as udf1
    ...
```
In the above example `CollapseProject` doesn't modify the 2 project nodes, which then causes 2 `BatchEvalPython` nodes to appear in the plan when `ExtractPythonUDFs` extracts them:
```
Project a + a as a_plus_a, udf2, udf1
  BatchEvalPython PythonUDF(...) -> udf2
    Project <expensive calculation> as a, udf1
      BatchEvalPython PythonUDF(...) -> udf1
        ...
```
The 2 `BatchEvalPython` nodes can cause significant serialization/deserialization overhead compared to the case when the original project nodes were collapsed and we had only 1 `BatchEvalPython` node.

The old behaviour can be restored with setting `spark.sql.optimizer.collapseProjectAlwaysInline=true`, but it is still not ideal as we lose the performance improvement in other cases.

This PR improves to the `CollapseProject` rule to force merging Python UDFs in project groups (multiple adjacent project nodes) when they can be executed in one run.

### Why are the changes needed?

To fix performance regression caused by latest changes to `CollapseProject`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New and existing UTs.

### Was this patch authored or co-authored using generative AI tooling?

No.