### PR TITLE
[SPARK-53674][SQL] Handle single-pass analyzer LCAs when assigning aliases

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AliasResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AliasResolution.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.catalyst.analysis.MultiAlias
+import org.apache.spark.sql.catalyst.analysis.resolver.ResolverTag
 import org.apache.spark.sql.catalyst.expressions.{
   Alias,
   Attribute,
@@ -69,7 +70,7 @@ object AliasResolution {
   private def extractOnly(e: Expression): Boolean = e match {
     case _: ExtractValue => e.children.forall(extractOnly)
     case _: Literal => true
-    case _: Attribute => true
+    case attr: Attribute if attr.getTagValue(ResolverTag.SINGLE_PASS_IS_LCA).isEmpty => true
     case _ => false
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -22,6 +22,7 @@ import java.util.{Objects, UUID}
 import org.apache.spark.{SparkException, SparkUnsupportedOperationException}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.analysis.resolver.ResolverTag
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.plans.logical.EventTimeWatermark
 import org.apache.spark.sql.catalyst.trees.{TreeNodeTag, TreePattern}
@@ -410,7 +411,21 @@ case class PrettyAttribute(
   })
 
   override def toString: String = name
-  override def sql: String = toString
+  override def sql: String = {
+    if (getTagValue(ResolverTag.SINGLE_PASS_IS_LCA).nonEmpty) {
+      // For a query like:
+      //
+      // {{{ select 1 as a, a + 1 }}}
+      //
+      // the output schema will be: [a: int, lateralAliasReference(a): int]
+      //
+      // With current alias resolution single-pass cannot reproduce this behavior, therefore we
+      // need to explicitly assign this name if the attribute is an LCA.
+      s"lateralAliasReference($toString)"
+    } else {
+      toString
+    }
+  }
 
   override def withNullability(newNullability: Boolean): Attribute =
     throw SparkUnsupportedOperationException()

--- a/sql/core/src/test/scala/org/apache/spark/sql/LateralColumnAliasSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/LateralColumnAliasSuite.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, ExpressionSe
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Project}
 import org.apache.spark.sql.catalyst.trees.TreePattern.OUTER_REFERENCE
+import org.apache.spark.sql.catalyst.util.AUTO_GENERATED_ALIAS
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -1391,5 +1392,11 @@ class LateralColumnAliasSuite extends LateralColumnAliasSuiteBase {
         assert(outerProjectList.map(_.name) == Seq("a", "b", "c", "d"))
         assert(innerProjectList.map(_.name) == Seq("a", "b"))
     }
+  }
+
+  test("SPARK-53674: Strip metadata from lateral reference of complex type column") {
+    val schema = sql("SELECT array(1,2,3) AS a, a[1]").queryExecution.analyzed.schema
+    assert(!schema("a").metadata.contains(AUTO_GENERATED_ALIAS))
+    assert(schema("lateralAliasReference(a)[1]").metadata.contains(AUTO_GENERATED_ALIAS))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR adds handling for some edge cases for assigning implicit aliases to LCAs in single-pass analyzer. 

1. Adds the correct `AUTO_GENERATED_ALIAS` metadata for LCAs on complex types
2. Computes the same name as fixed-point for implicit aliases 

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  3. If you fix some SQL features, you can provide some references of other DBMSes.
  4. If there is design documentation, please add the link.
  5. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?

For a query like `SELECT ARRAY(1,2,3) AS a, a[1]`, fixed-point analyzer will first resolve aliases before resolving lateral column references. Because of this, fixed-point won't match `ExtractValue` case in `AliasResolution.scala` (it's child won't be attribute, it will be `LateralColumnAliasReference`). Instead, it will default to auto generated alias case and the `toPrettySQL` will produce `lateralAliasReference` name.

On the other hand, single-pass doesn't use `LateralColumnAliasReference` node and calls AliasResolution only when LCAs have previously been resolved. Because of this it will always match `ExtractValue` case. In order to stay compatible with fixed-point, we prevent this with this little hack

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
