### PR TITLE
[SPARK-53715][SQL] Refactor getWritePrivileges for MergeIntoTable

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -915,12 +915,13 @@ object MergeIntoTable {
       matchedActions: Iterable[MergeAction],
       notMatchedActions: Iterable[MergeAction],
       notMatchedBySourceActions: Iterable[MergeAction]): Seq[TableWritePrivilege] = {
-    val privileges = scala.collection.mutable.HashSet.empty[TableWritePrivilege]
-    (matchedActions.iterator ++ notMatchedActions ++ notMatchedBySourceActions).foreach {
-      case _: DeleteAction => privileges.add(TableWritePrivilege.DELETE)
-      case _: UpdateAction | _: UpdateStarAction => privileges.add(TableWritePrivilege.UPDATE)
-      case _: InsertAction | _: InsertStarAction => privileges.add(TableWritePrivilege.INSERT)
-    }
+    val privileges = (matchedActions ++ notMatchedActions ++ notMatchedBySourceActions)
+      .collect {
+        case _: DeleteAction => TableWritePrivilege.DELETE
+        case _: UpdateAction | _: UpdateStarAction => TableWritePrivilege.UPDATE
+        case _: InsertAction | _: InsertStarAction => TableWritePrivilege.INSERT
+      }
+      .toSet
     privileges.toSeq
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -915,14 +915,14 @@ object MergeIntoTable {
       matchedActions: Iterable[MergeAction],
       notMatchedActions: Iterable[MergeAction],
       notMatchedBySourceActions: Iterable[MergeAction]): Seq[TableWritePrivilege] = {
-    val privileges = (matchedActions ++ notMatchedActions ++ notMatchedBySourceActions)
+    (matchedActions ++ notMatchedActions ++ notMatchedBySourceActions)
       .collect {
         case _: DeleteAction => TableWritePrivilege.DELETE
         case _: UpdateAction | _: UpdateStarAction => TableWritePrivilege.UPDATE
         case _: InsertAction | _: InsertStarAction => TableWritePrivilege.INSERT
       }
       .toSet
-    privileges.toSeq
+      .toSeq
   }
 
   def schemaChanges(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to refactor `getWritePrivileges` for `MergeIntoTable`.


### Why are the changes needed?
The object `MergeIntoTable` has a function `getWritePrivileges`. 
There exists some optimization points.

**Eliminating variability**: using `toSet` instead of mutable `HashSet`
**Reduce intermediate variables**: use chain calls
**Improving readability**: The collect method expresses the intention of "transforming and filtering" more clearly
**Performance optimization**: Avoid unnecessary creation of intermediate sets


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
GA tests.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
