### PR TITLE
[DRAFT][SPARK-51519][SQL] MERGE INTO/UPDATE/DELETE support join hint

### DIFF
--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -650,7 +650,7 @@ dmlStatementNoWith
     | fromClause multiInsertQueryBody+                                             #multiInsertQuery
     | DELETE FROM identifierReference tableAlias whereClause?                      #deleteFromTable
     | UPDATE identifierReference tableAlias setClause whereClause?                 #updateTable
-    | MERGE (WITH SCHEMA EVOLUTION)? INTO target=identifierReference targetAlias=tableAlias
+    | MERGE (hints+=hint)* (WITH SCHEMA EVOLUTION)? INTO target=identifierReference targetAlias=tableAlias
         USING (source=identifierReference |
           LEFT_PAREN sourceQuery=query RIGHT_PAREN) sourceAlias=tableAlias
         ON mergeCondition=booleanExpression

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1141,7 +1141,7 @@ class AstBuilder extends DataTypeAstBuilder
         matchedActions, notMatchedActions, notMatchedBySourceActions))
     val targetTableAlias = getTableAliasWithoutColumnAlias(ctx.targetAlias, "MERGE")
     val aliasedTarget = targetTableAlias.map(SubqueryAlias(_, targetTable)).getOrElse(targetTable)
-    MergeIntoTable(
+    val plan: LogicalPlan = MergeIntoTable(
       aliasedTarget,
       aliasedSource,
       mergeCondition,
@@ -1149,6 +1149,7 @@ class AstBuilder extends DataTypeAstBuilder
       notMatchedActions,
       notMatchedBySourceActions,
       withSchemaEvolution)
+    ctx.hints.asScala.foldRight(plan)(withHints)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -879,6 +879,7 @@ case class MergeIntoTable(
   lazy val rewritable: Boolean = {
     EliminateSubqueryAliases(targetTable) match {
       case DataSourceV2Relation(_: SupportsRowLevelOperations, _, _, _, _) => true
+      case ResolvedHint(DataSourceV2Relation(_: SupportsRowLevelOperations, _, _, _, _), _) => true
       case _ => false
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/InvokeProcedures.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/InvokeProcedures.scala
@@ -54,11 +54,13 @@ class InvokeProcedures(session: SparkSession) extends Rule[LogicalPlan] {
         CommandResult(
           Seq.empty,
           call,
+          call,
           LocalTableScanExec(Seq.empty, Seq.empty, None),
           Seq.empty)
       case Seq(relation: LocalRelation) =>
         CommandResult(
           relation.output,
+          call,
           call,
           LocalTableScanExec(relation.output, relation.data, None),
           relation.data)

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CommandResult.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CommandResult.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.execution.SparkPlan
 case class CommandResult(
     output: Seq[Attribute],
     @transient commandLogicalPlan: LogicalPlan,
+    @transient commandOptimizedLogicalPlan: LogicalPlan,
     @transient commandPhysicalPlan: SparkPlan,
     @transient rows: Seq[InternalRow]) extends LeafNode {
   override def innerChildren: Seq[QueryPlan[_]] = Seq(commandLogicalPlan)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -160,6 +160,7 @@ class QueryExecution(
       CommandResult(
         qe.analyzed.output,
         qe.commandExecuted,
+        qe.optimizedPlan,
         qe.executedPlan,
         result.toImmutableArraySeq)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -1031,7 +1031,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       case logical.LocalRelation(output, data, _, stream) =>
         LocalTableScanExec(output, data, stream) :: Nil
       case logical.EmptyRelation(l) => EmptyRelationExec(l) :: Nil
-      case CommandResult(output, _, plan, data) => CommandResultExec(output, plan, data) :: Nil
+      case CommandResult(output, _, _, plan, data) => CommandResultExec(output, plan, data) :: Nil
       // We should match the combination of limit and offset first, to get the optimal physical
       // plan, instead of planning limit and offset separately.
       case LimitAndOffset(limit, offset, child) =>

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/execute-immediate.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/execute-immediate.sql.out
@@ -48,14 +48,14 @@ SetVariable [variablereference(system.session.sql_string=CAST(NULL AS STRING))]
 -- !query
 EXECUTE IMMEDIATE 'SET spark.sql.ansi.enabled=true'
 -- !query analysis
-CommandResult [key#x, value#x], Execute SetCommand, [[spark.sql.ansi.enabled,true]]
+CommandResult [key#x, value#x], SetCommand (spark.sql.ansi.enabled,Some(true)), Execute SetCommand, [[spark.sql.ansi.enabled,true]]
    +- SetCommand (spark.sql.ansi.enabled,Some(true))
 
 
 -- !query
 EXECUTE IMMEDIATE 'CREATE TEMPORARY VIEW IDENTIFIER(:tblName) AS SELECT id, name FROM tbl_view' USING 'tbl_view_tmp' as tblName
 -- !query analysis
-CommandResult Execute CreateViewCommand
+CommandResult CreateViewCommand `tbl_view_tmp`, SELECT id, name FROM tbl_view, false, false, LocalTempView, UNSUPPORTED, true, Execute CreateViewCommand
    +- CreateViewCommand `tbl_view_tmp`, SELECT id, name FROM tbl_view, false, false, LocalTempView, UNSUPPORTED, true
          +- Project [id#x, name#x]
             +- SubqueryAlias tbl_view
@@ -85,7 +85,7 @@ Project [id#x, name#x]
 -- !query
 EXECUTE IMMEDIATE 'REFRESH TABLE IDENTIFIER(:tblName)' USING 'x' as tblName
 -- !query analysis
-CommandResult Execute RefreshTableCommand
+CommandResult RefreshTableCommand `spark_catalog`.`default`.`x`, Execute RefreshTableCommand
    +- RefreshTableCommand `spark_catalog`.`default`.`x`
 
 
@@ -206,7 +206,7 @@ Project [id#x, name#x, data#x]
 -- !query
 EXECUTE IMMEDIATE 'INSERT INTO x VALUES(?)' USING 1
 -- !query analysis
-CommandResult Execute InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_dir}/x, false, CSV, [path=file:[not included in comparison]/{warehouse_dir}/x], Append, `spark_catalog`.`default`.`x`, org.apache.spark.sql.execution.datasources.InMemoryFileIndex(file:[not included in comparison]/{warehouse_dir}/x), [id]
+CommandResult InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_dir}/x, false, CSV, [path=file:[not included in comparison]/{warehouse_dir}/x], Append, `spark_catalog`.`default`.`x`, org.apache.spark.sql.execution.datasources.InMemoryFileIndex(file:[not included in comparison]/{warehouse_dir}/x), [id], Execute InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_dir}/x, false, CSV, [path=file:[not included in comparison]/{warehouse_dir}/x], Append, `spark_catalog`.`default`.`x`, org.apache.spark.sql.execution.datasources.InMemoryFileIndex(file:[not included in comparison]/{warehouse_dir}/x), [id]
    +- InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_dir}/x, false, CSV, [path=file:[not included in comparison]/{warehouse_dir}/x], Append, `spark_catalog`.`default`.`x`, org.apache.spark.sql.execution.datasources.InMemoryFileIndex(file:[not included in comparison]/{warehouse_dir}/x), [id]
       +- Project [col1#x AS id#x]
          +- LocalRelation [col1#x]
@@ -311,7 +311,7 @@ Project [id#x, name#x, data#x, name7 AS p#x]
 -- !query
 EXECUTE IMMEDIATE 'SET VAR sql_string = ?' USING 'SELECT id from tbl_view where name = :first'
 -- !query analysis
-CommandResult SetVariable [variablereference(system.session.sql_string='SELECT * from tbl_view where name = :first or id = :second')]
+CommandResult SetVariable [variablereference(system.session.sql_string='SELECT * from tbl_view where name = :first or id = :second')], SetVariable [variablereference(system.session.sql_string='SELECT * from tbl_view where name = :first or id = :second')]
    +- SetVariable [variablereference(system.session.sql_string='SELECT * from tbl_view where name = :first or id = :second')]
       +- Project [SELECT id from tbl_view where name = :first AS sql_string#x]
          +- OneRowRelation

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2OptionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2OptionSuite.scala
@@ -102,7 +102,7 @@ class DataSourceV2OptionSuite extends DatasourceV2SQLBase {
       val df = sql(s"INSERT INTO $t1 WITH (`write.split-size` = 10) VALUES (1, 'a'), (2, 'b')")
 
       var collected = df.queryExecution.optimizedPlan.collect {
-        case CommandResult(_, AppendData(relation: DataSourceV2Relation, _, _, _, _, _), _, _) =>
+        case CommandResult(_, AppendData(relation: DataSourceV2Relation, _, _, _, _, _), _, _, _) =>
           assert(relation.options.get("write.split-size") == "10")
       }
       assert (collected.size == 1)
@@ -187,7 +187,7 @@ class DataSourceV2OptionSuite extends DatasourceV2SQLBase {
       var collected = df.queryExecution.optimizedPlan.collect {
         case CommandResult(_,
           OverwriteByExpression(relation: DataSourceV2Relation, _, _, _, _, _, _),
-          _, _) =>
+          _, _, _) =>
           assert(relation.options.get("write.split-size") === "10")
       }
       assert (collected.size == 1)
@@ -247,7 +247,7 @@ class DataSourceV2OptionSuite extends DatasourceV2SQLBase {
       var collected = df.queryExecution.optimizedPlan.collect {
         case CommandResult(_,
           OverwriteByExpression(relation: DataSourceV2Relation, _, _, _, _, _, _),
-          _, _) =>
+          _, _, _) =>
           assert(relation.options.get("write.split-size") == "10")
       }
       assert (collected.size == 1)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeIntoTableWithJoinHintSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeIntoTableWithJoinHintSuite.scala
@@ -1,0 +1,3788 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector
+
+import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.catalyst.plans.logical.{BROADCAST, CommandResult, HintInfo, Join, JoinHint, NO_BROADCAST_AND_REPLICATION, ResolvedHint, SHUFFLE_HASH, SHUFFLE_MERGE, SHUFFLE_REPLICATE_NL}
+import org.apache.spark.sql.execution.{CommandResultExec, SparkPlan}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
+import org.apache.spark.sql.execution.datasources.v2.{AppendDataExec, ReplaceDataExec, WriteDeltaExec}
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, CartesianProductExec, ShuffledHashJoinExec, SortMergeJoinExec}
+import org.apache.spark.sql.internal.SQLConf
+
+class DeltaBasedMergeIntoTableWithJoinHintSuite extends RowLevelOperationSuiteBase {
+
+  import testImplicits._
+
+  override protected lazy val extraTableProps: java.util.Map[String, String] = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("supports-deltas", "true")
+    props
+  }
+
+  def verifyJoinHint(df: DataFrame, expectedHints: Seq[JoinHint]): Unit = {
+    val optimizedPlan = df.queryExecution.optimizedPlan
+    assert(optimizedPlan.isInstanceOf[CommandResult])
+    val joinHints = optimizedPlan.asInstanceOf[CommandResult].commandOptimizedLogicalPlan collect {
+      case Join(_, _, _, _, hint) => hint
+      case _: ResolvedHint => fail("ResolvedHint should not appear after optimize.")
+    }
+    assert(joinHints == expectedHints)
+  }
+
+  private def getCommandResultExec(df: DataFrame): CommandResultExec = {
+    assert(df.queryExecution.executedPlan.isInstanceOf[CommandResultExec])
+    df.queryExecution.executedPlan.asInstanceOf[CommandResultExec]
+  }
+
+  def verifyBroadcastHashJoinExec(query: SparkPlan, num: Int): Unit = {
+    assert(query.isInstanceOf[AdaptiveSparkPlanExec])
+    val adaptiveSparkPlanExec = query.asInstanceOf[AdaptiveSparkPlanExec]
+    val actualNum = collect(adaptiveSparkPlanExec.inputPlan) {
+      case p: BroadcastHashJoinExec => p
+    }.size
+    assert(actualNum == num)
+  }
+
+  def verifySortMergeJoinExec(query: SparkPlan, num: Int): Unit = {
+    assert(query.isInstanceOf[AdaptiveSparkPlanExec])
+    val adaptiveSparkPlanExec = query.asInstanceOf[AdaptiveSparkPlanExec]
+    val actualNum = collect(adaptiveSparkPlanExec.inputPlan) {
+      case p: SortMergeJoinExec => p
+    }.size
+    assert(actualNum == num)
+  }
+
+  def verifyShuffleHashJoinExec(query: SparkPlan, num: Int): Unit = {
+    assert(query.isInstanceOf[AdaptiveSparkPlanExec])
+    val adaptiveSparkPlanExec = query.asInstanceOf[AdaptiveSparkPlanExec]
+    val actualNum = collect(adaptiveSparkPlanExec.inputPlan) {
+      case p: ShuffledHashJoinExec => p
+    }.size
+    assert(actualNum == num)
+  }
+
+  def verifyCartesianProductExec(query: SparkPlan, num: Int): Unit = {
+    assert(query.isInstanceOf[AdaptiveSparkPlanExec])
+    val adaptiveSparkPlanExec = query.asInstanceOf[AdaptiveSparkPlanExec]
+    val actualNum = collect(adaptiveSparkPlanExec.inputPlan) {
+      case p: CartesianProductExec => p
+    }.size
+    assert(actualNum == num)
+  }
+
+  // calling buildAppendDataPlan begin
+
+  test("merge into empty table with NOT MATCHED clause (broadcast left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left anti join doesn't support broadcast left
+      withTempView("source") {
+        createTable("pk INT NOT NULL, salary INT, dep STRING")
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (2, 200, "finance"),
+          (3, 300, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ broadcast(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED THEN
+             | INSERT *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(BROADCAST))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[AppendDataExec])
+        val appendDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[AppendDataExec]
+        verifyBroadcastHashJoinExec(appendDataExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // insert
+            Row(2, 200, "finance"), // insert
+            Row(3, 300, "hr"))) // insert
+      }
+    }
+  }
+
+  test("merge into empty table with NOT MATCHED clause (broadcast right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left anti join supports broadcast right
+      withTempView("source") {
+        createTable("pk INT NOT NULL, salary INT, dep STRING")
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (2, 200, "finance"),
+          (3, 300, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ broadcast(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED THEN
+             | INSERT *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(BROADCAST)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[AppendDataExec])
+        val appendDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[AppendDataExec]
+        verifyBroadcastHashJoinExec(appendDataExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // insert
+            Row(2, 200, "finance"), // insert
+            Row(3, 300, "hr"))) // insert
+      }
+    }
+  }
+
+  test("merge into empty table with NOT MATCHED clause (sort merge left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      withTempView("source") {
+        createTable("pk INT NOT NULL, salary INT, dep STRING")
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (2, 200, "finance"),
+          (3, 300, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ MERGE(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED THEN
+             | INSERT *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(SHUFFLE_MERGE))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[AppendDataExec])
+        val appendDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[AppendDataExec]
+        verifySortMergeJoinExec(appendDataExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // insert
+            Row(2, 200, "finance"), // insert
+            Row(3, 300, "hr"))) // insert
+      }
+    }
+  }
+
+  test("merge into empty table with NOT MATCHED clause (sort merge right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      withTempView("source") {
+        createTable("pk INT NOT NULL, salary INT, dep STRING")
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (2, 200, "finance"),
+          (3, 300, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ MERGE(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED THEN
+             | INSERT *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(SHUFFLE_MERGE)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[AppendDataExec])
+        val appendDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[AppendDataExec]
+        verifySortMergeJoinExec(appendDataExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // insert
+            Row(2, 200, "finance"), // insert
+            Row(3, 300, "hr"))) // insert
+      }
+    }
+  }
+
+  test("merge into empty table with NOT MATCHED clause (shuffle hash left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left anti join doesn't support shuffle hash left
+      withTempView("source") {
+        createTable("pk INT NOT NULL, salary INT, dep STRING")
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (2, 200, "finance"),
+          (3, 300, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_HASH(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED THEN
+             | INSERT *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(SHUFFLE_HASH))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[AppendDataExec])
+        val appendDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[AppendDataExec]
+        verifyShuffleHashJoinExec(appendDataExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // insert
+            Row(2, 200, "finance"), // insert
+            Row(3, 300, "hr"))) // insert
+      }
+    }
+  }
+
+  test("merge into empty table with NOT MATCHED clause (shuffle hash right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left anti join supports shuffle hash right
+      withTempView("source") {
+        createTable("pk INT NOT NULL, salary INT, dep STRING")
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (2, 200, "finance"),
+          (3, 300, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_HASH(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED THEN
+             | INSERT *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(SHUFFLE_HASH)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[AppendDataExec])
+        val appendDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[AppendDataExec]
+        verifyShuffleHashJoinExec(appendDataExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // insert
+            Row(2, 200, "finance"), // insert
+            Row(3, 300, "hr"))) // insert
+      }
+    }
+  }
+
+  test("merge into empty table with NOT MATCHED clause (cartesian product left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left anti join doesn't support cartesian product
+      withTempView("source") {
+        createTable("pk INT NOT NULL, salary INT, dep STRING")
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (2, 200, "finance"),
+          (3, 300, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_REPLICATE_NL(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED THEN
+             | INSERT *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(SHUFFLE_REPLICATE_NL))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[AppendDataExec])
+        val appendDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[AppendDataExec]
+        verifyCartesianProductExec(appendDataExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // insert
+            Row(2, 200, "finance"), // insert
+            Row(3, 300, "hr"))) // insert
+      }
+    }
+  }
+
+  test("merge into empty table with NOT MATCHED clause (cartesian product right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left anti join doesn't support cartesian product
+      withTempView("source") {
+        createTable("pk INT NOT NULL, salary INT, dep STRING")
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (2, 200, "finance"),
+          (3, 300, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_REPLICATE_NL(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED THEN
+             | INSERT *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(SHUFFLE_REPLICATE_NL)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[AppendDataExec])
+        val appendDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[AppendDataExec]
+        verifyCartesianProductExec(appendDataExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // insert
+            Row(2, 200, "finance"), // insert
+            Row(3, 300, "hr"))) // insert
+      }
+    }
+  }
+
+  test("merge into empty table with conditional NOT MATCHED clause (broadcast left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left anti join doesn't support broadcast left
+      withTempView("source") {
+        createTable("pk INT NOT NULL, salary INT, dep STRING")
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (2, 200, "finance"),
+          (3, 300, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED AND s.pk >= 2 THEN
+             | INSERT *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(BROADCAST))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[AppendDataExec])
+        val appendDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[AppendDataExec]
+        verifyBroadcastHashJoinExec(appendDataExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(2, 200, "finance"), // insert
+            Row(3, 300, "hr"))) // insert
+      }
+    }
+  }
+
+  test("merge into empty table with conditional NOT MATCHED clause (broadcast right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left anti join supports broadcast right
+      withTempView("source") {
+        createTable("pk INT NOT NULL, salary INT, dep STRING")
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (2, 200, "finance"),
+          (3, 300, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED AND s.pk >= 2 THEN
+             | INSERT *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(BROADCAST)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[AppendDataExec])
+        val appendDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[AppendDataExec]
+        verifyBroadcastHashJoinExec(appendDataExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(2, 200, "finance"), // insert
+            Row(3, 300, "hr"))) // insert
+      }
+    }
+  }
+
+  // calling buildAppendDataPlanForMultipleNotMatchedActions begin
+
+  test("merge into empty table with multiple NOT MATCHED clause (broadcast left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left anti join doesn't support broadcast left
+      withTempView("source") {
+        createTable("pk INT NOT NULL, salary INT, dep STRING")
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (2, 200, "finance"),
+          (3, 300, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED AND s.pk >= 2 THEN
+             | INSERT *
+             |WHEN NOT MATCHED THEN
+             | INSERT *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(BROADCAST))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[AppendDataExec])
+        val appendDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[AppendDataExec]
+        verifyBroadcastHashJoinExec(appendDataExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // insert
+            Row(2, 200, "finance"), // insert
+            Row(3, 300, "hr"))) // insert
+      }
+    }
+  }
+
+  test("merge into empty table with multiple NOT MATCHED clause (broadcast right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left anti join supports broadcast right
+      withTempView("source") {
+        createTable("pk INT NOT NULL, salary INT, dep STRING")
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (2, 200, "finance"),
+          (3, 300, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED AND s.pk >= 2 THEN
+             | INSERT *
+             |WHEN NOT MATCHED THEN
+             | INSERT *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(BROADCAST)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[AppendDataExec])
+        val appendDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[AppendDataExec]
+        verifyBroadcastHashJoinExec(appendDataExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // insert
+            Row(2, 200, "finance"), // insert
+            Row(3, 300, "hr"))) // insert
+      }
+    }
+  }
+
+  test("merge into empty table with multiple NOT MATCHED clause (sort merge left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      withTempView("source") {
+        createTable("pk INT NOT NULL, salary INT, dep STRING")
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (2, 200, "finance"),
+          (3, 300, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ MERGE(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED AND s.pk >= 2 THEN
+             | INSERT *
+             |WHEN NOT MATCHED THEN
+             | INSERT *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(SHUFFLE_MERGE))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[AppendDataExec])
+        val appendDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[AppendDataExec]
+        verifySortMergeJoinExec(appendDataExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // insert
+            Row(2, 200, "finance"), // insert
+            Row(3, 300, "hr"))) // insert
+      }
+    }
+  }
+
+  test("merge into empty table with multiple NOT MATCHED clause (sort merge right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      withTempView("source") {
+        createTable("pk INT NOT NULL, salary INT, dep STRING")
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (2, 200, "finance"),
+          (3, 300, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ MERGE(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED AND s.pk >= 2 THEN
+             | INSERT *
+             |WHEN NOT MATCHED THEN
+             | INSERT *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(SHUFFLE_MERGE)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[AppendDataExec])
+        val appendDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[AppendDataExec]
+        verifySortMergeJoinExec(appendDataExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // insert
+            Row(2, 200, "finance"), // insert
+            Row(3, 300, "hr"))) // insert
+      }
+    }
+  }
+
+  test("merge into empty table with multiple NOT MATCHED clause (shuffle hash left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left anti join doesn't support shuffle hash left
+      withTempView("source") {
+        createTable("pk INT NOT NULL, salary INT, dep STRING")
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (2, 200, "finance"),
+          (3, 300, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_HASH(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED AND s.pk >= 2 THEN
+             | INSERT *
+             |WHEN NOT MATCHED THEN
+             | INSERT *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(SHUFFLE_HASH))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[AppendDataExec])
+        val appendDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[AppendDataExec]
+        verifyShuffleHashJoinExec(appendDataExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // insert
+            Row(2, 200, "finance"), // insert
+            Row(3, 300, "hr"))) // insert
+      }
+    }
+  }
+
+  test("merge into empty table with multiple NOT MATCHED clause (shuffle hash right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left anti join supports shuffle hash right
+      withTempView("source") {
+        createTable("pk INT NOT NULL, salary INT, dep STRING")
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (2, 200, "finance"),
+          (3, 300, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_HASH(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED AND s.pk >= 2 THEN
+             | INSERT *
+             |WHEN NOT MATCHED THEN
+             | INSERT *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(SHUFFLE_HASH)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[AppendDataExec])
+        val appendDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[AppendDataExec]
+        verifyShuffleHashJoinExec(appendDataExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // insert
+            Row(2, 200, "finance"), // insert
+            Row(3, 300, "hr"))) // insert
+      }
+    }
+  }
+
+  test("merge into empty table with multiple NOT MATCHED clause (cartesian product left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left anti join doesn't support cartesian product
+      withTempView("source") {
+        createTable("pk INT NOT NULL, salary INT, dep STRING")
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (2, 200, "finance"),
+          (3, 300, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_REPLICATE_NL(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED AND s.pk >= 2 THEN
+             | INSERT *
+             |WHEN NOT MATCHED THEN
+             | INSERT *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(SHUFFLE_REPLICATE_NL))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[AppendDataExec])
+        val appendDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[AppendDataExec]
+        verifyCartesianProductExec(appendDataExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // insert
+            Row(2, 200, "finance"), // insert
+            Row(3, 300, "hr"))) // insert
+      }
+    }
+  }
+
+  test("merge into empty table with multiple NOT MATCHED clause (cartesian product right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left anti join doesn't support cartesian product
+      withTempView("source") {
+        createTable("pk INT NOT NULL, salary INT, dep STRING")
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (2, 200, "finance"),
+          (3, 300, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_REPLICATE_NL(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED AND s.pk >= 2 THEN
+             | INSERT *
+             |WHEN NOT MATCHED THEN
+             | INSERT *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(SHUFFLE_REPLICATE_NL)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[AppendDataExec])
+        val appendDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[AppendDataExec]
+        verifyCartesianProductExec(appendDataExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // insert
+            Row(2, 200, "finance"), // insert
+            Row(3, 300, "hr"))) // insert
+      }
+    }
+  }
+
+  // calling buildWriteDeltaPlan begin
+
+  test("merge into with conditional WHEN MATCHED clause (update) (broadcast right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // we can't apply hint due to cardinality check
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "corrupted" }
+            |""".stripMargin)
+
+        val sourceRows = Seq(
+          (1, 100, "software"),
+          (2, 200, "finance"),
+          (3, 300, "software"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED AND s.pk = 2 THEN
+             | UPDATE SET *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // unchanged
+            Row(2, 200, "finance"))) // update
+      }
+    }
+  }
+
+  test("merge into with conditional WHEN MATCHED clause (update) (broadcast left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // we can't apply hint due to cardinality check
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "corrupted" }
+            |""".stripMargin)
+
+        val sourceRows = Seq(
+          (1, 100, "software"),
+          (2, 200, "finance"),
+          (3, 300, "software"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED AND s.pk = 2 THEN
+             | UPDATE SET *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // unchanged
+            Row(2, 200, "finance"))) // update
+      }
+    }
+  }
+
+  test("merge into with conditional WHEN MATCHED clause (update) (sort merge right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // we can't apply hint due to cardinality check
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "corrupted" }
+            |""".stripMargin)
+
+        val sourceRows = Seq(
+          (1, 100, "software"),
+          (2, 200, "finance"),
+          (3, 300, "software"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ MERGE(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED AND s.pk = 2 THEN
+             | UPDATE SET *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifySortMergeJoinExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // unchanged
+            Row(2, 200, "finance"))) // update
+      }
+    }
+  }
+
+  test("merge into with conditional WHEN MATCHED clause (update) (sort merge left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // we can't apply hint due to cardinality check
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "corrupted" }
+            |""".stripMargin)
+
+        val sourceRows = Seq(
+          (1, 100, "software"),
+          (2, 200, "finance"),
+          (3, 300, "software"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ MERGE(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED AND s.pk = 2 THEN
+             | UPDATE SET *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifySortMergeJoinExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // unchanged
+            Row(2, 200, "finance"))) // update
+      }
+    }
+  }
+
+  test("merge into with conditional WHEN MATCHED clause (update) (cartesian product right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // we can't apply hint due to cardinality check
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "corrupted" }
+            |""".stripMargin)
+
+        val sourceRows = Seq(
+          (1, 100, "software"),
+          (2, 200, "finance"),
+          (3, 300, "software"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_REPLICATE_NL(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED AND s.pk = 2 THEN
+             | UPDATE SET *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyCartesianProductExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // unchanged
+            Row(2, 200, "finance"))) // update
+      }
+    }
+  }
+
+  test("merge into with conditional WHEN MATCHED clause (update) (cartesian product left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // we can't apply hint due to cardinality check
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "corrupted" }
+            |""".stripMargin)
+
+        val sourceRows = Seq(
+          (1, 100, "software"),
+          (2, 200, "finance"),
+          (3, 300, "software"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_REPLICATE_NL(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED AND s.pk = 2 THEN
+             | UPDATE SET *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyCartesianProductExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // unchanged
+            Row(2, 200, "finance"))) // update
+      }
+    }
+  }
+
+  test("merge into with conditional WHEN MATCHED clause (delete) (broadcast right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // we can't apply hint due to cardinality check
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "corrupted" }
+            |""".stripMargin)
+
+        Seq(1, 2, 3).toDF("pk").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED AND t.salary = 200 THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(Row(1, 100, "hr"))) // unchanged
+      }
+    }
+  }
+
+  test("merge into with conditional WHEN MATCHED clause (delete) (broadcast left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // we can't apply hint due to cardinality check
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "corrupted" }
+            |""".stripMargin)
+
+        Seq(1, 2, 3).toDF("pk").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED AND t.salary = 200 THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(Row(1, 100, "hr"))) // unchanged
+      }
+    }
+  }
+
+  test("merge with one NOT MATCHED BY SOURCE clause causes (broadcast right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left join supports broadcast right
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(1, 2).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(BROADCAST)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // unchanged
+            Row(2, 200, "software"))) // unchanged
+      }
+    }
+  }
+
+  test("merge with one NOT MATCHED BY SOURCE clause causes (broadcast left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left join doesn't support broadcast left
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(1, 2).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(BROADCAST))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // unchanged
+            Row(2, 200, "software"))) // unchanged
+      }
+    }
+  }
+
+  test("merge with one NOT MATCHED BY SOURCE clause causes (sort merge right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(1, 2).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ MERGE(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(SHUFFLE_MERGE)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifySortMergeJoinExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // unchanged
+            Row(2, 200, "software"))) // unchanged
+      }
+    }
+  }
+
+  test("merge with one NOT MATCHED BY SOURCE clause causes (sort merge left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(1, 2).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ MERGE(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(SHUFFLE_MERGE))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifySortMergeJoinExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // unchanged
+            Row(2, 200, "software"))) // unchanged
+      }
+    }
+  }
+
+  test("merge with one NOT MATCHED BY SOURCE clause causes (shuffle hash right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left join supports shuffle hash right
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(1, 2).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_HASH(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(SHUFFLE_HASH)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyShuffleHashJoinExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // unchanged
+            Row(2, 200, "software"))) // unchanged
+      }
+    }
+  }
+
+  test("merge with one NOT MATCHED BY SOURCE clause causes (shuffle hash left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left join supports shuffle hash left
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(1, 2).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_HASH(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(SHUFFLE_HASH))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyShuffleHashJoinExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // unchanged
+            Row(2, 200, "software"))) // unchanged
+      }
+    }
+  }
+
+  test("merge with one NOT MATCHED BY SOURCE clause causes (cartesian product right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left join doesn't support cartesian product
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(1, 2).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_REPLICATE_NL(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(SHUFFLE_REPLICATE_NL)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyCartesianProductExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // unchanged
+            Row(2, 200, "software"))) // unchanged
+      }
+    }
+  }
+
+  test("merge with one NOT MATCHED BY SOURCE clause causes (cartesian product left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left join doesn't support cartesian product
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(1, 2).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_REPLICATE_NL(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(SHUFFLE_REPLICATE_NL))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyCartesianProductExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 100, "hr"), // unchanged
+            Row(2, 200, "software"))) // unchanged
+      }
+    }
+  }
+
+  test("merge with one conditional NOT MATCHED BY SOURCE clause (broadcast right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left join supports broadcast right
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(2).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED BY SOURCE AND salary = 100 THEN
+             | UPDATE SET salary = -1
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(BROADCAST)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, -1, "hr"), // updated
+            Row(2, 200, "software"), // unchanged
+            Row(3, 300, "hr"))) // unchanged
+      }
+    }
+  }
+
+  test("merge with one conditional NOT MATCHED BY SOURCE clause (broadcast left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left join doesn't support broadcast left
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(2).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED BY SOURCE AND salary = 100 THEN
+             | UPDATE SET salary = -1
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(BROADCAST))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, -1, "hr"), // updated
+            Row(2, 200, "software"), // unchanged
+            Row(3, 300, "hr"))) // unchanged
+      }
+    }
+  }
+
+  test("merge with MATCHED and NOT MATCHED BY SOURCE clauses (broadcast right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left join supports broadcast right
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(2).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | DELETE
+             |WHEN NOT MATCHED BY SOURCE AND salary = 100 THEN
+             | UPDATE SET salary = -1
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(BROADCAST)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, -1, "hr"), // updated
+            Row(3, 300, "hr"))) // unchanged
+      }
+    }
+  }
+
+  test("merge with MATCHED and NOT MATCHED BY SOURCE clauses (broadcast left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left join doesn't support broadcast left
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(2).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | DELETE
+             |WHEN NOT MATCHED BY SOURCE AND salary = 100 THEN
+             | UPDATE SET salary = -1
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(BROADCAST))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, -1, "hr"), // updated
+            Row(3, 300, "hr"))) // unchanged
+      }
+    }
+  }
+
+  test("merge with all types of clauses (broadcast right hint)") {
+    // we can't apply hint due to cardinality check
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+        """{ "pk": 1, "salary": 100, "dep": "hr" }
+          |{ "pk": 2, "salary": 200, "dep": "software" }
+          |{ "pk": 3, "salary": 300, "dep": "hr" }
+          |{ "pk": 4, "salary": 400, "dep": "hr" }
+          |{ "pk": 5, "salary": 500, "dep": "hr" }
+          |""".stripMargin)
+
+      val sourceDF = Seq(3, 4, 5, 6).toDF("pk")
+      sourceDF.createOrReplaceTempView("source")
+
+      val df = sql(
+        s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString t
+           |USING source s
+           |ON t.pk = s.pk
+           |WHEN MATCHED THEN
+           | UPDATE SET t.salary = t.salary + 1
+           |WHEN NOT MATCHED THEN
+           | INSERT (pk, salary, dep) VALUES (s.pk, 0, 'new')
+           |WHEN NOT MATCHED BY SOURCE AND pk = 1 THEN
+           | DELETE
+           |""".stripMargin)
+
+      verifyJoinHint(df, JoinHint(
+        Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+        None) :: Nil)
+
+      val commandResultExec = getCommandResultExec(df)
+      assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+      val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+      verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(2, 200, "software"), // unchanged
+          Row(3, 301, "hr"), // update
+          Row(4, 401, "hr"), // update
+          Row(5, 501, "hr"), // update
+          Row(6, 0, "new"))) // insert
+    }
+  }
+
+  test("merge with all types of clauses (broadcast left hint)") {
+    // we can't apply hint due to cardinality check
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+        """{ "pk": 1, "salary": 100, "dep": "hr" }
+          |{ "pk": 2, "salary": 200, "dep": "software" }
+          |{ "pk": 3, "salary": 300, "dep": "hr" }
+          |{ "pk": 4, "salary": 400, "dep": "hr" }
+          |{ "pk": 5, "salary": 500, "dep": "hr" }
+          |""".stripMargin)
+
+      val sourceDF = Seq(3, 4, 5, 6).toDF("pk")
+      sourceDF.createOrReplaceTempView("source")
+
+      val df = sql(
+        s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString t
+           |USING source s
+           |ON t.pk = s.pk
+           |WHEN MATCHED THEN
+           | UPDATE SET t.salary = t.salary + 1
+           |WHEN NOT MATCHED THEN
+           | INSERT (pk, salary, dep) VALUES (s.pk, 0, 'new')
+           |WHEN NOT MATCHED BY SOURCE AND pk = 1 THEN
+           | DELETE
+           |""".stripMargin)
+
+      verifyJoinHint(df, JoinHint(
+        Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+        None) :: Nil)
+
+      val commandResultExec = getCommandResultExec(df)
+      assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+      val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+      verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(2, 200, "software"), // unchanged
+          Row(3, 301, "hr"), // update
+          Row(4, 401, "hr"), // update
+          Row(5, 501, "hr"), // update
+          Row(6, 0, "new"))) // insert
+    }
+  }
+
+  test("merge with NOT MATCHED and NOT MATCHED BY SOURCE clauses (broadcast right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The full outer join doesn't support broadcast right
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(2, 3, 4).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED THEN
+             | INSERT (pk, salary, dep) VALUES (pk, -1, 'new')
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(BROADCAST)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(2, 200, "software"), // unchanged
+            Row(3, 300, "hr"), // unchanged
+            Row(4, -1, "new"))) // insert
+      }
+    }
+  }
+
+  test("merge with NOT MATCHED and NOT MATCHED BY SOURCE clauses (broadcast left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The full outer join doesn't support broadcast left
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(2, 3, 4).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED THEN
+             | INSERT (pk, salary, dep) VALUES (pk, -1, 'new')
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(BROADCAST))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(2, 200, "software"), // unchanged
+            Row(3, 300, "hr"), // unchanged
+            Row(4, -1, "new"))) // insert
+      }
+    }
+  }
+
+  test("merge with NOT MATCHED and NOT MATCHED BY SOURCE clauses (sort merge right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(2, 3, 4).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ MERGE(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED THEN
+             | INSERT (pk, salary, dep) VALUES (pk, -1, 'new')
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(SHUFFLE_MERGE)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifySortMergeJoinExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(2, 200, "software"), // unchanged
+            Row(3, 300, "hr"), // unchanged
+            Row(4, -1, "new"))) // insert
+      }
+    }
+  }
+
+  test("merge with NOT MATCHED and NOT MATCHED BY SOURCE clauses (sort merge left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(2, 3, 4).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ MERGE(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED THEN
+             | INSERT (pk, salary, dep) VALUES (pk, -1, 'new')
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(SHUFFLE_MERGE))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifySortMergeJoinExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(2, 200, "software"), // unchanged
+            Row(3, 300, "hr"), // unchanged
+            Row(4, -1, "new"))) // insert
+      }
+    }
+  }
+
+  test("merge with NOT MATCHED and NOT MATCHED BY SOURCE clauses (shuffle hash right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The full outer join supports shuffle hash right
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(2, 3, 4).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_HASH(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED THEN
+             | INSERT (pk, salary, dep) VALUES (pk, -1, 'new')
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(SHUFFLE_HASH)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyShuffleHashJoinExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(2, 200, "software"), // unchanged
+            Row(3, 300, "hr"), // unchanged
+            Row(4, -1, "new"))) // insert
+      }
+    }
+  }
+
+  test("merge with NOT MATCHED and NOT MATCHED BY SOURCE clauses (shuffle hash left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The full outer join supports shuffle hash left
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(2, 3, 4).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_HASH(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED THEN
+             | INSERT (pk, salary, dep) VALUES (pk, -1, 'new')
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(SHUFFLE_HASH))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyShuffleHashJoinExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(2, 200, "software"), // unchanged
+            Row(3, 300, "hr"), // unchanged
+            Row(4, -1, "new"))) // insert
+      }
+    }
+  }
+
+  test("merge with NOT MATCHED and NOT MATCHED BY SOURCE clauses (cartesian product right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The full outer join doesn't support cartesian product
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(2, 3, 4).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_REPLICATE_NL(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED THEN
+             | INSERT (pk, salary, dep) VALUES (pk, -1, 'new')
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(SHUFFLE_REPLICATE_NL)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyCartesianProductExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(2, 200, "software"), // unchanged
+            Row(3, 300, "hr"), // unchanged
+            Row(4, -1, "new"))) // insert
+      }
+    }
+  }
+
+  test("merge with NOT MATCHED and NOT MATCHED BY SOURCE clauses (cartesian product left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The full outer join doesn't support cartesian product
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(2, 3, 4).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_REPLICATE_NL(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED THEN
+             | INSERT (pk, salary, dep) VALUES (pk, -1, 'new')
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(SHUFFLE_REPLICATE_NL))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyCartesianProductExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(2, 200, "software"), // unchanged
+            Row(3, 300, "hr"), // unchanged
+            Row(4, -1, "new"))) // insert
+      }
+    }
+  }
+
+  test("merge with multiple NOT MATCHED BY SOURCE clauses (broadcast right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left join supports broadcast right
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(5, 6, 7).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED BY SOURCE AND salary = 100 THEN
+             | UPDATE SET salary = salary + 1
+             |WHEN NOT MATCHED BY SOURCE AND salary = 300 THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(BROADCAST)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 101, "hr"), // update
+            Row(2, 200, "software"))) // unchanged
+      }
+    }
+  }
+
+  test("merge with multiple NOT MATCHED BY SOURCE clauses (broadcast left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left join doesn't support broadcast left
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        val sourceDF = Seq(5, 6, 7).toDF("pk")
+        sourceDF.createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN NOT MATCHED BY SOURCE AND salary = 100 THEN
+             | UPDATE SET salary = salary + 1
+             |WHEN NOT MATCHED BY SOURCE AND salary = 300 THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(BROADCAST))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 101, "hr"), // update
+            Row(2, 200, "software"))) // unchanged
+      }
+    }
+  }
+
+  test("merge with CTE (broadcast right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // we can't apply hint due to cardinality check
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |""".stripMargin)
+
+        val sourceRows = Seq(
+          (0, 101, "support"),
+          (2, 301, "support"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""WITH cte1 AS (SELECT pk + 1 as pk, salary, dep FROM source)
+             |MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString AS t
+             |USING cte1 AS s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | UPDATE SET *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 101, "support"), // unchanged
+            Row(2, 200, "software"))) // unchanged
+      }
+    }
+  }
+
+  test("merge with CTE (broadcast left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // we can't apply hint due to cardinality check
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |""".stripMargin)
+
+        val sourceRows = Seq(
+          (0, 101, "support"),
+          (2, 301, "support"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""WITH cte1 AS (SELECT pk + 1 as pk, salary, dep FROM source)
+             |MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString AS t
+             |USING cte1 AS s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | UPDATE SET *
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 101, "support"), // unchanged
+            Row(2, 200, "software"))) // unchanged
+      }
+    }
+  }
+
+  test("merge with subquery as source (broadcast right hint)") {
+    // we can't apply hint due to cardinality check
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+        """{ "pk": 1, "salary": 100, "dep": "hr" }
+          |{ "pk": 6, "salary": 600, "dep": "software" }
+          |""".stripMargin)
+
+      val sourceRows = Seq(
+        (2, 201, "support"),
+        (1, 101, "support"),
+        (3, 301, "support"),
+        (6, 601, "support"))
+      sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+      val subquery =
+        s"""
+           |SELECT * FROM source WHERE pk = 2
+           |UNION ALL
+           |SELECT * FROM source WHERE pk = 1 OR pk = 6
+           |""".stripMargin
+
+      val df = sql(
+        s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString AS t
+           |USING ($subquery) AS s
+           |ON t.pk = s.pk
+           |WHEN MATCHED THEN
+           | UPDATE SET *
+           |WHEN NOT MATCHED THEN
+           | INSERT *
+           |""".stripMargin)
+
+      verifyJoinHint(df, JoinHint(
+        Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+        None) :: Nil)
+
+      val commandResultExec = getCommandResultExec(df)
+      assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+      val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+      verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(1, 101, "support"), // update
+          Row(2, 201, "support"), // insert
+          Row(6, 601, "support"))) // update
+    }
+  }
+
+  test("merge with subquery as source (broadcast left hint)") {
+    // we can't apply hint due to cardinality check
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+        """{ "pk": 1, "salary": 100, "dep": "hr" }
+          |{ "pk": 6, "salary": 600, "dep": "software" }
+          |""".stripMargin)
+
+      val sourceRows = Seq(
+        (2, 201, "support"),
+        (1, 101, "support"),
+        (3, 301, "support"),
+        (6, 601, "support"))
+      sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+      val subquery =
+        s"""
+           |SELECT * FROM source WHERE pk = 2
+           |UNION ALL
+           |SELECT * FROM source WHERE pk = 1 OR pk = 6
+           |""".stripMargin
+
+      val df = sql(
+        s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString AS t
+           |USING ($subquery) AS s
+           |ON t.pk = s.pk
+           |WHEN MATCHED THEN
+           | UPDATE SET *
+           |WHEN NOT MATCHED THEN
+           | INSERT *
+           |""".stripMargin)
+
+      verifyJoinHint(df, JoinHint(
+        Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+        None) :: Nil)
+
+      val commandResultExec = getCommandResultExec(df)
+      assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+      val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+      verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(1, 101, "support"), // update
+          Row(2, 201, "support"), // insert
+          Row(6, 601, "support"))) // update
+    }
+  }
+
+  test("merge cardinality check with unconditional MATCHED clause (delete)" +
+    " (broadcast right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The inner join supports broadcast right
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 6, "salary": 600, "dep": "software" }
+            |""".stripMargin)
+
+        val sourceRows = Seq(
+          (1, 101, "support"),
+          (1, 102, "support"),
+          (2, 201, "support"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString AS t
+             |USING source AS s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(BROADCAST)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(Row(6, 600, "software"))) // unchanged
+      }
+    }
+  }
+
+  test("merge cardinality check with unconditional MATCHED clause (delete)" +
+    " (broadcast left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The inner join supports broadcast left
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 6, "salary": 600, "dep": "software" }
+            |""".stripMargin)
+
+        val sourceRows = Seq(
+          (1, 101, "support"),
+          (1, 102, "support"),
+          (2, 201, "support"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString AS t
+             |USING source AS s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(BROADCAST))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(Row(6, 600, "software"))) // unchanged
+      }
+    }
+  }
+
+  test("merge cardinality check with unconditional MATCHED clause (delete)" +
+    " (sort merge right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 6, "salary": 600, "dep": "software" }
+            |""".stripMargin)
+
+        val sourceRows = Seq(
+          (1, 101, "support"),
+          (1, 102, "support"),
+          (2, 201, "support"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ MERGE(s) */ INTO $tableNameAsString AS t
+             |USING source AS s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(SHUFFLE_MERGE)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifySortMergeJoinExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(Row(6, 600, "software"))) // unchanged
+      }
+    }
+  }
+
+  test("merge cardinality check with unconditional MATCHED clause (delete)" +
+    " (sort merge left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 6, "salary": 600, "dep": "software" }
+            |""".stripMargin)
+
+        val sourceRows = Seq(
+          (1, 101, "support"),
+          (1, 102, "support"),
+          (2, 201, "support"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ MERGE(t) */ INTO $tableNameAsString AS t
+             |USING source AS s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(SHUFFLE_MERGE))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifySortMergeJoinExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(Row(6, 600, "software"))) // unchanged
+      }
+    }
+  }
+
+  test("merge cardinality check with unconditional MATCHED clause (delete)" +
+    " (shuffle hash right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The inner join supports shuffle hash right
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 6, "salary": 600, "dep": "software" }
+            |""".stripMargin)
+
+        val sourceRows = Seq(
+          (1, 101, "support"),
+          (1, 102, "support"),
+          (2, 201, "support"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_HASH(s) */ INTO $tableNameAsString AS t
+             |USING source AS s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(SHUFFLE_HASH)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyShuffleHashJoinExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(Row(6, 600, "software"))) // unchanged
+      }
+    }
+  }
+
+  test("merge cardinality check with unconditional MATCHED clause (delete)" +
+    " (shuffle hash left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The inner join supports shuffle hash left
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 6, "salary": 600, "dep": "software" }
+            |""".stripMargin)
+
+        val sourceRows = Seq(
+          (1, 101, "support"),
+          (1, 102, "support"),
+          (2, 201, "support"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_HASH(t) */ INTO $tableNameAsString AS t
+             |USING source AS s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(SHUFFLE_HASH))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyShuffleHashJoinExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(Row(6, 600, "software"))) // unchanged
+      }
+    }
+  }
+
+  test("merge cardinality check with unconditional MATCHED clause (delete)" +
+    " (cartesian product right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The inner join supports cartesian product
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 6, "salary": 600, "dep": "software" }
+            |""".stripMargin)
+
+        val sourceRows = Seq(
+          (1, 101, "support"),
+          (1, 102, "support"),
+          (2, 201, "support"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_REPLICATE_NL(s) */ INTO $tableNameAsString AS t
+             |USING source AS s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(SHUFFLE_REPLICATE_NL)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyCartesianProductExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(Row(6, 600, "software"))) // unchanged
+      }
+    }
+  }
+
+  test("merge cardinality check with unconditional MATCHED clause (delete)" +
+    " (cartesian product left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The inner join supports cartesian product
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 6, "salary": 600, "dep": "software" }
+            |""".stripMargin)
+
+        val sourceRows = Seq(
+          (1, 101, "support"),
+          (1, 102, "support"),
+          (2, 201, "support"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_REPLICATE_NL(t) */ INTO $tableNameAsString AS t
+             |USING source AS s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(SHUFFLE_REPLICATE_NL))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyCartesianProductExec(writeDeltaExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(Row(6, 600, "software"))) // unchanged
+      }
+    }
+  }
+
+  test("self merge (broadcast right hint)") {
+    // we can't apply hint due to cardinality check
+    createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "dep": "software" }
+        |{ "pk": 3, "salary": 300, "dep": "hr" }
+        |""".stripMargin)
+
+    val df = sql(
+      s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString t
+         |USING $tableNameAsString s
+         |ON t.pk = s.pk
+         |WHEN MATCHED AND t.salary = 100 THEN
+         | UPDATE SET salary = t.salary + 1
+         |WHEN NOT MATCHED THEN
+         | INSERT *
+         |""".stripMargin)
+
+    verifyJoinHint(df, JoinHint(
+      Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+      None) :: Nil)
+
+    val commandResultExec = getCommandResultExec(df)
+    assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+    val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+    verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString"),
+      Seq(
+        Row(1, 101, "hr"), // update
+        Row(2, 200, "software"), // unchanged
+        Row(3, 300, "hr"))) // unchanged
+  }
+
+  test("self merge (broadcast left hint)") {
+    // we can't apply hint due to cardinality check
+    createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "dep": "software" }
+        |{ "pk": 3, "salary": 300, "dep": "hr" }
+        |""".stripMargin)
+
+    val df = sql(
+      s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString t
+         |USING $tableNameAsString s
+         |ON t.pk = s.pk
+         |WHEN MATCHED AND t.salary = 100 THEN
+         | UPDATE SET salary = t.salary + 1
+         |WHEN NOT MATCHED THEN
+         | INSERT *
+         |""".stripMargin)
+
+    verifyJoinHint(df, JoinHint(
+      Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+      None) :: Nil)
+
+    val commandResultExec = getCommandResultExec(df)
+    assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+    val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+    verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString"),
+      Seq(
+        Row(1, 101, "hr"), // update
+        Row(2, 200, "software"), // unchanged
+        Row(3, 300, "hr"))) // unchanged
+  }
+
+  test("merge with self subquery (broadcast right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // we can't apply hint due to cardinality check
+      withTempView("ids") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        Seq(1, 2).toDF("value").createOrReplaceTempView("ids")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString t
+             |USING (SELECT pk FROM $tableNameAsString r JOIN ids ON r.pk = ids.value) s
+             |ON t.pk = s.pk
+             |WHEN MATCHED AND t.salary = 100 THEN
+             | UPDATE SET salary = t.salary + 1
+             |WHEN NOT MATCHED THEN
+             | INSERT (dep, salary, pk) VALUES ('new', 300, 1)
+             |""".stripMargin)
+
+        verifyJoinHint(df, Seq(JoinHint(
+          Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+          None), JoinHint.NONE))
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 101, "hr"), // update
+            Row(2, 200, "software"), // unchanged
+            Row(3, 300, "hr"))) // unchanged
+      }
+    }
+  }
+
+  test("merge with self subquery (broadcast left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // we can't apply hint due to cardinality check
+      withTempView("ids") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |{ "pk": 3, "salary": 300, "dep": "hr" }
+            |""".stripMargin)
+
+        Seq(1, 2).toDF("value").createOrReplaceTempView("ids")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString t
+             |USING (SELECT pk FROM $tableNameAsString r JOIN ids ON r.pk = ids.value) s
+             |ON t.pk = s.pk
+             |WHEN MATCHED AND t.salary = 100 THEN
+             | UPDATE SET salary = t.salary + 1
+             |WHEN NOT MATCHED THEN
+             | INSERT (dep, salary, pk) VALUES ('new', 300, 1)
+             |""".stripMargin)
+
+        verifyJoinHint(df, Seq(JoinHint(
+          Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+          None), JoinHint.NONE))
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 101, "hr"), // update
+            Row(2, 200, "software"), // unchanged
+            Row(3, 300, "hr"))) // unchanged
+      }
+    }
+  }
+
+  test("merge with NULL values in target and source (broadcast right hint)") {
+    // we can't apply hint due to cardinality check
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, id INT, salary INT, dep STRING",
+        """{ "pk": 1, "id": null, "salary": 100, "dep": "hr" }
+          |{ "pk": 2, "id": 2, "salary": 200, "dep": "software" }
+          |""".stripMargin)
+
+      val sourceRows = Seq(
+        (5, None, 501, "support"),
+        (6, Some(6), 601, "support"))
+      sourceRows.toDF("pk", "id", "salary", "dep").createOrReplaceTempView("source")
+
+      val df = sql(
+        s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString t
+           |USING source s
+           |ON t.id = s.id
+           |WHEN MATCHED THEN
+           | UPDATE SET *
+           |WHEN NOT MATCHED THEN
+           | INSERT *
+           |""".stripMargin)
+
+      verifyJoinHint(df, JoinHint(
+        Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+        None) :: Nil)
+
+      val commandResultExec = getCommandResultExec(df)
+      assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+      val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+      verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(1, null, 100, "hr"), // unchanged
+          Row(2, 2, 200, "software"), // unchanged
+          Row(5, null, 501, "support"), // insert
+          Row(6, 6, 601, "support"))) // insert
+    }
+  }
+
+  test("merge with NULL values in target and source (broadcast left hint)") {
+    // we can't apply hint due to cardinality check
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, id INT, salary INT, dep STRING",
+        """{ "pk": 1, "id": null, "salary": 100, "dep": "hr" }
+          |{ "pk": 2, "id": 2, "salary": 200, "dep": "software" }
+          |""".stripMargin)
+
+      val sourceRows = Seq(
+        (5, None, 501, "support"),
+        (6, Some(6), 601, "support"))
+      sourceRows.toDF("pk", "id", "salary", "dep").createOrReplaceTempView("source")
+
+      val df = sql(
+        s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString t
+           |USING source s
+           |ON t.id = s.id
+           |WHEN MATCHED THEN
+           | UPDATE SET *
+           |WHEN NOT MATCHED THEN
+           | INSERT *
+           |""".stripMargin)
+
+      verifyJoinHint(df, JoinHint(
+        Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+        None) :: Nil)
+
+      val commandResultExec = getCommandResultExec(df)
+      assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+      val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+      verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(1, null, 100, "hr"), // unchanged
+          Row(2, 2, 200, "software"), // unchanged
+          Row(5, null, 501, "support"), // insert
+          Row(6, 6, 601, "support"))) // insert
+    }
+  }
+
+  test("merge with <=> (broadcast right hint)") {
+    // we can't apply hint due to cardinality check
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, id INT, salary INT, dep STRING",
+        """{ "pk": 1, "id": null, "salary": 100, "dep": "hr" }
+          |{ "pk": 2, "id": 2, "salary": 200, "dep": "software" }
+          |""".stripMargin)
+
+      val sourceRows = Seq(
+        (5, None, 501, "support"),
+        (6, Some(6), 601, "support"))
+      sourceRows.toDF("pk", "id", "salary", "dep").createOrReplaceTempView("source")
+
+      val df = sql(
+        s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString t
+           |USING source s
+           |ON t.id <=> s.id
+           |WHEN MATCHED THEN
+           | UPDATE SET *
+           |WHEN NOT MATCHED THEN
+           | INSERT *
+           |""".stripMargin)
+
+      verifyJoinHint(df, JoinHint(
+        Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+        None) :: Nil)
+
+      val commandResultExec = getCommandResultExec(df)
+      assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+      val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+      verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(2, 2, 200, "software"), // unchanged
+          Row(5, null, 501, "support"), // updated
+          Row(6, 6, 601, "support"))) // insert
+    }
+  }
+
+  test("merge with <=> (broadcast left hint)") {
+    // we can't apply hint due to cardinality check
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, id INT, salary INT, dep STRING",
+        """{ "pk": 1, "id": null, "salary": 100, "dep": "hr" }
+          |{ "pk": 2, "id": 2, "salary": 200, "dep": "software" }
+          |""".stripMargin)
+
+      val sourceRows = Seq(
+        (5, None, 501, "support"),
+        (6, Some(6), 601, "support"))
+      sourceRows.toDF("pk", "id", "salary", "dep").createOrReplaceTempView("source")
+
+      val df = sql(
+        s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString t
+           |USING source s
+           |ON t.id <=> s.id
+           |WHEN MATCHED THEN
+           | UPDATE SET *
+           |WHEN NOT MATCHED THEN
+           | INSERT *
+           |""".stripMargin)
+
+      verifyJoinHint(df, JoinHint(
+        Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+        None) :: Nil)
+
+      val commandResultExec = getCommandResultExec(df)
+      assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+      val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+      verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(2, 2, 200, "software"), // unchanged
+          Row(5, null, 501, "support"), // updated
+          Row(6, 6, 601, "support"))) // insert
+    }
+  }
+
+  test("merge with NULL ON condition (broadcast right hint)") {
+    // we can't apply hint due to cardinality check
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, id INT, salary INT, dep STRING",
+        """{ "pk": 1, "id": null, "salary": 100, "dep": "hr" }
+          |{ "pk": 2, "id": 2, "salary": 200, "dep": "software" }
+          |""".stripMargin)
+
+      val sourceRows = Seq(
+        (5, None, 501, "support"),
+        (6, Some(2), 201, "support"))
+      sourceRows.toDF("pk", "id", "salary", "dep").createOrReplaceTempView("source")
+
+      val df = sql(
+        s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString t
+           |USING source s
+           |ON t.id = s.id AND NULL
+           |WHEN MATCHED THEN
+           | UPDATE SET salary = s.salary
+           |WHEN NOT MATCHED THEN
+           | INSERT *
+           |""".stripMargin)
+
+      verifyJoinHint(df, Seq.empty)
+
+      val commandResultExec = getCommandResultExec(df)
+      assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+      val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+      verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(1, null, 100, "hr"), // unchanged
+          Row(2, 2, 200, "software"), // unchanged
+          Row(5, null, 501, "support"), // new
+          Row(6, 2, 201, "support"))) // new
+    }
+  }
+
+  test("merge with NULL ON condition (broadcast left hint)") {
+    // we can't apply hint due to cardinality check
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, id INT, salary INT, dep STRING",
+        """{ "pk": 1, "id": null, "salary": 100, "dep": "hr" }
+          |{ "pk": 2, "id": 2, "salary": 200, "dep": "software" }
+          |""".stripMargin)
+
+      val sourceRows = Seq(
+        (5, None, 501, "support"),
+        (6, Some(2), 201, "support"))
+      sourceRows.toDF("pk", "id", "salary", "dep").createOrReplaceTempView("source")
+
+      val df = sql(
+        s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString t
+           |USING source s
+           |ON t.id = s.id AND NULL
+           |WHEN MATCHED THEN
+           | UPDATE SET salary = s.salary
+           |WHEN NOT MATCHED THEN
+           | INSERT *
+           |""".stripMargin)
+
+      verifyJoinHint(df, Seq.empty)
+
+      val commandResultExec = getCommandResultExec(df)
+      assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+      val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+      verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(1, null, 100, "hr"), // unchanged
+          Row(2, 2, 200, "software"), // unchanged
+          Row(5, null, 501, "support"), // new
+          Row(6, 2, 201, "support"))) // new
+    }
+  }
+
+  test("merge with NULL clause conditions (broadcast right hint)") {
+    // we can't apply hint due to cardinality check
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+        """{ "pk": 1, "salary": 100, "dep": "hr" }
+          |{ "pk": 2, "salary": 200, "dep": "software" }
+          |""".stripMargin)
+
+      val sourceRows = Seq(
+        (1, 101, "support"),
+        (3, 301, "support"))
+      sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+      val df = sql(
+        s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString t
+           |USING source s
+           |ON t.pk = s.pk
+           |WHEN MATCHED AND NULL THEN
+           | UPDATE SET salary = s.salary
+           |WHEN NOT MATCHED AND NULL THEN
+           | INSERT *
+           |WHEN NOT MATCHED BY SOURCE AND NULL THEN
+           | DELETE
+           |""".stripMargin)
+
+      verifyJoinHint(df, JoinHint(
+        Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+        None) :: Nil)
+
+      val commandResultExec = getCommandResultExec(df)
+      assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+      val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+      verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(1, 100, "hr"), // unchanged
+          Row(2, 200, "software"))) // unchanged
+    }
+  }
+
+  test("merge with NULL clause conditions (broadcast left hint)") {
+    // we can't apply hint due to cardinality check
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+        """{ "pk": 1, "salary": 100, "dep": "hr" }
+          |{ "pk": 2, "salary": 200, "dep": "software" }
+          |""".stripMargin)
+
+      val sourceRows = Seq(
+        (1, 101, "support"),
+        (3, 301, "support"))
+      sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+      val df = sql(
+        s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString t
+           |USING source s
+           |ON t.pk = s.pk
+           |WHEN MATCHED AND NULL THEN
+           | UPDATE SET salary = s.salary
+           |WHEN NOT MATCHED AND NULL THEN
+           | INSERT *
+           |WHEN NOT MATCHED BY SOURCE AND NULL THEN
+           | DELETE
+           |""".stripMargin)
+
+      verifyJoinHint(df, JoinHint(
+        Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+        None) :: Nil)
+
+      val commandResultExec = getCommandResultExec(df)
+      assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+      val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+      verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(1, 100, "hr"), // unchanged
+          Row(2, 200, "software"))) // unchanged
+    }
+  }
+
+  test("merge with multiple matching clauses (broadcast right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // we can't apply hint due to cardinality check
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |""".stripMargin)
+
+        val sourceRows = Seq(
+          (1, 101, "support"),
+          (3, 301, "support"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED AND t.pk = 1 THEN
+             | UPDATE SET salary = t.salary + 5
+             |WHEN MATCHED AND t.salary = 100 THEN
+             | UPDATE SET salary = t.salary + 2
+             |WHEN NOT MATCHED BY SOURCE AND t.pk = 2 THEN
+             | UPDATE SET salary = salary - 1
+             |WHEN NOT MATCHED BY SOURCE AND t.salary = 200 THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 105, "hr"), // updated (matched)
+            Row(2, 199, "software"))) // updated (not matched by source)
+      }
+    }
+  }
+
+  test("merge with multiple matching clauses (broadcast left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // we can't apply hint due to cardinality check
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |""".stripMargin)
+
+        val sourceRows = Seq(
+          (1, 101, "support"),
+          (3, 301, "support"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED AND t.pk = 1 THEN
+             | UPDATE SET salary = t.salary + 5
+             |WHEN MATCHED AND t.salary = 100 THEN
+             | UPDATE SET salary = t.salary + 2
+             |WHEN NOT MATCHED BY SOURCE AND t.pk = 2 THEN
+             | UPDATE SET salary = salary - 1
+             |WHEN NOT MATCHED BY SOURCE AND t.salary = 200 THEN
+             | DELETE
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[WriteDeltaExec])
+        val writeDeltaExec = commandResultExec.commandPhysicalPlan.asInstanceOf[WriteDeltaExec]
+        verifyBroadcastHashJoinExec(writeDeltaExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, 105, "hr"), // updated (matched)
+            Row(2, 199, "software"))) // updated (not matched by source)
+      }
+    }
+  }
+
+  // calling buildReplaceDataPlan begin
+
+  test("merge into table containing added column with default value (broadcast right hint)") {
+    // we can't apply hint due to cardinality check
+    withTempView("source") {
+      sql(
+        s"""CREATE TABLE $tableNameAsString (
+           | pk INT NOT NULL,
+           | salary INT NOT NULL DEFAULT -1,
+           | dep STRING)
+           |PARTITIONED BY (dep)
+           |""".stripMargin)
+
+      append("pk INT NOT NULL, dep STRING",
+        """{ "pk": 1, "dep": "hr" }
+          |{ "pk": 2, "dep": "hr" }
+          |{ "pk": 3, "dep": "hr" }
+          |""".stripMargin)
+
+      sql(s"ALTER TABLE $tableNameAsString ADD COLUMN txt STRING DEFAULT 'initial-text'")
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(1, -1, "hr", "initial-text"),
+          Row(2, -1, "hr", "initial-text"),
+          Row(3, -1, "hr", "initial-text")))
+
+      val sourceRows = Seq(
+        (1, 100, "hr"),
+        (4, 400, "hr"))
+      sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+      val df = sql(
+        s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString t
+           |USING source s
+           |ON t.pk = s.pk
+           |WHEN MATCHED THEN
+           | UPDATE SET t.salary = s.salary, t.txt = DEFAULT
+           |WHEN NOT MATCHED THEN
+           | INSERT (pk, salary, dep) VALUES (s.pk, DEFAULT, s.dep)
+           |WHEN NOT MATCHED BY SOURCE THEN
+           | UPDATE SET salary = DEFAULT
+           |""".stripMargin)
+
+      verifyJoinHint(df, JoinHint(
+        Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+        None) :: Nil)
+
+      val commandResultExec = getCommandResultExec(df)
+      assert(commandResultExec.commandPhysicalPlan.isInstanceOf[ReplaceDataExec])
+      val replaceDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[ReplaceDataExec]
+      verifyBroadcastHashJoinExec(replaceDataExec.query, 0)
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(1, 100, "hr", "initial-text"),
+          Row(2, -1, "hr", "initial-text"),
+          Row(3, -1, "hr", "initial-text"),
+          Row(4, -1, "hr", "initial-text")))
+    }
+  }
+
+  test("merge into table containing added column with default value (broadcast left hint)") {
+    // we can't apply hint due to cardinality check
+    withTempView("source") {
+      sql(
+        s"""CREATE TABLE $tableNameAsString (
+           | pk INT NOT NULL,
+           | salary INT NOT NULL DEFAULT -1,
+           | dep STRING)
+           |PARTITIONED BY (dep)
+           |""".stripMargin)
+
+      append("pk INT NOT NULL, dep STRING",
+        """{ "pk": 1, "dep": "hr" }
+          |{ "pk": 2, "dep": "hr" }
+          |{ "pk": 3, "dep": "hr" }
+          |""".stripMargin)
+
+      sql(s"ALTER TABLE $tableNameAsString ADD COLUMN txt STRING DEFAULT 'initial-text'")
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(1, -1, "hr", "initial-text"),
+          Row(2, -1, "hr", "initial-text"),
+          Row(3, -1, "hr", "initial-text")))
+
+      val sourceRows = Seq(
+        (1, 100, "hr"),
+        (4, 400, "hr"))
+      sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+      val df = sql(
+        s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString t
+           |USING source s
+           |ON t.pk = s.pk
+           |WHEN MATCHED THEN
+           | UPDATE SET t.salary = s.salary, t.txt = DEFAULT
+           |WHEN NOT MATCHED THEN
+           | INSERT (pk, salary, dep) VALUES (s.pk, DEFAULT, s.dep)
+           |WHEN NOT MATCHED BY SOURCE THEN
+           | UPDATE SET salary = DEFAULT
+           |""".stripMargin)
+
+      verifyJoinHint(df, JoinHint(
+        Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION))),
+        None) :: Nil)
+
+      val commandResultExec = getCommandResultExec(df)
+      assert(commandResultExec.commandPhysicalPlan.isInstanceOf[ReplaceDataExec])
+      val replaceDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[ReplaceDataExec]
+      verifyBroadcastHashJoinExec(replaceDataExec.query, 0)
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(1, 100, "hr", "initial-text"),
+          Row(2, -1, "hr", "initial-text"),
+          Row(3, -1, "hr", "initial-text"),
+          Row(4, -1, "hr", "initial-text")))
+    }
+  }
+
+  test("merge into table containing added column with default value (matched delete action)" +
+    " (broadcast right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left join supports broadcast right
+      withTempView("source") {
+        sql(
+          s"""CREATE TABLE $tableNameAsString (
+             | pk INT NOT NULL,
+             | salary INT NOT NULL DEFAULT -1,
+             | dep STRING)
+             |PARTITIONED BY (dep)
+             |""".stripMargin)
+
+        append("pk INT NOT NULL, dep STRING",
+          """{ "pk": 1, "dep": "hr" }
+            |{ "pk": 2, "dep": "hr" }
+            |{ "pk": 3, "dep": "hr" }
+            |""".stripMargin)
+
+        sql(s"ALTER TABLE $tableNameAsString ADD COLUMN txt STRING DEFAULT 'initial-text'")
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, -1, "hr", "initial-text"),
+            Row(2, -1, "hr", "initial-text"),
+            Row(3, -1, "hr", "initial-text")))
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (4, 400, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | DELETE
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | UPDATE SET salary = DEFAULT
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(BROADCAST)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[ReplaceDataExec])
+        val replaceDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[ReplaceDataExec]
+        verifyBroadcastHashJoinExec(replaceDataExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(2, -1, "hr", "initial-text"),
+            Row(3, -1, "hr", "initial-text")))
+      }
+    }
+  }
+
+  test("merge into table containing added column with default value (matched delete action)" +
+    " (broadcast left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left join doesn't support broadcast left
+      withTempView("source") {
+        sql(
+          s"""CREATE TABLE $tableNameAsString (
+             | pk INT NOT NULL,
+             | salary INT NOT NULL DEFAULT -1,
+             | dep STRING)
+             |PARTITIONED BY (dep)
+             |""".stripMargin)
+
+        append("pk INT NOT NULL, dep STRING",
+          """{ "pk": 1, "dep": "hr" }
+            |{ "pk": 2, "dep": "hr" }
+            |{ "pk": 3, "dep": "hr" }
+            |""".stripMargin)
+
+        sql(s"ALTER TABLE $tableNameAsString ADD COLUMN txt STRING DEFAULT 'initial-text'")
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, -1, "hr", "initial-text"),
+            Row(2, -1, "hr", "initial-text"),
+            Row(3, -1, "hr", "initial-text")))
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (4, 400, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ BROADCAST(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | DELETE
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | UPDATE SET salary = DEFAULT
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(BROADCAST))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[ReplaceDataExec])
+        val replaceDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[ReplaceDataExec]
+        verifyBroadcastHashJoinExec(replaceDataExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(2, -1, "hr", "initial-text"),
+            Row(3, -1, "hr", "initial-text")))
+      }
+    }
+  }
+
+  test("merge into table containing added column with default value (matched delete action)" +
+    " (sort merge right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      withTempView("source") {
+        sql(
+          s"""CREATE TABLE $tableNameAsString (
+             | pk INT NOT NULL,
+             | salary INT NOT NULL DEFAULT -1,
+             | dep STRING)
+             |PARTITIONED BY (dep)
+             |""".stripMargin)
+
+        append("pk INT NOT NULL, dep STRING",
+          """{ "pk": 1, "dep": "hr" }
+            |{ "pk": 2, "dep": "hr" }
+            |{ "pk": 3, "dep": "hr" }
+            |""".stripMargin)
+
+        sql(s"ALTER TABLE $tableNameAsString ADD COLUMN txt STRING DEFAULT 'initial-text'")
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, -1, "hr", "initial-text"),
+            Row(2, -1, "hr", "initial-text"),
+            Row(3, -1, "hr", "initial-text")))
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (4, 400, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ MERGE(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | DELETE
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | UPDATE SET salary = DEFAULT
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(SHUFFLE_MERGE)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[ReplaceDataExec])
+        val replaceDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[ReplaceDataExec]
+        verifySortMergeJoinExec(replaceDataExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(2, -1, "hr", "initial-text"),
+            Row(3, -1, "hr", "initial-text")))
+      }
+    }
+  }
+
+  test("merge into table containing added column with default value (matched delete action)" +
+    " (sort merge left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      withTempView("source") {
+        sql(
+          s"""CREATE TABLE $tableNameAsString (
+             | pk INT NOT NULL,
+             | salary INT NOT NULL DEFAULT -1,
+             | dep STRING)
+             |PARTITIONED BY (dep)
+             |""".stripMargin)
+
+        append("pk INT NOT NULL, dep STRING",
+          """{ "pk": 1, "dep": "hr" }
+            |{ "pk": 2, "dep": "hr" }
+            |{ "pk": 3, "dep": "hr" }
+            |""".stripMargin)
+
+        sql(s"ALTER TABLE $tableNameAsString ADD COLUMN txt STRING DEFAULT 'initial-text'")
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, -1, "hr", "initial-text"),
+            Row(2, -1, "hr", "initial-text"),
+            Row(3, -1, "hr", "initial-text")))
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (4, 400, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ MERGE(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | DELETE
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | UPDATE SET salary = DEFAULT
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(SHUFFLE_MERGE))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[ReplaceDataExec])
+        val replaceDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[ReplaceDataExec]
+        verifySortMergeJoinExec(replaceDataExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(2, -1, "hr", "initial-text"),
+            Row(3, -1, "hr", "initial-text")))
+      }
+    }
+  }
+
+  test("merge into table containing added column with default value (matched delete action)" +
+    " (shuffle hash right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left join supports shuffle hash right
+      withTempView("source") {
+        sql(
+          s"""CREATE TABLE $tableNameAsString (
+             | pk INT NOT NULL,
+             | salary INT NOT NULL DEFAULT -1,
+             | dep STRING)
+             |PARTITIONED BY (dep)
+             |""".stripMargin)
+
+        append("pk INT NOT NULL, dep STRING",
+          """{ "pk": 1, "dep": "hr" }
+            |{ "pk": 2, "dep": "hr" }
+            |{ "pk": 3, "dep": "hr" }
+            |""".stripMargin)
+
+        sql(s"ALTER TABLE $tableNameAsString ADD COLUMN txt STRING DEFAULT 'initial-text'")
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, -1, "hr", "initial-text"),
+            Row(2, -1, "hr", "initial-text"),
+            Row(3, -1, "hr", "initial-text")))
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (4, 400, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_HASH(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | DELETE
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | UPDATE SET salary = DEFAULT
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(SHUFFLE_HASH)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[ReplaceDataExec])
+        val replaceDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[ReplaceDataExec]
+        verifyShuffleHashJoinExec(replaceDataExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(2, -1, "hr", "initial-text"),
+            Row(3, -1, "hr", "initial-text")))
+      }
+    }
+  }
+
+  test("merge into table containing added column with default value (matched delete action)" +
+    " (shuffle hash left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left join supports shuffle hash left
+      withTempView("source") {
+        sql(
+          s"""CREATE TABLE $tableNameAsString (
+             | pk INT NOT NULL,
+             | salary INT NOT NULL DEFAULT -1,
+             | dep STRING)
+             |PARTITIONED BY (dep)
+             |""".stripMargin)
+
+        append("pk INT NOT NULL, dep STRING",
+          """{ "pk": 1, "dep": "hr" }
+            |{ "pk": 2, "dep": "hr" }
+            |{ "pk": 3, "dep": "hr" }
+            |""".stripMargin)
+
+        sql(s"ALTER TABLE $tableNameAsString ADD COLUMN txt STRING DEFAULT 'initial-text'")
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, -1, "hr", "initial-text"),
+            Row(2, -1, "hr", "initial-text"),
+            Row(3, -1, "hr", "initial-text")))
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (4, 400, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_HASH(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | DELETE
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | UPDATE SET salary = DEFAULT
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(SHUFFLE_HASH))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[ReplaceDataExec])
+        val replaceDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[ReplaceDataExec]
+        verifyShuffleHashJoinExec(replaceDataExec.query, 1)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(2, -1, "hr", "initial-text"),
+            Row(3, -1, "hr", "initial-text")))
+      }
+    }
+  }
+
+  test("merge into table containing added column with default value (matched delete action)" +
+    " (cartesian product right hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left join doesn't support cartesian product
+      withTempView("source") {
+        sql(
+          s"""CREATE TABLE $tableNameAsString (
+             | pk INT NOT NULL,
+             | salary INT NOT NULL DEFAULT -1,
+             | dep STRING)
+             |PARTITIONED BY (dep)
+             |""".stripMargin)
+
+        append("pk INT NOT NULL, dep STRING",
+          """{ "pk": 1, "dep": "hr" }
+            |{ "pk": 2, "dep": "hr" }
+            |{ "pk": 3, "dep": "hr" }
+            |""".stripMargin)
+
+        sql(s"ALTER TABLE $tableNameAsString ADD COLUMN txt STRING DEFAULT 'initial-text'")
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, -1, "hr", "initial-text"),
+            Row(2, -1, "hr", "initial-text"),
+            Row(3, -1, "hr", "initial-text")))
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (4, 400, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_REPLICATE_NL(s) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | DELETE
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | UPDATE SET salary = DEFAULT
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          None,
+          Some(HintInfo(strategy = Some(SHUFFLE_REPLICATE_NL)))) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[ReplaceDataExec])
+        val replaceDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[ReplaceDataExec]
+        verifyCartesianProductExec(replaceDataExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(2, -1, "hr", "initial-text"),
+            Row(3, -1, "hr", "initial-text")))
+      }
+    }
+  }
+
+  test("merge into table containing added column with default value (matched delete action)" +
+    " (cartesian product left hint)") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      // The left join doesn't support cartesian product
+      withTempView("source") {
+        sql(
+          s"""CREATE TABLE $tableNameAsString (
+             | pk INT NOT NULL,
+             | salary INT NOT NULL DEFAULT -1,
+             | dep STRING)
+             |PARTITIONED BY (dep)
+             |""".stripMargin)
+
+        append("pk INT NOT NULL, dep STRING",
+          """{ "pk": 1, "dep": "hr" }
+            |{ "pk": 2, "dep": "hr" }
+            |{ "pk": 3, "dep": "hr" }
+            |""".stripMargin)
+
+        sql(s"ALTER TABLE $tableNameAsString ADD COLUMN txt STRING DEFAULT 'initial-text'")
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(1, -1, "hr", "initial-text"),
+            Row(2, -1, "hr", "initial-text"),
+            Row(3, -1, "hr", "initial-text")))
+
+        val sourceRows = Seq(
+          (1, 100, "hr"),
+          (4, 400, "hr"))
+        sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+        val df = sql(
+          s"""MERGE /*+ SHUFFLE_REPLICATE_NL(t) */ INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | DELETE
+             |WHEN NOT MATCHED BY SOURCE THEN
+             | UPDATE SET salary = DEFAULT
+             |""".stripMargin)
+
+        verifyJoinHint(df, JoinHint(
+          Some(HintInfo(strategy = Some(SHUFFLE_REPLICATE_NL))),
+          None) :: Nil)
+
+        val commandResultExec = getCommandResultExec(df)
+        assert(commandResultExec.commandPhysicalPlan.isInstanceOf[ReplaceDataExec])
+        val replaceDataExec = commandResultExec.commandPhysicalPlan.asInstanceOf[ReplaceDataExec]
+        verifyCartesianProductExec(replaceDataExec.query, 0)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString"),
+          Seq(
+            Row(2, -1, "hr", "initial-text"),
+            Row(3, -1, "hr", "initial-text")))
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to make MERGE INTO/UPDATE/DELETE support join hint.


### Why are the changes needed?
This feature request aims to enhance Spark SQL by adding support for join hints in `MERGE INTO`, `UPDATE`, and `DELETE` operations. Join hints can help optimize query execution by providing the Spark SQL engine with additional information about how to perform joins more efficiently. This improvement will allow users to specify join strategies (e.g., broadcast, shuffle) directly within these operations, leading to potentially significant performance gains in large-scale data processing scenarios.


### Does this PR introduce _any_ user-facing change?
'No'.
Just inner change.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
