### PR TITLE
[SPARK-53538][SQL][4.0] `ExpandExec` should initialize the unsafe projections

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExpandExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExpandExec.scala
@@ -56,8 +56,9 @@ case class ExpandExec(
   protected override def doExecute(): RDD[InternalRow] = {
     val numOutputRows = longMetric("numOutputRows")
 
-    child.execute().mapPartitions { iter =>
+    child.execute().mapPartitionsWithIndexInternal { (index, iter) =>
       val groups = projections.map(projection).toArray
+      groups.foreach(_.initialize(index))
       new Iterator[InternalRow] {
         private[this] var result: InternalRow = _
         private[this] var idx = -1  // -1 means the initial state

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/UpdateTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/UpdateTableSuiteBase.scala
@@ -21,6 +21,7 @@ import org.apache.spark.SparkRuntimeException
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.connector.catalog.{Column, ColumnDefaultValue}
 import org.apache.spark.sql.connector.expressions.LiteralValue
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{IntegerType, StringType}
 
 abstract class UpdateTableSuiteBase extends RowLevelOperationSuiteBase {
@@ -519,6 +520,25 @@ abstract class UpdateTableSuiteBase extends RowLevelOperationSuiteBase {
         |{ "pk": 2, "id": 2, "value": 2.0,  "dep": "software" }
         |{ "pk": 3, "id": 3, "value": 2.0, "dep": "hr" }
         |""".stripMargin)
+
+    // rand() always generates values in [0, 1) range
+    sql(s"UPDATE $tableNameAsString SET value = rand() WHERE id <= 2")
+
+    checkAnswer(
+      sql(s"SELECT count(*) FROM $tableNameAsString WHERE value < 2.0"),
+      Row(2) :: Nil)
+  }
+
+  test("SPARK-53538: update with nondeterministic assignments and no wholestage codegen") {
+    val extraColCount = SQLConf.get.wholeStageMaxNumFields - 4
+    val schema = "pk INT NOT NULL, id INT, value DOUBLE, dep STRING, " +
+      ((1 to extraColCount).map(i => s"col$i INT").mkString(", "))
+    val data = (1 to 3).map { i =>
+      s"""{ "pk": $i, "id": $i, "value": 2.0, "dep": "hr", """ +
+        ((1 to extraColCount).map(j => s""""col$j": $i""").mkString(", ")) +
+      "}"
+    }.mkString("\n")
+    createAndInitTable(schema, data)
 
     // rand() always generates values in [0, 1) range
     sql(s"UPDATE $tableNameAsString SET value = rand() WHERE id <= 2")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR back-ports #52292.

Change `ExpandExec#doExecute` to initialize the unsafe projections before using them.

### Why are the changes needed?

The unsafe projections might contain non-deterministic expressions, and non-deterministic expressions must be initialized before used.

For example, see the test added by this PR (which is essentially the test right above it, except with whole-stage codegen turned off). In the case where the "split-updates" property is set to "true", `RewriteUpdateTable` will create an `Expand` operator with a set of projections, one of which will contain a nondeterministic expression (the assignment value). `ExpandExec` fails to initialize the derived `UnsafeProjection`s before using them, resulting in a `NullPointerException`:
```
[info]   org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 11.0 failed 1 times, most recent failure: Lost task 0.0 in stage 11.0 (TID 11) (10.0.0.101 executor driver):
java.lang.NullPointerException: Cannot invoke "java.util.Random.nextDouble()" because "<parameter1>.mutableStateArray_0[0]" is null
[info] 	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.writeFields_0_0$(Unknown Source)
[info] 	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.apply(Unknown Source)
[info] 	at org.apache.spark.sql.execution.ExpandExec$$anon$1.next(ExpandExec.scala:75)
...
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New test.