### PR TITLE
[SPARK-53676][PYTHON] Extend to support column name

### DIFF
--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1638,8 +1638,10 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             self.sparkSession,
         )
 
-    def withColumn(self, colName: str, col: Column) -> ParentDataFrame:
-        if not isinstance(col, Column):
+    def withColumn(self, colName: str, col: "ColumnOrName") -> ParentDataFrame:
+        if isinstance(col, str):
+            col = F.col(col)
+        elif not isinstance(col, Column):
             raise PySparkTypeError(
                 errorClass="NOT_COLUMN",
                 messageParameters={"arg_name": "col", "arg_type": type(col).__name__},

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -932,8 +932,10 @@ class DataFrame(ParentDataFrame):
             session=self._session,
         )
 
-    def withColumn(self, colName: str, col: Column) -> ParentDataFrame:
-        if not isinstance(col, Column):
+    def withColumn(self, colName: str, col: "ColumnOrName") -> ParentDataFrame:
+        if isinstance(col, str):
+            col = F.col(col)
+        elif not isinstance(col, Column):
             raise PySparkTypeError(
                 errorClass="NOT_COLUMN",
                 messageParameters={"arg_name": "col", "arg_type": type(col).__name__},

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -5651,7 +5651,7 @@ class DataFrame:
         ...
 
     @dispatch_df_method
-    def withColumn(self, colName: str, col: Column) -> "DataFrame":
+    def withColumn(self, colName: str, col: "ColumnOrName") -> "DataFrame":
         """
         Returns a new :class:`DataFrame` by adding a column or replacing the
         existing column that has the same name.
@@ -5668,8 +5668,8 @@ class DataFrame:
         ----------
         colName : str
             string, name of the new column.
-        col : :class:`Column`
-            a :class:`Column` expression for the new column.
+        cols: str or :class:`Column`
+            A name of a column, or a :class:`Column` expression for the new column.
 
         Returns
         -------

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -413,6 +413,10 @@ class DataFrameTestsMixin:
         keys = self.df.withColumn("key", self.df.key).select("key").collect()
         self.assertEqual([r.key for r in keys], list(range(100)))
 
+    def test_with_column_with_column_name(self):
+        keys = self.df.withColumn("key", "key").select("key").collect()
+        self.assertEqual([r.key for r in keys], list(range(100)))
+
     # regression test for SPARK-10417
     def test_column_iterator(self):
         def foo():


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

This extends `DataFrame.withColumn` to accept a column name (i.e. string) in addition to a `Column` expression–see [SPARK-53675](https://issues.apache.org/jira/browse/SPARK-53675).


### Why are the changes needed?

This follows the API changes introduced in 3.0 where constructs "that previously only accepted a Column object to specify a column can now take a string specifying the column by name".

### Does this PR introduce _any_ user-facing change?
Yes, this extends the allowed type to _column or name_, previous just column.

### How was this patch tested?
Simple test added.


### Was this patch authored or co-authored using generative AI tooling?
No.