### PR TITLE
[SPARK-52745][SQL][FOLLOWUP] Allow the absense of exists default

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/ColumnDefaultValue.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/ColumnDefaultValue.java
@@ -56,7 +56,7 @@ public class ColumnDefaultValue extends DefaultValue {
    * will be the evaluated current_date() at the time the column was added/altered.
    * Spark always sets this value when passing ColumnDefaultValue to createTable/alterTable,
    * but {@link Table#columns()} may not do so as some data sources have its own system to do
-   * back-fill.
+   * column default value back-fill.
    */
   @Nullable
   public Literal<?> getValue() {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/ColumnDefaultValue.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/ColumnDefaultValue.java
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.connector.catalog;
 
 import java.util.Objects;
-import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.expressions.Expression;
@@ -52,10 +52,13 @@ public class ColumnDefaultValue extends DefaultValue {
 
   /**
    * Returns the default value literal. This is the literal value corresponding to
-   * {@link #getSql()}. For the example in the doc of {@link #getSql()}, this returns a literal
-   * integer with a value of 42.
+   * {@link #getSql()}. For example if the SQL is "current_date()", this literal value
+   * will be the evaluated current_date() at the time the column was added/altered.
+   * Spark always sets this value when passing ColumnDefaultValue to createTable/alterTable,
+   * but {@link Table#columns()} may not do so as some data sources have its own system to do
+   * back-fill.
    */
-  @Nonnull
+  @Nullable
   public Literal<?> getValue() {
     return value;
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.util.Utils
  */
 class DescribeTableSuite extends command.DescribeTableSuiteBase
   with CommandSuiteBase {
+  import testImplicits._
 
   test("Describing a partition is not supported") {
     withNamespaceAndTable("ns", "table") { tbl =>
@@ -46,7 +47,7 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase
       sql(s"CREATE TABLE $tbl (s struct<id:INT, a:BIGINT>, data string) " +
         s"$defaultUsing PARTITIONED BY (s.id, s.a)")
       val descriptionDf = sql(s"DESCRIBE TABLE $tbl")
-      QueryTest.checkAnswer(
+      checkAnswer(
         descriptionDf.filter("col_name != 'Created Time'"),
         Seq(
           Row("data", "string", null),
@@ -70,7 +71,7 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase
         ("col_name", StringType),
         ("data_type", StringType),
         ("comment", StringType)))
-      QueryTest.checkAnswer(
+      checkAnswer(
         descriptionDf,
         Seq(
           Row("id", "bigint", null),
@@ -162,7 +163,7 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase
       assert(descriptionDf.schema.map(field => (field.name, field.dataType)) === Seq(
         ("info_name", StringType),
         ("info_value", StringType)))
-      QueryTest.checkAnswer(
+      checkAnswer(
         descriptionDf,
         Seq(
           Row("col_name", "key"),
@@ -189,7 +190,7 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase
       assert(descriptionDf.schema.map(field => (field.name, field.dataType)) === Seq(
         ("info_name", StringType),
         ("info_value", StringType)))
-      QueryTest.checkAnswer(
+      checkAnswer(
         descriptionDf,
         Seq(
           Row("col_name", "key"),
@@ -266,6 +267,16 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase
         assert(descDdL === expectedConstraintsDdl
           .filter(_ != "c1,CHECK (c IS NOT NULL) ENFORCED,"))
       }
+    }
+  }
+
+  test("describe table with column having only current default value") {
+    withNamespaceAndTable("ns", "tbl") { tbl =>
+      sql(s"CREATE TABLE $tbl (key int DEFAULT 13579) $defaultUsing " +
+        "TBLPROPERTIES ('dropExistsDefault'=true)")
+      checkAnswer(
+        sql(s"DESCRIBE TABLE EXTENDED $tbl").where($"comment" === "13579"),
+        Seq(Row("key", "int", "13579")))
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is a followup of https://github.com/apache/spark/pull/51434 to fix a regression. Previously, `DescribeTableExec` extracts the column current default from the table schema, but after https://github.com/apache/spark/pull/51434, we get the table v2 columns, which may be converted from the table schema via `CatalogV2Util.structTypeToV2Columns`.

This conversion only sets the default value in v2 `Column` if both current default and exists default are present in the `StructField` metadata. However, some data source may not store the exists default in its column information as they have their own back-fill systems.

This PR fixes this regression by allowing the absense of exists default in v2 `Column`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix DESCRIBE TABLE regression

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, the regression is not released yet.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no