### PR TITLE
[SPARK-53858][PYTHON][TESTS] Skip doctests in `pyspark.sql.functions.builtin` if pyarrow is not installed

### DIFF
--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -4709,6 +4709,7 @@ def _test() -> None:
 
     if not have_pandas or not have_pyarrow:
         del pyspark.sql.connect.functions.builtin.udf.__doc__
+        del pyspark.sql.connect.functions.builtin.arrow_udtf.__doc__
 
     globs["spark"] = (
         PySparkSession.builder.appName("sql.connect.functions tests")

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -4703,8 +4703,12 @@ def _test() -> None:
     import doctest
     from pyspark.sql import SparkSession as PySparkSession
     import pyspark.sql.connect.functions.builtin
+    from pyspark.testing.utils import have_pandas, have_pyarrow
 
     globs = pyspark.sql.connect.functions.builtin.__dict__.copy()
+
+    if not have_pandas or not have_pyarrow:
+        del pyspark.sql.connect.functions.builtin.udf.__doc__
 
     globs["spark"] = (
         PySparkSession.builder.appName("sql.connect.functions tests")

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -27895,8 +27895,13 @@ def _test() -> None:
     import doctest
     from pyspark.sql import SparkSession
     import pyspark.sql.functions.builtin
+    from pyspark.testing.utils import have_pandas, have_pyarrow
 
     globs = pyspark.sql.functions.builtin.__dict__.copy()
+
+    if not have_pandas or not have_pyarrow:
+        del pyspark.sql.functions.builtin.udf.__doc__
+
     spark = (
         SparkSession.builder.master("local[4]").appName("sql.functions.builtin tests").getOrCreate()
     )

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -27901,6 +27901,7 @@ def _test() -> None:
 
     if not have_pandas or not have_pyarrow:
         del pyspark.sql.functions.builtin.udf.__doc__
+        del pyspark.sql.functions.builtin.arrow_udtf.__doc__
 
     spark = (
         SparkSession.builder.master("local[4]").appName("sql.functions.builtin tests").getOrCreate()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Skip `udf` doctests without pyarrow


### Why are the changes needed?
to make python 3.14 scheduled workflow work


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
manually check without pyarrow

```
(spark_dev_313) ➜  spark git:(py_314_udf) pip uninstall pyarrow
Found existing installation: pyarrow 21.0.0
Uninstalling pyarrow-21.0.0:
  Would remove:
    /Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/site-packages/pyarrow-21.0.0.dist-info/*
    /Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/site-packages/pyarrow/*
Proceed (Y/n)? y
  Successfully uninstalled pyarrow-21.0.0

(spark_dev_313) ➜  spark git:(py_314_udf) ✗ python/run-tests -k --testnames 'pyspark.sql.functions.builtin'
Running PySpark tests. Output is in /Users/ruifeng.zheng/spark/python/unit-tests.log
Will test against the following Python executables: ['/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/bin/python3']
Will test the following Python tests: ['pyspark.sql.functions.builtin']
/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/bin/python3 python_implementation is CPython
/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/bin/python3 version is: Python 3.13.5
Starting test(/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/bin/python3): pyspark.sql.functions.builtin (temp output: /Users/ruifeng.zheng/spark/python/target/cff4b76c-ff9c-4226-89dd-e1eabe4ebbad/Users_ruifeng.zheng_.dev_miniconda3_envs_spark_dev_313_bin_python3__pyspark.sql.functions.builtin__unaf2g6y.log)
Finished test(/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/bin/python3): pyspark.sql.functions.builtin (64s)
Tests passed in 64 seconds
```



### Was this patch authored or co-authored using generative AI tooling?
no