### PR TITLE
[SPARK-52426][SQL][FOLLOWUP] Fix spark-sql repl w/ RedirectConsolePlugin

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
@@ -33,6 +33,9 @@ import org.apache.spark.util.Utils
 private[hive] object SparkSQLEnv extends Logging {
   logDebug("Initializing SparkSQLEnv")
 
+  val out = new PrintStream(System.out, true, UTF_8)
+  val err = new PrintStream(System.err, true, UTF_8)
+
   var sparkSession: SparkSession = _
   var sparkContext: SparkContext = _
 
@@ -72,9 +75,9 @@ private[hive] object SparkSQLEnv extends Logging {
       if (!shouldUseInMemoryCatalog) {
         val metadataHive = sparkSession
           .sharedState.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog].client
-        metadataHive.setOut(new PrintStream(System.out, true, UTF_8.name()))
-        metadataHive.setInfo(new PrintStream(System.err, true, UTF_8.name()))
-        metadataHive.setError(new PrintStream(System.err, true, UTF_8.name()))
+        metadataHive.setOut(out)
+        metadataHive.setInfo(err)
+        metadataHive.setError(err)
       }
     }
   }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -831,7 +831,7 @@ class CliSuite extends SparkFunSuite {
       "SELECT CURRENT_SCHEMA();" -> "SYS")
   }
 
-  test("SPARK-52426: do not redirect stderr to stdout in spark-sql") {
+  test("SPARK-52426: do not redirect stderr and stdout in spark-sql") {
     runCliWithin(
       2.minute,
       extraArgs = "--conf" :: s"spark.plugins=${classOf[RedirectConsolePlugin].getName}" :: Nil)(

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -31,7 +31,7 @@ import org.apache.hadoop.hive.ql.session.SessionState
 
 import org.apache.spark.{ErrorMessageFormat, SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.ProcessTestUtils.ProcessOutputCapturer
-import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.deploy.{RedirectConsolePlugin, SparkHadoopUtil}
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
 import org.apache.spark.sql.hive.HiveUtils._
 import org.apache.spark.sql.hive.client.HiveClientImpl
@@ -829,5 +829,12 @@ class CliSuite extends SparkFunSuite {
         Seq("--conf", s"spark.sql.defaultCatalog=$catalogName", "--database", "SYS"))(
       "SELECT CURRENT_CATALOG();" -> catalogName,
       "SELECT CURRENT_SCHEMA();" -> "SYS")
+  }
+
+  test("SPARK-52426: do not redirect stderr to stdout in spark-sql") {
+    runCliWithin(
+      2.minute,
+      extraArgs = "--conf" :: s"spark.plugins=${classOf[RedirectConsolePlugin].getName}" :: Nil)(
+      "SELECT 1;" -> "1")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

While RedirectConsolePlugin is set, the spark-sql shell behaves strangely, as if stuck. This PR fixes this by using the original `System.out/err` streams.

### Why are the changes needed?
Improve UX


### Does this PR introduce _any_ user-facing change?
No, unreleased feature


### How was this patch tested?
new tests


### Was this patch authored or co-authored using generative AI tooling?
no