### PR TITLE
[SPARK-53601][INFRA] Use Java 25 instead of 25-ea

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -947,7 +947,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: zulu
-        java-version: 25-ea
+        java-version: 25
     - name: Build with Maven
       run: |
         export MAVEN_OPTS="-Xss64m -Xmx4g -Xms4g -XX:ReservedCodeCacheSize=128m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java 25 instead of 25-ea.

### Why are the changes needed?

Java 25 is officially released. Although we are not supporting Java 25-ea yet due to the Hadoop issue, we need to use Java 25 instead of 25-ea.
- https://www.oracle.com/news/announcement/oracle-releases-java-25-2025-09-16/

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and check the CI logs.

```
Trying to resolve the latest version from remote
  Resolved latest version as 25.0.0+36
  Trying to download...
  Downloading Java 25.0.0+36 (Zulu) from https://cdn.azul.com/zulu/bin/zulu25.28.85-ca-jdk25.0.0-linux_x64.tar.gz ...
  Extracting Java archive...
  /usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/f4cc5ec3-6a14-4281-9a94-d0df2bce32eb -f /home/runner/work/_temp/3087ced7-a3d6-4709-a1dc-796b240efb42
  Java 25.0.0+36 was downloaded
  Setting Java 25.0.0+36 as the default
  Creating toolchains.xml for JDK version 25 from zulu
  Writing to /home/runner/.m2/toolchains.xml
```

### Was this patch authored or co-authored using generative AI tooling?

No.