### PR TITLE
[SPARK-53340][CONNECT] Make StreamingQueryCommand in SparkConnectPlanner side effect free

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/command/ConnectLeafRunnableCommand.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/command/ConnectLeafRunnableCommand.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.connect.execution.command
+
+import io.grpc.stub.StreamObserver
+
+import org.apache.spark.connect.proto
+import org.apache.spark.sql.{classic, Row, SparkSession}
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+
+trait ConnectLeafRunnableCommand extends LeafRunnableCommand {
+
+  final override def run(sparkSession: SparkSession): Seq[Row] = {
+    run(sparkSession.asInstanceOf[classic.SparkSession])
+  }
+
+  def run(sparkSession: classic.SparkSession): Seq[Row]
+
+  def handleConnectResponse(
+      responseObserver: StreamObserver[proto.ExecutePlanResponse],
+      sessionId: String,
+      serverSessionId: String): Unit = {
+    // Default implementation does nothing.
+  }
+}

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/command/StreamingQueryCommand.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/command/StreamingQueryCommand.scala
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.connect.execution.command
+
+import scala.jdk.CollectionConverters._
+
+import io.grpc.stub.StreamObserver
+
+import org.apache.spark.SparkException
+import org.apache.spark.connect.proto
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.classic.SparkSession
+import org.apache.spark.sql.connect.planner.InvalidInputErrors
+import org.apache.spark.sql.connect.service.SparkConnectService
+import org.apache.spark.sql.execution.streaming.runtime.StreamingQueryWrapper
+import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryProgress}
+import org.apache.spark.util.Utils
+
+case class StreamingQueryCommand(
+    command: proto.StreamingQueryCommand,
+    sparkSessionTags: Set[String],
+    responseBuilder: proto.StreamingQueryCommandResult.Builder)
+    extends ConnectLeafRunnableCommand
+    with Logging {
+
+  override def run(session: SparkSession): Seq[Row] = {
+    responseBuilder.setQueryId(command.getQueryId)
+
+    val id = command.getQueryId.getId
+    val runId = command.getQueryId.getRunId
+
+    // Find the query in connect service level cache, otherwise check session's active streams.
+    val query = SparkConnectService.streamingSessionManager
+      // Common case: query is cached in the cache.
+      .getCachedQuery(id, runId, sparkSessionTags, session)
+      .map(_.query)
+      .orElse { // Else try to find it in active streams. Mostly will not be found here either.
+        Option(session.streams.get(id))
+      } match {
+      case Some(query) if query.runId.toString == runId =>
+        query
+      case Some(query) =>
+        throw InvalidInputErrors.streamingQueryRunIdMismatch(id, runId, query.runId.toString)
+      case None =>
+        throw InvalidInputErrors.streamingQueryNotFound(id)
+    }
+    command.getCommandCase match {
+      case proto.StreamingQueryCommand.CommandCase.STATUS =>
+        val queryStatus = query.status
+
+        val statusResult = proto.StreamingQueryCommandResult.StatusResult
+          .newBuilder()
+          .setStatusMessage(queryStatus.message)
+          .setIsDataAvailable(queryStatus.isDataAvailable)
+          .setIsTriggerActive(queryStatus.isTriggerActive)
+          .setIsActive(query.isActive)
+          .build()
+
+        responseBuilder.setStatus(statusResult)
+
+      case proto.StreamingQueryCommand.CommandCase.LAST_PROGRESS |
+          proto.StreamingQueryCommand.CommandCase.RECENT_PROGRESS =>
+        val progressReports = if (command.getLastProgress) {
+          Option(query.lastProgress).toSeq
+        } else {
+          query.recentProgress.toSeq
+        }
+        responseBuilder.setRecentProgress(
+          proto.StreamingQueryCommandResult.RecentProgressResult
+            .newBuilder()
+            .addAllRecentProgressJson(
+              progressReports.map(StreamingQueryProgress.jsonString).asJava)
+            .build())
+
+      case proto.StreamingQueryCommand.CommandCase.STOP =>
+        query.stop()
+
+      case proto.StreamingQueryCommand.CommandCase.PROCESS_ALL_AVAILABLE =>
+        // This might take a long time, Spark-connect client keeps this connection alive.
+        query.processAllAvailable()
+
+      case proto.StreamingQueryCommand.CommandCase.EXPLAIN =>
+        val result = query match {
+          case q: StreamingQueryWrapper =>
+            q.streamingQuery.explainInternal(command.getExplain.getExtended)
+          case _ =>
+            throw SparkException.internalError(s"Unexpected type for streaming query: $query")
+        }
+        val explain = proto.StreamingQueryCommandResult.ExplainResult
+          .newBuilder()
+          .setResult(result)
+          .build()
+        responseBuilder.setExplain(explain)
+
+      case proto.StreamingQueryCommand.CommandCase.EXCEPTION =>
+        val result = query.exception
+        if (result.isDefined) {
+          // Throw StreamingQueryException directly and rely on error translation on the
+          // client-side to reconstruct the exception. Keep the remaining implementation
+          // for backward-compatibility
+          if (!command.getException) {
+            throw result.get
+          }
+          val e = result.get
+          val exception_builder = proto.StreamingQueryCommandResult.ExceptionResult
+            .newBuilder()
+          exception_builder
+            .setExceptionMessage(e.toString())
+            .setErrorClass(e.getCondition)
+
+          val stackTrace = Option(Utils.stackTraceToString(e))
+          stackTrace.foreach { s =>
+            exception_builder.setStackTrace(s)
+          }
+          responseBuilder.setException(exception_builder.build())
+        }
+
+      case proto.StreamingQueryCommand.CommandCase.AWAIT_TERMINATION =>
+        val timeout = if (command.getAwaitTermination.hasTimeoutMs) {
+          Some(command.getAwaitTermination.getTimeoutMs)
+        } else {
+          None
+        }
+        val terminated = handleStreamingAwaitTermination(query, timeout)
+        responseBuilder.getAwaitTerminationBuilder.setTerminated(terminated)
+
+      case other =>
+        throw InvalidInputErrors.invalidOneOfField(other, command.getDescriptorForType)
+    }
+
+    Seq.empty
+  }
+
+  override def handleConnectResponse(
+      responseObserver: StreamObserver[proto.ExecutePlanResponse],
+      sessionId: String,
+      serverSessionId: String): Unit = {
+    responseObserver.onNext(
+      proto.ExecutePlanResponse
+        .newBuilder()
+        .setSessionId(sessionId)
+        .setServerSideSessionId(serverSessionId)
+        .setStreamingQueryCommandResult(responseBuilder.build())
+        .build())
+  }
+
+  /**
+   * A helper function to handle streaming awaitTermination(). awaitTermination() can be a long
+   * running command. In this function, we periodically check if the RPC call has been cancelled.
+   * If so, we can stop the operation and release resources early.
+   * @param query
+   *   the query waits to be terminated
+   * @param timeoutOptionMs
+   *   optional. Timeout to wait for termination. If None, no timeout is set
+   * @return
+   *   if the query has terminated
+   */
+  private def handleStreamingAwaitTermination(
+      query: StreamingQuery,
+      timeoutOptionMs: Option[Long]): Boolean = {
+    // How often to check if RPC is cancelled and call awaitTermination()
+    val awaitTerminationIntervalMs = 10000
+    val startTimeMs = System.currentTimeMillis()
+
+    val timeoutTotalMs = timeoutOptionMs.getOrElse(Long.MaxValue)
+    var timeoutLeftMs = timeoutTotalMs
+    require(timeoutLeftMs > 0, "Timeout has to be positive")
+
+    val grpcContext = io.grpc.Context.current
+    while (!grpcContext.isCancelled) {
+      val awaitTimeMs = math.min(awaitTerminationIntervalMs, timeoutLeftMs)
+
+      val terminated = query.awaitTermination(awaitTimeMs)
+      if (terminated) {
+        return true
+      }
+
+      timeoutLeftMs = timeoutTotalMs - (System.currentTimeMillis() - startTimeMs)
+      if (timeoutLeftMs <= 0) {
+        return false
+      }
+    }
+
+    // gRPC is cancelled
+    logWarning("RPC context is cancelled when executing awaitTermination()")
+    throw new io.grpc.StatusRuntimeException(io.grpc.Status.CANCELLED)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR refactors `StreamingQueryCommand` handling in Spark Connect to make it side effect free by moving it from the planner to the execution layer:

1. **Created `ConnectLeafRunnableCommand` trait**: Extends `LeafRunnableCommand` with a `handleConnectResponse` method for Connect-specific response handling.

2. **Transform `proto.StreamingQueryCommand` to a command**: Previously handled directly in `SparkConnectPlanner.process()`, now transformed `proto.StreamingQueryCommand` to a command first.

3. **Enhanced `SparkConnectPlanExecution`**: Added logic to detect `ConnectLeafRunnableCommand` instances and call their `handleConnectResponse` method after execution.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Better separation of concerns by splitting the transformation and execution phases for proto.StreamingQueryCommand.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, this is purely an internal refactoring. The external API and behavior of streaming query commands remain exactly the same.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Cursor 1.5.9