### PR TITLE
[SPARK-53498][SDP] Correctly Reference `pyspark/pipelines/cli.py` from `spark-pipelines` Binary

### DIFF
--- a/bin/spark-pipelines
+++ b/bin/spark-pipelines
@@ -30,4 +30,11 @@ fi
 export PYTHONPATH="${SPARK_HOME}/python/:$PYTHONPATH"
 export PYTHONPATH="${SPARK_HOME}/python/lib/py4j-0.10.9.9-src.zip:$PYTHONPATH"
 
-exec "${SPARK_HOME}"/bin/spark-class org.apache.spark.deploy.SparkPipelines "$@"
+SDP_CLI_PY_FILE_PATH=$("${PYSPARK_PYTHON}" - <<'EOF'
+import pyspark, os
+from pathlib import Path
+print(Path(os.path.dirname(pyspark.__file__)) / "pipelines" / "cli.py")
+EOF
+)
+
+exec "${SPARK_HOME}"/bin/spark-class org.apache.spark.deploy.SparkPipelines "$SDP_CLI_PY_FILE_PATH" "$@"

--- a/core/src/main/scala/org/apache/spark/deploy/SparkPipelines.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkPipelines.scala
@@ -34,15 +34,16 @@ import org.apache.spark.util.SparkExitCode
  */
 object SparkPipelines extends Logging {
   def main(args: Array[String]): Unit = {
-    val sparkHome = sys.env("SPARK_HOME")
-    SparkSubmit.main(constructSparkSubmitArgs(args, sparkHome).toArray)
+    val pipelinesCliFile = args(0)
+    val sparkSubmitAndPipelinesArgs = args.slice(1, args.length)
+    SparkSubmit.main(
+      constructSparkSubmitArgs(pipelinesCliFile, sparkSubmitAndPipelinesArgs).toArray)
   }
 
   protected[deploy] def constructSparkSubmitArgs(
-      args: Array[String],
-      sparkHome: String): Seq[String] = {
+      pipelinesCliFile: String,
+      args: Array[String]): Seq[String] = {
     val (sparkSubmitArgs, pipelinesArgs) = splitArgs(args)
-    val pipelinesCliFile = s"$sparkHome/python/pyspark/pipelines/cli.py"
     (sparkSubmitArgs ++ Seq(pipelinesCliFile) ++ pipelinesArgs)
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/SparkPipelinesSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkPipelinesSuite.scala
@@ -36,7 +36,8 @@ class SparkPipelinesSuite extends SparkSubmitTestUtils with Matchers with Before
       "spark.conf2=3"
     )
     assert(
-      SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
+      SparkPipelines.constructSparkSubmitArgs(
+        pipelinesCliFile = "abc/python/pyspark/pipelines/cli.py", args = args) ==
       Seq(
         "--deploy-mode",
         "client",
@@ -61,7 +62,8 @@ class SparkPipelinesSuite extends SparkSubmitTestUtils with Matchers with Before
       "pipeline.yml"
     )
     assert(
-      SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
+      SparkPipelines.constructSparkSubmitArgs(
+        pipelinesCliFile = "abc/python/pyspark/pipelines/cli.py", args = args) ==
       Seq(
         "--conf",
         "spark.api.mode=connect",
@@ -87,7 +89,8 @@ class SparkPipelinesSuite extends SparkSubmitTestUtils with Matchers with Before
       "spark.conf2=3"
     )
     assert(
-      SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
+      SparkPipelines.constructSparkSubmitArgs(
+        pipelinesCliFile = "abc/python/pyspark/pipelines/cli.py", args = args) ==
       Seq(
         "--supervise",
         "--conf",
@@ -110,7 +113,8 @@ class SparkPipelinesSuite extends SparkSubmitTestUtils with Matchers with Before
       "org.apache.spark.deploy.SparkPipelines"
     )
     intercept[SparkUserAppException] {
-      SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc")
+      SparkPipelines.constructSparkSubmitArgs(
+        pipelinesCliFile = "abc/python/pyspark/pipelines/cli.py", args = args)
     }
   }
 
@@ -121,7 +125,8 @@ class SparkPipelinesSuite extends SparkSubmitTestUtils with Matchers with Before
       "myproject"
     )
     assert(
-      SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
+      SparkPipelines.constructSparkSubmitArgs(
+        pipelinesCliFile = "abc/python/pyspark/pipelines/cli.py", args = args) ==
         Seq(
           "--conf",
           "spark.api.mode=connect",

--- a/python/packaging/classic/setup.py
+++ b/python/packaging/classic/setup.py
@@ -306,6 +306,7 @@ try:
             "pyspark.pandas.spark",
             "pyspark.pandas.typedef",
             "pyspark.pandas.usage_logging",
+            "pyspark.pipelines",
             "pyspark.python.pyspark",
             "pyspark.python.lib",
             "pyspark.testing",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
When the `spark-pipelines` binary is run, SDP's `cli.py` is submitted to the configured spark cluster via a `spark-submit` request.

Previously, the file path to retrieve `cli.py` was hard-coded with respect to the resolved `SPARK_HOME`. This is incorrect as the package layout is different depending on how spark was installed (ex. Spark tarball installation vs PyPi pyspark installation). 

The proposed change is to resolve the file path as a hard coded string with respect to where the pyspark module source code is, rather than `SPARK_HOME`.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
