### PR TITLE
[SPARK-53505][CONNECT][FOLLOWUP][4.0] Import SparkException in `SparkConnectPlanner.scala` to make build success

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -32,7 +32,7 @@ import io.grpc.{Context, Status, StatusRuntimeException}
 import io.grpc.stub.StreamObserver
 import org.apache.commons.lang3.exception.ExceptionUtils
 
-import org.apache.spark.{SparkEnv, TaskContext}
+import org.apache.spark.{SparkEnv, SparkException, TaskContext}
 import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.api.python.{PythonEvalType, SimplePythonFunction}
 import org.apache.spark.connect.proto


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is a followup PR for #52253 for `branch-4.0`.
Because `SparkConnectPlanner.scala` in `branch-4.0` doesn't import `SparkException`, build fails.

* https://github.com/apache/spark/actions/runs/17544781168/job/49823768902

### Why are the changes needed?
To make GA happy.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
No.