### PR TITLE
[SPARK-53512] [SQL] Better unification of DSv2 PushDownUtils

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/SupportsPushDownCatalystFilters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/SupportsPushDownCatalystFilters.scala
@@ -18,14 +18,15 @@ package org.apache.spark.sql.internal.connector
 
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.connector.expressions.filter.Predicate
+import org.apache.spark.sql.connector.read.ScanBuilder
 
 /**
- * A mix-in interface for {@link FileScanBuilder}. File sources can implement this interface to
- * push down filters to the file source. The pushed down filters will be separated into partition
+ * A mix-in interface for {@link ScanBuilder}. Data sources can implement this interface to
+ * push down filters to the data source. The pushed down filters will be separated into partition
  * filters and data filters. Partition filters are used for partition pruning and data filters are
  * used to reduce the size of the data to be read.
  */
-trait SupportsPushDownCatalystFilters {
+trait SupportsPushDownCatalystFilters extends ScanBuilder {
 
   /**
    * Pushes down catalyst Expression filters (which will be separated into partition filters and

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownLimit, SupportsPushDownOffset, SupportsPushDownRequiredColumns, SupportsPushDownTableSample, SupportsPushDownTopN, SupportsPushDownV2Filters}
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.connector.SupportsPushDownCatalystFilters
 import org.apache.spark.sql.sources
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.ArrayImplicits._
@@ -107,9 +108,9 @@ object PushDownUtils {
         (Right(r.pushedPredicates.toImmutableArraySeq),
           (postScanFilters ++ untranslatableExprs).toImmutableArraySeq)
 
-      case f: FileScanBuilder =>
-        val postScanFilters = f.pushFilters(filters)
-        (Right(f.pushedFilters.toImmutableArraySeq), postScanFilters)
+      case r: SupportsPushDownCatalystFilters =>
+        val postScanFilters = r.pushFilters(filters)
+        (Right(r.pushedFilters.toImmutableArraySeq), postScanFilters)
       case _ => (Left(Nil), filters)
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR makes SupportsPushDownCatalystFilters a trait that extends ScanBuilder, and adds it to the pattern matching of PushDownUtils. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently, the PushDownUtils has following matching cases:

 ```
object PushDownUtils {
  def pushFilters(scanBuilder: ScanBuilder, filters: Seq[Expression])
    : (Either[Seq[sources.Filter], Seq[Predicate]], Seq[Expression]) = {
    scanBuilder match {
      case r: SupportsPushDownFilters => ...  // public interface extends ScanBuilder
      case r: SupportsPushDownV2Filters => ... // public interface extends ScanBuilder
      case f: FileScanBuilder => ... // which extends with SupportsPushDownCatalystFilters
      case _ => (Left(Nil), filters)
    }
  }
}  
```

As a result, when a new scanBuilder wants to SupportsPushDownCatalystFilters (but doesn't want to extend FileScanBuilder), it will not be picked up by PushDownUtils. To better unify these filter pushdown interfaces, it would be better if the matching cases are like following:

```
scanBuilder match { 
  case r: SupportsPushDownFilters => ... // public interface extends ScanBuilder
  case r: SupportsPushDownV2Filters => ... // public interface extends ScanBuilder
  case r: SupportsPushDownCatalystFilters => ... // trait extends ScanBuilder
  case _ => (Left(Nil), filters)
}
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing tests. 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.