### PR TITLE
[SPARK-53677][SQL] Improve debuggability for JDBC data source when query contains syntax error

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4039,7 +4039,7 @@
   },
   "JDBC_EXTERNAL_ENGINE_SYNTAX_ERROR" : {
     "message" : [
-      "JDBC external engine syntax error. The error was caused by the query <jdbcQuery>."
+      "JDBC external engine syntax error. The error was caused by the query <jdbcQuery>. <externalEngineError>."
     ],
     "subClass" : {
       "DURING_OUTPUT_SCHEMA_RESOLUTION" : {

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/SharedJDBCIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/SharedJDBCIntegrationSuite.scala
@@ -65,7 +65,7 @@ abstract class SharedJDBCIntegrationSuite extends DockerJDBCIntegrationSuite {
       condition = "JDBC_EXTERNAL_ENGINE_SYNTAX_ERROR.DURING_OUTPUT_SCHEMA_RESOLUTION",
       parameters = Map(
         "jdbcQuery" -> "SELECT * FROM \\(.*",
-        "externalEngineQuery" -> ".*"
+        "externalEngineError" -> ".*"
       )
     )
   }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/SharedJDBCIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/SharedJDBCIntegrationSuite.scala
@@ -60,12 +60,15 @@ abstract class SharedJDBCIntegrationSuite extends DockerJDBCIntegrationSuite {
         .option("url", jdbcUrl)
         .option("query", "THIS IS NOT VALID SQL").load()
     }
+
+    // Exception should be detected in analysis phase first when we resolve a schema from
+    // through JDBC by sending SELECT * FROM (<subquery>) [LIMIT 1][WHERE 1=0] query.
     checkErrorMatchPVals(
       ex,
       condition = "JDBC_EXTERNAL_ENGINE_SYNTAX_ERROR.DURING_OUTPUT_SCHEMA_RESOLUTION",
       parameters = Map(
-        "jdbcQuery" -> "SELECT * FROM \\(.*",
-        "externalEngineError" -> ".*"
+        "jdbcQuery" -> "SELECT \\* FROM \\(.*",
+        "externalEngineError" -> "[\\s\\S]*"
       )
     )
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -340,7 +340,7 @@ class JDBCRDD(
             errorClass = "JDBC_EXTERNAL_ENGINE_SYNTAX_ERROR.DURING_QUERY_EXECUTION",
             messageParameters = Map(
               "jdbcQuery" -> sqlText,
-              "externalEngineQuery" -> e.getMessage.replaceAll("\\.+$", "")
+              "externalEngineError" -> e.getMessage.replaceAll("\\.+$", "")
             ),
             cause = e)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -67,7 +67,10 @@ object JDBCRDD extends Logging {
       case e: SQLException if dialect.isSyntaxErrorBestEffort(e) =>
         throw new SparkException(
           errorClass = "JDBC_EXTERNAL_ENGINE_SYNTAX_ERROR.DURING_OUTPUT_SCHEMA_RESOLUTION",
-          messageParameters = Map("jdbcQuery" -> fullQuery),
+          messageParameters = Map(
+            "jdbcQuery" -> fullQuery,
+            "externalEngineError" -> e.getMessage.replaceAll("\\.+$", "")
+          ),
           cause = e)
     }
   }
@@ -335,7 +338,10 @@ class JDBCRDD(
         case e: SQLException if dialect.isSyntaxErrorBestEffort(e) =>
           throw new SparkException(
             errorClass = "JDBC_EXTERNAL_ENGINE_SYNTAX_ERROR.DURING_QUERY_EXECUTION",
-            messageParameters = Map("jdbcQuery" -> sqlText),
+            messageParameters = Map(
+              "jdbcQuery" -> sqlText,
+              "externalEngineQuery" -> e.getMessage.replaceAll("\\.+$", "")
+            ),
             cause = e)
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Improve the error message for syntax errors in the JDBC data source, since users complain that it is hard to fix a query currently, as they don't have hints from the remote engine parser.

### Why are the changes needed?
- Improve UX


### Does this PR introduce _any_ user-facing change?
Yes, slight difference in error message


### How was this patch tested?
Modified existing test

### Was this patch authored or co-authored using generative AI tooling?
No