### PR TITLE
[SPARK-53590][BUILD] Add `huaweicloud-provided` profile

### DIFF
--- a/hadoop-cloud/pom.xml
+++ b/hadoop-cloud/pom.xml
@@ -166,6 +166,12 @@
       <version>${hadoop.version}</version>
       <scope>${hadoop.deps.scope}</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-huaweicloud</artifactId>
+      <version>${hadoop.version}</version>
+      <scope>${huaweicloud.deps.scope}</scope>
+    </dependency>
     <!--
     There's now a hadoop-cloud-storage which transitively pulls in the store JARs,
     but it still needs some selective exclusion across versions, especially 3.0.x.
@@ -191,6 +197,10 @@
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-cos</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-huaweicloud</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <!--
@@ -215,11 +225,13 @@
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
       <version>${okhttp.version}</version>
+      <scope>${huaweicloud.deps.scope}</scope>
     </dependency>
     <dependency>
       <groupId>com.squareup.okio</groupId>
       <artifactId>okio</artifactId>
       <version>${okio.version}</version>
+      <scope>${huaweicloud.deps.scope}</scope>
     </dependency>
   </dependencies>
 
@@ -248,6 +260,12 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>huaweicloud-provided</id>
+      <properties>
+        <huaweicloud.deps.scope>provided</huaweicloud.deps.scope>
+      </properties>
+    </profile>
     <profile>
       <id>integration-test</id>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,7 @@
     -->
     <derby.deps.scope>compile</derby.deps.scope>
     <hadoop.deps.scope>compile</hadoop.deps.scope>
+    <huaweicloud.deps.scope>compile</huaweicloud.deps.scope>
     <hive.deps.scope>compile</hive.deps.scope>
     <hive.storage.version>2.8.1</hive.storage.version>
     <hive.storage.scope>compile</hive.storage.scope>
@@ -3526,6 +3527,7 @@
       <id>hadoop-provided</id>
       <properties>
         <spark.yarn.isHadoopProvided>true</spark.yarn.isHadoopProvided>
+        <huaweicloud.deps.scope>provided</huaweicloud.deps.scope>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a new profile, `huaweicloud-provided`.

### Why are the changes needed?

Since Apache Spark 4.0.0, Apache Spark module is moving from `OkHttp` to `Vert.x` implementation via the following.
- #49159
- [SPARK-37687 Cleanup direct usage of OkHttpClient](https://issues.apache.org/jira/browse/SPARK-37687)

Like Apache Hadoop community, we are moving away further from `okhttp` transitive dependencies from `hadoop-huaweicloud` dependency.
- [HADOOP-18503](https://issues.apache.org/jira/browse/HADOOP-18503) Upgrade Huawei OBS client to 3.22.3.1
- [HADOOP-18890](https://issues.apache.org/jira/browse/HADOOP-18890) Remove okhttp usage

This PR will allow users to exclude and add their `huaweicloud` and its transitive dependencies. Technically, the scope of following dependencies are changed to `provided`. As a result, those are removed from Spark distribution.
```
-esdk-obs-java/3.20.4.2//esdk-obs-java-3.20.4.2.jar
-hadoop-huaweicloud/3.4.2//hadoop-huaweicloud-3.4.2.jar
-java-xmlbuilder/1.2//java-xmlbuilder-1.2.jar
-okhttp/3.12.12//okhttp-3.12.12.jar
-okio/1.17.6//okio-1.17.6.jar
```

### Does this PR introduce _any_ user-facing change?

No, this is a new profile which is disabled by default.

### How was this patch tested?

Manually check like the following.

```
$ mvn dependency:tree -Phadoop-cloud | grep okhttp
[INFO] +- com.squareup.okhttp3:okhttp:jar:3.12.12:compile
[INFO] |  +- com.squareup.okhttp3:okhttp:jar:3.12.12:compile

$ mvn dependency:tree -Phadoop-cloud -Phuaweicloud-provided | grep okhttp
[INFO] +- com.squareup.okhttp3:okhttp:jar:3.12.12:provided
```

### Was this patch authored or co-authored using generative AI tooling?

No.