### PR TITLE
[SPARK-53585][BUILD] Upgrade Scala to 2.13.17

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -118,7 +118,7 @@ jakarta.validation-api/3.0.2//jakarta.validation-api-3.0.2.jar
 jakarta.ws.rs-api/3.0.0//jakarta.ws.rs-api-3.0.0.jar
 jakarta.xml.bind-api/4.0.2//jakarta.xml.bind-api-4.0.2.jar
 janino/3.1.9//janino-3.1.9.jar
-java-diff-utils/4.15//java-diff-utils-4.15.jar
+java-diff-utils/4.16//java-diff-utils-4.16.jar
 java-xmlbuilder/1.2//java-xmlbuilder-1.2.jar
 javassist/3.30.2-GA//javassist-3.30.2-GA.jar
 javax.jdo/3.2.0-m3//javax.jdo-3.2.0-m3.jar
@@ -142,7 +142,7 @@ jjwt-api/0.12.6//jjwt-api-0.12.6.jar
 jjwt-impl/0.12.6//jjwt-impl-0.12.6.jar
 jjwt-jackson/0.12.6//jjwt-jackson-0.12.6.jar
 jline/2.14.6//jline-2.14.6.jar
-jline/3.27.1/jdk8/jline-3.27.1-jdk8.jar
+jline/3.29.0/jdk8/jline-3.29.0-jdk8.jar
 joda-time/2.14.0//joda-time-2.14.0.jar
 jpam/1.1//jpam-1.1.jar
 json/1.8//json-1.8.jar
@@ -264,11 +264,11 @@ pickle/1.5//pickle-1.5.jar
 py4j/0.10.9.9//py4j-0.10.9.9.jar
 remotetea-oncrpc/1.1.2//remotetea-oncrpc-1.1.2.jar
 rocksdbjni/9.8.4//rocksdbjni-9.8.4.jar
-scala-compiler/2.13.16//scala-compiler-2.13.16.jar
-scala-library/2.13.16//scala-library-2.13.16.jar
+scala-compiler/2.13.17//scala-compiler-2.13.17.jar
+scala-library/2.13.17//scala-library-2.13.17.jar
 scala-parallel-collections_2.13/1.2.0//scala-parallel-collections_2.13-1.2.0.jar
 scala-parser-combinators_2.13/2.4.0//scala-parser-combinators_2.13-2.4.0.jar
-scala-reflect/2.13.16//scala-reflect-2.13.16.jar
+scala-reflect/2.13.17//scala-reflect-2.13.17.jar
 scala-xml_2.13/2.3.0//scala-xml_2.13-2.3.0.jar
 slf4j-api/2.0.17//slf4j-api-2.0.17.jar
 snakeyaml-engine/2.10//snakeyaml-engine-2.10.jar

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -22,7 +22,7 @@ include:
 SPARK_VERSION: 4.1.0-SNAPSHOT
 SPARK_VERSION_SHORT: 4.1.0
 SCALA_BINARY_VERSION: "2.13"
-SCALA_VERSION: "2.13.16"
+SCALA_VERSION: "2.13.17"
 SPARK_ISSUE_TRACKER_URL: https://issues.apache.org/jira/browse/SPARK
 SPARK_GITHUB_URL: https://github.com/apache/spark
 # Before a new release, we should:

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <!-- managed up from 3.2.1 for SPARK-11652 -->
     <commons.collections.version>3.2.2</commons.collections.version>
     <commons.collections4.version>4.5.0</commons.collections4.version>
-    <scala.version>2.13.16</scala.version>
+    <scala.version>2.13.17</scala.version>
     <scala.binary.version>2.13</scala.binary.version>
     <scalatest-maven-plugin.version>2.2.0</scalatest-maven-plugin.version>
     <scala-maven-plugin.version>4.9.5</scala-maven-plugin.version>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -223,7 +223,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
     children.map(_.height).reduceOption(_ max _).getOrElse(0) + 1)
   def height: Int = _height()
 
-  private val _hashCode = new BestEffortLazyVal[Integer](() => MurmurHash3.productHash(this))
+  private val _hashCode = new BestEffortLazyVal[Integer](() => MurmurHash3.caseClassHash(this))
   override def hashCode(): Int = _hashCode()
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade to scala 2.13.17


### Why are the changes needed?
To bring the latest bug fixes and improvements like JDK 25 support. Note that Scala community announces two breaking changes due to the bug fixes.

> Breaking changes
> - Mix in the productPrefix hash statically in case class hashCode
> - Improve scala.util.Using suppression order

- https://github.com/scala/scala/releases/tag/v2.13.17
  - https://github.com/scala/scala/pull/11046
  - https://github.com/scala/scala/pull/10937
  - https://github.com/scala/scala/pull/10927
    - https://github.com/scala/bug/issues/13058
  - https://github.com/scala/scala/pull/11023
    - https://github.com/scala/bug/issues/13033
  - https://github.com/scala/scala/pull/11000

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
local and github builds


### Was this patch authored or co-authored using generative AI tooling?
No
