### PR TITLE
[SPARK-53728][SDP] Print PipelineEvent Message with Error In Test

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSender.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelineEventSender.scala
@@ -158,18 +158,6 @@ class PipelineEventSender(
   }
 
   private def constructProtoEvent(event: PipelineEvent): proto.PipelineEvent = {
-    val message = if (event.error.nonEmpty) {
-      // Returns the message associated with a Throwable and all its causes
-      def getExceptionMessages(throwable: Throwable): Seq[String] = {
-        throwable.getMessage +:
-          Option(throwable.getCause).map(getExceptionMessages).getOrElse(Nil)
-      }
-      val errorMessages = getExceptionMessages(event.error.get)
-      s"""${event.message}
-         |Error: ${errorMessages.mkString("\n")}""".stripMargin
-    } else {
-      event.message
-    }
     val protoEventBuilder = proto.PipelineEvent
       .newBuilder()
       .setTimestamp(
@@ -182,7 +170,7 @@ class PipelineEventSender(
           .setSeconds(event.timestamp.getTime / 1000)
           .setNanos(event.timestamp.getNanos)
           .build())
-      .setMessage(message)
+      .setMessage(event.messageWithError)
     protoEventBuilder.build()
   }
 }

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/logging/PipelineEvent.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/logging/PipelineEvent.scala
@@ -39,7 +39,23 @@ case class PipelineEvent(
     message: String,
     details: EventDetails,
     error: Option[Throwable]
-)
+) {
+  /** Combines the message and error (if any) into a single string */
+  def messageWithError: String = {
+    if (error.nonEmpty) {
+      // Returns the message associated with a Throwable and all its causes
+      def getExceptionMessages(throwable: Throwable): Seq[String] = {
+        throwable.getMessage +:
+          Option(throwable.getCause).map(getExceptionMessages).getOrElse(Nil)
+      }
+      val errorMessages = getExceptionMessages(error.get)
+      s"""${message}
+         |Error: ${errorMessages.mkString("\n")}""".stripMargin
+    } else {
+      message
+    }
+  }
+}
 
 /**
  * Describes where the event originated from

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/ExecutionTest.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/ExecutionTest.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.pipelines.utils
 
+import org.scalatest.Assertions.fail
+
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.pipelines.common.{FlowStatus, RunState}
@@ -51,13 +53,15 @@ trait TestPipelineUpdateContextMixin {
    * @param fullRefreshTables Set of tables to be fully refreshed.
    * @param refreshTables  Set of tables to be refreshed.
    * @param resetCheckpointFlows Set of flows to be reset.
+   * @param failOnErrorEvent Whether to fail test when receiving event with error.
    */
   case class TestPipelineUpdateContext(
       spark: SparkSession,
       unresolvedGraph: DataflowGraph,
       fullRefreshTables: TableFilter = NoTables,
       refreshTables: TableFilter = AllTables,
-      resetCheckpointFlows: FlowFilter = AllFlows
+      resetCheckpointFlows: FlowFilter = AllFlows,
+      failOnErrorEvent: Boolean = false
   ) extends PipelineUpdateContext {
     val eventBuffer = new PipelineRunEventBuffer()
 
@@ -72,6 +76,9 @@ trait TestPipelineUpdateContextMixin {
         println(event.messageWithError)
         println("=================================")
         // scalastyle:on println
+        if (failOnErrorEvent) {
+          fail(s"Pipeline event with error received: ${event.messageWithError}")
+        }
       }
     }
 

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/ExecutionTest.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/ExecutionTest.scala
@@ -61,7 +61,19 @@ trait TestPipelineUpdateContextMixin {
   ) extends PipelineUpdateContext {
     val eventBuffer = new PipelineRunEventBuffer()
 
-    override val eventCallback: PipelineEvent => Unit = eventBuffer.addEvent
+    override val eventCallback: PipelineEvent => Unit = { event =>
+      eventBuffer.addEvent(event)
+      // For debugging purposes, print the event to the console.
+      // Most tests expects pipeline to succeed, this makes it easier to see
+      // the error when it happens.
+      if (event.error.nonEmpty) {
+        // scalastyle:off println
+        println("\n=== Received Pipeline Event with Error ===")
+        println(event.messageWithError)
+        println("=================================")
+        // scalastyle:on println
+      }
+    }
 
     override def flowProgressEventLogger: FlowProgressEventLogger = {
       new FlowProgressEventLogger(eventCallback = eventCallback)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Pulling some changes from #51644 
For debugging purposes, print PipelineEvent with error to the console. Most tests expects pipeline to succeed, this makes it easier to see the error when it happens. Otherwise, developers have to manually add println to print the error message contained in the event, which is cumbersome.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Easier to debug test failures, avoid the need to manually add println for test failures.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No