### PR TITLE
[SPARK-53651][SDP] Add support for persistent views in pipelines

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
@@ -183,7 +183,8 @@ private[connect] object PipelinesHandler extends Logging {
               objectType = Option(QueryOriginType.View.toString),
               objectName = Option(viewIdentifier.unquotedString),
               language = Option(Python())),
-            properties = Map.empty))
+            properties = Map.empty,
+            sqlText = None))
       case _ =>
         throw new IllegalArgumentException(s"Unknown dataset type: ${dataset.getDatasetType}")
     }

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DataflowGraph.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DataflowGraph.scala
@@ -115,6 +115,10 @@ case class DataflowGraph(flows: Seq[Flow], tables: Seq[Table], views: Seq[View])
     }.toMap
   }
 
+  /** The [[Flow]]s that write to a given destination. */
+  lazy val resolvedFlowsTo: Map[TableIdentifier, Seq[ResolvedFlow]] =
+    resolvedFlows.groupBy(_.destinationIdentifier)
+
   lazy val resolutionFailedFlows: Seq[ResolutionFailedFlow] = {
     flows.collect { case f: ResolutionFailedFlow => f }
   }

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DataflowGraphTransformer.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DataflowGraphTransformer.scala
@@ -42,7 +42,7 @@ import org.apache.spark.util.ThreadUtils
  * Assumptions:
  * 1. Each output will have at-least 1 flow to it.
  * 2. Each flow may or may not have a destination table. If a flow does not have a destination
- *    table, the destination is a temporary view.
+ *    table, the destination is a view.
  *
  * The way graph is structured is that flows, tables and sinks all are graph elements or nodes.
  * While we expose transformation functions for each of these entities, we also expose a way to

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphValidations.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphValidations.scala
@@ -331,10 +331,12 @@ trait GraphValidations extends Logging {
               throw new AnalysisException(
                 errorClass = "INVALID_TEMP_OBJ_REFERENCE",
                 messageParameters = Map(
-                  "persistedViewName" -> persistedView.identifier.toString,
-                  "temporaryViewName" -> tempView.identifier.toString
+                  "objName" -> persistedView.identifier.toString,
+                  "obj" -> "view",
+                  "tempObjName" -> tempView.identifier.toString,
+                  "tempObj" -> "temporary view"
                 ),
-                cause = null
+                cause = None
               )
             case _ =>
           }

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/SqlGraphRegistrationContext.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/SqlGraphRegistrationContext.scala
@@ -322,7 +322,8 @@ class SqlGraphRegistrationContext(
             objectName = Option(viewIdentifier.unquotedString),
             objectType = Option(QueryOriginType.View.toString)
           ),
-          properties = cv.properties
+          properties = cv.properties,
+          sqlText = cv.originalText
         )
       )
 
@@ -365,7 +366,8 @@ class SqlGraphRegistrationContext(
             objectName = Option(viewIdentifier.unquotedString),
             objectType = Option(QueryOriginType.View.toString)
           ),
-          properties = Map.empty
+          properties = Map.empty,
+          sqlText = cvc.originalText
         )
       )
 

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/ViewHelpers.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/ViewHelpers.scala
@@ -22,13 +22,13 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 object ViewHelpers {
 
   /** Map of view identifier to corresponding unresolved flow */
-  def persistedViewIdentifierToFlow(graph: DataflowGraph): Map[TableIdentifier, Flow] = {
+  def persistedViewIdentifierToFlow(graph: DataflowGraph): Map[TableIdentifier, ResolvedFlow] = {
     graph.persistedViews.map { v =>
       require(
         graph.flowsTo.get(v.identifier).isDefined,
         s"No flows to view ${v.identifier} were found"
       )
-      val flowsToView = graph.flowsTo(v.identifier)
+      val flowsToView = graph.resolvedFlowsTo(v.identifier)
       require(
         flowsToView.size == 1,
         s"Expected a single flow to the view, found ${flowsToView.size} flows to ${v.identifier}"

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/elements.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/elements.scala
@@ -225,34 +225,31 @@ trait View extends GraphElement {
   /** Properties of this view */
   val properties: Map[String, String]
 
+  /** (SQL-specific) The raw query that defines the [[View]]. */
+  val sqlText: Option[String]
+
   /** User-specified comment that can be placed on the [[View]]. */
   val comment: Option[String]
 }
 
 /**
  * Representing a temporary [[View]] in a [[DataflowGraph]].
- *
- * @param identifier The identifier of this view within the graph.
- * @param properties Properties of the view
- * @param comment when defining a view
  */
 case class TemporaryView(
     identifier: TableIdentifier,
     properties: Map[String, String],
+    sqlText: Option[String],
     comment: Option[String],
     origin: QueryOrigin
 ) extends View {}
 
 /**
  * Representing a persisted [[View]] in a [[DataflowGraph]].
- *
- * @param identifier The identifier of this view within the graph.
- * @param properties Properties of the view
- * @param comment when defining a view
  */
 case class PersistedView(
     identifier: TableIdentifier,
     properties: Map[String, String],
+    sqlText: Option[String],
     comment: Option[String],
     origin: QueryOrigin
 ) extends View {}

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
@@ -151,9 +151,8 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
 
     assert(
       resolvedDataflowGraph.resolvedFlows
-        .exists(
-          f => f.identifier == fullyQualifiedIdentifier("other-hyphen-mv") && !f.df.isStreaming
-        )
+        .exists(f =>
+          f.identifier == fullyQualifiedIdentifier("other-hyphen-mv") && !f.df.isStreaming)
     )
   }
 
@@ -208,7 +207,7 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
     checkAnswer(
       spark
         .sql(s"SELECT * FROM ${fullyQualifiedIdentifier("b").quotedString}"),
-      Seq(Row(0), Row(1), Row(2))
+        Seq(Row(0), Row(1), Row(2))
     )
   }
 
@@ -227,7 +226,7 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
     checkAnswer(
       spark
         .sql(s"SELECT * FROM ${fullyQualifiedIdentifier("b").quotedString}"),
-      Seq(Row(0, 8), Row(1, 9))
+        Seq(Row(0, 8), Row(1, 9))
     )
   }
 
@@ -246,7 +245,7 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
     checkAnswer(
       spark
         .sql(s"SELECT * FROM ${fullyQualifiedIdentifier("c").quotedString}"),
-      Seq(Row(1, 1), Row(2, 2))
+        Seq(Row(1, 1), Row(2, 2))
     )
   }
 
@@ -271,7 +270,8 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
   test("MV/ST with partition columns works") {
     withTable("mv", "st") {
       val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
-        sqlText = """
+        sqlText =
+          """
             |CREATE MATERIALIZED VIEW mv
             |PARTITIONED BY (id_mod)
             |AS
@@ -446,7 +446,8 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
 
     withTable(externalTableIdent.quotedString) {
       val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
-        sqlText = s"""
+        sqlText =
+          s"""
              |CREATE MATERIALIZED VIEW a AS SELECT * FROM $fileFormat.`$tmpDir`;
              |CREATE STREAMING TABLE b AS SELECT * FROM STREAM $externalTableIdent
              |""".stripMargin
@@ -465,7 +466,7 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
         }
         assert(
           spark.sql(s"SELECT * FROM $datasetFullyQualifiedName").collect().toSet ==
-          expectedRows.map(Row(_))
+            expectedRows.map(Row(_))
         )
       }
     }
@@ -517,7 +518,7 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
     checkAnswer(
       spark
         .sql(s"SELECT * FROM ${fullyQualifiedIdentifier("d").quotedString}"),
-      Row(1)
+        Row(1)
     )
   }
 
@@ -649,7 +650,8 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
     val unresolvedDataflowGraph = unresolvedDataflowGraphFromSqlFiles(
       sqlFiles = Seq(
         TestSqlFile(
-          sqlText = s"""
+          sqlText =
+            s"""
                |-- Create table in default (pipeline) catalog and database
                |     CREATE MATERIALIZED VIEW mv AS SELECT * FROM RANGE(3);
                |
@@ -692,7 +694,8 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
           sqlFilePath = "file1.sql"
         ),
         TestSqlFile(
-          sqlText = s"""
+          sqlText =
+            s"""
                |-- The previous file's current catalog/database should not impact other files;
                |-- the catalog/database should be reset to the pipeline's.
                |--
@@ -758,27 +761,27 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
       (s"$otherDatabase2.upstream_mv4", "downstream_mv4"),
       (s"$otherCatalog.$otherDatabase.upstream_mv5", "downstream_mv5"),
       (s"$otherCatalog.$otherDatabase.upstream_mv6", s"$otherDatabase2.downstream_mv6")
-    ).foreach {
-      case (table1Ident, table2Ident) =>
-        // The pipeline catalog is [[TestGraphRegistrationContext.DEFAULT_CATALOG]] and database is
-        // [[TestGraphRegistrationContext.DEFAULT_DATABASE]].
-        val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
-          sqlText = s"""
+    ).foreach { case (table1Ident, table2Ident) =>
+      // The pipeline catalog is [[TestGraphRegistrationContext.DEFAULT_CATALOG]] and database is
+      // [[TestGraphRegistrationContext.DEFAULT_DATABASE]].
+      val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
+        sqlText =
+          s"""
              |CREATE MATERIALIZED VIEW $table1Ident (id BIGINT) AS SELECT * FROM RANGE(10);
              |CREATE MATERIALIZED VIEW $table2Ident AS SELECT id FROM $table1Ident
              |WHERE (id%2)=0;
              |""".stripMargin
-        )
+      )
 
-        startPipelineAndWaitForCompletion(unresolvedDataflowGraph)
+      startPipelineAndWaitForCompletion(unresolvedDataflowGraph)
 
-        checkAnswer(
-          spark.sql(s"SELECT * FROM $table2Ident"),
-          Seq(Row(0), Row(2), Row(4), Row(6), Row(8))
-        )
+      checkAnswer(
+        spark.sql(s"SELECT * FROM $table2Ident"),
+        Seq(Row(0), Row(2), Row(4), Row(6), Row(8))
+      )
 
-        spark.sql(s"DROP TABLE $table1Ident")
-        spark.sql(s"DROP TABLE $table2Ident")
+      spark.sql(s"DROP TABLE $table1Ident")
+      spark.sql(s"DROP TABLE $table2Ident")
     }
   }
 
@@ -855,7 +858,8 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
     Seq("a.b", "a.b.c").foreach { flowIdentifier =>
       val ex = intercept[AnalysisException] {
         unresolvedDataflowGraphFromSql(
-          sqlText = s"""
+          sqlText =
+            s"""
                |CREATE STREAMING TABLE st;
                |CREATE FLOW $flowIdentifier AS INSERT INTO st BY NAME
                |SELECT * FROM STREAM $externalTable1Ident
@@ -877,7 +881,8 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
       unresolvedDataflowGraphFromSqlFiles(
         sqlFiles = Seq(
           TestSqlFile(
-            sqlText = s"""
+            sqlText =
+              s"""
                  |CREATE STREAMING TABLE st;
                  |CREATE FLOW f AS INSERT INTO st BY NAME
                  |SELECT * FROM STREAM $externalTable1Ident
@@ -885,7 +890,8 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
             sqlFilePath = "file1.sql"
           ),
           TestSqlFile(
-            sqlText = s"""
+            sqlText =
+              s"""
                  |CREATE FLOW f AS INSERT INTO st BY NAME
                  |SELECT * FROM STREAM $externalTable1Ident
                  |""".stripMargin,
@@ -911,14 +917,16 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
       unresolvedDataflowGraphFromSqlFiles(
         sqlFiles = Seq(
           TestSqlFile(
-            sqlText = s"""
+            sqlText =
+              s"""
                  |CREATE STREAMING TABLE st AS SELECT * FROM STREAM $externalTable1Ident;
                  |CREATE STREAMING TABLE st2;
                  |""".stripMargin,
             sqlFilePath = "file1.sql"
           ),
           TestSqlFile(
-            sqlText = s"""
+            sqlText =
+              s"""
                  |CREATE FLOW st AS INSERT INTO st2 BY NAME
                  |SELECT * FROM STREAM $externalTable2Ident
                  |""".stripMargin,
@@ -932,10 +940,8 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
       condition = "PIPELINE_DUPLICATE_IDENTIFIERS.FLOW",
       parameters = Map(
         "flowName" -> fullyQualifiedIdentifier("st").unquotedString,
-        "datasetNames" -> Seq(
-          fullyQualifiedIdentifier("st").quotedString,
-          fullyQualifiedIdentifier("st2").quotedString
-        ).mkString(",")
+        "datasetNames" -> Seq(fullyQualifiedIdentifier("st").quotedString,
+          fullyQualifiedIdentifier("st2").quotedString).mkString(",")
       )
     )
   }

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
@@ -151,8 +151,9 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
 
     assert(
       resolvedDataflowGraph.resolvedFlows
-        .exists(f =>
-          f.identifier == fullyQualifiedIdentifier("other-hyphen-mv") && !f.df.isStreaming)
+        .exists(
+          f => f.identifier == fullyQualifiedIdentifier("other-hyphen-mv") && !f.df.isStreaming
+        )
     )
   }
 
@@ -207,7 +208,7 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
     checkAnswer(
       spark
         .sql(s"SELECT * FROM ${fullyQualifiedIdentifier("b").quotedString}"),
-        Seq(Row(0), Row(1), Row(2))
+      Seq(Row(0), Row(1), Row(2))
     )
   }
 
@@ -226,7 +227,7 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
     checkAnswer(
       spark
         .sql(s"SELECT * FROM ${fullyQualifiedIdentifier("b").quotedString}"),
-        Seq(Row(0, 8), Row(1, 9))
+      Seq(Row(0, 8), Row(1, 9))
     )
   }
 
@@ -245,7 +246,7 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
     checkAnswer(
       spark
         .sql(s"SELECT * FROM ${fullyQualifiedIdentifier("c").quotedString}"),
-        Seq(Row(1, 1), Row(2, 2))
+      Seq(Row(1, 1), Row(2, 2))
     )
   }
 
@@ -270,8 +271,7 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
   test("MV/ST with partition columns works") {
     withTable("mv", "st") {
       val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
-        sqlText =
-          """
+        sqlText = """
             |CREATE MATERIALIZED VIEW mv
             |PARTITIONED BY (id_mod)
             |AS
@@ -446,8 +446,7 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
 
     withTable(externalTableIdent.quotedString) {
       val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
-        sqlText =
-          s"""
+        sqlText = s"""
              |CREATE MATERIALIZED VIEW a AS SELECT * FROM $fileFormat.`$tmpDir`;
              |CREATE STREAMING TABLE b AS SELECT * FROM STREAM $externalTableIdent
              |""".stripMargin
@@ -466,7 +465,7 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
         }
         assert(
           spark.sql(s"SELECT * FROM $datasetFullyQualifiedName").collect().toSet ==
-            expectedRows.map(Row(_))
+          expectedRows.map(Row(_))
         )
       }
     }
@@ -518,7 +517,7 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
     checkAnswer(
       spark
         .sql(s"SELECT * FROM ${fullyQualifiedIdentifier("d").quotedString}"),
-        Row(1)
+      Row(1)
     )
   }
 
@@ -614,6 +613,23 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
     assert(ex.errorClass.contains("TEMP_VIEW_NAME_TOO_MANY_NAME_PARTS"))
   }
 
+  test("create view syntax for persisted views") {
+    val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
+      sqlText = s"CREATE VIEW b COMMENT 'my persisted comment' AS SELECT * FROM range(1, 4);"
+    )
+    val graph = unresolvedDataflowGraph.resolve().validate()
+
+    val view = graph.views.last
+
+    // view identifier should be multipart for persisted views
+    assert(view.identifier == fullyQualifiedIdentifier("b"))
+    assert(view.isInstanceOf[PersistedView])
+    assert(
+      view.sqlText.isDefined && view.sqlText.get == "SELECT * FROM range(1, 4)"
+    )
+    assert(view.comment.get == "my persisted comment")
+  }
+
   test("Use database and set catalog works") {
     val pipelineCatalog = TestGraphRegistrationContext.DEFAULT_CATALOG
     val pipelineDatabase = TestGraphRegistrationContext.DEFAULT_DATABASE
@@ -633,8 +649,7 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
     val unresolvedDataflowGraph = unresolvedDataflowGraphFromSqlFiles(
       sqlFiles = Seq(
         TestSqlFile(
-          sqlText =
-            s"""
+          sqlText = s"""
                |-- Create table in default (pipeline) catalog and database
                |     CREATE MATERIALIZED VIEW mv AS SELECT * FROM RANGE(3);
                |
@@ -677,8 +692,7 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
           sqlFilePath = "file1.sql"
         ),
         TestSqlFile(
-          sqlText =
-            s"""
+          sqlText = s"""
                |-- The previous file's current catalog/database should not impact other files;
                |-- the catalog/database should be reset to the pipeline's.
                |--
@@ -744,27 +758,27 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
       (s"$otherDatabase2.upstream_mv4", "downstream_mv4"),
       (s"$otherCatalog.$otherDatabase.upstream_mv5", "downstream_mv5"),
       (s"$otherCatalog.$otherDatabase.upstream_mv6", s"$otherDatabase2.downstream_mv6")
-    ).foreach { case (table1Ident, table2Ident) =>
-      // The pipeline catalog is [[TestGraphRegistrationContext.DEFAULT_CATALOG]] and database is
-      // [[TestGraphRegistrationContext.DEFAULT_DATABASE]].
-      val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
-        sqlText =
-          s"""
+    ).foreach {
+      case (table1Ident, table2Ident) =>
+        // The pipeline catalog is [[TestGraphRegistrationContext.DEFAULT_CATALOG]] and database is
+        // [[TestGraphRegistrationContext.DEFAULT_DATABASE]].
+        val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
+          sqlText = s"""
              |CREATE MATERIALIZED VIEW $table1Ident (id BIGINT) AS SELECT * FROM RANGE(10);
              |CREATE MATERIALIZED VIEW $table2Ident AS SELECT id FROM $table1Ident
              |WHERE (id%2)=0;
              |""".stripMargin
-      )
+        )
 
-      startPipelineAndWaitForCompletion(unresolvedDataflowGraph)
+        startPipelineAndWaitForCompletion(unresolvedDataflowGraph)
 
-      checkAnswer(
-        spark.sql(s"SELECT * FROM $table2Ident"),
-        Seq(Row(0), Row(2), Row(4), Row(6), Row(8))
-      )
+        checkAnswer(
+          spark.sql(s"SELECT * FROM $table2Ident"),
+          Seq(Row(0), Row(2), Row(4), Row(6), Row(8))
+        )
 
-      spark.sql(s"DROP TABLE $table1Ident")
-      spark.sql(s"DROP TABLE $table2Ident")
+        spark.sql(s"DROP TABLE $table1Ident")
+        spark.sql(s"DROP TABLE $table2Ident")
     }
   }
 
@@ -841,8 +855,7 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
     Seq("a.b", "a.b.c").foreach { flowIdentifier =>
       val ex = intercept[AnalysisException] {
         unresolvedDataflowGraphFromSql(
-          sqlText =
-            s"""
+          sqlText = s"""
                |CREATE STREAMING TABLE st;
                |CREATE FLOW $flowIdentifier AS INSERT INTO st BY NAME
                |SELECT * FROM STREAM $externalTable1Ident
@@ -864,8 +877,7 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
       unresolvedDataflowGraphFromSqlFiles(
         sqlFiles = Seq(
           TestSqlFile(
-            sqlText =
-              s"""
+            sqlText = s"""
                  |CREATE STREAMING TABLE st;
                  |CREATE FLOW f AS INSERT INTO st BY NAME
                  |SELECT * FROM STREAM $externalTable1Ident
@@ -873,8 +885,7 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
             sqlFilePath = "file1.sql"
           ),
           TestSqlFile(
-            sqlText =
-              s"""
+            sqlText = s"""
                  |CREATE FLOW f AS INSERT INTO st BY NAME
                  |SELECT * FROM STREAM $externalTable1Ident
                  |""".stripMargin,
@@ -900,16 +911,14 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
       unresolvedDataflowGraphFromSqlFiles(
         sqlFiles = Seq(
           TestSqlFile(
-            sqlText =
-              s"""
+            sqlText = s"""
                  |CREATE STREAMING TABLE st AS SELECT * FROM STREAM $externalTable1Ident;
                  |CREATE STREAMING TABLE st2;
                  |""".stripMargin,
             sqlFilePath = "file1.sql"
           ),
           TestSqlFile(
-            sqlText =
-              s"""
+            sqlText = s"""
                  |CREATE FLOW st AS INSERT INTO st2 BY NAME
                  |SELECT * FROM STREAM $externalTable2Ident
                  |""".stripMargin,
@@ -923,8 +932,10 @@ class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
       condition = "PIPELINE_DUPLICATE_IDENTIFIERS.FLOW",
       parameters = Map(
         "flowName" -> fullyQualifiedIdentifier("st").unquotedString,
-        "datasetNames" -> Seq(fullyQualifiedIdentifier("st").quotedString,
-          fullyQualifiedIdentifier("st2").quotedString).mkString(",")
+        "datasetNames" -> Seq(
+          fullyQualifiedIdentifier("st").quotedString,
+          fullyQualifiedIdentifier("st2").quotedString
+        ).mkString(",")
       )
     )
   }

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ViewSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ViewSuite.scala
@@ -1,0 +1,364 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.pipelines.graph
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.pipelines.common.FlowStatus
+import org.apache.spark.sql.pipelines.logging.EventLevel
+import org.apache.spark.sql.pipelines.utils.ExecutionTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+class ViewSuite extends ExecutionTest with SharedSparkSession {
+  private val externalTable1Ident = fullyQualifiedIdentifier("external_t1")
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    // Create mock external tables that tests can reference, ex. to stream from.
+    spark.sql(s"CREATE TABLE $externalTable1Ident AS SELECT * FROM RANGE(3)")
+  }
+
+  override def afterEach(): Unit = {
+    spark.sql(s"DROP TABLE IF EXISTS $externalTable1Ident")
+    super.afterEach()
+  }
+
+
+  test("create persisted views") {
+    val session = spark
+    import session.implicits._
+
+    val viewName = "mypersistedview"
+    val viewIdentifier = fullyQualifiedIdentifier(viewName)
+
+    val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
+      sqlText = s"CREATE VIEW $viewName AS SELECT * FROM range(1, 4);"
+    )
+    val updateContext = TestPipelineUpdateContext(spark, unresolvedDataflowGraph)
+    updateContext.pipelineExecution.startPipeline()
+    updateContext.pipelineExecution.awaitCompletion()
+
+    val executedGraph = updateContext.pipelineExecution.graphExecution.get.graphForExecution
+    verifyPersistedViewMetadata(
+      graph = executedGraph,
+      viewMetadata = Map(
+        viewIdentifier -> "SELECT * FROM range(1, 4)"
+      )
+    )
+
+    checkAnswer(
+      spark.sql(s"SELECT * FROM $viewIdentifier"),
+      Seq(1L, 2L, 3L).toDF()
+    )
+  }
+
+  test("persisted view reads from external table") {
+    val session = spark
+    import session.implicits._
+
+    val viewName = "mypersistedview"
+    val viewIdentifier = fullyQualifiedIdentifier(viewName)
+
+    val tableIdentifier = fullyQualifiedIdentifier("mytable")
+
+    spark.sql(s"CREATE TABLE $tableIdentifier AS SELECT * FROM range(1, 4)")
+
+    val source = tableIdentifier.toString
+    val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
+      sqlText = s"CREATE VIEW $viewName AS SELECT * FROM $source;"
+    )
+    val updateContext = TestPipelineUpdateContext(spark, unresolvedDataflowGraph)
+    updateContext.pipelineExecution.startPipeline()
+    updateContext.pipelineExecution.awaitCompletion()
+
+    val graph = updateContext.pipelineExecution.graphExecution.get.graphForExecution
+
+    verifyPersistedViewMetadata(
+      graph = graph,
+      viewMetadata = Map(
+        viewIdentifier -> s"SELECT * FROM $source"
+      )
+    )
+
+    checkAnswer(
+      spark.sql(s"SELECT * FROM $viewIdentifier"),
+      Seq(1L, 2L, 3L).toDF()
+    )
+  }
+
+  test("persisted view reads from a temporary view") {
+    val viewName = "pv"
+    val pv = fullyQualifiedIdentifier(viewName)
+
+    val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
+      sqlText = s"""CREATE TEMPORARY VIEW temp_view AS SELECT * FROM range(1, 4);
+                   |CREATE VIEW $viewName AS SELECT * FROM temp_view;""".stripMargin
+    )
+    val updateContext = TestPipelineUpdateContext(spark, unresolvedDataflowGraph)
+
+    val ex = intercept[AnalysisException] {
+      updateContext.pipelineExecution.startPipeline()
+      updateContext.pipelineExecution.awaitCompletion()
+    }
+
+    assertAnalysisException(
+      ex,
+      errorClass = "INVALID_TEMP_OBJ_REFERENCE",
+      metadata = Map(
+        "objName" -> pv.toString,
+        "obj" -> "view",
+        "tempObjName" -> "`temp_view`",
+        "tempObj" -> "temporary view"
+      )
+    )
+  }
+
+  test("persisted view reads from a non-existent dataset") {
+    val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
+      sqlText = s"CREATE VIEW myview AS SELECT * FROM nonexistent_view;"
+    )
+    val updateContext = TestPipelineUpdateContext(spark, unresolvedDataflowGraph)
+
+    val ex = intercept[Exception] {
+      updateContext.pipelineExecution.startPipeline()
+      updateContext.pipelineExecution.awaitCompletion()
+    }
+    ex match {
+      case u: UnresolvedPipelineException =>
+        assert(u.directFailures.keySet == Set(fullyQualifiedIdentifier("myview")))
+      case _ => fail("Unexpected error", ex)
+    }
+  }
+
+  test("persisted view reads from a streaming source") {
+    val viewName = "mypersistedview"
+    val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
+      sqlText = s"""CREATE STREAMING TABLE source AS SELECT * FROM STREAM($externalTable1Ident);
+                   |CREATE VIEW $viewName AS SELECT * FROM STREAM(source);""".stripMargin
+    )
+    val updateContext = TestPipelineUpdateContext(spark, unresolvedDataflowGraph)
+
+    val ex = intercept[AnalysisException] {
+      updateContext.pipelineExecution.startPipeline()
+      updateContext.pipelineExecution.awaitCompletion()
+    }
+
+    assertAnalysisException(
+      ex,
+      errorClass = "INVALID_FLOW_QUERY_TYPE.STREAMING_RELATION_FOR_PERSISTED_VIEW"
+    )
+  }
+
+  test("persisted view reads from an external streaming source") {
+    val viewName = "mypersistedview"
+    val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
+      sqlText = s"CREATE VIEW $viewName AS SELECT * FROM STREAM($externalTable1Ident);"
+    )
+    val updateContext = TestPipelineUpdateContext(spark, unresolvedDataflowGraph)
+
+    val ex = intercept[AnalysisException] {
+      updateContext.pipelineExecution.startPipeline()
+      updateContext.pipelineExecution.awaitCompletion()
+    }
+
+    assertAnalysisException(
+      ex,
+      errorClass = "INVALID_FLOW_QUERY_TYPE.STREAMING_RELATION_FOR_PERSISTED_VIEW"
+    )
+  }
+
+  test("persisted view reads from another persisted view") {
+    val session = spark
+    import session.implicits._
+
+    val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
+      sqlText = s"""CREATE VIEW pv3 AS SELECT * FROM pv2;
+                   |CREATE VIEW pv2 AS SELECT * FROM pv1;
+                   |CREATE VIEW pv1 AS SELECT * FROM range(1, 4);""".stripMargin
+    )
+    val updateContext = TestPipelineUpdateContext(spark, unresolvedDataflowGraph)
+    updateContext.pipelineExecution.startPipeline()
+    updateContext.pipelineExecution.awaitCompletion()
+
+    val graph = updateContext.pipelineExecution.graphExecution.get.graphForExecution
+
+    verifyPersistedViewMetadata(
+      graph = graph,
+      viewMetadata = Map(
+        fullyQualifiedIdentifier("pv1") -> "SELECT * FROM range(1, 4)",
+        fullyQualifiedIdentifier("pv2") -> s"SELECT * FROM pv1",
+        fullyQualifiedIdentifier("pv3") -> s"SELECT * FROM pv2"
+      )
+    )
+
+    checkAnswer(
+      spark.sql(buildSelectQuery(fullyQualifiedIdentifier("pv3"))),
+      Seq(1L, 2L, 3L).toDF()
+    )
+  }
+
+  test("persisted view reads from a failed persisted view") {
+    val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
+      sqlText = s"""
+        |CREATE VIEW pv2 AS SELECT * FROM pv1;
+        |CREATE VIEW pv1 AS SELECT 1 + 1;""".stripMargin
+    )
+    val updateContext = TestPipelineUpdateContext(spark, unresolvedDataflowGraph)
+    updateContext.pipelineExecution.startPipeline()
+    updateContext.pipelineExecution.awaitCompletion()
+
+    // assert that pv1 fails
+    assertFlowProgressEvent(
+      updateContext.eventBuffer,
+      fullyQualifiedIdentifier("pv1"),
+      expectedFlowStatus = FlowStatus.FAILED,
+      expectedEventLevel = EventLevel.ERROR,
+      errorChecker = _.getMessage.contains("CREATE_PERMANENT_VIEW_WITHOUT_ALIAS")
+    )
+
+    // assert that pv2 is skipped (as it depends on pv1)
+    assertFlowProgressEvent(
+      updateContext.eventBuffer,
+      fullyQualifiedIdentifier("pv2"),
+      expectedFlowStatus = FlowStatus.SKIPPED,
+      expectedEventLevel = EventLevel.INFO
+    )
+  }
+
+  test("persisted view reads from MV") {
+    val session = spark
+    import session.implicits._
+
+    val viewName = "mypersistedview"
+    val viewIdentifier = fullyQualifiedIdentifier(viewName)
+
+    val mvIdentifier = fullyQualifiedIdentifier("mymv")
+
+    val source = mvIdentifier.toString
+    val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
+      sqlText = s"""CREATE MATERIALIZED VIEW mymv AS SELECT * FROM RANGE(1, 4);
+                   |CREATE VIEW $viewName AS SELECT * FROM $source;""".stripMargin
+    )
+    val updateContext = TestPipelineUpdateContext(spark, unresolvedDataflowGraph)
+    updateContext.pipelineExecution.startPipeline()
+    updateContext.pipelineExecution.awaitCompletion()
+
+    val graph = updateContext.pipelineExecution.graphExecution.get.graphForExecution
+
+    verifyPersistedViewMetadata(
+      graph = graph,
+      viewMetadata = Map(
+        viewIdentifier -> s"SELECT * FROM $source"
+      )
+    )
+
+    checkAnswer(
+      spark.sql(s"SELECT * FROM $viewIdentifier"),
+      Seq(1L, 2L, 3L).toDF()
+    )
+  }
+
+  test("persisted view reads from ST") {
+    val session = spark
+    import session.implicits._
+
+    val viewName = "mypersistedview"
+    val viewIdentifier = fullyQualifiedIdentifier(viewName)
+
+    val stIdentifier = fullyQualifiedIdentifier("myst")
+
+    val source = stIdentifier.toString
+    val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
+      sqlText = s"""CREATE STREAMING TABLE myst AS SELECT * FROM STREAM($externalTable1Ident);
+                   |CREATE VIEW $viewName AS SELECT * FROM $source;""".stripMargin
+    )
+    val updateContext = TestPipelineUpdateContext(spark, unresolvedDataflowGraph)
+    updateContext.pipelineExecution.startPipeline()
+    updateContext.pipelineExecution.awaitCompletion()
+
+    val graph = updateContext.pipelineExecution.graphExecution.get.graphForExecution
+
+    verifyPersistedViewMetadata(
+      graph = graph,
+      viewMetadata = Map(
+        viewIdentifier -> s"SELECT * FROM $source"
+      )
+    )
+
+    checkAnswer(
+      spark.sql(s"SELECT * FROM $viewIdentifier"),
+      Seq(0L, 1L, 2L).toDF()
+    )
+  }
+
+  test("mv reading from a persisted view") {
+    val session = spark
+    import session.implicits._
+
+    val viewName = "pv"
+    val viewIdentifier = fullyQualifiedIdentifier(viewName)
+
+    val unresolvedDataflowGraph = unresolvedDataflowGraphFromSql(
+      sqlText = s"""
+        |CREATE VIEW $viewName AS SELECT * FROM range(1, 4);
+        |CREATE MATERIALIZED VIEW myviewreader AS SELECT * FROM $viewName;""".stripMargin
+    )
+    val updateContext = TestPipelineUpdateContext(spark, unresolvedDataflowGraph)
+    updateContext.pipelineExecution.startPipeline()
+    updateContext.pipelineExecution.awaitCompletion()
+
+    val graph = updateContext.pipelineExecution.graphExecution.get.graphForExecution
+
+    verifyPersistedViewMetadata(
+      graph = graph,
+      viewMetadata = Map(
+        viewIdentifier -> "SELECT * FROM range(1, 4)"
+      )
+    )
+
+    val q = buildSelectQuery(fullyQualifiedIdentifier("myviewreader"))
+
+    checkAnswer(
+      spark.sql(q),
+      Seq(1L, 2L, 3L).toDF()
+    )
+    checkAnswer(
+      spark.sql(s"SELECT * FROM $viewIdentifier"),
+      Seq(1L, 2L, 3L).toDF()
+    )
+
+  }
+
+  private def verifyPersistedViewMetadata(
+      graph: DataflowGraph,
+      viewMetadata: Map[TableIdentifier, String]
+  ): Unit = {
+    viewMetadata.foreach {
+      case (key, value) =>
+        val viewOpt = graph.view.get(key)
+        assert(viewOpt.isDefined)
+        val view = viewOpt.get
+        assert(view.isInstanceOf[PersistedView])
+        assert(view.sqlText.isDefined && view.sqlText.get == value)
+    }
+  }
+
+  /** Builds a select query for the given dataset name. */
+  private def buildSelectQuery(identifier: TableIdentifier): String = {
+    s"SELECT * FROM $identifier"
+  }
+}

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/TestGraphRegistrationContext.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/TestGraphRegistrationContext.scala
@@ -189,7 +189,8 @@ class TestGraphRegistrationContext(
       origin: QueryOrigin = QueryOrigin.empty,
       viewType: ViewType = LocalTempView,
       catalog: Option[String] = None,
-      database: Option[String] = None
+      database: Option[String] = None,
+      sqlText: Option[String] = None
   ): Unit = {
 
     val viewIdentifier = GraphIdentifierManager
@@ -202,14 +203,16 @@ class TestGraphRegistrationContext(
             identifier = viewIdentifier,
             comment = comment,
             origin = origin,
-            properties = Map.empty
+            properties = Map.empty,
+            sqlText = sqlText
           )
         case _ =>
           PersistedView(
             identifier = viewIdentifier,
             comment = comment,
             origin = origin,
-            properties = Map.empty
+            properties = Map.empty,
+            sqlText = sqlText
           )
       }
     )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Adds support for defining non-temporary views within Declarative Pipelines definitions.

E.g.
```sql
CREATE VIEW my_view AS SELECT * FROM range(5)
```

When the pipeline is executed, the view will be updated or created if they don't already exist.

This will only work in SQL definitions files, because views can't generally be defined via PySpark DataFrame APIs.

### Why are the changes needed?

Closes a gap in Declarative Pipelines support for generating common catalog objects.

### Does this PR introduce _any_ user-facing change?

Yes, only additive.

### How was this patch tested?

Tests for:
- SQL syntax
- Failures
- Views that read from other objects that can be defined in pipelines
- Other objects defined in pipelines reading from views
- Views reading from other views

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
