### PR TITLE
[SPARK-53792][SS] Fix rocksdbPinnedBlocksMemoryUsage when bounded memory …

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -1461,7 +1461,6 @@ class RocksDB(
   private def metrics: RocksDBMetrics = {
     import HistogramType._
     val totalSSTFilesBytes = getDBProperty("rocksdb.total-sst-files-size")
-    val pinnedBlocksMemUsage = getDBProperty("rocksdb.block-cache-pinned-usage")
     val nativeOpsHistograms = Seq(
       "get" -> DB_GET,
       "put" -> DB_WRITE,
@@ -1496,6 +1495,11 @@ class RocksDB(
 
     // Use RocksDBMemoryManager to calculate the memory usage accounting
     val memoryUsage = RocksDBMemoryManager.getInstanceMemoryUsage(instanceUniqueId, getMemoryUsage)
+
+    val requestedPinnedBlocksMemUsage = getDBProperty("rocksdb.block-cache-pinned-usage")
+    val globalPinnedBlocksMemUsage = lruCache.getPinnedUsage()
+    val pinnedBlocksMemUsage = RocksDBMemoryManager.getInstancePinnedBlocksMemUsage(
+      instanceUniqueId, globalPinnedBlocksMemUsage, requestedPinnedBlocksMemUsage)
 
     RocksDBMetrics(
       numKeysOnLoadedVersion,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -1496,10 +1496,9 @@ class RocksDB(
     // Use RocksDBMemoryManager to calculate the memory usage accounting
     val memoryUsage = RocksDBMemoryManager.getInstanceMemoryUsage(instanceUniqueId, getMemoryUsage)
 
-    val requestedPinnedBlocksMemUsage = getDBProperty("rocksdb.block-cache-pinned-usage")
-    val globalPinnedBlocksMemUsage = lruCache.getPinnedUsage()
+    val totalPinnedBlocksMemUsage = lruCache.getPinnedUsage()
     val pinnedBlocksMemUsage = RocksDBMemoryManager.getInstancePinnedBlocksMemUsage(
-      instanceUniqueId, globalPinnedBlocksMemUsage, requestedPinnedBlocksMemUsage)
+      instanceUniqueId, totalPinnedBlocksMemUsage)
 
     RocksDBMetrics(
       numKeysOnLoadedVersion,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBMemoryManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBMemoryManager.scala
@@ -125,22 +125,22 @@ object RocksDBMemoryManager extends Logging with UnmanagedMemoryConsumer {
    * Get the pinned blocks memory usage for a specific instance, accounting for bounded memory
    * sharing.
    * @param uniqueId The instance's unique identifier
-   * @param globalPinnedUsage The total pinned usage from the cache
+   * @param totalPinnedUsage The total pinned usage from the cache
    * @return The adjusted pinned blocks memory usage accounting for sharing in bounded memory mode
    */
   def getInstancePinnedBlocksMemUsage(
       uniqueId: String,
-      pinnedUsage: Long): Long = {
+      totalPinnedUsage: Long): Long = {
     val instanceInfo = instanceMemoryMap.
       getOrDefault(uniqueId, InstanceMemoryInfo(0L, isBoundedMemory = false))
     if (instanceInfo.isBoundedMemory) {
       // In bounded memory mode, divide by the number of bounded instances
       // since they share the same cache
       val numBoundedInstances = getNumRocksDBInstances(true /* boundedMemory */)
-      pinnedUsage / numBoundedInstances
+      totalPinnedUsage / numBoundedInstances
     } else {
       // In unbounded memory mode, each instance has its own cache
-      pinnedUsage
+      totalPinnedUsage
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -3791,6 +3791,53 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
   }
 
   def listFiles(file: String): Seq[File] = listFiles(new File(file))
+
+  test("SPARK-53792: RocksDBMemoryManager getInstancePinnedBlocksMemUsage") {
+    try {
+      // Clear any existing providers from previous tests
+      RocksDBMemoryManager.resetWriteBufferManagerAndCache
+
+      val boundedMemoryId1 = "test-instance-1"
+      val boundedMemoryId2 = "test-instance-2"
+      val unboundedMemoryId = "test-instance"
+      val sharedCachePinnedUsage = 1000L
+      val requestedPinnedUsage = 300L  // This should be ignored for bounded memory
+
+      // Register two bounded memory instances
+      RocksDBMemoryManager.updateMemoryUsage(boundedMemoryId1, 0L, isBoundedMemory = true)
+      RocksDBMemoryManager.updateMemoryUsage(boundedMemoryId2, 0L, isBoundedMemory = true)
+      RocksDBMemoryManager.updateMemoryUsage(unboundedMemoryId, 0L, isBoundedMemory = false)
+
+      // Test that both instances get the same divided value from globalPinnedUsage
+      val result1 = RocksDBMemoryManager.getInstancePinnedBlocksMemUsage(
+        boundedMemoryId1,
+        sharedCachePinnedUsage,
+        requestedPinnedUsage)
+      val result2 = RocksDBMemoryManager.getInstancePinnedBlocksMemUsage(
+        boundedMemoryId2,
+        sharedCachePinnedUsage,
+        requestedPinnedUsage)
+      val result3 = RocksDBMemoryManager.getInstancePinnedBlocksMemUsage(
+        unboundedMemoryId,
+        sharedCachePinnedUsage,
+        requestedPinnedUsage)
+
+      // With 2 bounded instances, each should get half of globalPinnedUsage
+      assert(result1 === 500L, s"Expected 500L for bounded instance 1, got $result1")
+      assert(result2 === 500L, s"Expected 500L for bounded instance 2, got $result2")
+      assert(result3 === 300L, s"Expected 300L for unbounded instance, got $result3")
+
+      // Test with zero instances (unregistered instance)
+      RocksDBMemoryManager.resetWriteBufferManagerAndCache
+      val resultZero = RocksDBMemoryManager.getInstancePinnedBlocksMemUsage(
+        boundedMemoryId1,
+        sharedCachePinnedUsage,
+        requestedPinnedUsage)
+      assert(resultZero === 0L, s"Expected 0L when no instances, got $resultZero")
+    } finally {
+      RocksDBMemoryManager.resetWriteBufferManagerAndCache
+    }
+  }
 }
 
 object RocksDBSuite {


### PR DESCRIPTION
…usage is enabled

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Changing the way we calculate `pinnedBlocksMemUsage` when an instance has bounded memory enabled. 
Before the change, we always report back `getDBProperty("rocksdb.block-cache-pinned-usage")` which returns that size of pinned block requested by an instance. This is not accurate when instances share the same cached, because instances might share the same pinned block

After this change, when isMemoryBounded is enabled for an instance, we call `lruCache.getPinnedUsage()` to get the total memory usage of SHARED pinned blocks, and divide the global usage with the number of IS_MEMORY_BOUNDED instances. This is because RocksDBMemoryManager will return the same cache for all the instance that has isMemoryBounded = true

Unit test: 
build/mvn -Dtest=none -DwildcardSuites=org.apache.spark.sql.execution.streaming.state.RocksDBSuite test

### Why are the changes needed?
See above for why this is a bug. 
This fix prevents us from over-reporting `pinnedBlocksMemUsage` when isBoundedMemory is enabled for an instance 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
See added unit tests on the correctness of the calculation. 


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes. Generated-by cursor and 'claude-4-sonnet'