### PR TITLE
[SPARK-53688][PYTHON][INFRA][TESTS] Increase the timeout and skip UDF type tests in Python-only on MacOS

### DIFF
--- a/.github/workflows/python_hosted_runner_test.yml
+++ b/.github/workflows/python_hosted_runner_test.yml
@@ -59,7 +59,8 @@ jobs:
   build:
     name: "PySpark test on macos: ${{ matrix.modules }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 120
+    # TODO(SPARK-53605): Restore pyspark execution timeout to 2 hours after fixing test_pandas_transform_with_state
+    timeout-minutes: 150
     strategy:
       fail-fast: false
       matrix:

--- a/python/pyspark/sql/tests/udf_type_tests/test_udf_input_types.py
+++ b/python/pyspark/sql/tests/udf_type_tests/test_udf_input_types.py
@@ -16,6 +16,7 @@
 #
 
 import os
+import platform
 import unittest
 import pandas as pd
 
@@ -59,8 +60,12 @@ if have_numpy:
     not have_pandas
     or not have_pyarrow
     or not have_numpy
-    or LooseVersion(np.__version__) < LooseVersion("2.0.0"),
-    pandas_requirement_message or pyarrow_requirement_message or numpy_requirement_message,
+    or LooseVersion(np.__version__) < LooseVersion("2.0.0")
+    or platform.system() == "Darwin",
+    pandas_requirement_message
+    or pyarrow_requirement_message
+    or numpy_requirement_message
+    or "float128 not supported on macos",
 )
 class UDFInputTypeTests(ReusedSQLTestCase):
     @classmethod

--- a/python/pyspark/sql/tests/udf_type_tests/test_udf_return_types.py
+++ b/python/pyspark/sql/tests/udf_type_tests/test_udf_return_types.py
@@ -18,6 +18,7 @@
 import array
 import datetime
 import os
+import platform
 import unittest
 from decimal import Decimal
 import numpy as np
@@ -63,8 +64,12 @@ if have_numpy:
     not have_pandas
     or not have_pyarrow
     or not have_numpy
-    or LooseVersion(np.__version__) < LooseVersion("2.0.0"),
-    pandas_requirement_message or pyarrow_requirement_message or numpy_requirement_message,
+    or LooseVersion(np.__version__) < LooseVersion("2.0.0")
+    or platform.system() == "Darwin",
+    pandas_requirement_message
+    or pyarrow_requirement_message
+    or numpy_requirement_message
+    or "float128 not supported on macos",
 )
 class UDFReturnTypeTests(ReusedSQLTestCase):
     @classmethod


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Restore scheduled job Python on MacOS


### Why are the changes needed?
there are several issues in `Build / Python-only (master, Python 3.11, MacOS)`:
1, timeout (see https://github.com/apache/spark/actions/runs/17959033758/job/51077768376)
due to
```
Starting test(python3.11): pyspark.sql.tests.pandas.test_pandas_transform_with_state (temp output: /Users/runner/work/spark/spark/python/target/e6f2d46f-d9dd-48ac-8a90-d6e23b1fa732/python3.11__pyspark.sql.tests.pandas.test_pandas_transform_with_state__w2vr990g.log)
Finished test(python3.11): pyspark.sql.tests.pandas.test_pandas_transform_with_state (2627s) ... 4 tests were skipped
```
and 
```
Starting test(python3.11): pyspark.sql.tests.connect.pandas.test_parity_pandas_transform_with_state (temp output: /Users/runner/work/spark/spark/python/target/cb180fcf-43fa-4399-af2c-cb4fbce43cc5/python3.11__pyspark.sql.tests.connect.pandas.test_parity_pandas_transform_with_state___59n8od_.log)
Finished test(python3.11): pyspark.sql.tests.connect.pandas.test_parity_pandas_transform_with_state (1353s) ... 4 tests were skipped
```

2, test failure of newly added UDF input/output type check
```
======================================================================
ERROR [0.004s]: test_assert_classic_mode (__main__.UDFReturnTypeTests.test_assert_classic_mode)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/runner/work/spark/spark/python/pyspark/sql/tests/udf_type_tests/test_udf_return_types.py", line 107, in setUp
    np.arange(1, 3).astype("float128"),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: data type 'float128' not understood
```
based on my investigation, `np.float128` is platform specific, and seems not supported on macos;

3, flaky ml tests, which failed occasionally


this PR attempt to resolve 1) and 2)

### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
will monitor the CI

### Was this patch authored or co-authored using generative AI tooling?
no