### PR TITLE
[SPARK-53682][INFRA] Refresh `spark-rm` Docker Image with `jammy-20250819`

### DIFF
--- a/dev/create-release/spark-rm/Dockerfile
+++ b/dev/create-release/spark-rm/Dockerfile
@@ -16,14 +16,14 @@
 #
 
 # Image for building Spark releases. Based on Ubuntu 22.04.
-FROM ubuntu:jammy-20240911.1
+FROM ubuntu:jammy-20250819
 LABEL org.opencontainers.image.authors="Apache Spark project <dev@spark.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.ref.name="Apache Spark Release Manager Image"
 # Overwrite this label to avoid exposing the underlying Ubuntu OS version label
 LABEL org.opencontainers.image.version=""
 
-ENV FULL_REFRESH_DATE=20241119
+ENV FULL_REFRESH_DATE=20250819
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to refresh `spark-rm` Docker Image with `jammy-20250819`.

```
-FROM ubuntu:jammy-20240911.1
+FROM ubuntu:jammy-20250819
```

```
-ENV FULL_REFRESH_DATE=20241119
+ENV FULL_REFRESH_DATE=20250819
```

### Why are the changes needed?

To use the up-to-date image for Apache Spark 4.1.0 preparation.

### Does this PR introduce _any_ user-facing change?

No, this is used by Apache Spark release managers.

### How was this patch tested?

Manual tests.

### Was this patch authored or co-authored using generative AI tooling?

Pass the CIs.