### PR TITLE
[SPARK-53593][SDP] Fix: Use unquoted for response fields

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/identifiers.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/identifiers.scala
@@ -36,17 +36,17 @@ sealed trait CatalystIdentifier {
    */
   private def quoteIdentifier(name: String): String = name.replace("`", "``")
 
-  def resolvedId: String = quoteIdentifier(identifier)
-  def resolvedDb: Option[String] = database.map(quoteIdentifier)
-  def resolvedCatalog: Option[String] = catalog.map(quoteIdentifier)
-
   def quotedString: String = {
-    if (resolvedCatalog.isDefined && resolvedDb.isDefined) {
-      s"`${resolvedCatalog.get}`.`${resolvedDb.get}`.`$resolvedId`"
-    } else if (resolvedDb.isDefined) {
-      s"`${resolvedDb.get}`.`$resolvedId`"
+    val replacedId = quoteIdentifier(identifier)
+    val replacedDb = database.map(quoteIdentifier)
+    val replacedCatalog = catalog.map(quoteIdentifier)
+
+    if (replacedCatalog.isDefined && replacedDb.isDefined) {
+      s"`${replacedCatalog.get}`.`${replacedDb.get}`.`$replacedId`"
+    } else if (replacedDb.isDefined) {
+      s"`${replacedDb.get}`.`$replacedId`"
     } else {
-      s"`$resolvedId`"
+      s"`$replacedId`"
     }
   }
 

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
@@ -84,11 +84,11 @@ private[connect] object PipelinesHandler extends Logging {
         val resolvedDataset =
           defineDataset(cmd.getDefineDataset, sessionHolder)
         val identifierBuilder = ResolvedIdentifier.newBuilder()
-        resolvedDataset.resolvedCatalog.foreach(identifierBuilder.setCatalogName)
-        resolvedDataset.resolvedDb.foreach { ns =>
+        resolvedDataset.catalog.foreach(identifierBuilder.setCatalogName)
+        resolvedDataset.database.foreach { ns =>
           identifierBuilder.addNamespace(ns)
         }
-        identifierBuilder.setTableName(resolvedDataset.resolvedId)
+        identifierBuilder.setTableName(resolvedDataset.identifier)
         val identifier = identifierBuilder.build()
         PipelineCommandResult
           .newBuilder()
@@ -103,11 +103,11 @@ private[connect] object PipelinesHandler extends Logging {
         val resolvedFlow =
           defineFlow(cmd.getDefineFlow, transformRelationFunc, sessionHolder)
         val identifierBuilder = ResolvedIdentifier.newBuilder()
-        resolvedFlow.resolvedCatalog.foreach(identifierBuilder.setCatalogName)
-        resolvedFlow.resolvedDb.foreach { ns =>
+        resolvedFlow.catalog.foreach(identifierBuilder.setCatalogName)
+        resolvedFlow.database.foreach { ns =>
           identifierBuilder.addNamespace(ns)
         }
-        identifierBuilder.setTableName(resolvedFlow.resolvedId)
+        identifierBuilder.setTableName(resolvedFlow.identifier)
         val identifier = identifierBuilder.build()
         PipelineCommandResult
           .newBuilder()

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerSuite.scala
@@ -495,6 +495,7 @@ class SparkDeclarativePipelinesServerSuite
       datasetName: String,
       defaultCatalog: String = "",
       defaultDatabase: String = "",
+      expectedResolvedDatasetName: String,
       expectedResolvedCatalog: String,
       expectedResolvedNamespace: Seq[String])
 
@@ -503,18 +504,21 @@ class SparkDeclarativePipelinesServerSuite
       name = "TEMPORARY_VIEW",
       datasetType = DatasetType.TEMPORARY_VIEW,
       datasetName = "tv",
+      expectedResolvedDatasetName = "tv",
       expectedResolvedCatalog = "",
       expectedResolvedNamespace = Seq.empty),
     DefineDatasetTestCase(
       name = "TABLE",
       datasetType = DatasetType.TABLE,
-      datasetName = "tb",
+      datasetName = "`tb`",
+      expectedResolvedDatasetName = "tb",
       expectedResolvedCatalog = "spark_catalog",
       expectedResolvedNamespace = Seq("default")),
     DefineDatasetTestCase(
       name = "MV",
       datasetType = DatasetType.MATERIALIZED_VIEW,
       datasetName = "mv",
+      expectedResolvedDatasetName = "mv",
       expectedResolvedCatalog = "spark_catalog",
       expectedResolvedNamespace = Seq("default"))).map(tc => tc.name -> tc).toMap
 
@@ -525,22 +529,25 @@ class SparkDeclarativePipelinesServerSuite
       datasetName = "tv",
       defaultCatalog = "custom_catalog",
       defaultDatabase = "custom_db",
+      expectedResolvedDatasetName = "tv",
       expectedResolvedCatalog = "",
       expectedResolvedNamespace = Seq.empty),
     DefineDatasetTestCase(
       name = "TABLE",
       datasetType = DatasetType.TABLE,
-      datasetName = "tb",
-      defaultCatalog = "my_catalog",
-      defaultDatabase = "my_db",
-      expectedResolvedCatalog = "my_catalog",
-      expectedResolvedNamespace = Seq("my_db")),
+      datasetName = "`tb`",
+      defaultCatalog = "`my_catalog`",
+      defaultDatabase = "`my_db`",
+      expectedResolvedDatasetName = "tb",
+      expectedResolvedCatalog = "`my_catalog`",
+      expectedResolvedNamespace = Seq("`my_db`")),
     DefineDatasetTestCase(
       name = "MV",
       datasetType = DatasetType.MATERIALIZED_VIEW,
       datasetName = "mv",
       defaultCatalog = "another_catalog",
       defaultDatabase = "another_db",
+      expectedResolvedDatasetName = "mv",
       expectedResolvedCatalog = "another_catalog",
       expectedResolvedNamespace = Seq("another_db")))
     .map(tc => tc.name -> tc)
@@ -571,7 +578,7 @@ class SparkDeclarativePipelinesServerSuite
 
       assert(identifier.getCatalogName == testCase.expectedResolvedCatalog)
       assert(identifier.getNamespaceList.asScala == testCase.expectedResolvedNamespace)
-      assert(identifier.getTableName == testCase.datasetName)
+      assert(identifier.getTableName == testCase.expectedResolvedDatasetName)
     }
   }
 
@@ -608,7 +615,7 @@ class SparkDeclarativePipelinesServerSuite
 
       assert(identifier.getCatalogName == testCase.expectedResolvedCatalog)
       assert(identifier.getNamespaceList.asScala == testCase.expectedResolvedNamespace)
-      assert(identifier.getTableName == testCase.datasetName)
+      assert(identifier.getTableName == testCase.expectedResolvedDatasetName)
     }
   }
 
@@ -618,6 +625,7 @@ class SparkDeclarativePipelinesServerSuite
       flowName: String,
       defaultCatalog: String,
       defaultDatabase: String,
+      expectedResolvedFlowName: String,
       expectedResolvedCatalog: String,
       expectedResolvedNamespace: Seq[String])
 
@@ -625,9 +633,10 @@ class SparkDeclarativePipelinesServerSuite
     DefineFlowTestCase(
       name = "MV",
       datasetType = DatasetType.MATERIALIZED_VIEW,
-      flowName = "mv",
-      defaultCatalog = "spark_catalog",
-      defaultDatabase = "default",
+      flowName = "`mv`",
+      defaultCatalog = "`spark_catalog`",
+      defaultDatabase = "`default`",
+      expectedResolvedFlowName = "mv",
       expectedResolvedCatalog = "spark_catalog",
       expectedResolvedNamespace = Seq("default")),
     DefineFlowTestCase(
@@ -636,6 +645,7 @@ class SparkDeclarativePipelinesServerSuite
       flowName = "tv",
       defaultCatalog = "spark_catalog",
       defaultDatabase = "default",
+      expectedResolvedFlowName = "tv",
       expectedResolvedCatalog = "",
       expectedResolvedNamespace = Seq.empty)).map(tc => tc.name -> tc).toMap
 
@@ -646,6 +656,7 @@ class SparkDeclarativePipelinesServerSuite
       flowName = "mv",
       defaultCatalog = "custom_catalog",
       defaultDatabase = "custom_db",
+      expectedResolvedFlowName = "mv",
       expectedResolvedCatalog = "custom_catalog",
       expectedResolvedNamespace = Seq("custom_db")),
     DefineFlowTestCase(
@@ -654,6 +665,7 @@ class SparkDeclarativePipelinesServerSuite
       flowName = "tv",
       defaultCatalog = "custom_catalog",
       defaultDatabase = "custom_db",
+      expectedResolvedFlowName = "tv",
       expectedResolvedCatalog = "",
       expectedResolvedNamespace = Seq.empty)).map(tc => tc.name -> tc).toMap
 
@@ -711,7 +723,7 @@ class SparkDeclarativePipelinesServerSuite
 
       assert(identifier.getCatalogName == testCase.expectedResolvedCatalog)
       assert(identifier.getNamespaceList.asScala == testCase.expectedResolvedNamespace)
-      assert(identifier.getTableName == testCase.flowName)
+      assert(identifier.getTableName == testCase.expectedResolvedFlowName)
     }
   }
 
@@ -775,7 +787,7 @@ class SparkDeclarativePipelinesServerSuite
 
       assert(identifier.getCatalogName == testCase.expectedResolvedCatalog)
       assert(identifier.getNamespaceList.asScala == testCase.expectedResolvedNamespace)
-      assert(identifier.getTableName == testCase.flowName)
+      assert(identifier.getTableName == testCase.expectedResolvedFlowName)
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR fixes the bug where quoted names were being set in the proto response fields for catalog, database, and identifier.

Changes include:
- Removing the use of quoteIdentifier when populating resolvedCatalog, resolvedDb, and resolvedId in the proto response.
- Updating the code to return the raw catalog, database, and identifier values from CatalystIdentifier instead.
- Adjusting unit tests in SparkDeclarativePipelinesServerSuite to validate that proto fields contain unquoted strings, even when names contain special characters like backticks.


### Why are the changes needed?
Quoted names are only required when constructing fully qualified string identifiers (e.g., `cat`.`db`.`table`). Proto messages keep catalog, database, and identifier as separate fields and should store the raw values. Returning quoted names in proto fields was a bug and could cause inconsistencies in client usage.

### Does this PR introduce _any_ user-facing change?
Yes. The proto responses for dataset and flow definitions will now return raw catalog, database, and identifier values instead of quoted versions. For example, a catalog named a`b will be returned as a\bin the proto field, not ``ab` .


### How was this patch tested?
Updated SparkDeclarativePipelinesServerSuite to verify that proto fields contain raw, unquoted names.


### Was this patch authored or co-authored using generative AI tooling?
No.
