### PR TITLE
[SPARK-53692][DOCS] Remove a unused configuration spark.appStatusStore.diskStoreDir

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1806,14 +1806,6 @@ Apart from these, the following properties are also available, and may be useful
   </td>
   <td>1.4.0</td>
 </tr>
-<tr>
-  <td><code>spark.appStatusStore.diskStoreDir</code></td>
-  <td>None</td>
-  <td>
-    Local directory where to store diagnostic information of SQL executions. This configuration is only for live UI.
-  </td>
-  <td>3.4.0</td>
-</tr>
 </table>
 
 ### Compression and Serialization


### PR DESCRIPTION
### What changes were proposed in this pull request?

`spark.appStatusStore.diskStoreDir` is not in use

### Why are the changes needed?

Docfix

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
passing docs build


### Was this patch authored or co-authored using generative AI tooling?
no
