### PR TITLE
[SPARK-53904][SS] Use `Consumer.poll(Duration)` instead of `Consumer.poll(long)`

### DIFF
--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderConsumer.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderConsumer.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.kafka010
 
 import java.{util => ju}
+import java.time.Duration
 
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
@@ -135,7 +136,7 @@ private[kafka010] class KafkaOffsetReaderConsumer(
     uninterruptibleThreadRunner.runUninterruptibly {
       assert(Thread.currentThread().isInstanceOf[UninterruptibleThread])
       // Poll to get the latest assigned partitions
-      consumer.poll(0)
+      consumer.poll(Duration.ofMillis(500))
       val partitions = consumer.assignment()
       consumer.pause(partitions)
       partitions.asScala.toSet
@@ -579,7 +580,7 @@ private[kafka010] class KafkaOffsetReaderConsumer(
 
     withRetriesWithoutInterrupt {
       // Poll to get the latest assigned partitions
-      consumer.poll(0)
+      consumer.poll(Duration.ofMillis(500))
       val partitions = consumer.assignment()
 
       if (!fetchingEarliestOffset) {

--- a/connector/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/ConsumerStrategy.scala
+++ b/connector/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/ConsumerStrategy.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.streaming.kafka010
 
 import java.{lang => jl, util => ju}
+import java.time.Duration
 import java.util.Locale
 
 import scala.jdk.CollectionConverters._
@@ -105,7 +106,7 @@ private case class Subscribe[K, V](
       val shouldSuppress =
         aor != null && aor.asInstanceOf[String].toUpperCase(Locale.ROOT) == "NONE"
       try {
-        consumer.poll(0)
+        consumer.poll(Duration.ZERO)
       } catch {
         case x: NoOffsetForPartitionException if shouldSuppress =>
           logWarning(log"Catching NoOffsetForPartitionException since " +
@@ -159,7 +160,7 @@ private case class SubscribePattern[K, V](
       val shouldSuppress =
         aor != null && aor.asInstanceOf[String].toUpperCase(Locale.ROOT) == "NONE"
       try {
-        consumer.poll(0)
+        consumer.poll(Duration.ZERO)
       } catch {
         case x: NoOffsetForPartitionException if shouldSuppress =>
           logWarning(log"Catching NoOffsetForPartitionException since " +

--- a/connector/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
+++ b/connector/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.streaming.kafka010
 
 import java.io.File
 import java.lang.{Long => JLong}
+import java.time.Duration
 import java.util.{Arrays, HashMap => JHashMap, Map => JMap, UUID}
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -255,7 +256,7 @@ class DirectKafkaStreamSuite
         preferredHosts,
         ConsumerStrategies.Subscribe[String, String](List(topic), kafkaParams.asScala),
         new DefaultPerPartitionConfig(sparkConf))
-      s.consumer().poll(0)
+      s.consumer().poll(Duration.ofMillis(500))
       assert(
         s.consumer().position(topicPartition) >= offsetBeforeStart,
         "Start offset not from latest"
@@ -311,7 +312,7 @@ class DirectKafkaStreamSuite
           kafkaParams.asScala,
           Map(topicPartition -> 11L)),
         new DefaultPerPartitionConfig(sparkConf))
-      s.consumer().poll(0)
+      s.consumer().poll(Duration.ZERO)
       assert(
         s.consumer().position(topicPartition) >= offsetBeforeStart,
         "Start offset not from latest"
@@ -473,7 +474,7 @@ class DirectKafkaStreamSuite
     ssc.stop()
     val consumer = new KafkaConsumer[String, String](kafkaParams)
     consumer.subscribe(Arrays.asList(topic))
-    consumer.poll(0)
+    consumer.poll(Duration.ofMillis(500))
     committed.asScala.foreach {
       case (k, v) =>
         // commits are async, not exactly once


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `Consumer.poll(Duration)` instead of `Consumer.poll(long)`.

- https://kafka.apache.org/documentation.html#upgrade_400_notable_consumer

  > The poll(long) method was removed from the consumer. Please use poll(Duration) instead. Note that there is a difference in behavior between the two methods. The poll(Duration) method does not block beyond the timeout awaiting partition assignment, whereas the earlier poll(long) method used to wait beyond the timeout.

This PR is consistent with KAFKA-15908's approach which uses `Duration.ZERO` and `Duration.ofMillis(500)` together. In general, `Duration.ZERO` is used like the following except `KafkaOffsetReaderConsumer` (and `DirectKafkaStreamSuite`) classes which use `Duration.ofMillis(500)` to make CI passes. 

```scala
- consumer.poll(0)
+ consumer.poll(Duration.ZERO)
```

### Why are the changes needed?

- Apache Kafka 2.0.0 deprecated `Consumer.poll(long)` via [KIP-266: Fix consumer indefinite blocking behavior](https://cwiki.apache.org/confluence/display/KAFKA/KIP-266%3A+Fix+consumer+indefinite+blocking+behavior).

  > The pre-existing variant poll(long timeout) would block indefinitely for metadata updates if they were needed, then it would issue a fetch and poll for timeout ms for new records. The initial indefinite metadata block caused applications to become stuck when the brokers became unavailable. The existence of the timeout parameter made the indefinite block especially unintuitive.

- Apache Kafka 4.0.0 removed it at KAFKA-15908.
  - https://github.com/apache/kafka/pull/17368

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.