### PR TITLE
[SPARK-53514][DOCS] Update `Gemfile` to allow Ruby 3.0+ explicitly

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+ruby ">= 3.0.0"
 source "https://rubygems.org"
 
 # Keep these specifications as flexible as possible and leave it to Bundler


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `Gemfile` to allow Ruby 3.0+ explicitly from Apache Spark 4.1.0. Gradually, we are going to update this more accurately to a higher tested Ruby versions in order to prevent any accidental documentation corruptions.

### Why are the changes needed?

1. We use `public_suffix` v6.0.2 which requires `Ruby 3.0+` officially.

    https://github.com/apache/spark/blob/0dc38b02f4a72573c88d438fedd6df6271c8edd3/docs/Gemfile.lock#L60

    - https://rubygems.org/gems/public_suffix/versions/6.0.2

2. We use `jekyll-sass-converter` v3.1.0 which requires `Ruby 3.1+` officially.

    https://github.com/apache/spark/blob/0dc38b02f4a72573c88d438fedd6df6271c8edd3/docs/Gemfile.lock#L44

    - https://rubygems.org/gems/jekyll-sass-converter/versions/3.1.0

3. `Ruby 3.1` and below have been in the EOL status technically. So, it's not a surprise when one of our Ruby dependencies drops Ruby 3.1 and older support completely at any point of time.

    - https://www.ruby-lang.org/en/downloads/branches/

```
Ruby 3.1
status: eol
release date: 2021-12-25
normal maintenance until: 2024-04-01
EOL: 2025-03-26
```

4. Apache Spark 4.1 has Ruby 3.3 test coverage only and `release` script has been using `Ruby 3.0.2` on `Ubuntu Jammy`.

    https://github.com/apache/spark/blob/d9a23c2f447f7e11430c83799472cb7053119016/.github/workflows/pages.yml#L71

    https://github.com/apache/spark/blob/d9a23c2f447f7e11430c83799472cb7053119016/dev/create-release/spark-rm/Dockerfile#L19

```
root@7b0327607ed7:/# ruby --version
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [aarch64-linux-gnu]
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Since CI passes with Ruby 3.3 always, we need to verify manually like the following.

```
$ cd docs

$ docker run -it --rm -v $PWD:/docs -w /docs ruby:2.7.8 bash

root@5328792f5392:/docs# gem install bundler -v 2.4.22
Fetching bundler-2.4.22.gem
Successfully installed bundler-2.4.22
1 gem installed

root@5328792f5392:/docs# bundle install
Your Ruby version is 2.7.8, but your Gemfile specified >= 3.0.0
```

### Was this patch authored or co-authored using generative AI tooling?

No.