### PR TITLE
[SPARK-53908][CONNECT] Fix observations on Spark Connect with plan cache

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -2064,6 +2064,8 @@ case class CollectMetrics(
   override def doCanonicalize(): LogicalPlan = {
     super.doCanonicalize().asInstanceOf[CollectMetrics].copy(dataframeId = 0L)
   }
+
+  final override val nodePatterns: Seq[TreePattern] = Seq(COLLECT_METRICS)
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -122,6 +122,7 @@ object TreePattern extends Enumeration  {
   val AGGREGATE: Value = Value
   val APPEND_COLUMNS: Value = Value
   val AS_OF_JOIN: Value = Value
+  val COLLECT_METRICS: Value = Value
   val COMMAND: Value = Value
   val CTE: Value = Value
   val DESERIALIZE_TO_OBJECT: Value = Value

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -246,7 +246,8 @@ class SparkConnectPlanner(
           // TODO this might be too complex for no good reason. It might
           //  be easier to inspect the plan after it completes.
           val observation = session.observationManager.getOrNewObservation(
-            collectMetrics.name, collectMetrics.dataframeId)
+            collectMetrics.name,
+            collectMetrics.dataframeId)
           executeHolder.addObservation(collectMetrics.name, observation)
           collectMetrics
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/ObservationManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/ObservationManager.scala
@@ -45,7 +45,7 @@ private[sql] class ObservationManager(session: SparkSession) {
     observations.putIfAbsent((observation.name, dataFrameId), observation)
   }
 
-  private[sql] def getOrNewObservation(name: String, dataFrameId: Long): Observation =
+  def getOrNewObservation(name: String, dataFrameId: Long): Observation =
     observations.computeIfAbsent((name, dataFrameId), { _ =>
       val observation = Observation(name)
       observation.markRegistered()

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/ObservationManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/ObservationManager.scala
@@ -46,10 +46,10 @@ private[sql] class ObservationManager(session: SparkSession) {
   }
 
   private[sql] def getOrNewObservation(name: String, dataFrameId: Long): Observation =
-    observations.computeIfAbsent((name, dataFrameId), _ => {
-      val obs = Observation(name)
-      obs.markRegistered()
-      obs
+    observations.computeIfAbsent((name, dataFrameId), { _ =>
+      val observation = Observation(name)
+      observation.markRegistered()
+      observation
     })
 
   private def tryComplete(qe: QueryExecution): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/ObservationManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/ObservationManager.scala
@@ -45,6 +45,13 @@ private[sql] class ObservationManager(session: SparkSession) {
     observations.putIfAbsent((observation.name, dataFrameId), observation)
   }
 
+  private[sql] def getOrNewObservation(name: String, dataFrameId: Long): Observation =
+    observations.computeIfAbsent((name, dataFrameId), _ => {
+      val obs = Observation(name)
+      obs.markRegistered()
+      obs
+    })
+
   private def tryComplete(qe: QueryExecution): Unit = {
     val allMetrics = qe.observedMetrics
     qe.logical.foreach {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes observations on Spark Connect with plan cache enabled.

### Why are the changes needed?

The observations on Spark Connect with plan cache enabled has cases that can't see the observed values.

```py
>>> from pyspark.sql.observation import Observation
>>> from pyspark.sql import functions as F
>>>
>>> df = spark.range(10)
>>> observation = Observation()
>>> observed_df = df.observe(observation, F.count(F.lit(1)).alias("cnt"))
>>>
>>> observed_df.schema  # causes to cache
StructType([StructField('id', LongType(), False)])
>>>
>>> observed_df.show()
+---+
| id|
+---+
...
+---+

>>>
>>> observation.get
{}
```

This should be:

```py
>>> spark.conf.set('spark.connect.session.planCache.enabled', False)
...
>>> observation.get
{'cnt': 10}
```

This is because the cached plan by the Analyze request for `observed_df.schema` doesn't register the new `Observation` for the actual execution.

The observations should be registered later.

### Does this PR introduce _any_ user-facing change?

Yes, the observations will be available.

### How was this patch tested?

Modified the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
