### PR TITLE
[SPARK-53660][SQL][TESTS] Add unit test for Metadata equality check

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/MetadataSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/MetadataSuite.scala
@@ -79,6 +79,18 @@ class MetadataSuite extends SparkFunSuite {
     intercept[NoSuchElementException](meta.getLong("no_such_key"))
   }
 
+  test("Metadata equality check") {
+
+    // Create a StructField with empty metadata
+    val field1 = StructField("myField", IntegerType, nullable = true, Metadata.empty)
+
+    // Create a StructField with non-empty metadata
+    val metadata = new MetadataBuilder().putString("description", "An integer field").build()
+    val field2 = StructField("myField", IntegerType, nullable = true, metadata)
+
+    assert(!(field1 == field2), s"field1 = $field1, field2 = $field2")
+  }
+
   test("Kryo serialization for expressions") {
     val conf = new SparkConf()
     val serializer = new KryoSerializer(conf).newInstance()


### PR DESCRIPTION
### What changes were proposed in this commit?
This commit introduces a new unit test to verify the equality check of `StructField` instances with different metadata configurations.

### Why are the changes needed?
To ensure that the equality check correctly identifies `StructField` instances with empty and non-empty metadata as unequal.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added a new unit test.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
