### PR TITLE
[SPARK-53892][SS] Use `DescribeTopicsResult.allTopicNames` instead of the deprecated `all` API

### DIFF
--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/ConsumerStrategy.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/ConsumerStrategy.scala
@@ -62,14 +62,15 @@ private[kafka010] sealed trait ConsumerStrategy extends Logging {
       .build()
 
   protected def retrieveAllPartitions(admin: Admin, topics: Set[String]): Set[TopicPartition] = {
-    admin.describeTopics(topics.asJava).all().get().asScala.filterNot(_._2.isInternal).flatMap {
-      case (topic, topicDescription) =>
-        topicDescription.partitions().asScala.map { topicPartitionInfo =>
-          val partition = topicPartitionInfo.partition()
-          logDebug(s"Partition found: $topic:$partition")
-          new TopicPartition(topic, partition)
-        }
-    }.toSet
+    admin.describeTopics(topics.asJava).allTopicNames().get().asScala.filterNot(_._2.isInternal)
+      .flatMap {
+        case (topic, topicDescription) =>
+          topicDescription.partitions().asScala.map { topicPartitionInfo =>
+            val partition = topicPartitionInfo.partition()
+            logDebug(s"Partition found: $topic:$partition")
+            new TopicPartition(topic, partition)
+          }
+      }.toSet
   }
 }
 

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaTestUtils.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaTestUtils.scala
@@ -454,7 +454,7 @@ class KafkaTestUtils(
   }
 
   private def getOffsets(topics: Set[String], offsetSpec: OffsetSpec): Map[TopicPartition, Long] = {
-    val listOffsetsParams = adminClient.describeTopics(topics.asJava).all().get().asScala
+    val listOffsetsParams = adminClient.describeTopics(topics.asJava).allTopicNames().get().asScala
       .flatMap { topicDescription =>
         topicDescription._2.partitions().asScala.map { topicPartitionInfo =>
           new TopicPartition(topicDescription._1, topicPartitionInfo.partition())


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `DescribeTopicsResult.allTopicNames` API instead of the deprecated `all` API.

### Why are the changes needed?

`all` API was deprecated at Apache Kafka 3.1.0 and removed at 4.0.0.
- https://github.com/apache/kafka/pull/9769
- https://github.com/apache/kafka/pull/18255

> The <code>all()</code> method was removed from the <code>org.apache.kafka.clients.admin.DescribeTopicsResult</code>. Please use <code>allTopicNames()</code> instead.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.