### PR TITLE
[SPARK-53549][SS] Always close the arrow allocator when list state request process is completed

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkDeserializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkDeserializer.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch, Column
  */
 class TransformWithStateInPySparkDeserializer(deserializer: ExpressionEncoder.Deserializer[Row])
   extends Logging {
-  private val allocator = ArrowUtils.rootAllocator.newChildAllocator(
+  private lazy val allocator = ArrowUtils.rootAllocator.newChildAllocator(
         s"stdin reader for transformWithStateInPySpark state socket", 0, Long.MaxValue)
 
   /**
@@ -77,5 +77,9 @@ class TransformWithStateInPySparkDeserializer(deserializer: ExpressionEncoder.De
     }
 
     rows.toSeq
+  }
+
+  def close(): Unit = {
+    allocator.close()
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServerSuite.scala
@@ -329,6 +329,7 @@ class TransformWithStateInPySparkStateServerSuite extends SparkFunSuite with Bef
     stateServer.handleListStateRequest(message)
     // Verify that the data is not read from Arrow stream. It is inlined.
     verify(transformWithStateInPySparkDeserializer, times(0)).readArrowBatches(any)
+    verify(transformWithStateInPySparkDeserializer).close()
     verify(listState).put(any)
   }
 
@@ -337,6 +338,7 @@ class TransformWithStateInPySparkStateServerSuite extends SparkFunSuite with Bef
       .setListStatePut(ListStatePut.newBuilder().setFetchWithArrow(true).build()).build()
     stateServer.handleListStateRequest(message)
     verify(transformWithStateInPySparkDeserializer).readArrowBatches(any)
+    verify(transformWithStateInPySparkDeserializer).close()
     verify(listState).put(any)
   }
 
@@ -345,6 +347,7 @@ class TransformWithStateInPySparkStateServerSuite extends SparkFunSuite with Bef
     val message = ListStateCall.newBuilder().setStateName(stateName)
       .setAppendValue(AppendValue.newBuilder().setValue(byteString).build()).build()
     stateServer.handleListStateRequest(message)
+    verify(transformWithStateInPySparkDeserializer).close()
     verify(listState).appendValue(any[Row])
   }
 
@@ -354,6 +357,7 @@ class TransformWithStateInPySparkStateServerSuite extends SparkFunSuite with Bef
     stateServer.handleListStateRequest(message)
     // Verify that the data is not read from Arrow stream. It is inlined.
     verify(transformWithStateInPySparkDeserializer, times(0)).readArrowBatches(any)
+    verify(transformWithStateInPySparkDeserializer).close()
     verify(listState).appendList(any)
   }
 
@@ -362,6 +366,7 @@ class TransformWithStateInPySparkStateServerSuite extends SparkFunSuite with Bef
       .setAppendList(AppendList.newBuilder().setFetchWithArrow(true).build()).build()
     stateServer.handleListStateRequest(message)
     verify(transformWithStateInPySparkDeserializer).readArrowBatches(any)
+    verify(transformWithStateInPySparkDeserializer).close()
     verify(listState).appendList(any)
   }
 


### PR DESCRIPTION

We create a [TransformWithStateInPySparkDeserializer](https://github.com/apache/spark/blob/7201e60bb3e898f65db5045ec293c650e14cfa95/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServer.scala#L460-L464) every time when we process a list state request. Inside [TransformWithStateInPySparkDeserializer](https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkDeserializer.scala#L40), a child allocator is created from the ArrowUtils.rootAllocator when a new deserializer instance is created. However, we neither close this child allocator nor call rootAllocator.close, which leads to a memory leak in TWSStateServer.

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
* mark the `allocator` variable in `TransformWithStateInPySparkDeserializer` as `lazy`
* wrap the list state request process with `try-finally` to always close the arrow allocator.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Avoid the memory leak in TWS State Server.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing UTs

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
