### PR TITLE
[SPARK-53532][BUILD][3.5] Upgrade Jetty to 9.4.58.v20250814

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -130,8 +130,8 @@ jersey-container-servlet/2.40//jersey-container-servlet-2.40.jar
 jersey-hk2/2.40//jersey-hk2-2.40.jar
 jersey-server/2.40//jersey-server-2.40.jar
 jettison/1.1//jettison-1.1.jar
-jetty-util-ajax/9.4.56.v20240826//jetty-util-ajax-9.4.56.v20240826.jar
-jetty-util/9.4.56.v20240826//jetty-util-9.4.56.v20240826.jar
+jetty-util-ajax/9.4.58.v20250814//jetty-util-ajax-9.4.58.v20250814.jar
+jetty-util/9.4.58.v20250814//jetty-util-9.4.58.v20250814.jar
 jline/2.14.6//jline-2.14.6.jar
 joda-time/2.12.5//joda-time-2.12.5.jar
 jodd-core/3.5.2//jodd-core-3.5.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
     <parquet.version>1.13.1</parquet.version>
     <orc.version>1.9.7</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
-    <jetty.version>9.4.56.v20240826</jetty.version>
+    <jetty.version>9.4.58.v20250814</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>
     <chill.version>0.10.0</chill.version>
     <!--


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade Jetty from 9.4.56.v20240826 to 9.4.58.v20250814.


### Why are the changes needed?
Fix high-risk vulnerability.
https://github.com/jetty/jetty.project/security/advisories/GHSA-q4rv-gq96-w7c5

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass the CIs.


### Was this patch authored or co-authored using generative AI tooling?
No.
