### PR TITLE
[SPARK-53529][PYTHON][CONNECT] Fix `pyspark` connect client to support IPv6

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -393,22 +393,19 @@ class DefaultChannelBuilder(ChannelBuilder):
                     )
                 self.set(kv[0], urllib.parse.unquote(kv[1]))
 
-        netloc = self.url.netloc.split(":")
-        if len(netloc) == 1:
-            self._host = netloc[0]
-            self._port = DefaultChannelBuilder.default_port()
-        elif len(netloc) == 2:
-            self._host = netloc[0]
-            self._port = int(netloc[1])
-        else:
+        if not self.url.hostname:
             raise PySparkValueError(
                 errorClass="INVALID_CONNECT_URL",
                 messageParameters={
-                    "detail": f"Target destination '{self.url.netloc}' should match the "
-                    f"'<host>:<port>' pattern. Please update the destination to follow "
-                    f"the correct format, e.g., 'hostname:port'.",
+                    "detail": f"Hostname is missing in the URL: '{self.url.geturl()}'. "
+                    "Please update the URL to follow the correct format, "
+                    "e.g., 'sc://hostname:port'.",
                 },
             )
+        self._host = f"[{self.url.hostname}]" if ":" in self.url.hostname else self.url.hostname
+        self._port = (
+            self.url.port if self.url.port is not None else DefaultChannelBuilder.default_port()
+        )
 
     @property
     def secure(self) -> bool:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, python connect client doen't support remote address with ipv6 format. For example
```shell
bin/pyspark --remote "sc://[xxxx:xxxx:xx:xxx::xx]:yyyy" 
``` 

It will throw 
```
pyspark.errors.exceptions.base.PySparkValueError: [INVALID_CONNECT_URL] Invalid URL for Spark Connect: Target destination '[xxxx:xxxx:xx:xxx::xx]:yyyy' should match the '<host>:<port>' pattern. Please update the destination to follow the correct format, e.g., 'hostname:port'.
``` 

### Why are the changes needed?
Make spark connect supports remote address with ipv6 format


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manually.

My test Env:  
```
Spark 4.0
Python 3.10.18
 and some core pip packages are
    grpcio                        1.74.0
    pandas                        2.2.3
``` 

My test step
1. First start spark connect server by `sbin/start-connect-server.sh` on an ipv6 host
2. Connect it using **python** client with command `bin/pyspark --remote "sc://[$IPV6_ADDRESS]:$PORT"`

<img width="1974" height="690" alt="image" src="https://github.com/user-attachments/assets/feef4cb0-ef37-4442-9313-976883b34c94" />

3. Connect it using **scala** client with command `bin/spark-shell --remote "sc://[$IPV6_ADDRESS]:$PORT"`
<img width="2022" height="882" alt="image" src="https://github.com/user-attachments/assets/073bd7e1-e8d6-4494-ad94-fabff6c09b28" />


### Was this patch authored or co-authored using generative AI tooling?
No
