### PR TITLE
[SPARK-53506][PS] Disallow `%` between Decimal and float under ANSI

### DIFF
--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -463,6 +463,13 @@ class FractionalOps(NumericOps):
 
         return column_op(wrapped_mul)(left, new_right)
 
+    def mod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        is_ansi = is_ansi_mode_enabled(left._internal.spark_frame.sparkSession)
+        if is_ansi and _is_decimal_float_mixed(left, right):
+            raise TypeError("Modulo can not be applied to given types.")
+
+        return super().mod(left, right)
+
     def truediv(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
         if not is_valid_operand_for_numeric_arithmetic(right):
@@ -565,6 +572,13 @@ class FractionalOps(NumericOps):
         if is_ansi and _is_decimal_float_mixed(left, right):
             raise TypeError("Multiplication can not be applied to given types.")
         return super().rmul(left, right)
+
+    def rmod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        is_ansi = is_ansi_mode_enabled(left._internal.spark_frame.sparkSession)
+        if is_ansi and _is_decimal_float_mixed(left, right):
+            raise TypeError("Modulo can not be applied to given types.")
+
+        return super().rmod(left, right)
 
     def isnull(self, index_ops: IndexOpsLike) -> IndexOpsLike:
         return index_ops._with_new_scol(

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_mul_div.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_mul_div.py
@@ -111,6 +111,36 @@ class NumMulDivTestsMixin:
             self.assertRaises(TypeError, lambda: psdf["decimal"] // 0.1)
             self.assertRaises(TypeError, lambda: 0.1 // psdf["decimal"])
 
+    def test_mod(self):
+        pdf, psdf = self.pdf, self.psdf
+
+        # element-wise modulo for numeric columns
+        for col in self.numeric_df_cols:
+            pser, psser = pdf[col], psdf[col]
+
+            if psser.dtype in [float, int, np.int32]:
+                self.assert_eq(pser % pser, psser % psser)
+                self.assert_eq(pser % pser.astype(bool), psser % psser.astype(bool))
+                self.assert_eq(pser % True, psser % True)
+                # TODO: align the data type to pandas when ints % False
+                # self.assert_eq(pser % False, psser % False)
+
+            # modulo with non-numeric columns
+            for n_col in self.non_numeric_df_cols:
+                if n_col == "bool":
+                    # follow pandas semantics for modulo with a boolean Series
+                    self.assert_eq(pdf["float"] % pdf["bool"], psdf["float"] % psdf["bool"])
+                else:
+                    self.assertRaises(TypeError, lambda: psser % psdf[n_col])
+
+        if is_ansi_mode_test:
+            self.assertRaises(TypeError, lambda: psdf["decimal"] % psdf["float"])
+            self.assertRaises(TypeError, lambda: psdf["float"] % psdf["decimal"])
+            self.assertRaises(TypeError, lambda: psdf["decimal"] % psdf["float32"])
+            self.assertRaises(TypeError, lambda: psdf["float32"] % psdf["decimal"])
+            self.assertRaises(TypeError, lambda: psdf["decimal"] % 0.1)
+            self.assertRaises(TypeError, lambda: 0.1 % psdf["decimal"])
+
 
 class NumMulDivTests(
     NumMulDivTestsMixin,

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_mul_div.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_mul_div.py
@@ -122,8 +122,8 @@ class NumMulDivTestsMixin:
                 self.assert_eq(pser % pser, psser % psser)
                 self.assert_eq(pser % pser.astype(bool), psser % psser.astype(bool))
                 self.assert_eq(pser % True, psser % True)
-                # TODO: align the data type to pandas when ints % False
-                # self.assert_eq(pser % False, psser % False)
+                # TODO: decide if to follow pser % False
+                self.assert_eq(pser % 0, psser % False)
 
             # modulo with non-numeric columns
             for n_col in self.non_numeric_df_cols:

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_mul_div.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_mul_div.py
@@ -128,7 +128,6 @@ class NumMulDivTestsMixin:
             # modulo with non-numeric columns
             for n_col in self.non_numeric_df_cols:
                 if n_col == "bool":
-                    # follow pandas semantics for modulo with a boolean Series
                     self.assert_eq(pdf["float"] % pdf["bool"], psdf["float"] % psdf["bool"])
                 else:
                     self.assertRaises(TypeError, lambda: psser % psdf[n_col])


### PR DESCRIPTION
### What changes were proposed in this pull request?
Disallow `%` between Decimal and float under ANSI

pandas:
```py
>>> pdf['decimal'] % 0.1
Traceback (most recent call last):
...
TypeError: unsupported operand type(s) for %: 'decimal.Decimal' and 'float'
```


pandas on spark before:
```py
>>> psdf['decimal'] % 0.1
0    0.1                                                                        
1    0.1
2    0.1
Name: decimal, dtype: float64
```


pandas on spark after:
```py
>>> psdf['decimal'] % 0.1
Traceback (most recent call last):
...
TypeError: Modulo can not be applied to given types.
```

### Why are the changes needed?
Part of https://issues.apache.org/jira/browse/SPARK-53389


### Does this PR introduce _any_ user-facing change?
No, the feature is not released yet

### How was this patch tested?
Unit tests

Commands below passed:
```py
1097  SPARK_ANSI_SQL_MODE=true ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_num_mul_div NumMulDivTests.test_mod"
1098  SPARK_ANSI_SQL_MODE=false ./python/run-tests --python-executables=python3.11 --testnames "pyspark.pandas.tests.data_type_ops.test_num_mul_div NumMulDivTests.test_mod"

```

### Was this patch authored or co-authored using generative AI tooling?
No