### PR TITLE
[SPARK-53673][CONNECT][TESTS][3.5] Fix a flaky test failure in `SparkSessionE2ESuite - interrupt tag` caused by the usage of `ForkJoinPool`

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/SparkSessionE2ESuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/SparkSessionE2ESuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql
 
-import java.util.concurrent.ForkJoinPool
+import java.util.concurrent.Executors
 
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
@@ -116,7 +116,7 @@ class SparkSessionE2ESuite extends RemoteSparkSession {
     // global ExecutionContext has only 2 threads in Apache Spark CI
     // create own thread pool for four Futures used in this test
     val numThreads = 4
-    val fpool = new ForkJoinPool(numThreads)
+    val fpool = Executors.newFixedThreadPool(numThreads)
     val executionContext = ExecutionContext.fromExecutorService(fpool)
 
     val q1 = Future {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR backports #52417 to `branch-3.5`.

Different from `master` and `branch-4.0`, the SPARK-53673 doesn't seem to affect the `branch-3.5` at this time because the implementation of `ClientCalls#waitForNext` in `gRPC 1.56.0` which `branch-3.5` depends on is different from the one in `gRPC 1.67.1` which `master` and `branch-4.0` depend on.
More specifically,  the test doesn't go through the pass which calls `ArrayBlockingQueue#take` but go through [this else block](https://github.com/grpc/grpc-java/blob/v1.56.0/stub/src/main/java/io/grpc/stub/ClientCalls.java#L634).
But I think it's better to backport #52417 to `branch-3.5` to prevent future changes from causing that issue.

### Why are the changes needed?
Just in case to prevent future changes from causing that issue.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
1.  Temporarily enable the test and insert a sleep into the test like as follows

```
   // TODO(SPARK-48139): Re-enable `SparkSessionE2ESuite.interrupt tag`
-  ignore("interrupt tag") {
+  test("interrupt tag") {
     val session = spark
     import session.implicits._
 
@@ -204,6 +204,7 @@ class SparkSessionE2ESuite extends ConnectFunSuite with RemoteSparkSession {
         spark.clearTags() // clear for the case of thread reuse by another Future
       }
     }(executionContext)
+    Thread.sleep(1000)
     val q4 = Future {
       assert(spark.getTags() == Set())
       spark.addTag("one")
```

2. Run the test and confirm it passes
```
$ build/sbt 'connect-client-jvm/testOnly org.apache.spark.sql.SparkSessionE2ESuite -- -z "interrupt tag"'
```


### Was this patch authored or co-authored using generative AI tooling?
No.
