### PR TITLE
[SPARK-53572][SQL] Avoid throwing from ExtractValue.isExtractable

### DIFF
--- a/sql/core/src/test/resources/sql-tests/analyzer-results/having-and-order-by-recursive-type-name-resolution.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/having-and-order-by-recursive-type-name-resolution.sql.out
@@ -311,3 +311,63 @@ HAVING col1['b'] > 1
 Filter (col1#x[b] > 1)
 +- Aggregate [col1#x], [map(a, 1, b, 2) AS col1#x, col1#x]
    +- LocalRelation [col1#x]
+
+
+-- !query
+SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 ORDER BY col1.a
+-- !query analysis
+Project [col1#x]
++- Sort [col1#x.a ASC NULLS FIRST], true
+   +- Aggregate [col1#x], [named_struct(b, 1) AS col1#x, col1#x]
+      +- SubqueryAlias t
+         +- LocalRelation [col1#x]
+
+
+-- !query
+SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 HAVING col1.a > 0
+-- !query analysis
+Project [col1#x]
++- Filter (col1#x.a > 0)
+   +- Aggregate [col1#x], [named_struct(b, 1) AS col1#x, col1#x]
+      +- SubqueryAlias t
+         +- LocalRelation [col1#x]
+
+
+-- !query
+SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 HAVING col1.a > 0 ORDER BY col1.a
+-- !query analysis
+Project [col1#x]
++- Sort [col1#x.a ASC NULLS FIRST], true
+   +- Project [col1#x, col1#x]
+      +- Filter (col1#x.a > 0)
+         +- Aggregate [col1#x], [named_struct(b, 1) AS col1#x, col1#x]
+            +- SubqueryAlias t
+               +- LocalRelation [col1#x]
+
+
+-- !query
+SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 ORDER BY col1.b
+-- !query analysis
+Sort [col1#x.b ASC NULLS FIRST], true
++- Aggregate [col1#x], [named_struct(b, 1) AS col1#x]
+   +- SubqueryAlias t
+      +- LocalRelation [col1#x]
+
+
+-- !query
+SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 HAVING col1.b > 0
+-- !query analysis
+Filter (col1#x.b > 0)
++- Aggregate [col1#x], [named_struct(b, 1) AS col1#x]
+   +- SubqueryAlias t
+      +- LocalRelation [col1#x]
+
+
+-- !query
+SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 HAVING col1.b > 0 ORDER BY col1.b
+-- !query analysis
+Sort [col1#x.b ASC NULLS FIRST], true
++- Filter (col1#x.b > 0)
+   +- Aggregate [col1#x], [named_struct(b, 1) AS col1#x]
+      +- SubqueryAlias t
+         +- LocalRelation [col1#x]

--- a/sql/core/src/test/resources/sql-tests/inputs/having-and-order-by-recursive-type-name-resolution.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/having-and-order-by-recursive-type-name-resolution.sql
@@ -74,3 +74,15 @@ SELECT map('a', 1, 'b', 2) AS col1, col1
 FROM values(map('a', 1, 'b', 2))
 GROUP BY col1
 HAVING col1['b'] > 1;
+
+-- Both alias and column are named the `col1`, but fields are named `a` and `b`
+
+-- Reference to column field
+SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 ORDER BY col1.a;
+SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 HAVING col1.a > 0;
+SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 HAVING col1.a > 0 ORDER BY col1.a;
+
+-- Reference to alias field
+SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 ORDER BY col1.b;
+SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 HAVING col1.b > 0;
+SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 HAVING col1.b > 0 ORDER BY col1.b;

--- a/sql/core/src/test/resources/sql-tests/results/having-and-order-by-recursive-type-name-resolution.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/having-and-order-by-recursive-type-name-resolution.sql.out
@@ -276,3 +276,51 @@ HAVING col1['b'] > 1
 struct<col1:map<string,int>,col1:map<string,int>>
 -- !query output
 {"a":1,"b":2}	{"a":1,"b":2}
+
+
+-- !query
+SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 ORDER BY col1.a
+-- !query schema
+struct<col1:struct<b:int>>
+-- !query output
+{"b":1}
+
+
+-- !query
+SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 HAVING col1.a > 0
+-- !query schema
+struct<col1:struct<b:int>>
+-- !query output
+
+
+
+-- !query
+SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 HAVING col1.a > 0 ORDER BY col1.a
+-- !query schema
+struct<col1:struct<b:int>>
+-- !query output
+
+
+
+-- !query
+SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 ORDER BY col1.b
+-- !query schema
+struct<col1:struct<b:int>>
+-- !query output
+{"b":1}
+
+
+-- !query
+SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 HAVING col1.b > 0
+-- !query schema
+struct<col1:struct<b:int>>
+-- !query output
+{"b":1}
+
+
+-- !query
+SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 HAVING col1.b > 0 ORDER BY col1.b
+-- !query schema
+struct<col1:struct<b:int>>
+-- !query output
+{"b":1}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Avoid throwing from `ExtractValue.isExtractable` -  It should return `None` even if `findFiled` did not find the requested field.

### Why are the changes needed?

This is necessary for the correct struct field/array item/map key prioritization in the single-pass Analyzer.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New golden file tests.

### Was this patch authored or co-authored using generative AI tooling?

No.