### PR TITLE
[SPARK-51426][PYTHON][SQL] Fix 'Setting metadata to empty dict does not work'

### DIFF
--- a/python/pyspark/sql/classic/column.py
+++ b/python/pyspark/sql/classic/column.py
@@ -525,7 +525,7 @@ class Column(ParentColumn):
 
         sc = get_active_spark_context()
         if len(alias) == 1:
-            if metadata:
+            if metadata is not None:
                 assert sc._jvm is not None
                 jmeta = getattr(sc._jvm, "org.apache.spark.sql.types.Metadata").fromJson(
                     json.dumps(metadata)

--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -203,7 +203,7 @@ class ColumnAlias(Expression):
             exp.alias.name.append(self._alias[0])
             exp.alias.expr.CopyFrom(self._child.to_plan(session))
 
-            if self._metadata:
+            if self._metadata is not None:
                 exp.alias.metadata = json.dumps(self._metadata)
             return exp
         else:

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1117,6 +1117,21 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             self.connect.range(1, 10).select(CF.col("id").alias("this", "is", "not")).collect()
         self.assertIn("(this, is, not)", str(exc.exception))
 
+    def test_alias_metadata(self):
+        df = self.connect.createDataFrame([("",)], ["a"])
+        df = df.withMetadata("a", {"foo": "bar"})
+        self.assertEqual(df.schema["a"].metadata, {"foo": "bar"})
+
+        # SPARK-51426: Ensure setting metadata to `{}` clears it
+        df = df.select([CF.col("a").alias("a", metadata={})])
+        self.assertEqual(df.schema["a"].metadata, {})
+
+        df = df.withMetadata("a", {"baz": "burr"})
+        self.assertEqual(df.schema["a"].metadata, {"baz": "burr"})
+
+        df = df.withMetadata("a", {})
+        self.assertEqual(df.schema["a"].metadata, {})
+
     def test_column_regexp(self) -> None:
         # SPARK-41438: test dataframe.colRegex()
         ndf = self.connect.read.table(self.tbl_name3)

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -232,20 +232,19 @@ class ColumnTestsMixin:
 
     # SPARK-51426: Ensure setting metadata to '{]' clears the metadata
     def test_alias_empty_metadata(self):
-        df = self.spark.createDataFrame([('',)], ['a'])
-        df = df.withMetadata('a', {'foo': 'bar'})
-        assert df.schema['a'].metadata == {'foo': 'bar'}
+        df = self.spark.createDataFrame([("",)], ["a"])
+        df = df.withMetadata("a", {"foo": "bar"})
+        self.assertEqual(df.schema["a"].metadata, {"foo": "bar"})
 
         # Ensure setting to `{}` clears the metadata
-        df = df.select([sf.col('a').alias('a', metadata={})])
-        assert df.schema['a'].metadata == {}
+        df = df.select([sf.col("a").alias("a", metadata={})])
+        self.assertEqual(df.schema["a"].metadata, {})
 
-        df = df.withMetadata('a', {'baz': 'burr'})
-        assert df.schema['a'].metadata == {'baz': 'burr'}
+        df = df.withMetadata("a", {"baz": "burr"})
+        self.assertEqual(df.schema["a"].metadata, {"baz": "burr"})
 
-        df = df.withMetadata('a', {})
-        assert df.schema['a'].metadata == {}
-
+        df = df.withMetadata("a", {})
+        self.assertEqual(df.schema["a"].metadata, {})
 
     def test_alias_negative(self):
         with self.assertRaises(PySparkValueError) as pe:

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -230,13 +230,12 @@ class ColumnTestsMixin:
         ).withColumn("square_value", mapping_expr[sf.col("key")])
         self.assertEqual(df.count(), 3)
 
-    # SPARK-51426: Ensure setting metadata to '{]' clears the metadata
-    def test_alias_empty_metadata(self):
+    def test_alias_metadata(self):
         df = self.spark.createDataFrame([("",)], ["a"])
         df = df.withMetadata("a", {"foo": "bar"})
         self.assertEqual(df.schema["a"].metadata, {"foo": "bar"})
 
-        # Ensure setting to `{}` clears the metadata
+        # SPARK-51426: Ensure setting metadata to '{]' clears it
         df = df.select([sf.col("a").alias("a", metadata={})])
         self.assertEqual(df.schema["a"].metadata, {})
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes a bug where setting `metadata={}` would be ignored instead of setting the metadata to the empty dictionary.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Users weren't previously able to clear the metadata completely. This PR enables that behavior.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added test


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
