### PR TITLE
[SPARK-53857] Enable messageTemplate propagation to SparkThrowable

### DIFF
--- a/common/utils/src/main/java/org/apache/spark/SparkThrowable.java
+++ b/common/utils/src/main/java/org/apache/spark/SparkThrowable.java
@@ -70,5 +70,27 @@ public interface SparkThrowable {
     return new HashMap<>();
   }
 
+  /**
+   * Returns the default message template for this error.
+   *
+   * The template is a machine-readable string with placeholders
+   * to be filled by {@code getMessageParameters()}.
+   *
+   * This is the default template known to Spark, but clients are
+   * free to generate their own messages (e.g., translations,
+   * alternate formats) using the provided error metadata.
+   *
+   * @return the default message template for this error, or null if unavailable
+   */
+  default String getDefaultMessageTemplate() {
+    try {
+      String cond = this.getCondition();
+      if (cond == null) return null;
+      return SparkThrowableHelper.getMessageTemplate(cond);
+    } catch (Throwable t) {
+      return null; // Unknown error condition
+    }
+  }
+
   default QueryContext[] getQueryContext() { return new QueryContext[0]; }
 }

--- a/common/utils/src/main/scala/org/apache/spark/ErrorClassesJSONReader.scala
+++ b/common/utils/src/main/scala/org/apache/spark/ErrorClassesJSONReader.scala
@@ -41,6 +41,13 @@ class ErrorClassesJsonReader(jsonFileURLs: Seq[URL]) {
 
   def getErrorMessage(errorClass: String, messageParameters: Map[String, Any]): String = {
     val messageTemplate = getMessageTemplate(errorClass)
+    getErrorMessage(errorClass, messageTemplate, messageParameters)
+  }
+
+  def getErrorMessage(
+      errorClass: String,
+      messageTemplate: String,
+      messageParameters: Map[String, Any]): String = {
     val sanitizedParameters = messageParameters.map {
       case (key, null) => key -> "null"
       case (key, value) => key -> value
@@ -71,6 +78,10 @@ class ErrorClassesJsonReader(jsonFileURLs: Seq[URL]) {
 
   def getMessageParameters(errorClass: String): Seq[String] = {
     val messageTemplate = getMessageTemplate(errorClass)
+    getMessageParametersFromTemplate(messageTemplate)
+  }
+
+  def getMessageParametersFromTemplate(messageTemplate: String): Seq[String] = {
     val matches = ErrorClassesJsonReader.TEMPLATE_REGEX.findAllIn(messageTemplate).toSeq
     matches.map(m => m.stripSuffix(">").stripPrefix("<"))
   }

--- a/common/utils/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
+++ b/common/utils/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
@@ -60,10 +60,7 @@ private[spark] object SparkThrowableHelper {
       context: String): String = {
     val displayMessage = errorReader.getErrorMessage(errorClass, messageParameters)
     val sqlState = getSqlState(errorClass)
-    val displaySqlState = if (sqlState == null) "" else s" SQLSTATE: $sqlState"
-    val displayQueryContext = (if (context.isEmpty) "" else "\n") + context
-    val prefix = if (errorClass.startsWith("_LEGACY_ERROR_")) "" else s"[$errorClass] "
-    s"$prefix$displayMessage$displaySqlState$displayQueryContext"
+    formatErrorMessage(errorClass, displayMessage, sqlState, context)
   }
 
   def getMessage(
@@ -75,9 +72,18 @@ private[spark] object SparkThrowableHelper {
       errorClass,
       messageTemplate,
       messageParameters)
+    formatErrorMessage(errorClass, displayMessage, sqlState, "")
+  }
+
+  def formatErrorMessage(
+      errorClass: String,
+      displayMessage: String,
+      sqlState: String,
+      context: String): String = {
     val displaySqlState = if (sqlState == null) "" else s" SQLSTATE: $sqlState"
+    val displayQueryContext = (if (context.isEmpty) "" else "\n") + context
     val prefix = if (errorClass.startsWith("_LEGACY_ERROR_")) "" else s"[$errorClass] "
-    s"$prefix$displayMessage$displaySqlState"
+    s"$prefix$displayMessage$displaySqlState$displayQueryContext"
   }
 
   def getSqlState(errorClass: String): String = {

--- a/sql/api/src/main/scala/org/apache/spark/sql/AnalysisException.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/AnalysisException.scala
@@ -52,16 +52,7 @@ class AnalysisException protected (
       errorClass: Option[String],
       messageParameters: Map[String, String],
       context: Array[QueryContext]) =
-    this(
-      message,
-      line,
-      startPosition,
-      cause,
-      errorClass,
-      messageParameters,
-      context,
-      None,
-      None)
+    this(message, line, startPosition, cause, errorClass, messageParameters, context, None, None)
 
   def this(errorClass: String, messageParameters: Map[String, String], cause: Option[Throwable]) =
     this(
@@ -83,14 +74,14 @@ class AnalysisException protected (
       cause = cause)
 
   /**
-   * External constructor for callers that want to supply error fields directly,
-   * without requiring a local JSON definition for the error class.
+   * External constructor for callers that want to supply error fields directly, without requiring
+   * a local JSON definition for the error class.
    *
-   * If `message` is provided (Some), it is used verbatim. Otherwise, the message
-   * is rendered from (errorClass, sqlState, messageTemplate, messageParameters).
+   * If `message` is provided (Some), it is used verbatim. Otherwise, the message is rendered from
+   * (errorClass, sqlState, messageTemplate, messageParameters).
    *
-   * `messageTemplate` is always persisted into the exception so clients can read
-   * it via SparkThrowable.getDefaultMessageTemplate().
+   * `messageTemplate` is always persisted into the exception so clients can read it via
+   * SparkThrowable.getDefaultMessageTemplate().
    */
   def this(
       errorClass: String,
@@ -101,8 +92,8 @@ class AnalysisException protected (
       message: Option[String]) =
     this(
       message = message.getOrElse(
-        SparkThrowableHelper.getMessage(errorClass, sqlState, messageTemplate, messageParameters)
-      ),
+        SparkThrowableHelper
+          .getMessage(errorClass, sqlState, messageTemplate, messageParameters)),
       cause = cause,
       errorClass = Option(errorClass),
       messageParameters = messageParameters,

--- a/sql/api/src/main/scala/org/apache/spark/sql/AnalysisException.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/AnalysisException.scala
@@ -64,7 +64,7 @@ class AnalysisException protected (
       cause = cause)
 
   /**
-   * External constructor for callers that want to supply NERF fields directly,
+   * External constructor for callers that want to supply error fields directly,
    * without requiring a local JSON definition for the error class.
    *
    * If `message` is provided (Some), it is used verbatim. Otherwise, the message

--- a/sql/api/src/main/scala/org/apache/spark/sql/AnalysisException.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/AnalysisException.scala
@@ -44,6 +44,25 @@ class AnalysisException protected (
     with Serializable
     with WithOrigin {
 
+  def this(
+      message: String,
+      line: Option[Int],
+      startPosition: Option[Int],
+      cause: Option[Throwable],
+      errorClass: Option[String],
+      messageParameters: Map[String, String],
+      context: Array[QueryContext]) =
+    this(
+      message,
+      line,
+      startPosition,
+      cause,
+      errorClass,
+      messageParameters,
+      context,
+      None,
+      None)
+
   def this(errorClass: String, messageParameters: Map[String, String], cause: Option[Throwable]) =
     this(
       SparkThrowableHelper.getMessage(errorClass, messageParameters),
@@ -127,6 +146,25 @@ class AnalysisException protected (
       messageParameters = messageParameters,
       context = origin.getQueryContext,
       cause = cause)
+
+  def copy(
+      message: String,
+      line: Option[Int],
+      startPosition: Option[Int],
+      cause: Option[Throwable],
+      errorClass: Option[String],
+      messageParameters: Map[String, String],
+      context: Array[QueryContext]): AnalysisException =
+    new AnalysisException(
+      message,
+      line,
+      startPosition,
+      cause,
+      errorClass,
+      messageParameters,
+      context,
+      this.sqlState,
+      this.messageTemplate)
 
   def copy(
       message: String = this.message,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ExtendedAnalysisException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ExtendedAnalysisException.scala
@@ -32,7 +32,9 @@ class ExtendedAnalysisException private(
     cause: Option[Throwable] = None,
     errorClass: Option[String] = None,
     messageParameters: Map[String, String] = Map.empty,
-    context: Array[QueryContext] = Array.empty)
+    context: Array[QueryContext] = Array.empty,
+    sqlState: Option[String] = None,
+    messageTemplate: Option[String] = None)
   extends AnalysisException(
     message,
     line,
@@ -40,7 +42,9 @@ class ExtendedAnalysisException private(
     cause,
     errorClass,
     messageParameters,
-    context) {
+    context,
+    sqlState,
+    messageTemplate) {
 
   def this(e: AnalysisException, plan: LogicalPlan) = {
     this(
@@ -62,9 +66,11 @@ class ExtendedAnalysisException private(
       cause: Option[Throwable],
       errorClass: Option[String],
       messageParameters: Map[String, String],
-      context: Array[QueryContext]): ExtendedAnalysisException = {
+      context: Array[QueryContext],
+      sqlState: Option[String] = this.sqlState,
+      messageTemplate: Option[String] = this.messageTemplate): ExtendedAnalysisException = {
     new ExtendedAnalysisException(message, line, startPosition, plan, cause, errorClass,
-      messageParameters, context)
+      messageParameters, context, sqlState, messageTemplate)
   }
 
   override def getMessage: String = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pull request enhances Spark error handling capabilities, primarily within `AnalysisException`, to support more flexible and maintainable error message rendering. 




### Why are the changes needed?
The goal is to add a new default method, `getDefaultMessageTemplate`, to the public `SparkThrowable` interface. This gives clients a consistent, machine-readable default template for error rendering, while leaving them free to localize or otherwise transform the message. 

This approach helps create a single source of truth for error definitions.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Unit tests and existing tests.


### Was this patch authored or co-authored using generative AI tooling?
No
