### PR TITLE
[SPARK-53533][BUILD] Upgrade Jetty to 11.0.26

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -137,8 +137,8 @@ jersey-container-servlet/3.0.18//jersey-container-servlet-3.0.18.jar
 jersey-hk2/3.0.18//jersey-hk2-3.0.18.jar
 jersey-server/3.0.18//jersey-server-3.0.18.jar
 jettison/1.5.4//jettison-1.5.4.jar
-jetty-util-ajax/11.0.25//jetty-util-ajax-11.0.25.jar
-jetty-util/11.0.25//jetty-util-11.0.25.jar
+jetty-util-ajax/11.0.26//jetty-util-ajax-11.0.26.jar
+jetty-util/11.0.26//jetty-util-11.0.26.jar
 jjwt-api/0.12.6//jjwt-api-0.12.6.jar
 jjwt-impl/0.12.6//jjwt-impl-0.12.6.jar
 jjwt-jackson/0.12.6//jjwt-jackson-0.12.6.jar

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
     <parquet.version>1.16.0</parquet.version>
     <orc.version>2.2.0</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
-    <jetty.version>11.0.25</jetty.version>
+    <jetty.version>11.0.26</jetty.version>
     <jakartaservlet.version>5.0.0</jakartaservlet.version>
     <!-- SPARK-46938: Required by Hive / LibThrift libs -->
     <javaxservlet.version>4.0.1</javaxservlet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade Jetty from 11.0.25 to 11.0.26.


### Why are the changes needed?
To bring some bug fixes.
https://github.com/jetty/jetty.project/releases/tag/jetty-11.0.26


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass the CIs.


### Was this patch authored or co-authored using generative AI tooling?
No.
