### PR TITLE
[SPARK-53500][PYTHON][TESTS] Make `test_unpivot` deterministic

### DIFF
--- a/python/pyspark/sql/tests/test_stat.py
+++ b/python/pyspark/sql/tests/test_stat.py
@@ -536,7 +536,7 @@ class DataFrameStatTestsMixin:
         with self.subTest(desc="with multiple identifier columns but none given value columns"):
             for ids in [["id", "str"], ("id", "str")]:
                 with self.subTest(ids=ids):
-                    actual = df.unpivot(ids, None, "var", "val").sort(sf.col("id"), sf.desc("val"))
+                    actual = df.unpivot(ids, None, "var", "val").sort("id", sf.desc("val"))
                     self.assertEqual(
                         actual.schema.simpleString(),
                         "struct<id:bigint,str:string,var:string,val:double>",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Make `test_unpivot` deterministic


### Why are the changes needed?
it occasionally fails with:
```
======================================================================
FAIL [0.000s]: test_unpivot (pyspark.sql.tests.connect.test_parity_stat.DataFrameStatParityTests.test_unpivot) (ids=[], desc='with no identifier')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/python/pyspark/sql/tests/test_stat.py", line 435, in test_unpivot
    self.assertEqual(
AssertionError: Lists differ: [Row([26 chars]var='int', val=20.0), Row(var='int', val=30.0)[80 chars]3.0)] != [Row([26 chars]var='double', val=1.0), Row(var='int', val=20.[80 chars]3.0)]
First differing element 1:
Row(var='int', val=20.0)
Row(var='double', val=1.0)
  [Row(var='int', val=10.0),
+  Row(var='double', val=1.0),
   Row(var='int', val=20.0),
+  Row(var='double', val=2.0),
   Row(var='int', val=30.0),
-  Row(var='double', val=1.0),
-  Row(var='double', val=2.0),
   Row(var='double', val=3.0)]
======================================================================
FAIL [0.000s]: test_unpivot (pyspark.sql.tests.connect.test_parity_stat.DataFrameStatParityTests.test_unpivot) (ids=(), desc='with no identifier')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/python/pyspark/sql/tests/test_stat.py", line 435, in test_unpivot
    self.assertEqual(
AssertionError: Lists differ: [Row([26 chars]var='int', val=20.0), Row(var='int', val=30.0)[80 chars]3.0)] != [Row([26 chars]var='double', val=1.0), Row(var='int', val=20.[80 chars]3.0)]
First differing element 1:
Row(var='int', val=20.0)
Row(var='double', val=1.0)
  [Row(var='int', val=10.0),
+  Row(var='double', val=1.0),
   Row(var='int', val=20.0),
+  Row(var='double', val=2.0),
   Row(var='int', val=30.0),
-  Row(var='double', val=1.0),
-  Row(var='double', val=2.0),
   Row(var='double', val=3.0)]
```


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
no