### PR TITLE
[SPARK-53700][SQL] Remove redundancy in `DataSourceV2RelationBase.simpleString`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -65,11 +65,7 @@ abstract class DataSourceV2RelationBase(
   override def skipSchemaResolution: Boolean = table.supports(TableCapability.ACCEPT_ANY_SCHEMA)
 
   override def simpleString(maxFields: Int): String = {
-    val qualifiedTableName = (catalog, identifier) match {
-      case (Some(cat), Some(ident)) => s"${cat.name()}.${ident.toString}"
-      case _ => ""
-    }
-    s"RelationV2${truncatedString(output, "[", ", ", "]", maxFields)} $qualifiedTableName $name"
+    s"RelationV2${truncatedString(output, "[", ", ", "]", maxFields)} $name"
   }
 
   override def computeStats(): Statistics = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -3870,6 +3870,17 @@ class DataSourceV2SQLSuiteV1Filter
     }
   }
 
+  test("EXPLAIN") {
+    val t = "testcat.tbl"
+    withTable(t) {
+      spark.sql(s"CREATE TABLE $t (id int, data string)")
+      val explain = spark.sql(s"EXPLAIN EXTENDED SELECT * FROM $t").head().getString(0)
+      val relationPattern = raw".*RelationV2\[[^\]]*]\s+$t\s*$$".r
+      val relations = explain.split("\n").filter(_.contains("RelationV2"))
+      assert(relations.nonEmpty && relations.forall(line => relationPattern.matches(line.trim)))
+    }
+  }
+
   private def testNotSupportedV2Command(
       sqlCommand: String,
       sqlParams: String,

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -79,6 +79,17 @@ abstract class DataSourceV2SQLSuite
   protected def analysisException(sqlText: String): AnalysisException = {
     intercept[AnalysisException](sql(sqlText))
   }
+
+  test("EXPLAIN") {
+    val t = "testcat.tbl"
+    withTable(t) {
+      spark.sql(s"CREATE TABLE $t (id int, data string)")
+      val explain = spark.sql(s"EXPLAIN EXTENDED SELECT * FROM $t").head().getString(0)
+      val relationPattern = raw".*RelationV2\[[^\]]*]\s+$t\s*$$".r
+      val relations = explain.split("\n").filter(_.contains("RelationV2"))
+      assert(relations.nonEmpty && relations.forall(line => relationPattern.matches(line.trim)))
+    }
+  }
 }
 
 class DataSourceV2SQLSuiteV1Filter
@@ -3867,17 +3878,6 @@ class DataSourceV2SQLSuiteV1Filter
           sql(s"SELECT * FROM $t"),
           Row(1, "txt", -1) :: Row(2, "txt", -1) :: Nil)
       }
-    }
-  }
-
-  test("EXPLAIN") {
-    val t = "testcat.tbl"
-    withTable(t) {
-      spark.sql(s"CREATE TABLE $t (id int, data string)")
-      val explain = spark.sql(s"EXPLAIN EXTENDED SELECT * FROM $t").head().getString(0)
-      val relationPattern = raw".*RelationV2\[[^\]]*]\s+$t\s*$$".r
-      val relations = explain.split("\n").filter(_.contains("RelationV2"))
-      assert(relations.nonEmpty && relations.forall(line => relationPattern.matches(line.trim)))
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR removes redundancy in simpleString in DataSourceV2RelationBase.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Before this change:

```
== Parsed Logical Plan ==
'Project [*]
+- 'UnresolvedRelation [cat, ns1, test_table], [], false

== Analyzed Logical Plan ==
pk: int, salary: int, dep: string
Project [pk#18, salary#19, dep#20]
+- SubqueryAlias cat.ns1.test_table
   +- RelationV2[pk#18, salary#19, dep#20] cat.ns1.test_table cat.ns1.test_table // !!! REDUNDANT !!!

== Optimized Logical Plan ==
RelationV2[pk#18, salary#19, dep#20] cat.ns1.test_table

== Physical Plan ==
*(1) Project [pk#18, salary#19, dep#20]
+- BatchScan cat.ns1.test_table[pk#18, salary#19, dep#20] class org.apache.spark.sql.connector.catalog.InMemoryBaseTable$InMemoryBatchScan RuntimeFilters: []
```

After this change:

```
== Parsed Logical Plan ==
'Project [*]
+- 'UnresolvedRelation [cat, ns1, test_table], [], false

== Analyzed Logical Plan ==
pk: int, salary: int, dep: string
Project [pk#25, salary#26, dep#27]
+- SubqueryAlias cat.ns1.test_table
   +- RelationV2[pk#25, salary#26, dep#27] cat.ns1.test_table

== Optimized Logical Plan ==
RelationV2[pk#25, salary#26, dep#27] cat.ns1.test_table

== Physical Plan ==
*(1) Project [pk#25, salary#26, dep#27]
+- BatchScan cat.ns1.test_table[pk#25, salary#26, dep#27] class org.apache.spark.sql.connector.catalog.InMemoryBaseTable$InMemoryBatchScan RuntimeFilters: []
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

This PR comes with tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.
