### PR TITLE
[SPARK-53603][BUILD] Upgrade Checkstyle to 11.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3233,7 +3233,7 @@
             -->
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.21.2</version>
+            <version>11.0.1</version>
           </dependency>
         </dependencies>
         <executions>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,7 +19,7 @@ addSbtPlugin("software.purpledragon" % "sbt-checkstyle-plugin" % "4.0.1")
 
 // If you are changing the dependency setting for checkstyle plugin,
 // please check pom.xml in the root of the source tree too.
-libraryDependencies += "com.puppycrawl.tools" % "checkstyle" % "10.21.2"
+libraryDependencies += "com.puppycrawl.tools" % "checkstyle" % "11.0.1"
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Checkstyle to 11.0.1 from 10.21.2.

### Why are the changes needed?

Checkstyle 11 is built on Java 17 and has many improvements for the latest Java language.
- https://checkstyle.org/releasenotes.html#Release_11.0.1
- https://checkstyle.org/releasenotes.html#Release_11.0.0
    - https://github.com/checkstyle/checkstyle/issues/17321
- https://checkstyle.org/releasenotes.html#Release_10.26.1
- https://checkstyle.org/releasenotes.html#Release_10.26.0
    - https://github.com/checkstyle/checkstyle/issues/14949
- https://checkstyle.org/releasenotes.html#Release_10.25.1
- https://checkstyle.org/releasenotes.html#Release_10.25.0
    - https://github.com/checkstyle/checkstyle/issues/14945
- https://checkstyle.org/releasenotes.html#Release_10.24.0
- https://checkstyle.org/releasenotes.html#Release_10.23.1
- https://checkstyle.org/releasenotes.html#Release_10.23.0
- https://checkstyle.org/releasenotes.html#Release_10.22.0
- https://checkstyle.org/releasenotes.html#Release_10.21.4
- https://checkstyle.org/releasenotes.html#Release_10.21.3

### Does this PR introduce _any_ user-facing change?

No, this is a kind of test environment during building.

### How was this patch tested?

Pass the CIs. Or, manually do.

```
$ dev/lint-java
Using `mvn` from path: /opt/homebrew/bin/mvn
Using SPARK_LOCAL_IP=localhost
Checkstyle checks passed.
```

### Was this patch authored or co-authored using generative AI tooling?

No.