### PR TITLE
[SPARK-53547] [PYTHON] Add make_timestamp_ntz overload with date/time parameters

### DIFF
--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -1374,6 +1374,11 @@
       "Value for `<arg_name>` must be between <lower_bound> and <upper_bound> (inclusive), got <actual>"
     ]
   },
+  "WRONG_NUM_ARGS": {
+    "message": [
+      "Function `<func_name>` expects <expected> but got <actual>."
+    ]
+  },
   "WRONG_NUM_ARGS_FOR_HIGHER_ORDER_FUNCTION": {
     "message": [
       "Function `<func_name>` should take between 1 and 3 arguments, but the provided function takes <num_args>."
@@ -1382,11 +1387,6 @@
   "WRONG_NUM_COLUMNS": {
     "message": [
       "Function `<func_name>` should take at least <num_cols> columns."
-    ]
-  },
-  "WRONG_NUM_ARGS": {
-    "message": [
-      "Function `<func_name>` expects <expected> but got <actual>."
     ]
   },
   "ZERO_INDEX": {

--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -1384,6 +1384,11 @@
       "Function `<func_name>` should take at least <num_cols> columns."
     ]
   },
+  "WRONG_NUM_ARGS": {
+    "message": [
+      "Function `<func_name>` expects <expected> but got <actual>."
+    ]
+  },
   "ZERO_INDEX": {
     "message": [
       "Index must be non-zero."

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -4036,14 +4036,14 @@ def make_timestamp_ntz(date: "ColumnOrName", time: "ColumnOrName") -> Column:
     ...
 
 
-def make_timestamp_ntz(*args: "ColumnOrName") -> Column:
-    if len(args) == 2:
+def make_timestamp_ntz(*cols: "ColumnOrName") -> Column:
+    if len(cols) == 2:
         # make_timestamp_ntz(date, time)
-        date, time = args
+        date, time = cols
         return _invoke_function_over_columns("make_timestamp_ntz", date, time)
-    elif len(args) == 6:
+    elif len(cols) == 6:
         # make_timestamp_ntz(years, months, days, hours, mins, secs)
-        years, months, days, hours, mins, secs = args
+        years, months, days, hours, mins, secs = cols
         return _invoke_function_over_columns(
             "make_timestamp_ntz", years, months, days, hours, mins, secs
         )
@@ -4053,8 +4053,8 @@ def make_timestamp_ntz(*args: "ColumnOrName") -> Column:
             errorClass="WRONG_NUM_ARGS",
             messageParameters={
                 "func_name": "make_timestamp_ntz",
-                "expected": "either 6 columns (years, months, days, hours, mins, secs) or 2 columns (date, time)",
-                "actual": f"{len(args)} columns",
+                "expected": "either (years, months, days, hours, mins, secs) or (date, time)",
+                "actual": f"{len(cols)} columns",
             },
         )
 

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -4019,7 +4019,7 @@ def try_make_timestamp_ltz(
 try_make_timestamp_ltz.__doc__ = pysparkfuncs.try_make_timestamp_ltz.__doc__
 
 
-@overload
+@overload  # type: ignore[no-redef]
 def make_timestamp_ntz(
     years: "ColumnOrName",
     months: "ColumnOrName",
@@ -4032,51 +4032,29 @@ def make_timestamp_ntz(
 
 
 @overload
-def make_timestamp_ntz(*, date: "ColumnOrName", time: "ColumnOrName") -> Column:
+def make_timestamp_ntz(date: "ColumnOrName", time: "ColumnOrName") -> Column:
     ...
 
 
-def make_timestamp_ntz(
-    years: Optional["ColumnOrName"] = None,
-    months: Optional["ColumnOrName"] = None,
-    days: Optional["ColumnOrName"] = None,
-    hours: Optional["ColumnOrName"] = None,
-    mins: Optional["ColumnOrName"] = None,
-    secs: Optional["ColumnOrName"] = None,
-    *,
-    date: Optional["ColumnOrName"] = None,
-    time: Optional["ColumnOrName"] = None,
-) -> Column:
-    # Check for mixed arguments (invalid)
-    if any(arg is not None for arg in [years, months, days, hours, mins, secs]) and (
-        date is not None or time is not None
-    ):
-        raise PySparkValueError(
-            errorClass="WRONG_NUM_ARGS",
-            messageParameters={
-                "func_name": "make_timestamp_ntz",
-                "expected": "either (years, months, days, hours, mins, secs) or (date, time)",
-                "actual": "mixed arguments from both approaches",
-            },
-        )
-
-    # Handle valid cases
-    if date is not None and time is not None:
-        # make_timestamp_ntz(date=..., time=...)
+def make_timestamp_ntz(*args: "ColumnOrName") -> Column:
+    if len(args) == 2:
+        # make_timestamp_ntz(date, time)
+        date, time = args
         return _invoke_function_over_columns("make_timestamp_ntz", date, time)
-    elif all(arg is not None for arg in [years, months, days, hours, mins, secs]):
+    elif len(args) == 6:
         # make_timestamp_ntz(years, months, days, hours, mins, secs)
+        years, months, days, hours, mins, secs = args
         return _invoke_function_over_columns(
             "make_timestamp_ntz", years, months, days, hours, mins, secs
         )
     else:
-        # Invalid argument combination (partial arguments)
+        # Invalid number of arguments
         raise PySparkValueError(
             errorClass="WRONG_NUM_ARGS",
             messageParameters={
                 "func_name": "make_timestamp_ntz",
-                "expected": "(years, months, days, hours, mins, secs) or (date, time)",
-                "actual": "incomplete arguments",
+                "expected": "either 6 arguments (years, months, days, hours, mins, secs) or 2 arguments (date, time)",
+                "actual": f"{len(args)} arguments",
             },
         )
 

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -4019,6 +4019,7 @@ def try_make_timestamp_ltz(
 try_make_timestamp_ltz.__doc__ = pysparkfuncs.try_make_timestamp_ltz.__doc__
 
 
+@overload
 def make_timestamp_ntz(
     years: "ColumnOrName",
     months: "ColumnOrName",
@@ -4027,9 +4028,51 @@ def make_timestamp_ntz(
     mins: "ColumnOrName",
     secs: "ColumnOrName",
 ) -> Column:
-    return _invoke_function_over_columns(
-        "make_timestamp_ntz", years, months, days, hours, mins, secs
-    )
+    ...
+
+
+@overload
+def make_timestamp_ntz(*, date: "ColumnOrName", time: "ColumnOrName") -> Column:
+    ...
+
+
+def make_timestamp_ntz(
+    years: Optional["ColumnOrName"] = None,
+    months: Optional["ColumnOrName"] = None,
+    days: Optional["ColumnOrName"] = None,
+    hours: Optional["ColumnOrName"] = None,
+    mins: Optional["ColumnOrName"] = None,
+    secs: Optional["ColumnOrName"] = None,
+    *,
+    date: Optional["ColumnOrName"] = None,
+    time: Optional["ColumnOrName"] = None,
+) -> Column:
+    # Check for date/time keyword arguments (2-parameter version)
+    if date is not None and time is not None:
+        # make_timestamp_ntz(date=..., time=...)
+        if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
+            raise PySparkValueError(
+                errorClass="WRONG_NUM_ARGS",
+                messageParameters={"func_name": "make_timestamp_ntz", "expected": "either 6 positional args or date/time keywords", "actual": "mixed"}
+            )
+        return _invoke_function_over_columns("make_timestamp_ntz", date, time)
+    
+    # Check for 6-parameter positional version
+    elif all(arg is not None for arg in [years, months, days, hours, mins, secs]):
+        # make_timestamp_ntz(years, months, days, hours, mins, secs)
+        if date is not None or time is not None:
+            raise PySparkValueError(
+                errorClass="WRONG_NUM_ARGS",
+                messageParameters={"func_name": "make_timestamp_ntz", "expected": "either 6 positional args or date/time keywords", "actual": "mixed"}
+            )
+        return _invoke_function_over_columns("make_timestamp_ntz", years, months, days, hours, mins, secs)
+    
+    else:
+        # Invalid argument combination
+        raise PySparkValueError(
+            errorClass="WRONG_NUM_ARGS",
+            messageParameters={"func_name": "make_timestamp_ntz", "expected": "either all 6 positional args (years, months, days, hours, mins, secs) or date/time keywords", "actual": "partial"}
+        )
 
 
 make_timestamp_ntz.__doc__ = pysparkfuncs.make_timestamp_ntz.__doc__

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -4075,7 +4075,7 @@ def make_timestamp_ntz(
             errorClass="WRONG_NUM_ARGS",
             messageParameters={
                 "func_name": "make_timestamp_ntz",
-                "expected": "either all 6 components (years, months, days, hours, mins, secs) or both date and time",
+                "expected": "(years, months, days, hours, mins, secs) or (date, time)",
                 "actual": "incomplete arguments",
             },
         )

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -4019,7 +4019,7 @@ def try_make_timestamp_ltz(
 try_make_timestamp_ltz.__doc__ = pysparkfuncs.try_make_timestamp_ltz.__doc__
 
 
-@overload  # type: ignore[no-redef]
+@overload
 def make_timestamp_ntz(
     years: "ColumnOrName",
     months: "ColumnOrName",
@@ -4053,8 +4053,8 @@ def make_timestamp_ntz(*args: "ColumnOrName") -> Column:
             errorClass="WRONG_NUM_ARGS",
             messageParameters={
                 "func_name": "make_timestamp_ntz",
-                "expected": "either 6 arguments (years, months, days, hours, mins, secs) or 2 arguments (date, time)",
-                "actual": f"{len(args)} arguments",
+                "expected": "either 6 columns (years, months, days, hours, mins, secs) or 2 columns (date, time)",
+                "actual": f"{len(args)} columns",
             },
         )
 

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -4047,25 +4047,37 @@ def make_timestamp_ntz(
     date: Optional["ColumnOrName"] = None,
     time: Optional["ColumnOrName"] = None,
 ) -> Column:
-    # Check for mixed arguments (invalid)    
-    if any(arg is not None for arg in [years, months, days, hours, mins, secs]) and (date is not None or time is not None):
+    # Check for mixed arguments (invalid)
+    if any(arg is not None for arg in [years, months, days, hours, mins, secs]) and (
+        date is not None or time is not None
+    ):
         raise PySparkValueError(
             errorClass="WRONG_NUM_ARGS",
-            messageParameters={"func_name": "make_timestamp_ntz", "expected": "either (years, months, days, hours, mins, secs) or (date, time)", "actual": "cannot mix both approaches"}
+            messageParameters={
+                "func_name": "make_timestamp_ntz",
+                "expected": "either (years, months, days, hours, mins, secs) or (date, time)",
+                "actual": "mixed arguments from both approaches",
+            },
         )
-    
+
     # Handle valid cases
     if date is not None and time is not None:
         # make_timestamp_ntz(date=..., time=...)
         return _invoke_function_over_columns("make_timestamp_ntz", date, time)
     elif all(arg is not None for arg in [years, months, days, hours, mins, secs]):
         # make_timestamp_ntz(years, months, days, hours, mins, secs)
-        return _invoke_function_over_columns("make_timestamp_ntz", years, months, days, hours, mins, secs)
+        return _invoke_function_over_columns(
+            "make_timestamp_ntz", years, months, days, hours, mins, secs
+        )
     else:
         # Invalid argument combination (partial arguments)
         raise PySparkValueError(
             errorClass="WRONG_NUM_ARGS",
-            messageParameters={"func_name": "make_timestamp_ntz", "expected": "either all 6 components (years, months, days, hours, mins, secs) or both date and time", "actual": "incomplete arguments"}
+            messageParameters={
+                "func_name": "make_timestamp_ntz",
+                "expected": "either all 6 components (years, months, days, hours, mins, secs) or both date and time",
+                "actual": "incomplete arguments",
+            },
         )
 
 

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -4047,31 +4047,25 @@ def make_timestamp_ntz(
     date: Optional["ColumnOrName"] = None,
     time: Optional["ColumnOrName"] = None,
 ) -> Column:
-    # Check for date/time keyword arguments (2-parameter version)
-    if date is not None and time is not None:
-        # make_timestamp_ntz(date=..., time=...)
-        if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
-            raise PySparkValueError(
-                errorClass="WRONG_NUM_ARGS",
-                messageParameters={"func_name": "make_timestamp_ntz", "expected": "either 6 positional args or date/time keywords", "actual": "mixed"}
-            )
-        return _invoke_function_over_columns("make_timestamp_ntz", date, time)
-    
-    # Check for 6-parameter positional version
-    elif all(arg is not None for arg in [years, months, days, hours, mins, secs]):
-        # make_timestamp_ntz(years, months, days, hours, mins, secs)
-        if date is not None or time is not None:
-            raise PySparkValueError(
-                errorClass="WRONG_NUM_ARGS",
-                messageParameters={"func_name": "make_timestamp_ntz", "expected": "either 6 positional args or date/time keywords", "actual": "mixed"}
-            )
-        return _invoke_function_over_columns("make_timestamp_ntz", years, months, days, hours, mins, secs)
-    
-    else:
-        # Invalid argument combination
+    # Check for mixed arguments (invalid)    
+    if any(arg is not None for arg in [years, months, days, hours, mins, secs]) and (date is not None or time is not None):
         raise PySparkValueError(
             errorClass="WRONG_NUM_ARGS",
-            messageParameters={"func_name": "make_timestamp_ntz", "expected": "either all 6 positional args (years, months, days, hours, mins, secs) or date/time keywords", "actual": "partial"}
+            messageParameters={"func_name": "make_timestamp_ntz", "expected": "either (years, months, days, hours, mins, secs) or (date, time)", "actual": "cannot mix both approaches"}
+        )
+    
+    # Handle valid cases
+    if date is not None and time is not None:
+        # make_timestamp_ntz(date=..., time=...)
+        return _invoke_function_over_columns("make_timestamp_ntz", date, time)
+    elif all(arg is not None for arg in [years, months, days, hours, mins, secs]):
+        # make_timestamp_ntz(years, months, days, hours, mins, secs)
+        return _invoke_function_over_columns("make_timestamp_ntz", years, months, days, hours, mins, secs)
+    else:
+        # Invalid argument combination (partial arguments)
+        raise PySparkValueError(
+            errorClass="WRONG_NUM_ARGS",
+            messageParameters={"func_name": "make_timestamp_ntz", "expected": "either all 6 components (years, months, days, hours, mins, secs) or both date and time", "actual": "incomplete arguments"}
         )
 
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -25252,7 +25252,7 @@ def make_timestamp_ntz(*cols: "ColumnOrName") -> Column:
             errorClass="WRONG_NUM_ARGS",
             messageParameters={
                 "func_name": "make_timestamp_ntz",
-                "expected": "either 6 columns (years, months, days, hours, mins, secs) or 2 columns (date, time)",
+                "expected": "either (years, months, days, hours, mins, secs) or (date, time)",
                 "actual": f"{len(cols)} columns",
             },
         )

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -25157,25 +25157,29 @@ def make_timestamp_ntz(*cols: "ColumnOrName") -> Column:
 
     Parameters
     ----------
-    years : :class:`~pyspark.sql.Column` or column name
-        The year to represent, from 1 to 9999
-    months : :class:`~pyspark.sql.Column` or column name
-        The month-of-year to represent, from 1 (January) to 12 (December)
-    days : :class:`~pyspark.sql.Column` or column name
-        The day-of-month to represent, from 1 to 31
-    hours : :class:`~pyspark.sql.Column` or column name
-        The hour-of-day to represent, from 0 to 23
-    mins : :class:`~pyspark.sql.Column` or column name
-        The minute-of-hour to represent, from 0 to 59
-    secs : :class:`~pyspark.sql.Column` or column name
-        The second-of-minute and its micro-fraction to represent, from 0 to 60.
-        The value can be either an integer like 13, or a fraction like 13.123.
-        If the sec argument equals to 60, the seconds field is set
-        to 0 and 1 minute is added to the final timestamp.
-    date : :class:`~pyspark.sql.Column` or column name
-        A date to represent, from 0001-01-01 to 9999-12-31
-    time : :class:`~pyspark.sql.Column` or column name
-        A local time to represent, from 00:00:00 to 23:59:59.999999
+    cols : :class:`~pyspark.sql.Column` or column name
+        Either 6 columns (years, months, days, hours, mins, secs)
+        Or 2 columns (date, time)
+
+        years : :class:`~pyspark.sql.Column` or column name
+            The year to represent, from 1 to 9999
+        months : :class:`~pyspark.sql.Column` or column name
+            The month-of-year to represent, from 1 (January) to 12 (December)
+        days : :class:`~pyspark.sql.Column` or column name
+            The day-of-month to represent, from 1 to 31
+        hours : :class:`~pyspark.sql.Column` or column name
+            The hour-of-day to represent, from 0 to 23
+        mins : :class:`~pyspark.sql.Column` or column name
+            The minute-of-hour to represent, from 0 to 59
+        secs : :class:`~pyspark.sql.Column` or column name
+            The second-of-minute and its micro-fraction to represent, from 0 to 60.
+            The value can be either an integer like 13, or a fraction like 13.123.
+            If the sec argument equals to 60, the seconds field is set
+            to 0 and 1 minute is added to the final timestamp.
+        date : :class:`~pyspark.sql.Column` or column name
+            A date to represent, from 0001-01-01 to 9999-12-31
+        time : :class:`~pyspark.sql.Column` or column name
+            A local time to represent, from 00:00:00 to 23:59:59.999999
 
     Notes
     -----
@@ -25246,8 +25250,8 @@ def make_timestamp_ntz(*cols: "ColumnOrName") -> Column:
             errorClass="WRONG_NUM_ARGS",
             messageParameters={
                 "func_name": "make_timestamp_ntz",
-                "expected": "either 6 arguments (years, months, days, hours, mins, secs) or 2 arguments (date, time)",
-                "actual": f"{len(cols)} arguments",
+                "expected": "either 6 columns (years, months, days, hours, mins, secs) or 2 columns (date, time)",
+                "actual": f"{len(cols)} columns",
             },
         )
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -25175,7 +25175,7 @@ def make_timestamp_ntz(
     mins : :class:`~pyspark.sql.Column` or column name
         The minute-of-hour to represent, from 0 to 59
     secs : :class:`~pyspark.sql.Column` or column name
-        The second-of-minute and its micro-fraction to represent, from 0 to 60.
+        The second-of-minute and its micro-fraction to represent, from 0 to 60..    
         The value can be either an integer like 13 , or a fraction like 13.123.
         If the sec argument equals to 60, the seconds field is set
         to 0 and 1 minute is added to the final timestamp.
@@ -25233,31 +25233,25 @@ def make_timestamp_ntz(
 
     >>> spark.conf.unset("spark.sql.session.timeZone")
     """
-    # Check for date/time keyword arguments (2-parameter version)
-    if date is not None and time is not None:
-        # make_timestamp_ntz(date=..., time=...)
-        if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
-            raise PySparkValueError(
-                errorClass="WRONG_NUM_ARGS",
-                messageParameters={"func_name": "make_timestamp_ntz", "expected": "either 6 positional args or date/time keywords", "actual": "mixed"}
-            )
-        return _invoke_function_over_columns("make_timestamp_ntz", date, time)
-    
-    # Check for 6-parameter positional version
-    elif all(arg is not None for arg in [years, months, days, hours, mins, secs]):
-        # make_timestamp_ntz(years, months, days, hours, mins, secs)
-        if date is not None or time is not None:
-            raise PySparkValueError(
-                errorClass="WRONG_NUM_ARGS",
-                messageParameters={"func_name": "make_timestamp_ntz", "expected": "either 6 positional args or date/time keywords", "actual": "mixed"}
-            )
-        return _invoke_function_over_columns("make_timestamp_ntz", years, months, days, hours, mins, secs)
-    
-    else:
-        # Invalid argument combination
+    # Check for mixed arguments (invalid)    
+    if any(arg is not None for arg in [years, months, days, hours, mins, secs]) and (date is not None or time is not None):
         raise PySparkValueError(
             errorClass="WRONG_NUM_ARGS",
-            messageParameters={"func_name": "make_timestamp_ntz", "expected": "either all 6 positional args (years, months, days, hours, mins, secs) or date/time keywords", "actual": "partial"}
+            messageParameters={"func_name": "make_timestamp_ntz", "expected": "either (years, months, days, hours, mins, secs) or (date, time)", "actual": "cannot mix both approaches"}
+        )
+    
+    # Handle valid cases
+    if date is not None and time is not None:
+        # make_timestamp_ntz(date=..., time=...)
+        return _invoke_function_over_columns("make_timestamp_ntz", date, time)
+    elif all(arg is not None for arg in [years, months, days, hours, mins, secs]):
+        # make_timestamp_ntz(years, months, days, hours, mins, secs)
+        return _invoke_function_over_columns("make_timestamp_ntz", years, months, days, hours, mins, secs)
+    else:
+        # Invalid argument combination (partial arguments)
+        raise PySparkValueError(
+            errorClass="WRONG_NUM_ARGS",
+            messageParameters={"func_name": "make_timestamp_ntz", "expected": "either all 6 components (years, months, days, hours, mins, secs) or both date and time", "actual": "incomplete arguments"}
         )
 
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -25175,7 +25175,7 @@ def make_timestamp_ntz(
     mins : :class:`~pyspark.sql.Column` or column name
         The minute-of-hour to represent, from 0 to 59
     secs : :class:`~pyspark.sql.Column` or column name
-        The second-of-minute and its micro-fraction to represent, from 0 to 60..    
+        The second-of-minute and its micro-fraction to represent, from 0 to 60..
         The value can be either an integer like 13 , or a fraction like 13.123.
         If the sec argument equals to 60, the seconds field is set
         to 0 and 1 minute is added to the final timestamp.
@@ -25233,25 +25233,37 @@ def make_timestamp_ntz(
 
     >>> spark.conf.unset("spark.sql.session.timeZone")
     """
-    # Check for mixed arguments (invalid)    
-    if any(arg is not None for arg in [years, months, days, hours, mins, secs]) and (date is not None or time is not None):
+    # Check for mixed arguments (invalid)
+    if any(arg is not None for arg in [years, months, days, hours, mins, secs]) and (
+        date is not None or time is not None
+    ):
         raise PySparkValueError(
             errorClass="WRONG_NUM_ARGS",
-            messageParameters={"func_name": "make_timestamp_ntz", "expected": "either (years, months, days, hours, mins, secs) or (date, time)", "actual": "cannot mix both approaches"}
+            messageParameters={
+                "func_name": "make_timestamp_ntz",
+                "expected": "either (years, months, days, hours, mins, secs) or (date, time)",
+                "actual": "mixed arguments from both approaches",
+            },
         )
-    
+
     # Handle valid cases
     if date is not None and time is not None:
         # make_timestamp_ntz(date=..., time=...)
         return _invoke_function_over_columns("make_timestamp_ntz", date, time)
     elif all(arg is not None for arg in [years, months, days, hours, mins, secs]):
         # make_timestamp_ntz(years, months, days, hours, mins, secs)
-        return _invoke_function_over_columns("make_timestamp_ntz", years, months, days, hours, mins, secs)
+        return _invoke_function_over_columns(
+            "make_timestamp_ntz", years, months, days, hours, mins, secs
+        )
     else:
         # Invalid argument combination (partial arguments)
         raise PySparkValueError(
             errorClass="WRONG_NUM_ARGS",
-            messageParameters={"func_name": "make_timestamp_ntz", "expected": "either all 6 components (years, months, days, hours, mins, secs) or both date and time", "actual": "incomplete arguments"}
+            messageParameters={
+                "func_name": "make_timestamp_ntz",
+                "expected": "either all 6 components (years, months, days, hours, mins, secs) or both date and time",
+                "actual": "incomplete arguments",
+            },
         )
 
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -25261,7 +25261,7 @@ def make_timestamp_ntz(
             errorClass="WRONG_NUM_ARGS",
             messageParameters={
                 "func_name": "make_timestamp_ntz",
-                "expected": "either all 6 components (years, months, days, hours, mins, secs) or both date and time",
+                "expected": "(years, months, days, hours, mins, secs) or (date, time)",
                 "actual": "incomplete arguments",
             },
         )

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -25146,7 +25146,8 @@ def make_timestamp_ntz(date: "ColumnOrName", time: "ColumnOrName") -> Column:
 @_try_remote_functions
 def make_timestamp_ntz(*cols: "ColumnOrName") -> Column:
     """
-    Create local date-time from years, months, days, hours, mins, secs fields, or from date and time fields.
+    Create local date-time from years, months, days, hours, mins, secs fields, or from
+    date and time fields.
     If there are 6 cols, then this creates a timestamp from individual time components.
     If there are 2 cols, then this creates a timestamp from date and time.
     If the configuration `spark.sql.ansi.enabled` is false, the function returns NULL

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -25125,6 +25125,7 @@ def try_make_timestamp_ltz(
             "try_make_timestamp_ltz", years, months, days, hours, mins, secs
         )
 
+
 @overload
 def make_timestamp_ntz(
     years: "ColumnOrName",
@@ -25135,6 +25136,7 @@ def make_timestamp_ntz(
     secs: "ColumnOrName",
 ) -> Column:
     ...
+
 
 @overload
 def make_timestamp_ntz(date: "ColumnOrName", time: "ColumnOrName") -> Column:
@@ -25151,7 +25153,7 @@ def make_timestamp_ntz(*cols: "ColumnOrName") -> Column:
     on invalid inputs. Otherwise, it will throw an error instead.
 
     .. versionadded:: 3.5.0
-    
+
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -513,8 +513,8 @@ class FunctionsTestsMixin:
             errorClass="WRONG_NUM_ARGS",
             messageParameters={
                 "func_name": "make_timestamp_ntz",
-                "expected": "either 6 arguments (years, months, days, hours, mins, secs) or 2 arguments (date, time)",
-                "actual": "0 arguments",
+                "expected": "either 6 columns (years, months, days, hours, mins, secs) or 2 columns (date, time)",
+                "actual": "0 columns",
             },
         )
 
@@ -526,8 +526,8 @@ class FunctionsTestsMixin:
             errorClass="WRONG_NUM_ARGS",
             messageParameters={
                 "func_name": "make_timestamp_ntz",
-                "expected": "either 6 arguments (years, months, days, hours, mins, secs) or 2 arguments (date, time)",
-                "actual": "1 arguments",
+                "expected": "either 6 columns (years, months, days, hours, mins, secs) or 2 columns (date, time)",
+                "actual": "1 columns",
             },
         )
 
@@ -540,8 +540,8 @@ class FunctionsTestsMixin:
             errorClass="WRONG_NUM_ARGS",
             messageParameters={
                 "func_name": "make_timestamp_ntz",
-                "expected": "either 6 arguments (years, months, days, hours, mins, secs) or 2 arguments (date, time)",
-                "actual": "3 arguments",
+                "expected": "either 6 columns (years, months, days, hours, mins, secs) or 2 columns (date, time)",
+                "actual": "3 columns",
             },
         )
 

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -513,7 +513,6 @@ class FunctionsTestsMixin:
             errorClass="WRONG_NUM_ARGS",
             messageParameters={"func_name": "make_timestamp_ntz", "expected": "either all 6 components (years, months, days, hours, mins, secs) or both date and time", "actual": "incomplete arguments"}
         )
-        
 
         with self.assertRaises(PySparkValueError) as pe:
             F.make_timestamp_ntz(F.lit(2024))  # Only 1 argument

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -513,7 +513,7 @@ class FunctionsTestsMixin:
             errorClass="WRONG_NUM_ARGS",
             messageParameters={
                 "func_name": "make_timestamp_ntz",
-                "expected": "either all 6 components (years, months, days, hours, mins, secs) or both date and time",
+                "expected": "(years, months, days, hours, mins, secs) or (date, time)",
                 "actual": "incomplete arguments",
             },
         )
@@ -526,7 +526,7 @@ class FunctionsTestsMixin:
             errorClass="WRONG_NUM_ARGS",
             messageParameters={
                 "func_name": "make_timestamp_ntz",
-                "expected": "either all 6 components (years, months, days, hours, mins, secs) or both date and time",
+                "expected": "(years, months, days, hours, mins, secs) or (date, time)",
                 "actual": "incomplete arguments",
             },
         )

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -507,30 +507,50 @@ class FunctionsTestsMixin:
         # Test error handling for wrong number of arguments
         with self.assertRaises(PySparkValueError) as pe:
             F.make_timestamp_ntz()  # No arguments
-        
+
         self.check_error(
             exception=pe.exception,
             errorClass="WRONG_NUM_ARGS",
-            messageParameters={"func_name": "make_timestamp_ntz", "expected": "either all 6 components (years, months, days, hours, mins, secs) or both date and time", "actual": "incomplete arguments"}
+            messageParameters={
+                "func_name": "make_timestamp_ntz",
+                "expected": "either all 6 components (years, months, days, hours, mins, secs) or both date and time",
+                "actual": "incomplete arguments",
+            },
         )
 
         with self.assertRaises(PySparkValueError) as pe:
             F.make_timestamp_ntz(F.lit(2024))  # Only 1 argument
-        
+
         self.check_error(
             exception=pe.exception,
             errorClass="WRONG_NUM_ARGS",
-            messageParameters={"func_name": "make_timestamp_ntz", "expected": "either all 6 components (years, months, days, hours, mins, secs) or both date and time", "actual": "incomplete arguments"}
+            messageParameters={
+                "func_name": "make_timestamp_ntz",
+                "expected": "either all 6 components (years, months, days, hours, mins, secs) or both date and time",
+                "actual": "incomplete arguments",
+            },
         )
-        
+
         # Test mixed argument error
         with self.assertRaises(PySparkValueError) as pe:
-            F.make_timestamp_ntz(F.lit(2024), F.lit(1), F.lit(1), F.lit(12), F.lit(0), F.lit(0), date=F.lit("2024-01-01"))
-        
+            F.make_timestamp_ntz(
+                F.lit(2024),
+                F.lit(1),
+                F.lit(1),
+                F.lit(12),
+                F.lit(0),
+                F.lit(0),
+                date=F.lit("2024-01-01"),
+            )
+
         self.check_error(
             exception=pe.exception,
             errorClass="WRONG_NUM_ARGS",
-            messageParameters={"func_name": "make_timestamp_ntz", "expected": "either (years, months, days, hours, mins, secs) or (date, time)", "actual": "cannot mix both approaches"}
+            messageParameters={
+                "func_name": "make_timestamp_ntz",
+                "expected": "either (years, months, days, hours, mins, secs) or (date, time)",
+                "actual": "mixed arguments from both approaches",
+            },
         )
 
     def test_string_functions(self):
@@ -2064,7 +2084,7 @@ class FunctionsTests(ReusedSQLTestCase, FunctionsTestsMixin):
 if __name__ == "__main__":
     import unittest
     from pyspark.sql.tests.test_functions import *  # noqa: F401
-    
+
     try:
         import xmlrunner
 

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -2063,7 +2063,8 @@ class FunctionsTests(ReusedSQLTestCase, FunctionsTestsMixin):
 
 if __name__ == "__main__":
     import unittest
-
+    from pyspark.sql.tests.test_functions import *  # noqa: F401
+    
     try:
         import xmlrunner
 

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -513,6 +513,7 @@ class FunctionsTestsMixin:
             errorClass="WRONG_NUM_ARGS",
             messageParameters={"func_name": "make_timestamp_ntz", "expected": "either all 6 components (years, months, days, hours, mins, secs) or both date and time", "actual": "incomplete arguments"}
         )
+        
 
         with self.assertRaises(PySparkValueError) as pe:
             F.make_timestamp_ntz(F.lit(2024))  # Only 1 argument

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -498,9 +498,7 @@ class FunctionsTestsMixin:
         # Test with to_date and to_time functions
         data = [("2024-05-22", "10:30:45.123")]
         df = self.spark.createDataFrame(data, ["date_str", "time_str"])
-        actual = df.select(
-            F.make_timestamp_ntz(F.to_date(df.date_str), F.to_time(df.time_str))
-        )
+        actual = df.select(F.make_timestamp_ntz(F.to_date(df.date_str), F.to_time(df.time_str)))
         assertDataFrameEqual(actual, [Row(datetime.datetime(2024, 5, 22, 10, 30, 45, 123000))])
 
     def test_make_timestamp_ntz_error_handling(self):

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -511,7 +511,7 @@ class FunctionsTestsMixin:
             errorClass="WRONG_NUM_ARGS",
             messageParameters={
                 "func_name": "make_timestamp_ntz",
-                "expected": "either 6 columns (years, months, days, hours, mins, secs) or 2 columns (date, time)",
+                "expected": "either (years, months, days, hours, mins, secs) or (date, time)",
                 "actual": "0 columns",
             },
         )
@@ -524,7 +524,7 @@ class FunctionsTestsMixin:
             errorClass="WRONG_NUM_ARGS",
             messageParameters={
                 "func_name": "make_timestamp_ntz",
-                "expected": "either 6 columns (years, months, days, hours, mins, secs) or 2 columns (date, time)",
+                "expected": "either (years, months, days, hours, mins, secs) or (date, time)",
                 "actual": "1 columns",
             },
         )
@@ -538,7 +538,7 @@ class FunctionsTestsMixin:
             errorClass="WRONG_NUM_ARGS",
             messageParameters={
                 "func_name": "make_timestamp_ntz",
-                "expected": "either 6 columns (years, months, days, hours, mins, secs) or 2 columns (date, time)",
+                "expected": "either (years, months, days, hours, mins, secs) or (date, time)",
                 "actual": "3 columns",
             },
         )

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -511,7 +511,7 @@ class FunctionsTestsMixin:
         self.check_error(
             exception=pe.exception,
             errorClass="WRONG_NUM_ARGS",
-            messageParameters={"func_name": "make_timestamp_ntz", "expected": "either all 6 positional args (years, months, days, hours, mins, secs) or date/time keywords", "actual": "partial"}
+            messageParameters={"func_name": "make_timestamp_ntz", "expected": "either all 6 components (years, months, days, hours, mins, secs) or both date and time", "actual": "incomplete arguments"}
         )
 
         with self.assertRaises(PySparkValueError) as pe:
@@ -520,7 +520,7 @@ class FunctionsTestsMixin:
         self.check_error(
             exception=pe.exception,
             errorClass="WRONG_NUM_ARGS",
-            messageParameters={"func_name": "make_timestamp_ntz", "expected": "either all 6 positional args (years, months, days, hours, mins, secs) or date/time keywords", "actual": "partial"}
+            messageParameters={"func_name": "make_timestamp_ntz", "expected": "either all 6 components (years, months, days, hours, mins, secs) or both date and time", "actual": "incomplete arguments"}
         )
         
         # Test mixed argument error
@@ -530,7 +530,7 @@ class FunctionsTestsMixin:
         self.check_error(
             exception=pe.exception,
             errorClass="WRONG_NUM_ARGS",
-            messageParameters={"func_name": "make_timestamp_ntz", "expected": "either 6 positional args or date/time keywords", "actual": "mixed"}
+            messageParameters={"func_name": "make_timestamp_ntz", "expected": "either (years, months, days, hours, mins, secs) or (date, time)", "actual": "cannot mix both approaches"}
         )
 
     def test_string_functions(self):

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -492,14 +492,14 @@ class FunctionsTestsMixin:
         # Test with date and time columns
         data = [(date(2024, 5, 22), time(10, 30, 45))]
         df = self.spark.createDataFrame(data, ["date_col", "time_col"])
-        actual = df.select(F.make_timestamp_ntz(date=df.date_col, time=df.time_col))
+        actual = df.select(F.make_timestamp_ntz(df.date_col, df.time_col))
         assertDataFrameEqual(actual, [Row(datetime.datetime(2024, 5, 22, 10, 30, 45))])
 
         # Test with to_date and to_time functions
         data = [("2024-05-22", "10:30:45.123")]
         df = self.spark.createDataFrame(data, ["date_str", "time_str"])
         actual = df.select(
-            F.make_timestamp_ntz(date=F.to_date(df.date_str), time=F.to_time(df.time_str))
+            F.make_timestamp_ntz(F.to_date(df.date_str), F.to_time(df.time_str))
         )
         assertDataFrameEqual(actual, [Row(datetime.datetime(2024, 5, 22, 10, 30, 45, 123000))])
 
@@ -513,8 +513,8 @@ class FunctionsTestsMixin:
             errorClass="WRONG_NUM_ARGS",
             messageParameters={
                 "func_name": "make_timestamp_ntz",
-                "expected": "(years, months, days, hours, mins, secs) or (date, time)",
-                "actual": "incomplete arguments",
+                "expected": "either 6 arguments (years, months, days, hours, mins, secs) or 2 arguments (date, time)",
+                "actual": "0 arguments",
             },
         )
 
@@ -526,30 +526,22 @@ class FunctionsTestsMixin:
             errorClass="WRONG_NUM_ARGS",
             messageParameters={
                 "func_name": "make_timestamp_ntz",
-                "expected": "(years, months, days, hours, mins, secs) or (date, time)",
-                "actual": "incomplete arguments",
+                "expected": "either 6 arguments (years, months, days, hours, mins, secs) or 2 arguments (date, time)",
+                "actual": "1 arguments",
             },
         )
 
-        # Test mixed argument error
+        # Test invalid number of arguments (3 arguments)
         with self.assertRaises(PySparkValueError) as pe:
-            F.make_timestamp_ntz(
-                F.lit(2024),
-                F.lit(1),
-                F.lit(1),
-                F.lit(12),
-                F.lit(0),
-                F.lit(0),
-                date=F.lit("2024-01-01"),
-            )
+            F.make_timestamp_ntz(F.lit(2024), F.lit(1), F.lit(1))
 
         self.check_error(
             exception=pe.exception,
             errorClass="WRONG_NUM_ARGS",
             messageParameters={
                 "func_name": "make_timestamp_ntz",
-                "expected": "either (years, months, days, hours, mins, secs) or (date, time)",
-                "actual": "mixed arguments from both approaches",
+                "expected": "either 6 arguments (years, months, days, hours, mins, secs) or 2 arguments (date, time)",
+                "actual": "3 arguments",
             },
         )
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add support for make_timestamp_ntz(date=..., time=...) overload in PySpark. This implements SPARK-53547 to provide an alternative way to create local date-time values using separate date and time columns.


### Why are the changes needed?
We need to align with Scala side API to make it flexible for users to create a timestamp with date and time.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
New PySpark function.


### How was this patch tested?
Added unit tests.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Tests Generated-by: Cursor
