### PR TITLE
[SPARK-53907][K8S] Support `spark.kubernetes.allocation.maximum`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -479,6 +479,14 @@ private[spark] object Config extends Logging {
       .checkValue(value => value > 100, "Allocation batch delay must be greater than 0.1s.")
       .createWithDefaultString("1s")
 
+  val KUBERNETES_ALLOCATION_MAXIMUM =
+    ConfigBuilder("spark.kubernetes.allocation.maximum")
+      .doc("The maximum number of executor pods to try to create during the whole job lifecycle.")
+      .version("4.1.0")
+      .intConf
+      .checkValue(value => value > 0, "Allocation maximum should be a positive integer")
+      .createWithDefault(Int.MaxValue)
+
   val KUBERNETES_ALLOCATION_DRIVER_READINESS_TIMEOUT =
     ConfigBuilder("spark.kubernetes.allocation.driver.readinessTimeout")
       .doc("Time to wait for driver pod to get ready before creating executor pods. This wait " +

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -48,6 +48,8 @@ class ExecutorPodsAllocator(
 
   protected val EXECUTOR_ID_COUNTER = new AtomicInteger(0)
 
+  protected val MAXIMUM = conf.get(KUBERNETES_ALLOCATION_MAXIMUM)
+
   protected val PVC_COUNTER = new AtomicInteger(0)
 
   protected val maxPVCs = if (Utils.isDynamicAllocationEnabled(conf)) {
@@ -68,6 +70,8 @@ class ExecutorPodsAllocator(
   protected val podAllocationSize = conf.get(KUBERNETES_ALLOCATION_BATCH_SIZE)
 
   protected val podAllocationDelay = conf.get(KUBERNETES_ALLOCATION_BATCH_DELAY)
+
+  protected val podAllocationMaximum = conf.get(KUBERNETES_ALLOCATION_MAXIMUM)
 
   protected val maxPendingPods = conf.get(KUBERNETES_MAX_PENDING_PODS)
 
@@ -426,6 +430,9 @@ class ExecutorPodsAllocator(
         return
       }
       val newExecutorId = EXECUTOR_ID_COUNTER.incrementAndGet()
+      if (newExecutorId >= MAXIMUM) {
+        throw new SparkException(s"Exceed the pod creation limit: $MAXIMUM")
+      }
       val executorConf = KubernetesConf.createExecutorConf(
         conf,
         newExecutorId.toString,

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -48,8 +48,6 @@ class ExecutorPodsAllocator(
 
   protected val EXECUTOR_ID_COUNTER = new AtomicInteger(0)
 
-  protected val MAXIMUM = conf.get(KUBERNETES_ALLOCATION_MAXIMUM)
-
   protected val PVC_COUNTER = new AtomicInteger(0)
 
   protected val maxPVCs = if (Utils.isDynamicAllocationEnabled(conf)) {
@@ -430,8 +428,8 @@ class ExecutorPodsAllocator(
         return
       }
       val newExecutorId = EXECUTOR_ID_COUNTER.incrementAndGet()
-      if (newExecutorId >= MAXIMUM) {
-        throw new SparkException(s"Exceed the pod creation limit: $MAXIMUM")
+      if (newExecutorId >= podAllocationMaximum) {
+        throw new SparkException(s"Exceed the pod creation limit: $podAllocationMaximum")
       }
       val executorConf = KubernetesConf.createExecutorConf(
         conf,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `spark.kubernetes.allocation.maximum`.

### Why are the changes needed?

Since we use `AtomicInteger` ID generator, we hit the overflow at `Int.MaxValue`. We had better throw exceptions explicitly in this case because it's highly a malfunctioning situation when a Spark driver tries to create `2147483647 (Int.MaxValue)` executor pods.

https://github.com/apache/spark/blob/e05c75e105d5bc9947fb6142f40695ecd5e817e6/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala#L49

```
$ jshell
|  Welcome to JShell -- Version 21.0.8
|  For an introduction type: /help intro

jshell> var x = new java.util.concurrent.atomic.AtomicInteger(Integer.MAX_VALUE)
x ==> 2147483647

jshell> x.incrementAndGet()
$2 ==> -2147483648

jshell> x.incrementAndGet()
$3 ==> -2147483647

jshell> x.incrementAndGet()
$4 ==> -2147483646

jshell> var x = new java.util.concurrent.atomic.AtomicInteger(-1)
x ==> -1

jshell> x.incrementAndGet()
$6 ==> 0

jshell> x.incrementAndGet()
$7 ==> 1
```

### Does this PR introduce _any_ user-facing change?

Practically no because a normal Spark job and K8s cluster cannot handle `2147483647` executor pod creation. If a user has this case, it means the ID overflow happens and the ID will be rotated to `0` and the executor IDs will be reused. It's already a bug situation.

### How was this patch tested?

Pass the CIs with newly added test cases.

### Was this patch authored or co-authored using generative AI tooling?

No.