### PR TITLE
[SPARK-53906][K8S] Protect `ExecutorPodsAllocator.numOutstandingPods` as `protected val`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -105,8 +105,7 @@ class ExecutorPodsAllocator(
 
   protected val dynamicAllocationEnabled = Utils.isDynamicAllocationEnabled(conf)
 
-  // visible for tests
-  val numOutstandingPods = new AtomicInteger()
+  protected val numOutstandingPods = new AtomicInteger()
 
   protected var lastSnapshot = ExecutorPodsSnapshot()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to protect `ExecutorPodsAllocator.numOutstandingPods` as `protected val`.

### Why are the changes needed?

We had better protect this properly instead of commenting it.

https://github.com/apache/spark/blob/ff0f1ab95238b27af93c755b600b82c0769fb8d0/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala#L108-L109

### Does this PR introduce _any_ user-facing change?

No. This is not supposed to be used internally.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.