### PR TITLE
[WIP][SPARK-53501][PYTHON][CORE][SQL][SS] refactor python worker factory API

### DIFF
--- a/core/src/main/scala/org/apache/spark/PythonWorkerManager.scala
+++ b/core/src/main/scala/org/apache/spark/PythonWorkerManager.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark
+
+import javax.annotation.concurrent.GuardedBy
+
+import scala.collection.mutable
+
+import org.apache.spark.api.python.{PythonWorker, PythonWorkerFactory}
+
+/**
+ * The arguments for the PythonWorker.
+ * @param pythonExec The python executable to run the Python worker.
+ * @param workerModule The worker module to be called in the worker, e.g., "pyspark.worker".
+ * @param daemonModule The daemon module name to reuse the worker, e.g., "pyspark.daemon".
+ * @param envVars The environment variables for the worker.
+ * @param useDaemon Whether to use the daemon.
+ */
+private[spark] case class PythonWorkerArgs(
+  pythonExec: String,
+  workerModule: String,
+  envVars: Map[String, String],
+  useDaemon: Boolean,
+  daemonModule: String
+)
+
+/**
+ * The PythonWorkerManager is responsible for creating, releasing, and destroying Python workers.
+ * It maps each unique set of PythonWorkerArgs to its own PythonWorkerFactory. The python worker
+ * args can not be changed after a worker was created, thus we need to ensure that all workers
+ * within a factory have the same args.
+ */
+class PythonWorkerManager(val conf: SparkConf) { self =>
+  // visible for testing
+  @GuardedBy("self")
+  private[spark] val workerFactories = mutable.HashMap[PythonWorkerArgs, PythonWorkerFactory]()
+
+  /**
+   * Creates a new Python worker. Creates a new PythonWorkerFactory if it doesn't exist.
+   *
+   * @param args
+   * @return
+   */
+  private[spark] def createPythonWorker(args: PythonWorkerArgs): PythonWorker = {
+    self.synchronized {
+      workerFactories.getOrElseUpdate(args, new PythonWorkerFactory(args))
+        .create()
+    }
+  }
+
+  /**
+   * Releases the Python worker, so it can be reused. The factory might keep the
+   * worker alive in the idle pool.
+   *
+   * @param worker
+   */
+  private[spark] def releasePythonWorker(worker: PythonWorker): Unit = {
+    synchronized {
+      workerFactories.get(worker.args).foreach(_.releaseWorker(worker))
+    }
+  }
+
+  /**
+   * Destroys the Python worker, terminates it.
+   *
+   * @param worker
+   * @param exception
+   */
+  private[spark] def destroyPythonWorker(
+    worker: PythonWorker, exception: Option[Throwable]): Unit = {
+    synchronized {
+      workerFactories.get(worker.args).foreach(_.stopWorker(worker, exception))
+    }
+  }
+
+  private[spark] def stop(): Unit = {
+    workerFactories.values.foreach(_.stop())
+  }
+}

--- a/core/src/test/scala/org/apache/spark/api/python/PythonWorkerFactorySuite.scala
+++ b/core/src/test/scala/org/apache/spark/api/python/PythonWorkerFactorySuite.scala
@@ -26,7 +26,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-import org.apache.spark.SharedSparkContext
+import org.apache.spark.{PythonWorkerArgs, SharedSparkContext}
 import org.apache.spark.SparkException
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.util.ThreadUtils
@@ -38,9 +38,14 @@ class PythonWorkerFactorySuite extends SparkFunSuite with SharedSparkContext {
     // It verifies that server side times out in accept(), if the worker does not connect back.
     // E.g. the worker might fail at the beginning before it tries to connect back.
 
-    val workerFactory = new PythonWorkerFactory(
-      "python3", "pyspark.testing.non_existing_worker_module", Map.empty, false
+    val workerArgs = PythonWorkerArgs(
+      pythonExec = "python3",
+      workerModule = "pyspark.testing.non_existing_worker_module",
+      envVars = Map.empty,
+      useDaemon = false,
+      daemonModule = PythonWorkerFactory.defaultDaemonModule
     )
+    val workerFactory = new PythonWorkerFactory(workerArgs)
 
     // Create the worker in a separate thread so that if there is a bug where it does not
     // return (accept() used to be blocking), the test doesn't hang for a long time.
@@ -61,7 +66,14 @@ class PythonWorkerFactorySuite extends SparkFunSuite with SharedSparkContext {
   test("idle worker pool is unbounded when idleWorkerMaxPoolSize is not set") {
     sc.conf.remove("spark.python.factory.idleWorkerMaxPoolSize")
 
-    val factory = new PythonWorkerFactory("python3", "pyspark.worker", Map.empty, true)
+    val workerArgs = PythonWorkerArgs(
+      pythonExec = "python3",
+      workerModule = "pyspark.worker",
+      envVars = Map.empty,
+      useDaemon = true,
+      daemonModule = PythonWorkerFactory.defaultDaemonModule
+    )
+    val factory = new PythonWorkerFactory(workerArgs)
 
     assert(factory.idleWorkers.size === 0)
 
@@ -70,20 +82,27 @@ class PythonWorkerFactorySuite extends SparkFunSuite with SharedSparkContext {
       (1 to 3).foreach { _ =>
         val mockChannel = java.nio.channels.SocketChannel.open()
         mockChannel.configureBlocking(false)
-        mockWorkers.enqueue(PythonWorker(mockChannel))
+        mockWorkers.enqueue(PythonWorker(workerArgs, mockChannel, None))
       }
       mockWorkers.foreach(factory.releaseWorker)
       assert(factory.idleWorkers.size === 3)
 
     } finally {
-      mockWorkers.foreach(factory.stopWorker)
+      mockWorkers.foreach(factory.stopWorker(_, None))
     }
   }
 
   test("idle worker pool is bounded when idleWorkerMaxPoolSize is set") {
     sc.conf.set("spark.python.factory.idleWorkerMaxPoolSize", "2")
 
-    val factory = new PythonWorkerFactory("python3", "pyspark.worker", Map.empty, true)
+    val workerArgs = PythonWorkerArgs(
+      pythonExec = "python3",
+      workerModule = "pyspark.worker",
+      envVars = Map.empty,
+      useDaemon = true,
+      daemonModule = PythonWorkerFactory.defaultDaemonModule
+    )
+    val factory = new PythonWorkerFactory(workerArgs)
 
     assert(factory.idleWorkers.size === 0)
     val mockWorkers: mutable.Queue[PythonWorker] = mutable.Queue.empty
@@ -91,7 +110,7 @@ class PythonWorkerFactorySuite extends SparkFunSuite with SharedSparkContext {
       (1 to 2).foreach { _ =>
         val mockChannel = java.nio.channels.SocketChannel.open()
         mockChannel.configureBlocking(false)
-        mockWorkers.enqueue(PythonWorker(mockChannel))
+        mockWorkers.enqueue(PythonWorker(workerArgs, mockChannel, None))
       }
       mockWorkers.foreach(factory.releaseWorker)
       assert(factory.idleWorkers.size === 2)
@@ -100,13 +119,13 @@ class PythonWorkerFactorySuite extends SparkFunSuite with SharedSparkContext {
       val worker3 = {
         val mockChannel = java.nio.channels.SocketChannel.open()
         mockChannel.configureBlocking(false)
-        PythonWorker(mockChannel)
+        PythonWorker(workerArgs, mockChannel, None)
       }
       mockWorkers.enqueue(worker3)
       factory.releaseWorker(worker3)
       assert(factory.idleWorkers.size === 2)
     } finally {
-      mockWorkers.foreach(factory.stopWorker)
+      mockWorkers.foreach(factory.stopWorker(_, None))
     }
   }
 }

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -93,6 +93,9 @@ object MimaExcludes {
     ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.network.util.ByteUnit"),
     ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.network.util.JavaUtils"),
 
+    // SPARK-53501: PythonWorker JVM class is internal
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.api.python.PythonWorker"),
+
     (problem: Problem) => problem match {
       case MissingClassProblem(cls) => !cls.fullName.startsWith("org.sparkproject.jpmml") &&
           !cls.fullName.startsWith("org.sparkproject.dmg.pmml")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
- this is a refactoring, it should have no functional changes. 
  - moves all factory management logic out of SparkEnv and to a separate, coherent class. This introduces a PythonWorkerManager, which abstracts over the different factories. We now guarantee that all arguments passed to the python worker are part of the factory key, as we must assume that none of the arguments are changeable at worker runtime
  - cleans up the worker api to remove unused overloads, and packages all parameters into a single object that can be easily extended without updating all api usages
  - Makes the `PythonWorker` class the one and only resource holder for all relevant data. PythonWorker now contains the args with which it was created, the channel, and the process handle. This means that we can now just pass the `PythonWorker` around.
  - passes through the exception (if it exists) when `destroyWorker` is called so that we can log the shutdown reason
- makes pythonworker internal to spark. this class is only intended for internal tracking purposes, and all of the APIs that return PythonWorkers were already marked with `private[spark]`, so I think this was just an oversight. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- it gets increasingly difficult to make changes to the worker factory logic

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No