### PR TITLE
Added Execution Frame Subclasses

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -1225,7 +1225,7 @@ class ForStatementExec(
 class ExceptionHandlerExec(
     val body: CompoundBodyExec,
     val handlerType: ExceptionHandlerType,
-    val scopeLabel: Option[String]) extends NonLeafStatementExec {
+    val scopeLabel: String) extends NonLeafStatementExec {
 
   protected[scripting] var curr: Option[CompoundStatementExec] = body.curr
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreter.scala
@@ -91,7 +91,7 @@ case class SqlScriptingInterpreter(session: SparkSession) {
       val handlerExec = new ExceptionHandlerExec(
         handlerBodyExec,
         handler.handlerType,
-        Some(compoundBody.label.get))
+        compoundBody.label.get)
 
       // For each condition handler is defined for, add corresponding key value pair
       // to the conditionHandlerMap.

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingLocalVariableManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingLocalVariableManager.scala
@@ -87,7 +87,10 @@ class SqlScriptingLocalVariableManager(context: SqlScriptingExecutionContext)
     // including the scope where the previously checked exception handler frame is defined.
     // Exception handler frames should not have access to variables from scopes
     // which are nested below the scope where the handler is defined.
-    var previousFrameDefinitionLabel = context.currentFrame.scopeLabel
+    var previousFrameDefinitionLabel = context.currentFrame match {
+      case frame: SqlScriptingHandlerExecutionFrame => Some(frame.scopeLabel)
+      case _ => None
+    }
 
     // dropRight(1) removes the current frame, which we already checked above.
     context.frames.dropRight(1).reverseIterator.foreach(frame => {
@@ -105,7 +108,10 @@ class SqlScriptingLocalVariableManager(context: SqlScriptingExecutionContext)
       // in this frame. If we still have not found the variable, we now have to find the definition
       // of this new frame, so we reassign the frame definition label to search for.
       if (candidateScopes.nonEmpty) {
-        previousFrameDefinitionLabel = frame.scopeLabel
+        previousFrameDefinitionLabel = frame match {
+          case frame: SqlScriptingHandlerExecutionFrame => Some(frame.scopeLabel)
+          case _ => None
+        }
       }
     })
     None

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingTestUtils.scala
@@ -53,7 +53,7 @@ trait SqlScriptingTestUtils {
     val context = new SqlScriptingExecutionContext()
     val executionPlan = interpreter.buildExecutionPlan(compoundBody, args, context)
     context.frames.append(
-      new SqlScriptingExecutionFrame(executionPlan, SqlScriptingFrameType.SQL_SCRIPT)
+      new SqlScriptingSqlScriptExecutionFrame(executionPlan)
     )
     executionPlan.enterScope()
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Changes proposed are the refactoring of SqlScriptingExecutionFrame class. Instead of using an enum to encompass the frame type, class hierarchy was added added to the SqlScriptingExecutionFrame base class, and for every subtype a new class was added.

These classes will contain:
 - Fields that are only used by their frame type.
 - Their own implementations for gracefully exiting the frame.

New class hierarchy:

```
SqlScriptingExecutionFrame
|
*--------------------------------------------------------\
|                                                        |
SqlScriptingHandlerExecutionFrame            SqlScriptingSqlScriptExecutionFrame
|
*---------------------------------------------------------------\
|                                                               |
SqlScriptingExitHandlerExecutionFrame         SqlScriptingContinueHandlerExecutionFrame
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Refactor was done for increased code robustness and clarity. Also, it loses at least a field per execution frame object.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

It was tested using existing tests, to retain old behavior.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.