### PR TITLE
[SPARK-53833][PYTHON] Update `dev/requirements.txt` to skip `torch/torchvision` in Python 3.14

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -76,8 +76,8 @@ graphviz==0.20.3
 flameprof==0.4
 
 # TorchDistributor dependencies
-torch
-torchvision
+torch; python_version < '3.14'
+torchvision; python_version < '3.14'
 torcheval
 
 # DeepspeedTorchDistributor dependencies


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `dev/requirements.txt` to skip `torch` and `torchvision` packages in Python 3.14.

### Why are the changes needed?

Although `Python 3.14` is released, both `torch` and `torchvision` do not support `Python 3.14` yet. We had better disable it for `Python 3.14` until they become ready.
- https://pypi.org/project/torch/
- https://pypi.org/project/torchvision/

```
$ python3 --version
Python 3.14.0

$ pip3 install torch
ERROR: Could not find a version that satisfies the requirement torch (from versions: none)
ERROR: No matching distribution found for torch

$ pip3 install torchvision
ERROR: Ignored the following yanked versions: 0.1.6, 0.1.7, 0.1.8, 0.1.9, 0.2.0, 0.2.1, 0.2.2, 0.2.2.post2, 0.2.2.post3
ERROR: Could not find a version that satisfies the requirement torchvision (from versions: none)
ERROR: No matching distribution found for torchvision
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Manual review.

```
$ python3 --version
Python 3.14.0

$ pip3 install -r dev/requirements.txt # Success
```

### Was this patch authored or co-authored using generative AI tooling?

No.