### PR TITLE
[SPARK-53523][SQL] Named parameters respect `spark.sql.caseSensitive`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2360,7 +2360,8 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
         val inputType = extractInputType(args)
         val bound = unbound.bind(inputType)
         validateParameterModes(bound)
-        val rearrangedArgs = NamedParametersSupport.defaultRearrange(bound, args)
+        val rearrangedArgs =
+          NamedParametersSupport.defaultRearrange(bound, args, SQLConf.get.resolver)
         Call(ResolvedProcedure(catalog, ident, bound), rearrangedArgs, execute)
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.catalyst.expressions.xml._
 import org.apache.spark.sql.catalyst.plans.logical.{FunctionBuilderBase, Generate, LogicalPlan, OneRowRelation, Range}
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.util.ArrayImplicits._
 
@@ -1024,9 +1025,9 @@ object FunctionRegistry {
       name: String,
       builder: T,
       expressions: Seq[Expression]) : Seq[Expression] = {
-    val rearrangedExpressions = if (!builder.functionSignature.isEmpty) {
+    val rearrangedExpressions = if (builder.functionSignature.isDefined) {
       val functionSignature = builder.functionSignature.get
-      builder.rearrange(functionSignature, expressions, name)
+      builder.rearrange(functionSignature, expressions, name, SQLConf.get.resolver)
     } else {
       expressions
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -1936,7 +1936,7 @@ class SessionCatalog(
       }
 
     NamedParametersSupport.defaultRearrange(
-      FunctionSignature(paramNames), expressions, functionName)
+      FunctionSignature(paramNames), expressions, functionName, SQLConf.get.resolver)
   }
 
   /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/NamedParameterFunctionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/NamedParameterFunctionSuite.scala
@@ -22,8 +22,9 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, NamedArgu
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.plans.logical.{FunctionSignature, InputParameter, NamedParametersSupport}
 import org.apache.spark.sql.catalyst.util.TypeUtils.toSQLId
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.SQLConf._
 import org.apache.spark.sql.types.DataType
-
 
 case class DummyExpression(
     k1: Expression,
@@ -62,6 +63,8 @@ class NamedParameterFunctionSuite extends AnalysisTest {
   final val k3Arg = NamedArgumentExpression("k3", Literal("v3"))
   final val k4Arg = NamedArgumentExpression("k4", Literal("v4"))
   final val namedK1Arg = NamedArgumentExpression("k1", Literal("v1-2"))
+  final val upperCaseNamedK1Arg = NamedArgumentExpression("K1", Literal("v1"))
+  final val upperCaseNamedK4Arg = NamedArgumentExpression("K4", Literal("v4"))
   final val args = Seq(k1Arg, k4Arg, k2Arg, k3Arg)
 
   final val expectedSeq = Seq(Literal("v1"), Literal("v2"), Literal("v3"), Literal("v4"))
@@ -70,77 +73,203 @@ class NamedParameterFunctionSuite extends AnalysisTest {
     InputParameter("k1"), InputParameter("k2", Option(Literal("v2"))), InputParameter("k3")))
 
   test("Check rearrangement of expressions") {
-    val rearrangedArgs = NamedParametersSupport.defaultRearrange(
-      signature, args, "function")
-    for ((returnedArg, expectedArg) <- rearrangedArgs.zip(expectedSeq)) {
-      assert(returnedArg == expectedArg)
-    }
-    val rearrangedArgsWithBuilder =
-      FunctionRegistry.rearrangeExpressions("function", DummyExpressionBuilder, args)
-    for ((returnedArg, expectedArg) <- rearrangedArgsWithBuilder.zip(expectedSeq)) {
-      assert(returnedArg == expectedArg)
+    Seq("true", "false").foreach { cs =>
+      withSQLConf(CASE_SENSITIVE.key -> cs) {
+        val rearrangedArgs = NamedParametersSupport.defaultRearrange(
+          signature, args, "function", SQLConf.get.resolver)
+        for ((returnedArg, expectedArg) <- rearrangedArgs.zip(expectedSeq)) {
+          assert(returnedArg == expectedArg)
+        }
+        val rearrangedArgsWithBuilder =
+          FunctionRegistry.rearrangeExpressions("function", DummyExpressionBuilder, args)
+        for ((returnedArg, expectedArg) <- rearrangedArgsWithBuilder.zip(expectedSeq)) {
+          assert(returnedArg == expectedArg)
+        }
+      }
     }
   }
 
-  private def parseRearrangeException(functionSignature: FunctionSignature,
-                                      expressions: Seq[Expression],
-                                      functionName: String = "function"): SparkThrowable = {
+  private def parseRearrangeException(
+      functionSignature: FunctionSignature,
+      expressions: Seq[Expression],
+      functionName: String = "function"): SparkThrowable = {
     intercept[SparkThrowable](
-      NamedParametersSupport.defaultRearrange(functionSignature, expressions, functionName))
+      NamedParametersSupport.defaultRearrange(
+        functionSignature, expressions, functionName, SQLConf.get.resolver))
   }
 
   test("DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT") {
-    val condition =
-      "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT.BOTH_POSITIONAL_AND_NAMED"
-    checkError(
-      exception = parseRearrangeException(
-        signature, Seq(k1Arg, k2Arg, k3Arg, k4Arg, namedK1Arg), "foo"),
-      condition = condition,
-      parameters = Map("routineName" -> toSQLId("foo"), "parameterName" -> toSQLId("k1"))
-    )
-    checkError(
-      exception = parseRearrangeException(
-        signature, Seq(k1Arg, k2Arg, k3Arg, k4Arg, k4Arg), "foo"),
-      condition = "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT.DOUBLE_NAMED_ARGUMENT_REFERENCE",
-      parameters = Map("routineName" -> toSQLId("foo"), "parameterName" -> toSQLId("k4"))
-    )
+    Seq("true", "false").foreach { cs =>
+      withSQLConf(CASE_SENSITIVE.key -> cs) {
+        checkError(
+          exception = parseRearrangeException(
+            signature, Seq(k1Arg, k2Arg, k3Arg, k4Arg, namedK1Arg), "foo"),
+          condition = "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT.BOTH_POSITIONAL_AND_NAMED",
+          parameters = Map(
+            "routineName" -> toSQLId("foo"),
+            "parameterName" -> toSQLId("k1"))
+        )
+        checkError(
+          exception = parseRearrangeException(
+            signature, Seq(k1Arg, k2Arg, k3Arg, k4Arg, k4Arg), "foo"),
+          condition = "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT.DOUBLE_NAMED_ARGUMENT_REFERENCE",
+          parameters = Map(
+            "routineName" -> toSQLId("foo"),
+            "parameterName" -> toSQLId("k4"))
+        )
+      }
+    }
+
+    withSQLConf(CASE_SENSITIVE.key -> "true") {
+      checkError(
+        exception = parseRearrangeException(
+          signature, Seq(k1Arg, k2Arg, k3Arg, k4Arg, upperCaseNamedK1Arg), "foo"),
+        condition = "UNRECOGNIZED_PARAMETER_NAME",
+        parameters = Map(
+          "routineName" -> toSQLId("foo"),
+          "argumentName" -> toSQLId("K1"),
+          "proposal" -> (toSQLId("k1") + " " + toSQLId("k2") + " " + toSQLId("k3")))
+      )
+      checkError(
+        exception = parseRearrangeException(
+          signature, Seq(k1Arg, k2Arg, k3Arg, k4Arg, upperCaseNamedK4Arg), "foo"),
+        condition = "UNRECOGNIZED_PARAMETER_NAME",
+        parameters = Map(
+          "routineName" -> toSQLId("foo"),
+          "argumentName" -> toSQLId("K4"),
+          "proposal" -> (toSQLId("k4") + " " + toSQLId("k1") + " " + toSQLId("k2")))
+      )
+    }
+
+    withSQLConf(CASE_SENSITIVE.key -> "false") {
+      checkError(
+        exception = parseRearrangeException(
+          signature, Seq(k1Arg, k2Arg, k3Arg, k4Arg, upperCaseNamedK1Arg), "foo"),
+        condition = "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT.BOTH_POSITIONAL_AND_NAMED",
+        parameters = Map("routineName" -> toSQLId("foo"), "parameterName" -> toSQLId("K1"))
+      )
+      checkError(
+        exception = parseRearrangeException(
+          signature, Seq(k1Arg, k2Arg, k3Arg, k4Arg, upperCaseNamedK4Arg), "foo"),
+        condition = "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT.DOUBLE_NAMED_ARGUMENT_REFERENCE",
+        parameters = Map(
+          "routineName" -> toSQLId("foo"),
+          "parameterName" -> toSQLId("K4"))
+      )
+    }
   }
 
   test("REQUIRED_PARAMETER_NOT_FOUND") {
-    checkError(
-      exception = parseRearrangeException(signature, Seq(k1Arg, k2Arg, k3Arg), "foo"),
-      condition = "REQUIRED_PARAMETER_NOT_FOUND",
-      parameters = Map(
-        "routineName" -> toSQLId("foo"), "parameterName" -> toSQLId("k4"), "index" -> "2"))
+    Seq("true", "false").foreach { cs =>
+      withSQLConf(CASE_SENSITIVE.key -> cs) {
+        checkError(
+          exception = parseRearrangeException(signature, Seq(k1Arg, k2Arg, k3Arg), "foo"),
+          condition = "REQUIRED_PARAMETER_NOT_FOUND",
+          parameters = Map(
+            "routineName" -> toSQLId("foo"),
+            "parameterName" -> toSQLId("k4"),
+            "index" -> "2"))
+      }
+    }
+
+    withSQLConf(CASE_SENSITIVE.key -> "true") {
+      checkError(
+        exception = parseRearrangeException(
+          signature, Seq(upperCaseNamedK1Arg, k2Arg, k3Arg), "foo"),
+        condition = "UNRECOGNIZED_PARAMETER_NAME",
+        parameters = Map(
+          "routineName" -> toSQLId("foo"),
+          "argumentName" -> toSQLId("K1"),
+          "proposal" -> (toSQLId("k1") + " " + toSQLId("k2") + " " + toSQLId("k3"))))
+    }
+
+    withSQLConf(CASE_SENSITIVE.key -> "false") {
+      checkError(
+        exception = parseRearrangeException(
+          signature, Seq(upperCaseNamedK1Arg, k2Arg, k3Arg), "foo"),
+        condition = "REQUIRED_PARAMETER_NOT_FOUND",
+        parameters = Map(
+          "routineName" -> toSQLId("foo"),
+          "parameterName" -> toSQLId("k4"),
+          "index" -> "3"))
+    }
   }
 
   test("UNRECOGNIZED_PARAMETER_NAME") {
-    checkError(
-      exception = parseRearrangeException(signature,
-        Seq(k1Arg, k2Arg, k3Arg, k4Arg, NamedArgumentExpression("k5", Literal("k5"))), "foo"),
-      condition = "UNRECOGNIZED_PARAMETER_NAME",
-      parameters = Map("routineName" -> toSQLId("foo"), "argumentName" -> toSQLId("k5"),
-        "proposal" -> (toSQLId("k1") + " " + toSQLId("k2") + " " + toSQLId("k3")))
-    )
+    Seq("true", "false").foreach { cs =>
+      withSQLConf(CASE_SENSITIVE.key -> cs) {
+        checkError(
+          exception = parseRearrangeException(signature,
+            Seq(k1Arg, k2Arg, k3Arg, k4Arg, NamedArgumentExpression("k5", Literal("k5"))), "foo"),
+          condition = "UNRECOGNIZED_PARAMETER_NAME",
+          parameters = Map(
+            "routineName" -> toSQLId("foo"),
+            "argumentName" -> toSQLId("k5"),
+            "proposal" -> (toSQLId("k1") + " " + toSQLId("k2") + " " + toSQLId("k3")))
+        )
+      }
+    }
+
+    withSQLConf(CASE_SENSITIVE.key -> "true") {
+      checkError(
+        exception = parseRearrangeException(
+          signature, Seq(upperCaseNamedK1Arg, k2Arg, k3Arg, k4Arg), "foo"),
+        condition = "UNRECOGNIZED_PARAMETER_NAME",
+        parameters = Map(
+          "routineName" -> toSQLId("foo"),
+          "argumentName" -> toSQLId("K1"),
+          "proposal" -> (toSQLId("k1") + " " + toSQLId("k2") + " " + toSQLId("k3"))))
+    }
+
+    withSQLConf(CASE_SENSITIVE.key -> "false") {
+      val rearrangedArgs = NamedParametersSupport.defaultRearrange(
+        signature, Seq(upperCaseNamedK1Arg, k2Arg, k3Arg, k4Arg), "foo", SQLConf.get.resolver)
+      for ((returnedArg, expectedArg) <- rearrangedArgs.zip(expectedSeq)) {
+        assert(returnedArg == expectedArg)
+      }
+    }
   }
 
   test("UNEXPECTED_POSITIONAL_ARGUMENT") {
-    checkError(
-      exception = parseRearrangeException(signature,
-        Seq(k2Arg, k3Arg, k1Arg, k4Arg), "foo"),
-      condition = "UNEXPECTED_POSITIONAL_ARGUMENT",
-      parameters = Map("routineName" -> toSQLId("foo"), "parameterName" -> toSQLId("k3"))
-    )
+    Seq("true", "false").foreach { cs =>
+      withSQLConf(CASE_SENSITIVE.key -> cs) {
+        checkError(
+          exception = parseRearrangeException(signature,
+            Seq(k4Arg, k3Arg, k1Arg, k2Arg), "foo"),
+          condition = "UNEXPECTED_POSITIONAL_ARGUMENT",
+          parameters = Map(
+            "routineName" -> toSQLId("foo"),
+            "parameterName" -> toSQLId("k3"))
+        )
+      }
+    }
+
+    Seq("true", "false").foreach { cs =>
+      withSQLConf(CASE_SENSITIVE.key -> cs) {
+        checkError(
+          exception = parseRearrangeException(signature,
+            Seq(upperCaseNamedK4Arg, k3Arg, k1Arg, k2Arg), "foo"),
+          condition = "UNEXPECTED_POSITIONAL_ARGUMENT",
+          parameters = Map(
+            "routineName" -> toSQLId("foo"),
+            "parameterName" -> toSQLId("k3"))
+        )
+      }
+    }
   }
 
   test("INTERNAL_ERROR: Enforce optional arguments after required arguments") {
     val errorMessage = s"Routine ${toSQLId("foo")} has an unexpected required argument for" +
       s" the provided routine signature ${illegalSignature.parameters.mkString("[", ", ", "]")}." +
       s" All required arguments should come before optional arguments."
-    checkError(
-      exception = parseRearrangeException(illegalSignature, args, "foo"),
-      condition = "INTERNAL_ERROR",
-      parameters = Map("message" -> errorMessage)
-    )
+    Seq("true", "false").foreach { cs =>
+      withSQLConf(CASE_SENSITIVE.key -> cs) {
+        checkError(
+          exception = parseRearrangeException(illegalSignature, args, "foo"),
+          condition = "INTERNAL_ERROR",
+          parameters = Map("message" -> errorMessage)
+        )
+      }
+    }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.classic.{DataFrame, Dataset, SparkSession}
 import org.apache.spark.sql.classic.ClassicConversions._
 import org.apache.spark.sql.classic.ExpressionUtils.expression
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.internal.TableValuedFunctionArgument
+import org.apache.spark.sql.internal.{SQLConf, TableValuedFunctionArgument}
 import org.apache.spark.sql.types.{DataType, StructType}
 
 /**
@@ -57,7 +57,7 @@ case class UserDefinedPythonFunction(
        * - don't have duplicated names
        * - don't contain positional arguments after named arguments
        */
-      NamedParametersSupport.splitAndCheckNamedArguments(e, name)
+      NamedParametersSupport.splitAndCheckNamedArguments(e, name, SQLConf.get.resolver)
     } else if (e.exists(_.isInstanceOf[NamedArgumentExpression])) {
       throw QueryCompilationErrors.namedArgumentsNotSupported(name)
     }
@@ -121,7 +121,7 @@ case class UserDefinedPythonTableFunction(
      * - don't have duplicated names
      * - don't contain positional arguments after named arguments
      */
-    NamedParametersSupport.splitAndCheckNamedArguments(exprs, name)
+    NamedParametersSupport.splitAndCheckNamedArguments(exprs, name, SQLConf.get.resolver)
 
     // Check which argument is a table argument here since it will be replaced with
     // `UnresolvedAttribute` to construct lateral join.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
As the title.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The issue was originally found during 

- https://github.com/apache/iceberg/pull/13106

I don't see any special reason that named parameters should always be case sensitive. (correct me if I'm wrong)

I tested PostgreSQL, and the named parameters are case-insensitive by default. 

```
psql (17.6 (Debian 17.6-1.pgdg13+1))
Type "help" for help.

postgres=# CREATE FUNCTION concat_lower_or_upper(a text, b text, uppercase boolean DEFAULT false)
RETURNS text
AS
$$
 SELECT CASE
        WHEN $3 THEN UPPER($1 || ' ' || $2)
        ELSE LOWER($1 || ' ' || $2)
        END;
$$
LANGUAGE SQL IMMUTABLE STRICT;
CREATE FUNCTION
postgres=# SELECT concat_lower_or_upper('Hello', 'World', true);
 concat_lower_or_upper
-----------------------
 HELLO WORLD
(1 row)

postgres=# SELECT concat_lower_or_upper(a => 'Hello', b => 'World');
 concat_lower_or_upper
-----------------------
 hello world
(1 row)

postgres=# SELECT concat_lower_or_upper(A => 'Hello', b => 'World');
 concat_lower_or_upper
-----------------------
 hello world
(1 row)

postgres=#
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, named parameters used by functions, procedures now respect `spark.sql.caseSensitive`, instead of always performing case sensitive.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added UT.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.