### PR TITLE
[SPARK-53561][SS] Catch Interruption Exception in TransformWithStateInPySparkStateServer during outputStream.flush to avoid the worker crash

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServer.scala
@@ -192,9 +192,9 @@ class TransformWithStateInPySparkStateServer(
             case _: InterruptedException | _: InterruptedIOException |
                  _: ClosedByInterruptException =>
               logInfo(log"Thread is interrupted during flushing error response, " +
-                              "shutting down state server")
+                log"shutting down state server")
             case e: Throwable =>
-              logError(log"Error during flushing error response: " +
+              logError(log"Failed to flush with errorMsg=" +
                 log"${MDC(LogKeys.ERROR, e.getMessage)}", e)
               throw e
           }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->
When the `query.stop` is invoked, we first close the the state store running in the query main thread and then close the TWS state server thread as part of the [task completion listener event](https://github.com/apache/spark/blob/bb41e19ae9ee0f7c228ac395800e740944ee355f/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkPythonRunner.scala#L227-L231). So it's possible that query main thread has already closed the state store while in TWS state server thread, we are still doing the state store operations. This results in throwing out Exception like
```

ERROR TransformWithStateInPySparkStateServer: Error reading message: [STATE_STORE_OPERATION_OUT_OF_ORDER]
Streaming stateful operator attempted to access state store out of order. This is a bug, please retry. error_msg=Cannot 
update after ABORTED SQLSTATE: XXKST 
org.apache.spark.sql.execution.streaming.state.StateStoreOperationOutOfOrder: 
[STATE_STORE_OPERATION_OUT_OF_ORDER] Streaming stateful operator attempted to access state store out of order. 
This is a bug, please retry. error_msg=Cannot update after ABORTED SQLSTATE: XXKST
```

This exception is caught [here](https://github.com/apache/spark/blob/bb41e19ae9ee0f7c228ac395800e740944ee355f/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServer.scala#L180-L185). At this time, the TWS client in python worker may have already closed, then [outputStream.flush()](https://github.com/apache/spark/blob/bb41e19ae9ee0f7c228ac395800e740944ee355f/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServer.scala#L183) will throw out `java.nio.channels.ClosedByInterruptException` which is not handled properly and crashes the worker.

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Handle the interruption exception properly in TransformWithStateInPySparkStateServer to avoid the worker crash


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
worker will be crashed when `query.stop` is invoked for TWS python query. This is not desired state for isolation.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Built a image and ran the test manually and confirmed `query.stop` would not crash the worker


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No