### PR TITLE
[SPARK-53902] [SQL] Add tree node pattern bits for supported expressions in `ParameterizedQuery` argument list

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/VariableReference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/VariableReference.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.VariableDefinition
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
+import org.apache.spark.sql.catalyst.trees.TreePattern.{TreePattern, VARIABLE_REFERENCE}
 import org.apache.spark.sql.catalyst.util.quoteIfNeeded
 import org.apache.spark.sql.connector.catalog.{CatalogPlugin, Identifier}
 import org.apache.spark.sql.types.DataType
@@ -57,4 +58,6 @@ case class VariableReference(
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     varDef.currentValue.doGenCode(ctx, ev)
   }
+
+  final override val nodePatterns: Seq[TreePattern] = Seq(VARIABLE_REFERENCE)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -32,7 +32,12 @@ import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.trees.{BinaryLike, UnaryLike}
-import org.apache.spark.sql.catalyst.trees.TreePattern.{ARRAYS_ZIP, CONCAT, TreePattern}
+import org.apache.spark.sql.catalyst.trees.TreePattern.{
+  ARRAYS_ZIP,
+  CONCAT,
+  MAP_FROM_ENTRIES,
+  TreePattern
+}
 import org.apache.spark.sql.catalyst.types.{DataTypeUtils, PhysicalDataType, PhysicalIntegralType}
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
@@ -895,6 +900,8 @@ case class MapFromEntries(child: Expression)
 
   override protected def withNewChildInternal(newChild: Expression): MapFromEntries =
     copy(child = newChild)
+
+  final override val nodePatterns: Seq[TreePattern] = Seq(MAP_FROM_ENTRIES)
 }
 
 case class MapSort(base: Expression)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
@@ -282,6 +282,8 @@ case class CreateMap(children: Seq[Expression], useStringTypeWhenEmpty: Boolean)
 
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): CreateMap =
     copy(children = newChildren)
+
+  final override val nodePatterns: Seq[TreePattern] = Seq(CREATE_MAP)
 }
 
 object CreateMap {
@@ -348,6 +350,8 @@ case class MapFromArrays(left: Expression, right: Expression)
   override protected def withNewChildrenInternal(
       newLeft: Expression, newRight: Expression): MapFromArrays =
     copy(left = newLeft, right = newRight)
+
+  final override val nodePatterns: Seq[TreePattern] = Seq(MAP_FROM_ARRAYS)
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -40,6 +40,7 @@ object TreePattern extends Enumeration  {
   val COMMON_EXPR_REF: Value = Value
   val CONCAT: Value = Value
   val COUNT: Value = Value
+  val CREATE_MAP: Value = Value
   val CREATE_NAMED_STRUCT: Value = Value
   val CURRENT_LIKE: Value = Value
   val DYNAMIC_PRUNING_EXPRESSION: Value = Value
@@ -65,6 +66,8 @@ object TreePattern extends Enumeration  {
   val LIKE_FAMLIY: Value = Value
   val LIST_SUBQUERY: Value = Value
   val LITERAL: Value = Value
+  val MAP_FROM_ARRAYS: Value = Value
+  val MAP_FROM_ENTRIES: Value = Value
   val MAP_OBJECTS: Value = Value
   val MULTI_ALIAS: Value = Value
   val NEW_INSTANCE: Value = Value
@@ -99,6 +102,7 @@ object TreePattern extends Enumeration  {
   val UPDATE_FIELDS: Value = Value
   val UPPER_OR_LOWER: Value = Value
   val UP_CAST: Value = Value
+  val VARIABLE_REFERENCE: Value = Value
   val DISTRIBUTED_SEQUENCE_ID: Value = Value
 
   // Unresolved expression patterns (Alphabetically ordered)


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR I propose that we add tree node pattern bits for supported expressions in `ParameterizedQuery` argument list to prepare implementation of parameters in single-pass framework.

### Why are the changes needed?
To prepare support for parameters in single-pass framework.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.