### PR TITLE
[SPARK-53555] Fix: SparkML-connect can't load SparkML (legacy mode) saved model

### DIFF
--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -78,7 +78,6 @@ from pyspark.ml.util import (
     DefaultParamsReader,
     DefaultParamsWriter,
     JavaMLReadable,
-    JavaMLReader,
     JavaMLWritable,
     JavaMLWriter,
     MLReader,

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -3991,9 +3991,7 @@ class OneVsRestModelReader(MLReader[OneVsRestModel]):
         subModels = [None] * numClasses
         for idx in range(numClasses):
             subModelPath = os.path.join(path, f"model_{idx}")
-            subModels[idx] = DefaultParamsReader.loadParamsInstance(
-                subModelPath, self.sparkSession
-            )
+            subModels[idx] = DefaultParamsReader.loadParamsInstance(subModelPath, self.sparkSession)
         ovaModel = OneVsRestModel(cast(List[ClassificationModel], subModels))._resetUid(
             metadata["uid"]
         )

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -3703,7 +3703,10 @@ class OneVsRest(
 
     @try_remote_write
     def write(self) -> MLWriter:
-        return OneVsRestWriter(self)
+        if isinstance(self.getClassifier(), JavaMLWritable):
+            return JavaMLWriter(self)  # type: ignore[arg-type]
+        else:
+            return OneVsRestWriter(self)
 
 
 class _OneVsRestSharedReadWrite:
@@ -3964,7 +3967,15 @@ class OneVsRestModel(
 
     @try_remote_write
     def write(self) -> MLWriter:
-        return OneVsRestModelWriter(self)
+        if all(
+            map(
+                lambda elem: isinstance(elem, JavaMLWritable),
+                [self.getClassifier()] + self.models,  # type: ignore[operator]
+            )
+        ):
+            return JavaMLWriter(self)  # type: ignore[arg-type]
+        else:
+            return OneVsRestModelWriter(self)
 
 
 @inherit_doc

--- a/python/pyspark/ml/pipeline.py
+++ b/python/pyspark/ml/pipeline.py
@@ -25,7 +25,6 @@ from pyspark.ml.util import (
     MLReadable,
     MLWritable,
     JavaMLWriter,
-    JavaMLReader,
     DefaultParamsReader,
     DefaultParamsWriter,
     MLWriter,

--- a/python/pyspark/ml/pipeline.py
+++ b/python/pyspark/ml/pipeline.py
@@ -169,6 +169,9 @@ class Pipeline(Estimator["PipelineModel"], MLReadable["Pipeline"], MLWritable):
     @try_remote_write
     def write(self) -> MLWriter:
         """Returns an MLWriter instance for this ML instance."""
+        allStagesAreJava = PipelineSharedReadWrite.checkStagesForJava(self.getStages())
+        if allStagesAreJava:
+            return JavaMLWriter(self)  # type: ignore[arg-type]
         return PipelineWriter(self)
 
     @classmethod
@@ -320,6 +323,11 @@ class PipelineModel(Model, MLReadable["PipelineModel"], MLWritable):
     @try_remote_write
     def write(self) -> MLWriter:
         """Returns an MLWriter instance for this ML instance."""
+        allStagesAreJava = PipelineSharedReadWrite.checkStagesForJava(
+            cast(List["PipelineStage"], self.stages)
+        )
+        if allStagesAreJava:
+            return JavaMLWriter(self)  # type: ignore[arg-type]
         return PipelineModelWriter(self)
 
     @classmethod

--- a/python/pyspark/ml/pipeline.py
+++ b/python/pyspark/ml/pipeline.py
@@ -29,7 +29,6 @@ from pyspark.ml.util import (
     DefaultParamsWriter,
     MLWriter,
     MLReader,
-    JavaMLReadable,
     JavaMLWritable,
     try_remote_read,
     try_remote_write,

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -453,7 +453,7 @@ class _ValidatorSharedReadWrite:
                 est = uidToParams[jsonParam["parent"]]
                 param = getattr(est, jsonParam["name"])
 
-                def extract_value(key):
+                def extract_value(key: str) -> Any:
                     if is_saved_by_python_writer:
                         return jsonParam[key]
                     # If the the params are serialized by java writer,

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -52,7 +52,6 @@ from pyspark.ml.util import (
     MLReader,
     MLWritable,
     MLWriter,
-    JavaMLReader,
     JavaMLWriter,
     try_remote_write,
     try_remote_read,

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -515,6 +515,7 @@ class CrossValidatorReader(MLReader["CrossValidator"]):
         self.cls = cls
 
     def load(self, path: str) -> "CrossValidator":
+        metadata = DefaultParamsReader.loadMetadata(path, self.sparkSession)
         metadata, estimator, evaluator, estimatorParamMaps = _ValidatorSharedReadWrite.load(
             path, self.sparkSession, metadata
         )
@@ -544,6 +545,7 @@ class CrossValidatorModelReader(MLReader["CrossValidatorModel"]):
         self.cls = cls
 
     def load(self, path: str) -> "CrossValidatorModel":
+        metadata = DefaultParamsReader.loadMetadata(path, self.sparkSession)
         metadata, estimator, evaluator, estimatorParamMaps = _ValidatorSharedReadWrite.load(
             path, self.sparkSession, metadata
         )
@@ -1185,6 +1187,7 @@ class TrainValidationSplitReader(MLReader["TrainValidationSplit"]):
         self.cls = cls
 
     def load(self, path: str) -> "TrainValidationSplit":
+        metadata = DefaultParamsReader.loadMetadata(path, self.sparkSession)
         metadata, estimator, evaluator, estimatorParamMaps = _ValidatorSharedReadWrite.load(
             path, self.sparkSession, metadata
         )
@@ -1214,6 +1217,7 @@ class TrainValidationSplitModelReader(MLReader["TrainValidationSplitModel"]):
         self.cls = cls
 
     def load(self, path: str) -> "TrainValidationSplitModel":
+        metadata = DefaultParamsReader.loadMetadata(path, self.sparkSession)
         metadata, estimator, evaluator, estimatorParamMaps = _ValidatorSharedReadWrite.load(
             path, self.sparkSession, metadata
         )

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -461,7 +461,7 @@ class _ValidatorSharedReadWrite:
                     return json.loads(jsonParam[key])
 
                 if "isJson" not in jsonParam or ("isJson" in jsonParam and extract_value("isJson")):
-                    value = extract_value("value")
+                    value = json.loads(jsonParam["value"])
                 else:
                     relativePath = extract_value("value")
                     valueSavedPath = os.path.join(path, relativePath)

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -552,9 +552,7 @@ class CrossValidatorModelReader(MLReader["CrossValidatorModel"]):
         )
         numFolds = metadata["paramMap"]["numFolds"]
         bestModelPath = os.path.join(path, "bestModel")
-        bestModel: Model = DefaultParamsReader.loadParamsInstance(
-            bestModelPath, self.sparkSession
-        )
+        bestModel: Model = DefaultParamsReader.loadParamsInstance(bestModelPath, self.sparkSession)
         avgMetrics = metadata["avgMetrics"]
         if "stdMetrics" in metadata:
             stdMetrics = metadata["stdMetrics"]
@@ -585,9 +583,7 @@ class CrossValidatorModelReader(MLReader["CrossValidatorModel"]):
         cvModel.set(cvModel.estimator, estimator)
         cvModel.set(cvModel.estimatorParamMaps, estimatorParamMaps)
         cvModel.set(cvModel.evaluator, evaluator)
-        DefaultParamsReader.getAndSetParams(
-            cvModel, metadata, skipParams=["estimatorParamMaps"]
-        )
+        DefaultParamsReader.getAndSetParams(cvModel, metadata, skipParams=["estimatorParamMaps"])
         return cvModel
 
 
@@ -1223,9 +1219,7 @@ class TrainValidationSplitModelReader(MLReader["TrainValidationSplitModel"]):
             path, self.sparkSession, metadata
         )
         bestModelPath = os.path.join(path, "bestModel")
-        bestModel: Model = DefaultParamsReader.loadParamsInstance(
-            bestModelPath, self.sparkSession
-        )
+        bestModel: Model = DefaultParamsReader.loadParamsInstance(bestModelPath, self.sparkSession)
         validationMetrics = metadata["validationMetrics"]
         persistSubModels = ("persistSubModels" in metadata) and metadata["persistSubModels"]
 
@@ -1248,9 +1242,7 @@ class TrainValidationSplitModelReader(MLReader["TrainValidationSplitModel"]):
         tvsModel.set(tvsModel.estimator, estimator)
         tvsModel.set(tvsModel.estimatorParamMaps, estimatorParamMaps)
         tvsModel.set(tvsModel.evaluator, evaluator)
-        DefaultParamsReader.getAndSetParams(
-            tvsModel, metadata, skipParams=["estimatorParamMaps"]
-        )
+        DefaultParamsReader.getAndSetParams(tvsModel, metadata, skipParams=["estimatorParamMaps"])
         return tvsModel
 
 

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import json
 import os
 import sys
 import itertools
@@ -415,7 +416,7 @@ class _ValidatorSharedReadWrite:
                         "is estimator, it cannot be meta estimator such as Validator or OneVsRest"
                     )
                 else:
-                    jsonParam["value"] = v
+                    jsonParam["value"] = json.dumps(v)
                     jsonParam["isJson"] = True
                 jsonParamMap.append(jsonParam)
             jsonEstimatorParamMaps.append(jsonParamMap)
@@ -451,7 +452,7 @@ class _ValidatorSharedReadWrite:
                 est = uidToParams[jsonParam["parent"]]
                 param = getattr(est, jsonParam["name"])
                 if "isJson" not in jsonParam or ("isJson" in jsonParam and jsonParam["isJson"]):
-                    value = jsonParam["value"]
+                    value = json.loads(jsonParam["value"])
                 else:
                     relativePath = jsonParam["value"]
                     valueSavedPath = os.path.join(path, relativePath)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix: SparkML-connect can't load SparkML (legacy mode) saved model

For meta algorithm like pipeline / cross-validator / one-vs-rest,  if saving under **legacy Spark mode**, its writer goes through `JavaWriter` path but when loading under **Spark-connect mode**, its reader goes through `Python Reader` path,

 `Python Reader` does not work with the data `JavaWriter` writes, because python reader requires metadata containing `language` field with `Python` value.

In this PR, I make the following changes:
* Make meta algorithm always use python reader, without checking metadata `language` field. Note that python reader is compatible with model written by JavaWriter, we don't need the metadata `language` field checking.
* Fix `_ValidatorParams` load methods:  the `isJson` field and `value` field (non-json case) in `estimatorParamMaps` metadata should be deserialized from **JSON** string if it is saved by Java writer.

All model / estimator writer implementation code keeps intact.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bug fix.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Manually.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.