### PR TITLE
[SPARK-53919][BUILD] Make Maven plugins up-to-date

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <java.minimum.version>17.0.11</java.minimum.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <maven.version>3.9.11</maven.version>
-    <exec-maven-plugin.version>3.5.1</exec-maven-plugin.version>
+    <exec-maven-plugin.version>3.6.1</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.8</asm.version>
     <slf4j.version>2.0.17</slf4j.version>
@@ -177,7 +177,7 @@
     <scala.version>2.13.17</scala.version>
     <scala.binary.version>2.13</scala.binary.version>
     <scalatest-maven-plugin.version>2.2.0</scalatest-maven-plugin.version>
-    <scala-maven-plugin.version>4.9.5</scala-maven-plugin.version>
+    <scala-maven-plugin.version>4.9.6</scala-maven-plugin.version>
     <maven.scaladoc.skip>false</maven.scaladoc.skip>
     <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
@@ -2619,7 +2619,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.6.2</version>
           <executions>
             <execution>
               <id>enforce-versions</id>
@@ -2803,7 +2803,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.14.0</version>
+          <version>3.14.1</version>
           <configuration>
             <skipMain>true</skipMain> <!-- skip compile -->
             <skip>true</skip> <!-- skip testCompile -->
@@ -3039,7 +3039,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.6.1</version>
           <dependencies>
             <dependency>
               <groupId>org.ow2.asm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3039,7 +3039,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.6.1</version>
+          <version>3.6.0</version>
           <dependencies>
             <dependency>
               <groupId>org.ow2.asm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
     <scala.version>2.13.17</scala.version>
     <scala.binary.version>2.13</scala.binary.version>
     <scalatest-maven-plugin.version>2.2.0</scalatest-maven-plugin.version>
-    <scala-maven-plugin.version>4.9.6</scala-maven-plugin.version>
+    <scala-maven-plugin.version>4.9.5</scala-maven-plugin.version>
     <maven.scaladoc.skip>false</maven.scaladoc.skip>
     <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
     <!-- for now, not running scalafmt as part of default verify pipeline -->


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `Maven` plugins up-to-date as a part of Apache Spark 4.1.0 preparation.

### Why are the changes needed?

To bring the latest bug fixes and improvements.

- exec-maven-plugin
  - https://github.com/mojohaus/exec-maven-plugin/releases/tag/3.6.1
  - https://github.com/mojohaus/exec-maven-plugin/releases/tag/3.6.0
    - https://github.com/mojohaus/exec-maven-plugin/pull/484
- maven-compiler-plugin
  - https://github.com/apache/maven-compiler-plugin/releases/tag/maven-compiler-plugin-3.14.1
- maven-enforcer-plugin
  - https://github.com/apache/maven-enforcer/releases/tag/enforcer-3.6.2
  - https://github.com/apache/maven-enforcer/releases/tag/enforcer-3.6.1

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.