### PR TITLE
[SPARK-53600][SQL] Revise `SessionHolder` last access time log message

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -262,8 +262,8 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
     lastAccessTimeMs = System.currentTimeMillis()
     logInfo(
       log"Session with userId: ${MDC(LogKeys.USER_ID, userId)} and " +
-        log"sessionId: ${MDC(LogKeys.SESSION_ID, sessionId)} accessed," +
-        log"time ${MDC(LogKeys.LAST_ACCESS_TIME, lastAccessTimeMs)} ms.")
+        log"sessionId: ${MDC(LogKeys.SESSION_ID, sessionId)} accessed at " +
+        log"timestamp ${MDC(LogKeys.LAST_ACCESS_TIME, lastAccessTimeMs)}.")
   }
 
   private[connect] def setCustomInactiveTimeoutMs(newInactiveTimeoutMs: Option[Long]): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to revise `SessionHolder` last access time log message.

### Why are the changes needed?

To be clear that it's the last access time (timestamp) instead of durations.

**BEFORE**
```
Session with userId: dongjoon and sessionId: *<id>* accessed,time 1758044807121 ms.
```

**AFTER**
```
Session with userId: dongjoon and sessionId: *<id>* accessed at timestamp 1758044739284.
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Manual review.

```
$ sbin/start-connect-server.sh --wait
```
```
$ bin/spark-connect-shell --remote sc://localhost:15002
```

### Was this patch authored or co-authored using generative AI tooling?

No.