### PR TITLE
[SPARK-53789][SQL][CONNECT] Canonicalize error condition CANNOT_MODIFY_STATIC_CONFIG

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -444,7 +444,7 @@
     "message" : [
       "Cannot modify the value of the static Spark config: <key>."
     ],
-    "sqlState" : "46111"
+    "sqlState" : "46110"
   },
   "CANNOT_PARSE_DECIMAL" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -440,6 +440,12 @@
     ],
     "sqlState" : "46110"
   },
+  "CANNOT_MODIFY_STATIC_CONFIG" : {
+    "message" : [
+      "Cannot modify the value of the static Spark config: <key>."
+    ],
+    "sqlState" : "46111"
+  },
   "CANNOT_PARSE_DECIMAL" : {
     "message" : [
       "Cannot parse decimal. Please ensure that the input is a valid number with optional decimal point or comma separators."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -9144,11 +9144,6 @@
       "Failed to get block <blockId>, which is not a shuffle block"
     ]
   },
-  "_LEGACY_ERROR_TEMP_3050" : {
-    "message" : [
-      "Cannot modify the value of a static config: <k>"
-    ]
-  },
   "_LEGACY_ERROR_TEMP_3052" : {
     "message" : [
       "Unexpected resolved action: <other>"

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/CompilationErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/CompilationErrors.scala
@@ -136,8 +136,8 @@ private[sql] trait CompilationErrors extends DataTypeErrorsBase {
   def cannotModifyValueOfStaticConfigError(key: String): Throwable = {
     new AnalysisException(
       errorClass = "CANNOT_MODIFY_CONFIG",
-      messageParameters = Map("key" -> toSQLConf(key), "docroot" -> SparkBuildInfo.spark_doc_root)
-    )
+      messageParameters =
+        Map("key" -> toSQLConf(key), "docroot" -> SparkBuildInfo.spark_doc_root))
   }
 
   def cannotModifyValueOfSparkConfigError(key: String, docroot: String): Throwable = {

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/CompilationErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/CompilationErrors.scala
@@ -135,9 +135,8 @@ private[sql] trait CompilationErrors extends DataTypeErrorsBase {
 
   def cannotModifyValueOfStaticConfigError(key: String): Throwable = {
     new AnalysisException(
-      errorClass = "CANNOT_MODIFY_CONFIG",
-      messageParameters =
-        Map("key" -> toSQLConf(key), "docroot" -> SparkBuildInfo.spark_doc_root))
+      errorClass = "CANNOT_MODIFY_STATIC_CONFIG",
+      messageParameters = Map("key" -> toSQLConf(key)))
   }
 
   def cannotModifyValueOfSparkConfigError(key: String, docroot: String): Throwable = {

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/CompilationErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/CompilationErrors.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.sql.errors
 
+import org.apache.spark.SparkBuildInfo
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.internal.SqlApiConf
 
@@ -130,6 +131,19 @@ private[sql] trait CompilationErrors extends DataTypeErrorsBase {
     new AnalysisException(
       errorClass = "SPECIFY_CLUSTER_BY_WITH_BUCKETING_IS_NOT_ALLOWED",
       messageParameters = Map.empty)
+  }
+
+  def cannotModifyValueOfStaticConfigError(key: String): Throwable = {
+    new AnalysisException(
+      errorClass = "CANNOT_MODIFY_CONFIG",
+      messageParameters = Map("key" -> toSQLConf(key), "docroot" -> SparkBuildInfo.spark_doc_root)
+    )
+  }
+
+  def cannotModifyValueOfSparkConfigError(key: String, docroot: String): Throwable = {
+    new AnalysisException(
+      errorClass = "CANNOT_MODIFY_CONFIG",
+      messageParameters = Map("key" -> toSQLConf(key), "docroot" -> docroot))
   }
 }
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/CompilationErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/CompilationErrors.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.sql.errors
 
-import org.apache.spark.SparkBuildInfo
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.internal.SqlApiConf
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SQLConfHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SQLConfHelper.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst
 
-import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.errors.CompilationErrors
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -47,9 +47,7 @@ trait SQLConfHelper {
     }
     keys.lazyZip(values).foreach { (k, v) =>
       if (SQLConf.isStaticConfigKey(k)) {
-        throw new AnalysisException(
-          errorClass = "_LEGACY_ERROR_TEMP_3050",
-          messageParameters = Map("k" -> k))
+        throw CompilationErrors.cannotModifyValueOfStaticConfigError(k)
       }
       conf.setConfString(k, v)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3475,19 +3475,6 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
         "config" -> SQLConf.DATAFRAME_PIVOT_MAX_VALUES.key))
   }
 
-  def cannotModifyValueOfStaticConfigError(key: String): Throwable = {
-    new AnalysisException(
-      errorClass = "CANNOT_MODIFY_CONFIG",
-      messageParameters = Map("key" -> toSQLConf(key), "docroot" -> SPARK_DOC_ROOT)
-    )
-  }
-
-  def cannotModifyValueOfSparkConfigError(key: String, docroot: String): Throwable = {
-    new AnalysisException(
-      errorClass = "CANNOT_MODIFY_CONFIG",
-      messageParameters = Map("key" -> toSQLConf(key), "docroot" -> docroot))
-  }
-
   def commandExecutionInRunnerUnsupportedError(runner: String): Throwable = {
     new AnalysisException(
       errorClass = "_LEGACY_ERROR_TEMP_1327",

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/SQLHelper.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/SQLHelper.scala
@@ -21,9 +21,9 @@ import java.util.UUID
 
 import org.scalatest.Assertions.fail
 
-import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.connect.{DataFrame, SparkSession, SQLImplicits}
+import org.apache.spark.sql.errors.CompilationErrors
 import org.apache.spark.util.{SparkErrorUtils, SparkFileUtils}
 
 trait SQLHelper {
@@ -59,11 +59,8 @@ trait SQLHelper {
       if (spark.conf.isModifiable(k)) {
         spark.conf.set(k, v)
       } else {
-        throw new AnalysisException(
-          errorClass = "_LEGACY_ERROR_TEMP_3050",
-          messageParameters = Map("k" -> k))
+        throw CompilationErrors.cannotModifyValueOfStaticConfigError(k)
       }
-
     }
     try f
     finally {

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -236,8 +236,8 @@ class SQLConfSuite extends QueryTest with SharedSparkSession {
     // static sql configs
     checkError(
       exception = intercept[AnalysisException](sql(s"RESET ${StaticSQLConf.WAREHOUSE_PATH.key}")),
-      condition = "CANNOT_MODIFY_CONFIG",
-      parameters = Map("key" -> "\"spark.sql.warehouse.dir\"", "docroot" -> SPARK_DOC_ROOT))
+      condition = "CANNOT_MODIFY_STATIC_CONFIG",
+      parameters = Map("key" -> "\"spark.sql.warehouse.dir\""))
 
   }
 
@@ -348,13 +348,13 @@ class SQLConfSuite extends QueryTest with SharedSparkSession {
   test("cannot set/unset static SQL conf") {
     checkError(
       exception = intercept[AnalysisException](sql(s"SET ${GLOBAL_TEMP_DATABASE.key}=10")),
-      condition = "CANNOT_MODIFY_CONFIG",
-      parameters = Map("key" -> "\"spark.sql.globalTempDatabase\"", "docroot" -> SPARK_DOC_ROOT)
+      condition = "CANNOT_MODIFY_STATIC_CONFIG",
+      parameters = Map("key" -> "\"spark.sql.globalTempDatabase\"")
     )
     checkError(
       exception = intercept[AnalysisException](spark.conf.unset(GLOBAL_TEMP_DATABASE.key)),
-      condition = "CANNOT_MODIFY_CONFIG",
-      parameters = Map("key" -> "\"spark.sql.globalTempDatabase\"", "docroot" -> SPARK_DOC_ROOT)
+      condition = "CANNOT_MODIFY_STATIC_CONFIG",
+      parameters = Map("key" -> "\"spark.sql.globalTempDatabase\"")
     )
   }
 

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
@@ -1063,7 +1063,7 @@ class SingleSessionSuite extends HiveThriftServer2TestBase {
         statement.executeQuery("SET spark.sql.hive.thriftServer.singleSession=false")
       }.getMessage
       assert(e.contains(
-        "CANNOT_MODIFY_CONFIG"))
+        "CANNOT_MODIFY_STATIC_CONFIG"))
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -25,7 +25,7 @@ import java.util.{Locale, Set}
 
 import org.apache.hadoop.fs.{FileSystem, Path}
 
-import org.apache.spark.{SPARK_DOC_ROOT, SparkException, TestUtils}
+import org.apache.spark.{SparkException, TestUtils}
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -2464,9 +2464,8 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
       "spark.sql.hive.metastore.barrierPrefixes").foreach { key =>
       checkError(
         exception = intercept[AnalysisException](sql(s"set $key=abc")),
-        condition = "CANNOT_MODIFY_CONFIG",
-        parameters = Map(
-          "key" -> toSQLConf(key), "docroot" -> SPARK_DOC_ROOT)
+        condition = "CANNOT_MODIFY_STATIC_CONFIG",
+        parameters = Map("key" -> toSQLConf(key))
       )
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Introduce `CANNOT_MODIFY_STATIC_CONFIG` and

1. Migrate error condition `_LEGACY_ERROR_TEMP_3050` to `CANNOT_MODIFY_STATIC_CONFIG`
2. Migrate `cannotModifyValueOfStaticConfigError` from `CANNOT_MODIFY_CONFIG`(with suggestion that directs to DDL migration guide) to use `CANNOT_MODIFY_STATIC_CONFIG` because the DDL migration guide does not help for this case.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
More consistent error message.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
More consistent error message.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass GHA.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.