### PR TITLE
[SPARK-53860][BUILD][TESTS] Upgrade `sbt-jupiter-interface` to 0.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
       SPARK-50299: When updating `sbt-jupiter-interface.version`,
       also need to update the version in `SparkBuild.scala` and `plugins.sbt`.
     -->
-    <sbt-jupiter-interface.version>0.15.1</sbt-jupiter-interface.version>
+    <sbt-jupiter-interface.version>0.17.0</sbt-jupiter-interface.version>
     <!--
     If you are changing Arrow version specification, please check
     ./python/pyspark/sql/pandas/utils.py, ./python/packaging/classic/setup.py,

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1757,7 +1757,7 @@ object TestSettings {
     (Test / testOptions) += Tests.Argument(TestFrameworks.ScalaTest, "-W", "120", "300"),
     (Test / testOptions) += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
     // Enable Junit testing.
-    libraryDependencies += "com.github.sbt.junit" % "jupiter-interface" % "0.15.1" % "test",
+    libraryDependencies += "com.github.sbt.junit" % "jupiter-interface" % "0.17.0" % "test",
     // `parallelExecutionInTest` controls whether test suites belonging to the same SBT project
     // can run in parallel with one another. It does NOT control whether tests execute in parallel
     // within the same JVM (which is controlled by `testForkedParallel`) or whether test cases

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -41,6 +41,6 @@ addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.3")
 
 addSbtPlugin("com.github.sbt" % "sbt-pom-reader" % "2.4.0")
 
-addSbtPlugin("com.github.sbt.junit" % "sbt-jupiter-interface" % "0.15.1")
+addSbtPlugin("com.github.sbt.junit" % "sbt-jupiter-interface" % "0.17.0")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.7")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `sbt-jupiter-interfac` to `0.17.0`.

### Why are the changes needed?

To bring the latest improvements including JUnit 6 support.

- https://github.com/sbt/sbt-jupiter-interface/releases/tag/v0.17.0 (2025-10-09)
  - https://github.com/sbt/sbt-jupiter-interface/pull/194

- https://github.com/sbt/sbt-jupiter-interface/releases/tag/v0.16.0 (2025-10-08)
  - https://github.com/sbt/sbt-jupiter-interface/pull/186

### Does this PR introduce _any_ user-facing change?

No behavior change because this is a test dependency.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.