### PR TITLE
[SPARK-53695][PYTHON][TESTS] Add tests for 0-arg grouped agg UDF

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf_grouped_agg.py
@@ -951,6 +951,33 @@ class GroupedAggArrowUDFTestsMixin:
                 def func_a(a: pa.Array) -> pa.Scalar:
                     return pa.compute.max(a)
 
+    def test_0_args(self):
+        import pyarrow as pa
+
+        df = self.spark.range(10).withColumn("k", sf.col("id") % 3)
+
+        @arrow_udf("long", ArrowUDFType.GROUPED_AGG)
+        def arrow_max(v) -> int:
+            return pa.compute.max(v).as_py()
+
+        @arrow_udf("long", ArrowUDFType.GROUPED_AGG)
+        def arrow_lit_1() -> int:
+            return 1
+
+        expected1 = df.select(sf.max("id").alias("res1"), sf.lit(1).alias("res1"))
+        result1 = df.select(arrow_max("id").alias("res1"), arrow_lit_1().alias("res1"))
+        self.assertEqual(expected1.collect(), result1.collect())
+
+        expected2 = (
+            df.groupby("k").agg(sf.max("id").alias("res1"), sf.lit(1).alias("res1")).sort("k")
+        )
+        result2 = (
+            df.groupby("k")
+            .agg(arrow_max("id").alias("res1"), arrow_lit_1().alias("res1"))
+            .sort("k")
+        )
+        self.assertEqual(expected2.collect(), result2.collect())
+
 
 class GroupedAggArrowUDFTests(GroupedAggArrowUDFTestsMixin, ReusedSQLTestCase):
     pass

--- a/python/pyspark/sql/tests/arrow/test_arrow_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf_grouped_agg.py
@@ -969,11 +969,19 @@ class GroupedAggArrowUDFTestsMixin:
         self.assertEqual(expected1.collect(), result1.collect())
 
         expected2 = (
-            df.groupby("k").agg(sf.max("id").alias("res1"), sf.lit(1).alias("res1")).sort("k")
+            df.groupby("k")
+            .agg(
+                sf.max("id").alias("res1"),
+                sf.lit(1).alias("res1"),
+            )
+            .sort("k")
         )
         result2 = (
             df.groupby("k")
-            .agg(arrow_max("id").alias("res1"), arrow_lit_1().alias("res1"))
+            .agg(
+                arrow_max("id").alias("res1"),
+                arrow_lit_1().alias("res1"),
+            )
             .sort("k")
         )
         self.assertEqual(expected2.collect(), result2.collect())

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_grouped_agg.py
@@ -777,11 +777,19 @@ class GroupedAggPandasUDFTestsMixin:
         self.assertEqual(expected1.collect(), result1.collect())
 
         expected2 = (
-            df.groupby("k").agg(sf.max("id").alias("res1"), sf.lit(1).alias("res1")).sort("k")
+            df.groupby("k")
+            .agg(
+                sf.max("id").alias("res1"),
+                sf.lit(1).alias("res1"),
+            )
+            .sort("k")
         )
         result2 = (
             df.groupby("k")
-            .agg(pandas_max("id").alias("res1"), pandas_lit_1().alias("res1"))
+            .agg(
+                pandas_max("id").alias("res1"),
+                pandas_lit_1().alias("res1"),
+            )
             .sort("k")
         )
         self.assertEqual(expected2.collect(), result2.collect())

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_grouped_agg.py
@@ -19,7 +19,7 @@ import unittest
 from typing import cast
 
 from pyspark.util import PythonEvalType
-from pyspark.sql import Row
+from pyspark.sql import Row, functions as sf
 from pyspark.sql.functions import (
     array,
     explode,
@@ -760,6 +760,31 @@ class GroupedAggPandasUDFTestsMixin:
 
                 row = df.groupby("id").agg(test(df.id)).first()
                 self.assertEqual(row[1], 123)
+
+    def test_0_args(self):
+        df = self.spark.range(10).withColumn("k", sf.col("id") % 3)
+
+        @pandas_udf("long", PandasUDFType.GROUPED_AGG)
+        def pandas_max(v) -> int:
+            return v.max()
+
+        @pandas_udf("long", PandasUDFType.GROUPED_AGG)
+        def pandas_lit_1() -> int:
+            return 1
+
+        expected1 = df.select(sf.max("id").alias("res1"), sf.lit(1).alias("res1"))
+        result1 = df.select(pandas_max("id").alias("res1"), pandas_lit_1().alias("res1"))
+        self.assertEqual(expected1.collect(), result1.collect())
+
+        expected2 = (
+            df.groupby("k").agg(sf.max("id").alias("res1"), sf.lit(1).alias("res1")).sort("k")
+        )
+        result2 = (
+            df.groupby("k")
+            .agg(pandas_max("id").alias("res1"), pandas_lit_1().alias("res1"))
+            .sort("k")
+        )
+        self.assertEqual(expected2.collect(), result2.collect())
 
 
 class GroupedAggPandasUDFTests(GroupedAggPandasUDFTestsMixin, ReusedSQLTestCase):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add tests for 0-arg vectorized UDF

### Why are the changes needed?
to guard the 0-args cases:
```
In [6]: @pandas_udf("double")
   ...: def mean_udf2() -> float:
   ...:     return 1.0
   ...:

In [7]: spark.range(10).select(mean_udf2()).show()
+-----------+
|mean_udf2()|
+-----------+
|        1.0|
+-----------+
```


### Does this PR introduce _any_ user-facing change?
no, test-only

### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no