### PR TITLE
[SPARK-53502][CONNECT][SQL] Improve the naming of methods in LiteralValueProtoConverter

### DIFF
--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkResult.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkResult.scala
@@ -382,7 +382,7 @@ private[sql] object SparkResult {
     values.sizeHint(metric.getKeysCount)
     (0 until metric.getKeysCount).foreach { i =>
       val key = metric.getKeys(i)
-      val value = LiteralValueProtoConverter.toCatalystValue(metric.getValues(i))
+      val value = LiteralValueProtoConverter.toScalaValue(metric.getValues(i))
       schema = schema.add(key, LiteralValueProtoConverter.toDataType(value.getClass))
       values += value
     }

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
@@ -365,7 +365,7 @@ object LiteralValueProtoConverter {
       throw new UnsupportedOperationException(s"Unsupported component type $clz in arrays.")
   }
 
-  def toCatalystValue(literal: proto.Expression.Literal): Any = {
+  def toScalaValue(literal: proto.Expression.Literal): Any = {
     literal.getLiteralTypeCase match {
       case proto.Expression.Literal.LiteralTypeCase.NULL => null
 
@@ -412,10 +412,10 @@ object LiteralValueProtoConverter {
         SparkIntervalUtils.microsToDuration(literal.getDayTimeInterval)
 
       case proto.Expression.Literal.LiteralTypeCase.ARRAY =>
-        toCatalystArray(literal.getArray)
+        toScalaArray(literal.getArray)
 
       case proto.Expression.Literal.LiteralTypeCase.STRUCT =>
-        toCatalystStruct(literal.getStruct)
+        toScalaStruct(literal.getStruct)
 
       case other =>
         throw new UnsupportedOperationException(
@@ -445,11 +445,11 @@ object LiteralValueProtoConverter {
           val interval = v.getCalendarInterval
           new CalendarInterval(interval.getMonths, interval.getDays, interval.getMicroseconds)
       case proto.DataType.KindCase.ARRAY =>
-        v => toCatalystArrayInternal(v.getArray, dataType.getArray)
+        v => toScalaArrayInternal(v.getArray, dataType.getArray)
       case proto.DataType.KindCase.MAP =>
-        v => toCatalystMapInternal(v.getMap, dataType.getMap)
+        v => toScalaMapInternal(v.getMap, dataType.getMap)
       case proto.DataType.KindCase.STRUCT =>
-        v => toCatalystStructInternal(v.getStruct, dataType.getStruct)
+        v => toScalaStructInternal(v.getStruct, dataType.getStruct)
       case _ =>
         throw InvalidPlanInput(s"Unsupported Literal Type: ${dataType.getKindCase}")
     }
@@ -580,7 +580,7 @@ object LiteralValueProtoConverter {
     Some(builder.build())
   }
 
-  private def toCatalystArrayInternal(
+  private def toScalaArrayInternal(
       array: proto.Expression.Literal.Array,
       arrayType: proto.DataType.Array): Array[_] = {
     def makeArrayData[T](converter: proto.Expression.Literal => T)(implicit
@@ -615,11 +615,11 @@ object LiteralValueProtoConverter {
     }
   }
 
-  def toCatalystArray(array: proto.Expression.Literal.Array): Array[_] = {
-    toCatalystArrayInternal(array, getProtoArrayType(array))
+  def toScalaArray(array: proto.Expression.Literal.Array): Array[_] = {
+    toScalaArrayInternal(array, getProtoArrayType(array))
   }
 
-  private def toCatalystMapInternal(
+  private def toScalaMapInternal(
       map: proto.Expression.Literal.Map,
       mapType: proto.DataType.Map): mutable.Map[_, _] = {
     def makeMapData[K, V](
@@ -661,11 +661,11 @@ object LiteralValueProtoConverter {
     }
   }
 
-  def toCatalystMap(map: proto.Expression.Literal.Map): mutable.Map[_, _] = {
-    toCatalystMapInternal(map, getProtoMapType(map))
+  def toScalaMap(map: proto.Expression.Literal.Map): mutable.Map[_, _] = {
+    toScalaMapInternal(map, getProtoMapType(map))
   }
 
-  private def toCatalystStructInternal(
+  private def toScalaStructInternal(
       struct: proto.Expression.Literal.Struct,
       structType: proto.DataType.Struct): Any = {
     def toTuple[A <: Object](data: Seq[A]): Product = {
@@ -703,7 +703,7 @@ object LiteralValueProtoConverter {
     }
   }
 
-  def toCatalystStruct(struct: proto.Expression.Literal.Struct): Any = {
-    toCatalystStructInternal(struct, getProtoStructType(struct))
+  def toScalaStruct(struct: proto.Expression.Literal.Struct): Any = {
+    toScalaStructInternal(struct, getProtoStructType(struct))
   }
 }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
@@ -140,7 +140,7 @@ private[ml] object MLUtils {
           }
 
         case _ =>
-          val paramValue = LiteralValueProtoConverter.toCatalystValue(literal)
+          val paramValue = LiteralValueProtoConverter.toScalaValue(literal)
           val paramType: Class[_] = if (p.dataClass == null) {
             if (paramValue.isInstanceOf[String]) {
               classOf[String]

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/LiteralExpressionProtoConverter.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/LiteralExpressionProtoConverter.scala
@@ -105,7 +105,7 @@ object LiteralExpressionProtoConverter {
         expressions.Literal(lit.getTime.getNano, TimeType(precision))
 
       case proto.Expression.Literal.LiteralTypeCase.ARRAY =>
-        val arrayData = LiteralValueProtoConverter.toCatalystArray(lit.getArray)
+        val arrayData = LiteralValueProtoConverter.toScalaArray(lit.getArray)
         val dataType = DataTypeProtoConverter.toCatalystType(
           proto.DataType.newBuilder
             .setArray(LiteralValueProtoConverter.getProtoArrayType(lit.getArray))
@@ -113,7 +113,7 @@ object LiteralExpressionProtoConverter {
         expressions.Literal.create(arrayData, dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.MAP =>
-        val mapData = LiteralValueProtoConverter.toCatalystMap(lit.getMap)
+        val mapData = LiteralValueProtoConverter.toScalaMap(lit.getMap)
         val dataType = DataTypeProtoConverter.toCatalystType(
           proto.DataType.newBuilder
             .setMap(LiteralValueProtoConverter.getProtoMapType(lit.getMap))
@@ -121,7 +121,7 @@ object LiteralExpressionProtoConverter {
         expressions.Literal.create(mapData, dataType)
 
       case proto.Expression.Literal.LiteralTypeCase.STRUCT =>
-        val structData = LiteralValueProtoConverter.toCatalystStruct(lit.getStruct)
+        val structData = LiteralValueProtoConverter.toScalaStruct(lit.getStruct)
         val dataType = DataTypeProtoConverter.toCatalystType(
           proto.DataType.newBuilder
             .setStruct(LiteralValueProtoConverter.getProtoStructType(lit.getStruct))

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -424,13 +424,13 @@ class SparkConnectPlanner(
     val cols = rel.getColsList.asScala.toArray
     val values = rel.getValuesList.asScala.toArray
     if (values.length == 1) {
-      val value = LiteralValueProtoConverter.toCatalystValue(values.head)
+      val value = LiteralValueProtoConverter.toScalaValue(values.head)
       val columns = if (cols.nonEmpty) Some(cols.toImmutableArraySeq) else None
       dataset.na.fillValue(value, columns).logicalPlan
     } else {
       val valueMap = mutable.Map.empty[String, Any]
       cols.zip(values).foreach { case (col, value) =>
-        valueMap.update(col, LiteralValueProtoConverter.toCatalystValue(value))
+        valueMap.update(col, LiteralValueProtoConverter.toScalaValue(value))
       }
       dataset.na.fill(valueMap = valueMap.toMap).logicalPlan
     }
@@ -457,8 +457,8 @@ class SparkConnectPlanner(
     val replacement = mutable.Map.empty[Any, Any]
     rel.getReplacementsList.asScala.foreach { replace =>
       replacement.update(
-        LiteralValueProtoConverter.toCatalystValue(replace.getOldValue),
-        LiteralValueProtoConverter.toCatalystValue(replace.getNewValue))
+        LiteralValueProtoConverter.toScalaValue(replace.getOldValue),
+        LiteralValueProtoConverter.toScalaValue(replace.getNewValue))
     }
 
     if (rel.getColsCount == 0) {

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/LiteralExpressionProtoConverterSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/LiteralExpressionProtoConverterSuite.scala
@@ -46,7 +46,7 @@ class LiteralExpressionProtoConverterSuite extends AnyFunSuite { // scalastyle:i
   test("basic proto value and catalyst value conversion") {
     val values = Array(null, true, 1.toByte, 1.toShort, 1, 1L, 1.1d, 1.1f, "spark")
     for (v <- values) {
-      assertResult(v)(LiteralValueProtoConverter.toCatalystValue(toLiteralProto(v)))
+      assertResult(v)(LiteralValueProtoConverter.toScalaValue(toLiteralProto(v)))
     }
   }
 
@@ -78,7 +78,7 @@ class LiteralExpressionProtoConverterSuite extends AnyFunSuite { // scalastyle:i
     .foreach { case ((v, t), idx) =>
       test(s"complex proto value and catalyst value conversion #$idx") {
         assertResult(v)(
-          LiteralValueProtoConverter.toCatalystValue(
+          LiteralValueProtoConverter.toScalaValue(
             LiteralValueProtoConverter.toLiteralProtoWithOptions(
               v,
               Some(t),
@@ -87,7 +87,7 @@ class LiteralExpressionProtoConverterSuite extends AnyFunSuite { // scalastyle:i
 
       test(s"complex proto value and catalyst value conversion #$idx - backward compatibility") {
         assertResult(v)(
-          LiteralValueProtoConverter.toCatalystValue(
+          LiteralValueProtoConverter.toScalaValue(
             LiteralValueProtoConverter.toLiteralProtoWithOptions(
               v,
               Some(t),
@@ -194,7 +194,7 @@ class LiteralExpressionProtoConverterSuite extends AnyFunSuite { // scalastyle:i
       .addElements(LiteralValueProtoConverter.toLiteralProto("test"))
       .build()
 
-    val result = LiteralValueProtoConverter.toCatalystStruct(structProto)
+    val result = LiteralValueProtoConverter.toScalaStruct(structProto)
     val resultType = LiteralValueProtoConverter.getProtoStructType(structProto)
 
     // Verify the result is a tuple with correct values


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR improves the naming of methods in `LiteralValueProtoConverter` to better reflect their actual functionality. The changes rename several methods from using "Catalyst" terminology to "Scala" terminology:

- `toCatalystValue()` → `toScalaValue()`
- `toCatalystArray()` → `toScalaArray()`
- `toCatalystArrayInternal()` → `toScalaArrayInternal()`
- `toCatalystMap()` → `toScalaMap()`
- `toCatalystMapInternal()` → `toScalaMapInternal()`
- `toCatalystStruct()` → `toScalaStruct()`
- `toCatalystStructInternal()` → `toScalaStructInternal()`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The previous method names using "Catalyst" terminology were misleading because these methods actually convert protobuf literal values to standard Scala values (like `Array`, `String`, etc.), not to Catalyst's internal data structures (like `GenericArrayData`, `UTF8String`, etc.). The "Catalyst" naming suggested these methods were part of Spark's Catalyst optimizer, when in fact they are utility methods for converting between protobuf and Scala representations.

This naming inconsistency could confuse developers about the purpose and scope of these methods, potentially leading to incorrect usage or maintenance issues.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, this is an internal refactoring that improves method naming

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Cursor 1.5.9