### PR TITLE
[SPARK-53793][SQL] Use DSv2 predicate to evaluate InternalRow

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -224,6 +224,12 @@
     ],
     "sqlState" : "42846"
   },
+  "CANNOT_CONVERT_DSV2_PREDICATE_TO_CATALYST" : {
+    "message" : [
+      "Cannot convert the datasource v2 predicate <predicate> to Catalyst expression."
+    ],
+    "sqlState" : "42846"
+  },
   "CANNOT_CONVERT_PROTOBUF_FIELD_TYPE_TO_SQL_TYPE" : {
     "message" : [
       "Cannot convert Protobuf <protobufColumn> to SQL <sqlColumn> because schema is incompatible (protobufType = <protobufType>, sqlType = <sqlType>)."
@@ -1795,6 +1801,12 @@
       "Failed to convert the row value <value> of the class <class> to the target SQL type <sqlType> in the JSON format."
     ],
     "sqlState" : "2203G"
+  },
+  "FAILED_TO_EVALUATE_DSV2_PREDICATE" : {
+    "message" : [
+      "Failed to evaluate internalRow on datasource v2 predicate <predicate>, because cannot convert the predicate to Catalyst expression."
+    ],
+    "sqlState" : "42846"
   },
   "FAILED_TO_LOAD_ROUTINE" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -224,12 +224,6 @@
     ],
     "sqlState" : "42846"
   },
-  "CANNOT_CONVERT_DSV2_PREDICATE_TO_CATALYST" : {
-    "message" : [
-      "Cannot convert the datasource v2 predicate <predicate> to Catalyst expression."
-    ],
-    "sqlState" : "42846"
-  },
   "CANNOT_CONVERT_PROTOBUF_FIELD_TYPE_TO_SQL_TYPE" : {
     "message" : [
       "Cannot convert Protobuf <protobufColumn> to SQL <sqlColumn> because schema is incompatible (protobufType = <protobufType>, sqlType = <sqlType>)."

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionEvaluator.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionEvaluator.java
@@ -24,9 +24,9 @@ import java.util.Optional;
 import scala.jdk.javaapi.CollectionConverters;
 
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.catalyst.expressions.BasePredicate;
 import org.apache.spark.sql.catalyst.expressions.BoundReference;
 import org.apache.spark.sql.catalyst.expressions.Expression;
+import org.apache.spark.sql.catalyst.expressions.InterpretedPredicate;
 import org.apache.spark.sql.connector.expressions.LiteralValue;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.expressions.filter.Predicate;
@@ -368,8 +368,8 @@ public final class V2ExpressionEvaluator {
     if (catalystExpr.isEmpty()) {
       return Optional.empty();
     }
-    BasePredicate evaluator =
-        org.apache.spark.sql.catalyst.expressions.Predicate.create(catalystExpr.get());
+    InterpretedPredicate evaluator =
+        org.apache.spark.sql.catalyst.expressions.Predicate.createInterpreted(catalystExpr.get());
     return Optional.of(evaluator.eval(internalRow));
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionEvaluator.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionEvaluator.java
@@ -1,0 +1,375 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import scala.jdk.javaapi.CollectionConverters;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.BasePredicate;
+import org.apache.spark.sql.catalyst.expressions.BoundReference;
+import org.apache.spark.sql.catalyst.expressions.Expression;
+import org.apache.spark.sql.connector.expressions.LiteralValue;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * Utility class for evaluating an {@link InternalRow} against a data source V2 {@link Predicate}.
+ *
+ * <p>This class provides methods to translate DSV2 predicates into Catalyst expressions based on a
+ * given schema, and to evaluate these predicates against InternalRows.
+ *
+ * @since 4.1.0
+ */
+public final class V2ExpressionEvaluator {
+
+  /**
+   * Converts a Spark DataSourceV2 {@link Predicate} to a Catalyst {@link Expression}.
+   *
+   * <p>This method translates supported DSV2 predicates into their equivalent Catalyst expressions,
+   * using the provided schema for column resolution. Unsupported predicates, or those referencing
+   * unknown columns, will result in an empty Optional.
+   *
+   * <p>Supported predicates include:
+   *
+   * <ul>
+   *   <li>Null tests: IS_NULL, IS_NOT_NULL
+   *   <li>String functions: STARTS_WITH, ENDS_WITH, CONTAINS
+   *   <li>IN operator
+   *   <li>Comparison: =, >, >=, <, <=
+   *   <li>Null-safe comparison: <=>
+   *   <li>Logical operators: AND, OR, NOT
+   *   <li>Constant predicates: ALWAYS_TRUE, ALWAYS_FALSE
+   * </ul>
+   *
+   * @param predicate the DSV2 Predicate to convert
+   * @param schema    the schema used for resolving column references
+   * @return Catalyst Expression representing the converted predicate, or empty if the predicate is
+   * unsupported or references unknown columns
+   */
+  public static Optional<Expression> dsv2PredicateToCatalystExpression(
+      org.apache.spark.sql.connector.expressions.filter.Predicate predicate, StructType schema) {
+    String predicateName = predicate.name();
+    org.apache.spark.sql.connector.expressions.Expression[] children = predicate.children();
+
+    switch (predicateName) {
+      case "IS_NULL":
+        if (children.length == 1) {
+          Optional<Expression> expressionOpt =
+              dsv2ExpressionToCatalystExpression(children[0], schema);
+          if (expressionOpt.isPresent()) {
+            return Optional.of(
+                new org.apache.spark.sql.catalyst.expressions.IsNull(expressionOpt.get()));
+          }
+        }
+        break;
+
+      case "IS_NOT_NULL":
+        if (children.length == 1) {
+          Optional<Expression> expressionOpt =
+              dsv2ExpressionToCatalystExpression(children[0], schema);
+          if (expressionOpt.isPresent()) {
+            return Optional.of(
+                new org.apache.spark.sql.catalyst.expressions.IsNotNull(expressionOpt.get()));
+          }
+        }
+        break;
+
+      case "STARTS_WITH":
+        if (children.length == 2) {
+          Optional<Expression> leftOpt = dsv2ExpressionToCatalystExpression(children[0], schema);
+          Optional<Expression> rightOpt = dsv2ExpressionToCatalystExpression(children[1], schema);
+          if (leftOpt.isPresent() && rightOpt.isPresent()) {
+            return Optional.of(
+                new org.apache.spark.sql.catalyst.expressions.StartsWith(
+                    leftOpt.get(), rightOpt.get()));
+          }
+        }
+        break;
+
+      case "ENDS_WITH":
+        if (children.length == 2) {
+          Optional<Expression> leftOpt = dsv2ExpressionToCatalystExpression(children[0], schema);
+          Optional<Expression> rightOpt = dsv2ExpressionToCatalystExpression(children[1], schema);
+          if (leftOpt.isPresent() && rightOpt.isPresent()) {
+            return Optional.of(
+                new org.apache.spark.sql.catalyst.expressions.EndsWith(
+                    leftOpt.get(), rightOpt.get()));
+          }
+        }
+        break;
+
+      case "CONTAINS":
+        if (children.length == 2) {
+          Optional<Expression> leftOpt = dsv2ExpressionToCatalystExpression(children[0], schema);
+          Optional<Expression> rightOpt = dsv2ExpressionToCatalystExpression(children[1], schema);
+          if (leftOpt.isPresent() && rightOpt.isPresent()) {
+            return Optional.of(
+                new org.apache.spark.sql.catalyst.expressions.Contains(
+                    leftOpt.get(), rightOpt.get()));
+          }
+        }
+        break;
+
+      case "IN":
+        if (children.length >= 2) {
+          Optional<Expression> firstOpt = dsv2ExpressionToCatalystExpression(children[0], schema);
+          if (firstOpt.isPresent()) {
+            List<Expression> values = new ArrayList<>();
+            for (int i = 1; i < children.length; i++) {
+              Optional<Expression> valueOpt =
+                  dsv2ExpressionToCatalystExpression(children[i], schema);
+              if (valueOpt.isPresent()) {
+                values.add(valueOpt.get());
+              } else {
+                // if any value in the IN list cannot be converted, return empty
+                return Optional.empty();
+              }
+            }
+            return Optional.of(
+                new org.apache.spark.sql.catalyst.expressions.In(
+                    firstOpt.get(), CollectionConverters.asScala(values).toSeq()
+                ));
+          }
+        }
+        break;
+
+      case "=":
+        if (children.length == 2) {
+          Optional<Expression> leftOpt = dsv2ExpressionToCatalystExpression(children[0], schema);
+          Optional<Expression> rightOpt = dsv2ExpressionToCatalystExpression(children[1], schema);
+          if (leftOpt.isPresent() && rightOpt.isPresent()) {
+            return Optional.of(
+                new org.apache.spark.sql.catalyst.expressions.EqualTo(
+                    leftOpt.get(), rightOpt.get()));
+          }
+        }
+        break;
+
+      case "<>":
+        if (children.length == 2) {
+          Optional<Expression> leftOpt = dsv2ExpressionToCatalystExpression(children[0], schema);
+          Optional<Expression> rightOpt = dsv2ExpressionToCatalystExpression(children[1], schema);
+          if (leftOpt.isPresent() && rightOpt.isPresent()) {
+            return Optional.of(
+                new org.apache.spark.sql.catalyst.expressions.Not(
+                    new org.apache.spark.sql.catalyst.expressions.EqualTo(
+                        leftOpt.get(), rightOpt.get())));
+          }
+        }
+        break;
+
+      case "<=>":
+        if (children.length == 2) {
+          Optional<Expression> leftOpt = dsv2ExpressionToCatalystExpression(children[0], schema);
+          Optional<Expression> rightOpt = dsv2ExpressionToCatalystExpression(children[1], schema);
+          if (leftOpt.isPresent() && rightOpt.isPresent()) {
+            return Optional.of(
+                new org.apache.spark.sql.catalyst.expressions.EqualNullSafe(
+                    leftOpt.get(), rightOpt.get()));
+          }
+        }
+        break;
+
+      case "<":
+        if (children.length == 2) {
+          Optional<Expression> leftOpt = dsv2ExpressionToCatalystExpression(children[0], schema);
+          Optional<Expression> rightOpt = dsv2ExpressionToCatalystExpression(children[1], schema);
+          if (leftOpt.isPresent() && rightOpt.isPresent()) {
+            return Optional.of(
+                new org.apache.spark.sql.catalyst.expressions.LessThan(
+                    leftOpt.get(), rightOpt.get()));
+          }
+        }
+        break;
+
+      case "<=":
+        if (children.length == 2) {
+          Optional<Expression> leftOpt = dsv2ExpressionToCatalystExpression(children[0], schema);
+          Optional<Expression> rightOpt = dsv2ExpressionToCatalystExpression(children[1], schema);
+          if (leftOpt.isPresent() && rightOpt.isPresent()) {
+            return Optional.of(
+                new org.apache.spark.sql.catalyst.expressions.LessThanOrEqual(
+                    leftOpt.get(), rightOpt.get()));
+          }
+        }
+        break;
+
+      case ">":
+        if (children.length == 2) {
+          Optional<Expression> leftOpt = dsv2ExpressionToCatalystExpression(children[0], schema);
+          Optional<Expression> rightOpt = dsv2ExpressionToCatalystExpression(children[1], schema);
+          if (leftOpt.isPresent() && rightOpt.isPresent()) {
+            return Optional.of(
+                new org.apache.spark.sql.catalyst.expressions.GreaterThan(
+                    leftOpt.get(), rightOpt.get()));
+          }
+        }
+        break;
+
+      case ">=":
+        if (children.length == 2) {
+          Optional<Expression> leftOpt = dsv2ExpressionToCatalystExpression(children[0], schema);
+          Optional<Expression> rightOpt = dsv2ExpressionToCatalystExpression(children[1], schema);
+          if (leftOpt.isPresent() && rightOpt.isPresent()) {
+            return Optional.of(
+                new org.apache.spark.sql.catalyst.expressions.GreaterThanOrEqual(
+                    leftOpt.get(), rightOpt.get()));
+          }
+        }
+        break;
+
+      case "AND":
+        if (children.length == 2) {
+          Optional<Expression> leftOpt =
+              dsv2PredicateToCatalystExpression(
+                  (org.apache.spark.sql.connector.expressions.filter.Predicate)
+                      predicate.children()[0],
+                  schema);
+          Optional<Expression> rightOpt =
+              dsv2PredicateToCatalystExpression(
+                  (org.apache.spark.sql.connector.expressions.filter.Predicate)
+                      predicate.children()[1],
+                  schema);
+          if (leftOpt.isPresent() && rightOpt.isPresent()) {
+            return Optional.of(
+                new org.apache.spark.sql.catalyst.expressions.And(leftOpt.get(), rightOpt.get()));
+          }
+        }
+        break;
+
+      case "OR":
+        if (children.length == 2) {
+          Optional<Expression> leftOpt =
+              dsv2PredicateToCatalystExpression(
+                  (org.apache.spark.sql.connector.expressions.filter.Predicate)
+                      predicate.children()[0],
+                  schema);
+          Optional<Expression> rightOpt =
+              dsv2PredicateToCatalystExpression(
+                  (org.apache.spark.sql.connector.expressions.filter.Predicate)
+                      predicate.children()[1],
+                  schema);
+          if (leftOpt.isPresent() && rightOpt.isPresent()) {
+            return Optional.of(
+                new org.apache.spark.sql.catalyst.expressions.Or(leftOpt.get(), rightOpt.get()));
+          }
+        }
+        break;
+
+      case "NOT":
+        if (children.length == 1) {
+          Optional<Expression> childOpt =
+              dsv2PredicateToCatalystExpression(
+                  (org.apache.spark.sql.connector.expressions.filter.Predicate)
+                      predicate.children()[0],
+                  schema);
+          if (childOpt.isPresent()) {
+            return Optional.of(new org.apache.spark.sql.catalyst.expressions.Not(childOpt.get()));
+          }
+        }
+        break;
+
+      case "ALWAYS_TRUE":
+        if (children.length == 0) {
+          return Optional.of(
+              org.apache.spark.sql.catalyst.expressions.Literal.create(
+                  true, org.apache.spark.sql.types.DataTypes.BooleanType));
+        }
+        break;
+
+      case "ALWAYS_FALSE":
+        if (children.length == 0) {
+          return Optional.of(
+              org.apache.spark.sql.catalyst.expressions.Literal.create(
+                  false, org.apache.spark.sql.types.DataTypes.BooleanType));
+        }
+        break;
+    }
+
+    return Optional.empty();
+  }
+
+  /**
+   * Translate a DSV2 Expression to a Catalyst {@link Expression} using the provided schema.
+   *
+   * <p>This method handles NamedReference and LiteralValue expressions. NamedReferences are
+   * resolved to BoundReferences based on the schema, while LiteralValues are converted to Catalyst
+   * Literals. Unsupported expression types or references to unknown columns will result in an empty
+   * Optional.
+   *
+   * @param expr   the DSV2 Expression to resolve
+   * @param schema the schema used for resolving column references
+   * @return Catalyst Expression representing the resolved expression, or empty if the expression is
+   * unsupported or references unknown columns
+   */
+  public static Optional<Expression> dsv2ExpressionToCatalystExpression(
+      org.apache.spark.sql.connector.expressions.Expression expr, StructType schema) {
+    if (expr instanceof NamedReference ref) {
+      String columnName = ref.fieldNames()[0];
+      try {
+        int index = schema.fieldIndex(columnName);
+        StructField field = schema.fields()[index];
+        return Optional.of(new BoundReference(index, field.dataType(), field.nullable()));
+      } catch (IllegalArgumentException e) {
+        // schema.fieldIndex(columnName) throws IllegalArgumentException if a field with the given
+        // name does not exist
+        return Optional.empty();
+      }
+    } else if (expr instanceof LiteralValue<?> literal) {
+      return Optional.of(
+          org.apache.spark.sql.catalyst.expressions.Literal.create(
+              literal.value(), literal.dataType()));
+    } else {
+      return Optional.empty();
+    }
+  }
+
+
+  /**
+   * Evaluates a DSV2 {@link Predicate} on an {@link InternalRow} of the provided schema.
+   *
+   * <p>This method first converts the DSV2 Predicate to a Catalyst Expression using the provided
+   * schema. If the conversion is successful, it creates a Predicate evaluator and evaluates it
+   * against the given InternalRow. If the predicate cannot be converted, an empty Optional is
+   * returned.
+   *
+   * @param predicate   the DSV2 Predicate to evaluate
+   * @param internalRow the InternalRow to evaluate the predicate against
+   * @param schema      the schema used for resolving column references in the predicate
+   * @return Optional containing the result of the evaluation (true or false), or empty if the
+   * predicate could not be converted
+   */
+  public static Optional<Boolean> evaluateInternalRowOnDsv2Predicate(
+      org.apache.spark.sql.connector.expressions.filter.Predicate predicate,
+      InternalRow internalRow,
+      StructType schema) {
+    Optional<Expression> catalystExpr = dsv2PredicateToCatalystExpression(predicate, schema);
+    if (catalystExpr.isEmpty()) {
+      return Optional.empty();
+    }
+    BasePredicate evaluator =
+        org.apache.spark.sql.catalyst.expressions.Predicate.create(catalystExpr.get());
+    return Optional.of(evaluator.eval(internalRow));
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -48,6 +48,7 @@ import org.apache.spark.sql.catalyst.util.{sideBySide, CharsetProvider, DateTime
 import org.apache.spark.sql.connector.catalog.{CatalogNotFoundException, Table, TableProvider}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf.GLOBAL_TEMP_DATABASE
 import org.apache.spark.sql.streaming.OutputMode
@@ -2837,6 +2838,13 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
     new SparkRuntimeException(
       errorClass = "MERGE_CARDINALITY_VIOLATION",
       messageParameters = Map.empty)
+  }
+
+  def failedToEvaluateV2Predicate(predicate: Predicate): Throwable = {
+    new SparkRuntimeException(
+      errorClass = "FAILED_TO_EVALUATE_DSV2_PREDICATE",
+      messageParameters = Map("predicate" -> predicate.name())
+    )
   }
 
   def unsupportedPurgePartitionError(): SparkUnsupportedOperationException = {

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/connector/util/V2ExpressionEvaluatorSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/connector/util/V2ExpressionEvaluatorSuite.java
@@ -1,0 +1,133 @@
+package org.apache.spark.sql.connector.util;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import static org.apache.spark.sql.connector.util.V2ExpressionEvaluator.dsv2PredicateToCatalystExpression;
+import static org.apache.spark.sql.connector.util.V2ExpressionEvaluator.evaluateInternalRowOnDsv2Predicate;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.Expression;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.LiteralValue;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+
+public class V2ExpressionEvaluatorSuite {
+
+  private final org.apache.spark.sql.types.StructType testSchema =
+      new org.apache.spark.sql.types.StructType()
+          .add("id", org.apache.spark.sql.types.DataTypes.IntegerType, false)
+          .add("name", org.apache.spark.sql.types.DataTypes.StringType, true)
+          .add("age", org.apache.spark.sql.types.DataTypes.IntegerType, true);
+
+  private final InternalRow[] testData = new InternalRow[]{
+      new GenericInternalRow(new Object[]{1, org.apache.spark.unsafe.types.UTF8String.fromString("Alice"), 30}),
+      new GenericInternalRow(new Object[]{2, org.apache.spark.unsafe.types.UTF8String.fromString("Bob"), null}),
+      new GenericInternalRow(new Object[]{3, null, 25}),
+      new GenericInternalRow(new Object[]{4, org.apache.spark.unsafe.types.UTF8String.fromString("David"), 35})
+  };
+
+  private final NamedReference idRef = FieldReference.apply("id");
+  private final NamedReference nameRef = FieldReference.apply("name");
+  private final NamedReference ageRef = FieldReference.apply("age");
+
+  private final org.apache.spark.sql.connector.expressions.filter.Predicate isNullPredicate =
+      new org.apache.spark.sql.connector.expressions.filter.Predicate(
+          "IS_NULL", new org.apache.spark.sql.connector.expressions.Expression[]{nameRef});
+  private final org.apache.spark.sql.connector.expressions.filter.Predicate isNotNullPredicate =
+      new org.apache.spark.sql.connector.expressions.filter.Predicate(
+          "IS_NOT_NULL", new org.apache.spark.sql.connector.expressions.Expression[]{nameRef});
+  private final org.apache.spark.sql.connector.expressions.filter.Predicate inPredicate =
+      new org.apache.spark.sql.connector.expressions.filter.Predicate(
+          "IN",
+          new org.apache.spark.sql.connector.expressions.Expression[]{
+              idRef,
+              LiteralValue.apply(1, org.apache.spark.sql.types.DataTypes.IntegerType),
+              LiteralValue.apply(3, org.apache.spark.sql.types.DataTypes.IntegerType)});
+  private final org.apache.spark.sql.connector.expressions.filter.Predicate equalsPredicate =
+      new org.apache.spark.sql.connector.expressions.filter.Predicate(
+          "=",
+          new org.apache.spark.sql.connector.expressions.Expression[]{
+              idRef,
+              LiteralValue.apply(2, org.apache.spark.sql.types.DataTypes.IntegerType)});
+  private final org.apache.spark.sql.connector.expressions.filter.Predicate greaterThanPredicate =
+      new org.apache.spark.sql.connector.expressions.filter.Predicate(
+          ">",
+          new org.apache.spark.sql.connector.expressions.Expression[]{
+              ageRef,
+              LiteralValue.apply(20, org.apache.spark.sql.types.DataTypes.IntegerType)});
+  private final org.apache.spark.sql.connector.expressions.filter.Predicate notPredicate =
+      new org.apache.spark.sql.connector.expressions.filter.Predicate(
+          "NOT",
+          new org.apache.spark.sql.connector.expressions.Expression[]{isNullPredicate});
+  private final org.apache.spark.sql.connector.expressions.filter.Predicate andPredicate =
+      new org.apache.spark.sql.connector.expressions.filter.Predicate(
+          "AND",
+          new org.apache.spark.sql.connector.expressions.Expression[]{isNotNullPredicate, greaterThanPredicate});
+  private final org.apache.spark.sql.connector.expressions.filter.Predicate orPredicate =
+      new org.apache.spark.sql.connector.expressions.filter.Predicate(
+          "OR",
+          new org.apache.spark.sql.connector.expressions.Expression[]{isNullPredicate, equalsPredicate});
+  private final org.apache.spark.sql.connector.expressions.filter.Predicate unsupportedPredicate =
+      new org.apache.spark.sql.connector.expressions.filter.Predicate(
+          "UNSUPPORTED_OP",
+          new org.apache.spark.sql.connector.expressions.Expression[]{idRef});
+
+  @Test
+  public void testDsv2PredicateToCatalystExpression() {
+    // Null tests
+    checkExpressionConversionAndEvaluation(isNullPredicate, true, new Boolean[]{false, false, true, false});
+    checkExpressionConversionAndEvaluation(isNotNullPredicate, true, new Boolean[]{true, true, false, true});
+
+    // IN operator
+    checkExpressionConversionAndEvaluation(inPredicate, true, new Boolean[]{true, false, true, false});
+
+    // Comparison operators
+    checkExpressionConversionAndEvaluation(equalsPredicate, true, new Boolean[]{false, true, false, false});
+    checkExpressionConversionAndEvaluation(greaterThanPredicate, true, new Boolean[]{true, false, true, true});
+
+    // Logical operators
+    checkExpressionConversionAndEvaluation(notPredicate, true, new Boolean[]{true, true, false, true});
+    // AND: name IS NOT NULL AND age > 20
+    // Row 0: Alice, 30 -> true AND true = true
+    // Row 1: Bob, null -> true AND false = false
+    // Row 2: null, 25 -> false AND true = false
+    // Row 3: David, 35 -> true AND true = true
+    checkExpressionConversionAndEvaluation(andPredicate, true, new Boolean[]{true, false, false, true});
+    // OR: name IS NULL OR id = 2
+    // Row 0: false OR false = false
+    // Row 1: false OR true = true
+    // Row 2: true OR false = true
+    // Row 3: false OR false = false
+    checkExpressionConversionAndEvaluation(orPredicate, true, new Boolean[]{false, true, true, false});
+
+    // Unsupported predicate
+    checkExpressionConversionAndEvaluation(unsupportedPredicate, false, null);
+  }
+
+  private void checkExpressionConversionAndEvaluation(
+      org.apache.spark.sql.connector.expressions.filter.Predicate predicate,
+      boolean isConvertible,
+      Boolean[] expectedResults) {
+    Optional<Expression> catalystExpr = dsv2PredicateToCatalystExpression(predicate, testSchema);
+
+    if (isConvertible) {
+      assertTrue(catalystExpr.isPresent(), "Predicate should be convertible");
+      for (int i = 0; i < testData.length; i++) {
+        Optional<Boolean> evalResult = evaluateInternalRowOnDsv2Predicate(predicate, testData[i], testSchema);
+        assertTrue(evalResult.isPresent(), "Evaluation result should be present");
+        assertEquals(evalResult.get(), expectedResults[i], String.format("Row %d: expected %s but got %s", i, expectedResults[i], evalResult.get()));
+      }
+    } else {
+      assertTrue(catalystExpr.isEmpty(), "Predicate should not be convertible");
+      for (InternalRow row : testData) {
+        Optional<Boolean> evalResult = evaluateInternalRowOnDsv2Predicate(predicate, row, testSchema);
+        assertTrue(evalResult.isEmpty(), "Evaluation result should not be present");
+      }
+    }
+  }
+
+}

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/connector/util/V2ExpressionEvaluatorSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/connector/util/V2ExpressionEvaluatorSuite.java
@@ -134,16 +134,8 @@ public class V2ExpressionEvaluatorSuite {
   @Test
   public void testV2ExpressionEvaluatorThrowException() {
     SparkRuntimeException e = Assertions.assertThrows(SparkRuntimeException.class,
-      () -> {
-        try {
-          evaluateInternalRowOnDsv2Predicate(unsupportedPredicate, testData[0], testSchema, false);
-        } catch (Throwable throwable) {
-          if (throwable instanceof SparkRuntimeException sparkException) {
-            throw sparkException;
-          }
-          throw new RuntimeException(throwable);
-        }
-      });
+      () -> evaluateInternalRowOnDsv2Predicate(
+              unsupportedPredicate, testData[0], testSchema, false));
     Assertions.assertEquals("FAILED_TO_EVALUATE_DSV2_PREDICATE", e.getCondition());
     Assertions.assertTrue(e.getMessage().contains("UNSUPPORTED_OP"));
   }

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/connector/util/V2ExpressionEvaluatorSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/connector/util/V2ExpressionEvaluatorSuite.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.sql.connector.util;
 
 import java.util.Optional;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR proposes to add a utility class to enable the evaluation of an InternalRow using a DSv2 predicate. In particular, it includes 
- converting dsv2 predicates to catalyst expressions
- converting dsv2 expression to catalyst expressions
  - NamedReference -> BoundReference
  - LiteralValue -> catalyst Literal
- Creating InterpretedPredicate and evaluate internalRow

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This would be helpful for partition pruning, where the [runtime filters are DSv2 predicates](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsRuntimeV2Filtering.java#L66) and the partitionValue are internalRows (for [partitionFiles in Spark](https://github.com/apache/spark/blob/65ff85a31fe8a8ea4a2ba713ba2c624709ce815a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala#L58)). In this way, partitionFiles can be pruned directly with DSv2 predicates at the scan level.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit tests. 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No