### PR TITLE
[SPARK-53695][PYTHON][TESTS][FOLLOW-UP] Additional test for type hint

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_udf_typehints.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf_typehints.py
@@ -168,7 +168,8 @@ class ArrowUDFTypeHintsTests(ReusedSQLTestCase):
             pass
 
         self.assertEqual(
-            infer_eval_type(signature(func), get_type_hints(func)), ArrowUDFType.GROUPED_AGG
+            infer_eval_type(signature(func), get_type_hints(func), "arrow"),
+            ArrowUDFType.GROUPED_AGG,
         )
 
     def test_type_annotation_negative(self):

--- a/python/pyspark/sql/tests/arrow/test_arrow_udf_typehints.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf_typehints.py
@@ -164,6 +164,13 @@ class ArrowUDFTypeHintsTests(ReusedSQLTestCase):
             infer_eval_type(signature(func), get_type_hints(func)), ArrowUDFType.GROUPED_AGG
         )
 
+        def func() -> float:
+            pass
+
+        self.assertEqual(
+            infer_eval_type(signature(func), get_type_hints(func)), ArrowUDFType.GROUPED_AGG
+        )
+
     def test_type_annotation_negative(self):
         def func(col: str) -> pa.Array:
             pass

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_typehints.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_typehints.py
@@ -182,7 +182,8 @@ class PandasUDFTypeHintsTests(ReusedSQLTestCase):
             pass
 
         self.assertEqual(
-            infer_eval_type(signature(func), get_type_hints(func)), PandasUDFType.GROUPED_AGG
+            infer_eval_type(signature(func), get_type_hints(func), "pandas"),
+            PandasUDFType.GROUPED_AGG,
         )
 
     def test_type_annotation_negative(self):

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_typehints.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_typehints.py
@@ -178,6 +178,13 @@ class PandasUDFTypeHintsTests(ReusedSQLTestCase):
             infer_eval_type(signature(func), get_type_hints(func)), PandasUDFType.GROUPED_AGG
         )
 
+        def func() -> float:
+            pass
+
+        self.assertEqual(
+            infer_eval_type(signature(func), get_type_hints(func)), PandasUDFType.GROUPED_AGG
+        )
+
     def test_type_annotation_negative(self):
         def func(col: str) -> pd.Series:
             pass

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_typehints_with_future_annotations.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_typehints_with_future_annotations.py
@@ -158,6 +158,13 @@ class PandasUDFTypeHintsWithFutureAnnotationsTests(ReusedSQLTestCase):
             infer_eval_type(signature(func), get_type_hints(func)), PandasUDFType.GROUPED_AGG
         )
 
+        def func() -> float:
+            pass
+
+        self.assertEqual(
+            infer_eval_type(signature(func), get_type_hints(func)), PandasUDFType.GROUPED_AGG
+        )
+
     def test_type_annotation_negative(self):
         def func(col: str) -> pd.Series:
             pass

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_typehints_with_future_annotations.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_typehints_with_future_annotations.py
@@ -162,7 +162,8 @@ class PandasUDFTypeHintsWithFutureAnnotationsTests(ReusedSQLTestCase):
             pass
 
         self.assertEqual(
-            infer_eval_type(signature(func), get_type_hints(func)), PandasUDFType.GROUPED_AGG
+            infer_eval_type(signature(func), get_type_hints(func), "pandas"),
+            PandasUDFType.GROUPED_AGG,
         )
 
     def test_type_annotation_negative(self):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
follow up of https://github.com/apache/spark/pull/52437


### Why are the changes needed?
check the eval type inference of 0-arg grouped agg UDF


### Does this PR introduce _any_ user-facing change?
no, test-only

### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no