### PR TITLE
Add option to skip Unix native rm explicitly

### DIFF
--- a/common/utils-java/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/utils-java/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -264,7 +264,7 @@ public class JavaUtils {
     // On Unix systems, use operating system command to run faster
     // If that does not work out, fallback to the Java IO way
     // We exclude Apple Silicon test environment due to the limited resource issues.
-    if (isUnix && filter == null && !(isMac && isTesting())) {
+    if (shouldTryUnixNativeRm()) {
       try {
         deleteRecursivelyUsingUnixNative(file);
         return;
@@ -689,6 +689,16 @@ public class JavaUtils {
    */
   public static boolean isTesting() {
     return System.getenv("SPARK_TESTING") != null || System.getProperty("spark.testing") != null;
+  }
+
+  /**
+   * Indicates whether Unix native rm binaries should be tried.
+   */
+  public static boolean shouldTryUnixNativeRm() {
+    Boolean shouldSkipUnixNativeRm = Boolean.parseBoolean(
+      System.getProperty("spark.skipUnixNativeRm", "false")
+    );
+    return isUnix && filter == null && !(shouldSkipUnixNativeRm) && !(isMac && isTesting());
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Added a new configuration property, `spark.skipUnixNativeRm`, to explicitly skip trying the Unix rm binary
- Grouped boolean conditions for skipping the native rm binary into a helper, `shouldTryUnixNativeRm`

### Why are the changes needed?
In some Unix setups such as when using minimal containers, the `rm` binary is not available. Receiving an error message every time a call to `deleteRecursively()` is made is confusing and noisy, even with the presence of the warning message. Making calls to an nonexistent binary also has a slight performance impact.

As an application maintainer, I would like to be able to avoid this situation when I know my setup will never have the `rm` Unix binary.

### Does this PR introduce _any_ user-facing change?
- When a user sets the `spark.skipUnixNativeRm` property, `deleteRecursivelyUsingUnixNative` in `deleteRecursively` is never called.

### How was this patch tested?
No unit tests exist for this specific class, and change is minor enough that I do not consider it worth the risk to add unit tests to the file, especially given my limited knowledge of Spark and the intended behaviour of that file, including potentially unexpected side-effects.

### Was this patch authored or co-authored using generative AI tooling?
No
