### PR TITLE
[SPARK-53661][BUILD][TESTS] Upgrade `bouncycastle` to 1.82

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
     <maven-antrun.version>3.1.0</maven-antrun.version>
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.10.0</commons-cli.version>
-    <bouncycastle.version>1.81</bouncycastle.version>
+    <bouncycastle.version>1.82</bouncycastle.version>
     <tink.version>1.16.0</tink.version>
     <datasketches.version>6.2.0</datasketches.version>
     <netty.version>4.1.127.Final</netty.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `bouncycastle` to 1.82.

Note that `bouncycastle` was demoted to the `test` scope after Apache Hadoop 3.4.2
- #52390
- [HADOOP-19152: Do not hard code security providers](https://issues.apache.org/jira/browse/HADOOP-19152)

### Why are the changes needed?

- Release Note: https://www.bouncycastle.org/download/bouncy-castle-java/?filter=java%3Drelease-1-82

### Does this PR introduce _any_ user-facing change?

No, this is a test dependency change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.