### PR TITLE
[SPARK-53681][BUILD][TESTS] Upgrade `snowflake-jdbc` to 3.26.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
     <mssql.jdbc.version>12.8.1.jre11</mssql.jdbc.version>
     <ojdbc17.version>23.6.0.24.10</ojdbc17.version>
     <databricks.jdbc.version>2.7.1</databricks.jdbc.version>
-    <snowflake.jdbc.version>3.23.2</snowflake.jdbc.version>
+    <snowflake.jdbc.version>3.26.1</snowflake.jdbc.version>
     <terajdbc.version>20.00.00.39</terajdbc.version>
     <!-- Used for SBT build to retrieve the Spark version -->
     <spark.version>${project.version}</spark.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `snowflake-jdbc` to 3.26.1.

### Why are the changes needed?

To bring the latest bug fixed version for testing:

- https://docs.snowflake.com/en/release-notes/clients-drivers/jdbc-2025#version-3-26-1-august-29-2025
  - Fixed an issue with a NullPointerException when MFA is enabled in Okta and native Okta authentication is used.
  - Fixed an issue with CloseableHttpClient being cached indefinitely.
  - Fixed a bug preventing the use of auto-config with connection pooling.
  - Fixed a bug preventing application termination immediately because of telemetry threads.
  - Fixed a bug that prevented TelemetryThreadPool from scaling based on the workload.

### Does this PR introduce _any_ user-facing change?

No. This is a test-only dependency.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.