### PR TITLE
[SPARK-53784] Additional Source APIs needed to support RTM execution

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/SupportsRealTimeMode.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/SupportsRealTimeMode.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.read.streaming;
+
+import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.connector.read.InputPartition;
+import org.apache.spark.sql.connector.read.Scan;
+
+/**
+ * A {@link MicroBatchStream} for streaming queries with real time mode.
+ *
+ */
+@Evolving
+public interface SupportsRealTimeMode {
+    /**
+     * Returns a list of {@link InputPartition input partitions} given the start offset. Each
+     * {@link InputPartition} represents a data split that can be processed by one Spark task. The
+     * number of input partitions returned here is the same as the number of RDD partitions this scan
+     * outputs.
+     */
+    InputPartition[] planInputPartitions(Offset start);
+
+    /**
+     * Merge partitioned offsets coming from {@link SupportsRealTimeMode} instances
+     * for each partition to a single global offset.
+     */
+    Offset mergeOffsets(PartitionOffset[] offsets);
+
+    /**
+     * Called during logical planning to inform the source if it's in real time mode
+     */
+    default void prepareForRealTimeMode() {}
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/SupportsRealTimeMode.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/SupportsRealTimeMode.java
@@ -19,7 +19,6 @@ package org.apache.spark.sql.connector.read.streaming;
 
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.read.InputPartition;
-import org.apache.spark.sql.connector.read.Scan;
 
 /**
  * A {@link MicroBatchStream} for streaming queries with real time mode.
@@ -30,8 +29,8 @@ public interface SupportsRealTimeMode {
     /**
      * Returns a list of {@link InputPartition input partitions} given the start offset. Each
      * {@link InputPartition} represents a data split that can be processed by one Spark task. The
-     * number of input partitions returned here is the same as the number of RDD partitions this scan
-     * outputs.
+     * number of input partitions returned here is the same as the number of RDD partitions
+     * this scan outputs.
      */
     InputPartition[] planInputPartitions(Offset start);
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/SupportsRealTimeRead.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/SupportsRealTimeRead.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.read.streaming;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.connector.read.PartitionReader;
+
+/**
+ * A variation on {@link PartitionReader} for use with low latency streaming processing.
+ *
+ */
+@Evolving
+public interface SupportsRealTimeRead<T> extends PartitionReader<T> {
+
+    /**
+     * A class to represent the status of a record to be read as the return type of nextWithTimeout.
+     * It contains whether the next record is available and the ingestion time of the record
+     * if the source connector provided relevant info. A list of source connector that has ingestion
+     * time is listed below:
+     * - Kafka when the record timestamp type is LogAppendTime
+     * - Kinesis has ApproximateArrivalTimestamp
+     */
+    class RecordStatus {
+        private final boolean hasRecord;
+        private final Optional<Long> recArrivalTime;
+
+        private RecordStatus(boolean hasRecord, Optional<Long> recArrivalTime) {
+            this.hasRecord = hasRecord;
+            this.recArrivalTime = recArrivalTime;
+        }
+
+        // Public factory methods to control instance creation
+        public static RecordStatus newStatusWithoutArrivalTime(boolean hasRecord) {
+            return new RecordStatus(hasRecord, Optional.empty());
+        }
+
+        public static RecordStatus newStatusWithArrivalTimeMs(Long recArrivalTime) {
+            return new RecordStatus(true, Optional.of(recArrivalTime));
+        }
+
+        public boolean hasRecord() {
+            return hasRecord;
+        }
+
+        public Optional<Long> recArrivalTime() {
+            return recArrivalTime;
+        }
+    }
+
+    /**
+     * Get the offset of the next record, or the start offset if no records have been read.
+     * <p>
+     * The execution engine will call this method along with get() to keep track of the current
+     * offset. When a task ends, the offset in each partition will be passed back to the driver.
+     * They will be used as the start offsets of the next batch.
+     */
+    PartitionOffset getOffset();
+
+    /**
+     * Alternative function to be called than next(), that proceed to the next record. The different
+     * from next() is that, if there is no more records, the call needs to keep waiting until
+     * the timeout.
+     * @param timeout if no result is available after this timeout (milliseconds), return
+     * @return {@link RecordStatus} describing whether a record is available and its arrival time
+     * @throws IOException
+     */
+    RecordStatus nextWithTimeout(Long timeout) throws IOException;
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Described in the jira ticket: https://issues.apache.org/jira/browse/SPARK-53784 

Here is an example for reference of how the API is used to craft a in-memory source that supports RTM:

[sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/LowLatencyMemoryStream.scala 
](https://github.com/apache/spark/pull/52502/files#diff-b49f6f9fba5c2683792c52015219d3f29ed683cc2e676da8781c0e8b84a5e272)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  3. If you fix a bug, you can clarify why it is a bug.
-->

Needed to support Real-time Mode time based batch execution in sources.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, adds additional APIs needed for sources to be able integrate with Real-time mode.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Not applicable since only interfaces are introduced

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

no
