### PR TITLE
[SPARK-53516][CORE][TESTS][FOLLOWUP] Fix compilation errors in `SparkPipelinesSuite` 

### DIFF
--- a/core/src/test/scala/org/apache/spark/deploy/SparkPipelinesSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkPipelinesSuite.scala
@@ -120,15 +120,18 @@ class SparkPipelinesSuite extends SparkSubmitTestUtils with BeforeAndAfterEach {
   test("spark.api.mode arg") {
     var args = Array("--conf", "spark.api.mode=classic")
     intercept[SparkUserAppException] {
-      SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc")
+      SparkPipelines.constructSparkSubmitArgs(
+        pipelinesCliFile = "abc/python/pyspark/pipelines/cli.py", args = args)
     }
     args = Array("-c", "spark.api.mode=classic")
     intercept[SparkUserAppException] {
-      SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc")
+      SparkPipelines.constructSparkSubmitArgs(
+        pipelinesCliFile = "abc/python/pyspark/pipelines/cli.py", args = args)
     }
     args = Array("--conf", "spark.api.mode=CONNECT")
     assert(
-      SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
+      SparkPipelines.constructSparkSubmitArgs(
+        pipelinesCliFile = "abc/python/pyspark/pipelines/cli.py", args = args) ==
         Seq(
           "--conf",
           "spark.api.mode=connect",
@@ -139,7 +142,8 @@ class SparkPipelinesSuite extends SparkSubmitTestUtils with BeforeAndAfterEach {
     )
     args = Array("--conf", "spark.api.mode=CoNNect")
     assert(
-      SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
+      SparkPipelines.constructSparkSubmitArgs(
+        pipelinesCliFile = "abc/python/pyspark/pipelines/cli.py", args = args) ==
         Seq(
           "--conf",
           "spark.api.mode=connect",
@@ -150,7 +154,8 @@ class SparkPipelinesSuite extends SparkSubmitTestUtils with BeforeAndAfterEach {
     )
     args = Array("--conf", "spark.api.mode=connect")
     assert(
-      SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
+      SparkPipelines.constructSparkSubmitArgs(
+        pipelinesCliFile = "abc/python/pyspark/pipelines/cli.py", args = args) ==
         Seq(
           "--conf",
           "spark.api.mode=connect",
@@ -161,7 +166,8 @@ class SparkPipelinesSuite extends SparkSubmitTestUtils with BeforeAndAfterEach {
     )
     args = Array("--conf", "spark.api.mode= connect")
     assert(
-      SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
+      SparkPipelines.constructSparkSubmitArgs(
+        pipelinesCliFile = "abc/python/pyspark/pipelines/cli.py", args = args) ==
         Seq(
           "--conf",
           "spark.api.mode=connect",
@@ -172,7 +178,8 @@ class SparkPipelinesSuite extends SparkSubmitTestUtils with BeforeAndAfterEach {
     )
     args = Array("-c", "spark.api.mode=connect")
     assert(
-      SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
+      SparkPipelines.constructSparkSubmitArgs(
+        pipelinesCliFile = "abc/python/pyspark/pipelines/cli.py", args = args) ==
         Seq(
           "--conf",
           "spark.api.mode=connect",


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aim to fix compilation errors in SparkPipelinesSuite

### Why are the changes needed?
Restore GA:
- https://github.com/apache/spark/actions/runs/17952456210/job/51055288793

```
[error] /home/runner/work/spark/spark/core/src/test/scala/org/apache/spark/deploy/SparkPipelinesSuite.scala:123:63: unknown parameter name: sparkHome
[error]       SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc")
[error]                                                               ^
[error] /home/runner/work/spark/spark/core/src/test/scala/org/apache/spark/deploy/SparkPipelinesSuite.scala:127:63: unknown parameter name: sparkHome
[error]       SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc")
[error]                                                               ^
[error] /home/runner/work/spark/spark/core/src/test/scala/org/apache/spark/deploy/SparkPipelinesSuite.scala:131:63: unknown parameter name: sparkHome
[error]       SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
[error]                                                               ^
[error] /home/runner/work/spark/spark/core/src/test/scala/org/apache/spark/deploy/SparkPipelinesSuite.scala:142:63: unknown parameter name: sparkHome
[error]       SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
[error]                                                               ^
[error] /home/runner/work/spark/spark/core/src/test/scala/org/apache/spark/deploy/SparkPipelinesSuite.scala:153:63: unknown parameter name: sparkHome
[error]       SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
[error]                                                               ^
[error] /home/runner/work/spark/spark/core/src/test/scala/org/apache/spark/deploy/SparkPipelinesSuite.scala:164:63: unknown parameter name: sparkHome
[error]       SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
[error]                                                               ^
[error] /home/runner/work/spark/spark/core/src/test/scala/org/apache/spark/deploy/SparkPipelinesSuite.scala:175:63: unknown parameter name: sparkHome
[error]       SparkPipelines.constructSparkSubmitArgs(args, sparkHome = "abc") ==
[error]                                                               ^
```

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Pass GitHub Actions
- Manual checked `build/sbt clean "core/testOnly org.apache.spark.deploy.SparkPipelinesSuite"`

```
WARNING: Using incubator modules: jdk.incubator.vector
[info] SparkPipelinesSuite:
[info] - only spark submit args (20 milliseconds)
[info] - only pipelines args (1 millisecond)
[info] - spark-submit and pipelines args (0 milliseconds)
[info] - class arg prohibited (2 milliseconds)
[info] - spark.api.mode arg (1 millisecond)
[info] - name arg (0 milliseconds)
[info] Run completed in 692 milliseconds.
[info] Total number of tests run: 6
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 6, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```

### Was this patch authored or co-authored using generative AI tooling?
No