### PR TITLE
[SPARK-53729][PYTHON][CONNECT] Fix serialization of `pyspark.sql.connect.window.WindowSpec`

### DIFF
--- a/python/pyspark/sql/connect/window.py
+++ b/python/pyspark/sql/connect/window.py
@@ -69,6 +69,9 @@ class WindowSpec(ParentWindowSpec):
         self.__init__(partitionSpec, orderSpec, frame)  # type: ignore[misc]
         return self
 
+    def __getnewargs__(self):
+        return (self._partitionSpec, self._orderSpec, self._frame)
+
     def __init__(
         self,
         partitionSpec: Sequence[Expression],

--- a/python/pyspark/sql/connect/window.py
+++ b/python/pyspark/sql/connect/window.py
@@ -18,7 +18,7 @@ from pyspark.sql.connect.utils import check_dependencies
 
 check_dependencies(__name__)
 
-from typing import TYPE_CHECKING, Union, Sequence, List, Optional, Tuple, cast, Iterable
+from typing import TYPE_CHECKING, Any, Union, Sequence, List, Optional, Tuple, cast, Iterable
 
 from pyspark.sql.column import Column
 from pyspark.sql.window import (
@@ -69,7 +69,7 @@ class WindowSpec(ParentWindowSpec):
         self.__init__(partitionSpec, orderSpec, frame)  # type: ignore[misc]
         return self
 
-    def __getnewargs__(self):
+    def __getnewargs__(self) -> Tuple[Any, ...]:
         return (self._partitionSpec, self._orderSpec, self._frame)
 
     def __init__(

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -136,7 +136,7 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         self.assertEqual(cdf.collect(), cdf2.collect())
 
     def test_window_spec_serialization(self):
-        from pyspark.sql.connect.window import Window, WindowSpec
+        from pyspark.sql.connect.window import Window
         from pyspark.serializers import CPickleSerializer
 
         pickle_ser = CPickleSerializer()

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -135,6 +135,16 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         cdf2 = loads(data)
         self.assertEqual(cdf.collect(), cdf2.collect())
 
+    def test_window_spec_serialization(self):
+        from pyspark.sql.connect.window import Window, WindowSpec
+        from pyspark.serializers import CPickleSerializer
+
+        pickle_ser = CPickleSerializer()
+        w = Window.partitionBy("some_string").orderBy("value")
+        b = pickle_ser.dumps(w)
+        w2 = pickle_ser.loads(b)
+        self.assertEqual(str(w), str(w2))
+
     def test_df_getattr_behavior(self):
         cdf = self.connect.range(10)
         sdf = self.spark.range(10)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix serialization of `pyspark.sql.connect.window.WindowSpec`


### Why are the changes needed?
this query fails
```
from pyspark.sql import Window, WindowSpec
from pyspark.sql.functions import *

df = ( spark.readStream.format("rate-micro-batch")
        .option("rowsPerBatch", 1000)
        .option("numPartitions", 2)
        .load()
        .withColumn("some_string",lit("apples")) )
        

window_spec = Window.partitionBy("some_string").orderBy("value")

def get_calculate_row_number_in_batch(window_spec):
    def calculate_row_number_in_batch(df, batch_id):
        df.withColumn("row_number", row_number().over(window_spec)).show()
    return calculate_row_number_in_batch


(df.writeStream
 .queryName('streaming_query')
 .foreachBatch(get_calculate_row_number_in_batch(window_spec))
 .trigger(processingTime='30 seconds')
 .start()
 )
```

due to
```
TypeError: WindowSpec.__new__() missing 3 required positional arguments: 'partitionSpec', 'orderSpec', and 'frame'
```

### Does this PR introduce _any_ user-facing change?
bug-fix


### How was this patch tested?
added test, and also manually checked above-mentioned query

### Was this patch authored or co-authored using generative AI tooling?
no
