### PR TITLE
[SPARK-53737][SQL][SS] Add Real-time Mode trigger

### DIFF
--- a/sql/api/src/main/java/org/apache/spark/sql/streaming/Trigger.java
+++ b/sql/api/src/main/java/org/apache/spark/sql/streaming/Trigger.java
@@ -22,10 +22,12 @@ import java.util.concurrent.TimeUnit;
 import scala.concurrent.duration.Duration;
 
 import org.apache.spark.annotation.Evolving;
+import org.apache.spark.annotation.Experimental;
 import org.apache.spark.sql.execution.streaming.AvailableNowTrigger$;
 import org.apache.spark.sql.execution.streaming.ContinuousTrigger;
 import org.apache.spark.sql.execution.streaming.OneTimeTrigger$;
 import org.apache.spark.sql.execution.streaming.ProcessingTimeTrigger;
+import org.apache.spark.sql.execution.streaming.RealTimeTrigger;
 
 /**
  * Policy used to indicate how often results should be produced by a [[StreamingQuery]].
@@ -175,5 +177,57 @@ public class Trigger {
    */
   public static Trigger Continuous(String interval) {
     return ContinuousTrigger.apply(interval);
+  }
+
+  /**
+   * A trigger for real time mode, with batch at the specified duration.
+   *
+   */
+  @Experimental
+  public static Trigger RealTime(long batchDurationMs) {
+    return RealTimeTrigger.apply(batchDurationMs);
+  }
+
+  /**
+   * A trigger for real time mode, with batch at the specified duration.
+   *
+   */
+  @Experimental
+  public static Trigger RealTime(long batchDuration, TimeUnit timeUnit) {
+    return RealTimeTrigger.create(batchDuration, timeUnit);
+  }
+
+  /**
+   * A trigger for real time mode, with batch at the specified duration.
+   *
+   * {{{
+   *    import scala.concurrent.duration._
+   *    df.writeStream.trigger(Trigger.RealTime(10.seconds))
+   * }}}
+   */
+  @Experimental
+  public static Trigger RealTime(Duration batchDuration) {
+    return RealTimeTrigger.apply(batchDuration);
+  }
+
+  /**
+   * A trigger for real time mode, with batch at the specified duration.
+   *
+   * {{{
+   *    df.writeStream.trigger(Trigger.RealTime("10 seconds"))
+   * }}}
+   */
+  @Experimental
+  public static Trigger RealTime(String batchDuration) {
+    return RealTimeTrigger.apply(batchDuration);
+  }
+
+  /**
+   * A trigger for real time mode, with batch at the specified duration. The default duration is 5
+   * minutes.
+   */
+  @Experimental
+  public static Trigger RealTime() {
+    return RealTimeTrigger.apply();
   }
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/execution/streaming/Triggers.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/execution/streaming/Triggers.scala
@@ -19,9 +19,12 @@ package org.apache.spark.sql.execution.streaming
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{Duration, MINUTES}
+
+import org.json4s.DefaultFormats
 
 import org.apache.spark.SparkIllegalArgumentException
+import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.catalyst.util.DateTimeConstants.MICROS_PER_DAY
 import org.apache.spark.sql.catalyst.util.SparkDateTimeUtils.microsToMillis
 import org.apache.spark.sql.catalyst.util.SparkIntervalUtils
@@ -112,5 +115,42 @@ object ContinuousTrigger {
 
   def create(interval: Long, unit: TimeUnit): ContinuousTrigger = {
     ContinuousTrigger(convert(interval, unit))
+  }
+}
+
+/**
+ * A [[Trigger]] that runs a query in real time mode.
+ * @param batchDurationMs
+ *   The duration of each batch in milliseconds. This must be strictly positive.
+ */
+@Experimental
+case class RealTimeTrigger(batchDurationMs: Long) extends Trigger {
+  require(batchDurationMs > 0, "the batch duration should not be negative")
+
+  implicit val defaultFormats: DefaultFormats = DefaultFormats
+}
+
+@Experimental
+object RealTimeTrigger {
+  import Triggers._
+
+  def apply(): RealTimeTrigger = {
+    RealTimeTrigger(Duration(5, MINUTES))
+  }
+
+  def apply(batchDuration: String): RealTimeTrigger = {
+    RealTimeTrigger(convert(batchDuration))
+  }
+
+  def apply(batchDuration: Duration): RealTimeTrigger = {
+    RealTimeTrigger(convert(batchDuration))
+  }
+
+  def create(batchDuration: String): RealTimeTrigger = {
+    apply(batchDuration)
+  }
+
+  def create(batchDuration: Long, unit: TimeUnit): RealTimeTrigger = {
+    RealTimeTrigger(convert(batchDuration, unit))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeSuite.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.streaming
+
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.Duration
+
+import org.apache.spark.sql.execution.streaming.RealTimeTrigger
+
+class StreamRealTimeModeSuite extends StreamTest {
+
+  test("test trigger") {
+    def testTrigger(trigger: Trigger, actual: Long): Unit = {
+      val realTimeTrigger = trigger.asInstanceOf[RealTimeTrigger]
+      assert(
+        realTimeTrigger.batchDurationMs == actual,
+        s"Real time trigger duration should be ${actual} ms" +
+          s" but got ${realTimeTrigger.batchDurationMs} ms"
+      )
+    }
+
+    // test default
+    testTrigger(Trigger.RealTime(), 300000)
+
+    testTrigger(Trigger.RealTime("1 second"), 1000)
+    testTrigger(Trigger.RealTime("1 minute"), 60000)
+    testTrigger(Trigger.RealTime("1 hour"), 3600000)
+    testTrigger(Trigger.RealTime("1 day"), 86400000)
+    testTrigger(Trigger.RealTime("1 week"), 604800000)
+
+    testTrigger(Trigger.RealTime(1000), 1000)
+    testTrigger(Trigger.RealTime(60000), 60000)
+    testTrigger(Trigger.RealTime(3600000), 3600000)
+    testTrigger(Trigger.RealTime(86400000), 86400000)
+    testTrigger(Trigger.RealTime(604800000), 604800000)
+
+    testTrigger(Trigger.RealTime(Duration.apply(1000, "ms")), 1000)
+    testTrigger(Trigger.RealTime(Duration.apply(60, "s")), 60000)
+    testTrigger(Trigger.RealTime(Duration.apply(1, "h")), 3600000)
+    testTrigger(Trigger.RealTime(Duration.apply(1, "d")), 86400000)
+
+    testTrigger(Trigger.RealTime(1000, TimeUnit.MILLISECONDS), 1000)
+    testTrigger(Trigger.RealTime(60, TimeUnit.SECONDS), 60000)
+    testTrigger(Trigger.RealTime(1, TimeUnit.HOURS), 3600000)
+    testTrigger(Trigger.RealTime(1, TimeUnit.DAYS), 86400000)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeSuite.scala
@@ -31,33 +31,71 @@ class StreamRealTimeModeSuite extends StreamTest {
       assert(
         realTimeTrigger.batchDurationMs == actual,
         s"Real time trigger duration should be ${actual} ms" +
-          s" but got ${realTimeTrigger.batchDurationMs} ms"
+        s" but got ${realTimeTrigger.batchDurationMs} ms"
       )
     }
 
     // test default
     testTrigger(Trigger.RealTime(), 300000)
 
-    testTrigger(Trigger.RealTime("1 second"), 1000)
-    testTrigger(Trigger.RealTime("1 minute"), 60000)
-    testTrigger(Trigger.RealTime("1 hour"), 3600000)
-    testTrigger(Trigger.RealTime("1 day"), 86400000)
-    testTrigger(Trigger.RealTime("1 week"), 604800000)
+    List(
+      ("1 second", 1000),
+      ("1 minute", 60000),
+      ("1 hour", 3600000),
+      ("1 day", 86400000),
+      ("1 week", 604800000)
+    ).foreach {
+      case (str, ms) =>
+        testTrigger(Trigger.RealTime(str), ms)
+        testTrigger(RealTimeTrigger(str), ms)
+        testTrigger(RealTimeTrigger.create(str), ms)
 
-    testTrigger(Trigger.RealTime(1000), 1000)
-    testTrigger(Trigger.RealTime(60000), 60000)
-    testTrigger(Trigger.RealTime(3600000), 3600000)
-    testTrigger(Trigger.RealTime(86400000), 86400000)
-    testTrigger(Trigger.RealTime(604800000), 604800000)
+    }
 
-    testTrigger(Trigger.RealTime(Duration.apply(1000, "ms")), 1000)
-    testTrigger(Trigger.RealTime(Duration.apply(60, "s")), 60000)
-    testTrigger(Trigger.RealTime(Duration.apply(1, "h")), 3600000)
-    testTrigger(Trigger.RealTime(Duration.apply(1, "d")), 86400000)
+    List(1000, 60000, 3600000, 86400000, 604800000).foreach { ms =>
+      testTrigger(Trigger.RealTime(ms), ms)
+      testTrigger(RealTimeTrigger(ms), ms)
+      testTrigger(new RealTimeTrigger(ms), ms)
+    }
 
-    testTrigger(Trigger.RealTime(1000, TimeUnit.MILLISECONDS), 1000)
-    testTrigger(Trigger.RealTime(60, TimeUnit.SECONDS), 60000)
-    testTrigger(Trigger.RealTime(1, TimeUnit.HOURS), 3600000)
-    testTrigger(Trigger.RealTime(1, TimeUnit.DAYS), 86400000)
+    List(
+      (Duration.apply(1000, "ms"), 1000),
+      (Duration.apply(60, "s"), 60000),
+      (Duration.apply(1, "h"), 3600000),
+      (Duration.apply(1, "d"), 86400000)
+    ).foreach {
+      case (duration, ms) =>
+        testTrigger(Trigger.RealTime(duration), ms)
+        testTrigger(RealTimeTrigger(duration), ms)
+        testTrigger(RealTimeTrigger(duration), ms)
+    }
+
+    List(
+      (1000, TimeUnit.MILLISECONDS, 1000),
+      (60, TimeUnit.SECONDS, 60000),
+      (1, TimeUnit.HOURS, 3600000),
+      (1, TimeUnit.DAYS, 86400000)
+    ).foreach {
+      case (interval, unit, ms) =>
+        testTrigger(Trigger.RealTime(interval, unit), ms)
+        testTrigger(RealTimeTrigger(interval, unit), ms)
+        testTrigger(RealTimeTrigger.create(interval, unit), ms)
+    }
+    // test invalid
+    List("-1", "0").foreach(
+      str =>
+        intercept[IllegalArgumentException] {
+          testTrigger(Trigger.RealTime(str), -1)
+          testTrigger(RealTimeTrigger.create(str), -1)
+        }
+    )
+
+    List(-1, 0).foreach(
+      duration =>
+        intercept[IllegalArgumentException] {
+          testTrigger(Trigger.RealTime(duration), -1)
+          testTrigger(RealTimeTrigger(duration), -1)
+        }
+    )
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Introduce a new trigger type for Real-time Mode (RTM) in Structured Streaming.  This new trigger will be how users enable their Structured Streaming query to run in Real-time Mode.

Please note this PR just adds the trigger.  Users cannot yet run queries in Real-time Mode. Other functionality will come in later PRs. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This serves as the first PR to add Real-time mode to Structured Streaming.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, it adds a new trigger type to Structured Streaming.  This change does not effect or change any existing behaviors.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Unit test added.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
