### PR TITLE
[SPARK-53875][SQL] Fix bit_count incorrect results for negative byte/short/int values

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
@@ -231,14 +231,17 @@ case class BitwiseCount(child: Expression)
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = child.dataType match {
     case BooleanType => defineCodeGen(ctx, ev, c => s"($c) ? 1 : 0")
+    case ByteType => defineCodeGen(ctx, ev, c => s"java.lang.Integer.bitCount($c & 0xFF)")
+    case ShortType => defineCodeGen(ctx, ev, c => s"java.lang.Integer.bitCount($c & 0xFFFF)")
+    case IntegerType => defineCodeGen(ctx, ev, c => s"java.lang.Integer.bitCount($c)")
     case _ => defineCodeGen(ctx, ev, c => s"java.lang.Long.bitCount($c)")
   }
 
   protected override def nullSafeEval(input: Any): Any = child.dataType match {
     case BooleanType => if (input.asInstanceOf[Boolean]) 1 else 0
-    case ByteType => java.lang.Long.bitCount(input.asInstanceOf[Byte])
-    case ShortType => java.lang.Long.bitCount(input.asInstanceOf[Short])
-    case IntegerType => java.lang.Long.bitCount(input.asInstanceOf[Int])
+    case ByteType => java.lang.Integer.bitCount(input.asInstanceOf[Byte] & 0xFF)
+    case ShortType => java.lang.Integer.bitCount(input.asInstanceOf[Short] & 0xFFFF)
+    case IntegerType => java.lang.Integer.bitCount(input.asInstanceOf[Int])
     case LongType => java.lang.Long.bitCount(input.asInstanceOf[Long])
   }
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/bitwise.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/bitwise.sql.out
@@ -112,6 +112,27 @@ Project [bit_count(-1) AS bit_count(-1)#x]
 
 
 -- !query
+select bit_count(-2)
+-- !query analysis
+Project [bit_count(-2) AS bit_count(-2)#x]
++- OneRowRelation
+
+
+-- !query
+select bit_count(-3S)
+-- !query analysis
+Project [bit_count(-3) AS bit_count(-3)#x]
++- OneRowRelation
+
+
+-- !query
+select bit_count(-4Y)
+-- !query analysis
+Project [bit_count(-4) AS bit_count(-4)#x]
++- OneRowRelation
+
+
+-- !query
 select bit_count(9223372036854775807L)
 -- !query analysis
 Project [bit_count(9223372036854775807) AS bit_count(9223372036854775807)#x]

--- a/sql/core/src/test/resources/sql-tests/inputs/bitwise.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/bitwise.sql
@@ -29,6 +29,9 @@ select bit_count(3L);
 
 -- negative num
 select bit_count(-1L);
+select bit_count(-2);
+select bit_count(-3S);
+select bit_count(-4Y);
 
 -- edge value
 select bit_count(9223372036854775807L);

--- a/sql/core/src/test/resources/sql-tests/results/bitwise.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/bitwise.sql.out
@@ -128,6 +128,30 @@ struct<bit_count(-1):int>
 
 
 -- !query
+select bit_count(-2)
+-- !query schema
+struct<bit_count(-2):int>
+-- !query output
+31
+
+
+-- !query
+select bit_count(-3S)
+-- !query schema
+struct<bit_count(-3):int>
+-- !query output
+15
+
+
+-- !query
+select bit_count(-4Y)
+-- !query schema
+struct<bit_count(-4):int>
+-- !query output
+6
+
+
+-- !query
 select bit_count(9223372036854775807L)
 -- !query schema
 struct<bit_count(9223372036854775807):int>


### PR DESCRIPTION


### What changes were proposed in this pull request?

Add bitmasking before calculating the bit count to fix incorrect results for negative byte/short/int values


### Why are the changes needed?

fix a correctness bug

### Does this PR introduce _any_ user-facing change?

Yes, this changes the results, but not the user behavior

### How was this patch tested?
new ut

### Was this patch authored or co-authored using generative AI tooling?
no