### PR TITLE
[SPARK-53577][DOCS] Fix Scaladoc source links for java sources

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1498,7 +1498,7 @@ object Unidoc {
     ) ++ (
       // Add links to sources when generating Scaladoc for a non-snapshot release
       if (!isSnapshot.value) {
-        Opts.doc.sourceUrl(unidocSourceBase.value + "€{FILE_PATH}.scala")
+        Opts.doc.sourceUrl(unidocSourceBase.value + "€{FILE_PATH_EXT}")
       } else {
         Seq()
       }


### PR DESCRIPTION


### What changes were proposed in this pull request?
Replace `€{FILE_PATH}.scala` with `€{FILE_PATH_EXT}` as the placeholder for generating Scaladoc source links


### Why are the changes needed?
Fix 404 for cases like https://spark.apache.org/docs/latest/api/scala/org/apache/spark/launcher/JavaModuleOptions.html


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?

Build Scala doc locally to verify

### Was this patch authored or co-authored using generative AI tooling?
no
