### PR TITLE
[SPARK-53897][CONNECT][TESTS] Add dependency checks for Python-related tests in the `connect` module

### DIFF
--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/PythonTestDepsChecker.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/PythonTestDepsChecker.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.connect
+
+import scala.sys.process.Process
+import scala.util.Try
+
+import org.apache.spark.sql.IntegratedUDFTestUtils._
+
+object PythonTestDepsChecker {
+  lazy val isConnectDepsAvailable: Boolean = isPythonAvailable && isPySparkAvailable && Try {
+    Process(
+      Seq(
+        pythonExec,
+        "-c",
+        "from pyspark.sql.connect.utils import check_dependencies;" +
+          "check_dependencies('pyspark.sql.connect.fake_module')"),
+      None,
+      "PYTHONPATH" -> s"$pysparkPythonPath:$pythonPath").!!
+    true
+  }.getOrElse(false)
+
+  lazy val isYamlAvailable: Boolean = isPythonAvailable && isPySparkAvailable && Try {
+    Process(
+      Seq(pythonExec, "-c", "import yaml"),
+      None,
+      "PYTHONPATH" -> s"$pysparkPythonPath:$pythonPath").!!
+    true
+  }.getOrElse(false)
+}

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/EndToEndAPISuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/EndToEndAPISuite.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.Duration
 
 import org.apache.spark.api.python.PythonUtils
-import org.apache.spark.sql.connect.SparkConnectServerTest
+import org.apache.spark.sql.connect.{PythonTestDepsChecker, SparkConnectServerTest}
 import org.apache.spark.sql.pipelines.utils.{APITest, PipelineReference, PipelineSourceFile, PipelineTest, TestPipelineConfiguration, TestPipelineSpec}
 
 case class PipelineReferenceImpl(executionProcess: Process) extends PipelineReference
@@ -111,6 +111,8 @@ class EndToEndAPISuite extends PipelineTest with APITest with SparkConnectServer
   }
 
   override def awaitPipelineTermination(pipeline: PipelineReference, duration: Duration): Unit = {
+    assume(PythonTestDepsChecker.isConnectDepsAvailable)
+    assume(PythonTestDepsChecker.isYamlAvailable)
     pipeline match {
       case ref: PipelineReferenceImpl =>
         val process = ref.executionProcess

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
@@ -29,6 +29,7 @@ import scala.util.Try
 import org.apache.spark.api.python.PythonUtils
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.connect.PythonTestDepsChecker
 import org.apache.spark.sql.connect.service.SparkConnectService
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
 import org.apache.spark.sql.pipelines.Language.Python
@@ -48,6 +49,7 @@ class PythonPipelineSuite
     with EventVerificationTestHelpers {
 
   def buildGraph(pythonText: String): DataflowGraph = {
+    assume(PythonTestDepsChecker.isConnectDepsAvailable)
     val indentedPythonText = pythonText.linesIterator.map("    " + _).mkString("\n")
     // create a unique identifier to allow identifying the session and dataflow graph
     val customSessionIdentifier = UUID.randomUUID().toString
@@ -389,6 +391,7 @@ class PythonPipelineSuite
   }
 
   test("create dataset with the same name will fail") {
+    assume(PythonTestDepsChecker.isConnectDepsAvailable)
     val ex = intercept[AnalysisException] {
       buildGraph(s"""
            |@dp.materialized_view
@@ -462,6 +465,7 @@ class PythonPipelineSuite
   }
 
   test("create datasets with three part names") {
+    assume(PythonTestDepsChecker.isConnectDepsAvailable)
     val graphTry = Try {
       buildGraph(s"""
            |@dp.table(name = "some_catalog.some_schema.mv")
@@ -514,6 +518,7 @@ class PythonPipelineSuite
   }
 
   test("create named flow with multipart name will fail") {
+    assume(PythonTestDepsChecker.isConnectDepsAvailable)
     val ex = intercept[RuntimeException] {
       buildGraph(s"""
            |@dp.table
@@ -661,6 +666,7 @@ class PythonPipelineSuite
   }
 
   test("create pipeline without table will throw RUN_EMPTY_PIPELINE exception") {
+    assume(PythonTestDepsChecker.isConnectDepsAvailable)
     checkError(
       exception = intercept[AnalysisException] {
         buildGraph(s"""
@@ -672,6 +678,7 @@ class PythonPipelineSuite
   }
 
   test("create pipeline with only temp view will throw RUN_EMPTY_PIPELINE exception") {
+    assume(PythonTestDepsChecker.isConnectDepsAvailable)
     checkError(
       exception = intercept[AnalysisException] {
         buildGraph(s"""
@@ -685,6 +692,7 @@ class PythonPipelineSuite
   }
 
   test("create pipeline with only flow will throw RUN_EMPTY_PIPELINE exception") {
+    assume(PythonTestDepsChecker.isConnectDepsAvailable)
     checkError(
       exception = intercept[AnalysisException] {
         buildGraph(s"""

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionHolderSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionHolderSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.SparkEnv
 import org.apache.spark.api.python.SimplePythonFunction
 import org.apache.spark.connect.proto
 import org.apache.spark.sql.IntegratedUDFTestUtils
-import org.apache.spark.sql.connect.SparkConnectTestUtils
+import org.apache.spark.sql.connect.{PythonTestDepsChecker, SparkConnectTestUtils}
 import org.apache.spark.sql.connect.common.InvalidPlanInput
 import org.apache.spark.sql.connect.config.Connect
 import org.apache.spark.sql.connect.planner.{PythonStreamingQueryListener, SparkConnectPlanner, StreamingForeachBatchHelper}
@@ -180,6 +180,7 @@ class SparkConnectSessionHolderSuite extends SharedSparkSession {
   test("python listener process: process terminates after listener is removed") {
     // scalastyle:off assume
     assume(IntegratedUDFTestUtils.shouldTestPandasUDFs)
+    assume(PythonTestDepsChecker.isConnectDepsAvailable)
     // scalastyle:on assume
 
     val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
@@ -230,6 +231,7 @@ class SparkConnectSessionHolderSuite extends SharedSparkSession {
   test("python foreachBatch process: process terminates after query is stopped") {
     // scalastyle:off assume
     assume(IntegratedUDFTestUtils.shouldTestPandasUDFs)
+    assume(PythonTestDepsChecker.isConnectDepsAvailable)
     // scalastyle:on assume
 
     val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)

--- a/sql/core/src/test/scala/org/apache/spark/sql/IntegratedUDFTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/IntegratedUDFTestUtils.scala
@@ -112,9 +112,9 @@ object IntegratedUDFTestUtils extends SQLHelper {
     sparkHome, "python", "lib", PythonUtils.PY4J_ZIP_NAME).toAbsolutePath
   private[spark] lazy val pysparkPythonPath = s"$py4jPath:$sourcePath"
 
-  private lazy val isPythonAvailable: Boolean = TestUtils.testCommandAvailable(pythonExec)
+  private[spark] lazy val isPythonAvailable: Boolean = TestUtils.testCommandAvailable(pythonExec)
 
-  private lazy val isPySparkAvailable: Boolean = isPythonAvailable && Try {
+  private[spark] lazy val isPySparkAvailable: Boolean = isPythonAvailable && Try {
     Process(
       Seq(pythonExec, "-c", "import pyspark"),
       None,


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr adds a pre-check for module dependencies to the test cases in the `connect` module that utilize Python client code. This ensures that when the required Python modules are missing, the relevant tests are skipped rather than failing.

### Why are the changes needed?
Some test cases in the `connect` module involve interactions between Python client code and the Connect server. These tests currently fail due to the absence of the required Python modules.

`build/sbt 'connect/test'`

```
[info] - Pipeline with selective full_refresh *** FAILED *** (374 milliseconds)
[info]   java.lang.RuntimeException: Pipeline update process failed with exit code 1.
[info] Output: 
[info] Error: Traceback (most recent call last):
[info]   File "/Users/yangjie01/SourceCode/git/spark-sbt/python/pyspark/sql/connect/utils.py", line 47, in require_minimum_grpc_version
[info]     import grpc
[info] ModuleNotFoundError: No module named 'grpc'
[info] 
[info] The above exception was the direct cause of the following exception:
[info] 
[info] Traceback (most recent call last):
[info]   File "/Users/yangjie01/SourceCode/git/spark-sbt/python/pyspark/pipelines/cli.py", line 36, in <module>
[info]     from pyspark.pipelines.block_session_mutations import block_session_mutations
[info]   File "/Users/yangjie01/SourceCode/git/spark-sbt/python/pyspark/pipelines/block_session_mutations.py", line 21, in <module>
[info]     from pyspark.sql.connect.catalog import Catalog
[info]   File "/Users/yangjie01/SourceCode/git/spark-sbt/python/pyspark/sql/connect/catalog.py", line 20, in <module>
[info]     check_dependencies(__name__)
[info]   File "/Users/yangjie01/SourceCode/git/spark-sbt/python/pyspark/sql/connect/utils.py", line 37, in check_dependencies
[info]     require_minimum_grpc_version()
[info]   File "/Users/yangjie01/SourceCode/git/spark-sbt/python/pyspark/sql/connect/utils.py", line 49, in require_minimum_grpc_version
[info]     raise PySparkImportError(
[info] pyspark.errors.exceptions.base.PySparkImportError: [PACKAGE_NOT_INSTALLED] grpcio >= 1.48.1 must be installed; however, it was not found.
...
raceback (most recent call last):
  File "/Users/yangjie01/SourceCode/git/spark-sbt/python/pyspark/sql/connect/utils.py", line 47, in require_minimum_grpc_version
    import grpc
ModuleNotFoundError: No module named 'grpc'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/yangjie01/SourceCode/gravitino/.gradle/python/MacOSX/Miniforge3/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/yangjie01/SourceCode/gravitino/.gradle/python/MacOSX/Miniforge3/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/yangjie01/SourceCode/git/spark-sbt/python/pyspark/sql/connect/streaming/worker/foreach_batch_worker.py", line 32, in <module>
    from pyspark.sql.connect.session import SparkSession
  File "/Users/yangjie01/SourceCode/git/spark-sbt/python/pyspark/sql/connect/session.py", line 20, in <module>
    check_dependencies(__name__)
  File "/Users/yangjie01/SourceCode/git/spark-sbt/python/pyspark/sql/connect/utils.py", line 37, in check_dependencies
    require_minimum_grpc_version()
  File "/Users/yangjie01/SourceCode/git/spark-sbt/python/pyspark/sql/connect/utils.py", line 49, in require_minimum_grpc_version
    raise PySparkImportError(
pyspark.errors.exceptions.base.PySparkImportError: [PACKAGE_NOT_INSTALLED] grpcio >= 1.48.1 must be installed; however, it was not found.
[info] - python foreachBatch process: process terminates after query is stopped *** FAILED *** (14 seconds, 188 milliseconds)
[info]   org.apache.spark.SparkException: Python worker failed to connect back.

...
[info] *** 48 TESTS FAILED ***
[error] Failed tests:
[error]   org.apache.spark.sql.connect.pipelines.PythonPipelineSuite
[error]   org.apache.spark.sql.connect.pipelines.EndToEndAPISuite
[error]   org.apache.spark.sql.connect.service.SparkConnectSessionHolderSuite
[error] (connect / Test / test) sbt.TestsFailedException: Tests unsuccessful
```

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Pass Github Actions
- Manually verified by running `build/sbt 'connect/test'`

```
[info] - temporary views works !!! CANCELED !!! (0 milliseconds)
[info]   org.apache.spark.sql.connect.PythonTestDepsChecker.isConnectDepsAvailable was false (PythonPipelineSuite.scala:52)
...
[info] - create named flow with multipart name will fail !!! CANCELED !!! (1 millisecond)
[info]   org.apache.spark.sql.connect.PythonTestDepsChecker.isConnectDepsAvailable was false (PythonPipelineSuite.scala:521)
...
[info] - create flow with multipart target and no explicit name succeeds !!! CANCELED !!! (1 millisecond)
[info]   org.apache.spark.sql.connect.PythonTestDepsChecker.isConnectDepsAvailable was false (PythonPipelineSuite.scala:52)
...
[info] Run completed in 3 minutes, 27 seconds.
[info] Total number of tests run: 1088
[info] Suites: completed 37, aborted 0
[info] Tests: succeeded 1088, failed 0, canceled 45, ignored 0, pending 0
[info] All tests passed.
```

### Was this patch authored or co-authored using generative AI tooling?
No