### PR TITLE
[SPARK-53582][SQL] Extend `isExtractable` so it can be applied on `UnresolvedExtractValue`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/NameScope.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/NameScope.scala
@@ -700,7 +700,11 @@ class NameScope(
 
     val filteredCandidates = if (nestedFields.nonEmpty) {
       candidates.filter { attribute =>
-        ExtractValue.isExtractable(attribute, nestedFields, nameComparator)
+        ExtractValue.isExtractable(
+          attribute = attribute,
+          nestedFields = nestedFields,
+          resolver = nameComparator
+        )
       }
     } else {
       candidates

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/DecorrelateInnerQuery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/DecorrelateInnerQuery.scala
@@ -532,7 +532,10 @@ object DecorrelateInnerQuery extends PredicateHelper {
               if (!cond.resolved) {
                 if (!RowOrdering.isOrderable(a.dataType)) {
                   throw QueryCompilationErrors.unsupportedCorrelatedReferenceDataTypeError(
-                    o, a.dataType, plan.origin)
+                    expr = a,
+                    dataType = a.dataType,
+                    origin = a.origin
+                  )
                 } else {
                   throw SparkException.internalError(s"Unable to decorrelate subquery: " +
                     s"join condition '${cond.sql}' cannot be resolved.")

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/having-and-order-by-recursive-type-name-resolution.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/having-and-order-by-recursive-type-name-resolution.sql.out
@@ -371,3 +371,132 @@ Sort [col1#x.b ASC NULLS FIRST], true
    +- Aggregate [col1#x], [named_struct(b, 1) AS col1#x]
       +- SubqueryAlias t
          +- LocalRelation [col1#x]
+
+
+-- !query
+SELECT col1.name
+FROM VALUES (NAMED_STRUCT('name', 'test', 'id', 1)) t (col1)
+GROUP BY col1
+HAVING col1.id > 0
+ORDER BY col1.name
+-- !query analysis
+Project [name#x]
++- Sort [col1#x.name ASC NULLS FIRST], true
+   +- Project [name#x, col1#x]
+      +- Filter (col1#x.id > 0)
+         +- Aggregate [col1#x], [col1#x.name AS name#x, col1#x]
+            +- SubqueryAlias t
+               +- LocalRelation [col1#x]
+
+
+-- !query
+SELECT col1.items[0]
+FROM VALUES (NAMED_STRUCT('items', ARRAY(1, 2, 3))) t (col1)
+GROUP BY col1
+HAVING col1.items[0] > 0
+ORDER BY col1.items[0]
+-- !query analysis
+Sort [col1.items[0]#x ASC NULLS FIRST], true
++- Filter (col1.items[0]#x > 0)
+   +- Aggregate [col1#x], [col1#x.items[0] AS col1.items[0]#x]
+      +- SubqueryAlias t
+         +- LocalRelation [col1#x]
+
+
+-- !query
+SELECT col1.data['key']
+FROM VALUES (NAMED_STRUCT('data', MAP('key', 'value', 'num', '42'))) t (col1)
+GROUP BY col1
+HAVING col1.data['num'] IS NOT NULL
+ORDER BY col1.data['key']
+-- !query analysis
+Project [col1.data[key]#x]
++- Sort [col1#x.data[key] ASC NULLS FIRST], true
+   +- Project [col1.data[key]#x, col1#x]
+      +- Filter isnotnull(col1#x.data[num])
+         +- Aggregate [col1#x], [col1#x.data[key] AS col1.data[key]#x, col1#x]
+            +- SubqueryAlias t
+               +- LocalRelation [col1#x]
+
+
+-- !query
+SELECT col1.users[0].name
+FROM VALUES (
+             NAMED_STRUCT('users', ARRAY(NAMED_STRUCT('name', 'John', 'age', 30)))
+     ) t (col1)
+GROUP BY col1
+HAVING col1.users[0].age > 25
+ORDER BY col1.users[0].name
+-- !query analysis
+Project [col1.users[0].name#x]
++- Sort [col1#x.users[0].name ASC NULLS FIRST], true
+   +- Project [col1.users[0].name#x, col1#x]
+      +- Filter (col1#x.users[0].age > 25)
+         +- Aggregate [col1#x], [col1#x.users[0].name AS col1.users[0].name#x, col1#x]
+            +- SubqueryAlias t
+               +- LocalRelation [col1#x]
+
+
+-- !query
+SELECT col1.person.address.city
+FROM VALUES (
+             NAMED_STRUCT('person', NAMED_STRUCT('address', NAMED_STRUCT('city', 'NYC', 'zip', 10001)))
+     ) t (col1)
+GROUP BY col1
+HAVING col1.person.address.zip > 10000
+ORDER BY col1.person.address.city
+-- !query analysis
+Project [city#x]
++- Sort [col1#x.person.address.city ASC NULLS FIRST], true
+   +- Project [city#x, col1#x]
+      +- Filter (col1#x.person.address.zip > 10000)
+         +- Aggregate [col1#x], [col1#x.person.address.city AS city#x, col1#x]
+            +- SubqueryAlias t
+               +- LocalRelation [col1#x]
+
+
+-- !query
+SELECT col1.matrix[0][1]
+FROM VALUES (
+             NAMED_STRUCT('matrix', ARRAY(ARRAY(1, 2), ARRAY(3, 4)))
+     ) t (col1)
+GROUP BY col1
+HAVING col1.matrix[0][0] < 5
+ORDER BY col1.matrix[0][1]
+-- !query analysis
+Project [col1.matrix[0][1]#x]
++- Sort [col1#x.matrix[0][1] ASC NULLS FIRST], true
+   +- Project [col1.matrix[0][1]#x, col1#x]
+      +- Filter (col1#x.matrix[0][0] < 5)
+         +- Aggregate [col1#x], [col1#x.matrix[0][1] AS col1.matrix[0][1]#x, col1#x]
+            +- SubqueryAlias t
+               +- LocalRelation [col1#x]
+
+
+-- !query
+SELECT col1.data[0].props['status']
+FROM VALUES (
+             NAMED_STRUCT('data', ARRAY(NAMED_STRUCT('props', MAP('status', 'active'))))
+     ) t (col1)
+GROUP BY col1
+HAVING col1.data[0].props['status'] = 'active'
+-- !query analysis
+Filter (col1.data[0].props[status]#x = active)
++- Aggregate [col1#x], [col1#x.data[0].props[status] AS col1.data[0].props[status]#x]
+   +- SubqueryAlias t
+      +- LocalRelation [col1#x]
+
+
+-- !query
+SELECT col1.nums[0] + col1.nums[1] AS sum_val
+FROM VALUES (NAMED_STRUCT('nums', ARRAY(10, 20))) t (col1)
+GROUP BY col1
+HAVING col1.nums[0] + col1.nums[1] > 25
+ORDER BY col1.nums[0]
+-- !query analysis
+Project [sum_val#x]
++- Sort [col1#x.nums[0] ASC NULLS FIRST], true
+   +- Filter (sum_val#x > 25)
+      +- Aggregate [col1#x], [(col1#x.nums[0] + col1#x.nums[1]) AS sum_val#x, col1#x]
+         +- SubqueryAlias t
+            +- LocalRelation [col1#x]

--- a/sql/core/src/test/resources/sql-tests/inputs/having-and-order-by-recursive-type-name-resolution.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/having-and-order-by-recursive-type-name-resolution.sql
@@ -86,3 +86,58 @@ SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) 
 SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 ORDER BY col1.b;
 SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 HAVING col1.b > 0;
 SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) GROUP BY col1 HAVING col1.b > 0 ORDER BY col1.b;
+
+SELECT col1.name
+FROM VALUES (NAMED_STRUCT('name', 'test', 'id', 1)) t (col1)
+GROUP BY col1
+HAVING col1.id > 0
+ORDER BY col1.name;
+
+SELECT col1.items[0]
+FROM VALUES (NAMED_STRUCT('items', ARRAY(1, 2, 3))) t (col1)
+GROUP BY col1
+HAVING col1.items[0] > 0
+ORDER BY col1.items[0];
+
+SELECT col1.data['key']
+FROM VALUES (NAMED_STRUCT('data', MAP('key', 'value', 'num', '42'))) t (col1)
+GROUP BY col1
+HAVING col1.data['num'] IS NOT NULL
+ORDER BY col1.data['key'];
+
+SELECT col1.users[0].name
+FROM VALUES (
+             NAMED_STRUCT('users', ARRAY(NAMED_STRUCT('name', 'John', 'age', 30)))
+     ) t (col1)
+GROUP BY col1
+HAVING col1.users[0].age > 25
+ORDER BY col1.users[0].name;
+
+SELECT col1.person.address.city
+FROM VALUES (
+             NAMED_STRUCT('person', NAMED_STRUCT('address', NAMED_STRUCT('city', 'NYC', 'zip', 10001)))
+     ) t (col1)
+GROUP BY col1
+HAVING col1.person.address.zip > 10000
+ORDER BY col1.person.address.city;
+
+SELECT col1.matrix[0][1]
+FROM VALUES (
+             NAMED_STRUCT('matrix', ARRAY(ARRAY(1, 2), ARRAY(3, 4)))
+     ) t (col1)
+GROUP BY col1
+HAVING col1.matrix[0][0] < 5
+ORDER BY col1.matrix[0][1];
+
+SELECT col1.data[0].props['status']
+FROM VALUES (
+             NAMED_STRUCT('data', ARRAY(NAMED_STRUCT('props', MAP('status', 'active'))))
+     ) t (col1)
+GROUP BY col1
+HAVING col1.data[0].props['status'] = 'active';
+
+SELECT col1.nums[0] + col1.nums[1] AS sum_val
+FROM VALUES (NAMED_STRUCT('nums', ARRAY(10, 20))) t (col1)
+GROUP BY col1
+HAVING col1.nums[0] + col1.nums[1] > 25
+ORDER BY col1.nums[0];

--- a/sql/core/src/test/resources/sql-tests/results/having-and-order-by-recursive-type-name-resolution.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/having-and-order-by-recursive-type-name-resolution.sql.out
@@ -324,3 +324,106 @@ SELECT NAMED_STRUCT('b', 1) AS col1 FROM VALUES (NAMED_STRUCT('a', 0)) t (col1) 
 struct<col1:struct<b:int>>
 -- !query output
 {"b":1}
+
+
+-- !query
+SELECT col1.name
+FROM VALUES (NAMED_STRUCT('name', 'test', 'id', 1)) t (col1)
+GROUP BY col1
+HAVING col1.id > 0
+ORDER BY col1.name
+-- !query schema
+struct<name:string>
+-- !query output
+test
+
+
+-- !query
+SELECT col1.items[0]
+FROM VALUES (NAMED_STRUCT('items', ARRAY(1, 2, 3))) t (col1)
+GROUP BY col1
+HAVING col1.items[0] > 0
+ORDER BY col1.items[0]
+-- !query schema
+struct<col1.items[0]:int>
+-- !query output
+1
+
+
+-- !query
+SELECT col1.data['key']
+FROM VALUES (NAMED_STRUCT('data', MAP('key', 'value', 'num', '42'))) t (col1)
+GROUP BY col1
+HAVING col1.data['num'] IS NOT NULL
+ORDER BY col1.data['key']
+-- !query schema
+struct<col1.data[key]:string>
+-- !query output
+value
+
+
+-- !query
+SELECT col1.users[0].name
+FROM VALUES (
+             NAMED_STRUCT('users', ARRAY(NAMED_STRUCT('name', 'John', 'age', 30)))
+     ) t (col1)
+GROUP BY col1
+HAVING col1.users[0].age > 25
+ORDER BY col1.users[0].name
+-- !query schema
+struct<col1.users[0].name:string>
+-- !query output
+John
+
+
+-- !query
+SELECT col1.person.address.city
+FROM VALUES (
+             NAMED_STRUCT('person', NAMED_STRUCT('address', NAMED_STRUCT('city', 'NYC', 'zip', 10001)))
+     ) t (col1)
+GROUP BY col1
+HAVING col1.person.address.zip > 10000
+ORDER BY col1.person.address.city
+-- !query schema
+struct<city:string>
+-- !query output
+NYC
+
+
+-- !query
+SELECT col1.matrix[0][1]
+FROM VALUES (
+             NAMED_STRUCT('matrix', ARRAY(ARRAY(1, 2), ARRAY(3, 4)))
+     ) t (col1)
+GROUP BY col1
+HAVING col1.matrix[0][0] < 5
+ORDER BY col1.matrix[0][1]
+-- !query schema
+struct<col1.matrix[0][1]:int>
+-- !query output
+2
+
+
+-- !query
+SELECT col1.data[0].props['status']
+FROM VALUES (
+             NAMED_STRUCT('data', ARRAY(NAMED_STRUCT('props', MAP('status', 'active'))))
+     ) t (col1)
+GROUP BY col1
+HAVING col1.data[0].props['status'] = 'active'
+-- !query schema
+struct<col1.data[0].props[status]:string>
+-- !query output
+active
+
+
+-- !query
+SELECT col1.nums[0] + col1.nums[1] AS sum_val
+FROM VALUES (NAMED_STRUCT('nums', ARRAY(10, 20))) t (col1)
+GROUP BY col1
+HAVING col1.nums[0] + col1.nums[1] > 25
+ORDER BY col1.nums[0]
+-- !query schema
+struct<sum_val:int>
+-- !query output
+30

--- a/sql/core/src/test/resources/sql-tests/results/subquery/subquery-nested-data.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/subquery-nested-data.sql.out
@@ -252,9 +252,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 44,
-    "stopIndex" : 44,
-    "fragment" : "y"
+    "startIndex" : 23,
+    "stopIndex" : 66,
+    "fragment" : "(select sum(y2) from y where xm[y2] = ym[1])"
   } ]
 }
 
@@ -283,9 +283,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 44,
-    "stopIndex" : 44,
-    "fragment" : "y"
+    "startIndex" : 23,
+    "stopIndex" : 65,
+    "fragment" : "(select sum(y2) from y where xm[1] = ym[1])"
   } ]
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -2562,9 +2562,9 @@ class SubquerySuite extends QueryTest
             "UNSUPPORTED_CORRELATED_REFERENCE_DATA_TYPE",
           parameters = Map("expr" -> "v1.x", "dataType" -> "map"),
           context = ExpectedContext(
-            fragment = "select upper(x['a'] + rand()) as a",
-            start = 39,
-            stop = 72)
+            fragment = "(\n  select concat(a, a) from\n  (select upper(x['a'] + rand()) as a)\n)",
+            start = 7,
+            stop = 75)
         )
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Extend isExtractable so it can be applied on UnresolvedExtractValue. Additionally, fix the error context for `UNSUPPORTED_CORRELATED_REFERENCE_DATA_TYPE` error
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
The extension to `ExtractValue.isExtractable` is necessary in order to implement `UnresolvedExtractValue` in single-pass analyzer. 

We are also fixing the context, because current context is inconsistent and often doesn't make sense. This is makes it hard for single-pass analyzer to be compatible with fixed-point. For example, query like:
```
select * from x where (select sum(y2) from y where xm[y2] = ym[1]) > 2
```
will show the error on relation `y`, which has nothing to do with actual issue. This PR fixed that
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### How was this patch tested?
Existing tests.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
