### PR TITLE
[SPARK-51489][SQL]Represent SQL scripts in Spark UI

### DIFF
--- a/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
+++ b/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
@@ -424,6 +424,7 @@ message SQLExecutionUIData {
   repeated int64 stages = 12;
   bool metric_values_is_null = 13;
   map<int64, string> metric_values = 14;
+  optional string sql_script_id = 101;
 }
 
 message SparkPlanGraphNode {

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -3144,6 +3144,7 @@ object SparkContext extends Logging {
   private[spark] val SPARK_SCHEDULER_POOL = "spark.scheduler.pool"
   private[spark] val RDD_SCOPE_KEY = "spark.rdd.scope"
   private[spark] val RDD_SCOPE_NO_OVERRIDE_KEY = "spark.rdd.scope.noOverride"
+  private[spark] val SQL_SCRIPT_ID = "spark.execution.scriptId"
 
   /**
    * Executor id for the driver.  In earlier versions of Spark, this was `<driver>`, but this was

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SqlScriptingExecutionContextExtension.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SqlScriptingExecutionContextExtension.scala
@@ -17,7 +17,11 @@
 
 package org.apache.spark.sql.catalyst.catalog
 
+import java.util.UUID
+
 /**
  * Trait which provides an interface extension for SQL scripting execution context.
  */
-trait SqlScriptingExecutionContextExtension {}
+trait SqlScriptingExecutionContextExtension {
+  def scriptId: UUID
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -20,8 +20,12 @@ package org.apache.spark.sql.execution
 import java.io.{BufferedWriter, OutputStreamWriter}
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
+
+import scala.util.Try
 import scala.util.control.NonFatal
+
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.{SparkContext, SparkException}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.EXTENDED_EXPLAIN_GENERATOR
@@ -48,8 +52,6 @@ import org.apache.spark.sql.scripting.SqlScriptingExecution
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.util.{LazyTry, Utils}
 import org.apache.spark.util.ArrayImplicits._
-
-import scala.util.Try
 
 /**
  * The primary workflow for executing relational queries using Spark.  Designed to allow easy

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -149,7 +149,8 @@ object SQLExecution extends Logging {
               time = System.currentTimeMillis(),
               modifiedConfigs = redactedConfigs,
               jobTags = sc.getJobTags(),
-              jobGroupId = Option(sc.getLocalProperty(SparkContext.SPARK_JOB_GROUP_ID))
+              jobGroupId = Option(sc.getLocalProperty(SparkContext.SPARK_JOB_GROUP_ID)),
+              sqlScriptId = queryExecution.sqlScriptId.map(_.toString)
             )
             try {
               body match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/AllExecutionsPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/AllExecutionsPage.scala
@@ -273,6 +273,8 @@ private[ui] class ExecutionPagedTable(
 
   private val showSubExecutions = subExecutions.exists(_._2.nonEmpty)
 
+  private val showScriptId = data.exists(_.sqlScriptId.isDefined)
+
   override def tableId: String = s"$executionTag-table"
 
   override def tableCssClass: String =
@@ -302,6 +304,12 @@ private[ui] class ExecutionPagedTable(
       ("Submitted", true, None),
       ("Duration", true, Some("Time from query submission to completion (or if still executing," +
         " time since submission)"))) ++ {
+      if (showScriptId) {
+        Seq(("SQL Script ID", true, None))
+      } else {
+        Nil
+      }
+    } ++ {
       if (showRunningJobs && showSucceededJobs && showFailedJobs) {
         Seq(
           ("Running Job IDs", true, None),
@@ -381,6 +389,11 @@ private[ui] class ExecutionPagedTable(
         <td sorttable_customkey={duration.toString}>
           {UIUtils.formatDuration(duration)}
         </td>
+        {if (showScriptId) {
+        <td sorttable_customkey={executionUIData.sqlScriptId.getOrElse("")}>
+          {executionUIData.sqlScriptId.getOrElse("")}
+        </td>
+        }}
         {if (showRunningJobs) {
           <td>
             {jobLinks(executionTableRow.runningJobData)}
@@ -437,6 +450,11 @@ private[ui] class ExecutionPagedTable(
                     <td sorttable_customkey={duration.toString}>
                       {UIUtils.formatDuration(duration)}
                     </td>
+                    {if (showScriptId) {
+                    <td sorttable_customkey={executionUIData.sqlScriptId.getOrElse("")}>
+                      {executionUIData.sqlScriptId.getOrElse("")}
+                    </td>
+                    }}
                     {if (showRunningJobs) {
                       <td>
                         {jobLinks(rowData.runningJobData)}
@@ -569,6 +587,7 @@ private[ui] class ExecutionDataSource(
       case "Description" => Ordering.by(_.executionUIData.description)
       case "Submitted" => Ordering.by(_.executionUIData.submissionTime)
       case "Duration" => Ordering.by(_.duration)
+      case "SQL Script ID" => Ordering.by(_.executionUIData.sqlScriptId)
       case "Job IDs" | "Succeeded Job IDs" => Ordering by (_.completedJobData.headOption)
       case "Running Job IDs" => Ordering.by(_.runningJobData.headOption)
       case "Failed Job IDs" => Ordering.by(_.failedJobData.headOption)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
@@ -75,6 +75,13 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
               <strong>Duration: </strong>{UIUtils.formatDuration(duration)}
             </li>
             {
+              if (executionUIData.sqlScriptId.isDefined) {
+                <li>
+                  <Strong>SQL Script ID: </Strong>{executionUIData.sqlScriptId.get}
+                </li>
+              }
+            }
+            {
               if (executionUIData.rootExecutionId != executionId) {
                 <li>
                   <strong>Parent Execution: </strong>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListener.scala
@@ -343,7 +343,7 @@ class SQLAppStatusListener(
 
   private def onExecutionStart(event: SparkListenerSQLExecutionStart): Unit = {
     val SparkListenerSQLExecutionStart(executionId, rootExecutionId, description, details,
-      physicalPlanDescription, sparkPlanInfo, time, modifiedConfigs, _, _) = event
+      physicalPlanDescription, sparkPlanInfo, time, modifiedConfigs, _, _, sqlScriptId) = event
 
     val planGraph = SparkPlanGraph(sparkPlanInfo)
     val sqlPlanMetrics = planGraph.allNodes.flatMap { node =>
@@ -364,6 +364,7 @@ class SQLAppStatusListener(
     exec.modifiedConfigs = modifiedConfigs
     exec.addMetrics(sqlPlanMetrics)
     exec.submissionTime = time
+    exec.sqlScriptId = sqlScriptId
     update(exec)
   }
 
@@ -505,6 +506,8 @@ private class LiveExecutionData(val executionId: Long) extends LiveEntity {
   var stages = Set[Int]()
   var driverAccumUpdates = Seq[(Long, Long)]()
 
+  var sqlScriptId: Option[String] = None
+
   @volatile var metricsValues: Map[Long, String] = null
 
   // Just in case job end and execution end arrive out of order, keep track of how many
@@ -525,7 +528,8 @@ private class LiveExecutionData(val executionId: Long) extends LiveEntity {
       errorMessage,
       jobs,
       stages,
-      metricsValues)
+      metricsValues,
+      sqlScriptId)
   }
 
   def addMetrics(newMetrics: collection.Seq[SQLPlanMetric]): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLAppStatusStore.scala
@@ -102,7 +102,8 @@ class SQLExecutionUIData(
      * from the SQL listener instance.
      */
     @JsonDeserialize(keyAs = classOf[JLong])
-    val metricValues: Map[Long, String]) {
+    val metricValues: Map[Long, String],
+    val sqlScriptId: Option[String]) {
 
   @JsonIgnore @KVIndex("completionTime")
   private def completionTimeIndex: Long = completionTime.map(_.getTime).getOrElse(-1L)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLListener.scala
@@ -55,7 +55,8 @@ case class SparkListenerSQLExecutionStart(
     time: Long,
     modifiedConfigs: Map[String, String] = Map.empty,
     jobTags: Set[String] = Set.empty,
-    jobGroupId: Option[String] = None)
+    jobGroupId: Option[String] = None,
+    sqlScriptId: Option[String])
   extends SparkListenerEvent
 
 @DeveloperApi

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLListener.scala
@@ -56,7 +56,7 @@ case class SparkListenerSQLExecutionStart(
     modifiedConfigs: Map[String, String] = Map.empty,
     jobTags: Set[String] = Set.empty,
     jobGroupId: Option[String] = None,
-    sqlScriptId: Option[String])
+    sqlScriptId: Option[String] = None)
   extends SparkListenerEvent
 
 @DeveloperApi

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecution.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.scripting
 
+import java.util.UUID
+
 import org.apache.spark.{SparkContext, SparkThrowable}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.SqlScriptingContextManager
@@ -25,8 +27,6 @@ import org.apache.spark.sql.catalyst.plans.logical.{CommandResult, CompoundBody,
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.classic.{DataFrame, SparkSession}
 import org.apache.spark.sql.types.StructType
-
-import java.util.UUID
 
 /**
  * SQL scripting executor - executes script and returns result statements.

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionContext.scala
@@ -18,8 +18,10 @@
 package org.apache.spark.sql.scripting
 
 import java.util.{Locale, UUID}
+
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
+
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.catalog.{SqlScriptingExecutionContextExtension, VariableDefinition}
 import org.apache.spark.sql.scripting.SqlScriptingFrameType.SqlScriptingFrameType

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionContext.scala
@@ -17,11 +17,9 @@
 
 package org.apache.spark.sql.scripting
 
-import java.util.Locale
-
+import java.util.{Locale, UUID}
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.catalog.{SqlScriptingExecutionContextExtension, VariableDefinition}
 import org.apache.spark.sql.scripting.SqlScriptingFrameType.SqlScriptingFrameType
@@ -29,7 +27,9 @@ import org.apache.spark.sql.scripting.SqlScriptingFrameType.SqlScriptingFrameTyp
 /**
  * SQL scripting execution context - keeps track of the current execution state.
  */
-class SqlScriptingExecutionContext extends SqlScriptingExecutionContextExtension {
+class SqlScriptingExecutionContext(
+  override val scriptId: UUID
+) extends SqlScriptingExecutionContextExtension {
   // List of frames that are currently active.
   private[scripting] val frames: ListBuffer[SqlScriptingExecutionFrame] = ListBuffer.empty
   private[scripting] var firstHandlerScopeLabel: Option[String] = None

--- a/sql/core/src/main/scala/org/apache/spark/status/protobuf/sql/SQLExecutionUIDataSerializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/protobuf/sql/SQLExecutionUIDataSerializer.scala
@@ -57,6 +57,7 @@ private[protobuf] class SQLExecutionUIDataSerializer extends ProtobufSerDe[SQLEx
         case (k, v) => builder.putMetricValues(k, v)
       }
     }
+    builder.setSqlScriptId(ui.sqlScriptId.orNull)
     builder.build().toByteArray
   }
 
@@ -92,7 +93,8 @@ private[protobuf] class SQLExecutionUIDataSerializer extends ProtobufSerDe[SQLEx
       errorMessage = errorMessage,
       jobs = jobs,
       stages = ui.getStagesList.asScala.map(_.toInt).toSet,
-      metricValues = metricValues
+      metricValues = metricValues,
+      sqlScriptId = Option(ui.getSqlScriptId)
     )
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/status/protobuf/sql/SQLExecutionUIDataSerializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/protobuf/sql/SQLExecutionUIDataSerializer.scala
@@ -57,7 +57,7 @@ private[protobuf] class SQLExecutionUIDataSerializer extends ProtobufSerDe[SQLEx
         case (k, v) => builder.putMetricValues(k, v)
       }
     }
-    builder.setSqlScriptId(ui.sqlScriptId.orNull)
+    ui.sqlScriptId.foreach(id => builder.setSqlScriptId(id))
     builder.build().toByteArray
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLExecutionSuite.scala
@@ -20,11 +20,9 @@ package org.apache.spark.sql.execution
 import java.util.Locale
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
-
 import scala.collection.parallel.immutable.ParRange
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
-
 import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListenerJobStart}
@@ -32,9 +30,12 @@ import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.classic
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.util.ThreadUtils
 import org.apache.spark.util.Utils.REDACTION_REPLACEMENT_TEXT
+
+import scala.collection.mutable.ListBuffer
 
 class SQLExecutionSuite extends SparkFunSuite with SQLConfHelper {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLExecutionSuite.scala
@@ -20,9 +20,11 @@ package org.apache.spark.sql.execution
 import java.util.Locale
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
+
 import scala.collection.parallel.immutable.ParRange
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
+
 import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListenerJobStart}
@@ -30,12 +32,9 @@ import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.classic
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.util.ThreadUtils
 import org.apache.spark.util.Utils.REDACTION_REPLACEMENT_TEXT
-
-import scala.collection.mutable.ListBuffer
 
 class SQLExecutionSuite extends SparkFunSuite with SQLConfHelper {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
@@ -344,7 +344,7 @@ abstract class SQLAppStatusListenerSuite extends SharedSparkSession with JsonTes
       val listener = new SparkListener {
         override def onOtherEvent(event: SparkListenerEvent): Unit = {
           event match {
-            case SparkListenerSQLExecutionStart(_, _, _, _, planDescription, _, _, _, _, _) =>
+            case SparkListenerSQLExecutionStart(_, _, _, _, planDescription, _, _, _, _, _, _) =>
               assert(expected.forall(planDescription.contains))
               checkDone = true
             case _ => // ignore other events

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.scripting
 
+import java.util.UUID
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Literal}
@@ -89,7 +91,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
     override def output: Seq[Attribute] = Seq.empty
   }
 
-  case class MockScriptingContext() extends SqlScriptingExecutionContext {
+  case class MockScriptingContext() extends SqlScriptingExecutionContext(UUID.randomUUID()) {
     override def enterScope(
       label: String,
       triggerHandlerMap: TriggerToExceptionHandlerMap

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -17,11 +17,12 @@
 
 package org.apache.spark.sql.scripting
 
-import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}
-
 import java.util.UUID
+
 import scala.collection.mutable.ListBuffer
+
 import org.apache.spark.{SparkArithmeticException, SparkConf}
+import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.CompoundBody

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingTestUtils.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.scripting
 
+import java.util.UUID
+
 import org.apache.spark.sql.catalyst.SqlScriptingContextManager
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.CompoundBody
@@ -50,7 +52,7 @@ trait SqlScriptingTestUtils {
 
     val interpreter = SqlScriptingInterpreter(spark)
 
-    val context = new SqlScriptingExecutionContext()
+    val context = new SqlScriptingExecutionContext(UUID.randomUUID())
     val executionPlan = interpreter.buildExecutionPlan(compoundBody, args, context)
     context.frames.append(
       new SqlScriptingExecutionFrame(executionPlan, SqlScriptingFrameType.SQL_SCRIPT)

--- a/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
@@ -94,7 +94,8 @@ object SqlResourceSuite {
         1 -> JobExecutionStatus.SUCCEEDED),
       stages = Set[Int](),
       metricValues = getMetricValues(),
-      errorMessage = None
+      errorMessage = None,
+      sqlScriptId = None
     )
   }
 
@@ -217,7 +218,8 @@ class SqlResourceSuite extends SparkFunSuite with PrivateMethodTester {
       jobs = Map.empty[Int, JobExecutionStatus],
       stages = Set[Int](),
       metricValues = getMetricValues(),
-      errorMessage = Some("now you see me, now you don't"))
+      errorMessage = Some("now you see me, now you don't"),
+      sqlScriptId = None)
     val executionData =
       sqlResource invokePrivate prepareExecutionData(
         d,

--- a/sql/core/src/test/scala/org/apache/spark/status/protobuf/sql/KVStoreProtobufSerializerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/status/protobuf/sql/KVStoreProtobufSerializerSuite.scala
@@ -51,7 +51,8 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
       errorMessage = normal.errorMessage,
       jobs = normal.jobs,
       stages = normal.stages,
-      metricValues = normal.metricValues
+      metricValues = normal.metricValues,
+      sqlScriptId = normal.sqlScriptId
     )
     Seq(normal, withNull).foreach { input =>
       val bytes = serializer.serialize(input)
@@ -88,7 +89,8 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
       errorMessage = templateData.errorMessage,
       jobs = templateData.jobs,
       stages = templateData.stages,
-      metricValues = Map.empty
+      metricValues = Map.empty,
+      sqlScriptId = templateData.sqlScriptId
     )
     val bytes1 = serializer.serialize(input1)
     val result1 = serializer.deserialize(bytes1, classOf[SQLExecutionUIData])
@@ -108,7 +110,8 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
       errorMessage = templateData.errorMessage,
       jobs = templateData.jobs,
       stages = templateData.stages,
-      metricValues = null
+      metricValues = null,
+      sqlScriptId = templateData.sqlScriptId
     )
     val bytes2 = serializer.serialize(input2)
     val result2 = serializer.deserialize(bytes2, classOf[SQLExecutionUIData])


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR introduces support for SQL Scripts in the Spark UI. A "SQL Script ID" sortable column is introduced in the All Executions table in `SQL / Dataframe` tab of Spark UI. The column is only shown if there is at least one statement which has been executed by a script. Also, it introduces a SQL Script ID label in the single SQL Execution page, which is only present if the SQL Execution is executed by a script.

A `sqlScriptId` is introduced for this purpose. It is an identifier which is unique per script **execution**. All statements within a single script execution will have the same `sqlScriptId`.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, Spark UI is expanded to show SQL Scripting information.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit test added for script id.
UI changes manually - screenshots below.

SQL / Dataframe tab before running script (unchanged):
<img width="1800" height="426" alt="image" src="https://github.com/user-attachments/assets/aecbd753-d296-4791-a6db-8aa22c1da732" />

SQL / Dataframe tab after running two scripts with two statements each:

<img width="1800" height="686" alt="image" src="https://github.com/user-attachments/assets/f28bcded-3410-42a5-af87-a499d280e5ee" />

Single execution page:
<img width="852" height="774" alt="image" src="https://github.com/user-attachments/assets/ff55176e-9225-48a4-972e-6903a0de8ce5" />


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
