### PR TITLE
[SPARK-53604][INFRA] Temporarily increase PySpark job execution time to 150 minutes

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -499,6 +499,7 @@ jobs:
     if: (!cancelled()) && (fromJson(needs.precondition.outputs.required).pyspark == 'true' || fromJson(needs.precondition.outputs.required).pyspark-pandas == 'true')
     name: "Build modules: ${{ matrix.modules }}"
     runs-on: ubuntu-latest
+    # TODO(SPARK-53605): Restore pyspark execution timeout to 2 hours after fixing test_pandas_transform_with_state
     timeout-minutes: 150
     container:
       image: ${{ needs.precondition.outputs.image_pyspark_url_link }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -499,7 +499,7 @@ jobs:
     if: (!cancelled()) && (fromJson(needs.precondition.outputs.required).pyspark == 'true' || fromJson(needs.precondition.outputs.required).pyspark-pandas == 'true')
     name: "Build modules: ${{ matrix.modules }}"
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 150
     container:
       image: ${{ needs.precondition.outputs.image_pyspark_url_link }}
     strategy:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Temporarily increase PySpark job execution time to 150 minutes


### Why are the changes needed?
The job `pyspark-sql, pyspark-resource, pyspark-testing` is hitting this limitation, e.g. 
https://github.com/apache/spark/actions/runs/17782421036/job/50543951992#logs

and it is affecting unrelated PRs.

It is due to `test_pandas_transform_with_state` becoming extremely slow.
```
Starting test(python3.11): pyspark.sql.tests.pandas.test_pandas_transform_with_state (temp output: /__w/spark/spark/python/target/3ebfaa1f-283b-43b4-8584-bdb5a2fb8634/python3.11__pyspark.sql.tests.pandas.test_pandas_transform_with_state__juw_ehv_.log)
Finished test(python3.11): pyspark.sql.tests.pandas.test_pandas_transform_with_state (2700s) ... 4 tests were skipped
```



### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no