### PR TITLE
[SPARK-53623][SQL] improve reading large table properties performance

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -765,20 +765,15 @@ object CatalogTable {
 
   def readLargeTableProp(props: Map[String, String], key: String): Option[String] = {
     props.get(key).orElse {
-      if (props.exists { case (mapKey, _) => mapKey.startsWith(key) }) {
-        props.get(s"$key.numParts") match {
-          case None => None
-          case Some(numParts) =>
-            val parts = (0 until numParts.toInt).map { index =>
-              val keyPart = s"$key.part.$index"
-              props.getOrElse(keyPart, {
-                throw QueryCompilationErrors.insufficientTablePropertyPartError(keyPart, numParts)
-              })
-            }
-            Some(parts.mkString)
+      // only construct the property from parts if numParts exist,
+      props.get(s"$key.numParts").map { numParts =>
+        val parts = (0 until numParts.toInt).map { index =>
+          val keyPart = s"$key.part.$index"
+          props.getOrElse(keyPart, {
+            throw QueryCompilationErrors.insufficientTablePropertyPartError(keyPart, numParts)
+          })
         }
-      } else {
-        None
+        parts.mkString
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The CatalogColumnStat.readLargeTableProp is an O(N) operation. Considering a table can have a lot of table properties, this effectively becomes an O(N^2) operation, which can be very slow for tables with a lot of table properties.

This PR improves the algorithmic complexity to O(N) by only constructing the large table properties if numParts exists.


### Why are the changes needed?
For fixing a performance issue unintentionally introduced before.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing unit tests. A previous patch already tested the side effect of this change https://github.com/apache/spark/pull/52355


### Was this patch authored or co-authored using generative AI tooling?
No
