### PR TITLE
[SPARK-53482][SQL] MERGE INTO support for when source has less nested field than target

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AssignmentUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AssignmentUtils.scala
@@ -121,7 +121,7 @@ object AssignmentUtils extends SQLConfHelper with CastSupport {
         val actualAttr = restoreActualType(attr)
         val value = matchingAssignments.head.value
         TableOutputResolver.resolveUpdate(
-          "", value, actualAttr, conf, err => errors += err, colPath)
+          "", value, actualAttr, conf, err => errors += err, colPath, true)
       }
       Assignment(attr, resolvedValue)
     }
@@ -165,7 +165,8 @@ object AssignmentUtils extends SQLConfHelper with CastSupport {
       TableOutputResolver.checkNullability(colExpr, col, conf, colPath)
     } else if (exactAssignments.nonEmpty) {
       val value = exactAssignments.head.value
-      TableOutputResolver.resolveUpdate("", value, col, conf, addError, colPath)
+      TableOutputResolver.resolveUpdate("", value, col, conf, addError, colPath,
+        fillDefaultValue = true)
     } else {
       applyFieldAssignments(col, colExpr, fieldAssignments, addError, colPath)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AssignmentUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AssignmentUtils.scala
@@ -89,8 +89,8 @@ object AssignmentUtils extends SQLConfHelper with CastSupport {
    *
    * @param attrs table attributes
    * @param assignments insert assignments to align
-   * @param coerceNestedType whether to coerce nested types to match the target type
-   *                         for complex types
+   * @param coerceNestedTypes whether to coerce nested types to match the target type
+   *                          for complex types
    * @return aligned insert assignments that match table attributes
    */
   def alignInsertAssignments(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AssignmentUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AssignmentUtils.scala
@@ -50,7 +50,7 @@ object AssignmentUtils extends SQLConfHelper with CastSupport {
    *
    * @param attrs table attributes
    * @param assignments assignments to align
-   * @param coerceNestedType whether to coerce nested types to match the target type
+   * @param coerceNestedTypes whether to coerce nested types to match the target type
    *                         for complex types
    * @return aligned update assignments that match table attributes
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AssignmentUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AssignmentUtils.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.analysis
 import scala.collection.mutable
 
 import org.apache.spark.sql.catalyst.SQLConfHelper
+import org.apache.spark.sql.catalyst.analysis.TableOutputResolver.DefaultValueFillMode
 import org.apache.spark.sql.catalyst.expressions.{Attribute, CreateNamedStruct, Expression, GetStructField, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.Assignment
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
@@ -121,7 +122,7 @@ object AssignmentUtils extends SQLConfHelper with CastSupport {
         val actualAttr = restoreActualType(attr)
         val value = matchingAssignments.head.value
         TableOutputResolver.resolveUpdate(
-          "", value, actualAttr, conf, err => errors += err, colPath, true)
+          "", value, actualAttr, conf, err => errors += err, colPath, DefaultValueFillMode.RECURSE)
       }
       Assignment(attr, resolvedValue)
     }
@@ -166,7 +167,7 @@ object AssignmentUtils extends SQLConfHelper with CastSupport {
     } else if (exactAssignments.nonEmpty) {
       val value = exactAssignments.head.value
       TableOutputResolver.resolveUpdate("", value, col, conf, addError, colPath,
-        fillDefaultValue = true)
+        DefaultValueFillMode.RECURSE)
     } else {
       applyFieldAssignments(col, colExpr, fieldAssignments, addError, colPath)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AssignmentUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AssignmentUtils.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.analysis
 import scala.collection.mutable
 
 import org.apache.spark.sql.catalyst.SQLConfHelper
-import org.apache.spark.sql.catalyst.analysis.TableOutputResolver.DefaultValueFillMode
+import org.apache.spark.sql.catalyst.analysis.TableOutputResolver.DefaultValueFillMode.{NONE, RECURSE}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, CreateNamedStruct, Expression, GetStructField, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.Assignment
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
@@ -50,11 +50,14 @@ object AssignmentUtils extends SQLConfHelper with CastSupport {
    *
    * @param attrs table attributes
    * @param assignments assignments to align
+   * @param coerceNestedType whether to coerce nested types to match the target type
+   *                         for complex types
    * @return aligned update assignments that match table attributes
    */
   def alignUpdateAssignments(
       attrs: Seq[Attribute],
-      assignments: Seq[Assignment]): Seq[Assignment] = {
+      assignments: Seq[Assignment],
+      coerceNestedTypes: Boolean): Seq[Assignment] = {
 
     val errors = new mutable.ArrayBuffer[String]()
 
@@ -64,7 +67,8 @@ object AssignmentUtils extends SQLConfHelper with CastSupport {
         colExpr = attr,
         assignments,
         addError = err => errors += err,
-        colPath = Seq(attr.name))
+        colPath = Seq(attr.name),
+        coerceNestedTypes)
     }
 
     if (errors.nonEmpty) {
@@ -85,11 +89,14 @@ object AssignmentUtils extends SQLConfHelper with CastSupport {
    *
    * @param attrs table attributes
    * @param assignments insert assignments to align
+   * @param coerceNestedType whether to coerce nested types to match the target type
+   *                         for complex types
    * @return aligned insert assignments that match table attributes
    */
   def alignInsertAssignments(
       attrs: Seq[Attribute],
-      assignments: Seq[Assignment]): Seq[Assignment] = {
+      assignments: Seq[Assignment],
+      coerceNestedTypes: Boolean = false): Seq[Assignment] = {
 
     val errors = new mutable.ArrayBuffer[String]()
 
@@ -121,8 +128,9 @@ object AssignmentUtils extends SQLConfHelper with CastSupport {
         val colPath = Seq(attr.name)
         val actualAttr = restoreActualType(attr)
         val value = matchingAssignments.head.value
+        val coerceMode = if (coerceNestedTypes) RECURSE else NONE
         TableOutputResolver.resolveUpdate(
-          "", value, actualAttr, conf, err => errors += err, colPath, DefaultValueFillMode.RECURSE)
+          "", value, actualAttr, conf, err => errors += err, colPath, coerceMode)
       }
       Assignment(attr, resolvedValue)
     }
@@ -143,7 +151,8 @@ object AssignmentUtils extends SQLConfHelper with CastSupport {
       colExpr: Expression,
       assignments: Seq[Assignment],
       addError: String => Unit,
-      colPath: Seq[String]): Expression = {
+      colPath: Seq[String],
+      coerceNestedTypes: Boolean = false): Expression = {
 
     val (exactAssignments, otherAssignments) = assignments.partition { assignment =>
       assignment.key.semanticEquals(colExpr)
@@ -166,10 +175,10 @@ object AssignmentUtils extends SQLConfHelper with CastSupport {
       TableOutputResolver.checkNullability(colExpr, col, conf, colPath)
     } else if (exactAssignments.nonEmpty) {
       val value = exactAssignments.head.value
-      TableOutputResolver.resolveUpdate("", value, col, conf, addError, colPath,
-        DefaultValueFillMode.RECURSE)
+      val coerceMode = if (coerceNestedTypes) RECURSE else NONE
+      TableOutputResolver.resolveUpdate("", value, col, conf, addError, colPath, coerceMode)
     } else {
-      applyFieldAssignments(col, colExpr, fieldAssignments, addError, colPath)
+      applyFieldAssignments(col, colExpr, fieldAssignments, addError, colPath, coerceNestedTypes)
     }
   }
 
@@ -178,7 +187,8 @@ object AssignmentUtils extends SQLConfHelper with CastSupport {
       colExpr: Expression,
       assignments: Seq[Assignment],
       addError: String => Unit,
-      colPath: Seq[String]): Expression = {
+      colPath: Seq[String],
+      coerceNestedTyptes: Boolean): Expression = {
 
     col.dataType match {
       case structType: StructType =>
@@ -187,7 +197,8 @@ object AssignmentUtils extends SQLConfHelper with CastSupport {
           GetStructField(colExpr, ordinal, Some(field.name))
         }
         val updatedFieldExprs = fieldAttrs.zip(fieldExprs).map { case (fieldAttr, fieldExpr) =>
-          applyAssignments(fieldAttr, fieldExpr, assignments, addError, colPath :+ fieldAttr.name)
+          applyAssignments(fieldAttr, fieldExpr, assignments, addError, colPath :+ fieldAttr.name,
+            coerceNestedTyptes)
         }
         toNamedStruct(structType, updatedFieldExprs)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveRowLevelCommandAssignments.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveRowLevelCommandAssignments.scala
@@ -81,8 +81,7 @@ object ResolveRowLevelCommandAssignments extends Rule[LogicalPlan] {
     }
   }
 
-  private def resolveAssignments(
-      p: LogicalPlan): LogicalPlan = {
+  private def resolveAssignments(p: LogicalPlan): LogicalPlan = {
     p.transformExpressions {
       case assignment: Assignment =>
         val nullHandled = if (!assignment.key.nullable && assignment.value.nullable) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveRowLevelCommandAssignments.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveRowLevelCommandAssignments.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.trees.TreePattern.COMMAND
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.StoreAssignmentPolicy
 
 /**
@@ -42,7 +43,8 @@ object ResolveRowLevelCommandAssignments extends Rule[LogicalPlan] {
     case u: UpdateTable if !u.skipSchemaResolution && u.resolved && u.rewritable && !u.aligned =>
       validateStoreAssignmentPolicy()
       val newTable = cleanAttrMetadata(u.table)
-      val newAssignments = AssignmentUtils.alignUpdateAssignments(u.table.output, u.assignments)
+      val newAssignments = AssignmentUtils.alignUpdateAssignments(u.table.output, u.assignments,
+        coerceNestedTypes = false)
       u.copy(table = newTable, assignments = newAssignments)
 
     case u: UpdateTable if !u.skipSchemaResolution && u.resolved && !u.aligned =>
@@ -51,11 +53,14 @@ object ResolveRowLevelCommandAssignments extends Rule[LogicalPlan] {
     case m: MergeIntoTable if !m.skipSchemaResolution && m.resolved && m.rewritable && !m.aligned &&
       !m.needSchemaEvolution =>
       validateStoreAssignmentPolicy()
+      val coerceNestedTypes = SQLConf.get.coerceMergeNestedTypes
       m.copy(
         targetTable = cleanAttrMetadata(m.targetTable),
-        matchedActions = alignActions(m.targetTable.output, m.matchedActions),
-        notMatchedActions = alignActions(m.targetTable.output, m.notMatchedActions),
-        notMatchedBySourceActions = alignActions(m.targetTable.output, m.notMatchedBySourceActions))
+        matchedActions = alignActions(m.targetTable.output, m.matchedActions, coerceNestedTypes),
+        notMatchedActions = alignActions(m.targetTable.output, m.notMatchedActions,
+          coerceNestedTypes),
+        notMatchedBySourceActions = alignActions(m.targetTable.output, m.notMatchedBySourceActions,
+          coerceNestedTypes))
 
     case m: MergeIntoTable if !m.skipSchemaResolution && m.resolved && !m.aligned
       && !m.needSchemaEvolution =>
@@ -76,7 +81,8 @@ object ResolveRowLevelCommandAssignments extends Rule[LogicalPlan] {
     }
   }
 
-  private def resolveAssignments(p: LogicalPlan): LogicalPlan = {
+  private def resolveAssignments(
+      p: LogicalPlan): LogicalPlan = {
     p.transformExpressions {
       case assignment: Assignment =>
         val nullHandled = if (!assignment.key.nullable && assignment.value.nullable) {
@@ -109,14 +115,17 @@ object ResolveRowLevelCommandAssignments extends Rule[LogicalPlan] {
 
   private def alignActions(
       attrs: Seq[Attribute],
-      actions: Seq[MergeAction]): Seq[MergeAction] = {
+      actions: Seq[MergeAction],
+      coerceNestedTypes: Boolean): Seq[MergeAction] = {
     actions.map {
       case u @ UpdateAction(_, assignments) =>
-        u.copy(assignments = AssignmentUtils.alignUpdateAssignments(attrs, assignments))
+        u.copy(assignments = AssignmentUtils.alignUpdateAssignments(attrs, assignments,
+          coerceNestedTypes))
       case d: DeleteAction =>
         d
       case i @ InsertAction(_, assignments) =>
-        i.copy(assignments = AssignmentUtils.alignInsertAssignments(attrs, assignments))
+        i.copy(assignments = AssignmentUtils.alignInsertAssignments(attrs, assignments,
+          coerceNestedTypes))
       case other =>
         throw new AnalysisException(
           errorClass = "_LEGACY_ERROR_TEMP_3052",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -6427,6 +6427,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val MERGE_INTO_SOURCE_NESTED_TYPE_COERCION_ENABLED =
+    buildConf("spark.sql.merge.source.nested.type.coercion.enabled")
+      .internal()
+      .doc("If enabled, allow MERGE INTO to coerce source nested types if they have less" +
+        "nested fields than the target table's nested types.")
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(true)
+
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -7554,6 +7563,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def legacyXMLParserEnabled: Boolean =
     getConf(SQLConf.LEGACY_XML_PARSER_ENABLED)
+
+  def coerceMergeNestedTypes: Boolean =
+    getConf(SQLConf.MERGE_INTO_SOURCE_NESTED_TYPE_COERCION_ENABLED)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeIntoTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeIntoTableSuite.scala
@@ -17,8 +17,9 @@
 
 package org.apache.spark.sql.connector
 
-import org.apache.spark.sql.Row
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 class DeltaBasedMergeIntoTableSuite extends DeltaBasedMergeIntoTableSuiteBase {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeIntoTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeIntoTableSuite.scala
@@ -17,9 +17,8 @@
 
 package org.apache.spark.sql.connector
 
-import org.apache.spark.sql.{AnalysisException, Row}
-import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.StructType
 
 class DeltaBasedMergeIntoTableSuite extends DeltaBasedMergeIntoTableSuiteBase {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoTableSuiteBase.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.datasources.v2.MergeRowsExec
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec, CartesianProductExec}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{ArrayType, BooleanType, IntegerType, LongType, MapType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{ArrayType, BooleanType, IntegerType, MapType, StringType, StructField, StructType}
 
 abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase
   with AdaptiveSparkPlanHelper {
@@ -2332,65 +2332,6 @@ abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase
     }
   }
 
-  test("Merge schema evolution replacing column with default value and set all column") {
-    Seq((true, true), (false, true), (true, false)).foreach {
-      case (withSchemaEvolution, schemaEvolutionEnabled) =>
-        withTempView("source") {
-          createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
-            """{ "pk": 1, "salary": 100, "dep": "hr" }
-              |{ "pk": 2, "salary": 200, "dep": "software" }
-              |{ "pk": 3, "salary": 300, "dep": "hr" }
-              |{ "pk": 4, "salary": 400, "dep": "marketing" }
-              |{ "pk": 5, "salary": 500, "dep": "executive" }
-              |""".stripMargin)
-
-          if (!schemaEvolutionEnabled) {
-            sql(s"""ALTER TABLE $tableNameAsString SET TBLPROPERTIES
-                   | ('auto-schema-evolution' = 'false')""".stripMargin)
-          }
-          sql(s"""ALTER TABLE $tableNameAsString ALTER COLUMN dep SET DEFAULT 'unknown'""")
-
-          val sourceDF = Seq((4, 150, true),
-            (5, 250, true),
-            (6, 350, false)).toDF("pk", "salary", "active")
-          sourceDF.createOrReplaceTempView("source")
-
-          val schemaEvolutionClause = if (withSchemaEvolution) "WITH SCHEMA EVOLUTION" else ""
-          sql(s"""MERGE $schemaEvolutionClause
-                 |INTO $tableNameAsString t
-                 |USING source s
-                 |ON t.pk = s.pk
-                 |WHEN MATCHED THEN
-                 | UPDATE SET *
-                 |WHEN NOT MATCHED THEN
-                 | INSERT *
-                 |""".stripMargin)
-          if (withSchemaEvolution && schemaEvolutionEnabled) {
-            checkAnswer(
-              sql(s"SELECT * FROM $tableNameAsString"),
-              Seq(
-                Row(1, 100, "hr", null),
-                Row(2, 200, "software", null),
-                Row(3, 300, "hr", null),
-                Row(4, 150, "marketing", true),
-                Row(5, 250, "executive", true),
-                Row(6, 350, "unknown", false)))
-          } else {
-            checkAnswer(
-              sql(s"SELECT * FROM $tableNameAsString"),
-              Seq(
-                Row(1, 100, "hr"),
-                Row(2, 200, "software"),
-                Row(3, 300, "hr"),
-                Row(4, 150, "marketing"),
-                Row(5, 250, "executive"),
-                Row(6, 350, "unknown")))
-          }
-          sql(s"DROP TABLE $tableNameAsString")
-        }
-    }
-  }
-
   test("Merge schema evolution replacing column with set explicit column") {
     Seq((true, true), (false, true), (true, false)).foreach {
       case (withSchemaEvolution, schemaEvolutionEnabled) =>
@@ -2450,7 +2391,7 @@ abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase
     }
   }
 
-  test("merge into schema evolution add column with nested field and set explicit columns") {
+  test("merge into schema evolution add column with nested struct and set explicit columns") {
     Seq(true, false).foreach { withSchemaEvolution =>
       withTempView("source") {
         createAndInitTable(
@@ -2631,8 +2572,7 @@ abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase
     }
   }
 
-  // TODO- support schema evolution for missing nested types using UPDATE SET * and INSERT *
-  test("merge into schema evolution replace column with nested field and set all columns") {
+  test("merge into schema evolution replace column with nested struct and set all columns") {
     Seq(true, false).foreach { withSchemaEvolution =>
       withTempView("source") {
         createAndInitTable(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlignAssignmentsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlignAssignmentsSuiteBase.scala
@@ -218,6 +218,13 @@ abstract class AlignAssignmentsSuiteBase extends AnalysisTest {
     }
   }
 
+  protected def assertNoNullCheckExists(plan: LogicalPlan): Unit = {
+    val asserts = plan.expressions.flatMap(e => e.collect {
+      case assert: AssertNotNull => assert
+    })
+    assert(asserts.isEmpty, s"Must not have NOT NULL checks")
+  }
+
   protected def assertNullCheckExists(plan: LogicalPlan, colPath: Seq[String]): Unit = {
     val asserts = plan.expressions.flatMap(e => e.collect {
       case assert: AssertNotNull if assert.walkedTypePath == colPath => assert


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support MERGE INTO where source has less fields than target.  This is already partially supported as part of: https://github.com/apache/spark/pull/51698, but only for top level fields.  This support it even for nested fields (structs, including within other structs, arrays, and maps)

This patch modifies the MERGE INTO assignment to re-use existing logic in TableOutputResolver to resolve empty values in structs to null or default.


UPDATE can also benefit from this, but we can do it in a subsequent pr.

### Why are the changes needed?
For cases where source has less fields than target in MERGE INTO, it should behave more gracefully (inserting null values where source field does not exist).


### Does this PR introduce _any_ user-facing change?
No, only that this scenario used to fail and will now pass.

This gates on a new flag: "spark.sql.merge.source.nested.type.coercion.enabled", enabled by default.



### How was this patch tested?
Add unit test to MergeIntoTableSuiteBase


### Was this patch authored or co-authored using generative AI tooling?
No
