### PR TITLE
 [SPARK-53785][SS] Memory Source for RTM

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RealTimeStreamScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RealTimeStreamScanExec.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.util.{Clock, SystemClock}
+
+/* The singleton object to control the time in testing */
+object LowLatencyClock {
+  private var clock: Clock = new SystemClock
+
+  def getClock: Clock = clock
+
+  def getTimeMillis(): Long = {
+    clock.getTimeMillis()
+  }
+
+  def waitTillTime(targetTime: Long): Unit = {
+    clock.waitTillTime(targetTime)
+  }
+
+  def setClock(inputClock: Clock): Unit = {
+    clock = inputClock
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/memory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/memory.scala
@@ -158,6 +158,13 @@ case class MemoryStream[A : Encoder](
     id: Int,
     sqlContext: SQLContext,
     numPartitions: Option[Int] = None)
+  extends MemoryStreamBaseClass[A](
+    id, sqlContext, numPartitions = numPartitions)
+
+abstract class MemoryStreamBaseClass[A: Encoder](
+    id: Int,
+    sqlContext: SQLContext,
+    numPartitions: Option[Int] = None)
   extends MemoryStreamBase[A](sqlContext)
   with MicroBatchStream
   with SupportsTriggerAvailableNow

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/LowLatencyMemoryStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/LowLatencyMemoryStream.scala
@@ -1,0 +1,300 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming
+
+import java.util.concurrent.atomic.AtomicInteger
+import javax.annotation.concurrent.GuardedBy
+
+import scala.collection.mutable.ListBuffer
+
+import org.json4s.{Formats, NoTypeHints}
+import org.json4s.jackson.Serialization
+
+import org.apache.spark.{SparkEnv, TaskContext}
+import org.apache.spark.rpc.{RpcAddress, RpcEndpointRef}
+import org.apache.spark.sql.{Encoder, SQLContext}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.connector.read.PartitionReader
+import org.apache.spark.sql.connector.read.PartitionReaderFactory
+import org.apache.spark.sql.connector.read.streaming.{
+  Offset => OffsetV2,
+  PartitionOffset,
+  ReadLimit,
+  SupportsRealTimeMode,
+  SupportsRealTimeRead
+}
+import org.apache.spark.sql.connector.read.streaming.SupportsRealTimeRead.RecordStatus
+import org.apache.spark.sql.execution.datasources.v2.LowLatencyClock
+import org.apache.spark.sql.execution.streaming.runtime._
+import org.apache.spark.util.{Clock, RpcUtils}
+
+/**
+ * A low latency memory source from memory, only for unit test purpose.
+ * This class is very similar to ContinuousMemoryStream, except that it implements the
+ * interface of SupportsRealTimeMode, rather than ContinuousStream
+ * The overall strategy here is:
+ *  * LowLatencyMemoryStream maintains a list of records for each partition. addData() will
+ *    distribute records evenly-ish across partitions.
+ *  * RecordEndpoint is set up as an endpoint for executor-side
+ *    LowLatencyMemoryStreamInputPartitionReader instances to poll. It returns the record at
+ *    the specified offset within the list, or null if that offset doesn't yet have a record.
+ * This differs from the existing memory source implementation as data is sent once to
+ * tasks as part of the Partition/Split metadata at the beginning of a batch.
+ */
+class LowLatencyMemoryStream[A: Encoder](
+    id: Int,
+    sqlContext: SQLContext,
+    numPartitions: Int = 2,
+    clock: Clock = LowLatencyClock.getClock)
+    extends MemoryStreamBaseClass[A](0, sqlContext)
+    with SupportsRealTimeMode {
+  private implicit val formats: Formats = Serialization.formats(NoTypeHints)
+
+  @GuardedBy("this")
+  private val records = Seq.fill(numPartitions)(new ListBuffer[UnsafeRow])
+
+  private val recordEndpoint = new ContinuousRecordEndpoint(records, this)
+  @volatile private var endpointRef: RpcEndpointRef = _
+
+  override def addData(data: IterableOnce[A]): Offset = synchronized {
+    // Distribute data evenly among partition lists.
+    data.iterator.to(Seq).zipWithIndex.map {
+      case (item, index) =>
+        records(index % numPartitions) += toRow(item).copy().asInstanceOf[UnsafeRow]
+    }
+
+    // The new target offset is the offset where all records in all partitions have been processed.
+    LowLatencyMemoryStreamOffset((0 until numPartitions).map(i => (i, records(i).size)).toMap)
+  }
+
+  def addData(partitionId: Int, data: IterableOnce[A]): Offset = synchronized {
+    require(
+      partitionId >= 0 && partitionId < numPartitions,
+      s"Partition ID $partitionId is out of bounds for $numPartitions partitions."
+    )
+
+    // Add data to the specified partition.
+    records(partitionId) ++= data.iterator.map(item => toRow(item).copy().asInstanceOf[UnsafeRow])
+
+    // The new target offset is the offset where all records in all partitions have been processed.
+    LowLatencyMemoryStreamOffset((0 until numPartitions).map(i => (i, records(i).size)).toMap)
+  }
+
+  override def initialOffset(): OffsetV2 = {
+    LowLatencyMemoryStreamOffset((0 until numPartitions).map(i => (i, 0)).toMap)
+  }
+
+  override def latestOffset(startOffset: OffsetV2, limit: ReadLimit): OffsetV2 = {
+    LowLatencyMemoryStreamOffset((0 until numPartitions).map(i => (i, records(i).size)).toMap)
+  }
+
+  override def deserializeOffset(json: String): LowLatencyMemoryStreamOffset = {
+    LowLatencyMemoryStreamOffset(Serialization.read[Map[Int, Int]](json))
+  }
+
+  override def mergeOffsets(offsets: Array[PartitionOffset]): LowLatencyMemoryStreamOffset = {
+    LowLatencyMemoryStreamOffset(
+      offsets.map {
+        case ContinuousRecordPartitionOffset(part, num) => (part, num)
+      }.toMap
+    )
+  }
+
+  override def planInputPartitions(start: OffsetV2): Array[InputPartition] = {
+    val startOffset = start.asInstanceOf[LowLatencyMemoryStreamOffset]
+    synchronized {
+      val endpointName = s"LowLatencyRecordEndpoint-${java.util.UUID.randomUUID()}-$id"
+      endpointRef = recordEndpoint.rpcEnv.setupEndpoint(endpointName, recordEndpoint)
+
+      startOffset.partitionNums.map {
+        case (part, index) =>
+          LowLatencyMemoryStreamInputPartition(
+            endpointName,
+            endpointRef.address,
+            part,
+            index,
+            Int.MaxValue
+          )
+      }.toArray
+    }
+  }
+
+  override def planInputPartitions(start: OffsetV2, end: OffsetV2): Array[InputPartition] = {
+    val startOffset = start.asInstanceOf[LowLatencyMemoryStreamOffset]
+    val endOffset = end.asInstanceOf[LowLatencyMemoryStreamOffset]
+    synchronized {
+      val endpointName = s"LowLatencyRecordEndpoint-${java.util.UUID.randomUUID()}-$id"
+      endpointRef = recordEndpoint.rpcEnv.setupEndpoint(endpointName, recordEndpoint)
+
+      startOffset.partitionNums.map {
+        case (part, index) =>
+          LowLatencyMemoryStreamInputPartition(
+            endpointName,
+            endpointRef.address,
+            part,
+            index,
+            endOffset.partitionNums(part)
+          )
+      }.toArray
+    }
+  }
+
+  override def createReaderFactory(): PartitionReaderFactory = {
+    new LowLatencyMemoryStreamReaderFactory(clock)
+  }
+
+  override def stop(): Unit = {
+    if (endpointRef != null) recordEndpoint.rpcEnv.stop(endpointRef)
+  }
+
+  override def commit(end: OffsetV2): Unit = {}
+
+  override def reset(): Unit = {
+    super.reset()
+    records.foreach(_.clear())
+  }
+}
+
+object LowLatencyMemoryStream {
+  protected val memoryStreamId = new AtomicInteger(0)
+
+  def apply[A: Encoder](implicit sqlContext: SQLContext): LowLatencyMemoryStream[A] =
+    new LowLatencyMemoryStream[A](memoryStreamId.getAndIncrement(), sqlContext)
+
+  def apply[A: Encoder](numPartitions: Int)(
+      implicit
+      sqlContext: SQLContext): LowLatencyMemoryStream[A] =
+    new LowLatencyMemoryStream[A](
+      memoryStreamId.getAndIncrement(),
+      sqlContext,
+      numPartitions = numPartitions
+    )
+
+  def singlePartition[A: Encoder](implicit sqlContext: SQLContext): LowLatencyMemoryStream[A] =
+    new LowLatencyMemoryStream[A](memoryStreamId.getAndIncrement(), sqlContext, 1)
+}
+
+/**
+ * An input partition for LowLatency memory stream.
+ */
+case class LowLatencyMemoryStreamInputPartition(
+    driverEndpointName: String,
+    driverEndpointAddress: RpcAddress,
+    partition: Int,
+    startOffset: Int,
+    endOffset: Int)
+    extends InputPartition
+
+class LowLatencyMemoryStreamReaderFactory(clock: Clock) extends PartitionReaderFactory {
+  override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
+    val p = partition.asInstanceOf[LowLatencyMemoryStreamInputPartition]
+    new LowLatencyMemoryStreamPartitionReader(
+      p.driverEndpointName,
+      p.driverEndpointAddress,
+      p.partition,
+      p.startOffset,
+      p.endOffset,
+      clock
+    )
+  }
+}
+
+/**
+ * An input partition reader for LowLatency memory stream.
+ *
+ * Polls the driver endpoint for new records.
+ */
+class LowLatencyMemoryStreamPartitionReader(
+    driverEndpointName: String,
+    driverEndpointAddress: RpcAddress,
+    partition: Int,
+    startOffset: Int,
+    endOffset: Int,
+    clock: Clock)
+    extends SupportsRealTimeRead[InternalRow] {
+  // Avoid tracking the ref, given that we create a new one for each partition reader
+  // because a new driver endpoint is created for each LowLatencyMemoryStream. If we track the ref,
+  // we can end up with a lot of refs (1000s) if a test suite has so many test cases and can lead to
+  // issues with the tracking array. Causing the test suite to be flaky.
+  private val endpoint = RpcUtils.makeDriverRef(
+    driverEndpointName,
+    driverEndpointAddress.host,
+    driverEndpointAddress.port,
+    SparkEnv.get.rpcEnv
+  )
+
+  private var currentOffset = startOffset
+  private var current: Option[InternalRow] = None
+
+  // Defense-in-depth against failing to propagate the task context. Since it's not inheritable,
+  // we have to do a bit of error prone work to get it into every thread used by LowLatency
+  // processing. We hope that some unit test will end up instantiating a LowLatency memory stream
+  // in such cases.
+  if (TaskContext.get() == null) {
+    throw new IllegalStateException("Task context was not set!")
+  }
+  override def nextWithTimeout(timeout: java.lang.Long): RecordStatus = {
+    val startReadTime = clock.nanoTime()
+    var elapsedTimeMs = 0L
+    current = getRecord
+    while (current.isEmpty) {
+      val POLL_TIME = 10L
+      if (elapsedTimeMs >= timeout) {
+        return RecordStatus.newStatusWithoutArrivalTime(false)
+      }
+      Thread.sleep(POLL_TIME)
+      current = getRecord
+      elapsedTimeMs = (clock.nanoTime() - startReadTime) / 1000 / 1000
+    }
+    currentOffset += 1
+    RecordStatus.newStatusWithoutArrivalTime(true)
+  }
+
+  override def next(): Boolean = {
+    current = getRecord
+    if (current.isDefined) {
+      currentOffset += 1
+      true
+    } else {
+      false
+    }
+  }
+
+  override def get(): InternalRow = current.get
+
+  override def close(): Unit = {}
+
+  override def getOffset: ContinuousRecordPartitionOffset =
+    ContinuousRecordPartitionOffset(partition, currentOffset)
+
+  private def getRecord: Option[InternalRow] = {
+    if (currentOffset >= endOffset) {
+      return None
+    }
+    endpoint.askSync[Option[InternalRow]](
+      GetRecord(ContinuousRecordPartitionOffset(partition, currentOffset))
+    )
+  }
+}
+
+case class LowLatencyMemoryStreamOffset(partitionNums: Map[Int, Int]) extends Offset {
+  private implicit val formats: Formats = Serialization.formats(NoTypeHints)
+  override def json(): String = Serialization.write(partitionNums)
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/LowLatencyMemoryStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/LowLatencyMemoryStream.scala
@@ -101,7 +101,7 @@ class LowLatencyMemoryStream[A: Encoder](
     LowLatencyMemoryStreamOffset((0 until numPartitions).map(i => (i, 0)).toMap)
   }
 
-  override def latestOffset(startOffset: OffsetV2, limit: ReadLimit): OffsetV2 = {
+  override def latestOffset(startOffset: OffsetV2, limit: ReadLimit): OffsetV2 = synchronized {
     LowLatencyMemoryStreamOffset((0 until numPartitions).map(i => (i, records(i).size)).toMap)
   }
 
@@ -166,7 +166,7 @@ class LowLatencyMemoryStream[A: Encoder](
 
   override def commit(end: OffsetV2): Unit = {}
 
-  override def reset(): Unit = {
+  override def reset(): Unit = synchronized {
     super.reset()
     records.foreach(_.clear())
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add a memory source implementation that support Real-time Mode.  This source is going to be used to test Real-time Mode.  In this implementation of the memory source, a RPC server is set up on the driver and source tasks will constantly pull this RPC server for new data.  This differs from the existing memory source implementation as data is sent once to tasks as part of the Partition/Split metadata at the beginning of a batch.  



### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To test Real-time Mode queries.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No, this source is purely to help testing.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Actual unit tests to test RTM will be added in the future once the engine supports actually running queries in RTM. 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
