### PR TITLE
[SPARK-53671][PYTHON] Exclude 0-args from `@udf` eval type inference

### DIFF
--- a/python/pyspark/sql/connect/udf.py
+++ b/python/pyspark/sql/connect/udf.py
@@ -92,11 +92,11 @@ def _create_py_udf(
     eval_type: Optional[int] = None
     if useArrow is None:
         # If the user doesn't explicitly set useArrow
-        from pyspark.sql.pandas.typehints import infer_eval_type_from_func
+        from pyspark.sql.pandas.typehints import infer_eval_type_for_udf
 
         try:
             # Try to infer the eval type from type hints
-            eval_type = infer_eval_type_from_func(f)
+            eval_type = infer_eval_type_for_udf(f)
         except Exception:
             warnings.warn("Cannot infer the eval type from type hints. ", UserWarning)
 

--- a/python/pyspark/sql/pandas/typehints.py
+++ b/python/pyspark/sql/pandas/typehints.py
@@ -278,7 +278,8 @@ def infer_eval_type(
     return eval_type
 
 
-def infer_eval_type_from_func(  # type: ignore[no-untyped-def]
+# infer the eval type for @udf
+def infer_eval_type_for_udf(  # type: ignore[no-untyped-def]
     f,
 ) -> Optional[
     Union[
@@ -291,7 +292,8 @@ def infer_eval_type_from_func(  # type: ignore[no-untyped-def]
     ]
 ]:
     argspec = getfullargspec(f)
-    if len(argspec.annotations) > 0:
+    # different from inference of @pandas_udf/@arrow_udf, 0-arg is not allowed here
+    if len(argspec.args) > 0 and len(argspec.annotations) > 0:
         try:
             type_hints = get_type_hints(f)
         except NameError:

--- a/python/pyspark/sql/tests/test_unified_udf.py
+++ b/python/pyspark/sql/tests/test_unified_udf.py
@@ -423,6 +423,22 @@ class UnifiedUDFTestsMixin:
             result = self.spark.range(10).select(f("id").alias("res")).collect()
             self.assertEqual(result, expected)
 
+    def test_0_args(self):
+        with self.sql_conf({"spark.sql.execution.pythonUDF.arrow.enabled": False}):
+
+            @udf()
+            def f1() -> int:
+                return 1
+
+            @udf(returnType=LongType())
+            def f2() -> int:
+                return 1
+
+            for f in [f1, f2]:
+                self.assertEqual(f.evalType, PythonEvalType.SQL_BATCHED_UDF)
+                result = self.spark.range(10).select(f().alias("res")).collect()
+                self.assertEqual(len(result), 10)
+
 
 class UnifiedUDFTests(UnifiedUDFTestsMixin, ReusedSQLTestCase):
     pass

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -125,11 +125,11 @@ def _create_py_udf(
     eval_type: Optional[int] = None
     if useArrow is None:
         # If the user doesn't explicitly set useArrow
-        from pyspark.sql.pandas.typehints import infer_eval_type_from_func
+        from pyspark.sql.pandas.typehints import infer_eval_type_for_udf
 
         try:
             # Try to infer the eval type from type hints
-            eval_type = infer_eval_type_from_func(f)
+            eval_type = infer_eval_type_for_udf(f)
         except Exception:
             warnings.warn("Cannot infer the eval type from type hints. ", UserWarning)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Exclude 0-args from `@udf` eval type inference

### Why are the changes needed?
this case fails after https://github.com/apache/spark/pull/52323

```
In [5]: from pyspark.sql.functions import udf

In [6]: @udf()
   ...: def f1() -> int:
   ...:     return 1
   ...:

In [7]: spark.range(10).select(f1().alias("res")).collect()
25/09/23 10:08:16 ERROR Executor: Exception in task 0.0 in stage 5.0 (TID 21)
org.apache.spark.api.python.PythonException: Traceback (most recent call last):
  File "/Users/ruifeng.zheng/spark/python/lib/pyspark.zip/pyspark/sql/pandas/serializers.py", line 473, in _create_array
    return pa.Array.from_pandas(
           ~~~~~~~~~~~~~~~~~~~~^
        series, mask=mask, type=arrow_type, safe=self._safecheck
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "pyarrow/array.pxi", line 1259, in pyarrow.lib.Array.from_pandas
  File "pyarrow/array.pxi", line 365, in pyarrow.lib.array
  File "pyarrow/array.pxi", line 91, in pyarrow.lib._ndarray_to_array
  File "pyarrow/error.pxi", line 92, in pyarrow.lib.check_status
pyarrow.lib.ArrowTypeError: Expected a string or bytes dtype, got int64

The above exception was the direct cause of the following exception:
```

that is due to `f1` is inferred as a `SQL_GROUPED_AGG_PANDAS_UDF`.
I think 0-arg for `SQL_GROUPED_AGG_PANDAS_UDF` doesn't make sense, but to be conservative, I just exclude 0-arg in `@udf` side in this PR. We can revisit the `@pandas_udf` / `@arrow_udf` later.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
added UTs

### Was this patch authored or co-authored using generative AI tooling?
no