### PR TITLE
[SPARK-53645][PS] Implement `skipna` parameter for ps.DataFrame `any()`

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -11210,11 +11210,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             scol = self._internal.spark_column_for(label)
             if skipna:
                 # When skipna=True, nulls count as False
-                any_col = F.max(F.coalesce(scol.cast("boolean"), F.lit(False)))
+                any_col = F.max(scol.cast("boolean"))
                 applied.append(F.when(any_col.isNull(), False).otherwise(any_col))
             else:
                 # When skipna=False, nulls count as True
-                any_col = F.max(F.coalesce(scol.cast("boolean"), F.lit(True)))
+                any_col = F.max(scol.cast("boolean"))
                 applied.append(F.when(any_col.isNull(), True).otherwise(any_col))
 
         return self._result_aggregated(column_labels, applied)

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -11214,7 +11214,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 applied.append(F.when(any_col.isNull(), False).otherwise(any_col))
             else:
                 # When skipna=False, nulls count as True
-                any_col = F.max(scol.cast("boolean"))
+                any_col = F.max(F.coalesce(scol.cast("boolean"), F.lit(True)))
                 applied.append(F.when(any_col.isNull(), True).otherwise(any_col))
 
         return self._result_aggregated(column_labels, applied)

--- a/python/pyspark/pandas/tests/computation/test_any_all.py
+++ b/python/pyspark/pandas/tests/computation/test_any_all.py
@@ -149,7 +149,9 @@ class FrameAnyAllMixin:
             psdf.any(axis=1)
 
         # Test skipna parameter
-        pdf = pd.DataFrame({"A": [True, False], "B": [1, np.nan], "C": [True, None]})
+        pdf = pd.DataFrame(
+            {"A": [True, False], "B": [1, np.nan], "C": [True, None], "D": [None, np.nan]}
+        )
         psdf = ps.from_pandas(pdf)
 
         # bools and np.nan
@@ -158,13 +160,17 @@ class FrameAnyAllMixin:
         self.assert_eq(psdf[["A", "C"]].any(skipna=False), pdf[["A", "C"]].any(skipna=False))
         # bools, np.nan, and None
         self.assert_eq(psdf[["B", "C"]].any(skipna=False), pdf[["B", "C"]].any(skipna=False))
+        # np.nan, and None
+        self.assert_eq(psdf[["D"]].any(skipna=False), pdf[["D"]].any(skipna=False))
 
+        # np.nan only
         self.assert_eq(
             ps.DataFrame([np.nan]).any(skipna=False),
             pd.DataFrame([np.nan]).any(skipna=False),
             almost=True,
         )
 
+        # None only
         self.assert_eq(
             ps.DataFrame([None]).any(skipna=True),
             pd.DataFrame([None]).any(skipna=True),

--- a/python/pyspark/pandas/tests/computation/test_any_all.py
+++ b/python/pyspark/pandas/tests/computation/test_any_all.py
@@ -148,6 +148,29 @@ class FrameAnyAllMixin:
         ):
             psdf.any(axis=1)
 
+        # Test skipna parameter
+        pdf = pd.DataFrame({"A": [True, False], "B": [1, np.nan], "C": [True, None]})
+        psdf = ps.from_pandas(pdf)
+
+        # bools and np.nan
+        self.assert_eq(psdf[["A", "B"]].any(skipna=False), pdf[["A", "B"]].any(skipna=False))
+        # bools and None
+        self.assert_eq(psdf[["A", "C"]].any(skipna=False), pdf[["A", "C"]].any(skipna=False))
+        # bools, np.nan, and None
+        self.assert_eq(psdf[["B", "C"]].any(skipna=False), pdf[["B", "C"]].any(skipna=False))
+
+        self.assert_eq(
+            ps.DataFrame([np.nan]).any(skipna=False),
+            pd.DataFrame([np.nan]).any(skipna=False),
+            almost=True,
+        )
+
+        self.assert_eq(
+            ps.DataFrame([None]).any(skipna=True),
+            pd.DataFrame([None]).any(skipna=True),
+            almost=True,
+        )
+
 
 class FrameAnyAllTests(
     FrameAnyAllMixin,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Implement `skipna` parameter for `ps.DataFrame`'s `any()` function

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Previously the `any()` function only supported the default `skipna=True` behavior. This provides a way for users to specify `skina=False` to the `any()` function so that they can treat nulls as True instead of False, which was not previously possible through the pyspark pandas interface.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added test


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No