### PR TITLE
[SPARK-53866][PYTHON][TESTS] Skip doctest `pyspark.sql.pandas.functions` without pyarrow/pandas

### DIFF
--- a/python/pyspark/sql/pandas/functions.py
+++ b/python/pyspark/sql/pandas/functions.py
@@ -882,6 +882,10 @@ def _test() -> None:
     import doctest
     from pyspark.sql import SparkSession
     import pyspark.sql.pandas.functions
+    from pyspark.testing.utils import have_pandas, have_pyarrow
+
+    if not have_pandas or not have_pyarrow:
+        sys.exit(0)
 
     globs = pyspark.sql.column.__dict__.copy()
     spark = (

--- a/python/pyspark/sql/pandas/functions.py
+++ b/python/pyspark/sql/pandas/functions.py
@@ -884,10 +884,14 @@ def _test() -> None:
     import pyspark.sql.pandas.functions
     from pyspark.testing.utils import have_pandas, have_pyarrow
 
-    if not have_pandas or not have_pyarrow:
-        sys.exit(0)
-
     globs = pyspark.sql.column.__dict__.copy()
+
+    if not have_pandas or not have_pyarrow:
+        del pyspark.sql.pandas.functions.pandas_udf.__doc__
+
+    if not have_pyarrow:
+        del pyspark.sql.pandas.functions.arrow_udf.__doc__
+
     spark = (
         SparkSession.builder.master("local[4]")
         .appName("pyspark.sql.pandas.functions tests")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Skip doctest `pyspark.sql.pandas.functions` without pyarrow/pandas


### Why are the changes needed?
to resolve failure in https://github.com/apache/spark/actions/runs/18397357525/job/52419309837


### Does this PR introduce _any_ user-facing change?
no, test-only

### How was this patch tested?
manually check in my local


### Was this patch authored or co-authored using generative AI tooling?
no