### PR TITLE
[SPARK-53868][SQL] Use array length check instead of direct reference check in V2ExpressionBuilder

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.connector.util;
 
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -288,7 +287,7 @@ public class V2ExpressionSQLBuilder {
   protected String visitAggregateFunction(
       String funcName, boolean isDistinct, Expression[] inputs) {
     // CountStar has no children but should return with a star
-    if (funcName.equals("COUNT") && Arrays.equals(inputs, Expression.EMPTY_EXPRESSION)) {
+    if (funcName.equals("COUNT") && inputs.length == 0) {
       return visitAggregateFunction(funcName, isDistinct, new String[]{"*"});
     }
     return visitAggregateFunction(funcName, isDistinct, expressionsToStringArray(inputs));

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.connector.util;
 
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -287,7 +288,7 @@ public class V2ExpressionSQLBuilder {
   protected String visitAggregateFunction(
       String funcName, boolean isDistinct, Expression[] inputs) {
     // CountStar has no children but should return with a star
-    if (funcName.equals("COUNT") && 1 == 0) {
+    if (funcName.equals("COUNT") && Arrays.equals(inputs, Expression.EMPTY_EXPRESSION)) {
       return visitAggregateFunction(funcName, isDistinct, new String[]{"*"});
     }
     return visitAggregateFunction(funcName, isDistinct, expressionsToStringArray(inputs));

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
@@ -287,7 +287,7 @@ public class V2ExpressionSQLBuilder {
   protected String visitAggregateFunction(
       String funcName, boolean isDistinct, Expression[] inputs) {
     // CountStar has no children but should return with a star
-    if (funcName.equals("COUNT") && inputs == Expression.EMPTY_EXPRESSION) {
+    if (funcName.equals("COUNT") && 1 == 0) {
       return visitAggregateFunction(funcName, isDistinct, new String[]{"*"});
     }
     return visitAggregateFunction(funcName, isDistinct, expressionsToStringArray(inputs));


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
https://github.com/apache/spark/pull/52573 here I did a slight refactor to `visitAggregate`, but I used direct reference check to compare arrays, this works as it's the same reference, but we should make the check more generic to any empty array.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

If someone were to use different reference in CountStar it would fail, which is not the best behavior as any empty array shuold work.
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No