### PR TITLE
[SPARK-53689][BUILD] Respect RELEASE_VERSION environment variable if already defined

### DIFF
--- a/dev/create-release/release-util.sh
+++ b/dev/create-release/release-util.sh
@@ -106,7 +106,9 @@ function get_release_info {
   fi
 
   NEXT_VERSION="$VERSION"
-  RELEASE_VERSION="${VERSION/-SNAPSHOT/}"
+  if [ -z "$RELEASE_VERSION" ]; then
+    RELEASE_VERSION="${VERSION/-SNAPSHOT/}"
+  fi
   SHORT_VERSION=$(echo "$VERSION" | cut -d . -f 1-2)
   local REV=$(echo "$RELEASE_VERSION" | cut -d . -f 3)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the release script to respect RELEASE_VERSION environment variable if already defined

### Why are the changes needed?

Otherwise, pre-defined `RELEASE_VERSION` does not work.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.