### PR TITLE
[SPARK-53497][PS] Disallow `/`|`//`|`*` between Decimal and float under ANSI

### DIFF
--- a/python/pyspark/pandas/tests/data_type_ops/test_num_mul_div.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_mul_div.py
@@ -21,6 +21,7 @@ import pandas as pd
 import numpy as np
 
 from pyspark import pandas as ps
+from pyspark.testing.utils import is_ansi_mode_test
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
 
@@ -54,6 +55,14 @@ class NumMulDivTestsMixin:
             self.assertRaises(TypeError, lambda: psser * psdf["date"])
             self.assertRaises(TypeError, lambda: psser * psdf["categorical"])
 
+        if is_ansi_mode_test:
+            self.assertRaises(TypeError, lambda: psdf["decimal"] * psdf["float"])
+            self.assertRaises(TypeError, lambda: psdf["float"] * psdf["decimal"])
+            self.assertRaises(TypeError, lambda: psdf["decimal"] * psdf["float32"])
+            self.assertRaises(TypeError, lambda: psdf["float32"] * psdf["decimal"])
+            self.assertRaises(TypeError, lambda: psdf["decimal"] * 0.1)
+            self.assertRaises(TypeError, lambda: 0.1 * psdf["decimal"])
+
     def test_truediv(self):
         pdf, psdf = self.pdf, self.psdf
         for col in self.numeric_df_cols:
@@ -70,6 +79,14 @@ class NumMulDivTestsMixin:
                 else:
                     self.assertRaises(TypeError, lambda: psser / psdf[n_col])
 
+        if is_ansi_mode_test:
+            self.assertRaises(TypeError, lambda: psdf["decimal"] / psdf["float"])
+            self.assertRaises(TypeError, lambda: psdf["float"] / psdf["decimal"])
+            self.assertRaises(TypeError, lambda: psdf["decimal"] / psdf["float32"])
+            self.assertRaises(TypeError, lambda: psdf["float32"] / psdf["decimal"])
+            self.assertRaises(TypeError, lambda: psdf["decimal"] / 0.1)
+            self.assertRaises(TypeError, lambda: 0.1 / psdf["decimal"])
+
     def test_floordiv(self):
         pdf, psdf = self.pdf, self.psdf
         pser, psser = pdf["float"], psdf["float"]
@@ -85,6 +102,14 @@ class NumMulDivTestsMixin:
                 for col in self.numeric_df_cols:
                     psser = psdf[col]
                     self.assertRaises(TypeError, lambda: psser // psdf[n_col])
+
+        if is_ansi_mode_test:
+            self.assertRaises(TypeError, lambda: psdf["decimal"] // psdf["float"])
+            self.assertRaises(TypeError, lambda: psdf["float"] // psdf["decimal"])
+            self.assertRaises(TypeError, lambda: psdf["decimal"] // psdf["float32"])
+            self.assertRaises(TypeError, lambda: psdf["float32"] // psdf["decimal"])
+            self.assertRaises(TypeError, lambda: psdf["decimal"] // 0.1)
+            self.assertRaises(TypeError, lambda: 0.1 // psdf["decimal"])
 
 
 class NumMulDivTests(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Disallow `/`|`//`|`*` between Decimal and float under ANSI, following native pandas


pandas:
```py
>>> pdf['decimal'] * 0.1
Traceback (most recent call last):
...
TypeError: unsupported operand type(s) for *: 'decimal.Decimal' and 'float'
```


pandas on spark before:
```py
>>> psdf['decimal'] * 0.1
0    0.1                                                                        
1    0.2
2    0.3
Name: decimal, dtype: float64
```


pandas on spark after:
```py
>>> psdf['decimal'] * 0.1
Traceback (most recent call last):
...
TypeError: Multiplication can not be applied to given types.
```

### Why are the changes needed?
Part of https://issues.apache.org/jira/browse/SPARK-53389


### Does this PR introduce _any_ user-facing change?
No, the feature is not released yet

### How was this patch tested?
Unit tests

### Was this patch authored or co-authored using generative AI tooling?
No