### PR TITLE
[SPARK-52991][SQL][FOLLOW-UP] Revise `MergeIntoTable` to use `lazy val` and add a new test

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -883,21 +883,16 @@ case class MergeIntoTable(
     }
   }
 
-  def duplicateResolved: Boolean = targetTable.outputSet.intersect(sourceTable.outputSet).isEmpty
+  lazy val duplicateResolved: Boolean =
+    targetTable.outputSet.intersect(sourceTable.outputSet).isEmpty
 
-  def skipSchemaResolution: Boolean = targetTable match {
+  lazy val skipSchemaResolution: Boolean = targetTable match {
     case r: NamedRelation => r.skipSchemaResolution
     case SubqueryAlias(_, r: NamedRelation) => r.skipSchemaResolution
     case _ => false
   }
 
-  override def left: LogicalPlan = targetTable
-  override def right: LogicalPlan = sourceTable
-  override protected def withNewChildrenInternal(
-      newLeft: LogicalPlan, newRight: LogicalPlan): MergeIntoTable =
-    copy(targetTable = newLeft, sourceTable = newRight)
-
-  def needSchemaEvolution: Boolean =
+  lazy val needSchemaEvolution: Boolean =
     schemaEvolutionEnabled &&
       MergeIntoTable.schemaChanges(targetTable.schema, sourceTable.schema).nonEmpty
 
@@ -907,6 +902,12 @@ case class MergeIntoTable(
       case _ => false
     }
   }
+
+  override def left: LogicalPlan = targetTable
+  override def right: LogicalPlan = sourceTable
+  override protected def withNewChildrenInternal(
+      newLeft: LogicalPlan, newRight: LogicalPlan): MergeIntoTable =
+    copy(targetTable = newLeft, sourceTable = newRight)
 }
 
 object MergeIntoTable {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Minor follow up for https://github.com/apache/spark/pull/51698

1. Small optimization for MergeIntoTable node (@aokolnychyi noticed post-commit that the new states can be calculated once using `lazy val`, as each time rules will copy the node so the state never changes).
2. Relocate `left`, `right`, `withNewChildrenInternal`
3. Add test to validate that default values work in schema evolution case.

### Why are the changes needed?
Small analysis performance improvement and increase test coverage

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Run existing tests, and the patch adds another test

### Was this patch authored or co-authored using generative AI tooling?
No
