### PR TITLE
[SPARK-54887][CONNECT] Always set a sql state in spark connect client

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -912,6 +912,18 @@
     },
     "sqlState" : "56K00"
   },
+  "CONNECT_CLIENT_INTERNAL_ERROR" : {
+    "message" : [
+      "Spark Connect client internal error: <message>"
+    ],
+    "sqlState" : "XXKCI"
+  },
+  "CONNECT_CLIENT_UNEXPECTED_MISSING_SQL_STATE" : {
+    "message" : [
+      "The server response is missing SQL state: <message>"
+    ],
+    "sqlState" : "XXKCM"
+  },
   "CONNECT_INVALID_PLAN" : {
     "message" : [
       "The Spark Connect plan is invalid."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -912,15 +912,9 @@
     },
     "sqlState" : "56K00"
   },
-  "CONNECT_CLIENT_INTERNAL_ERROR" : {
-    "message" : [
-      "Spark Connect client internal error: <message>"
-    ],
-    "sqlState" : "XXKCI"
-  },
   "CONNECT_CLIENT_UNEXPECTED_MISSING_SQL_STATE" : {
     "message" : [
-      "The server response is missing SQL state: <message>"
+      "Unidentified Error: <message>"
     ],
     "sqlState" : "XXKCM"
   },

--- a/common/utils/src/main/resources/error/error-states.json
+++ b/common/utils/src/main/resources/error/error-states.json
@@ -7524,6 +7524,18 @@
         "standard": "N",
         "usedBy": ["PostgreSQL", "Redshift"]
     },
+    "XXKCI": {
+        "description": "Connect Client - Internal error",
+        "origin": "Spark",
+        "standard": "N",
+        "usedBy": ["Spark"]
+    },
+    "XXKCM": {
+        "description": "Connect Client - Unexpected missing SQL state",
+        "origin": "Spark",
+        "standard": "N",
+        "usedBy": ["Spark"]
+    },
     "XXKD0": {
         "description": "Analysis - Bad plan",
         "origin": "Databricks",

--- a/common/utils/src/main/resources/error/error-states.json
+++ b/common/utils/src/main/resources/error/error-states.json
@@ -7524,12 +7524,6 @@
         "standard": "N",
         "usedBy": ["PostgreSQL", "Redshift"]
     },
-    "XXKCI": {
-        "description": "Connect Client - Internal error",
-        "origin": "Spark",
-        "standard": "N",
-        "usedBy": ["Spark"]
-    },
     "XXKCM": {
         "description": "Connect Client - Unexpected missing SQL state",
         "origin": "Spark",

--- a/common/utils/src/main/scala/org/apache/spark/SparkException.scala
+++ b/common/utils/src/main/scala/org/apache/spark/SparkException.scala
@@ -198,6 +198,20 @@ private[spark] class SparkUpgradeException private(
     )
   }
 
+  def this(
+    errorClass: String,
+    messageParameters: Map[String, String],
+    cause: Throwable,
+    sqlState: Option[String]) = {
+    this(
+      SparkThrowableHelper.getMessage(errorClass, messageParameters),
+      Option(cause),
+      Option(errorClass),
+      messageParameters,
+      sqlState
+    )
+  }
+
   override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
 
   override def getCondition: String = errorClass.orNull
@@ -226,6 +240,20 @@ private[spark] class SparkArithmeticException private(
       Option(errorClass),
       messageParameters,
       context
+    )
+  }
+
+  def this(
+    errorClass: String,
+    messageParameters: Map[String, String],
+    context: Array[QueryContext],
+    sqlState: Option[String]) = {
+    this(
+      SparkThrowableHelper.getMessage(errorClass, messageParameters, ""),
+      Option(errorClass),
+      messageParameters,
+      context,
+      sqlState
     )
   }
 
@@ -265,6 +293,18 @@ private[spark] class SparkUnsupportedOperationException private(
 
   def this(
     errorClass: String,
+    messageParameters: Map[String, String],
+    sqlState: Option[String]) = {
+    this(
+      SparkThrowableHelper.getMessage(errorClass, messageParameters),
+      Option(errorClass),
+      messageParameters,
+      sqlState
+    )
+  }
+
+  def this(
+    errorClass: String,
     messageParameters: java.util.Map[String, String]) =
     this(errorClass, messageParameters.asScala.toMap)
 
@@ -273,7 +313,8 @@ private[spark] class SparkUnsupportedOperationException private(
     this(
       SparkThrowableHelper.getMessage(errorClass, Map.empty[String, String]),
       Option(errorClass),
-      Map.empty)
+      Map.empty,
+      None)
   }
 
   override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
@@ -379,6 +420,23 @@ private[spark] class SparkDateTimeException private(
   def this(
     errorClass: String,
     messageParameters: Map[String, String],
+    context: Array[QueryContext],
+    summary: String,
+    cause: Option[Throwable],
+    sqlState: Option[String]) = {
+    this(
+      SparkThrowableHelper.getMessage(errorClass, messageParameters, summary),
+      Option(errorClass),
+      messageParameters,
+      context,
+      cause.orElse(None),
+      sqlState
+    )
+  }
+
+  def this(
+    errorClass: String,
+    messageParameters: Map[String, String],
     context: Array[QueryContext]) = this(errorClass, messageParameters, context, "")
 
   override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
@@ -436,6 +494,20 @@ private[spark] class SparkNumberFormatException private(
   def this(
     errorClass: String,
     messageParameters: Map[String, String],
+    context: Array[QueryContext],
+    sqlState: Option[String]) = {
+    this(
+      SparkThrowableHelper.getMessage(errorClass, messageParameters, ""),
+      Option(errorClass),
+      messageParameters,
+      context,
+      sqlState
+    )
+  }
+
+  def this(
+    errorClass: String,
+    messageParameters: Map[String, String],
     context: Array[QueryContext]) = this(errorClass, messageParameters, context, "")
 
   override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
@@ -472,6 +544,23 @@ private[spark] class SparkIllegalArgumentException private(
       Option(errorClass),
       messageParameters,
       context
+    )
+  }
+
+  def this(
+    errorClass: String,
+    messageParameters: Map[String, String],
+    context: Array[QueryContext],
+    summary: String,
+    cause: Throwable,
+    sqlState: Option[String]) = {
+    this(
+      SparkThrowableHelper.getMessage(errorClass, messageParameters, summary),
+      Option(cause),
+      Option(errorClass),
+      messageParameters,
+      context,
+      sqlState
     )
   }
 
@@ -547,6 +636,22 @@ private[spark] class SparkRuntimeException private(
       messageParameters,
       context,
       None
+    )
+  }
+
+  def this(
+    errorClass: String,
+    messageParameters: Map[String, String],
+    cause: Throwable,
+    context: Array[QueryContext],
+    sqlState: Option[String]) = {
+    this(
+      SparkThrowableHelper.getMessage(errorClass, messageParameters, ""),
+      Option(cause),
+      Option(errorClass),
+      messageParameters,
+      context,
+      sqlState
     )
   }
 
@@ -655,6 +760,20 @@ private[spark] class SparkArrayIndexOutOfBoundsException private(
       Option(errorClass),
       messageParameters,
       context
+    )
+  }
+
+  def this(
+    errorClass: String,
+    messageParameters: Map[String, String],
+    context: Array[QueryContext],
+    sqlState: Option[String]) = {
+    this(
+      SparkThrowableHelper.getMessage(errorClass, messageParameters, ""),
+      Option(errorClass),
+      messageParameters,
+      context,
+      sqlState
     )
   }
 

--- a/common/utils/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryException.scala
+++ b/common/utils/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryException.scala
@@ -58,6 +58,23 @@ class StreamingQueryException private[sql](
       messageParameters)
   }
 
+  private[spark] def this(
+      message: String,
+      cause: Throwable,
+      errorClass: String,
+      messageParameters: Map[String, String],
+      sqlState: Option[String]) = {
+    this(
+      messageParameters.getOrElse("queryDebugString", ""),
+      message,
+      cause,
+      messageParameters.getOrElse("startOffset", ""),
+      messageParameters.getOrElse("endOffset", ""),
+      errorClass,
+      messageParameters,
+      sqlState)
+  }
+
   def this(
       queryDebugString: String,
       cause: Throwable,

--- a/sql/api/src/main/scala/org/apache/spark/sql/AnalysisException.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/AnalysisException.scala
@@ -138,6 +138,23 @@ class AnalysisException protected (
       context = origin.getQueryContext,
       cause = cause)
 
+  def this(
+      message: String,
+      cause: Option[Throwable],
+      errorClass: Option[String],
+      messageParameters: Map[String, String],
+      context: Array[QueryContext],
+      sqlState: Option[String]) =
+    this(
+      message = message,
+      line = None,
+      startPosition = None,
+      cause = cause,
+      errorClass = errorClass,
+      messageParameters = messageParameters,
+      context = context,
+      sqlState = sqlState)
+
   def copy(
       message: String,
       line: Option[Int],

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
@@ -1795,42 +1795,6 @@ class ClientE2ETestSuite
     assert(result(0).getAs[Array[Integer]]("arr_col") === Array(1, null))
   }
 
-  test(
-    "SPARK-53883: GrpcExceptionConverter ensures all exceptions have errorClass and sqlState") {
-    // Test that normal Spark errors have proper errorClass and sqlState
-    val analysisEx = intercept[AnalysisException] {
-      spark.sql("select nonexistent_column").collect()
-    }
-    assert(
-      analysisEx.getCondition == "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION",
-      s"AnalysisException should have correct errorClass, got: ${analysisEx.getCondition}")
-    assert(
-      analysisEx.getSqlState == "42703",
-      s"AnalysisException should have correct sqlState, got: ${analysisEx.getSqlState}")
-
-    val parseEx = intercept[ParseException] {
-      spark.sql("SELECT !!!").collect()
-    }
-    assert(
-      parseEx.getCondition.startsWith("PARSE_SYNTAX_ERROR"),
-      s"ParseException should have correct errorClass, got: ${parseEx.getCondition}")
-    assert(
-      parseEx.getSqlState == "42601",
-      s"ParseException should have correct sqlState, got: ${parseEx.getSqlState}")
-
-    // UDF exceptions are wrapped in SparkException with FAILED_EXECUTE_UDF error class
-    val udfEx = intercept[SparkException] {
-      spark.udf.register("badUdf", () => { throw new RuntimeException("test error") })
-      spark.sql("SELECT badUdf()").collect()
-    }
-    assert(
-      udfEx.getCondition == "FAILED_EXECUTE_UDF",
-      s"UDF exception should have FAILED_EXECUTE_UDF errorClass, got: ${udfEx.getCondition}")
-    assert(
-      udfEx.getSqlState == "39000",
-      s"UDF exception should have correct sqlState, got: ${udfEx.getSqlState}")
-  }
-
   // SQL Scripting tests
   test("SQL Script result") {
     val df = spark.sql("""BEGIN

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
@@ -133,7 +133,7 @@ class ClientE2ETestSuite
 
       val cause = ex.getCause.asInstanceOf[SparkException]
       assert(cause.getCondition == "CONNECT_CLIENT_UNEXPECTED_MISSING_SQL_STATE")
-      assert(cause.getMessageParameters.isEmpty)
+      assert(cause.getMessageParameters.asScala == Map("message" -> "test".repeat(10000)))
       assert(cause.getMessage.contains("test".repeat(10000)))
     }
   }

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
@@ -132,7 +132,7 @@ class ClientE2ETestSuite
       assert(ex.getCause.isInstanceOf[SparkException])
 
       val cause = ex.getCause.asInstanceOf[SparkException]
-      assert(cause.getCondition == null)
+      assert(cause.getCondition == "CONNECT_CLIENT_UNEXPECTED_MISSING_SQL_STATE")
       assert(cause.getMessageParameters.isEmpty)
       assert(cause.getMessage.contains("test".repeat(10000)))
     }
@@ -1793,6 +1793,42 @@ class ClientE2ETestSuite
     val result = df.collect()
     assert(result.length === 1)
     assert(result(0).getAs[Array[Integer]]("arr_col") === Array(1, null))
+  }
+
+  test(
+    "SPARK-53883: GrpcExceptionConverter ensures all exceptions have errorClass and sqlState") {
+    // Test that normal Spark errors have proper errorClass and sqlState
+    val analysisEx = intercept[AnalysisException] {
+      spark.sql("select nonexistent_column").collect()
+    }
+    assert(
+      analysisEx.getCondition == "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION",
+      s"AnalysisException should have correct errorClass, got: ${analysisEx.getCondition}")
+    assert(
+      analysisEx.getSqlState == "42703",
+      s"AnalysisException should have correct sqlState, got: ${analysisEx.getSqlState}")
+
+    val parseEx = intercept[ParseException] {
+      spark.sql("SELECT !!!").collect()
+    }
+    assert(
+      parseEx.getCondition.startsWith("PARSE_SYNTAX_ERROR"),
+      s"ParseException should have correct errorClass, got: ${parseEx.getCondition}")
+    assert(
+      parseEx.getSqlState == "42601",
+      s"ParseException should have correct sqlState, got: ${parseEx.getSqlState}")
+
+    // UDF exceptions are wrapped in SparkException with FAILED_EXECUTE_UDF error class
+    val udfEx = intercept[SparkException] {
+      spark.udf.register("badUdf", () => { throw new RuntimeException("test error") })
+      spark.sql("SELECT badUdf()").collect()
+    }
+    assert(
+      udfEx.getCondition == "FAILED_EXECUTE_UDF",
+      s"UDF exception should have FAILED_EXECUTE_UDF errorClass, got: ${udfEx.getCondition}")
+    assert(
+      udfEx.getSqlState == "39000",
+      s"UDF exception should have correct sqlState, got: ${udfEx.getSqlState}")
   }
 
   // SQL Scripting tests

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/SparkSessionSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/SparkSessionSuite.scala
@@ -107,8 +107,9 @@ class SparkSessionSuite extends ConnectFunSuite {
     }
     assert(ex.isInstanceOf[RuntimeException])
     assert(ex.getCondition == "CONNECT_CLIENT_INTERNAL_ERROR")
-    assert(ex.getMessage contains
-      "Spark Connect client internal error: java.lang.RuntimeException: Blocked")
+    assert(
+      ex.getMessage contains
+        "Spark Connect client internal error: java.lang.RuntimeException: Blocked")
     assert(ex.getSqlState == "XXKCI")
     closeSession(session)
   }

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/SparkSessionSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/SparkSessionSuite.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.{Executors, Phaser}
 import scala.util.control.NonFatal
 
 import io.grpc.{CallOptions, Channel, ClientCall, ClientInterceptor, MethodDescriptor}
+import io.grpc.StatusRuntimeException
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.connect.test.ConnectFunSuite
@@ -102,9 +103,10 @@ class SparkSessionSuite extends ConnectFunSuite {
       })
       .create()
 
-    assertThrows[RuntimeException] {
+    val ex = intercept[StatusRuntimeException] {
       session.range(10).count()
     }
+    assert(ex.getMessage == "Blocked")
     closeSession(session)
   }
 

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/SparkSessionSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/SparkSessionSuite.scala
@@ -22,7 +22,7 @@ import scala.util.control.NonFatal
 
 import io.grpc.{CallOptions, Channel, ClientCall, ClientInterceptor, MethodDescriptor}
 
-import org.apache.spark.{SparkException, SparkRuntimeException}
+import org.apache.spark.SparkException
 import org.apache.spark.sql.connect.test.ConnectFunSuite
 import org.apache.spark.util.SparkSerDeUtils
 
@@ -102,15 +102,9 @@ class SparkSessionSuite extends ConnectFunSuite {
       })
       .create()
 
-    val ex = intercept[SparkRuntimeException] {
+    assertThrows[RuntimeException] {
       session.range(10).count()
     }
-    assert(ex.isInstanceOf[RuntimeException])
-    assert(ex.getCondition == "CONNECT_CLIENT_INTERNAL_ERROR")
-    assert(
-      ex.getMessage contains
-        "Spark Connect client internal error: java.lang.RuntimeException: Blocked")
-    assert(ex.getSqlState == "XXKCI")
     closeSession(session)
   }
 

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
@@ -219,8 +219,9 @@ class SparkConnectClientSuite extends ConnectFunSuite {
 
     assert(ex.isInstanceOf[RuntimeException])
     assert(ex.getCondition == "CONNECT_CLIENT_INTERNAL_ERROR")
-    assert(ex.getMessage contains
-      "Spark Connect client internal error: java.lang.RuntimeException: Blocked")
+    assert(
+      ex.getMessage contains
+        "Spark Connect client internal error: java.lang.RuntimeException: Blocked")
     assert(ex.getSqlState == "XXKCI")
   }
 

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
@@ -29,7 +29,7 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.Futures.timeout
 import org.scalatest.time.SpanSugar._
 
-import org.apache.spark.{SparkException, SparkRuntimeException, SparkThrowable}
+import org.apache.spark.{SparkException, SparkThrowable}
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.{AddArtifactsRequest, AddArtifactsResponse, AnalyzePlanRequest, AnalyzePlanResponse, ArtifactStatusesRequest, ArtifactStatusesResponse, ExecutePlanRequest, ExecutePlanResponse, Relation, SparkConnectServiceGrpc, SQL}
 import org.apache.spark.sql.connect.SparkSession
@@ -213,16 +213,9 @@ class SparkConnectClientSuite extends ConnectFunSuite {
 
     val session = SparkSession.builder().client(client).create()
 
-    val ex = intercept[SparkRuntimeException] {
+    assertThrows[RuntimeException] {
       session.range(10).count()
     }
-
-    assert(ex.isInstanceOf[RuntimeException])
-    assert(ex.getCondition == "CONNECT_CLIENT_INTERNAL_ERROR")
-    assert(
-      ex.getMessage contains
-        "Spark Connect client internal error: java.lang.RuntimeException: Blocked")
-    assert(ex.getSqlState == "XXKCI")
   }
 
   test("error framework parameters") {

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
@@ -216,7 +216,12 @@ class SparkConnectClientSuite extends ConnectFunSuite {
     val ex = intercept[SparkRuntimeException] {
       session.range(10).count()
     }
-    assert(ex.getMessage == "Blocked")
+
+    assert(ex.isInstanceOf[RuntimeException])
+    assert(ex.getCondition == "CONNECT_CLIENT_INTERNAL_ERROR")
+    assert(ex.getMessage contains
+      "Spark Connect client internal error: java.lang.RuntimeException: Blocked")
+    assert(ex.getSqlState == "XXKCI")
   }
 
   test("error framework parameters") {

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
@@ -70,7 +70,7 @@ private[client] class GrpcExceptionConverter(channel: ManagedChannel) extends Lo
     val errorClass = Some("CONNECT_CLIENT_INTERNAL_ERROR")
     val messageParameters = Map("message" -> e.toString)
     val sqlState = Some("XXKCI")
-    val defaultCtor = errorFactory(classOf[SparkRuntimeException].getName)
+    val defaultCtor = errorFactory(classOf[SparkException].getName)
     val constructor =
       getClassHierarchy(e.getClass).flatMap(errorFactory.get).headOption.getOrElse(defaultCtor)
     val errParams = ErrorParams(

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
@@ -79,8 +79,7 @@ private[client] class GrpcExceptionConverter(channel: ManagedChannel) extends Lo
       errorClass = errorClass,
       messageParameters = messageParameters,
       queryContext = Array.empty,
-      sqlState = sqlState
-    )
+      sqlState = sqlState)
     val result = constructor(errParams)
     result.setStackTrace(e.getStackTrace)
     result
@@ -319,7 +318,8 @@ private[client] object GrpcExceptionConverter {
         errorParamsToMessageParameters(params),
         params.cause)),
     errorConstructor(params =>
-      new NoSuchNamespaceException(getErrorClassOrFallback(params),
+      new NoSuchNamespaceException(
+        getErrorClassOrFallback(params),
         errorParamsToMessageParameters(params))),
     errorConstructor(params =>
       new NoSuchTableException(

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
@@ -376,6 +376,7 @@ private[client] object GrpcExceptionConverter {
 
     val error = errors(errorIdx)
     val classHierarchy = error.getErrorTypeHierarchyList.asScala
+
     val constructor =
       classHierarchy
         .flatMap(errorFactory.get)

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
@@ -375,14 +375,15 @@ private[client] object GrpcExceptionConverter {
       errors: Seq[FetchErrorDetailsResponse.Error]): Throwable = {
 
     val error = errors(errorIdx)
-    val classHierarchy = error.getErrorTypeHierarchyList.asScala.toSeq
-    val constructor = classHierarchy
-      .flatMap(errorFactory.get)
-      .headOption
-      .getOrElse(((params: ErrorParams) =>
-        errorFactory
-          .get(classOf[SparkException].getName)
-          .get(params.copy(message = s"${classHierarchy.head}: ${params.message}"))))
+    val classHierarchy = error.getErrorTypeHierarchyList.asScala
+    val constructor =
+      classHierarchy
+        .flatMap(errorFactory.get)
+        .headOption
+        .getOrElse((params: ErrorParams) =>
+          errorFactory
+            .get(classOf[SparkException].getName)
+            .get(params.copy(message = s"${classHierarchy.head}: ${params.message}")))
 
     val causeOpt =
       if (error.hasCauseIdx) Some(errorsToThrowable(error.getCauseIdx, errors)) else None


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Ensure there exists an error class in every error thrown from spark connect client by providing fallback error class and fallback sql state.

```
   * +--------------+--------------+------------------------------------------------+
   * | errorClass   | sqlState     | Description                                    |
   * +--------------+--------------+------------------------------------------------+
   * | null         | null         | Set errorClass to                              |
   * |              |              | CONNECT_CLIENT_UNEXPECTED_MISSING_SQL_STATE.   |
   * |              |              | sqlState will be read from JSON file as "XXKCM"|
   * +--------------+--------------+------------------------------------------------+
   * | null         | not null     | Do nothing since sqlState is already provided. |
   * +--------------+--------------+------------------------------------------------+
   * | not null     | null         | Try to read sqlState from error class JSON     |
   * |              |              | file using errorClass. If not found, the       |
   * |              |              | client is out of date so fallback to "XXKCM".  |
   * +--------------+--------------+------------------------------------------------+
   * | not null     | not null     | Do nothing since the error is fully            |
   * |              |              | constructed.                                   |
   * +--------------+--------------+------------------------------------------------+
```

Expanded some exception class definitions to also accept more parameters like sqlState

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Note: This PR introduces a behavior change for Non spark exceptions thrown from GRPC layer as all exceptions thrown from GRPC layer will now be some form of SparkThrowable (this ensures we have sql state defined). 

### Why are the changes needed?

At the moment there are some cases where an errorClass is not thrown. This goes against the goal of promoting a definition for providing a sql state for every exception in better sql error messages.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Yes. A previous error message that did not throw an error class now does.
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit testing

### Was this patch authored or co-authored using generative AI tooling?
Yes
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
