### PR TITLE
[SPARK-53868][SQL] Only use signature with Expression[]  of `visitAggregateFunction` in V2ExpressionSQBuilder

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
@@ -131,22 +131,17 @@ public class V2ExpressionSQLBuilder {
         default -> visitUnexpectedExpr(expr);
       };
     } else if (expr instanceof Min min) {
-      return visitAggregateFunction("MIN", false,
-        expressionsToStringArray(min.children()));
+      return visitAggregateFunction("MIN", false, min.children());
     } else if (expr instanceof Max max) {
-      return visitAggregateFunction("MAX", false,
-        expressionsToStringArray(max.children()));
+      return visitAggregateFunction("MAX", false, max.children());
     } else if (expr instanceof Count count) {
-      return visitAggregateFunction("COUNT", count.isDistinct(),
-        expressionsToStringArray(count.children()));
+      return visitAggregateFunction("COUNT", count.isDistinct(), count.children());
     } else if (expr instanceof Sum sum) {
-      return visitAggregateFunction("SUM", sum.isDistinct(),
-        expressionsToStringArray(sum.children()));
-    } else if (expr instanceof CountStar) {
-      return visitAggregateFunction("COUNT", false, new String[]{"*"});
+      return visitAggregateFunction("SUM", sum.isDistinct(), sum.children());
+    } else if (expr instanceof CountStar countStar) {
+      return visitAggregateFunction("COUNT", false, countStar.children());
     } else if (expr instanceof Avg avg) {
-      return visitAggregateFunction("AVG", avg.isDistinct(),
-        expressionsToStringArray(avg.children()));
+      return visitAggregateFunction("AVG", avg.isDistinct(), avg.children());
     } else if (expr instanceof GeneralAggregateFunc f) {
       if (f.orderingWithinGroups().length == 0) {
         return visitAggregateFunction(f.name(), f.isDistinct(), f.children());
@@ -282,8 +277,19 @@ public class V2ExpressionSQLBuilder {
     return joinArrayToString(inputs, ", ", funcName + "(", ")");
   }
 
+  /**
+   * Builds SQL for an aggregate function.
+   *
+   * In V2ExpressionSQLBuilder, always use this override (with Expression[])
+   * instead of the String[] version, as the String[] version does not validate
+   * whether the function is supported in JDBC dialects.
+   */
   protected String visitAggregateFunction(
       String funcName, boolean isDistinct, Expression[] inputs) {
+    // CountStar has no children but should return with a star
+    if (funcName.equals("COUNT") && inputs == Expression.EMPTY_EXPRESSION) {
+      return visitAggregateFunction(funcName, isDistinct, new String[]{"*"});
+    }
     return visitAggregateFunction(funcName, isDistinct, expressionsToStringArray(inputs));
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -444,15 +444,7 @@ abstract class JdbcDialect extends Serializable with Logging {
 
     override def visitAggregateFunction(
         funcName: String, isDistinct: Boolean, inputs: Array[String]): String = {
-      if (isSupportedFunction(funcName)) {
-        super.visitAggregateFunction(dialectFunctionName(funcName), isDistinct, inputs)
-      } else {
-        throw new SparkUnsupportedOperationException(
-          errorClass = "_LEGACY_ERROR_TEMP_3177",
-          messageParameters = Map(
-            "class" -> this.getClass.getSimpleName,
-            "funcName" -> funcName))
-      }
+      super.visitAggregateFunction(dialectFunctionName(funcName), isDistinct, inputs)
     }
 
     override def visitInverseDistributionFunction(

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -444,7 +444,15 @@ abstract class JdbcDialect extends Serializable with Logging {
 
     override def visitAggregateFunction(
         funcName: String, isDistinct: Boolean, inputs: Array[String]): String = {
-      super.visitAggregateFunction(dialectFunctionName(funcName), isDistinct, inputs)
+      if (isSupportedFunction(funcName)) {
+        super.visitAggregateFunction(dialectFunctionName(funcName), isDistinct, inputs)
+      } else {
+        throw new SparkUnsupportedOperationException(
+          errorClass = "_LEGACY_ERROR_TEMP_3177",
+          messageParameters = Map(
+            "class" -> this.getClass.getSimpleName,
+            "funcName" -> funcName))
+      }
     }
 
     override def visitInverseDistributionFunction(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
https://github.com/apache/spark/pull/50143 This PR introduced `visitAggregateFunction` with `inputs: Array[Expression]`, but it's not the only usage of `visitAggregateFunction` for example here
https://github.com/apache/spark/blob/6eb4d3c9d38f6849b0acfcffdbadce03c8f49ac6/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java#L134
the old API is still used but it no longer checked if the function is supported.

This means that if some dialect did not support one of `(MIN, MAX, COUNT, SUM, AVG)` it would not be blocked, but as of now all the dialects have them in the `supportedFunctions` so this is not a behavioral change.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To unify the API in case in the future if some dialect does not support an aggregate function of `(MIN, MAX, COUNT, SUM, AVG)` it should be blocked.
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing tests.
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
