### PR TITLE
[SPARK-53552][SQL] Optimize substr SQL function

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -642,9 +642,13 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     }
 
     int j = i;
-    while (i < numBytes && c < until) {
-      i += numBytesForFirstByte(getByte(i));
-      c += 1;
+    if (until == Integer.MAX_VALUE) {
+      i = numBytes;
+    } else {
+      while (i < numBytes && c < until) {
+        i += numBytesForFirstByte(getByte(i));
+        c += 1;
+      }
     }
 
     if (i > j) {
@@ -663,9 +667,8 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     // refers to element i-1 in the sequence. If a start index i is less than 0, it refers
     // to the -ith element before the end of the sequence. If a start index i is 0, it
     // refers to the first element.
-    int len = numChars();
     // `len + pos` does not overflow as `len >= 0`.
-    int start = (pos > 0) ? pos -1 : ((pos < 0) ? len + pos : 0);
+    int start = (pos > 0) ? pos -1 : ((pos < 0) ? numChars() + pos : 0);
 
     int end;
     if ((long) start + length > Integer.MAX_VALUE) {


### PR DESCRIPTION

### What changes were proposed in this pull request?

In substringSQL() functions, if pos > 0 then we don't need to calculate numChars().
<img width="1846" height="388" alt="企业微信截图_96d4fc98-bce1-4b43-937c-68ca3c21e54c" src="https://github.com/user-attachments/assets/504eceee-83eb-45aa-91ab-b9c657993861" />


### Why are the changes needed?

SQL function substr performance improvement.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Exists UT

### Was this patch authored or co-authored using generative AI tooling?

No