### PR TITLE
[SPARK-53668][BUILD] Add `--enable-native-access=ALL-UNNAMED` to `build/sbt`

### DIFF
--- a/build/sbt
+++ b/build/sbt
@@ -36,7 +36,7 @@ fi
 declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
 declare -r sbt_opts_file=".sbtopts"
 declare -r etc_sbt_opts_file="/etc/sbt/sbtopts"
-declare -r default_sbt_opts="-Xss64m -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:GCLockerRetryAllocationCount=100"
+declare -r default_sbt_opts="-Xss64m -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:GCLockerRetryAllocationCount=100 --enable-native-access=ALL-UNNAMED"
 
 usage() {
  cat <<EOM


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `build/sbt` with `--enable-native-access=ALL-UNNAMED` to suppress excessive SBT warnings during building. This is similar to the previous `Maven` PR.
- #49972

Apache Spark already uses this configuration in general.

```
$ git grep enable-native-access
.mvn/jvm.config:--enable-native-access=ALL-UNNAMED
launcher/src/main/java/org/apache/spark/launcher/JavaModuleOptions.java:      "--enable-native-access=ALL-UNNAMED"};
pom.xml:      --enable-native-access=ALL-UNNAMED
pom.xml:              <jvmArg>--enable-native-access=ALL-UNNAMED</jvmArg>
project/SparkBuild.scala:        "--enable-native-access=ALL-UNNAMED").mkString(" ")
sql/connect/bin/spark-connect-scala-client:  --enable-native-access=ALL-UNNAMED"
```

### Why are the changes needed?

**BEFORE (Java 25)**

```
$ build/sbt package
...
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
[info] welcome to sbt 1.9.3 (Azul Systems, Inc. Java 25)
```

**AFTER (Java 25)**

```
$ build/sbt package
...
[info] welcome to sbt 1.9.3 (Azul Systems, Inc. Java 25)
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Manual review with `build/sbt package`.

### Was this patch authored or co-authored using generative AI tooling?

No.