### PR TITLE
[SPARK-53551][SQL] Improve `OffsetAndLimit` by avoiding duplicate evaluation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1652,14 +1652,14 @@ case class LocalLimit(limitExpr: Expression, child: LogicalPlan) extends OrderPr
 }
 
 object OffsetAndLimit {
-  def unapply(p: GlobalLimit): Option[(Int, Int, LogicalPlan)] = {
+  def unapply(p: GlobalLimit): Option[(Int, Int, Int, LogicalPlan)] = {
     p match {
       // Optimizer pushes local limit through offset, so we need to match the plan this way.
       case GlobalLimit(IntegerLiteral(globalLimit),
              Offset(IntegerLiteral(offset),
                LocalLimit(IntegerLiteral(localLimit), child)))
           if globalLimit + offset == localLimit =>
-        Some((offset, globalLimit, child))
+        Some((offset, globalLimit, localLimit, child))
       case _ => None
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -732,6 +732,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
       }
     case globalLimit @ OffsetAndLimit(offset, limit, localLimit, child) =>
       // For `df.offset(n).limit(m)`, we can push down `limit(m + n)` first.
+      // 'm + n' is equals to 'localLimit'.
       val (newChild, canRemoveLimit) = pushDownLimit(child, localLimit)
       if (canRemoveLimit) {
         // Try to push down OFFSET only if the LIMIT operator has been pushed and can be removed.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -730,9 +730,9 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
         // Keep the OFFSET operator if we can't remove LIMIT operator.
         offset
       }
-    case globalLimit @ OffsetAndLimit(offset, limit, child) =>
+    case globalLimit @ OffsetAndLimit(offset, limit, localLimit, child) =>
       // For `df.offset(n).limit(m)`, we can push down `limit(m + n)` first.
-      val (newChild, canRemoveLimit) = pushDownLimit(child, limit + offset)
+      val (newChild, canRemoveLimit) = pushDownLimit(child, localLimit)
       if (canRemoveLimit) {
         // Try to push down OFFSET only if the LIMIT operator has been pushed and can be removed.
         val isPushed = pushDownOffset(newChild, offset)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to improve `OffsetAndLimit` by avoiding duplicate evaluation.


### Why are the changes needed?
`OffsetAndLimit` doesn't return the local limit (the same as offset + global limit), it lead to duplicate evaluation.


### Does this PR introduce _any_ user-facing change?
'No'.
Inner change.


### How was this patch tested?
GA tests.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
