### PR TITLE
[SPARK-53233][SQL][FOLLOWUP] Add compatibility class/object for org.apache.spark.sql.execution.streaming

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/legacy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/legacy.scala
@@ -19,19 +19,13 @@ package org.apache.spark.sql.execution.streaming
 
 import scala.reflect.ClassTag
 
-import org.apache.hadoop.conf.Configuration
-
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.streaming.checkpointing.{HDFSMetadataLog => ActualHDFSMetadataLog}
 import org.apache.spark.sql.execution.streaming.runtime.{SerializedOffset => ActualSerializedOffset}
 
 @deprecated("use org.apache.spark.sql.execution.streaming.checkpointing.HDFSMetadataLog")
-class HDFSMetadataLog[T <: AnyRef: ClassTag](conf: Configuration, path: String)
-  extends ActualHDFSMetadataLog[T](conf, path) {
-  def this(spark: SparkSession, path: String) = {
-    this(spark.sessionState.newHadoopConf(), path)
-  }
-}
+class HDFSMetadataLog[T <: AnyRef: ClassTag](sparkSession: SparkSession, path: String)
+  extends ActualHDFSMetadataLog[T](sparkSession, path)
 
 @deprecated("use org.apache.spark.sql.execution.streaming.runtime.SerializedOffset")
 object SerializedOffset {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/legacy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/legacy.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming
+
+import scala.reflect.ClassTag
+
+import org.apache.hadoop.conf.Configuration
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.streaming.checkpointing.{HDFSMetadataLog => ActualHDFSMetadataLog}
+import org.apache.spark.sql.execution.streaming.runtime.{SerializedOffset => ActualSerializedOffset}
+
+@deprecated("use org.apache.spark.sql.execution.streaming.checkpointing.HDFSMetadataLog")
+class HDFSMetadataLog[T <: AnyRef: ClassTag](conf: Configuration, path: String)
+  extends ActualHDFSMetadataLog[T](conf, path) {
+  def this(spark: SparkSession, path: String) = {
+    this(spark.sessionState.newHadoopConf(), path)
+  }
+}
+
+@deprecated("use org.apache.spark.sql.execution.streaming.runtime.SerializedOffset")
+object SerializedOffset {
+  def apply(offset: String): ActualSerializedOffset = ActualSerializedOffset(offset)
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is a followup of https://github.com/apache/spark/pull/51959 . Although internal APIs are allowed to be changed, it's still better to keep compatibility if possible to avoid breaking existing Spark plugins.

This PR brings back `HDFSMetadataLog` and `SerializedOffset` to the original package, to avoid breaking the pulsar data source: https://github.com/streamnative/pulsar-spark/blob/master/src/main/scala/org/apache/spark/sql/pulsar/PulsarSources.scala#L27

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Avoid breaking Spark plugins

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
manual test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no