### PR TITLE
[SPARK-53518][SQL] No truncation for catalogString of User Defined Type

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/types/UserDefinedType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/UserDefinedType.scala
@@ -93,7 +93,7 @@ abstract class UserDefinedType[UserType >: Null] extends DataType with Serializa
     case _ => false
   }
 
-  override def catalogString: String = sqlType.simpleString
+  override def catalogString: String = sqlType.catalogString
 
   /**
    * This method is used to convert the value of a UDT to a string representation.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/TestUDT.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/TestUDT.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.types
 
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData}
@@ -131,4 +132,23 @@ private[spark] class ExampleSubTypeUDT extends UserDefinedType[IExampleSubType] 
   }
 
   override def userClass: Class[IExampleSubType] = classOf[IExampleSubType]
+}
+
+
+class ExampleIntRowUDT(cols: Int) extends UserDefinedType[Row] {
+  override def sqlType: DataType = {
+    StructType((0 until cols).map(i =>
+      StructField(s"col$i", IntegerType, nullable = false)))
+  }
+
+  override def serialize(obj: Row): InternalRow = {
+    InternalRow.fromSeq(obj.toSeq)
+  }
+
+  override def deserialize(datum: Any): Row = {
+    val internalRow = datum.asInstanceOf[InternalRow]
+    Row.fromSeq(internalRow.toSeq(sqlType.asInstanceOf[StructType]))
+  }
+
+  override def userClass: Class[Row] = classOf[Row]
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/UserDefinedTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UserDefinedTypeSuite.scala
@@ -330,4 +330,11 @@ class UserDefinedTypeSuite extends QueryTest with SharedSparkSession with Parque
       spark.range(10).map(i => Year.of(i.toInt + 2018)),
       (0 to 9).map(i => Year.of(i + 2018)): _*)
   }
+
+  test("SPARK-53518: No truncation for catalogString of User Defined Type") {
+    withSQLConf(SQLConf.MAX_TO_STRING_FIELDS.key -> "3") {
+      val string = new ExampleIntRowUDT(4).catalogString
+      assert(string == "struct<col0:int,col1:int,col2:int,col3:int>")
+    }
+  }
 }


### PR DESCRIPTION


### What changes were proposed in this pull request?

`catalogString` of User Defined Type is mistakenly truncated, which leads to catalog errors.


### Why are the changes needed?

bugfix


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
New Unit Test

### Was this patch authored or co-authored using generative AI tooling?
no
