### PR TITLE
[SPARK-53870][PYTHON][SS] Fix partial read bug for large proto messages in TransformWithStateInPySparkStateServer

### DIFF
--- a/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
@@ -200,6 +200,7 @@ class TransformWithStateTestsMixin:
         q.awaitTermination(10)
         self.assertTrue(q.exception() is None)
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_basic(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -216,6 +217,7 @@ class TransformWithStateTestsMixin:
 
         self._test_transform_with_state_basic(SimpleStatefulProcessorFactory(), check_results)
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_non_exist_value_state(self):
         def check_results(batch_df, _):
             batch_df.collect()
@@ -228,6 +230,7 @@ class TransformWithStateTestsMixin:
             InvalidSimpleStatefulProcessorFactory(), check_results, True
         )
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_query_restarts(self):
         root_path = tempfile.mkdtemp()
         input_path = root_path + "/input"
@@ -302,6 +305,7 @@ class TransformWithStateTestsMixin:
             Row(id="1", countAsString="2"),
         }
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_list_state(self):
         def check_results(batch_df, _):
             batch_df.collect()
@@ -314,6 +318,7 @@ class TransformWithStateTestsMixin:
             ListStateProcessorFactory(), check_results, True, "processingTime"
         )
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_list_state_large_list(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -389,6 +394,7 @@ class TransformWithStateTestsMixin:
         self.assertTrue(q.exception() is None)
 
     # test list state with ttl has the same behavior as list state when state doesn't expire.
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_list_state_large_ttl(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -401,6 +407,7 @@ class TransformWithStateTestsMixin:
             ListStateLargeTTLProcessorFactory(), check_results, True, "processingTime"
         )
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_map_state(self):
         def check_results(batch_df, _):
             batch_df.collect()
@@ -412,6 +419,7 @@ class TransformWithStateTestsMixin:
         self._test_transform_with_state_basic(MapStateProcessorFactory(), check_results, True)
 
     # test map state with ttl has the same behavior as map state when state doesn't expire.
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_map_state_large_ttl(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -426,6 +434,7 @@ class TransformWithStateTestsMixin:
 
     # test value state with ttl has the same behavior as value state when
     # state doesn't expire.
+    @unittest.skip("Temporarily disabled for testing")
     def test_value_state_ttl_basic(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -446,6 +455,7 @@ class TransformWithStateTestsMixin:
 
     # TODO SPARK-50908 holistic fix for TTL suite
     @unittest.skip("test is flaky and it is only a timing issue, skipping until we can resolve")
+    @unittest.skip("Temporarily disabled for testing")
     def test_value_state_ttl_expiration(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -595,6 +605,7 @@ class TransformWithStateTestsMixin:
         q.awaitTermination(10)
         self.assertTrue(q.exception() is None)
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_proc_timer(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -712,6 +723,7 @@ class TransformWithStateTestsMixin:
         q.awaitTermination(10)
         self.assertTrue(q.exception() is None)
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_event_time(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -744,6 +756,7 @@ class TransformWithStateTestsMixin:
             EventTimeStatefulProcessorFactory(), check_results
         )
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_with_wmark_and_non_event_time(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -842,6 +855,7 @@ class TransformWithStateTestsMixin:
         q.awaitTermination(10)
         self.assertTrue(q.exception() is None)
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_init_state(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -866,6 +880,7 @@ class TransformWithStateTestsMixin:
             SimpleStatefulProcessorWithInitialStateFactory(), check_results
         )
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_init_state_with_extra_transformation(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -945,6 +960,7 @@ class TransformWithStateTestsMixin:
         q.awaitTermination(10)
         self.assertTrue(q.exception() is None)
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_non_contiguous_grouping_cols(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -957,6 +973,7 @@ class TransformWithStateTestsMixin:
             SimpleStatefulProcessorWithInitialStateFactory(), check_results
         )
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_non_contiguous_grouping_cols_with_init_state(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -1040,6 +1057,7 @@ class TransformWithStateTestsMixin:
         q.processAllAvailable()
         q.awaitTermination(10)
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_chaining_ops(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -1076,6 +1094,7 @@ class TransformWithStateTestsMixin:
             ["outputTimestamp", "id"],
         )
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_init_state_with_timers(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -1106,6 +1125,7 @@ class TransformWithStateTestsMixin:
             StatefulProcessorWithInitialStateTimersFactory(), check_results, "processingTime"
         )
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_batch_query(self):
         data = [("0", 123), ("0", 46), ("1", 146), ("1", 346)]
         df = self.spark.createDataFrame(data, "id string, temperature int")
@@ -1137,6 +1157,7 @@ class TransformWithStateTestsMixin:
             Row(id="1", countAsString="2"),
         }
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_batch_query_initial_state(self):
         data = [("0", 123), ("0", 46), ("1", 146), ("1", 346)]
         df = self.spark.createDataFrame(data, "id string, temperature int")
@@ -1181,9 +1202,11 @@ class TransformWithStateTestsMixin:
     @unittest.skipIf(
         "COVERAGE_PROCESS_START" in os.environ, "Flaky with coverage enabled, skipping for now."
     )
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_map_state_metadata(self):
         self._test_transform_with_map_state_metadata(None)
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_map_state_metadata_with_init_state(self):
         # run the same test suite again but with no-op initial state
         # TWS with initial state is using a different python runner
@@ -1316,6 +1339,7 @@ class TransformWithStateTestsMixin:
         )
 
     # This test covers multiple list state variables and flatten option
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_list_state_metadata(self):
         checkpoint_path = tempfile.mktemp()
 
@@ -1396,6 +1420,7 @@ class TransformWithStateTestsMixin:
 
     # This test covers value state variable and read change feed,
     # snapshotStartBatchId related options
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_value_state_metadata(self):
         checkpoint_path = tempfile.mktemp()
 
@@ -1486,6 +1511,7 @@ class TransformWithStateTestsMixin:
                 checkpoint_path=checkpoint_path,
             )
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_restart_with_multiple_rows_init_state(self):
         def check_results(batch_df, _):
             batch_df.collect()
@@ -1545,6 +1571,7 @@ class TransformWithStateTestsMixin:
             initial_state=init_df,
         )
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_in_pandas_composite_type(self):
         def check_results(batch_df, batch_id):
             if batch_id == 0:
@@ -1904,6 +1931,7 @@ class TransformWithStateTestsMixin:
         )
 
     # run the same test suites again but with single shuffle partition
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_with_timers_single_partition(self):
         with self.sql_conf({"spark.sql.shuffle.partitions": "1"}):
             self.test_transform_with_state_init_state_with_timers()
@@ -1952,6 +1980,7 @@ class TransformWithStateTestsMixin:
         q.processAllAvailable()
         q.awaitTermination(10)
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_schema_evolution_scenarios(self):
         """Test various schema evolution scenarios"""
         with self.sql_conf({"spark.sql.streaming.stateStore.encodingFormat": "avro"}):
@@ -2020,6 +2049,7 @@ class TransformWithStateTestsMixin:
 
     # This test case verifies that an exception is thrown when downcasting, which violates
     # Avro's schema evolution rules
+    @unittest.skip("Temporarily disabled for testing")
     def test_schema_evolution_fails(self):
         with self.sql_conf({"spark.sql.streaming.stateStore.encodingFormat": "avro"}):
             with tempfile.TemporaryDirectory() as checkpoint_dir:
@@ -2072,6 +2102,7 @@ class TransformWithStateTestsMixin:
                         and "Schema evolution is not possible" in error_msg
                     )
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_not_nullable_fails(self):
         with self.sql_conf({"spark.sql.streaming.stateStore.encodingFormat": "avro"}):
             with tempfile.TemporaryDirectory() as checkpoint_dir:
@@ -2104,6 +2135,7 @@ class TransformWithStateTestsMixin:
                         and "column family state must be nullable" in error_msg
                     )
 
+    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_int_to_decimal_coercion(self):
         if not self.use_pandas():
             return

--- a/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_transform_with_state.py
@@ -200,7 +200,6 @@ class TransformWithStateTestsMixin:
         q.awaitTermination(10)
         self.assertTrue(q.exception() is None)
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_basic(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -217,7 +216,6 @@ class TransformWithStateTestsMixin:
 
         self._test_transform_with_state_basic(SimpleStatefulProcessorFactory(), check_results)
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_non_exist_value_state(self):
         def check_results(batch_df, _):
             batch_df.collect()
@@ -230,7 +228,6 @@ class TransformWithStateTestsMixin:
             InvalidSimpleStatefulProcessorFactory(), check_results, True
         )
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_query_restarts(self):
         root_path = tempfile.mkdtemp()
         input_path = root_path + "/input"
@@ -305,7 +302,6 @@ class TransformWithStateTestsMixin:
             Row(id="1", countAsString="2"),
         }
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_list_state(self):
         def check_results(batch_df, _):
             batch_df.collect()
@@ -318,7 +314,6 @@ class TransformWithStateTestsMixin:
             ListStateProcessorFactory(), check_results, True, "processingTime"
         )
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_list_state_large_list(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -394,7 +389,6 @@ class TransformWithStateTestsMixin:
         self.assertTrue(q.exception() is None)
 
     # test list state with ttl has the same behavior as list state when state doesn't expire.
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_list_state_large_ttl(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -407,7 +401,6 @@ class TransformWithStateTestsMixin:
             ListStateLargeTTLProcessorFactory(), check_results, True, "processingTime"
         )
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_map_state(self):
         def check_results(batch_df, _):
             batch_df.collect()
@@ -419,7 +412,6 @@ class TransformWithStateTestsMixin:
         self._test_transform_with_state_basic(MapStateProcessorFactory(), check_results, True)
 
     # test map state with ttl has the same behavior as map state when state doesn't expire.
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_map_state_large_ttl(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -434,7 +426,6 @@ class TransformWithStateTestsMixin:
 
     # test value state with ttl has the same behavior as value state when
     # state doesn't expire.
-    @unittest.skip("Temporarily disabled for testing")
     def test_value_state_ttl_basic(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -455,7 +446,6 @@ class TransformWithStateTestsMixin:
 
     # TODO SPARK-50908 holistic fix for TTL suite
     @unittest.skip("test is flaky and it is only a timing issue, skipping until we can resolve")
-    @unittest.skip("Temporarily disabled for testing")
     def test_value_state_ttl_expiration(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -605,7 +595,6 @@ class TransformWithStateTestsMixin:
         q.awaitTermination(10)
         self.assertTrue(q.exception() is None)
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_proc_timer(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -723,7 +712,6 @@ class TransformWithStateTestsMixin:
         q.awaitTermination(10)
         self.assertTrue(q.exception() is None)
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_event_time(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -756,7 +744,6 @@ class TransformWithStateTestsMixin:
             EventTimeStatefulProcessorFactory(), check_results
         )
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_with_wmark_and_non_event_time(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -855,7 +842,6 @@ class TransformWithStateTestsMixin:
         q.awaitTermination(10)
         self.assertTrue(q.exception() is None)
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_init_state(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -880,7 +866,6 @@ class TransformWithStateTestsMixin:
             SimpleStatefulProcessorWithInitialStateFactory(), check_results
         )
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_init_state_with_extra_transformation(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -960,7 +945,6 @@ class TransformWithStateTestsMixin:
         q.awaitTermination(10)
         self.assertTrue(q.exception() is None)
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_non_contiguous_grouping_cols(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -973,7 +957,6 @@ class TransformWithStateTestsMixin:
             SimpleStatefulProcessorWithInitialStateFactory(), check_results
         )
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_non_contiguous_grouping_cols_with_init_state(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -1057,7 +1040,6 @@ class TransformWithStateTestsMixin:
         q.processAllAvailable()
         q.awaitTermination(10)
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_chaining_ops(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -1094,7 +1076,6 @@ class TransformWithStateTestsMixin:
             ["outputTimestamp", "id"],
         )
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_init_state_with_timers(self):
         def check_results(batch_df, batch_id):
             batch_df.collect()
@@ -1125,7 +1106,6 @@ class TransformWithStateTestsMixin:
             StatefulProcessorWithInitialStateTimersFactory(), check_results, "processingTime"
         )
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_batch_query(self):
         data = [("0", 123), ("0", 46), ("1", 146), ("1", 346)]
         df = self.spark.createDataFrame(data, "id string, temperature int")
@@ -1157,7 +1137,6 @@ class TransformWithStateTestsMixin:
             Row(id="1", countAsString="2"),
         }
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_batch_query_initial_state(self):
         data = [("0", 123), ("0", 46), ("1", 146), ("1", 346)]
         df = self.spark.createDataFrame(data, "id string, temperature int")
@@ -1202,11 +1181,9 @@ class TransformWithStateTestsMixin:
     @unittest.skipIf(
         "COVERAGE_PROCESS_START" in os.environ, "Flaky with coverage enabled, skipping for now."
     )
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_map_state_metadata(self):
         self._test_transform_with_map_state_metadata(None)
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_map_state_metadata_with_init_state(self):
         # run the same test suite again but with no-op initial state
         # TWS with initial state is using a different python runner
@@ -1339,7 +1316,6 @@ class TransformWithStateTestsMixin:
         )
 
     # This test covers multiple list state variables and flatten option
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_list_state_metadata(self):
         checkpoint_path = tempfile.mktemp()
 
@@ -1420,7 +1396,6 @@ class TransformWithStateTestsMixin:
 
     # This test covers value state variable and read change feed,
     # snapshotStartBatchId related options
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_value_state_metadata(self):
         checkpoint_path = tempfile.mktemp()
 
@@ -1511,7 +1486,6 @@ class TransformWithStateTestsMixin:
                 checkpoint_path=checkpoint_path,
             )
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_restart_with_multiple_rows_init_state(self):
         def check_results(batch_df, _):
             batch_df.collect()
@@ -1571,7 +1545,6 @@ class TransformWithStateTestsMixin:
             initial_state=init_df,
         )
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_in_pandas_composite_type(self):
         def check_results(batch_df, batch_id):
             if batch_id == 0:
@@ -1931,7 +1904,6 @@ class TransformWithStateTestsMixin:
         )
 
     # run the same test suites again but with single shuffle partition
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_with_timers_single_partition(self):
         with self.sql_conf({"spark.sql.shuffle.partitions": "1"}):
             self.test_transform_with_state_init_state_with_timers()
@@ -1980,7 +1952,6 @@ class TransformWithStateTestsMixin:
         q.processAllAvailable()
         q.awaitTermination(10)
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_schema_evolution_scenarios(self):
         """Test various schema evolution scenarios"""
         with self.sql_conf({"spark.sql.streaming.stateStore.encodingFormat": "avro"}):
@@ -2049,7 +2020,6 @@ class TransformWithStateTestsMixin:
 
     # This test case verifies that an exception is thrown when downcasting, which violates
     # Avro's schema evolution rules
-    @unittest.skip("Temporarily disabled for testing")
     def test_schema_evolution_fails(self):
         with self.sql_conf({"spark.sql.streaming.stateStore.encodingFormat": "avro"}):
             with tempfile.TemporaryDirectory() as checkpoint_dir:
@@ -2102,7 +2072,6 @@ class TransformWithStateTestsMixin:
                         and "Schema evolution is not possible" in error_msg
                     )
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_not_nullable_fails(self):
         with self.sql_conf({"spark.sql.streaming.stateStore.encodingFormat": "avro"}):
             with tempfile.TemporaryDirectory() as checkpoint_dir:
@@ -2135,7 +2104,6 @@ class TransformWithStateTestsMixin:
                         and "column family state must be nullable" in error_msg
                     )
 
-    @unittest.skip("Temporarily disabled for testing")
     def test_transform_with_state_int_to_decimal_coercion(self):
         if not self.use_pandas():
             return

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServer.scala
@@ -208,14 +208,7 @@ class TransformWithStateInPySparkStateServer(
   private def parseProtoMessage(): StateRequest = {
     val messageLen = inputStream.readInt()
     val messageBytes = new Array[Byte](messageLen)
-    val readBytes = inputStream.read(messageBytes)
-    // inputStream.readFully(messageBytes)
-    // val readBytes = messageLen
-    if (readBytes != messageLen) {
-      throw new Exception(s"TESTING: Failed to read message bytes: expected $messageLen bytes, " +
-        s"but only read $readBytes bytes")
-    }
-
+    inputStream.readFully(messageBytes)
     StateRequest.parseFrom(ByteString.copyFrom(messageBytes))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServer.scala
@@ -208,7 +208,14 @@ class TransformWithStateInPySparkStateServer(
   private def parseProtoMessage(): StateRequest = {
     val messageLen = inputStream.readInt()
     val messageBytes = new Array[Byte](messageLen)
-    inputStream.readFully(messageBytes)
+    val readBytes = inputStream.read(messageBytes)
+    // inputStream.readFully(messageBytes)
+    // val readBytes = messageLen
+    if (readBytes != messageLen) {
+      throw new Exception(s"TESTING: Failed to read message bytes: expected $messageLen bytes, " +
+        s"but only read $readBytes bytes")
+    }
+
     StateRequest.parseFrom(ByteString.copyFrom(messageBytes))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/TransformWithStateInPySparkStateServer.scala
@@ -208,7 +208,7 @@ class TransformWithStateInPySparkStateServer(
   private def parseProtoMessage(): StateRequest = {
     val messageLen = inputStream.readInt()
     val messageBytes = new Array[Byte](messageLen)
-    inputStream.read(messageBytes)
+    inputStream.readFully(messageBytes)
     StateRequest.parseFrom(ByteString.copyFrom(messageBytes))
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Fix the TransformWithState StateServer's `parseProtoMessage` method to fully read the desired message using the correct [readFully DataInputStream API](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/DataInput.html#readFully(byte%5B%5D)) rather than `read` (InputStream/FilterInputStream) which only reads all available data and may not return the full message. [`readFully` (DataInputStream)](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/DataInput.html#readFully(byte%5B%5D)) will continue fetching until it fills up the provided buffer.

In addition to the linked API above, this StackOverflow post also illustrates the difference between the two APIs: https://stackoverflow.com/a/25900095

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For large state values used in the TransformWithState API, `inputStream.read` is not guaranteed to read `messageLen`'s bytes of data as per the InputStream API. For large values, `read` will return prematurely and the messageBytes will only be partially filled, yielding an incorrect and likely unparseable proto message. 

This is not a common scenario, as testing also indicated that the actual proto messages had to be somewhat large to consistently trigger this error. The test case I added uses 512KB strings in the state value updates. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added a new test case using 512KB strings:

- Value state update
- List state update with 3 (different) values (note: list state provides a multi-value update API, so this message is even larger than the other two)
- Map state update with single key/value

```
build/sbt -Phive -Phive-thriftserver -DskipTests package
python/run-tests --testnames 'pyspark.sql.tests.pandas.test_pandas_transform_with_state TransformWithStateInPandasTests'
python/run-tests --testnames 'pyspark.sql.tests.pandas.test_pandas_transform_with_state TransformWithStateInPySparkTests'
```

The configured data size (512KB) triggers an incomplete read, while also completing in a reasonable time (within 30s on my laptop). I had separately tested a larger input size of 4MB which took 30min which I considered too expensive to include in the test.
Below is sample/testing results from using `read` only (i.e., no fix) and adding a check on message length vs read bytes ([test code is included in this commit](https://github.com/apache/spark/pull/52539/commits/b68cfd7c814f7050515e785d6813b624d68c3a59) but reverted later for the PR). The check is no longer required after the `readFully` fix as that is handled within the provided API.
```
    TransformWithStateInPandasTests
        pyspark.errors.exceptions.base.PySparkRuntimeError: Error updating map state value: TESTING: Failed to read message bytes: expected 524369 bytes, but only read 261312 bytes

    TransformWithStateInPySparkTests
        pyspark.errors.exceptions.base.PySparkRuntimeError: Error updating value state: TESTING: Failed to read message bytes: expected 524336 bytes, but only read 392012 bytes

```


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Code (claude-sonnet-4-5-20250929)