### PR TITLE
[SPARK-53515][SQL] Remove unused `private lazy val` from `SchemaOfCsv/Xml`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
@@ -156,9 +156,6 @@ case class SchemaOfCsv(
 
   override def nullable: Boolean = false
 
-  @transient
-  private lazy val csv = child.eval().asInstanceOf[UTF8String]
-
   override def checkInputDataTypes(): TypeCheckResult = {
     if (!child.foldable) {
       DataTypeMismatch(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xmlExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xmlExpressions.scala
@@ -162,9 +162,6 @@ case class SchemaOfXml(
     new XmlInferSchema(xmlOptions, caseSensitive = SQLConf.get.caseSensitiveAnalysis)
   }
 
-  @transient
-  private lazy val xml = child.eval().asInstanceOf[UTF8String]
-
   override def checkInputDataTypes(): TypeCheckResult = {
     if (!child.foldable) {
       DataTypeMismatch(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR removes the unused `private lazy val` from both `SchemaOfCsv` and `SchemaOfXml`.

### Why are the changes needed?
Code cleanup.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No