### PR TITLE
[SPARK-53741][BUILD] Upgrade ORC to 2.2.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -232,10 +232,10 @@ opencsv/2.3//opencsv-2.3.jar
 opentracing-api/0.33.0//opentracing-api-0.33.0.jar
 opentracing-noop/0.33.0//opentracing-noop-0.33.0.jar
 opentracing-util/0.33.0//opentracing-util-0.33.0.jar
-orc-core/2.2.0/shaded-protobuf/orc-core-2.2.0-shaded-protobuf.jar
+orc-core/2.2.1/shaded-protobuf/orc-core-2.2.1-shaded-protobuf.jar
 orc-format/1.1.1/shaded-protobuf/orc-format-1.1.1-shaded-protobuf.jar
-orc-mapreduce/2.2.0/shaded-protobuf/orc-mapreduce-2.2.0-shaded-protobuf.jar
-orc-shims/2.2.0//orc-shims-2.2.0.jar
+orc-mapreduce/2.2.1/shaded-protobuf/orc-mapreduce-2.2.1-shaded-protobuf.jar
+orc-shims/2.2.1//orc-shims-2.2.1.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8.3//paranamer-2.8.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -382,10 +382,6 @@
         <enabled>false</enabled>
       </snapshots>
     </repository>
-    <repository>
-      <id>orc</id>
-      <url>https://repository.apache.org/content/repositories/orgapacheorc-1104/</url>
-    </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <!-- After 10.17.1.0, the minimum required version is JDK19 -->
     <derby.version>10.16.1.1</derby.version>
     <parquet.version>1.16.0</parquet.version>
-    <orc.version>2.2.0</orc.version>
+    <orc.version>2.2.1</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
     <jetty.version>11.0.26</jetty.version>
     <jakartaservlet.version>5.0.0</jakartaservlet.version>
@@ -381,6 +381,10 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
+    </repository>
+    <repository>
+      <id>orc</id>
+      <url>https://repository.apache.org/content/repositories/orgapacheorc-1104/</url>
     </repository>
   </repositories>
   <pluginRepositories>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -305,7 +305,6 @@ object SparkBuild extends PomBuild {
       "gcs-maven-central-mirror" at "https://maven-central.storage-download.googleapis.com/maven2/",
       DefaultMavenRepository,
       Resolver.mavenLocal,
-      "orc" at "https://repository.apache.org/content/repositories/orgapacheorc-1104/",
       Resolver.file("ivyLocal", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns)
     ),
     externalResolvers := resolvers.value,

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -305,6 +305,7 @@ object SparkBuild extends PomBuild {
       "gcs-maven-central-mirror" at "https://maven-central.storage-download.googleapis.com/maven2/",
       DefaultMavenRepository,
       Resolver.mavenLocal,
+      "orc" at "https://repository.apache.org/content/repositories/orgapacheorc-1104/",
       Resolver.file("ivyLocal", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns)
     ),
     externalResolvers := resolvers.value,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade ORC to 2.2.1.

### Why are the changes needed?

To bring the latest bug fix version. Although we upgraded ORC Format independently, ORC 2.2.1 is the first official version with ORC Format 1.1.1.
- https://orc.apache.org/news/2025/10/01/ORC-2.2.1/
- https://github.com/apache/orc/milestone/51?closed=1
  - https://github.com/apache/orc/pull/2355

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.