### PR TITLE
[SPARK-53598][SQL] Check the existence of numParts before reading large table property

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -763,11 +763,17 @@ object CatalogTable {
     }
   }
 
-  def readLargeTableProp(props: Map[String, String], key: String): Option[String] = {
+  def readLargeTableProp(
+      props: Map[String, String],
+      key: String,
+      failIfNumPartsMissing: Boolean = true): Option[String] = {
     props.get(key).orElse {
       if (props.exists { case (mapKey, _) => mapKey.startsWith(key) }) {
         props.get(s"$key.numParts") match {
-          case None => throw QueryCompilationErrors.insufficientTablePropertyError(key)
+          case None if failIfNumPartsMissing =>
+            throw QueryCompilationErrors.insufficientTablePropertyError(key)
+          case None =>
+            None
           case Some(numParts) =>
             val parts = (0 until numParts.toInt).map { index =>
               val keyPart = s"$key.part.$index"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -763,17 +763,11 @@ object CatalogTable {
     }
   }
 
-  def readLargeTableProp(
-      props: Map[String, String],
-      key: String,
-      failIfNumPartsMissing: Boolean = true): Option[String] = {
+  def readLargeTableProp(props: Map[String, String], key: String): Option[String] = {
     props.get(key).orElse {
       if (props.exists { case (mapKey, _) => mapKey.startsWith(key) }) {
         props.get(s"$key.numParts") match {
-          case None if failIfNumPartsMissing =>
-            throw QueryCompilationErrors.insufficientTablePropertyError(key)
-          case None =>
-            None
+          case None => None
           case Some(numParts) =>
             val parts = (0 until numParts.toInt).map { index =>
               val keyPart = s"$key.part.$index"

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -829,7 +829,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       case None if table.tableType == VIEW =>
         // If this is a view created by Spark 2.2 or higher versions, we should restore its schema
         // from table properties.
-        getSchemaFromTableProperties(table.properties, false).foreach { schemaFromTableProps =>
+        getSchemaFromTableProperties(table.properties).foreach { schemaFromTableProps =>
           table = table.copy(schema = schemaFromTableProps)
         }
 
@@ -881,7 +881,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
 
     // If this is a Hive serde table created by Spark 2.1 or higher versions, we should restore its
     // schema from table properties.
-    val maybeSchemaFromTableProps = getSchemaFromTableProperties(table.properties, false)
+    val maybeSchemaFromTableProps = getSchemaFromTableProperties(table.properties)
     if (maybeSchemaFromTableProps.isDefined) {
       val schemaFromTableProps = maybeSchemaFromTableProps.get
       val partColumnNames = getPartitionColumnsFromTableProperties(table)
@@ -911,12 +911,11 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
   }
 
   private def getSchemaFromTableProperties(
-      tableProperties: Map[String, String], failIfNumPartsMissing: Boolean): Option[StructType] = {
-    CatalogTable.readLargeTableProp(tableProperties, DATASOURCE_SCHEMA, failIfNumPartsMissing)
-      .map { schemaJson =>
-        val parsed = DataType.fromJson(schemaJson).asInstanceOf[StructType]
-        CharVarcharUtils.getRawSchema(parsed)
-      }
+      tableProperties: Map[String, String]): Option[StructType] = {
+    CatalogTable.readLargeTableProp(tableProperties, DATASOURCE_SCHEMA).map { schemaJson =>
+      val parsed = DataType.fromJson(schemaJson).asInstanceOf[StructType]
+      CharVarcharUtils.getRawSchema(parsed)
+    }
   }
 
   private def restoreDataSourceTable(table: CatalogTable, provider: String): CatalogTable = {
@@ -935,7 +934,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     val partitionProvider = table.properties.get(TABLE_PARTITION_PROVIDER)
 
     val schemaFromTableProps =
-      getSchemaFromTableProperties(table.properties, true).getOrElse(new StructType())
+      getSchemaFromTableProperties(table.properties).getOrElse(new StructType())
     val partColumnNames = getPartitionColumnsFromTableProperties(table)
     val reorderedSchema = reorderSchema(schema = schemaFromTableProps, partColumnNames)
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -1398,19 +1398,9 @@ class MetastoreDataSourcesSuite extends QueryTest
 
         hiveClient.createTable(hiveTableWithoutNumPartsProp, ignoreIfExists = false)
 
-        if (isHiveTable) {
-          val tableMeta = sharedState.externalCatalog.getTable("default", "t")
-          assert(tableMeta.identifier == TableIdentifier("t", Some("default")))
-          assert(!tableMeta.properties.contains(DATASOURCE_PROVIDER))
-        } else {
-          checkError(
-            exception = intercept[AnalysisException] {
-              sharedState.externalCatalog.getTable("default", "t")
-            },
-            condition = "INSUFFICIENT_TABLE_PROPERTY.MISSING_KEY",
-            parameters = Map("key" -> toSQLConf("spark.sql.sources.schema"))
-          )
-        }
+        val tableMeta = sharedState.externalCatalog.getTable("default", "t")
+        assert(tableMeta.identifier == TableIdentifier("t", Some("default")))
+        assert(!tableMeta.properties.contains(DATASOURCE_PROVIDER))
 
         val hiveTableWithNumPartsProp = CatalogTable(
           identifier = TableIdentifier("t2", Some("default")),

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -1378,62 +1378,88 @@ class MetastoreDataSourcesSuite extends QueryTest
   }
 
   test("read table with corrupted schema") {
-    try {
-      val schema = StructType(StructField("int", IntegerType) :: Nil)
-      val hiveTableWithoutNumPartsProp = CatalogTable(
-        identifier = TableIdentifier("t", Some("default")),
-        tableType = CatalogTableType.MANAGED,
-        schema = HiveExternalCatalog.EMPTY_DATA_SCHEMA,
-        provider = Some("json"),
-        storage = CatalogStorageFormat.empty,
-        properties = Map(
-          DATASOURCE_PROVIDER -> "json",
-          DATASOURCE_SCHEMA_PART_PREFIX + 0 -> schema.json))
+    Seq(true, false).foreach { isHiveTable =>
+      try {
+        val schema = StructType(StructField("int", IntegerType) :: Nil)
+        val hiveTableWithoutNumPartsProp = CatalogTable(
+          identifier = TableIdentifier("t", Some("default")),
+          tableType = CatalogTableType.MANAGED,
+          schema = HiveExternalCatalog.EMPTY_DATA_SCHEMA,
+          provider = if (isHiveTable) None else Some("json"),
+          storage = CatalogStorageFormat.empty,
+          properties = Map(
+            DATASOURCE_SCHEMA_PART_PREFIX + 0 -> schema.json) ++ {
+            if (isHiveTable) {
+              Map.empty
+            } else {
+              Map(DATASOURCE_PROVIDER -> "json")
+            }
+          })
 
-      hiveClient.createTable(hiveTableWithoutNumPartsProp, ignoreIfExists = false)
+        hiveClient.createTable(hiveTableWithoutNumPartsProp, ignoreIfExists = false)
 
-      checkError(
-        exception = intercept[AnalysisException] {
-          sharedState.externalCatalog.getTable("default", "t")
-        },
-        condition = "INSUFFICIENT_TABLE_PROPERTY.MISSING_KEY",
-        parameters = Map("key" -> toSQLConf("spark.sql.sources.schema"))
-      )
+        if (isHiveTable) {
+          val tableMeta = sharedState.externalCatalog.getTable("default", "t")
+          assert(tableMeta.identifier == TableIdentifier("t", Some("default")))
+          assert(!tableMeta.properties.contains(DATASOURCE_PROVIDER))
+        } else {
+          checkError(
+            exception = intercept[AnalysisException] {
+              sharedState.externalCatalog.getTable("default", "t")
+            },
+            condition = "INSUFFICIENT_TABLE_PROPERTY.MISSING_KEY",
+            parameters = Map("key" -> toSQLConf("spark.sql.sources.schema"))
+          )
+        }
 
-      val hiveTableWithNumPartsProp = CatalogTable(
-        identifier = TableIdentifier("t2", Some("default")),
-        tableType = CatalogTableType.MANAGED,
-        schema = HiveExternalCatalog.EMPTY_DATA_SCHEMA,
-        provider = Some("json"),
-        storage = CatalogStorageFormat.empty,
-        properties = Map(
-          DATASOURCE_PROVIDER -> "json",
-          DATASOURCE_SCHEMA_PREFIX + "numParts" -> "3",
-          DATASOURCE_SCHEMA_PART_PREFIX + 0 -> schema.json))
+        val hiveTableWithNumPartsProp = CatalogTable(
+          identifier = TableIdentifier("t2", Some("default")),
+          tableType = CatalogTableType.MANAGED,
+          schema = HiveExternalCatalog.EMPTY_DATA_SCHEMA,
+          provider = if (isHiveTable) None else Some("json"),
+          storage = CatalogStorageFormat.empty,
+          properties = Map(
+            DATASOURCE_SCHEMA_PREFIX + "numParts" -> "3",
+            DATASOURCE_SCHEMA_PART_PREFIX + 0 -> schema.json) ++ {
+              if (isHiveTable) {
+                Map.empty
+              } else {
+                Map(DATASOURCE_PROVIDER -> "json")
+              }
+            })
 
-      hiveClient.createTable(hiveTableWithNumPartsProp, ignoreIfExists = false)
+        hiveClient.createTable(hiveTableWithNumPartsProp, ignoreIfExists = false)
 
-      checkError(
-        exception = intercept[AnalysisException] {
-          sharedState.externalCatalog.getTable("default", "t2")
-        },
-        condition = "INSUFFICIENT_TABLE_PROPERTY.MISSING_KEY_PART",
-        parameters = Map(
-          "key" -> toSQLConf("spark.sql.sources.schema.part.1"),
-          "totalAmountOfParts" -> "3")
-      )
+        checkError(
+          exception = intercept[AnalysisException] {
+            sharedState.externalCatalog.getTable("default", "t2")
+          },
+          condition = "INSUFFICIENT_TABLE_PROPERTY.MISSING_KEY_PART",
+          parameters = Map(
+            "key" -> toSQLConf("spark.sql.sources.schema.part.1"),
+            "totalAmountOfParts" -> "3")
+        )
 
-      withDebugMode {
-        val tableMeta = sharedState.externalCatalog.getTable("default", "t")
-        assert(tableMeta.identifier == TableIdentifier("t", Some("default")))
-        assert(tableMeta.properties(DATASOURCE_PROVIDER) == "json")
-        val tableMeta2 = sharedState.externalCatalog.getTable("default", "t2")
-        assert(tableMeta2.identifier == TableIdentifier("t2", Some("default")))
-        assert(tableMeta2.properties(DATASOURCE_PROVIDER) == "json")
+        withDebugMode {
+          val tableMeta = sharedState.externalCatalog.getTable("default", "t")
+          assert(tableMeta.identifier == TableIdentifier("t", Some("default")))
+          if (isHiveTable) {
+            assert(!tableMeta.properties.contains(DATASOURCE_PROVIDER))
+          } else {
+            assert(tableMeta.properties(DATASOURCE_PROVIDER) == "json")
+          }
+          val tableMeta2 = sharedState.externalCatalog.getTable("default", "t2")
+          assert(tableMeta2.identifier == TableIdentifier("t2", Some("default")))
+          if (isHiveTable) {
+            assert(!tableMeta2.properties.contains(DATASOURCE_PROVIDER))
+          } else {
+            assert(tableMeta2.properties(DATASOURCE_PROVIDER) == "json")
+          }
+        }
+      } finally {
+        hiveClient.dropTable("default", "t", ignoreIfNotExists = true, purge = true)
+        hiveClient.dropTable("default", "t2", ignoreIfNotExists = true, purge = true)
       }
-    } finally {
-      hiveClient.dropTable("default", "t", ignoreIfNotExists = true, purge = true)
-      hiveClient.dropTable("default", "t2", ignoreIfNotExists = true, purge = true)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR proposes to fix a regression caused by SPARK-33812 (https://github.com/apache/spark/commit/de234eec8febce99ede5ef9ae2301e36739a0f85 3.2.0).

We hit an error when upgrading Spark from 3.1 to 3.3, the table is a Hive SerDe Parquet table, which TBLPROPERTIES looks like malformed (not sure how this happen), the table can be read and write normally with Spark 3.1, but fails on reading with Spark 3.3.

```
-- Hive DDL
CREATE EXTERNAL TABLE `foo`.`bar`(
  `id` bigint,
  ...
) PARTITIONED BY (`dt` string)
ROW FORMAT SERDE 
  'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe' 
STORED AS INPUTFORMAT
  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat' 
OUTPUTFORMAT 
  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
LOCATION
  'hdfs://...'
TBLPROPERTIES (
  ...
  'spark.sql.sources.schema.partCol.0'='dt',
  'transient_lastDdlTime'='1727333678')
```

```
org.apache.spark.sql.AnalysisException: Cannot read table property 'spark.sql.sources.schema' as it's corrupted.
	at org.apache.spark.sql.errors.QueryCompilationErrors$.cannotReadCorruptedTablePropertyError(QueryCompilationErrors.scala:840) ~[spark-catalyst_2.12-3.3.4.104.jar:3.3.4.104]
	at org.apache.spark.sql.catalyst.catalog.CatalogTable$.$anonfun$readLargeTableProp$1(interface.scala:502) ~[spark-catalyst_2.12-3.3.4.104.jar:3.3.4.104]
	at scala.Option.orElse(Option.scala:447) ~[scala-library-2.12.18.jar:?]
	at org.apache.spark.sql.catalyst.catalog.CatalogTable$.readLargeTableProp(interface.scala:497) ~[spark-catalyst_2.12-3.3.4.104.jar:3.3.4.104]
	at org.apache.spark.sql.hive.HiveExternalCatalog.getSchemaFromTableProperties(HiveExternalCatalog.scala:839) ~[spark-hive_2.12-3.3.4.104.jar:3.3.4.104]
	at org.apache.spark.sql.hive.HiveExternalCatalog.restoreHiveSerdeTable(HiveExternalCatalog.scala:809) ~[spark-hive_2.12-3.3.4.104.jar:3.3.4.104]
	at org.apache.spark.sql.hive.HiveExternalCatalog.restoreTableMetadata(HiveExternalCatalog.scala:765) ~[spark-hive_2.12-3.3.4.104.jar:3.3.4.104]
	at org.apache.spark.sql.hive.HiveExternalCatalog.$anonfun$getTable$1(HiveExternalCatalog.scala:734) ~[spark-hive_2.12-3.3.4.104.jar:3.3.4.104]
	at org.apache.spark.sql.hive.HiveExternalCatalog.withClient(HiveExternalCatalog.scala:101) ~[spark-hive_2.12-3.3.4.104.jar:3.3.4.104]
	at org.apache.spark.sql.hive.HiveExternalCatalog.getTable(HiveExternalCatalog.scala:734) ~[spark-hive_2.12-3.3.4.104.jar:3.3.4.104]
	at org.apache.spark.sql.catalyst.catalog.ExternalCatalogWithListener.getTable(ExternalCatalogWithListener.scala:138) ~[spark-catalyst_2.12-3.3.4.104.jar:3.3.4.104]
	at org.apache.spark.sql.catalyst.catalog.SessionCatalog.getTableRawMetadata(SessionCatalog.scala:544) ~[spark-catalyst_2.12-3.3.4.104.jar:3.3.4.104]
	at org.apache.spark.sql.catalyst.catalog.SessionCatalog.getTableMetadata(SessionCatalog.scala:529) ~[spark-catalyst_2.12-3.3.4.104.jar:3.3.4.104]
	...
```

Before SPARK-33812, it skipped reading the schema from table properties if `spark.sql.sources.schema.numParts` was missing for a Hive SerDe table.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Restore behavior before Spark 3.2.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, restores behavior before Spark 3.2.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT is added.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.