### PR TITLE
[SPARK-53764][SQL] Collapse nested get_json_object

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.codegen.Block.BlockHelper
 import org.apache.spark.sql.catalyst.expressions.json.{GetJsonObjectEvaluator, JsonExpressionUtils, JsonToStructsEvaluator, JsonTupleEvaluator, SchemaOfJsonEvaluator, StructsToJsonEvaluator}
 import org.apache.spark.sql.catalyst.expressions.objects.{Invoke, StaticInvoke}
 import org.apache.spark.sql.catalyst.json._
-import org.apache.spark.sql.catalyst.trees.TreePattern.{JSON_TO_STRUCT, RUNTIME_REPLACEABLE, TreePattern}
+import org.apache.spark.sql.catalyst.trees.TreePattern.{GET_JSON_OBJECT, JSON_TO_STRUCT, RUNTIME_REPLACEABLE, TreePattern}
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryErrorsBase}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.types.StringTypeWithCollation
@@ -61,6 +61,7 @@ case class GetJsonObject(json: Expression, path: Expression)
       StringTypeWithCollation(supportsTrimCollation = true),
       StringTypeWithCollation(supportsTrimCollation = true))
   override def nullable: Boolean = true
+  final override val nodePatterns: Seq[TreePattern] = Seq(GET_JSON_OBJECT)
   override def prettyName: String = "get_json_object"
 
   @transient

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -116,6 +116,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.expressions.ExtractSemiStructuredFields" ::
       // Catalyst Optimizer rules
       "org.apache.spark.sql.catalyst.optimizer.BooleanSimplification" ::
+      "org.apache.spark.sql.catalyst.optimizer.CollapseGetJsonObject" ::
       "org.apache.spark.sql.catalyst.optimizer.CollapseProject" ::
       "org.apache.spark.sql.catalyst.optimizer.CollapseRepartition" ::
       "org.apache.spark.sql.catalyst.optimizer.CollapseWindow" ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -49,6 +49,7 @@ object TreePattern extends Enumeration  {
   val EXTRACT_VALUE: Value = Value
   val FUNCTION_TABLE_RELATION_ARGUMENT_EXPRESSION: Value = Value
   val GENERATOR: Value = Value
+  val GET_JSON_OBJECT: Value = Value
   val GROUPING_ANALYTICS: Value = Value
   val HIGH_ORDER_FUNCTION: Value = Value
   val IF: Value = Value

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CollapseGetJsonObjectSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CollapseGetJsonObjectSuite.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.{GetJsonObject, Literal}
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.types.StringType
+
+class CollapseGetJsonObjectSuite extends PlanTest {
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("CollapseGetJsonObject", FixedPoint(10),
+        CollapseGetJsonObject) :: Nil
+  }
+
+  val testRelation = LocalRelation($"json".string)
+  val attr = testRelation.output.head
+
+  test("collapse adjacent get_json_object to one") {
+    val query = testRelation.select(
+      GetJsonObject(GetJsonObject(attr, Literal("$.a")), Literal("$.b")).as("b"))
+    val optimized = Optimize.execute(query.analyze)
+
+    val correctAnswer = testRelation.select(GetJsonObject(attr, Literal("$.a.b")).as("b"))
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("collapse multiple adjacent get_json_object to one") {
+    val query = testRelation.select(
+      GetJsonObject(
+        GetJsonObject(GetJsonObject(attr, Literal("$.a")), Literal("$.b")), Literal("$.c")).as("c"))
+    val optimized = Optimize.execute(query.analyze)
+
+    val correctAnswer = testRelation.select(GetJsonObject(attr, Literal("$.a.b.c")).as("c"))
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("collapse invalid path to null") {
+    val query = testRelation.select(
+      GetJsonObject(GetJsonObject(attr, Literal("$.a")), Literal(".b")).as("b"))
+    val optimized = Optimize.execute(query.analyze)
+
+    val correctAnswer = testRelation.select(
+      GetJsonObject(attr, Literal.create(null, StringType)).as("b"))
+
+    comparePlans(optimized, correctAnswer)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -1456,6 +1456,17 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
     checkAnswer(df, Row(null))
   }
 
+  test("function get_json_object - nested") {
+    val data = Seq("""{"a": {"b": 100}}""").toDF("json")
+    val df = data.selectExpr(
+      "get_json_object(get_json_object(json, '$.a'), '$.b')",
+      "get_json_object(get_json_object(json, '$.a'), '$. b')",
+      "get_json_object(get_json_object(json, '$.a'), '.b')")
+    val plan = df.queryExecution.executedPlan
+    assert(plan.isInstanceOf[WholeStageCodegenExec])
+    checkAnswer(df, Row("100", "100", null))
+  }
+
   test("function json_tuple - field names foldable") {
     withTempView("t") {
       val json = """{"a":1, "b":2, "c":3}"""


### PR DESCRIPTION
### What changes were proposed in this pull request?
Collapse the nested `GetJsonObject(GetJsonObject(col, '$.a'), '$.b')` to one with combined json path:
`GetJsonObject(col, '$.a.b')`.


### Why are the changes needed?
Avoid parsing json multi times to improve performance.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Added unit tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
