### PR TITLE
[SPARK-53881][BUILD][TESTS] Upgrade `Selenium` to 4.32.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,8 +209,8 @@
     <libthrift.version>0.16.0</libthrift.version>
     <antlr4.version>4.13.1</antlr4.version>
     <jpam.version>1.1</jpam.version>
-    <selenium.version>4.21.0</selenium.version>
-    <htmlunit3-driver.version>4.21.0</htmlunit3-driver.version>
+    <selenium.version>4.32.0</selenium.version>
+    <htmlunit3-driver.version>4.32.0</htmlunit3-driver.version>
     <maven-antrun.version>3.1.0</maven-antrun.version>
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.10.0</commons-cli.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `Selenium` to 4.32.0.

### Why are the changes needed?

To bring the updates. Note that 4.33 and the above is incompatible for now.
- https://www.selenium.dev/blog/2025/selenium-4-32-released/
- https://www.selenium.dev/blog/2025/selenium-4-31-released/
- https://www.selenium.dev/blog/2025/selenium-4-30-released/
- https://www.selenium.dev/blog/2025/selenium-4-29-released/
- https://www.selenium.dev/blog/2025/selenium-4-28-released/
- https://www.selenium.dev/blog/2024/selenium-4-27-released/
- https://www.selenium.dev/blog/2024/selenium-4-26-released/
- https://www.selenium.dev/blog/2024/selenium-4-25-released/
- https://www.selenium.dev/blog/2024/selenium-4-24-released/
- https://www.selenium.dev/blog/2024/selenium-4-23-released/
- https://www.selenium.dev/blog/2024/selenium-4-22-released/

### Does this PR introduce _any_ user-facing change?

No, this is a test dependency change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.