### PR TITLE
[SPARK-53609][PYTHON] Limit Arrow batch sizes in SQL_GROUPED_AGG_PANDAS_UDF

### DIFF
--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2611,7 +2611,10 @@ def read_udfs(pickleSer, infile, eval_type):
             or eval_type == PythonEvalType.SQL_GROUPED_MAP_ARROW_ITER_UDF
         ):
             ser = GroupArrowUDFSerializer(_assign_cols_by_name)
-        elif eval_type == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF:
+        elif eval_type in (
+            PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF,
+            PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF,
+        ):
             ser = GroupPandasUDFSerializer(
                 timezone, safecheck, _assign_cols_by_name, int_to_decimal_coercion_enabled
             )


### PR DESCRIPTION
### What changes were proposed in this pull request?
Limit Arrow batch sizes in SQL_GROUPED_AGG_PANDAS_UDF


### Why are the changes needed?
to avoid potential OOM in the JVM side (we will introduce iterator API for it in separate PRs)


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
added tests


### Was this patch authored or co-authored using generative AI tooling?
no