### PR TITLE
[SPARK-53516][SDP] Fix `spark.api.mode` arg process in SparkPipelines

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkPipelines.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkPipelines.scala
@@ -67,10 +67,10 @@ object SparkPipelines extends Logging {
           logError("--class argument not supported.")
           throw SparkUserAppException(SparkExitCode.EXIT_FAILURE)
         } else if ((opt == "--conf" || opt == "-c") && value.startsWith(s"$SPARK_API_MODE=")) {
-          val v = value.stripPrefix(s"$SPARK_API_MODE=")
-          if (v.trim.toLowerCase(Locale.ROOT) != "connect") {
+          val apiMode = value.stripPrefix(s"$SPARK_API_MODE=").trim
+          if (apiMode.toLowerCase(Locale.ROOT) != "connect") {
             logError(
-              s"$SPARK_API_MODE must be 'connect' (was '$v'). " +
+              s"$SPARK_API_MODE must be 'connect' (was '$apiMode'). " +
                 "Declarative Pipelines currently only supports Spark Connect."
             )
             throw SparkUserAppException(SparkExitCode.EXIT_FAILURE)

--- a/core/src/main/scala/org/apache/spark/deploy/SparkPipelines.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkPipelines.scala
@@ -25,6 +25,7 @@ import scala.jdk.CollectionConverters._
 
 import org.apache.spark.SparkUserAppException
 import org.apache.spark.internal.Logging
+import org.apache.spark.launcher.SparkLauncher.SPARK_API_MODE
 import org.apache.spark.launcher.SparkSubmitArgumentsParser
 import org.apache.spark.util.SparkExitCode
 
@@ -65,10 +66,11 @@ object SparkPipelines extends Logging {
         } else if (opt == "--class") {
           logError("--class argument not supported.")
           throw SparkUserAppException(SparkExitCode.EXIT_FAILURE)
-        } else if ((opt == "--conf" || opt == "-c") && value.startsWith("spark.api.mode=")) {
-          if (value.stripPrefix("spark.api.mode=").trim.toLowerCase(Locale.ROOT) != "connect") {
+        } else if ((opt == "--conf" || opt == "-c") && value.startsWith(s"$SPARK_API_MODE=")) {
+          val v = value.stripPrefix(s"$SPARK_API_MODE=")
+          if (v.trim.toLowerCase(Locale.ROOT) != "connect") {
             logError(
-              "spark.api.mode must be 'connect'. " +
+              s"$SPARK_API_MODE must be 'connect', but was '$v'. " +
                 "Declarative Pipelines currently only supports Spark Connect."
             )
             throw SparkUserAppException(SparkExitCode.EXIT_FAILURE)
@@ -99,7 +101,7 @@ object SparkPipelines extends Logging {
     }
 
     sparkSubmitArgs += "--conf"
-    sparkSubmitArgs += "spark.api.mode=connect"
+    sparkSubmitArgs += s"$SPARK_API_MODE=connect"
     sparkSubmitArgs += "--remote"
     sparkSubmitArgs += remote
     (sparkSubmitArgs.toSeq, pipelinesArgs.toSeq)

--- a/core/src/main/scala/org/apache/spark/deploy/SparkPipelines.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkPipelines.scala
@@ -70,7 +70,7 @@ object SparkPipelines extends Logging {
           val v = value.stripPrefix(s"$SPARK_API_MODE=")
           if (v.trim.toLowerCase(Locale.ROOT) != "connect") {
             logError(
-              s"$SPARK_API_MODE must be 'connect', but was '$v'. " +
+              s"$SPARK_API_MODE must be 'connect' (was '$v'). " +
                 "Declarative Pipelines currently only supports Spark Connect."
             )
             throw SparkUserAppException(SparkExitCode.EXIT_FAILURE)

--- a/core/src/main/scala/org/apache/spark/deploy/SparkPipelines.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkPipelines.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.deploy
 
 import java.util
+import java.util.Locale
 
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
@@ -62,16 +63,16 @@ object SparkPipelines extends Logging {
         if (opt == "--remote") {
           remote = value
         } else if (opt == "--class") {
-          logInfo("--class argument not supported.")
+          logError("--class argument not supported.")
           throw SparkUserAppException(SparkExitCode.EXIT_FAILURE)
-        } else if (opt == "--conf" &&
-          value.startsWith("spark.api.mode=") &&
-          value != "spark.api.mode=connect") {
-          logInfo(
-            "--spark.api.mode must be 'connect'. " +
-            "Declarative Pipelines currently only supports Spark Connect."
-          )
-          throw SparkUserAppException(SparkExitCode.EXIT_FAILURE)
+        } else if (opt == "--conf" && value.startsWith("spark.api.mode=")) {
+          if (value.toLowerCase(Locale.ROOT) != "spark.api.mode=connect") {
+            logError(
+              "--spark.api.mode must be 'connect'. " +
+                "Declarative Pipelines currently only supports Spark Connect."
+            )
+            throw SparkUserAppException(SparkExitCode.EXIT_FAILURE)
+          }
         } else if (Seq("--name", "-h", "--help").contains(opt)) {
           pipelinesArgs += opt
           if (value != null && value.nonEmpty) {

--- a/core/src/main/scala/org/apache/spark/deploy/SparkPipelines.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkPipelines.scala
@@ -65,10 +65,10 @@ object SparkPipelines extends Logging {
         } else if (opt == "--class") {
           logError("--class argument not supported.")
           throw SparkUserAppException(SparkExitCode.EXIT_FAILURE)
-        } else if (opt == "--conf" && value.startsWith("spark.api.mode=")) {
-          if (value.toLowerCase(Locale.ROOT) != "spark.api.mode=connect") {
+        } else if ((opt == "--conf" || opt == "-c") && value.startsWith("spark.api.mode=")) {
+          if (value.stripPrefix("spark.api.mode=").trim.toLowerCase(Locale.ROOT) != "connect") {
             logError(
-              "--spark.api.mode must be 'connect'. " +
+              "spark.api.mode must be 'connect'. " +
                 "Declarative Pipelines currently only supports Spark Connect."
             )
             throw SparkUserAppException(SparkExitCode.EXIT_FAILURE)

--- a/core/src/test/scala/org/apache/spark/deploy/SparkPipelinesSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkPipelinesSuite.scala
@@ -118,6 +118,10 @@ class SparkPipelinesSuite extends SparkSubmitTestUtils with BeforeAndAfterEach {
     intercept[SparkUserAppException] {
       SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc")
     }
+    args = Array("-c", "spark.api.mode=classic")
+    intercept[SparkUserAppException] {
+      SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc")
+    }
     args = Array("--conf", "spark.api.mode=CONNECT")
     assert(
       SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
@@ -141,6 +145,28 @@ class SparkPipelinesSuite extends SparkSubmitTestUtils with BeforeAndAfterEach {
         )
     )
     args = Array("--conf", "spark.api.mode=connect")
+    assert(
+      SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
+        Seq(
+          "--conf",
+          "spark.api.mode=connect",
+          "--remote",
+          "local",
+          "abc/python/pyspark/pipelines/cli.py"
+        )
+    )
+    args = Array("--conf", "spark.api.mode= connect")
+    assert(
+      SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
+        Seq(
+          "--conf",
+          "spark.api.mode=connect",
+          "--remote",
+          "local",
+          "abc/python/pyspark/pipelines/cli.py"
+        )
+    )
+    args = Array("-c", "spark.api.mode=connect")
     assert(
       SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
         Seq(

--- a/core/src/test/scala/org/apache/spark/deploy/SparkPipelinesSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkPipelinesSuite.scala
@@ -113,6 +113,46 @@ class SparkPipelinesSuite extends SparkSubmitTestUtils with BeforeAndAfterEach {
     }
   }
 
+  test("spark.api.mode arg") {
+    var args = Array("--conf", "spark.api.mode=classic")
+    intercept[SparkUserAppException] {
+      SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc")
+    }
+    args = Array("--conf", "spark.api.mode=CONNECT")
+    assert(
+      SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
+        Seq(
+          "--conf",
+          "spark.api.mode=connect",
+          "--remote",
+          "local",
+          "abc/python/pyspark/pipelines/cli.py"
+        )
+    )
+    args = Array("--conf", "spark.api.mode=CoNNect")
+    assert(
+      SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
+        Seq(
+          "--conf",
+          "spark.api.mode=connect",
+          "--remote",
+          "local",
+          "abc/python/pyspark/pipelines/cli.py"
+        )
+    )
+    args = Array("--conf", "spark.api.mode=connect")
+    assert(
+      SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
+        Seq(
+          "--conf",
+          "spark.api.mode=connect",
+          "--remote",
+          "local",
+          "abc/python/pyspark/pipelines/cli.py"
+        )
+    )
+  }
+
   test("name arg") {
     val args = Array(
       "init",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes below issues:

- Trim the value of `spark.api.mode` before evaluation
- The value of `spark.api.mode` should be case insensitive
- Support both `-c spark.api.mode=xxx` and `--conf spark.api.mode=xxx`
- Avoid duplicated `--conf spark.api.mode=connect` args in the final generated commands

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bug fix.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, SDP is an unreleased feature.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT is added.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.