### PR TITLE
[SPARK-53638][SS][PYTHON] Limit the byte size of arrow batch for TWS to avoid OOM

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -1689,6 +1689,7 @@ class TransformWithStateInPandasInitStateSerializer(TransformWithStateInPandasSe
         safecheck,
         assign_cols_by_name,
         arrow_max_records_per_batch,
+        arrow_max_bytes_per_batch,
         int_to_decimal_coercion_enabled,
     ):
         super(TransformWithStateInPandasInitStateSerializer, self).__init__(
@@ -1696,6 +1697,7 @@ class TransformWithStateInPandasInitStateSerializer(TransformWithStateInPandasSe
             safecheck,
             assign_cols_by_name,
             arrow_max_records_per_batch,
+            arrow_max_bytes_per_batch,
             int_to_decimal_coercion_enabled,
         )
         self.init_key_offsets = None

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -1639,10 +1639,12 @@ class TransformWithStateInPandasSerializer(ArrowStreamPandasUDFSerializer):
                     rows.append(row)
                     # Short circuit batch size calculation if the batch size is
                     # unlimited as computing batch size is computationally expensive.
-                    if self.arrow_max_bytes_per_batch != 2**31-1:
+                    if self.arrow_max_bytes_per_batch != 2**31 - 1:
                         accumulate_size += sum(sys.getsizeof(x) for x in row)
-                    if (len(rows) >= self.arrow_max_records_per_batch or
-                            accumulate_size >= self.arrow_max_bytes_per_batch):
+                    if (
+                        len(rows) >= self.arrow_max_records_per_batch
+                        or accumulate_size >= self.arrow_max_bytes_per_batch
+                    ):
                         yield (batch_key, pd.DataFrame(rows))
                         rows = []
                         accumulate_size = 0

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -1612,7 +1612,6 @@ class TransformWithStateInPandasSerializer(ArrowStreamPandasUDFSerializer):
         from pyspark.sql.streaming.stateful_processor_util import (
             TransformWithStateInPandasFuncMode,
         )
-        import sys
 
         def generate_data_batches(batches):
             """

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -20,7 +20,7 @@ Serializers for PyArrow and pandas conversions. See `pyspark.serializers` for mo
 """
 
 from decimal import Decimal
-from itertools import groupby, accumulate
+from itertools import groupby
 from typing import TYPE_CHECKING, Optional
 
 import pyspark

--- a/python/pyspark/sql/tests/pandas/helper/helper_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/helper/helper_pandas_transform_with_state.py
@@ -236,6 +236,9 @@ class StatefulProcessorCompositeTypeFactory(StatefulProcessorFactory):
     def row(self):
         return RowStatefulProcessorCompositeType()
 
+class ChunkCountProcessorFactory(StatefulProcessorFactory):
+    def pandas(self):
+        return PandasChunkCountProcessor()
 
 # StatefulProcessor implementations
 
@@ -1819,6 +1822,20 @@ class RowStatefulProcessorCompositeType(StatefulProcessor):
             map_state_arr=json.dumps(attributes_map, sort_keys=True),
             nested_map_state_arr=json.dumps(confs_map, sort_keys=True),
         )
+
+    def close(self) -> None:
+        pass
+
+class PandasChunkCountProcessor(StatefulProcessor):
+    def init(self, handle: StatefulProcessorHandle) -> None:
+        pass
+
+    def handleInputRows(self, key, rows, timerValues) -> Iterator[pd.DataFrame]:
+        chunk_count = 0
+        for _ in rows:
+            chunk_count += 1
+        yield pd.DataFrame({'id': [key[0]], 'chunkCount': [chunk_count]})
+
 
     def close(self) -> None:
         pass

--- a/python/pyspark/sql/tests/pandas/helper/helper_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/helper/helper_pandas_transform_with_state.py
@@ -236,13 +236,16 @@ class StatefulProcessorCompositeTypeFactory(StatefulProcessorFactory):
     def row(self):
         return RowStatefulProcessorCompositeType()
 
+
 class ChunkCountProcessorFactory(StatefulProcessorFactory):
     def pandas(self):
         return PandasChunkCountProcessor()
 
+
 class ChunkCountProcessorWithInitialStateFactory(StatefulProcessorFactory):
     def pandas(self):
         return PandasChunkCountWithInitialStateProcessor()
+
 
 # StatefulProcessor implementations
 
@@ -1830,6 +1833,7 @@ class RowStatefulProcessorCompositeType(StatefulProcessor):
     def close(self) -> None:
         pass
 
+
 class PandasChunkCountProcessor(StatefulProcessor):
     def init(self, handle: StatefulProcessorHandle) -> None:
         pass
@@ -1838,11 +1842,11 @@ class PandasChunkCountProcessor(StatefulProcessor):
         chunk_count = 0
         for _ in rows:
             chunk_count += 1
-        yield pd.DataFrame({'id': [key[0]], 'chunkCount': [chunk_count]})
-
+        yield pd.DataFrame({"id": [key[0]], "chunkCount": [chunk_count]})
 
     def close(self) -> None:
         pass
+
 
 class PandasChunkCountWithInitialStateProcessor(StatefulProcessor):
     def init(self, handle: StatefulProcessorHandle) -> None:
@@ -1853,7 +1857,7 @@ class PandasChunkCountWithInitialStateProcessor(StatefulProcessor):
         chunk_count = 0
         for _ in rows:
             chunk_count += 1
-        yield pd.DataFrame({'id': [key[0]], 'chunkCount': [chunk_count]})
+        yield pd.DataFrame({"id": [key[0]], "chunkCount": [chunk_count]})
 
     def handleInitialState(self, key, initialState, timerValues) -> None:
         init_val = initialState.at[0, "initVal"]

--- a/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
@@ -71,7 +71,7 @@ from pyspark.sql.tests.pandas.helper.helper_pandas_transform_with_state import (
     MinEventTimeStatefulProcessorFactory,
     StatefulProcessorCompositeTypeFactory,
     ChunkCountProcessorFactory,
-    ChunkCountProcessorWithInitialStateFactory
+    ChunkCountProcessorWithInitialStateFactory,
 )
 
 
@@ -1877,6 +1877,7 @@ class TransformWithStateTestsMixin:
                     assert set(batch_df.sort("id").collect()) == expected_per_batch[0]
                 else:
                     assert set(batch_df.sort("id").collect()) == expected_per_batch[1]
+
             return check_results
 
         result_with_small_limit = [
@@ -1887,7 +1888,7 @@ class TransformWithStateTestsMixin:
             {
                 Row(id="0", chunkCount=3),
                 Row(id="1", chunkCount=2),
-            }
+            },
         ]
 
         result_with_large_limit = [
@@ -1898,57 +1899,66 @@ class TransformWithStateTestsMixin:
             {
                 Row(id="0", chunkCount=1),
                 Row(id="1", chunkCount=1),
-            }
+            },
         ]
 
         data = [("0", 789), ("3", 987)]
         initial_state = self.spark.createDataFrame(data, "id string, initVal int").groupBy("id")
 
         with self.sql_conf(
-                # Set it to a very small number so that every row would be a separate pandas df
-                {"spark.sql.execution.arrow.maxBytesPerBatch": "2"}
+            # Set it to a very small number so that every row would be a separate pandas df
+            {"spark.sql.execution.arrow.maxBytesPerBatch": "2"}
         ):
             self._test_transform_with_state_basic(
                 ChunkCountProcessorFactory(),
                 make_check_results(result_with_small_limit),
-                output_schema=StructType([
-                    StructField("id", StringType(), True),
-                    StructField("chunkCount", IntegerType(), True)
-                ])
+                output_schema=StructType(
+                    [
+                        StructField("id", StringType(), True),
+                        StructField("chunkCount", IntegerType(), True),
+                    ]
+                ),
             )
 
             self._test_transform_with_state_basic(
                 ChunkCountProcessorWithInitialStateFactory(),
                 make_check_results(result_with_small_limit),
                 initial_state=initial_state,
-                output_schema=StructType([
-                    StructField("id", StringType(), True),
-                    StructField("chunkCount", IntegerType(), True)
-                ])
+                output_schema=StructType(
+                    [
+                        StructField("id", StringType(), True),
+                        StructField("chunkCount", IntegerType(), True),
+                    ]
+                ),
             )
 
         with self.sql_conf(
-                # Set it to a very large number so that every row would be in the same pandas df
-                {"spark.sql.execution.arrow.maxBytesPerBatch": "100000"}
+            # Set it to a very large number so that every row would be in the same pandas df
+            {"spark.sql.execution.arrow.maxBytesPerBatch": "100000"}
         ):
             self._test_transform_with_state_basic(
                 ChunkCountProcessorFactory(),
                 make_check_results(result_with_large_limit),
-                output_schema=StructType([
-                    StructField("id", StringType(), True),
-                    StructField("chunkCount", IntegerType(), True)
-                ])
+                output_schema=StructType(
+                    [
+                        StructField("id", StringType(), True),
+                        StructField("chunkCount", IntegerType(), True),
+                    ]
+                ),
             )
 
             self._test_transform_with_state_basic(
                 ChunkCountProcessorWithInitialStateFactory(),
                 make_check_results(result_with_large_limit),
                 initial_state=initial_state,
-                output_schema=StructType([
-                    StructField("id", StringType(), True),
-                    StructField("chunkCount", IntegerType(), True)
-                ])
+                output_schema=StructType(
+                    [
+                        StructField("id", StringType(), True),
+                        StructField("chunkCount", IntegerType(), True),
+                    ]
+                ),
             )
+
 
 @unittest.skipIf(
     not have_pyarrow or os.environ.get("PYTHON_GIL", "?") == "0",

--- a/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
@@ -70,7 +70,8 @@ from pyspark.sql.tests.pandas.helper.helper_pandas_transform_with_state import (
     UpcastProcessorFactory,
     MinEventTimeStatefulProcessorFactory,
     StatefulProcessorCompositeTypeFactory,
-    ChunkCountProcessorFactory
+    ChunkCountProcessorFactory,
+    ChunkCountProcessorWithInitialStateFactory
 )
 
 
@@ -1878,24 +1879,48 @@ class TransformWithStateTestsMixin:
                     assert set(batch_df.sort("id").collect()) == expected_per_batch[1]
             return check_results
 
+        result_with_small_limit = [
+            {
+                Row(id="0", chunkCount=2),
+                Row(id="1", chunkCount=2),
+            },
+            {
+                Row(id="0", chunkCount=3),
+                Row(id="1", chunkCount=2),
+            }
+        ]
+
+        result_with_large_limit = [
+            {
+                Row(id="0", chunkCount=1),
+                Row(id="1", chunkCount=1),
+            },
+            {
+                Row(id="0", chunkCount=1),
+                Row(id="1", chunkCount=1),
+            }
+        ]
+
+        data = [("0", 789), ("3", 987)]
+        initial_state = self.spark.createDataFrame(data, "id string, initVal int").groupBy("id")
+
         with self.sql_conf(
                 # Set it to a very small number so that every row would be a separate pandas df
                 {"spark.sql.execution.arrow.maxBytesPerBatch": "2"}
         ):
             self._test_transform_with_state_basic(
                 ChunkCountProcessorFactory(),
-                make_check_results(
-                    [
-                        {
-                            Row(id="0", chunkCount=2),
-                            Row(id="1", chunkCount=2),
-                        },
-                        {
-                            Row(id="0", chunkCount=3),
-                            Row(id="1", chunkCount=2),
-                        }
-                    ]
-                ),
+                make_check_results(result_with_small_limit),
+                output_schema=StructType([
+                    StructField("id", StringType(), True),
+                    StructField("chunkCount", IntegerType(), True)
+                ])
+            )
+
+            self._test_transform_with_state_basic(
+                ChunkCountProcessorWithInitialStateFactory(),
+                make_check_results(result_with_small_limit),
+                initial_state=initial_state,
                 output_schema=StructType([
                     StructField("id", StringType(), True),
                     StructField("chunkCount", IntegerType(), True)
@@ -1908,24 +1933,22 @@ class TransformWithStateTestsMixin:
         ):
             self._test_transform_with_state_basic(
                 ChunkCountProcessorFactory(),
-                make_check_results(
-                    [
-                        {
-                            Row(id="0", chunkCount=1),
-                            Row(id="1", chunkCount=1),
-                        },
-                        {
-                            Row(id="0", chunkCount=1),
-                            Row(id="1", chunkCount=1),
-                        }
-                    ]
-                ),
+                make_check_results(result_with_large_limit),
                 output_schema=StructType([
                     StructField("id", StringType(), True),
                     StructField("chunkCount", IntegerType(), True)
                 ])
             )
 
+            self._test_transform_with_state_basic(
+                ChunkCountProcessorWithInitialStateFactory(),
+                make_check_results(result_with_large_limit),
+                initial_state=initial_state,
+                output_schema=StructType([
+                    StructField("id", StringType(), True),
+                    StructField("chunkCount", IntegerType(), True)
+                ])
+            )
 
 @unittest.skipIf(
     not have_pyarrow or os.environ.get("PYTHON_GIL", "?") == "0",

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2577,11 +2577,17 @@ def read_udfs(pickleSer, infile, eval_type):
             )
             arrow_max_records_per_batch = int(arrow_max_records_per_batch)
 
+            arrow_max_bytes_per_batch = runner_conf.get(
+                "spark.sql.execution.arrow.maxBytesPerBatch", 64*1024*1024
+            )
+            arrow_max_bytes_per_batch = int(arrow_max_bytes_per_batch)
+
             ser = TransformWithStateInPandasSerializer(
                 timezone,
                 safecheck,
                 _assign_cols_by_name,
                 arrow_max_records_per_batch,
+                arrow_max_bytes_per_batch,
                 int_to_decimal_coercion_enabled=int_to_decimal_coercion_enabled,
             )
         elif eval_type == PythonEvalType.SQL_TRANSFORM_WITH_STATE_PANDAS_INIT_STATE_UDF:

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2578,7 +2578,7 @@ def read_udfs(pickleSer, infile, eval_type):
             arrow_max_records_per_batch = int(arrow_max_records_per_batch)
 
             arrow_max_bytes_per_batch = runner_conf.get(
-                "spark.sql.execution.arrow.maxBytesPerBatch", 64*1024*1024
+                "spark.sql.execution.arrow.maxBytesPerBatch", 2**31 - 1
             )
             arrow_max_bytes_per_batch = int(arrow_max_bytes_per_batch)
 
@@ -2597,7 +2597,7 @@ def read_udfs(pickleSer, infile, eval_type):
             arrow_max_records_per_batch = int(arrow_max_records_per_batch)
 
             arrow_max_bytes_per_batch = runner_conf.get(
-                "spark.sql.execution.arrow.maxBytesPerBatch", 64*1024*1024
+                "spark.sql.execution.arrow.maxBytesPerBatch", 2**31 - 1
             )
             arrow_max_bytes_per_batch = int(arrow_max_bytes_per_batch)
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2596,11 +2596,17 @@ def read_udfs(pickleSer, infile, eval_type):
             )
             arrow_max_records_per_batch = int(arrow_max_records_per_batch)
 
+            arrow_max_bytes_per_batch = runner_conf.get(
+                "spark.sql.execution.arrow.maxBytesPerBatch", 64*1024*1024
+            )
+            arrow_max_bytes_per_batch = int(arrow_max_bytes_per_batch)
+
             ser = TransformWithStateInPandasInitStateSerializer(
                 timezone,
                 safecheck,
                 _assign_cols_by_name,
                 arrow_max_records_per_batch,
+                arrow_max_bytes_per_batch,
                 int_to_decimal_coercion_enabled=int_to_decimal_coercion_enabled,
             )
         elif eval_type == PythonEvalType.SQL_TRANSFORM_WITH_STATE_PYTHON_ROW_UDF:

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/ApplyInPandasWithStatePythonRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/ApplyInPandasWithStatePythonRunner.scala
@@ -113,7 +113,7 @@ class ApplyInPandasWithStatePythonRunner(
   // to let Python worker read the config properly.
   override protected val workerConf: Map[String, String] = initialWorkerConf +
     (SQLConf.ARROW_EXECUTION_MAX_RECORDS_PER_BATCH.key -> arrowMaxRecordsPerBatch.toString) +
-    (SQLConf.ARROW_EXECUTION_MAX_RECORDS_PER_BATCH.key -> arrowMaxBytesPerBatch.toString)
+    (SQLConf.ARROW_EXECUTION_MAX_BYTES_PER_BATCH.key -> arrowMaxBytesPerBatch.toString)
 
   private val stateRowDeserializer = stateEncoder.createDeserializer()
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/ApplyInPandasWithStatePythonRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/ApplyInPandasWithStatePythonRunner.scala
@@ -106,12 +106,14 @@ class ApplyInPandasWithStatePythonRunner(
   }
 
   private val arrowMaxRecordsPerBatch = sqlConf.arrowMaxRecordsPerBatch
+  private val arrowMaxBytesPerBatch = sqlConf.arrowMaxBytesPerBatch
 
   // applyInPandasWithState has its own mechanism to construct the Arrow RecordBatch instance.
   // Configurations are both applied to executor and Python worker, set them to the worker conf
   // to let Python worker read the config properly.
   override protected val workerConf: Map[String, String] = initialWorkerConf +
-    (SQLConf.ARROW_EXECUTION_MAX_RECORDS_PER_BATCH.key -> arrowMaxRecordsPerBatch.toString)
+    (SQLConf.ARROW_EXECUTION_MAX_RECORDS_PER_BATCH.key -> arrowMaxRecordsPerBatch.toString) +
+    (SQLConf.ARROW_EXECUTION_MAX_RECORDS_PER_BATCH.key -> arrowMaxBytesPerBatch.toString)
 
   private val stateRowDeserializer = stateEncoder.createDeserializer()
 
@@ -142,7 +144,11 @@ class ApplyInPandasWithStatePythonRunner(
       dataOut: DataOutputStream,
       inputIterator: Iterator[InType]): Boolean = {
     if (pandasWriter == null) {
-      pandasWriter = new ApplyInPandasWithStateWriter(root, writer, arrowMaxRecordsPerBatch)
+      pandasWriter = new ApplyInPandasWithStateWriter(
+        root,
+        writer,
+        arrowMaxRecordsPerBatch,
+        arrowMaxBytesPerBatch)
     }
     if (inputIterator.hasNext) {
       val startData = dataOut.size()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/ApplyInPandasWithStateWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/ApplyInPandasWithStateWriter.scala
@@ -52,7 +52,7 @@ class ApplyInPandasWithStateWriter(
     writer: ArrowStreamWriter,
     arrowMaxRecordsPerBatch: Int,
     arrowMaxBytesPerBatch: Long)
-  extends BaseStreamingArrowWriter(root, writer, arrowMaxRecordsPerBatch, arrowMaxRecordsPerBatch) {
+  extends BaseStreamingArrowWriter(root, writer, arrowMaxRecordsPerBatch, arrowMaxBytesPerBatch) {
 
   import ApplyInPandasWithStateWriter._
 
@@ -145,7 +145,7 @@ class ApplyInPandasWithStateWriter(
 
     // If it exceeds the condition of batch (number of records) once the all data is received for
     // same group, finalize and construct a new batch.
-    if (totalNumRowsForBatch >= arrowMaxRecordsPerBatch) {
+    if (isBatchSizeLimitReached) {
       finalizeCurrentArrowBatch()
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/ApplyInPandasWithStateWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/ApplyInPandasWithStateWriter.scala
@@ -50,8 +50,9 @@ import org.apache.spark.unsafe.types.UTF8String
 class ApplyInPandasWithStateWriter(
     root: VectorSchemaRoot,
     writer: ArrowStreamWriter,
-    arrowMaxRecordsPerBatch: Int)
-  extends BaseStreamingArrowWriter(root, writer, arrowMaxRecordsPerBatch) {
+    arrowMaxRecordsPerBatch: Int,
+    arrowMaxBytesPerBatch: Long)
+  extends BaseStreamingArrowWriter(root, writer, arrowMaxRecordsPerBatch, arrowMaxRecordsPerBatch) {
 
   import ApplyInPandasWithStateWriter._
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkPythonRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkPythonRunner.scala
@@ -75,7 +75,12 @@ class TransformWithStateInPySparkPythonRunner(
       dataOut: DataOutputStream,
       inputIterator: Iterator[InType]): Boolean = {
     if (pandasWriter == null) {
-      pandasWriter = new BaseStreamingArrowWriter(root, writer, arrowMaxRecordsPerBatch)
+      pandasWriter = new BaseStreamingArrowWriter(
+        root,
+        writer,
+        arrowMaxRecordsPerBatch,
+        arrowMaxBytesPerBatch
+      )
     }
 
     // If we don't have data left for the current group, move to the next group.
@@ -145,7 +150,12 @@ class TransformWithStateInPySparkPythonInitialStateRunner(
       dataOut: DataOutputStream,
       inputIterator: Iterator[GroupedInType]): Boolean = {
     if (pandasWriter == null) {
-      pandasWriter = new BaseStreamingArrowWriter(root, writer, arrowMaxRecordsPerBatch)
+      pandasWriter = new BaseStreamingArrowWriter(
+        root,
+        writer,
+        arrowMaxRecordsPerBatch,
+        arrowMaxBytesPerBatch
+      )
     }
 
     if (inputIterator.hasNext) {
@@ -200,9 +210,11 @@ abstract class TransformWithStateInPySparkPythonBaseRunner[I](
 
   protected val sqlConf = SQLConf.get
   protected val arrowMaxRecordsPerBatch = sqlConf.arrowMaxRecordsPerBatch
+  protected val arrowMaxBytesPerBatch = sqlConf.arrowMaxBytesPerBatch
 
   override protected val workerConf: Map[String, String] = initialWorkerConf +
-    (SQLConf.ARROW_EXECUTION_MAX_RECORDS_PER_BATCH.key -> arrowMaxRecordsPerBatch.toString)
+    (SQLConf.ARROW_EXECUTION_MAX_RECORDS_PER_BATCH.key -> arrowMaxRecordsPerBatch.toString) +
+    (SQLConf.ARROW_EXECUTION_MAX_BYTES_PER_BATCH.key -> arrowMaxBytesPerBatch.toString)
 
   // Use lazy val to initialize the fields before these are accessed in [[PythonArrowInput]]'s
   // constructor.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/BaseStreamingArrowWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/BaseStreamingArrowWriterSuite.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.execution.python.streaming
 
 import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.arrow.vector.ipc.ArrowStreamWriter
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{mock, never, times, verify, when}
 import org.scalatest.BeforeAndAfterEach
 
@@ -68,7 +69,15 @@ class BaseStreamingArrowWriterSuite extends SparkFunSuite with BeforeAndAfterEac
 
   test("test maxBytesPerBatch can work") {
     val root: VectorSchemaRoot = mock(classOf[VectorSchemaRoot])
-    when(arrowWriter.sizeInBytes()).thenReturn(2)
+
+    var sizeCounter = 0
+    when(arrowWriter.write(any[InternalRow])).thenAnswer { _ =>
+      sizeCounter += 1
+      ()
+    }
+
+    when(arrowWriter.sizeInBytes()).thenAnswer { _ => sizeCounter }
+
     // Set arrowMaxBytesPerBatch to 1
     transformWithStateInPySparkWriter = new BaseStreamingArrowWriter(
       root, writer, arrowMaxRecordsPerBatch, 1, arrowWriter)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/BaseStreamingArrowWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/BaseStreamingArrowWriterSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.execution.python.streaming
 
 import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.arrow.vector.ipc.ArrowStreamWriter
-import org.mockito.Mockito.{mock, never, times, verify}
+import org.mockito.Mockito.{mock, never, times, verify, when}
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.SparkFunSuite
@@ -28,6 +28,7 @@ import org.apache.spark.sql.execution.arrow.ArrowWriter
 class BaseStreamingArrowWriterSuite extends SparkFunSuite with BeforeAndAfterEach {
   // Setting the maximum number of records per batch to 2 to make test easier.
   val arrowMaxRecordsPerBatch = 2
+  val arrowMaxBytesPerBatch = Int.MaxValue
   var transformWithStateInPySparkWriter: BaseStreamingArrowWriter = _
   var arrowWriter: ArrowWriter = _
   var writer: ArrowStreamWriter = _
@@ -37,7 +38,7 @@ class BaseStreamingArrowWriterSuite extends SparkFunSuite with BeforeAndAfterEac
     writer = mock(classOf[ArrowStreamWriter])
     arrowWriter = mock(classOf[ArrowWriter])
     transformWithStateInPySparkWriter = new BaseStreamingArrowWriter(
-      root, writer, arrowMaxRecordsPerBatch, arrowWriter)
+      root, writer, arrowMaxRecordsPerBatch, arrowMaxBytesPerBatch, arrowWriter)
   }
 
   test("test writeRow") {
@@ -63,5 +64,26 @@ class BaseStreamingArrowWriterSuite extends SparkFunSuite with BeforeAndAfterEac
     verify(arrowWriter).finish()
     verify(writer).writeBatch()
     verify(arrowWriter).reset()
+  }
+
+  test("test maxBytesPerBatch can work") {
+    val root: VectorSchemaRoot = mock(classOf[VectorSchemaRoot])
+    when(arrowWriter.sizeInBytes()).thenReturn(2)
+    // Set arrowMaxBytesPerBatch to 1
+    transformWithStateInPySparkWriter = new BaseStreamingArrowWriter(
+      root, writer, arrowMaxRecordsPerBatch, 1, arrowWriter)
+    val dataRow = mock(classOf[InternalRow])
+    transformWithStateInPySparkWriter.writeRow(dataRow)
+    verify(arrowWriter).write(dataRow)
+    verify(writer, never()).writeBatch()
+    transformWithStateInPySparkWriter.writeRow(dataRow)
+    verify(arrowWriter, times(2)).write(dataRow)
+    // Write batch is called since we reach arrowMaxBytesPerBatch
+    verify(writer).writeBatch()
+    transformWithStateInPySparkWriter.finalizeCurrentArrowBatch()
+    verify(arrowWriter, times(2)).finish()
+    // The second record would be written
+    verify(writer, times(2)).writeBatch()
+    verify(arrowWriter, times(2)).reset()
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Limit the byte size of Arrow batch for TWS to avoid OOM.


### Why are the changes needed?
On the Python worker side, when using the Pandas execution path, Arrow batches must be converted into Pandas DataFrames in memory. If an Arrow batch is too large, this conversion can lead to OOM errors in the Python worker. To mitigate this risk, we need to enforce a limit on the byte size of each Arrow batch. Similarly, processing the Pandas DataFrame inside `handleInputRows` also occurs entirely in memory, so applying a size limit to the DataFrame itself further helps prevent OOM issues.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT


### Was this patch authored or co-authored using generative AI tooling?
No
