### PR TITLE
[SPARK-53936][BUILD] Upgrade sbt-pom-reader from 2.4.0 to 2.5.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -39,7 +39,7 @@ libraryDependencies += "org.ow2.asm"  % "asm-commons" % "9.8"
 
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.3")
 
-addSbtPlugin("com.github.sbt" % "sbt-pom-reader" % "2.4.0")
+addSbtPlugin("com.github.sbt" % "sbt-pom-reader" % "2.5.0")
 
 addSbtPlugin("com.github.sbt.junit" % "sbt-jupiter-interface" % "0.17.0")
 


### PR DESCRIPTION
### Why are the changes needed?

This PR updates the sbt-pom-reader plugin from version 2.4.0 to 2.5.0 in project/plugins.sbt.

### What changes were proposed in this pull request?

The current build uses sbt-pom-reader 2.4.0, which hardcodes the Maven Central URL as http://repo.maven.apache.org/maven2. Our environment enforces HTTPS-only outbound connections, causing dependency resolution failures with that version.
Upstream PR(https://github.com/sbt/sbt-pom-reader/pull/81/files#diff-c2afee6a87a7bc518d0b31ecefaf824499b310218016b5865825dd6ef1eb216e) updates the plugin to use the secure https://repo.maven.apache.org/maven2 endpoint. This change is published in sbt-pom-reader 2.5.0.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing test suites.

### Was this patch authored or co-authored using generative AI tooling?

No.
