### PR TITLE
[SPARK-53689][BUILD][FOLLOW-UP] Check if RELEASE_VERSION is already set properly

### DIFF
--- a/dev/create-release/release-util.sh
+++ b/dev/create-release/release-util.sh
@@ -106,7 +106,7 @@ function get_release_info {
   fi
 
   NEXT_VERSION="$VERSION"
-  if [ -z "$RELEASE_VERSION" ]; then
+  if [ -n "$RELEASE_VERSION" ]; then
     SPARK_RELEASE_VERSION="$RELEASE_VERSION"
   fi
   RELEASE_VERSION="${VERSION/-SNAPSHOT/}"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR checks if RELEASE_VERSION is already set properly.

This PR is a followup of https://github.com/apache/spark/pull/52430

### Why are the changes needed?

Otherwise, pre-defined `RELEASE_VERSION` does not work.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.