### PR TITLE
[MINOR][TESTS] Restore classic-only python tests

### DIFF
--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -20,7 +20,6 @@ import uuid
 from collections.abc import Generator
 from typing import Optional, Any, Union
 
-from pyspark.errors.exceptions.connect import SparkConnectGrpcException
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 from pyspark.testing.utils import eventually
 
@@ -39,6 +38,7 @@ if should_test_connect:
     from pyspark.sql.connect.client.reattach import ExecutePlanResponseReattachableIterator
     from pyspark.sql.connect.session import SparkSession as RemoteSparkSession
     from pyspark.errors import PySparkRuntimeError
+    from pyspark.errors.exceptions.connect import SparkConnectGrpcException
     import pyspark.sql.connect.proto as proto
 
     class TestPolicy(DefaultPolicy):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Restore classic-only python tests


### Why are the changes needed?
https://github.com/apache/spark/actions/runs/17750573817/job/50444653160

it is failing with
```
Starting test(python3.11): pyspark.sql.tests.connect.client.test_client (temp output: /__w/spark/spark/python/target/8bab95ed-f5f1-47cb-9564-5c7d71b4239e/python3.11__pyspark.sql.tests.connect.client.test_client__h0939y47.log)
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/__w/spark/spark/python/pyspark/sql/tests/connect/client/test_client.py", line 23, in <module>
    from pyspark.errors.exceptions.connect import SparkConnectGrpcException
  File "/__w/spark/spark/python/pyspark/errors/exceptions/connect.py", line 17, in <module>
    import grpc
ModuleNotFoundError: No module named 'grpc'

```

### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
will monitor the scheduled jobs


### Was this patch authored or co-authored using generative AI tooling?
no