### PR TITLE
[SPARK-53832][K8S] Make `KubernetesClientUtils` Java-friendly

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
@@ -19,6 +19,7 @@ package org.apache.spark.deploy.k8s.submit
 
 import java.io.{File, StringWriter}
 import java.nio.charset.MalformedInputException
+import java.util.{List => JList, Map => JMap}
 import java.util.Properties
 
 import scala.collection.mutable
@@ -72,6 +73,18 @@ object KubernetesClientUtils extends Logging {
 
   /**
    * Build, file -> 'file's content' map of all the selected files in SPARK_CONF_DIR.
+   * (Java-friendly)
+   */
+  @Since("4.1.0")
+  def buildSparkConfDirFilesMapJava(
+      configMapName: String,
+      sparkConf: SparkConf,
+      resolvedPropertiesMap: JMap[String, String]): JMap[String, String] = synchronized {
+    buildSparkConfDirFilesMap(configMapName, sparkConf, resolvedPropertiesMap.asScala.toMap).asJava
+  }
+
+  /**
+   * Build, file -> 'file's content' map of all the selected files in SPARK_CONF_DIR.
    */
   @Since("3.1.1")
   def buildSparkConfDirFilesMap(
@@ -89,6 +102,11 @@ object KubernetesClientUtils extends Logging {
     }
   }
 
+  @Since("4.1.0")
+  def buildKeyToPathObjectsJava(confFilesMap: JMap[String, String]): JList[KeyToPath] = {
+    buildKeyToPathObjects(confFilesMap.asScala.toMap).asJava
+  }
+
   @Since("3.1.0")
   def buildKeyToPathObjects(confFilesMap: Map[String, String]): Seq[KeyToPath] = {
     confFilesMap.map {
@@ -96,6 +114,16 @@ object KubernetesClientUtils extends Logging {
         val filePermissionMode = 420  // 420 is decimal for octal literal 0644.
         new KeyToPath(fileName, filePermissionMode, fileName)
     }.toList.sortBy(x => x.getKey) // List is sorted to make mocking based tests work
+  }
+
+  /**
+   * Build a ConfigMap that will hold the content for environment variable SPARK_CONF_DIR
+   * on remote pods. (Java-friendly)
+   */
+  @Since("4.1.0")
+  def buildConfigMapJava(configMapName: String, confFileMap: JMap[String, String],
+      withLabels: JMap[String, String]): ConfigMap = {
+    buildConfigMap(configMapName, confFileMap.asScala.toMap, withLabels.asScala.toMap)
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `KubernetesClientUtils` more Java-friendly by adding three additional APIs. All the other public APIs are already Java-friendly.

| Scala Version | New Java-friendly Version |
| - | - |
| `buildConfigMap` (Since 3.1.0) | `buildConfigMapJava` (Since 4.1.0) |
| `buildKeyToPathObjects` (Since 3.1.0) | `buildKeyToPathObjectsJava` (Since 4.1.0) |
| `buildSparkConfDirFilesMap` (Since 3.1.1) | `buildSparkConfDirFilesMapJava` (Since 4.1.0) |

### Why are the changes needed?

Java-based downstream project like `Apache Spark K8s Operator` can take advantage of this improvement.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.