### PR TITLE
[SPARK-53894][BUILD][TESTS] Upgrade `docker-java` to 3.6.0

### DIFF
--- a/connector/docker-integration-tests/pom.xml
+++ b/connector/docker-integration-tests/pom.xml
@@ -39,7 +39,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>33.1.0-jre</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1318,7 +1318,7 @@
       <dependency>
         <groupId>com.github.docker-java</groupId>
         <artifactId>docker-java</artifactId>
-        <version>3.4.0</version>
+        <version>3.6.0</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>
@@ -1338,7 +1338,7 @@
       <dependency>
         <groupId>com.github.docker-java</groupId>
         <artifactId>docker-java-transport-zerodep</artifactId>
-        <version>3.4.0</version>
+        <version>3.6.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -985,9 +985,7 @@ object Unsafe {
 
 object DockerIntegrationTests {
   // This serves to override the override specified in DependencyOverrides:
-  lazy val settings = Seq(
-    dependencyOverrides += "com.google.guava" % "guava" % "33.1.0-jre"
-  )
+  lazy val settings = Seq()
 }
 
 /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `docker-java` to 3.6.0 and remove `Guava` override hack.

### Why are the changes needed?

To use the latest and stable `docker-java` for Docker IT tests and to simplify the test dependency by removing `Guava` override hack.

### Does this PR introduce _any_ user-facing change?

No, this is a test dependency change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.