### PR TITLE
[SPARK-53654][SQL][PYTHON] Support `seed` in function `uuid`

### DIFF
--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -4107,8 +4107,11 @@ def session_user() -> Column:
 session_user.__doc__ = pysparkfuncs.session_user.__doc__
 
 
-def uuid() -> Column:
-    return _invoke_function("uuid", lit(py_random.randint(0, sys.maxsize)))
+def uuid(seed: Optional[Union[Column, int]] = None) -> Column:
+    if seed is None:
+        return _invoke_function("uuid", lit(py_random.randint(0, sys.maxsize)))
+    else:
+        return _invoke_function("uuid", lit(seed))
 
 
 def assert_true(col: "ColumnOrName", errMsg: Optional[Union[Column, str]] = None) -> Column:

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -13617,10 +13617,12 @@ def uuid(seed: Optional[Union[Column, int]] = None) -> Column:
     |7478f235-f8bc-4112-8e59-a28f50e46890|
     +------------------------------------+
     """
+    from pyspark.sql.classic.column import _to_java_column
+
     if seed is None:
         return _invoke_function("uuid")
     else:
-        return _invoke_function_over_columns("uuid", lit(seed))
+        return _invoke_function("uuid", _to_java_column(lit(seed)))
 
 
 @_try_remote_functions

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -13576,15 +13576,22 @@ def session_user() -> Column:
 
 
 @_try_remote_functions
-def uuid() -> Column:
+def uuid(seed: Optional[Union[Column, int]] = None) -> Column:
     """Returns an universally unique identifier (UUID) string.
     The value is returned as a canonical UUID 36-character string.
 
     .. versionadded:: 4.1.0
 
+    Parameters
+    ----------
+    seed : :class:`~pyspark.sql.Column` or int
+        Optional random number seed to use.
+
     Examples
     --------
-    >>> import pyspark.sql.functions as sf
+    Example 1: Generate UUIDs with random seed
+
+    >>> from pyspark.sql import functions as sf
     >>> spark.range(5).select(sf.uuid()).show(truncate=False) # doctest: +SKIP
     +------------------------------------+
     |uuid()                              |
@@ -13595,8 +13602,25 @@ def uuid() -> Column:
     |fb1d6178-7676-4791-baa9-f2ddcc494515|
     |d48665e8-2657-4c6b-b7c8-8ae0cd646e41|
     +------------------------------------+
+
+    Example 2: Generate UUIDs with a specified seed
+
+    >>> from pyspark.sql import functions as sf
+    >>> spark.range(0, 5, 1, 1).select(sf.uuid(seed=123)).show(truncate=False)
+    +------------------------------------+
+    |uuid()                              |
+    +------------------------------------+
+    |4c99192d-23d6-4d88-b814-a634398120f0|
+    |af506873-3c53-41e3-8354-a24856b8de8a|
+    |7b4b370e-e867-47e2-93c0-f6990463a12d|
+    |1c4d1733-ff1a-4a6c-b144-0b0345adf0d0|
+    |7478f235-f8bc-4112-8e59-a28f50e46890|
+    +------------------------------------+
     """
-    return _invoke_function("uuid")
+    if seed is None:
+        return _invoke_function("uuid")
+    else:
+        return _invoke_function_over_columns("uuid", lit(seed))
 
 
 @_try_remote_functions

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3578,6 +3578,15 @@ object functions {
   def uuid(): Column = Column.fn("uuid", lit(SparkClassUtils.random.nextLong))
 
   /**
+   * Returns an universally unique identifier (UUID) string. The value is returned as a canonical
+   * UUID 36-character string.
+   *
+   * @group misc_funcs
+   * @since 4.1.0
+   */
+  def uuid(seed: Column): Column = Column.fn("uuid", seed)
+
+  /**
    * Returns an encrypted value of `input` using AES in given `mode` with the specified `padding`.
    * Key lengths of 16, 24 and 32 bits are supported. Supported combinations of (`mode`,
    * `padding`) are ('ECB', 'PKCS'), ('GCM', 'NONE') and ('CBC', 'PKCS'). Optional initialization


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support `seed` in function `uuid`


### Why are the changes needed?
`seed` was supported in SQL, but not in function APIs

```
In [3]: spark.sql("SELECT UUID(123) FROM RANGE(5)").show(truncate=False)
+------------------------------------+
|uuid()                              |
+------------------------------------+
|a4ab25b4-940b-45c0-96fa-bc7a0760ff0d|
|46763df2-4430-4f55-8287-a85e6452e075|
|a75062e7-7c8c-497a-bb1c-bc469328d5e5|
|63913d89-4de0-4eeb-973e-29e42874d672|
|4d4bdc8d-ca75-4a0a-90cc-6a1801cfe91c|
+------------------------------------+
```


### Does this PR introduce _any_ user-facing change?
yes,
```
    >>> from pyspark.sql import functions as sf
    >>> spark.range(0, 5, 1, 1).select(sf.uuid(seed=123)).show(truncate=False)
    +------------------------------------+
    |uuid()                              |
    +------------------------------------+
    |4c99192d-23d6-4d88-b814-a634398120f0|
    |af506873-3c53-41e3-8354-a24856b8de8a|
    |7b4b370e-e867-47e2-93c0-f6990463a12d|
    |1c4d1733-ff1a-4a6c-b144-0b0345adf0d0|
    |7478f235-f8bc-4112-8e59-a28f50e46890|
    +------------------------------------+

```


### How was this patch tested?
new doctest


### Was this patch authored or co-authored using generative AI tooling?
no