### PR TITLE
[SPARK-53448][PYTHON] Conversion of a pyspark DataFrame with a Variant column to pandas fails with an error

### DIFF
--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -69,10 +69,10 @@ if TYPE_CHECKING:
 
 
 def to_arrow_type(
-        dt: DataType,
-        error_on_duplicated_field_names_in_struct: bool = False,
-        timestamp_utc: bool = True,
-        prefers_large_types: bool = False,
+    dt: DataType,
+    error_on_duplicated_field_names_in_struct: bool = False,
+    timestamp_utc: bool = True,
+    prefers_large_types: bool = False,
 ) -> "pa.DataType":
     """
     Convert Spark data type to PyArrow type
@@ -237,10 +237,10 @@ def to_arrow_type(
 
 
 def to_arrow_schema(
-        schema: StructType,
-        error_on_duplicated_field_names_in_struct: bool = False,
-        timestamp_utc: bool = True,
-        prefers_large_types: bool = False,
+    schema: StructType,
+    error_on_duplicated_field_names_in_struct: bool = False,
+    timestamp_utc: bool = True,
+    prefers_large_types: bool = False,
 ) -> "pa.Schema":
     """
     Convert a schema from Spark to Arrow
@@ -289,10 +289,10 @@ def is_variant(at: "pa.DataType") -> bool:
 
     return any(
         (
-                field.name == "metadata"
-                and field.metadata is not None
-                and b"variant" in field.metadata
-                and field.metadata[b"variant"] == b"true"
+            field.name == "metadata"
+            and field.metadata is not None
+            and b"variant" in field.metadata
+            and field.metadata[b"variant"] == b"true"
         )
         for field in at
     ) and any(field.name == "value" for field in at)
@@ -460,10 +460,10 @@ def _get_local_timezone() -> str:
 
 
 def _check_arrow_array_timestamps_localize(
-        a: Union["pa.Array", "pa.ChunkedArray"],
-        dt: DataType,
-        truncate: bool = True,
-        timezone: Optional[str] = None,
+    a: Union["pa.Array", "pa.ChunkedArray"],
+    dt: DataType,
+    truncate: bool = True,
+    timezone: Optional[str] = None,
 ) -> Union["pa.Array", "pa.ChunkedArray"]:
     """
     Convert Arrow timestamps to timezone-naive in the specified timezone if the specified Spark
@@ -521,10 +521,10 @@ def _check_arrow_array_timestamps_localize(
     if types.is_map(a.type):
         # Return the MapArray as-is if it contains no nested fields or timestamps
         if (
-                not types.is_nested(a.type.key_type)
-                and not types.is_nested(a.type.item_type)
-                and not types.is_timestamp(a.type.key_type)
-                and not types.is_timestamp(a.type.item_type)
+            not types.is_nested(a.type.key_type)
+            and not types.is_nested(a.type.item_type)
+            and not types.is_timestamp(a.type.key_type)
+            and not types.is_timestamp(a.type.item_type)
         ):
             return a
 
@@ -546,11 +546,11 @@ def _check_arrow_array_timestamps_localize(
     if types.is_struct(a.type):
         # Return the StructArray as-is if it contains no nested fields or timestamps
         if all(
-                [
-                    not types.is_nested(a.type.field(i).type)
-                    and not types.is_timestamp(a.type.field(i).type)
-                    for i in range(a.type.num_fields)
-                ]
+            [
+                not types.is_nested(a.type.field(i).type)
+                and not types.is_timestamp(a.type.field(i).type)
+                for i in range(a.type.num_fields)
+            ]
         ):
             return a
 
@@ -576,7 +576,7 @@ def _check_arrow_array_timestamps_localize(
 
 
 def _check_arrow_table_timestamps_localize(
-        table: "pa.Table", schema: StructType, truncate: bool = True, timezone: Optional[str] = None
+    table: "pa.Table", schema: StructType, truncate: bool = True, timezone: Optional[str] = None
 ) -> "pa.Table":
     """
     Convert timestamps in a PyArrow Table to timezone-naive in the specified timezone if the
@@ -648,7 +648,7 @@ def _check_series_localize_timestamps(s: "PandasSeriesLike", timezone: str) -> "
 
 
 def _check_series_convert_timestamps_internal(
-        s: "PandasSeriesLike", timezone: str
+    s: "PandasSeriesLike", timezone: str
 ) -> "PandasSeriesLike":
     """
     Convert a tz-naive timestamp in the specified timezone or local timezone to UTC normalized for
@@ -715,7 +715,7 @@ def _check_series_convert_timestamps_internal(
 
 
 def _check_series_convert_timestamps_localize(
-        s: "PandasSeriesLike", from_timezone: Optional[str], to_timezone: Optional[str]
+    s: "PandasSeriesLike", from_timezone: Optional[str], to_timezone: Optional[str]
 ) -> "PandasSeriesLike":
     """
     Convert timestamp to timezone-naive in the specified timezone or local timezone
@@ -764,7 +764,7 @@ def _check_series_convert_timestamps_localize(
 
 
 def _check_series_convert_timestamps_local_tz(
-        s: "PandasSeriesLike", timezone: str
+    s: "PandasSeriesLike", timezone: str
 ) -> "PandasSeriesLike":
     """
     Convert timestamp to timezone-naive in the specified timezone or local timezone
@@ -784,7 +784,7 @@ def _check_series_convert_timestamps_local_tz(
 
 
 def _check_series_convert_timestamps_tz_local(
-        s: "PandasSeriesLike", timezone: str
+    s: "PandasSeriesLike", timezone: str
 ) -> "PandasSeriesLike":
     """
     Convert timestamp to timezone-naive in the specified timezone or local timezone
@@ -856,14 +856,14 @@ def _to_corrected_pandas_type(dt: DataType) -> Optional[Any]:
 
 
 def _create_converter_to_pandas(
-        data_type: DataType,
-        nullable: bool = True,
-        *,
-        timezone: Optional[str] = None,
-        struct_in_pandas: Optional[str] = None,
-        error_on_duplicated_field_names: bool = True,
-        timestamp_utc_localized: bool = True,
-        ndarray_as_list: bool = False,
+    data_type: DataType,
+    nullable: bool = True,
+    *,
+    timezone: Optional[str] = None,
+    struct_in_pandas: Optional[str] = None,
+    error_on_duplicated_field_names: bool = True,
+    timestamp_utc_localized: bool = True,
+    ndarray_as_list: bool = False,
 ) -> Callable[["pd.Series"], "pd.Series"]:
     """
     Create a converter of pandas Series that is created from Spark's Python objects,
@@ -940,7 +940,7 @@ def _create_converter_to_pandas(
         return correct_dtype
 
     def _converter(
-            dt: DataType, _struct_in_pandas: Optional[str], _ndarray_as_list: bool
+        dt: DataType, _struct_in_pandas: Optional[str], _ndarray_as_list: bool
     ) -> Optional[Callable[[Any], Any]]:
         if isinstance(dt, ArrayType):
             _element_conv = _converter(dt.elementType, _struct_in_pandas, _ndarray_as_list)
@@ -1160,9 +1160,9 @@ def _create_converter_to_pandas(
                 if isinstance(value, VariantVal):
                     return value
                 if (
-                        isinstance(value, dict)
-                        and all(key in value for key in ["value", "metadata"])
-                        and all(isinstance(value[key], bytes) for key in ["value", "metadata"])
+                    isinstance(value, dict)
+                    and all(key in value for key in ["value", "metadata"])
+                    and all(isinstance(value[key], bytes) for key in ["value", "metadata"])
                 ):
                     return VariantVal(value["value"], value["metadata"])
                 else:
@@ -1217,11 +1217,11 @@ def _create_converter_to_pandas(
 
 
 def _create_converter_from_pandas(
-        data_type: DataType,
-        *,
-        timezone: Optional[str] = None,
-        error_on_duplicated_field_names: bool = True,
-        ignore_unexpected_complex_type_values: bool = False,
+    data_type: DataType,
+    *,
+    timezone: Optional[str] = None,
+    error_on_duplicated_field_names: bool = True,
+    ignore_unexpected_complex_type_values: bool = False,
 ) -> Callable[["pd.Series"], "pd.Series"]:
     """
     Create a converter of pandas Series to create Spark DataFrame with Arrow optimization.
@@ -1564,22 +1564,22 @@ def _to_numpy_type(type: DataType) -> Optional["np.dtype"]:
 
 
 def convert_pandas_using_numpy_type(
-        df: "PandasDataFrameLike", schema: StructType
+    df: "PandasDataFrameLike", schema: StructType
 ) -> "PandasDataFrameLike":
     for field in schema.fields:
         if isinstance(
-                field.dataType,
-                (
-                        ByteType,
-                        ShortType,
-                        IntegerType,
-                        LongType,
-                        FloatType,
-                        DoubleType,
-                        TimestampType,
-                        TimestampNTZType,
-                        DayTimeIntervalType,
-                ),
+            field.dataType,
+            (
+                ByteType,
+                ShortType,
+                IntegerType,
+                LongType,
+                FloatType,
+                DoubleType,
+                TimestampType,
+                TimestampNTZType,
+                DayTimeIntervalType,
+            ),
         ):
             np_type = _to_numpy_type(field.dataType)
             df[field.name] = df[field.name].astype(np_type)

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -23,6 +23,8 @@ import datetime
 import itertools
 from typing import Any, Callable, Iterable, List, Optional, Union, TYPE_CHECKING
 
+from pyspark.errors import PySparkTypeError, UnsupportedOperationException, PySparkValueError
+from pyspark.loose_version import LooseVersion
 from pyspark.sql.types import (
     cast,
     BooleanType,
@@ -56,8 +58,6 @@ from pyspark.sql.types import (
     Geography,
     _create_row,
 )
-from pyspark.errors import PySparkTypeError, UnsupportedOperationException, PySparkValueError
-from pyspark.loose_version import LooseVersion
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -69,10 +69,10 @@ if TYPE_CHECKING:
 
 
 def to_arrow_type(
-    dt: DataType,
-    error_on_duplicated_field_names_in_struct: bool = False,
-    timestamp_utc: bool = True,
-    prefers_large_types: bool = False,
+        dt: DataType,
+        error_on_duplicated_field_names_in_struct: bool = False,
+        timestamp_utc: bool = True,
+        prefers_large_types: bool = False,
 ) -> "pa.DataType":
     """
     Convert Spark data type to PyArrow type
@@ -237,10 +237,10 @@ def to_arrow_type(
 
 
 def to_arrow_schema(
-    schema: StructType,
-    error_on_duplicated_field_names_in_struct: bool = False,
-    timestamp_utc: bool = True,
-    prefers_large_types: bool = False,
+        schema: StructType,
+        error_on_duplicated_field_names_in_struct: bool = False,
+        timestamp_utc: bool = True,
+        prefers_large_types: bool = False,
 ) -> "pa.Schema":
     """
     Convert a schema from Spark to Arrow
@@ -289,10 +289,10 @@ def is_variant(at: "pa.DataType") -> bool:
 
     return any(
         (
-            field.name == "metadata"
-            and field.metadata is not None
-            and b"variant" in field.metadata
-            and field.metadata[b"variant"] == b"true"
+                field.name == "metadata"
+                and field.metadata is not None
+                and b"variant" in field.metadata
+                and field.metadata[b"variant"] == b"true"
         )
         for field in at
     ) and any(field.name == "value" for field in at)
@@ -460,10 +460,10 @@ def _get_local_timezone() -> str:
 
 
 def _check_arrow_array_timestamps_localize(
-    a: Union["pa.Array", "pa.ChunkedArray"],
-    dt: DataType,
-    truncate: bool = True,
-    timezone: Optional[str] = None,
+        a: Union["pa.Array", "pa.ChunkedArray"],
+        dt: DataType,
+        truncate: bool = True,
+        timezone: Optional[str] = None,
 ) -> Union["pa.Array", "pa.ChunkedArray"]:
     """
     Convert Arrow timestamps to timezone-naive in the specified timezone if the specified Spark
@@ -521,10 +521,10 @@ def _check_arrow_array_timestamps_localize(
     if types.is_map(a.type):
         # Return the MapArray as-is if it contains no nested fields or timestamps
         if (
-            not types.is_nested(a.type.key_type)
-            and not types.is_nested(a.type.item_type)
-            and not types.is_timestamp(a.type.key_type)
-            and not types.is_timestamp(a.type.item_type)
+                not types.is_nested(a.type.key_type)
+                and not types.is_nested(a.type.item_type)
+                and not types.is_timestamp(a.type.key_type)
+                and not types.is_timestamp(a.type.item_type)
         ):
             return a
 
@@ -546,11 +546,11 @@ def _check_arrow_array_timestamps_localize(
     if types.is_struct(a.type):
         # Return the StructArray as-is if it contains no nested fields or timestamps
         if all(
-            [
-                not types.is_nested(a.type.field(i).type)
-                and not types.is_timestamp(a.type.field(i).type)
-                for i in range(a.type.num_fields)
-            ]
+                [
+                    not types.is_nested(a.type.field(i).type)
+                    and not types.is_timestamp(a.type.field(i).type)
+                    for i in range(a.type.num_fields)
+                ]
         ):
             return a
 
@@ -576,7 +576,7 @@ def _check_arrow_array_timestamps_localize(
 
 
 def _check_arrow_table_timestamps_localize(
-    table: "pa.Table", schema: StructType, truncate: bool = True, timezone: Optional[str] = None
+        table: "pa.Table", schema: StructType, truncate: bool = True, timezone: Optional[str] = None
 ) -> "pa.Table":
     """
     Convert timestamps in a PyArrow Table to timezone-naive in the specified timezone if the
@@ -648,7 +648,7 @@ def _check_series_localize_timestamps(s: "PandasSeriesLike", timezone: str) -> "
 
 
 def _check_series_convert_timestamps_internal(
-    s: "PandasSeriesLike", timezone: str
+        s: "PandasSeriesLike", timezone: str
 ) -> "PandasSeriesLike":
     """
     Convert a tz-naive timestamp in the specified timezone or local timezone to UTC normalized for
@@ -715,7 +715,7 @@ def _check_series_convert_timestamps_internal(
 
 
 def _check_series_convert_timestamps_localize(
-    s: "PandasSeriesLike", from_timezone: Optional[str], to_timezone: Optional[str]
+        s: "PandasSeriesLike", from_timezone: Optional[str], to_timezone: Optional[str]
 ) -> "PandasSeriesLike":
     """
     Convert timestamp to timezone-naive in the specified timezone or local timezone
@@ -764,7 +764,7 @@ def _check_series_convert_timestamps_localize(
 
 
 def _check_series_convert_timestamps_local_tz(
-    s: "PandasSeriesLike", timezone: str
+        s: "PandasSeriesLike", timezone: str
 ) -> "PandasSeriesLike":
     """
     Convert timestamp to timezone-naive in the specified timezone or local timezone
@@ -784,7 +784,7 @@ def _check_series_convert_timestamps_local_tz(
 
 
 def _check_series_convert_timestamps_tz_local(
-    s: "PandasSeriesLike", timezone: str
+        s: "PandasSeriesLike", timezone: str
 ) -> "PandasSeriesLike":
     """
     Convert timestamp to timezone-naive in the specified timezone or local timezone
@@ -856,14 +856,14 @@ def _to_corrected_pandas_type(dt: DataType) -> Optional[Any]:
 
 
 def _create_converter_to_pandas(
-    data_type: DataType,
-    nullable: bool = True,
-    *,
-    timezone: Optional[str] = None,
-    struct_in_pandas: Optional[str] = None,
-    error_on_duplicated_field_names: bool = True,
-    timestamp_utc_localized: bool = True,
-    ndarray_as_list: bool = False,
+        data_type: DataType,
+        nullable: bool = True,
+        *,
+        timezone: Optional[str] = None,
+        struct_in_pandas: Optional[str] = None,
+        error_on_duplicated_field_names: bool = True,
+        timestamp_utc_localized: bool = True,
+        ndarray_as_list: bool = False,
 ) -> Callable[["pd.Series"], "pd.Series"]:
     """
     Create a converter of pandas Series that is created from Spark's Python objects,
@@ -940,7 +940,7 @@ def _create_converter_to_pandas(
         return correct_dtype
 
     def _converter(
-        dt: DataType, _struct_in_pandas: Optional[str], _ndarray_as_list: bool
+            dt: DataType, _struct_in_pandas: Optional[str], _ndarray_as_list: bool
     ) -> Optional[Callable[[Any], Any]]:
         if isinstance(dt, ArrayType):
             _element_conv = _converter(dt.elementType, _struct_in_pandas, _ndarray_as_list)
@@ -1157,10 +1157,12 @@ def _create_converter_to_pandas(
         elif isinstance(dt, VariantType):
 
             def convert_variant(value: Any) -> Any:
+                if isinstance(value, VariantVal):
+                    return value
                 if (
-                    isinstance(value, dict)
-                    and all(key in value for key in ["value", "metadata"])
-                    and all(isinstance(value[key], bytes) for key in ["value", "metadata"])
+                        isinstance(value, dict)
+                        and all(key in value for key in ["value", "metadata"])
+                        and all(isinstance(value[key], bytes) for key in ["value", "metadata"])
                 ):
                     return VariantVal(value["value"], value["metadata"])
                 else:
@@ -1215,11 +1217,11 @@ def _create_converter_to_pandas(
 
 
 def _create_converter_from_pandas(
-    data_type: DataType,
-    *,
-    timezone: Optional[str] = None,
-    error_on_duplicated_field_names: bool = True,
-    ignore_unexpected_complex_type_values: bool = False,
+        data_type: DataType,
+        *,
+        timezone: Optional[str] = None,
+        error_on_duplicated_field_names: bool = True,
+        ignore_unexpected_complex_type_values: bool = False,
 ) -> Callable[["pd.Series"], "pd.Series"]:
     """
     Create a converter of pandas Series to create Spark DataFrame with Arrow optimization.
@@ -1562,22 +1564,22 @@ def _to_numpy_type(type: DataType) -> Optional["np.dtype"]:
 
 
 def convert_pandas_using_numpy_type(
-    df: "PandasDataFrameLike", schema: StructType
+        df: "PandasDataFrameLike", schema: StructType
 ) -> "PandasDataFrameLike":
     for field in schema.fields:
         if isinstance(
-            field.dataType,
-            (
-                ByteType,
-                ShortType,
-                IntegerType,
-                LongType,
-                FloatType,
-                DoubleType,
-                TimestampType,
-                TimestampNTZType,
-                DayTimeIntervalType,
-            ),
+                field.dataType,
+                (
+                        ByteType,
+                        ShortType,
+                        IntegerType,
+                        LongType,
+                        FloatType,
+                        DoubleType,
+                        TimestampType,
+                        TimestampNTZType,
+                        DayTimeIntervalType,
+                ),
         ):
             np_type = _to_numpy_type(field.dataType)
             df[field.name] = df[field.name].astype(np_type)

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -2452,6 +2452,23 @@ class TypesTestsMixin:
         with self.assertRaises(PySparkValueError, msg="Rows cannot be of type VariantVal"):
             self.spark.createDataFrame([VariantVal.parseJson("2")], "v variant")
 
+    def test_variant_to_pandas(self):
+        import pandas as pd
+        import json
+
+        expected_values = [
+            ("str", '"%s"' % ("0123456789" * 10), "0123456789" * 10),
+            ("short_str", '"abc"', "abc"),
+        ]
+        json_str = "{%s}" % ",".join(['"%s": %s' % (t[0], t[1]) for t in expected_values])
+        df = self.spark.createDataFrame([({"json": json_str})])
+        df_variant = df.select(F.parse_json(df.json).alias("v"))
+        pandas = df_variant.toPandas()
+        test_record = json.loads(pandas["v"].iloc[0].toJson())
+        self.assertIsInstance(pandas, pd.DataFrame)
+        self.assertEqual(expected_values[0][2], test_record["str"])
+        self.assertEqual(expected_values[1][2], test_record["short_str"])
+        
     def test_geospatial_encoding(self):
         df = self.spark.createDataFrame(
             [

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -2468,7 +2468,7 @@ class TypesTestsMixin:
         self.assertIsInstance(pandas, pd.DataFrame)
         self.assertEqual(expected_values[0][2], test_record["str"])
         self.assertEqual(expected_values[1][2], test_record["short_str"])
-        
+
     def test_geospatial_encoding(self):
         df = self.spark.createDataFrame(
             [


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When a dataframe is converted to Pandas, VariantVal is sent to the conversion function which is not checked resulting to error. This PR aims to fix it by returning the VariantVal value itself. 


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
df_variant = df.withColumn("variant_column", expr("parse_json(json_data)"))
pdf = df_variant.toPandas()
Above code returns error if there is no check for VariantVal value in convert varianttype method. 


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.
No

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Tested locally by doing the changes and running the code


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No