### PR TITLE
[SPARK-53546][SQL][TESTS] Fix InMemoryDataSource to return default value or null for new fields

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CatalogSuite.scala
@@ -1286,8 +1286,8 @@ class CatalogSuite extends SparkFunSuite {
     val table = catalog.createTable(testIdent, columns, emptyTrans, emptyProps)
       .asInstanceOf[InMemoryTable]
     table.withData(Array(
-      new BufferedRows("3").withRow(InternalRow(0, "abc", "3")),
-      new BufferedRows("4").withRow(InternalRow(1, "def", "4"))))
+      BufferedRows("3", table.columns()).withRow(InternalRow(0, "abc", "3")),
+      BufferedRows("4", table.columns()).withRow(InternalRow(1, "def", "4"))))
     assert(table.truncateTable())
     assert(table.rows.isEmpty)
   }
@@ -1308,8 +1308,8 @@ class CatalogSuite extends SparkFunSuite {
     partTable.createPartition(partIdent, new util.HashMap[String, String]())
     partTable.createPartition(partIdent1, new util.HashMap[String, String]())
     partTable.withData(Array(
-      new BufferedRows("0").withRow(InternalRow(0, 0)),
-      new BufferedRows("1").withRow(InternalRow(1, 1))
+      BufferedRows("0", table.columns()).withRow(InternalRow(0, 0)),
+      BufferedRows("1", table.columns()).withRow(InternalRow(1, 1))
     ))
     assert(partTable.listPartitionIdentifiers(Array.empty, InternalRow.empty).length == 2)
     assert(partTable.rows.nonEmpty)
@@ -1364,8 +1364,8 @@ class CatalogSuite extends SparkFunSuite {
       .asInstanceOf[InMemoryTable]
     assert(table.currentVersion() == "0")
     table.withData(Array(
-      new BufferedRows("3").withRow(InternalRow(0, "abc", "3")),
-      new BufferedRows("4").withRow(InternalRow(1, "def", "4"))))
+      BufferedRows("3", table.columns()).withRow(InternalRow(0, "abc", "3")),
+      BufferedRows("4", table.columns()).withRow(InternalRow(1, "def", "4"))))
     assert(table.currentVersion() == "1")
 
     table.truncateTable()

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -360,8 +360,8 @@ abstract class InMemoryBaseTable(
         val key = getKey(row, newSchema)
         dataMap += dataMap.get(key)
           .map { splits =>
-            val newSplits = if (splits.last.rows.size >= numRowsPerSplit) {
-              val oldSchema = splits.last.schema
+            val newSplits = if ((splits.last.rows.size >= numRowsPerSplit) ||
+                (splits.last.schema != oldSchema)) {
               splits :+ new BufferedRows(key, oldSchema)
             } else {
               splits

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
@@ -136,7 +136,7 @@ class InMemoryRowLevelOperationTable(
       val readPartitions = readRows.map(r => getKey(r, schema)).distinct
       dataMap --= readPartitions
       replacedPartitions = readPartitions
-      withData(newData, schema, newData = true)
+      withData(newData, schema)
       lastWriteLog = newData.flatMap(buffer => buffer.log).toImmutableArraySeq
     }
   }
@@ -190,7 +190,7 @@ class InMemoryRowLevelOperationTable(
     override def commit(messages: Array[WriterCommitMessage]): Unit = {
       val newData = messages.map(_.asInstanceOf[BufferedRows])
       withDeletes(newData)
-      withData(newData, CatalogV2Util.v2ColumnsToStructType(columns()), newData = true)
+      withData(newData, columns())
       lastWriteLog = newData.flatMap(buffer => buffer.log).toIndexedSeq
     }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTableCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTableCatalog.scala
@@ -60,7 +60,7 @@ class InMemoryRowLevelOperationTableCatalog extends InMemoryTableCatalog {
       partitioning = partitioning,
       properties = properties,
       constraints = constraints)
-    newTable.withData(table.data, schema, newData = false)
+    newTable.alterTableWithData(table.data, schema)
 
     tables.put(ident, newTable)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTableCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTableCatalog.scala
@@ -60,7 +60,7 @@ class InMemoryRowLevelOperationTableCatalog extends InMemoryTableCatalog {
       partitioning = partitioning,
       properties = properties,
       constraints = constraints)
-    newTable.withData(table.data)
+    newTable.withData(table.data, schema, newData = false)
 
     tables.put(ident, newTable)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala
@@ -157,7 +157,7 @@ class BasicInMemoryTableCatalog extends TableCatalog {
       partitioning = finalPartitioning,
       properties = properties,
       constraints = constraints)
-      .withData(table.data, schema, newData = false)
+      .alterTableWithData(table.data, schema)
     newTable.setCurrentVersion(currentVersion)
     changes.foreach {
       case a: TableChange.AddConstraint =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala
@@ -157,7 +157,7 @@ class BasicInMemoryTableCatalog extends TableCatalog {
       partitioning = finalPartitioning,
       properties = properties,
       constraints = constraints)
-      .withData(table.data)
+      .withData(table.data, schema, newData = false)
     newTable.setCurrentVersion(currentVersion)
     changes.foreach {
       case a: TableChange.AddConstraint =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/SupportsAtomicPartitionManagementSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/SupportsAtomicPartitionManagementSuite.scala
@@ -156,9 +156,9 @@ class SupportsAtomicPartitionManagementSuite extends SparkFunSuite {
     assert(partTable.listPartitionIdentifiers(Array.empty, InternalRow.empty).length == 3)
 
     partTable.withData(Array(
-      new BufferedRows("3").withRow(InternalRow(0, "abc", "3")),
-      new BufferedRows("4").withRow(InternalRow(1, "def", "4")),
-      new BufferedRows("5").withRow(InternalRow(2, "zyx", "5"))
+      BufferedRows("3", partTable.columns()).withRow(InternalRow(0, "abc", "3")),
+      BufferedRows("4", partTable.columns()).withRow(InternalRow(1, "def", "4")),
+      BufferedRows("5", partTable.columns()).withRow(InternalRow(2, "zyx", "5"))
     ))
 
     partTable.truncatePartitions(Array(InternalRow("3"), InternalRow("4")))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/SupportsPartitionManagementSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/SupportsPartitionManagementSuite.scala
@@ -258,8 +258,8 @@ class SupportsPartitionManagementSuite extends SparkFunSuite {
     assert(partTable.listPartitionIdentifiers(Array.empty, InternalRow.empty).length == 2)
 
     partTable.withData(Array(
-      new BufferedRows("3").withRow(InternalRow(0, "abc", "3")),
-      new BufferedRows("4").withRow(InternalRow(1, "def", "4"))
+      BufferedRows("3", partTable.columns()).withRow(InternalRow(0, "abc", "3")),
+      BufferedRows("4", partTable.columns()).withRow(InternalRow(1, "def", "4"))
     ))
 
     partTable.truncatePartition(partIdent)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSessionCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSessionCatalogSuite.scala
@@ -133,9 +133,7 @@ class InMemoryTableSessionCatalog extends TestV2SessionCatalogBase[InMemoryTable
         }
 
         val newTable = new InMemoryTable(table.name, schema, table.partitioning, properties)
-          .withData(table.data,
-            CatalogV2Util.v2ColumnsToStructType(table.columns()),
-            newData = false)
+          .alterTableWithData(table.data, schema)
 
         tables.put(ident, newTable)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSessionCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSessionCatalogSuite.scala
@@ -133,7 +133,9 @@ class InMemoryTableSessionCatalog extends TestV2SessionCatalogBase[InMemoryTable
         }
 
         val newTable = new InMemoryTable(table.name, schema, table.partitioning, properties)
-          .withData(table.data)
+          .withData(table.data,
+            CatalogV2Util.v2ColumnsToStructType(table.columns()),
+            newData = false)
 
         tables.put(ident, newTable)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoTableSuiteBase.scala
@@ -2728,8 +2728,7 @@ abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase
           sql(mergeStmt)
           checkAnswer(
             sql(s"SELECT * FROM $tableNameAsString"),
-            // TODO- InMemoryBaseTable does not return null for nested schema evolution.
-            Seq(Row(0, Map(Row(10, true) -> Row("c", true)), "hr"),
+            Seq(Row(0, Map(Row(10, null) -> Row("c", null)), "hr"),
               Row(1, Map(Row(10, true) -> Row("y", false)), "sales"),
               Row(2, Map(Row(20, false) -> Row("z", true)), "engineering")))
         } else {


### PR DESCRIPTION

### What changes were proposed in this pull request?
InMemoryTable does not handle schema evolution properly.  In particular, it always uses the current schema to read the in-memory rows.  For newly-added columns that don't exist in the row, the InternalRow sometimes return some junk value.

This fixes InMemoryDataSource to properly handle schema evolution.  Like modern table format, it persists the 'writeSchema' used to write the BufferedRows (on the BufferedRows object here), and then at read time resolves it with the 'readSchema'.


### Why are the changes needed?
While writing tests for MERGE INTO schema evolution, realized that in these cases InMemoryTable is returning junk values, unlike a real V2 data source.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add a new test in AlterTableTests

### Was this patch authored or co-authored using generative AI tooling?
No
