### PR TITLE
[SPARK-50888][CONNECT][TESTS][4.0] Remove flaky assertion from `SparkConnectServiceSuite`

### DIFF
--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
@@ -883,9 +883,6 @@ class SparkConnectServiceSuite
       }
     }
     def onNext(v: proto.ExecutePlanResponse): Unit = {
-      if (v.hasSchema) {
-        assert(executeHolder.eventsManager.status == ExecuteStatus.Analyzed)
-      }
       if (v.hasMetrics) {
         assert(executeHolder.eventsManager.status == ExecuteStatus.Finished)
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR backports #52248 to `branch-4.0`.

This PR removes an assertion from `SparkConnectServiceSuite.scala` to eliminate flakiness which affects the following tests in the test suite.

* `SPARK-44776: LocalTableScanExec`
* `SPARK-41224: collect data using arrow`

In those tests, [VerifyEvents#onNext](https://github.com/apache/spark/blob/9d27db940673196f64b1568d73c459f83eb6f788/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala#L913) is called and checked `assert(executeHolder.eventsManager.status == ExecuteStatus.Analyzed)`, which can fail and this PR proposes to remove this assertion.
If this assertion fails, an exception will be thrown and [VerifyEvents#onError](https://github.com/apache/spark/blob/9d27db940673196f64b1568d73c459f83eb6f788/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala#L921) is called but the reason this `onError` is called is not due to a query/command fails. So `executeHolder.eventsManager.hasError.isDefined` never changes to `true`.

`VerifyEvents#onNext` is indirectly called from [ExecuteGrpcResponseSender#sendResponse](https://github.com/apache/spark/blob/9d27db940673196f64b1568d73c459f83eb6f788/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteGrpcResponseSender.scala#L398), which runs on a sender thread.
On the other hand, an operation status is changed on another thread. Especially, transition to `Analyzed` status is done [here](https://github.com/apache/spark/blob/9d27db940673196f64b1568d73c459f83eb6f788/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/SparkConnectPlanExecution.scala#L75). But the status can transition to `ReadyForExecution` or `Finished` before `VerifyEvents#onNext` is called.
So, those tests can occasionally fail.

You can easily reproduce this issue by inserting sleep like as follows and then run those tests.
```
   def onNext(v: proto.ExecutePlanResponse): Unit = {
     if (v.hasSchema) {
+      Thread.sleep(5000)
       assert(executeHolder.eventsManager.status == ExecuteStatus.Analyzed)
     }
```

The solution this PR proposes is just removing the assertion.
In `VerifyEvents#onNext`, there is another assertion `assert(executeHolder.eventsManager.status == ExecuteStatus.Finished)` and I think having only this assertion is enough because the status changes to `Finished` through `Analyzed`.


### Why are the changes needed?
For test stability.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Inserting sleep into `onNext` like explained above and run the problematic tests.

### Was this patch authored or co-authored using generative AI tooling?
No.
