### PR TITLE
[SPARK-53653][DOC] Update `rexml` gem version to 3.4.4

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -28,4 +28,4 @@ gem "jekyll-redirect-from", "~> 0.16"
 # This resolves a build issue on Apple Silicon.
 # See: https://issues.apache.org/jira/browse/SPARK-38488
 gem "ffi", "~> 1.15"
-gem "rexml", "~> 3.3.9"
+gem "rexml", "~> 3.4.2"

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -28,4 +28,4 @@ gem "jekyll-redirect-from", "~> 0.16"
 # This resolves a build issue on Apple Silicon.
 # See: https://issues.apache.org/jira/browse/SPARK-38488
 gem "ffi", "~> 1.15"
-gem "rexml", "~> 3.4.2"
+gem "rexml", "~> 3.4.4"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -80,7 +80,7 @@ DEPENDENCIES
   ffi (~> 1.15)
   jekyll (~> 4.4)
   jekyll-redirect-from (~> 0.16)
-  rexml (~> 3.4.2)
+  rexml (~> 3.4.4)
 
 RUBY VERSION
    ruby 3.3.7p123

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.9)
+    rexml (3.4.4)
     rouge (4.5.2)
     safe_yaml (1.0.5)
     sass-embedded (1.89.2)
@@ -80,7 +80,10 @@ DEPENDENCIES
   ffi (~> 1.15)
   jekyll (~> 4.4)
   jekyll-redirect-from (~> 0.16)
-  rexml (~> 3.3.9)
+  rexml (~> 3.4.2)
+
+RUBY VERSION
+   ruby 3.3.7p123
 
 BUNDLED WITH
    2.4.22


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update rexml from version 3.3.9 to rexml 3.4.4

### Why are the changes needed?

There are also some fixes in the 2 last versions.
https://github.com/ruby/rexml/releases

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Installed ruby-dev and pip installed mkdocs and run `SKIP_API=1 bundle exec jekyll build`

```
Configuration file: /home/bjorn/github/spark/docs/_config.yml

************************
* Building error docs. *
************************
Generated: docs/_generated/error-conditions.html
            Source: /home/bjorn/github/spark/docs
       Destination: /home/bjorn/github/spark/docs/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
Warning: Tolerating missing API files because the following skip flags are set: SKIP_API
                    done in 4.27 seconds.
 Auto-regeneration: disabled. Use --watch to enable.
```


### Was this patch authored or co-authored using generative AI tooling?
No.
