### PR TITLE
Revert "[SPARK-53015][BUILD] Upgrade log4j to 2.25.1"

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -186,11 +186,11 @@ leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.16.0//libthrift-0.16.0.jar
 listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
-log4j-1.2-api/2.25.1//log4j-1.2-api-2.25.1.jar
-log4j-api/2.25.1//log4j-api-2.25.1.jar
-log4j-core/2.25.1//log4j-core-2.25.1.jar
-log4j-layout-template-json/2.25.1//log4j-layout-template-json-2.25.1.jar
-log4j-slf4j2-impl/2.25.1//log4j-slf4j2-impl-2.25.1.jar
+log4j-1.2-api/2.24.3//log4j-1.2-api-2.24.3.jar
+log4j-api/2.24.3//log4j-api-2.24.3.jar
+log4j-core/2.24.3//log4j-core-2.24.3.jar
+log4j-layout-template-json/2.24.3//log4j-layout-template-json-2.24.3.jar
+log4j-slf4j2-impl/2.24.3//log4j-slf4j2-impl-2.24.3.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 metrics-core/4.2.33//metrics-core-4.2.33.jar
 metrics-graphite/4.2.33//metrics-graphite-4.2.33.jar

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.8</asm.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <log4j.version>2.25.1</log4j.version>
+    <log4j.version>2.24.3</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.4.2</hadoop.version>
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->


### PR DESCRIPTION
This reverts commit 594d26cef8141fbcaefe6251d71c226946a2adb9.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
I observed an issue in CI that is likely related to this upgrade.

The failure links:
- https://github.com/pan3793/spark/actions/runs/18053335957/job/51379055871
- https://github.com/pan3793/spark/actions/runs/18055074525/job/51383753172

```
2025-09-27T02:32:39.571797348Z spark-listener-group-shared ERROR An exception occurred processing Appender File
java.lang.NullPointerException: Cannot read field "stackLength" because "metadata" is null
	at org.apache.logging.log4j.core.pattern.ThrowableStackTraceRenderer.renderStackTraceElements(ThrowableStackTraceRenderer.java:168)
	at org.apache.logging.log4j.core.pattern.ThrowableStackTraceRenderer.renderThrowable(ThrowableStackTraceRenderer.java:110)
	at org.apache.logging.log4j.core.pattern.ThrowableStackTraceRenderer.renderThrowable(ThrowableStackTraceRenderer.java:87)
	at org.apache.logging.log4j.core.pattern.ThrowableStackTraceRenderer.renderThrowable(ThrowableStackTraceRenderer.java:59)
	at org.apache.logging.log4j.core.pattern.ThrowablePatternConverter.format(ThrowablePatternConverter.java:130)
	at org.apache.logging.log4j.core.layout.PatternLayout$NoFormatPatternSerializer.toSerializable(PatternLayout.java:354)
	at org.apache.logging.log4j.core.layout.PatternLayout.toText(PatternLayout.java:251)
	...
```

Related issue reports on the log4j repo

- https://github.com/apache/logging-log4j2/issues/3929
- https://github.com/apache/logging-log4j2/issues/3933

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Revert a problematic dependency upgrade.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass GHA.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.