### PR TITLE
[SPARK-53694][SQL][TESTS] Improve `V1WriteHiveCommandSuite` test coverage

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/V1WriteHiveCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/V1WriteHiveCommandSuite.scala
@@ -19,33 +19,49 @@ package org.apache.spark.sql.hive.execution.command
 
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.execution.datasources.V1WriteCommandSuiteBase
+import org.apache.spark.sql.hive.HiveUtils._
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 
 class V1WriteHiveCommandSuite
     extends QueryTest with TestHiveSingleton with V1WriteCommandSuiteBase  {
 
+  def withCovnertMetastore(testFunc: Boolean => Any): Unit = {
+    Seq(true, false).foreach { enabled =>
+      withSQLConf(
+        CONVERT_METASTORE_PARQUET.key -> enabled.toString,
+        CONVERT_METASTORE_ORC.key -> enabled.toString) {
+        testFunc(enabled)
+      }
+    }
+  }
+
   test("create hive table as select - no partition column") {
-    withPlannedWrite { enabled =>
-      withTable("t") {
-        executeAndCheckOrdering(hasLogicalSort = false, orderingMatched = true) {
-          sql("CREATE TABLE t AS SELECT * FROM t0")
+    withCovnertMetastore { _ =>
+      withPlannedWrite { enabled =>
+        withTable("t") {
+          executeAndCheckOrdering(hasLogicalSort = false, orderingMatched = true) {
+            sql("CREATE TABLE t STORED AS Parquet AS SELECT * FROM t0")
+          }
         }
       }
     }
   }
 
   test("create hive table as select") {
-    withPlannedWrite { enabled =>
-      withTable("t") {
-        withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
-          executeAndCheckOrdering(
-            hasLogicalSort = enabled, orderingMatched = enabled, hasEmpty2Null = enabled) {
-            sql(
-              """
-                |CREATE TABLE t
-                |PARTITIONED BY (k)
-                |AS SELECT * FROM t0
-                |""".stripMargin)
+    withCovnertMetastore { _ =>
+      withPlannedWrite { enabled =>
+        withTable("t") {
+          withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
+            executeAndCheckOrdering(
+              hasLogicalSort = enabled, orderingMatched = enabled, hasEmpty2Null = enabled) {
+              sql(
+                """
+                  |CREATE TABLE t
+                  |PARTITIONED BY (k)
+                  |STORED AS Parquet
+                  |AS SELECT * FROM t0
+                  |""".stripMargin)
+            }
           }
         }
       }
@@ -53,18 +69,21 @@ class V1WriteHiveCommandSuite
   }
 
   test("insert into hive table") {
-    withPlannedWrite { enabled =>
-      withTable("t") {
-        sql(
-          """
-            |CREATE TABLE t (i INT, j INT)
-            |PARTITIONED BY (k STRING)
-            |CLUSTERED BY (i, j) SORTED BY (j) INTO 2 BUCKETS
-            |""".stripMargin)
-        withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
-          executeAndCheckOrdering(
-            hasLogicalSort = enabled, orderingMatched = enabled, hasEmpty2Null = enabled) {
-            sql("INSERT INTO t SELECT * FROM t0")
+    withCovnertMetastore { _ =>
+      withPlannedWrite { enabled =>
+        withTable("t") {
+          sql(
+            """
+              |CREATE TABLE t (i INT, j INT)
+              |PARTITIONED BY (k STRING)
+              |CLUSTERED BY (i, j) SORTED BY (j) INTO 2 BUCKETS
+              |STORED AS Parquet
+              |""".stripMargin)
+          withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
+            executeAndCheckOrdering(
+              hasLogicalSort = enabled, orderingMatched = enabled, hasEmpty2Null = enabled) {
+              sql("INSERT INTO t SELECT * FROM t0")
+            }
           }
         }
       }
@@ -72,18 +91,21 @@ class V1WriteHiveCommandSuite
   }
 
   test("insert overwrite hive table") {
-    withPlannedWrite { enabled =>
-      withTable("t") {
-        withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
-        sql(
-          """
-            |CREATE TABLE t
-            |PARTITIONED BY (k)
-            |AS SELECT * FROM t0
-            |""".stripMargin)
-          executeAndCheckOrdering(
-            hasLogicalSort = enabled, orderingMatched = enabled, hasEmpty2Null = enabled) {
-            sql("INSERT OVERWRITE t SELECT j AS i, i AS j, k FROM t0")
+    withCovnertMetastore { _ =>
+      withPlannedWrite { enabled =>
+        withTable("t") {
+          withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
+            sql(
+              """
+                |CREATE TABLE t
+                |PARTITIONED BY (k)
+                |STORED AS Parquet
+                |AS SELECT * FROM t0
+                |""".stripMargin)
+            executeAndCheckOrdering(
+              hasLogicalSort = enabled, orderingMatched = enabled, hasEmpty2Null = enabled) {
+              sql("INSERT OVERWRITE t SELECT j AS i, i AS j, k FROM t0")
+            }
           }
         }
       }
@@ -91,16 +113,19 @@ class V1WriteHiveCommandSuite
   }
 
   test("insert into hive table with static partitions only") {
-    withPlannedWrite { enabled =>
-      withTable("t") {
-        sql(
-          """
-            |CREATE TABLE t (i INT, j INT)
-            |PARTITIONED BY (k STRING)
-            |""".stripMargin)
-        // No dynamic partition so no sort is needed.
-        executeAndCheckOrdering(hasLogicalSort = false, orderingMatched = true) {
-          sql("INSERT INTO t PARTITION (k='0') SELECT i, j FROM t0 WHERE k = '0'")
+    withCovnertMetastore { _ =>
+      withPlannedWrite { enabled =>
+        withTable("t") {
+          sql(
+            """
+              |CREATE TABLE t (i INT, j INT)
+              |PARTITIONED BY (k STRING)
+              |STORED AS Parquet
+              |""".stripMargin)
+          // No dynamic partition so no sort is needed.
+          executeAndCheckOrdering(hasLogicalSort = false, orderingMatched = true) {
+            sql("INSERT INTO t PARTITION (k='0') SELECT i, j FROM t0 WHERE k = '0'")
+          }
         }
       }
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/V1WriteHiveCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/V1WriteHiveCommandSuite.scala
@@ -40,7 +40,7 @@ class V1WriteHiveCommandSuite
       withPlannedWrite { enabled =>
         withTable("t") {
           executeAndCheckOrdering(hasLogicalSort = false, orderingMatched = true) {
-            sql("CREATE TABLE t STORED AS Parquet AS SELECT * FROM t0")
+            sql("CREATE TABLE t STORED AS PARQUET AS SELECT * FROM t0")
           }
         }
       }
@@ -56,9 +56,8 @@ class V1WriteHiveCommandSuite
               hasLogicalSort = enabled, orderingMatched = enabled, hasEmpty2Null = enabled) {
               sql(
                 """
-                  |CREATE TABLE t
+                  |CREATE TABLE t STORED AS PARQUET
                   |PARTITIONED BY (k)
-                  |STORED AS Parquet
                   |AS SELECT * FROM t0
                   |""".stripMargin)
             }
@@ -74,10 +73,9 @@ class V1WriteHiveCommandSuite
         withTable("t") {
           sql(
             """
-              |CREATE TABLE t (i INT, j INT)
+              |CREATE TABLE t (i INT, j INT) STORED AS PARQUET
               |PARTITIONED BY (k STRING)
               |CLUSTERED BY (i, j) SORTED BY (j) INTO 2 BUCKETS
-              |STORED AS Parquet
               |""".stripMargin)
           withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
             executeAndCheckOrdering(
@@ -97,9 +95,8 @@ class V1WriteHiveCommandSuite
           withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
             sql(
               """
-                |CREATE TABLE t
+                |CREATE TABLE t STORED AS PARQUET
                 |PARTITIONED BY (k)
-                |STORED AS Parquet
                 |AS SELECT * FROM t0
                 |""".stripMargin)
             executeAndCheckOrdering(
@@ -118,9 +115,8 @@ class V1WriteHiveCommandSuite
         withTable("t") {
           sql(
             """
-              |CREATE TABLE t (i INT, j INT)
+              |CREATE TABLE t (i INT, j INT) STORED AS PARQUET
               |PARTITIONED BY (k STRING)
-              |STORED AS Parquet
               |""".stripMargin)
           // No dynamic partition so no sort is needed.
           executeAndCheckOrdering(hasLogicalSort = false, orderingMatched = true) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Previously, `V1WriteHiveCommandSuite` uses `CREATE TABLE` without declaring `USING` or `STORED AS`, which relies on `spark.sql.legacy.createHiveTableByDefault`'s default value, SPARK-46122 changes the default value of `spark.sql.legacy.createHiveTableByDefault` from `true` to `false`, which implicitly affects this test suite.

In addition, we should take `spark.sql.hive.convertMetastoreParquet` and `spark.sql.hive.convertMetastoreOrc` into account in `V1WriteHiveCommandSuite`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Restore and improve test coverage.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass GHA.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.