### PR TITLE
[SPARK-53678][SQL] Fix NPE when subclass of ColumnVector is created with null DataType

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnVector.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnVector.java
@@ -338,7 +338,7 @@ public abstract class ColumnVector implements AutoCloseable {
    * Sets up the data type of this column vector.
    */
   protected ColumnVector(DataType type) {
-    this.type = type.transformRecursively(
+    this.type = type == null ? null : type.transformRecursively(
       new PartialFunction<DataType, DataType>() {
         @Override
         public boolean isDefinedAt(DataType x) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ConstantColumnVectorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ConstantColumnVectorSuite.scala
@@ -204,4 +204,8 @@ class ConstantColumnVectorSuite extends SparkFunSuite {
       assert(vector.getChild(2).getLong(i) == 12345L)
     }
   }
+
+  testVector("null DataType", 0, null) { vector =>
+    assert(vector.dataType == null)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Check whether the parameter DataType is null in ColumnVector constructor before transforming it


### Why are the changes needed?
A subclass of ColumnVector, e.g. Iceberg's [ConstantColumnVector](https://github.com/apache/iceberg/blob/main/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ConstantColumnVector.java#L41), could be created with null `DataType`. It throws NPE after https://github.com/apache/spark/pull/51349, which can be verified by failed tests in [integrating Spark 4.1.0-preview1 in Iceberg](https://github.com/apache/iceberg/pull/14155)


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
UT.


### Was this patch authored or co-authored using generative AI tooling?
No.
