### PR TITLE
[SPARK-53594][PYTHON] Make arrow UDF respect user-specified eval type

### DIFF
--- a/python/pyspark/sql/pandas/functions.py
+++ b/python/pyspark/sql/pandas/functions.py
@@ -759,6 +759,16 @@ def _validate_vectorized_udf(f, evalType, kind: str = "pandas") -> int:
             UserWarning,
         )
     elif evalType in [
+        PythonEvalType.SQL_SCALAR_ARROW_UDF,
+        PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF,
+        PythonEvalType.SQL_GROUPED_AGG_ARROW_UDF,
+    ]:
+        warnings.warn(
+            "It is preferred to specify type hints for "
+            "arrow UDF instead of specifying arrow UDF type.",
+            UserWarning,
+        )
+    elif evalType in [
         PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF,
         PythonEvalType.SQL_MAP_PANDAS_ITER_UDF,
         PythonEvalType.SQL_MAP_ARROW_ITER_UDF,

--- a/python/pyspark/sql/tests/arrow/test_arrow_udf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf.py
@@ -19,6 +19,7 @@ import os
 import time
 import unittest
 import datetime
+from typing import Iterator
 
 from pyspark.sql.functions import arrow_udf, ArrowUDFType, PandasUDFType
 from pyspark.sql import functions as F, Row
@@ -279,14 +280,14 @@ class ArrowUDFTestsMixin:
         expected = df.selectExpr("(v + 1) as plus_one").collect()
 
         @arrow_udf("long", ArrowUDFType.SCALAR)
-        def plus_one(v):
+        def plus_one(v: pa.Array):
             return pa.compute.add(v, 1)
 
         result1 = df.select(plus_one("v").alias("plus_one")).collect()
         self.assertEqual(expected, result1)
 
         @arrow_udf("long", ArrowUDFType.SCALAR_ITER)
-        def plus_one_iter(it):
+        def plus_one_iter(it: Iterator[pa.Array]):
             for v in it:
                 yield pa.compute.add(v, 1)
 
@@ -300,7 +301,7 @@ class ArrowUDFTestsMixin:
         expected = df.selectExpr("max(v) as m").collect()
 
         @arrow_udf("long", ArrowUDFType.GROUPED_AGG)
-        def calc_max(v):
+        def calc_max(v: pa.Array):
             return pa.compute.max(v)
 
         result = df.select(calc_max("v").alias("m")).collect()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Make arrow UDF respect user-specified eval type


### Why are the changes needed?
to be consistent with pandas UDF, which allow type hints be partially set:

```
In [4]: @arrow_udf("long", ArrowUDFType.SCALAR_ITER)
   ...: def add_one(it: Iterator[pa.Array]):
   ...:     for v in it:
   ...:         yield pa.compute.add(v, 1)
```

before:
```
PySparkValueError: [TYPE_HINT_SHOULD_BE_SPECIFIED] Type hints for the return type should be specified; however, got (it: Iterator[pyarrow.lib.Array]).
```

after:
```
In [4]: @arrow_udf("long", ArrowUDFType.SCALAR_ITER)
   ...: def add_one(it: Iterator[pa.Array]):
   ...:     for v in it:
   ...:         yield pa.compute.add(v, 1)
   ...:
/Users/ruifeng.zheng/Dev/spark/python/pyspark/sql/pandas/functions.py:766: UserWarning: It is preferred to specify type hints for arrow UDF instead of specifying arrow UDF type.
  warnings.warn(
```


### Does this PR introduce _any_ user-facing change?
yes

### How was this patch tested?
new tests


### Was this patch authored or co-authored using generative AI tooling?
no