### PR TITLE
[SPARK-53841][PYTHON][CONNECT] Implement `transform()` in Column API

### DIFF
--- a/python/docs/source/reference/pyspark.sql/column.rst
+++ b/python/docs/source/reference/pyspark.sql/column.rst
@@ -58,6 +58,7 @@ Column
     Column.rlike
     Column.startswith
     Column.substr
+    Column.transform
     Column.try_cast
     Column.when
     Column.withField

--- a/python/pyspark/sql/classic/column.py
+++ b/python/pyspark/sql/classic/column.py
@@ -612,6 +612,9 @@ class Column(ParentColumn):
         jc = self._jc.over(window._jspec)
         return Column(jc)
 
+    def transform(self, f: Callable[[ParentColumn], ParentColumn]) -> ParentColumn:
+        return f(self)
+
     def outer(self) -> ParentColumn:
         jc = self._jc.outer()
         return Column(jc)

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -1565,27 +1565,29 @@ class Column(TableValuedFunctionArgument):
 
         >>> from pyspark.sql.functions import trim, upper
         >>> df = spark.createDataFrame([("  hello  ",), ("  world  ",)], ["text"])
-        >>> df.select(df.text.transform(trim).transform(upper)).show()
-        +-----------+
-        |upper(text)|
-        +-----------+
-        |      HELLO|
-        |      WORLD|
-        +-----------+
+        >>> df.select(df.text.transform(trim).transform(upper).alias("result")).show()
+        +------+
+        |result|
+        +------+
+        | HELLO|
+        | WORLD|
+        +------+
 
         Example 2: Use lambda functions
 
         >>> df = spark.createDataFrame([(10,), (20,), (30,)], ["value"])
         >>> df.select(
-        ...     df.value.transform(lambda c: c + 5).transform(lambda c: c * 2).transform(lambda c: c - 10)
+        ...     df.value.transform(lambda c: c + 5)
+        ...     .transform(lambda c: c * 2)
+        ...     .transform(lambda c: c - 10).alias("result")
         ... ).show()
-        +-----+
-        |value|
-        +-----+
-        |   20|
-        |   40|
-        |   60|
-        +-----+
+        +------+
+        |result|
+        +------+
+        |    20|
+        |    40|
+        |    60|
+        +------+
         """
         ...
 

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -21,6 +21,7 @@ import sys
 from typing import (
     overload,
     Any,
+    Callable,
     TYPE_CHECKING,
     Union,
 )
@@ -1535,6 +1536,56 @@ class Column(TableValuedFunctionArgument):
         |  5|  Bob|   1|  5|
         |  2|Alice|   1|  2|
         +---+-----+----+---+
+        """
+        ...
+
+    @dispatch_col_method
+    def transform(self, f: Callable[["Column"], "Column"]) -> "Column":
+        """
+        Applies a transformation function to this column.
+
+        This method allows you to apply a function that takes a Column and returns a Column,
+        enabling method chaining and functional transformations.
+
+        .. versionadded:: 4.1.0
+
+        Parameters
+        ----------
+        f : callable
+            A function that takes a :class:`Column` and returns a :class:`Column`.
+
+        Returns
+        -------
+        :class:`Column`
+            The result of applying the function to this column.
+
+        Examples
+        --------
+        Example 1: Chain built-in functions
+
+        >>> from pyspark.sql.functions import trim, upper
+        >>> df = spark.createDataFrame([("  hello  ",), ("  world  ",)], ["text"])
+        >>> df.select(df.text.transform(trim).transform(upper)).show()
+        +-----------+
+        |upper(text)|
+        +-----------+
+        |      HELLO|
+        |      WORLD|
+        +-----------+
+
+        Example 2: Use lambda functions
+
+        >>> df = spark.createDataFrame([(10,), (20,), (30,)], ["value"])
+        >>> df.select(
+        ...     df.value.transform(lambda c: c + 5).transform(lambda c: c * 2).transform(lambda c: c - 10)
+        ... ).show()
+        +-----+
+        |value|
+        +-----+
+        |   20|
+        |   40|
+        |   60|
+        +-----+
         """
         ...
 

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -25,6 +25,7 @@ import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Union,
     Optional,
     Tuple,
@@ -469,7 +470,7 @@ class Column(ParentColumn):
 
         return Column(WindowExpression(windowFunction=self._expr, windowSpec=window))
 
-    def transform(self, f: Any) -> ParentColumn:
+    def transform(self, f: Callable[[ParentColumn], ParentColumn]) -> ParentColumn:
         return f(self)
 
     def outer(self) -> ParentColumn:

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -469,6 +469,9 @@ class Column(ParentColumn):
 
         return Column(WindowExpression(windowFunction=self._expr, windowSpec=window))
 
+    def transform(self, f: Any) -> ParentColumn:
+        return f(self)
+
     def outer(self) -> ParentColumn:
         return Column(self._expr)
 

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -1071,6 +1071,7 @@ class SparkConnectColumnTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
             ).toPandas(),
         )
 
+
 if __name__ == "__main__":
     import unittest
     from pyspark.sql.tests.connect.test_connect_column import *  # noqa: F401

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -1044,6 +1044,32 @@ class SparkConnectColumnTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
         )
         self.assertEqual(cdf.columns, sdf.columns)
 
+    def test_transform(self):
+        # Test with built-in functions
+        cdf = self.connect.createDataFrame([("  hello  ",), ("  world  ",)], ["text"])
+        sdf = self.spark.createDataFrame([("  hello  ",), ("  world  ",)], ["text"])
+
+        self.assert_eq(
+            cdf.select(cdf.text.transform(CF.trim).transform(CF.upper)).toPandas(),
+            sdf.select(sdf.text.transform(SF.trim).transform(SF.upper)).toPandas(),
+        )
+
+        # Test with lambda functions
+        cdf = self.connect.createDataFrame([(10,), (20,), (30,)], ["value"])
+        sdf = self.spark.createDataFrame([(10,), (20,), (30,)], ["value"])
+
+        self.assert_eq(
+            cdf.select(
+                cdf.value.transform(lambda c: c + 5)
+                .transform(lambda c: c * 2)
+                .transform(lambda c: c - 10)
+            ).toPandas(),
+            sdf.select(
+                sdf.value.transform(lambda c: c + 5)
+                .transform(lambda c: c * 2)
+                .transform(lambda c: c - 10)
+            ).toPandas(),
+        )
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -468,6 +468,21 @@ class ColumnTestsMixin:
         for r, c, e in zip(result, cols, expected):
             self.assertEqual(r, e, str(c))
 
+    def test_transform(self):
+        # Test with built-in functions
+        df = self.spark.createDataFrame([("  hello  ",), ("  world  ",)], ["text"])
+        result = df.select(df.text.transform(sf.trim).transform(sf.upper)).collect()
+        self.assertEqual(result[0][0], "HELLO")
+        self.assertEqual(result[1][0], "WORLD")
+
+        # Test with lambda functions
+        df = self.spark.createDataFrame([(10,), (20,), (30,)], ["value"])
+        result = df.select(
+            df.value.transform(lambda c: c + 5).transform(lambda c: c * 2).transform(lambda c: c - 10)
+        ).collect()
+        self.assertEqual(result[0][0], 20)
+        self.assertEqual(result[1][0], 40)
+        self.assertEqual(result[2][0], 60)
 
 class ColumnTests(ColumnTestsMixin, ReusedSQLTestCase):
     pass

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -478,11 +478,14 @@ class ColumnTestsMixin:
         # Test with lambda functions
         df = self.spark.createDataFrame([(10,), (20,), (30,)], ["value"])
         result = df.select(
-            df.value.transform(lambda c: c + 5).transform(lambda c: c * 2).transform(lambda c: c - 10)
+            df.value.transform(lambda c: c + 5)
+            .transform(lambda c: c * 2)
+            .transform(lambda c: c - 10)
         ).collect()
         self.assertEqual(result[0][0], 20)
         self.assertEqual(result[1][0], 40)
         self.assertEqual(result[2][0], 60)
+
 
 class ColumnTests(ColumnTestsMixin, ReusedSQLTestCase):
     pass


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

To align with scala side, this PR adds `transform()` API in Columns API, similar to `Dataset.transform()`:
```
def transform(self, f: Callable[["Column"], "Column"]) -> "Column":
```


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We want to give users a way to chain their methods, such as 
```
 >>> from pyspark.sql.functions import trim, upper
 >>> df = spark.createDataFrame([("  hello  ",), ("  world  ",)], ["text"])
 >>> df.select(df.text.transform(trim).transform(upper)).show()
```
This pattern is also easier for AI agents to learn and write.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. New API is introduced.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Tests generated by Copilot. 