### PR TITLE
[SPARK-53900][CONNECT] Fix unintentional `Thread.wait(0)` under rare conditions in `ExecuteGrpcResponseSender`

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteGrpcResponseSender.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteGrpcResponseSender.scala
@@ -263,7 +263,7 @@ private[connect] class ExecuteGrpcResponseSender[T <: Message](
               timeoutNs = Math.min(progressTimeout * NANOS_PER_MILLIS, timeoutNs)
             }
             logTrace(s"Wait for response to become available with timeout=$timeoutNs ns.")
-            executionObserver.responseLock.wait(timeoutNs / NANOS_PER_MILLIS)
+            executionObserver.responseLock.wait(Math.max(1, timeoutNs / NANOS_PER_MILLIS))
             enqueueProgressMessage(force = true)
             logTrace(s"Reacquired executionObserver lock after waiting.")
             sleepEnd = System.nanoTime()
@@ -384,7 +384,7 @@ private[connect] class ExecuteGrpcResponseSender[T <: Message](
           val timeoutNs = Math.max(1, deadlineTimeNs - System.nanoTime())
           var sleepStart = System.nanoTime()
           logTrace(s"Wait for grpcCallObserver to become ready with timeout=$timeoutNs ns.")
-          grpcCallObserverReadySignal.wait(timeoutNs / NANOS_PER_MILLIS)
+          grpcCallObserverReadySignal.wait(Math.max(1, timeoutNs / NANOS_PER_MILLIS))
           logTrace(s"Reacquired grpcCallObserverReadySignal lock after waiting.")
           sleepEnd = System.nanoTime()
         }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Sets a lower bound of `1` to values passed into `Thread#wait` to avoid an unintentional indefinite wait.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

A bug in `ExecuteGrpcResponseSender` causes RPC streams to hang indefinitely when the configured deadline passes. The bug was introduced in [PR](https://github.com/apache/spark/pull/49003/files#diff-d4629281431427e41afd6d3db6630bcfdbfdbf77ba74cf7e48a988c1b66c13f1L244-L253]) during migration from System.currentTimeMillis() to System.nanoTime(), where an integer division error converts sub-millisecond timeout values to 0, triggering Java's wait(0) behavior (infinite wait).

#### Root Cause

`executionObserver.responseLock.wait(timeoutNs / NANOS_PER_MILLIS)  // ← BUG`
The Problem: When `deadlineTimeNs < System.nanoTime()` (deadline has passed):

- Math.max(1, negative_value) clamps to 1 nanosecond
- Math.min(progressInterval_ns, 1) remains 1 nanosecond
- Integer division: 1 / 1,000,000 = 0 milliseconds
- wait(0) in Java means wait indefinitely until notified
- No notification arrives (execution already completed), thread hangs forever

While one the loop conditions guards against `deadlineTimeNs < System.nanoTime()`, it isn’t sufficient as the deadline can elapse while inside the loop (the time is freshly fetched in the latter timeout calculation). The probability of occurrence can be exacerbated by GC pauses.

#### Conditions Required for Bug to Trigger

The bug manifests when all of the following conditions are met:

- Reattachable execution enabled (CONNECT_EXECUTE_REATTACHABLE_ENABLED = true)
- Execution completes prior to the deadline within the inner loop
- (all responses sent before deadline)
- Deadline passes within the inner loop

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
N/A

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.