### PR TITLE
[SPARK-53858][PYTHON][TESTS] Skip `pyarrow`-related doctests in `pyspark/sql/functions/builtin.py`

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -27578,14 +27578,14 @@ def udf(
     For example, define a 'Series to Series' type pandas UDF.
 
     >>> from pyspark.sql.functions import udf, PandasUDFType
-    >>> import pandas as pd
-    >>> @udf(returnType=IntegerType())
+    >>> import pandas as pd # doctest: +SKIP
+    >>> @udf(returnType=IntegerType()) # doctest: +SKIP
     ... def pd_calc(a: pd.Series, b: pd.Series) -> pd.Series:
     ...     return a + 10 * b
     ...
-    >>> pd_calc.evalType == PandasUDFType.SCALAR
+    >>> pd_calc.evalType == PandasUDFType.SCALAR # doctest: +SKIP
     True
-    >>> spark.range(2).select(pd_calc(b=col("id") * 10, a="id")).show()
+    >>> spark.range(2).select(pd_calc(b=col("id") * 10, a="id")).show() # doctest: +SKIP
     +--------------------------------+
     |pd_calc(b => (id * 10), a => id)|
     +--------------------------------+
@@ -27595,15 +27595,15 @@ def udf(
 
     For another example, define a 'Array to Array' type arrow UDF.
 
-    >>> from pyspark.sql.functions import udf, ArrowUDFType
-    >>> import pyarrow as pa
-    >>> @udf(returnType=IntegerType())
+    >>> from pyspark.sql.functions import udf, ArrowUDFType # doctest: +SKIP
+    >>> import pyarrow as pa # doctest: +SKIP
+    >>> @udf(returnType=IntegerType()) # doctest: +SKIP
     ... def pa_calc(a: pa.Array, b: pa.Array) -> pa.Array:
     ...     return pa.compute.add(a, pa.compute.multiply(b, 10))
     ...
-    >>> pa_calc.evalType == ArrowUDFType.SCALAR
+    >>> pa_calc.evalType == ArrowUDFType.SCALAR # doctest: +SKIP
     True
-    >>> spark.range(2).select(pa_calc(b=col("id") * 10, a="id")).show()
+    >>> spark.range(2).select(pa_calc(b=col("id") * 10, a="id")).show() # doctest: +SKIP
     +--------------------------------+
     |pa_calc(b => (id * 10), a => id)|
     +--------------------------------+
@@ -27849,9 +27849,9 @@ def arrow_udtf(
     --------
     UDTF with PyArrow RecordBatch input:
 
-    >>> import pyarrow as pa
-    >>> from pyspark.sql.functions import arrow_udtf
-    >>> @arrow_udtf(returnType="x int, y int")
+    >>> import pyarrow as pa # doctest: +SKIP
+    >>> from pyspark.sql.functions import arrow_udtf # doctest: +SKIP
+    >>> @arrow_udtf(returnType="x int, y int") # doctest: +SKIP
     ... class MyUDTF:
     ...     def eval(self, batch: pa.RecordBatch):
     ...         # Process the entire batch vectorized
@@ -27864,11 +27864,11 @@ def arrow_udtf(
     ...         yield result_table
     ...
     >>> df = spark.range(10).selectExpr("id as x", "id as y")
-    >>> MyUDTF(df.asTable()).show()  # doctest: +SKIP
+    >>> MyUDTF(df.asTable()).show() # doctest: +SKIP
 
     UDTF with PyArrow Array inputs:
 
-    >>> @arrow_udtf(returnType="x int, y int")
+    >>> @arrow_udtf(returnType="x int, y int") # doctest: +SKIP
     ... class MyUDTF2:
     ...     def eval(self, x: pa.Array, y: pa.Array):
     ...         # Process arrays vectorized


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to skip `pyarrow`-related doctests in `pyspark/sql/functions/builtin.py`.

### Why are the changes needed?

To make `Python 3.14` CI pass without `pyarrow` first. Currently, it fails at doctests.

- https://github.com/apache/spark/actions/workflows/build_python_3.14.yml
  - https://github.com/apache/spark/actions/runs/18368352911/job/52325744561

### Does this PR introduce _any_ user-facing change?

No, this is a test-only change.

### How was this patch tested?

Manually run `doctests` without `pyarrow`.

**BEFORE**

```bash
$ python/run-tests --parallelism 1 --testnames pyspark.sql.functions.builtin --python-executables python3
...
python3 version is: Python 3.14.0
...
**********************************************************************
   3 of   7 in pyspark.sql.functions.builtin.arrow_udtf
   6 of  21 in pyspark.sql.functions.builtin.udf
***Test Failed*** 9 failures and 36 skipped tests.
```

**AFTER**

```bash
$ python/run-tests --parallelism 1 --testnames pyspark.sql.functions.builtin --python-executables python3
...
python3 version is: Python 3.14.0
Starting test(python3): pyspark.sql.functions.builtin (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/3006d5b7-1ebc-4e44-aec9-9e04d6cb8857/python3__pyspark.sql.functions.builtin__ubueykpx.log)
Finished test(python3): pyspark.sql.functions.builtin (53s)
Tests passed in 53 seconds
```

### Was this patch authored or co-authored using generative AI tooling?

No.