### PR TITLE
[SPARK-53541][K8S][INFRA] Update K8s IT CI to use K8s 1.34

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1325,7 +1325,7 @@ jobs:
       - name: Start Minikube
         uses: medyagh/setup-minikube@v0.0.20
         with:
-          kubernetes-version: "1.33.0"
+          kubernetes-version: "1.34.0"
           # Github Action limit cpu:2, memory: 6947MB, limit to 2U6G for better resource statistic
           cpus: 2
           memory: 6144m


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to increase the K8s test version to 1.34

### Why are the changes needed?

To improve the test coverage because K8s 1.34.0 was released on 2025-08-27.
- https://kubernetes.io/blog/2025/08/27/kubernetes-v1-34-release/
- https://kubernetes.io/releases/#release-v1-34

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and check the CI log.

```
...
* Downloading Kubernetes v1.34.0 preload ...
...
System Info:
...
  Kubelet Version:            v1.34.0
```

### Was this patch authored or co-authored using generative AI tooling?

No.