### PR TITLE
[SPARK-53550][SQL] Union output partitioning should compare canonicalized attributes

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -708,7 +708,9 @@ case class UnionExec(children: Seq[SparkPlan]) extends SparkPlan {
     val firstAttrs = children.head.output
     val attributesMap = children.tail.map(_.output).map { otherAttrs =>
       otherAttrs.zip(firstAttrs).map { case (attr, firstAttr) =>
-        attr -> firstAttr
+        // Remove metadata and qualifier before comparing, as they may be different
+        // even if the attributes are semantically the same.
+        attr.canonicalized -> firstAttr
       }.toMap
     }
 
@@ -721,7 +723,8 @@ case class UnionExec(children: Seq[SparkPlan]) extends SparkPlan {
       p match {
         case e: Expression =>
           e.transform {
-            case a: Attribute if attributeMap.contains(a) => attributeMap(a)
+            case a: Attribute if attributeMap.contains(a.canonicalized) =>
+              attributeMap(a.canonicalized)
           }.asInstanceOf[Partitioning]
         case _ => p
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
@@ -1617,6 +1617,32 @@ class DataFrameSetOperationsSuite extends QueryTest
       }
     }
   }
+
+  test("SPARK-53550: union partitioning should compare canonicalized attributes") {
+    withSQLConf(
+      "spark.sql.autoBroadcastJoinThreshold" -> "-1") {
+      withTempView("person", "person_a", "person_b", "person_c") {
+        // scalastyle:off line.size.limit
+        sql(
+          """create or replace temp view person(id, name, age) as values
+            |(0, "mike", 30),
+            |(1, "jim", 20);
+            |""".stripMargin)
+        sql(
+          """create or replace temp view person_a as
+            |SELECT name, avg(age) as avg_age FROM person GROUP BY name;""".stripMargin)
+        sql(
+          """create or replace temp view person_b as
+            |SELECT p1.name, p2.avg_age FROM person p1 JOIN person_a p2 ON p1.name = p2.name;""".stripMargin)
+        sql(
+          """create or replace temp view person_c as
+            |SELECT * FROM person_a UNION SELECT * FROM person_b;""".stripMargin)
+        val df = sql("SELECT p1.name, p2.avg_age FROM person_c p1 JOIN person_c p2 ON p1.name = p2.name")
+        // scalastyle:on line.size.limit
+        checkAnswer(df, Row("jim", 20) :: Row("mike", 30) :: Nil)
+      }
+    }
+  }
 }
 
 case class UnionClass1a(a: Int, b: Long, nested: UnionClass2)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch fixes a bug when Union operator produces its `outputPartitioning`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

[SPARK-52921](https://issues.apache.org/jira/browse/SPARK-52921) added the explicit output partitioning support for Union operator if its children have the same output partitioning.

When comparing the output attributes from its children, currently it uses original attributes and it causes some errors when the attributes have some metadata or qualifier even they are semantically the same. We should compare them with their canonicalized forms.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Unit test


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No