### PR TITLE
[SPARK-53776][CONNECT] Support Spark Context Manager Support in Connect Mode

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -26,6 +26,7 @@ import warnings
 from collections.abc import Callable, Sized
 import functools
 from threading import RLock
+from types import TracebackType
 from typing import (
     Optional,
     Any,
@@ -40,6 +41,7 @@ from typing import (
     Mapping,
     TYPE_CHECKING,
     ClassVar,
+    Type,
 )
 
 import numpy as np
@@ -946,6 +948,57 @@ class SparkSession:
                 del os.environ["SPARK_CONNECT_MODE_ENABLED"]
                 if "SPARK_REMOTE" in os.environ:
                     del os.environ["SPARK_REMOTE"]
+
+    def __enter__(self) -> "SparkSession":
+        """
+        Enable 'with SparkSession.builder.(...).getOrCreate() as session: app' syntax.
+
+        .. versionadded:: 2.0.0
+
+        Examples
+        --------
+        >>> with SparkSession.builder.master("local").getOrCreate() as session:
+        ...     session.range(5).show()  # doctest: +SKIP
+        +---+
+        | id|
+        +---+
+        |  0|
+        |  1|
+        |  2|
+        |  3|
+        |  4|
+        +---+
+        """
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        """
+        Enable 'with SparkSession.builder.(...).getOrCreate() as session: app' syntax.
+
+        Specifically stop the SparkSession on exit of the with block.
+
+        .. versionadded:: 2.0.0
+
+        Examples
+        --------
+        >>> with SparkSession.builder.master("local").getOrCreate() as session:
+        ...     session.range(5).show()  # doctest: +SKIP
+        +---+
+        | id|
+        +---+
+        |  0|
+        |  1|
+        |  2|
+        |  3|
+        |  4|
+        +---+
+        """
+        self.stop()
 
     @property
     def is_stopped(self) -> bool:

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -953,7 +953,7 @@ class SparkSession:
         """
         Enable 'with SparkSession.builder.(...).getOrCreate() as session: app' syntax.
 
-        .. versionadded:: 2.0.0
+        .. versionadded:: 4.1.0
 
         Examples
         --------
@@ -982,7 +982,7 @@ class SparkSession:
 
         Specifically stop the SparkSession on exit of the with block.
 
-        .. versionadded:: 2.0.0
+        .. versionadded:: 4.1.0
 
         Examples
         --------

--- a/python/pyspark/sql/tests/connect/test_connect_session.py
+++ b/python/pyspark/sql/tests/connect/test_connect_session.py
@@ -328,7 +328,7 @@ class SparkConnectSessionWithOptionsTest(unittest.TestCase):
         """Test that SparkSession works as a context manager."""
         # Create a new session for testing
         with PySparkSession.builder.remote("local[2]").getOrCreate() as session:
-            self.assertIsInstance(session, PySparkSession)
+            self.assertIsInstance(session, RemoteSparkSession)
             self.assertFalse(session.is_stopped)
             
             df = session.range(3)
@@ -342,7 +342,7 @@ class SparkConnectSessionWithOptionsTest(unittest.TestCase):
         session = None
         try:
             with PySparkSession.builder.remote("local[2]").getOrCreate() as session:
-                self.assertIsInstance(session, PySparkSession)
+                self.assertIsInstance(session, RemoteSparkSession)
                 self.assertFalse(session.is_stopped)
                 raise ValueError("Test exception")
         except ValueError:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds missing context manager support (`__enter__` and `__exit__` methods) to the Spark Connect `SparkSession` class to enable `with` statement usage for automatic resource management.

The regular PySpark `SparkSession` already supports context manager syntax like:
```python
with SparkSession.builder.master("local").getOrCreate() as session:
    session.range(5).show()
```

However, this functionality was missing from the Spark Connect implementation, causing inconsistency between the two APIs.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

1. **API Consistency**: The Spark Connect `SparkSession` should have feature parity with the regular PySpark `SparkSession`
2. **Resource Management**: Context manager support enables automatic cleanup of sessions, preventing resource leaks
3. **User Experience**: Provides a more Pythonic way to handle session lifecycle management
4. **Documentation Compliance**: The existing docstrings in regular SparkSession show examples using context manager syntax, but this didn't work in Spark Connect mode


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, this PR enables new functionality for Spark Connect users:

**Before this PR:**
```python
# This would fail in Spark Connect mode
with SparkSession.builder.remote("sc://localhost").getOrCreate() as session:
    session.range(5).show()
# AttributeError: __enter__ method missing
```

**After this PR:**
```python
# This now works in Spark Connect mode
with SparkSession.builder.remote("sc://localhost").getOrCreate() as session:
    session.range(5).show()
# Session is automatically stopped when exiting the with block
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UTs

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes