### PR TITLE
[SPARK-53786][SQL] Default value with special column name should not conflict with real column 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -175,6 +175,14 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
             u.copy(child = newChild)
           }
 
+        case d @ DefaultValueExpression(u: UnresolvedAttribute, _, _) =>
+          d.copy(child = LiteralFunctionResolution.resolve(u.nameParts)
+            .map {
+              case Alias(child, _) if !isTopLevel => child
+              case other => other
+            }
+            .getOrElse(u))
+
         case _ => e.mapChildren(innerResolve(_, isTopLevel = false))
       }
       resolved.copyTagsFrom(e)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -271,6 +271,30 @@ object UnresolvedTVFAliases {
 }
 
 /**
+ * Holds the name of a literal function that has yet to be resolved.
+ * Similar to UnresolvedAttribute but specifically for literal functions.
+ */
+case class UnresolvedLiteralFunction(nameParts: Seq[String]) extends Expression with Unevaluable {
+
+  def name: String =
+    nameParts.map(n => if (n.contains(".")) s"`$n`" else n).mkString(".")
+
+  override def dataType: DataType = throw new UnresolvedException("dataType")
+  override def nullable: Boolean = throw new UnresolvedException("nullable")
+  override lazy val resolved = false
+  override def children: Seq[Expression] = Nil
+
+  final override val nodePatterns: Seq[TreePattern] = Seq(UNRESOLVED_LITERAL_FUNCTION)
+
+  override def toString: String = s"'$name"
+
+  override def sql: String = nameParts.map(quoteIfNeeded).mkString(".")
+
+  override protected def withNewChildrenInternal(
+      newChildren: IndexedSeq[Expression]): Expression = this
+}
+
+/**
  * Holds the name of an attribute that has yet to be resolved.
  */
 case class UnresolvedAttribute(nameParts: Seq[String]) extends Attribute with Unevaluable {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2932,9 +2932,9 @@ class AstBuilder extends DataTypeAstBuilder
           CurrentUser()
       }
     } else {
-      // If the parser is not in ansi mode, we should return `UnresolvedAttribute`, in case there
-      // are columns named `CURRENT_DATE` or `CURRENT_TIMESTAMP` or `CURRENT_TIME`
-      UnresolvedAttribute.quoted(ctx.name.getText)
+      // If the parser is not in ansi mode, we should return `UnresolvedLiteralFunction`,
+      // in case there are columns named `CURRENT_DATE` or `CURRENT_TIMESTAMP` or `CURRENT_TIME`
+      UnresolvedLiteralFunction(Seq(ctx.name.getText))
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -109,6 +109,7 @@ object TreePattern extends Enumeration  {
   val UNRESOLVED_DF_STAR: Value = Value
   val UNRESOLVED_FUNCTION: Value = Value
   val UNRESOLVED_IDENTIFIER: Value = Value
+  val UNRESOLVED_LITERAL_FUNCTION: Value = Value
   val UNRESOLVED_ORDINAL: Value = Value
   val UNRESOLVED_PLAN_ID: Value = Value
   val UNRESOLVED_WINDOW_EXPRESSION: Value = Value

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTableTests.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTableTests.scala
@@ -1591,6 +1591,13 @@ trait AlterTableTests extends SharedSparkSession with QueryErrorsBase {
     }
   }
 
+  private def checkConflictSpecialColNameResult(table: String): Unit = {
+    val result = sql(s"SELECT * FROM $table").collect()
+    assert(result.length == 1)
+    assert(!result(0).getBoolean(0))
+    assert(result(0).get(1) != null)
+  }
+
   test("Add column with special column name default value conflicting with column name") {
     withSQLConf(SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS.key -> s"$v2Format, ") {
       val t = fullTableName("table_name")
@@ -1599,40 +1606,28 @@ trait AlterTableTests extends SharedSparkSession with QueryErrorsBase {
         sql(s"CREATE TABLE $t (i boolean) USING $v2Format")
         sql(s"ALTER TABLE $t ADD COLUMN s timestamp DEFAULT current_timestamp")
         sql(s"INSERT INTO $t(i) VALUES(false)")
-        val result = sql(s"SELECT * FROM $t").collect()
-        assert(result.length == 1)
-        assert(!result(0).getBoolean(0))
-        assert(result(0).getTimestamp(1) != null)
+        checkConflictSpecialColNameResult(t)
       }
       // There is a default value with special column name 'current_user' but in uppercase.
       withTable(t) {
         sql(s"CREATE TABLE $t (i boolean) USING $v2Format")
         sql(s"ALTER TABLE $t ADD COLUMN s string DEFAULT CURRENT_USER")
         sql(s"INSERT INTO $t(i) VALUES(false)")
-        val result = sql(s"SELECT * FROM $t").collect()
-        assert(result.length == 1)
-        assert(!result(0).getBoolean(0))
-        assert(result(0).getString(1) != null)
+        checkConflictSpecialColNameResult(t)
       }
       // There is a default value with special column name same as current column name
       withTable(t) {
         sql(s"CREATE TABLE $t (b boolean) USING $v2Format")
         sql(s"ALTER TABLE $t ADD COLUMN current_timestamp timestamp DEFAULT current_timestamp")
         sql(s"INSERT INTO $t(b) VALUES(false)")
-        val result = sql(s"SELECT * FROM $t").collect()
-        assert(result.length == 1)
-        assert(!result(0).getBoolean(0))
-        assert(result(0).getTimestamp(1) != null)
+        checkConflictSpecialColNameResult(t)
       }
       // There is a default value with special column name same as another column name
       withTable(t) {
         sql(s"CREATE TABLE $t (current_date boolean) USING $v2Format")
         sql(s"ALTER TABLE $t ADD COLUMN s date DEFAULT current_date")
         sql(s"INSERT INTO $t(current_date) VALUES(false)")
-        val result = sql(s"SELECT * FROM $t").collect()
-        assert(result.length == 1)
-        assert(!result(0).getBoolean(0))
-        assert(result(0).getDate(1) != null)
+        checkConflictSpecialColNameResult(t)
       }
     }
   }
@@ -1645,40 +1640,28 @@ trait AlterTableTests extends SharedSparkSession with QueryErrorsBase {
         sql(s"CREATE TABLE $t (i boolean, s timestamp) USING $v2Format")
         sql(s"ALTER TABLE $t ALTER COLUMN s SET DEFAULT current_timestamp")
         sql(s"INSERT INTO $t(i) VALUES(false)")
-        val result = sql(s"SELECT * FROM $t").collect()
-        assert(result.length == 1)
-        assert(!result(0).getBoolean(0))
-        assert(result(0).getTimestamp(1) != null)
+        checkConflictSpecialColNameResult(t)
       }
       // There is a default value with special column name 'current_user' but in uppercase.
       withTable(t) {
         sql(s"CREATE TABLE $t (i boolean, s string) USING $v2Format")
         sql(s"ALTER TABLE $t ALTER COLUMN s SET DEFAULT CURRENT_USER")
         sql(s"INSERT INTO $t(i) VALUES(false)")
-        val result = sql(s"SELECT * FROM $t").collect()
-        assert(result.length == 1)
-        assert(!result(0).getBoolean(0))
-        assert(result(0).getString(1) != null)
+        checkConflictSpecialColNameResult(t)
       }
       // There is a default value with special column name same as current column name
       withTable(t) {
-        sql(s"CREATE TABLE $t (current_timestamp timestamp, b boolean) USING $v2Format")
+        sql(s"CREATE TABLE $t (b boolean, current_timestamp timestamp) USING $v2Format")
         sql(s"ALTER TABLE $t ALTER COLUMN current_timestamp SET DEFAULT current_timestamp")
         sql(s"INSERT INTO $t(b) VALUES(false)")
-        val result = sql(s"SELECT * FROM $t").collect()
-        assert(result.length == 1)
-        assert(result(0).getTimestamp(0) != null)
-        assert(!result(0).getBoolean(1))
+        checkConflictSpecialColNameResult(t)
       }
       // There is a default value with special column name same as another column name
       withTable(t) {
         sql(s"CREATE TABLE $t (current_date boolean, s date) USING $v2Format")
         sql(s"ALTER TABLE $t ALTER COLUMN s SET DEFAULT current_date")
         sql(s"INSERT INTO $t(current_date) VALUES(false)")
-        val result = sql(s"SELECT * FROM $t").collect()
-        assert(result.length == 1)
-        assert(!result(0).getBoolean(0))
-        assert(result(0).getDate(1) != null)
+        checkConflictSpecialColNameResult(t)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -3870,6 +3870,17 @@ class DataSourceV2SQLSuiteV1Filter
     }
   }
 
+  test("test default value conflicting with special column name") {
+    val t = "testcat.ns.t"
+    withTable("t") {
+      sql(s"""CREATE table $t (
+         c1 STRING,
+         c2 TIMESTAMP,
+         c3 BOOLEAN DEFAULT FALSE,
+         current_timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP)""")
+    }
+  }
+
   private def testNotSupportedV2Command(
       sqlCommand: String,
       sqlParams: String,

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -3917,7 +3917,7 @@ class DataSourceV2SQLSuiteV1Filter
       checkError(
         exception = intercept[AnalysisException] {
           sql(s"""CREATE table $t (
-           c1 STRING,
+           c1 timestamp,
            current_timestamp TIMESTAMP DEFAULT c1)""")
         },
         condition = "INVALID_DEFAULT_VALUE.NOT_CONSTANT",

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -3898,6 +3898,19 @@ class DataSourceV2SQLSuiteV1Filter
     }
   }
 
+  test("test default value special column name nested in function") {
+    val t = "testcat.ns.t"
+    withTable("t") {
+      sql(s"""CREATE table $t (
+         c1 STRING,
+         current_date DATE DEFAULT DATE_ADD(current_date, 7))""")
+      sql(s"INSERT INTO $t (c1) VALUES ('a')")
+      val result = sql(s"SELECT * FROM $t").collect()
+      assert(result.length == 1)
+      assert(result(0).getString(0) == "a")
+    }
+  }
+
   test("test default value should not refer to real column") {
     val t = "testcat.ns.t"
     withTable("t") {
@@ -3907,7 +3920,7 @@ class DataSourceV2SQLSuiteV1Filter
            c1 STRING,
            current_timestamp TIMESTAMP DEFAULT c1)""")
         },
-        condition = "INVALID_DEFAULT_VALUE.UNRESOLVED_EXPRESSION",
+        condition = "INVALID_DEFAULT_VALUE.NOT_CONSTANT",
         parameters = Map(
           "statement" -> "CREATE TABLE",
           "colName" -> "`current_timestamp`",

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -3887,14 +3887,7 @@ class DataSourceV2SQLSuiteV1Filter
       val result = sql(s"SELECT * FROM $t").collect()
       assert(result.length == 1)
       assert(result(0).getString(0) == "a")
-      assert(result(0).get(1) != null)
-      assert(result(0).get(2) != null)
-      assert(result(0).get(3) != null)
-      assert(result(0).get(4) != null)
-      assert(result(0).get(5) != null)
-      assert(result(0).get(6) != null)
-      assert(result(0).get(7) != null)
-      assert(result(0).get(8) != null)
+      Seq(1 to 8: _*).foreach(i => assert(result(0).get(i) != null))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the analysis of default value expression to not include column names

### Why are the changes needed?
The following query:

```CREATE TABLE t (current_timestamp DEFAULT current_timestamp)```
 

fails with an exception:
```
[INVALID_DEFAULT_VALUE.NOT_CONSTANT] Failed to execute CREATE TABLE command because the destination column or variable `current_timestamp` has a DEFAULT value CURRENT_TIMESTAMP, which is not a constant expression whose equivalent value is known at query planning time. SQLSTATE: 42623;

```
This is because , to create a default value DSV2 expression, the code now uses the main analyzer to analyze the default value, which resolves it to the column current_timestamp.  However, analyzer should not try to resolve default value to other columns.


### Does this PR introduce _any_ user-facing change?
Should fix a regression


### How was this patch tested?
Add new unit test in DataSourceV2SQLSuite


### Was this patch authored or co-authored using generative AI tooling?
No
