### PR TITLE
[SPARK-53537][Core] Adding Support for Parsing CONTINUE HANDLER

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -282,11 +282,13 @@ class AstBuilder extends DataTypeAstBuilder
       parsingCtx: SqlScriptingParsingContext): ExceptionHandler = {
     val exceptionHandlerTriggers = visitConditionValuesImpl(ctx.conditionValues())
 
-    if (Option(ctx.CONTINUE()).isDefined) {
-      throw SqlScriptingErrors.continueHandlerNotSupported(CurrentOrigin.get)
+    val handlerType = if (Option(ctx.CONTINUE()).isDefined) {
+      ExceptionHandlerType.CONTINUE
+    }
+    else {
+      ExceptionHandlerType.EXIT
     }
 
-    val handlerType = ExceptionHandlerType.EXIT
     val body = if (Option(ctx.beginEndCompoundBlock()).isDefined) {
       visitBeginEndCompoundBlockImpl(
         ctx.beginEndCompoundBlock(),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -283,6 +283,9 @@ class AstBuilder extends DataTypeAstBuilder
     val exceptionHandlerTriggers = visitConditionValuesImpl(ctx.conditionValues())
 
     val handlerType = if (Option(ctx.CONTINUE()).isDefined) {
+      if (!conf.getConf(SQLConf.SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED)) {
+        throw SqlScriptingErrors.continueHandlerNotSupported(CurrentOrigin.get)
+      }
       ExceptionHandlerType.CONTINUE
     } else {
       ExceptionHandlerType.EXIT

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -284,8 +284,7 @@ class AstBuilder extends DataTypeAstBuilder
 
     val handlerType = if (Option(ctx.CONTINUE()).isDefined) {
       ExceptionHandlerType.CONTINUE
-    }
-    else {
+    } else {
       ExceptionHandlerType.EXIT
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4146,9 +4146,10 @@ object SQLConf {
 
   val SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED =
     buildConf("spark.sql.scripting.continueHandlerEnabled")
-      .doc("SQL Scripting CONTINUE HANDLER feature is under development and its use should be " +
-        "done under this feature flag. SQL Scripting CONTINUE HANDLER enables users to use " +
-        "CONTINUE HANDLER syntax inside SQL Scripts.")
+      .doc("EXPERIMENTAL FEATURE/WORK IN PROGRESS: SQL Scripting CONTINUE HANDLER feature " +
+        "is under development and still not working as intended. This feature switch is intended " +
+        "to be used internally for development and testing, not by end users. " +
+        "YOU ARE ADVISED AGAINST USING THIS FEATURE AS ITS NOT FINISHED.")
       .version("4.0.0")
       .booleanConf
       .createWithDefault(false)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4144,6 +4144,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED =
+    buildConf("spark.sql.scripting.continueHandlerEnabled")
+      .doc("SQL Scripting CONTINUE HANDLER feature is under development and its use should be " +
+        "done under this feature flag. SQL Scripting CONTINUE HANDLER enables users to use " +
+        "CONTINUE HANDLER syntax inside SQL Scripts.")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val CONCAT_BINARY_AS_STRING = buildConf("spark.sql.function.concatBinaryAsString")
     .doc("When this option is set to false and all inputs are binary, `functions.concat` returns " +
       "an output as binary. Otherwise, it returns as a string.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4150,7 +4150,7 @@ object SQLConf {
         "is under development and still not working as intended. This feature switch is intended " +
         "to be used internally for development and testing, not by end users. " +
         "YOU ARE ADVISED AGAINST USING THIS FEATURE AS ITS NOT FINISHED.")
-      .version("4.0.0")
+      .version("4.1.0")
       .booleanConf
       .createWithDefault(false)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4146,6 +4146,7 @@ object SQLConf {
 
   val SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED =
     buildConf("spark.sql.scripting.continueHandlerEnabled")
+      .internal()
       .doc("EXPERIMENTAL FEATURE/WORK IN PROGRESS: SQL Scripting CONTINUE HANDLER feature " +
         "is under development and still not working as intended. This feature switch is intended " +
         "to be used internally for development and testing, not by end users. " +

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -2854,27 +2854,27 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
   }
 
   test("continue handler not supported") {
-    val sqlScript =
-      """
-        |BEGIN
-        |  DECLARE OR REPLACE flag INT = -1;
-        |  DECLARE CONTINUE HANDLER FOR SQLSTATE '22012'
-        |  BEGIN
-        |    SET flag = 1;
-        |  END;
-        |  SELECT 1/0;
-        |  SELECT flag;
-        |END
-        |""".stripMargin
+    withSQLConf(SQLConf.SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED.key -> "false") {
+      val sqlScript =
+        """
+          |BEGIN
+          |  DECLARE OR REPLACE flag INT = -1;
+          |  DECLARE CONTINUE HANDLER FOR SQLSTATE '22012'
+          |  BEGIN
+          |    SET flag = 1;
+          |  END;
+          |  SELECT 1/0;
+          |  SELECT flag;
+          |END
+          |""".stripMargin
 
-    conf.unsetConf(SQLConf.SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED.key)
-    checkError(
-      exception = intercept[SqlScriptingException] {
-        parsePlan(sqlScript)
-      },
-      condition = "UNSUPPORTED_FEATURE.CONTINUE_EXCEPTION_HANDLER",
-      parameters = Map.empty)
-    conf.setConfString(SQLConf.SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED.key, "true")
+      checkError(
+        exception = intercept[SqlScriptingException] {
+          parsePlan(sqlScript)
+        },
+        condition = "UNSUPPORTED_FEATURE.CONTINUE_EXCEPTION_HANDLER",
+        parameters = Map.empty)
+    }
   }
 
   test("declare exit handler for qualified condition name that is not supported") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -30,7 +30,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
 
   protected override def beforeAll(): Unit = {
     super.beforeAll()
-    conf.setConfString(SQLConf.SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED.key, "true")
+    conf.setConf(SQLConf.SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED, true)
   }
 
   protected override def afterAll(): Unit = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -23,9 +23,20 @@ import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.plans.logical.{CompoundBody, CreateVariable, ExceptionHandler, ForStatement, IfElseStatement, IterateStatement, LeaveStatement, LoopStatement, Project, RepeatStatement, SearchedCaseStatement, SetVariable, SimpleCaseStatement, SingleStatement, WhileStatement}
 import org.apache.spark.sql.errors.DataTypeErrors.toSQLId
 import org.apache.spark.sql.exceptions.SqlScriptingException
+import org.apache.spark.sql.internal.SQLConf
 
 class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
   import CatalystSqlParser._
+
+  protected override def beforeAll(): Unit = {
+    super.beforeAll()
+    conf.setConfString(SQLConf.SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED.key, "true")
+  }
+
+  protected override def afterAll(): Unit = {
+    conf.unsetConf(SQLConf.SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED.key)
+    super.afterAll()
+  }
 
   // Tests
   test("single select") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -38,6 +38,16 @@ class SqlScriptingInterpreterSuite
     with SharedSparkSession
     with SqlScriptingTestUtils {
 
+  protected override def beforeAll(): Unit = {
+    super.beforeAll()
+    conf.setConfString(SQLConf.SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED.key, "true")
+  }
+
+  protected override def afterAll(): Unit = {
+    conf.unsetConf(SQLConf.SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED.key)
+    super.afterAll()
+  }
+
   // Helpers
   private def runSqlScript(
       sqlText: String,

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -3467,7 +3467,7 @@ class SqlScriptingInterpreterSuite
     }
   }
 
-  test("Duplicate SQLEXCEPTION Handler") {
+  test("Duplicate SQLEXCEPTION EXIT/EXIT Handler") {
     val sqlScript =
       """
         |BEGIN
@@ -3490,11 +3490,146 @@ class SqlScriptingInterpreterSuite
     )
   }
 
-  test("Duplicate NOT FOUND Handler") {
+  test("Duplicate NOT FOUND EXIT/EXIT Handler") {
     val sqlScript =
       """
         |BEGIN
         |  DECLARE EXIT HANDLER FOR NOT FOUND
+        |  BEGIN
+        |    SELECT 1;
+        |  END;
+        |  DECLARE EXIT HANDLER FOR NOT FOUND
+        |  BEGIN
+        |    SELECT 2;
+        |  END;
+        |END""".stripMargin
+    checkError(
+      exception = intercept[SqlScriptingException] {
+        runSqlScript(sqlScript)
+      },
+      condition = "DUPLICATE_EXCEPTION_HANDLER.CONDITION",
+      parameters = Map("condition" -> "NOT FOUND")
+    )
+  }
+
+  test("Duplicate SQLEXCEPTION CONTINUE/CONTINUE Handler") {
+    val sqlScript =
+      """
+        |BEGIN
+        |  DECLARE CONTINUE HANDLER FOR SQLEXCEPTION
+        |  BEGIN
+        |    SELECT 1;
+        |  END;
+        |  DECLARE CONTINUE HANDLER FOR SQLEXCEPTION
+        |  BEGIN
+        |    SELECT 2;
+        |  END;
+        |
+        |END""".stripMargin
+    checkError(
+      exception = intercept[SqlScriptingException] {
+        runSqlScript(sqlScript)
+      },
+      condition = "DUPLICATE_EXCEPTION_HANDLER.CONDITION",
+      parameters = Map("condition" -> "SQLEXCEPTION")
+    )
+  }
+
+  test("Duplicate NOT FOUND CONTINUE/CONTINUE Handler") {
+    val sqlScript =
+      """
+        |BEGIN
+        |  DECLARE CONTINUE HANDLER FOR NOT FOUND
+        |  BEGIN
+        |    SELECT 1;
+        |  END;
+        |  DECLARE CONTINUE HANDLER FOR NOT FOUND
+        |  BEGIN
+        |    SELECT 2;
+        |  END;
+        |END""".stripMargin
+    checkError(
+      exception = intercept[SqlScriptingException] {
+        runSqlScript(sqlScript)
+      },
+      condition = "DUPLICATE_EXCEPTION_HANDLER.CONDITION",
+      parameters = Map("condition" -> "NOT FOUND")
+    )
+  }
+
+  test("Duplicate SQLEXCEPTION EXIT/CONTINUE Handler") {
+    val sqlScript =
+      """
+        |BEGIN
+        |  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+        |  BEGIN
+        |    SELECT 1;
+        |  END;
+        |  DECLARE CONTINUE HANDLER FOR SQLEXCEPTION
+        |  BEGIN
+        |    SELECT 2;
+        |  END;
+        |
+        |END""".stripMargin
+    checkError(
+      exception = intercept[SqlScriptingException] {
+        runSqlScript(sqlScript)
+      },
+      condition = "DUPLICATE_EXCEPTION_HANDLER.CONDITION",
+      parameters = Map("condition" -> "SQLEXCEPTION")
+    )
+  }
+
+  test("Duplicate NOT FOUND EXIT/CONTINUE Handler") {
+    val sqlScript =
+      """
+        |BEGIN
+        |  DECLARE EXIT HANDLER FOR NOT FOUND
+        |  BEGIN
+        |    SELECT 1;
+        |  END;
+        |  DECLARE CONTINUE HANDLER FOR NOT FOUND
+        |  BEGIN
+        |    SELECT 2;
+        |  END;
+        |END""".stripMargin
+    checkError(
+      exception = intercept[SqlScriptingException] {
+        runSqlScript(sqlScript)
+      },
+      condition = "DUPLICATE_EXCEPTION_HANDLER.CONDITION",
+      parameters = Map("condition" -> "NOT FOUND")
+    )
+  }
+
+  test("Duplicate SQLEXCEPTION CONTINUE/EXIT Handler") {
+    val sqlScript =
+      """
+        |BEGIN
+        |  DECLARE CONTINUE HANDLER FOR SQLEXCEPTION
+        |  BEGIN
+        |    SELECT 1;
+        |  END;
+        |  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+        |  BEGIN
+        |    SELECT 2;
+        |  END;
+        |
+        |END""".stripMargin
+    checkError(
+      exception = intercept[SqlScriptingException] {
+        runSqlScript(sqlScript)
+      },
+      condition = "DUPLICATE_EXCEPTION_HANDLER.CONDITION",
+      parameters = Map("condition" -> "SQLEXCEPTION")
+    )
+  }
+
+  test("Duplicate NOT FOUND CONTINUE/EXIT Handler") {
+    val sqlScript =
+      """
+        |BEGIN
+        |  DECLARE CONTINUE HANDLER FOR NOT FOUND
         |  BEGIN
         |    SELECT 1;
         |  END;

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -40,7 +40,7 @@ class SqlScriptingInterpreterSuite
 
   protected override def beforeAll(): Unit = {
     super.beforeAll()
-    conf.setConfString(SQLConf.SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED.key, "true")
+    conf.setConf(SQLConf.SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED, true)
   }
 
   protected override def afterAll(): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR lays the foundation for implementing support for `CONTINUE HANDLER`. `CONTINUE HANDLER` no longer throws an exception that it is not supported, and now behaves like an `EXIT HANDLER`.

Feature is under a new feature switch `spark.sql.scripting.continueHandlerEnabled` inside `SQLConfig.scala` .

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We want to add support for executing `CONTINUE HANDLER`. This feature is supported in documentation, but is not supported as of now inside SQL Scripts. Change is supposed to enable parsing of `CONTINUE HANDLER`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Tests were added to `SqlScriptingInterpreterSuite.scala` and `SqlScriptingParserSuite.scala` to facilitate the `CONTINUE HANDLER`.

Both test suites have `spark.sql.scripting.continueHandlerEnabled` config entry set to `true` before all tests, and unset after all of the tests have been run.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.