### PR TITLE
[SPARK-53372][INFRA][FOLLOWUP] Synchronize the installation of `pyyaml` into `maven_test.yml`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1376,3 +1376,9 @@ jobs:
           cd ui-test
           npm install --save-dev
           node --experimental-vm-modules node_modules/.bin/jest
+
+  maven-test:
+    name: "Run Maven Test"
+    permissions:
+      packages: write
+    uses: ./.github/workflows/maven_test.yml

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1376,9 +1376,3 @@ jobs:
           cd ui-test
           npm install --save-dev
           node --experimental-vm-modules node_modules/.bin/jest
-
-  maven-test:
-    name: "Run Maven Test"
-    permissions:
-      packages: write
-    uses: ./.github/workflows/maven_test.yml

--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -175,7 +175,7 @@ jobs:
       - name: Install Python packages (Python 3.11)
         if: contains(matrix.modules, 'resource-managers#yarn') || (contains(matrix.modules, 'sql#core')) || contains(matrix.modules, 'connect')
         run: |
-          python3.11 -m pip install 'numpy>=1.22' pyarrow pandas scipy unittest-xml-reporting 'grpcio==1.67.0' 'grpcio-status==1.67.0' 'protobuf==5.29.5'
+          python3.11 -m pip install 'numpy>=1.22' pyarrow pandas pyyaml scipy unittest-xml-reporting 'grpcio==1.67.0' 'grpcio-status==1.67.0' 'protobuf==5.29.5'
           python3.11 -m pip list
       # Run the tests using script command.
       # BSD's script command doesn't support -c option, and the usage is different from Linux's one.


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to synchronize the installation of `pyyaml` into `maven_test.yml`

### Why are the changes needed?
Restore maven daily tests:
- https://github.com/apache/spark/actions/runs/17977674122/job/51135114818

```
- SQL Pipeline with mv, st, and flows *** FAILED ***
  java.lang.RuntimeException: Pipeline update process failed with exit code 1.
Output: 
Error: Traceback (most recent call last):
  File "/home/runner/work/spark/spark/python/pyspark/pipelines/cli.py", line 29, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
  at org.apache.spark.sql.connect.pipelines.EndToEndAPISuite.awaitPipelineTermination(EndToEndAPISuite.scala:124)
  at org.apache.spark.sql.pipelines.utils.APITest.$anonfun$$init$$1(APITest.scala:114)
  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
  at org.apache.spark.sql.connect.pipelines.EndToEndAPISuite.$anonfun$test$2(EndToEndAPISuite.scala:47)
  at org.apache.spark.sql.connect.pipelines.EndToEndAPISuite.$anonfun$test$2$adapted(EndToEndAPISuite.scala:45)
  at org.apache.spark.sql.test.SQLTestUtils.$anonfun$withTempDir$1(SQLTestUtils.scala:81)
  at org.apache.spark.sql.test.SQLTestUtils.$anonfun$withTempDir$1$adapted(SQLTestUtils.scala:80)
  at org.apache.spark.SparkFunSuite.withTempDir(SparkFunSuite.scala:258)
  at org.apache.spark.sql.pipelines.utils.PipelineTest.org$apache$spark$sql$test$SQLTestUtils$$super$withTempDir(PipelineTest.scala:40)
  at org.apache.spark.sql.test.SQLTestUtils.withTempDir(SQLTestUtils.scala:80)
  ...
- SQL Pipeline with CTE *** FAILED ***
  java.lang.RuntimeException: Pipeline update process failed with exit code 1.
Output: 
Error: Traceback (most recent call last):
  File "/home/runner/work/spark/spark/python/pyspark/pipelines/cli.py", line 29, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
  at org.apache.spark.sql.connect.pipelines.EndToEndAPISuite.awaitPipelineTermination(EndToEndAPISuite.scala:124)
  at org.apache.spark.sql.pipelines.utils.APITest.$anonfun$$init$$2(APITest.scala:139)
  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
  at org.apache.spark.sql.connect.pipelines.EndToEndAPISuite.$anonfun$test$2(EndToEndAPISuite.scala:47)
  at org.apache.spark.sql.connect.pipelines.EndToEndAPISuite.$anonfun$test$2$adapted(EndToEndAPISuite.scala:45)
  at org.apache.spark.sql.test.SQLTestUtils.$anonfun$withTempDir$1(SQLTestUtils.scala:81)
  at org.apache.spark.sql.test.SQLTestUtils.$anonfun$withTempDir$1$adapted(SQLTestUtils.scala:80)
  at org.apache.spark.SparkFunSuite.withTempDir(SparkFunSuite.scala:258)
  at org.apache.spark.sql.pipelines.utils.PipelineTest.org$apache$spark$sql$test$SQLTestUtils$$super$withTempDir(PipelineTest.scala:40)
  at org.apache.spark.sql.test.SQLTestUtils.withTempDir(SQLTestUtils.scala:80)
  ...
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass Github Actions
- Test with maven: https://github.com/LuciferYang/spark/actions/runs/18000700692/job/51209057251

### Was this patch authored or co-authored using generative AI tooling?
No