### PR TITLE
[SPARK-53557][INFRA] Reduce automated vote email deadline from 4 days to 73 hours

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -990,7 +990,7 @@ if [[ "$1" == "publish-release" ]]; then
     EMAIL_SUBJECT="[VOTE] Release Spark ${SPARK_VERSION} (RC${SPARK_RC_COUNT})"
 
     # Calculate deadline in Pacific Time (PST/PDT)
-    DEADLINE=$(TZ=America/Los_Angeles date -d "+4 days" "+%a, %d %b %Y %H:%M:%S %Z")
+    DEADLINE=$(TZ=America/Los_Angeles date -d "+73 hour" "+%a, %d %b %Y %H:%M:%S %Z")
     PYSPARK_VERSION=`echo "$RELEASE_VERSION" |  sed -e "s/-/./" -e "s/preview/dev/"`
 
     JIRA_API_URL="https://issues.apache.org/jira/rest/api/2/project/SPARK/versions"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to reduce the automated vote email deadline from 4 days (=96 hours) to 73 hours.

### Why are the changes needed?

Although it's okay to use 4 days, it's a little longer than the requirement, 3 days (=72 hours).

- https://www.apache.org/foundation/voting.html

    > Voting periods should generally run for at least 72 hours to provide an opportunity for all concerned persons to participate, regardless of their geographic location.

It seems that we added 1 extra day as an overhead due to the processing time of automated email . In that case, we can use 1 hour overhead instead. As a result, 73 hour (= 72 hours + 1 hour).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

```
$ docker run -it --rm ubuntu:24.04 bash
root@09e9ef081365:/# TZ=America/Los_Angeles date -d "+4 days" "+%a, %d %b %Y %H:%M:%S %Z"
Mon, 15 Sep 2025 17:54:42 America
root@09e9ef081365:/# TZ=America/Los_Angeles date -d "+73 hour" "+%a, %d %b %Y %H:%M:%S %Z"
Sun, 14 Sep 2025 18:54:45 America
```

### Was this patch authored or co-authored using generative AI tooling?

No.