### PR TITLE
[SPARK-53779][SQL][CONNECT] Implement `transform()` in Column API

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Column.scala
@@ -1432,8 +1432,7 @@ class Column(val node: ColumnNode) extends Logging with TableValuedFunctionArgum
    *   df.select($"name".transform(addPrefix))
    *
    *   // Chaining multiple transformations
-   *   def uppercase(c: Column): Column = upper(c)
-   *   df.select($"name".transform(addPrefix).transform(uppercase))
+   *   df.select($"name".transform(addPrefix).transform(upper))
    * }}}
    *
    * @group expr_ops

--- a/sql/api/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Column.scala
@@ -1439,7 +1439,7 @@ class Column(val node: ColumnNode) extends Logging with TableValuedFunctionArgum
    * @group expr_ops
    * @since 4.1.0
    */
-  def transform(t: Column => Column): Column = t(this)
+  def transform(f: Column => Column): Column = f(this)
 
 }
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Column.scala
@@ -1424,6 +1424,23 @@ class Column(val node: ColumnNode) extends Logging with TableValuedFunctionArgum
    */
   def outer(): Column = Column(internal.LazyExpression(node))
 
+  /**
+   * Concise syntax for chaining custom transformations.
+   * {{{
+   *   def addPrefix(c: Column): Column = concat(lit("prefix_"), c)
+   *
+   *   df.select($"name".transform(addPrefix))
+   *
+   *   // Chaining multiple transformations
+   *   def uppercase(c: Column): Column = upper(c)
+   *   df.select($"name".transform(addPrefix).transform(uppercase))
+   * }}}
+   *
+   * @group expr_ops
+   * @since 4.1.0
+   */
+  def transform(t: Column => Column): Column = t(this)
+
 }
 
 /**

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ColumnTestSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ColumnTestSuite.scala
@@ -209,4 +209,30 @@ class ColumnTestSuite extends ConnectFunSuite {
   testColName(structType1, _.struct(structType1))
   import org.apache.spark.util.ArrayImplicits._
   testColName(structType2, _.struct(structType2.fields.toImmutableArraySeq: _*))
+
+  test("transform with named function") {
+    val a = fn.col("a")
+    def addOne(c: Column): Column = c + 1
+    val transformed = a.transform(addOne)
+    assert(transformed == (a + 1))
+  }
+
+  test("transform with lambda") {
+    val a = fn.col("a")
+    val transformed = a.transform(c => c * 2)
+    assert(transformed == (a * 2))
+  }
+
+  test("transform chaining") {
+    val a = fn.col("a")
+    val transformed = a.transform(c => c + 1).transform(c => c * 2)
+    assert(transformed == ((a + 1) * 2))
+  }
+
+  test("transform with complex lambda") {
+    val a = fn.col("a")
+    val transformed = a.transform(c => fn.when(c > 10, c * 2).otherwise(c))
+    val expected = fn.when(a > 10, a * 2).otherwise(a)
+    assert(transformed == expected)
+  }
 }

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ColumnTestSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ColumnTestSuite.scala
@@ -242,4 +242,18 @@ class ColumnTestSuite extends ConnectFunSuite {
     val expected = fn.upper(fn.trim(a))
     assert(transformed == expected)
   }
+
+  test("transform with arithmetic operations") {
+    val a = fn.col("a")
+    val transformed = a.transform(_ + 10).transform(_ * 2).transform(_ - 5)
+    assert(transformed == (((a + 10) * 2) - 5))
+  }
+
+  test("transform mixing named functions and lambdas") {
+    val a = fn.col("a")
+    def triple(c: Column): Column = c * 3
+    val transformed = a.transform(triple).transform(c => c + 10)
+    assert(transformed == ((a * 3) + 10))
+  }
+
 }

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ColumnTestSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ColumnTestSuite.scala
@@ -256,4 +256,11 @@ class ColumnTestSuite extends ConnectFunSuite {
     assert(transformed == ((a * 3) + 10))
   }
 
+  test("transform with nested transform") {
+    val a = fn.col("a")
+    val transformed = a.transform(_.transform(fn.upper))
+    val expected = fn.upper(a)
+    assert(transformed == expected)
+  }
+
 }

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ColumnTestSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ColumnTestSuite.scala
@@ -235,4 +235,11 @@ class ColumnTestSuite extends ConnectFunSuite {
     val expected = fn.when(a > 10, a * 2).otherwise(a)
     assert(transformed == expected)
   }
+
+  test("transform with built-in functions") {
+    val a = fn.col("a")
+    val transformed = a.transform(fn.trim).transform(fn.upper)
+    val expected = fn.upper(fn.trim(a))
+    assert(transformed == expected)
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -3145,44 +3145,8 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
       Seq((Duration.ofDays(2))).toDF())
   }
 
-  test("Column.transform: basic transformation") {
-    val df = Seq(1, 2, 3).toDF("value")
-
-    def addOne(c: Column): Column = c + 1
-
-    checkAnswer(
-      df.select($"value".transform(addOne)),
-      Seq(2, 3, 4).toDF()
-    )
-  }
-
-  test("Column.transform: chaining transformations") {
-    val df = Seq("apple", "banana", "cherry").toDF("fruit")
-
-    def addPrefix(c: Column): Column = concat(lit("fruit_"), c)
-
-    def uppercase(c: Column): Column = upper(c)
-
-    checkAnswer(
-      df.select($"fruit".transform(addPrefix).transform(uppercase)),
-      Seq("FRUIT_APPLE", "FRUIT_BANANA", "FRUIT_CHERRY").toDF()
-    )
-  }
-
-  test("Column.transform: with complex function") {
-    val df = Seq(1, 2, 3, 4, 5).toDF("num")
-
-    def conditionalDouble(c: Column): Column = when(c > 3, c * 2).otherwise(c)
-
-    checkAnswer(
-      df.select($"num".transform(conditionalDouble)),
-      Seq(1, 2, 3, 8, 10).toDF()
-    )
-  }
-
-  test("Column.transform: with functions from functions object") {
+  test("Column.transform") {
     val df = Seq("  hello  ", "  world  ").toDF("text")
-
     def trimAndUpper(c: Column): Column = upper(trim(c))
 
     checkAnswer(
@@ -3191,59 +3155,12 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
     )
   }
 
-  test("Column.transform: with lambda expression") {
-    val df = Seq(1, 2, 3, 4, 5).toDF("num")
-
-    // Simple lambda
-    checkAnswer(
-      df.select($"num".transform(c => c * 2)),
-      Seq(2, 4, 6, 8, 10).toDF()
-    )
-  }
-
-  test("Column.transform: chaining lambda expressions") {
+  test("Column.transform: chaining") {
     val df = Seq(10, 20, 30).toDF("value")
 
-    // Chain multiple lambdas
     checkAnswer(
-      df.select(
-        $"value"
-          .transform(c => c + 5)
-          .transform(c => c * 2)
-          .transform(c => c - 10)
-      ),
+      df.select($"value".transform(_ + 5).transform(_ * 2).transform(_ - 10)),
       Seq(20, 40, 60).toDF()
-    )
-  }
-
-  test("Column.transform: lambda with complex logic") {
-    val df = Seq("apple", "banana", "cherry", "date").toDF("fruit")
-
-    // Lambda with conditional and string operations
-    checkAnswer(
-      df.select(
-        $"fruit".transform(c =>
-          when(functions.length(c) > 5, concat(lit("long: "), upper(c)))
-            .otherwise(concat(lit("short: "), c))
-        )
-      ),
-      Seq("short: apple", "long: BANANA", "long: CHERRY", "short: date").toDF()
-    )
-  }
-
-  test("Column.transform: mixing lambdas and named functions") {
-    val df = Seq(1, 2, 3).toDF("num")
-
-    def triple(c: Column): Column = c * 3
-
-    // Mix named function and lambda
-    checkAnswer(
-      df.select(
-        $"num"
-          .transform(triple)
-          .transform(c => c + 10)
-      ),
-      Seq(13, 16, 19).toDF()
     )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -3202,4 +3202,59 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
       Seq("HELLO", "WORLD").toDF()
     )
   }
+
+  test("Column.transform: with lambda expression") {
+    val df = Seq(1, 2, 3, 4, 5).toDF("num")
+
+    // Simple lambda
+    checkAnswer(
+      df.select($"num".transform(c => c * 2)),
+      Seq(2, 4, 6, 8, 10).toDF()
+    )
+  }
+
+  test("Column.transform: chaining lambda expressions") {
+    val df = Seq(10, 20, 30).toDF("value")
+
+    // Chain multiple lambdas
+    checkAnswer(
+      df.select(
+        $"value"
+          .transform(c => c + 5)
+          .transform(c => c * 2)
+          .transform(c => c - 10)
+      ),
+      Seq(20, 40, 60).toDF()
+    )
+  }
+
+  test("Column.transform: lambda with complex logic") {
+    val df = Seq("apple", "banana", "cherry", "date").toDF("fruit")
+
+    // Lambda with conditional and string operations
+    checkAnswer(
+      df.select(
+        $"fruit".transform(c => 
+          when(length(c) > 5, concat(lit("long: "), upper(c)))
+            .otherwise(concat(lit("short: "), c))
+        )
+      ),
+      Seq("short: apple", "long: BANANA", "long: CHERRY", "short: date").toDF()
+    )
+  }
+
+  test("Column.transform: mixing lambdas and named functions") {
+    val df = Seq(1, 2, 3).toDF("num")
+    def triple(c: Column): Column = c * 3
+
+    // Mix named function and lambda
+    checkAnswer(
+      df.select(
+        $"num"
+          .transform(triple)
+          .transform(c => c + 10)
+      ),
+      Seq(13, 16, 19).toDF()
+    )
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -3243,7 +3243,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df.select(
         $"fruit".transform(c =>
-          when(length(c) > 5, concat(lit("long: "), upper(c)))
+          when(functions.length(c) > 5, concat(lit("long: "), upper(c)))
             .otherwise(concat(lit("short: "), c))
         )
       ),

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -3147,7 +3147,9 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
 
   test("Column.transform: basic transformation") {
     val df = Seq(1, 2, 3).toDF("value")
+
     def addOne(c: Column): Column = c + 1
+
     checkAnswer(
       df.select($"value".transform(addOne)),
       Seq(2, 3, 4).toDF()
@@ -3156,7 +3158,9 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
 
   test("Column.transform: chaining transformations") {
     val df = Seq("apple", "banana", "cherry").toDF("fruit")
+
     def addPrefix(c: Column): Column = concat(lit("fruit_"), c)
+
     def uppercase(c: Column): Column = upper(c)
 
     checkAnswer(
@@ -3167,6 +3171,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
 
   test("Column.transform: with complex function") {
     val df = Seq(1, 2, 3, 4, 5).toDF("num")
+
     def conditionalDouble(c: Column): Column = when(c > 3, c * 2).otherwise(c)
 
     checkAnswer(
@@ -3177,6 +3182,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
 
   test("Column.transform: with null values") {
     val df = Seq(Some(1), None, Some(3)).toDF("value")
+
     def addTen(c: Column): Column = c + 10
 
     checkAnswer(
@@ -3187,6 +3193,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
 
   test("Column.transform: preserves column type") {
     val df = Seq(1.5, 2.5, 3.5).toDF("num")
+
     def doubleIt(c: Column): Column = c * 2
 
     val result = df.select($"num".transform(doubleIt))
@@ -3195,6 +3202,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
 
   test("Column.transform: with functions from functions object") {
     val df = Seq("  hello  ", "  world  ").toDF("text")
+
     def trimAndUpper(c: Column): Column = upper(trim(c))
 
     checkAnswer(
@@ -3234,7 +3242,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
     // Lambda with conditional and string operations
     checkAnswer(
       df.select(
-        $"fruit".transform(c => 
+        $"fruit".transform(c =>
           when(length(c) > 5, concat(lit("long: "), upper(c)))
             .otherwise(concat(lit("short: "), c))
         )
@@ -3245,6 +3253,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
 
   test("Column.transform: mixing lambdas and named functions") {
     val df = Seq(1, 2, 3).toDF("num")
+
     def triple(c: Column): Column = c * 3
 
     // Mix named function and lambda

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -3180,26 +3180,6 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
     )
   }
 
-  test("Column.transform: with null values") {
-    val df = Seq(Some(1), None, Some(3)).toDF("value")
-
-    def addTen(c: Column): Column = c + 10
-
-    checkAnswer(
-      df.select($"value".transform(addTen)),
-      Seq(Some(11), None, Some(13)).toDF()
-    )
-  }
-
-  test("Column.transform: preserves column type") {
-    val df = Seq(1.5, 2.5, 3.5).toDF("num")
-
-    def doubleIt(c: Column): Column = c * 2
-
-    val result = df.select($"num".transform(doubleIt))
-    checkAnswer(result, Seq(3.0, 5.0, 7.0).toDF())
-  }
-
   test("Column.transform: with functions from functions object") {
     val df = Seq("  hello  ", "  world  ").toDF("text")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -3147,10 +3147,9 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
 
   test("Column.transform") {
     val df = Seq("  hello  ", "  world  ").toDF("text")
-    def trimAndUpper(c: Column): Column = upper(trim(c))
 
     checkAnswer(
-      df.select($"text".transform(trimAndUpper)),
+      df.select($"text".transform(trim).transform(upper)),
       Seq("HELLO", "WORLD").toDF()
     )
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -3145,7 +3145,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
       Seq((Duration.ofDays(2))).toDF())
   }
 
-  test("Column.transform") {
+  test("Column.transform: built-in functions") {
     val df = Seq("  hello  ", "  world  ").toDF("text")
 
     checkAnswer(
@@ -3154,7 +3154,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
     )
   }
 
-  test("Column.transform: chaining") {
+  test("Column.transform: lambda functions") {
     val df = Seq(10, 20, 30).toDF("value")
 
     checkAnswer(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->


### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add `transform()` API in Columns API, similar to `Dataset.transform()`:
```
def transform(f: Column => Column): Column
```


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We want to give users a way to chain their methods, such as 
```
df.select($"fruit"
  .transform(addPrefix)
  .transform(uppercase)
)
```
This pattern is also easier for AI agents to learn and write.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. New API is introduced.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests. 


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Tests generated by Copilot. 