### PR TITLE
[SPARK-53808][CONNECT] Allow to pass optional JVM args to `spark-connect-scala-client`

### DIFF
--- a/sql/connect/bin/spark-connect-scala-client
+++ b/sql/connect/bin/spark-connect-scala-client
@@ -70,6 +70,7 @@ JVM_ARGS="-XX:+IgnoreUnrecognizedVMOptions \
   --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED \
   -Djdk.reflect.useDirectMethodHandle=false \
   -Dio.netty.tryReflectionSetAccessible=true \
-  --enable-native-access=ALL-UNNAMED"
+  --enable-native-access=ALL-UNNAMED \
+  $JVM_ARGS"
 
 exec java $JVM_ARGS -cp "$SCCLASSPATH" org.apache.spark.sql.application.ConnectRepl "$@"

--- a/sql/connect/bin/spark-connect-scala-client
+++ b/sql/connect/bin/spark-connect-scala-client
@@ -31,6 +31,7 @@
 #
 # Set SCBUILD=0 to skip rebuilding the spark-connect server.
 # Set SCCLASSPATH to the client classpath to skip resolving it with sbt.
+# Set SCJVM_ARGS to optional JVM args for the client.
 
 # Go to the Spark project root directory
 FWDIR="$(cd "`dirname "$0"`"/../../..; pwd)"
@@ -71,6 +72,6 @@ JVM_ARGS="-XX:+IgnoreUnrecognizedVMOptions \
   -Djdk.reflect.useDirectMethodHandle=false \
   -Dio.netty.tryReflectionSetAccessible=true \
   --enable-native-access=ALL-UNNAMED \
-  $JVM_ARGS"
+  $SCJVM_ARGS"
 
 exec java $JVM_ARGS -cp "$SCCLASSPATH" org.apache.spark.sql.application.ConnectRepl "$@"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes an improvement to allow to pass optionaj JVM args to `spark-connect-scala-client` through an environment variable `SCJVM_ARGS`.

### Why are the changes needed?
Different from other REPL tools like `spark-shell`, `spark-connect-scala-client` doesn't support optional JVM args. `--driver-java-options` doesn't affect client side.


### Does this PR introduce _any_ user-facing change?
Yes but doesn't break compatibility.

### How was this patch tested?
To use debugger, set `-agentlib:jdwp=transport=dt_socket,suspend=n,server=y,address=9876` to `SCJVM_ARGS`, and I confirmed it worked.


### Was this patch authored or co-authored using generative AI tooling?
No.
