### PR TITLE
[DOCS][SQL] Cross-link CSV data source docs to generic options & JSON

### DIFF
--- a/docs/sql-data-sources-csv.md
+++ b/docs/sql-data-sources-csv.md
@@ -19,6 +19,11 @@ license: |
   limitations under the License.
 ---
 
+See also: [Generic File Source Options](sql-data-sources-generic-options.html) and
+[JSON Files](sql-data-sources-json.html).
+
+
+
 Spark SQL provides `spark.read().csv("file_name")` to read a file or directory of files in CSV format into Spark DataFrame, and `dataframe.write().csv("path")` to write to a CSV file. Function `option()` can be used to customize the behavior of reading or writing, such as controlling behavior of the header, delimiter character, character set, and so on.
 
 <div class="codetabs">

--- a/docs/sql-data-sources-json.md
+++ b/docs/sql-data-sources-json.md
@@ -19,6 +19,10 @@ license: |
   limitations under the License.
 ---
 
+See also: [Generic File Source Options](sql-data-sources-generic-options.html) and
+[CSV Files](sql-data-sources-csv.html).
+
+
 <div class="codetabs">
 
 <div data-lang="python"  markdown="1">


### PR DESCRIPTION
### What
Add a short “See also” paragraph to the CSV data source docs that links to:
- Generic File Source Options
- JSON Files

### Why
Helps readers discover generic file options (ignoreMissingFiles, recursiveFileLookup, etc.)
and navigate between closely related file formats.

### How
- Edit docs/sql-data-sources-csv.md to include two internal links.

### Notes
Per Spark’s contribution guide, trivial doc edits don’t require a JIRA.
