### PR TITLE
[SPARK-53920][Geo][SQL] Introduce GeometryType and GeographyType to Java API

### DIFF
--- a/sql/api/src/main/java/org/apache/spark/sql/types/DataTypes.java
+++ b/sql/api/src/main/java/org/apache/spark/sql/types/DataTypes.java
@@ -95,6 +95,42 @@ public class DataTypes {
   public static final DataType ShortType = ShortType$.MODULE$;
 
   /**
+   * Creates a GeographyType by specifying the SRID value.
+   *
+   * @since 4.1.0
+   */
+  public static GeographyType createGeographyType(int srid) {
+    return GeographyType$.MODULE$.apply(srid);
+  }
+
+  /**
+   * Creates a GeographyType by specifying the CRS value.
+   *
+   * @since 4.1.0
+   */
+  public static GeographyType createGeographyType(String crs) {
+    return GeographyType$.MODULE$.apply(crs);
+  }
+
+  /**
+   * Creates a GeometryType by specifying the SRID value.
+   *
+   * @since 4.1.0
+   */
+  public static GeometryType createGeometryType(int srid) {
+    return GeometryType$.MODULE$.apply(srid);
+  }
+
+  /**
+   * Creates a GeometryType by specifying the CRS value.
+   *
+   * @since 4.1.0
+   */
+  public static GeometryType createGeometryType(String crs) {
+    return GeometryType$.MODULE$.apply(crs);
+  }
+
+  /**
    * Gets the NullType object.
    */
   public static final DataType NullType = NullType$.MODULE$;

--- a/sql/core/src/test/scala/org/apache/spark/sql/types/JavaGeographyTypeSuite.java
+++ b/sql/core/src/test/scala/org/apache/spark/sql/types/JavaGeographyTypeSuite.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types;
+
+import org.apache.spark.sql.internal.types.SpatialReferenceSystemMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.apache.spark.SparkIllegalArgumentException;
+
+import java.util.stream.Stream;
+
+public class JavaGeographyTypeSuite {
+
+  /*
+   * Test cases GeographyType construction based on SRID.
+   */
+
+  @Test
+  public void geographyTypeWithSpecifiedValidSridTest() {
+    // Valid SRID values for GEOGRAPHY. Note that only 4326 is supported for now.
+    Stream.of(4326).forEach(srid -> {
+      DataType geographyType = DataTypes.createGeographyType(srid);
+      Assertions.assertEquals("GEOGRAPHY(" + srid + ")", geographyType.sql());
+      Assertions.assertEquals("geography(" + srid + ")", geographyType.typeName());
+      Assertions.assertEquals("geography(" + srid + ")", geographyType.simpleString());
+    });
+  }
+
+  @Test
+  public void geographyTypeWithSpecifiedInvalidSridTest() {
+    // Invalid SRID values for GEOGRAPHY.
+    Stream.of(-1, -2, 0, 1, 2).forEach(srid -> {
+      try {
+        DataTypes.createGeographyType(srid);
+        Assertions.fail("Expected SparkIllegalArgumentException for SRID: " + srid);
+      } catch (SparkIllegalArgumentException e) {
+        Assertions.assertEquals("ST_INVALID_SRID_VALUE", e.getCondition());
+        Assertions.assertEquals(String.valueOf(srid), e.getMessageParameters().get("srid"));
+      }
+    });
+  }
+
+  /*
+   * Test cases GeographyType construction based on CRS.
+   */
+
+  @Test
+  public void geographyTypeWithSpecifiedValidCrsTest() {
+    // Valid CRS values for GEOGRAPHY. Note that only 4326 is supported for now.
+    int srid = GeographyType.GEOGRAPHY_DEFAULT_SRID();
+    Stream.of("OGC:CRS84", "EPSG:4326").forEach(crs -> {
+      DataType geographyType = DataTypes.createGeographyType(crs);
+      Assertions.assertEquals("GEOGRAPHY(" + srid + ")", geographyType.sql());
+      Assertions.assertEquals("geography(" + srid + ")", geographyType.typeName());
+      Assertions.assertEquals("geography(" + srid + ")", geographyType.simpleString());
+    });
+  }
+
+  @Test
+  public void geographyTypeWithSpecifiedInvalidCrsTest() {
+    // Invalid CRS values for GEOGRAPHY.
+    Stream.of("0", "SRID", "SRID:-1", "SRID:4326", "CRS84", "").forEach(crs -> {
+      try {
+        DataTypes.createGeographyType(crs);
+        Assertions.fail("Expected SparkIllegalArgumentException for CRS: " + crs);
+      } catch (SparkIllegalArgumentException e) {
+        Assertions.assertEquals("ST_INVALID_CRS_VALUE", e.getCondition());
+        Assertions.assertEquals(crs, e.getMessageParameters().get("crs"));
+      }
+    });
+  }
+
+  @Test
+  public void geographyTypeWithSpecifiedAnyTest() {
+    // Special string value "ANY" in place of CRS is used to denote a mixed GEOGRAPHY type.
+    DataType geographyType = DataTypes.createGeographyType("ANY");
+    Assertions.assertEquals("GEOGRAPHY(ANY)", geographyType.sql());
+    Assertions.assertEquals("geography(any)", geographyType.typeName());
+    Assertions.assertEquals("geography(any)", geographyType.simpleString());
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/types/JavaGeometryTypeSuite.java
+++ b/sql/core/src/test/scala/org/apache/spark/sql/types/JavaGeometryTypeSuite.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types;
+
+import org.apache.spark.sql.internal.types.SpatialReferenceSystemMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.apache.spark.SparkIllegalArgumentException;
+
+import java.util.stream.Stream;
+
+public class JavaGeometryTypeSuite {
+
+  /*
+   * Test cases GeometryType construction based on SRID.
+   */
+
+  @Test
+  public void geometryTypeWithSpecifiedValidSridTest() {
+    // Valid SRID values for GEOMETRY.
+    Stream.of(0, 3857, 4326).forEach(srid -> {
+      DataType geometryType = DataTypes.createGeometryType(srid);
+      Assertions.assertEquals("GEOMETRY(" + srid + ")", geometryType.sql());
+      Assertions.assertEquals("geometry(" + srid + ")", geometryType.typeName());
+      Assertions.assertEquals("geometry(" + srid + ")", geometryType.simpleString());
+    });
+  }
+
+  @Test
+  public void geometryTypeWithSpecifiedInvalidSridTest() {
+    // Invalid SRID values for GEOMETRY.
+    Stream.of(-1, -2, 1, 2).forEach(srid -> {
+      try {
+        DataTypes.createGeometryType(srid);
+        Assertions.fail("Expected SparkIllegalArgumentException for SRID: " + srid);
+      } catch (SparkIllegalArgumentException e) {
+        Assertions.assertEquals("ST_INVALID_SRID_VALUE", e.getCondition());
+        Assertions.assertEquals(String.valueOf(srid), e.getMessageParameters().get("srid"));
+      }
+    });
+  }
+
+  /*
+   * Test cases GeometryType construction based on CRS.
+   */
+
+  @Test
+  public void geometryTypeWithSpecifiedValidCrsTest() {
+    // Valid CRS values for GEOMETRY.
+    SpatialReferenceSystemMapper srsMapper = SpatialReferenceSystemMapper.get();
+    Stream.of("SRID:0", "EPSG:3857", "OGC:CRS84").forEach(crs -> {
+      int srid = srsMapper.getSrid(crs);
+      DataType geometryType = DataTypes.createGeometryType(crs);
+      Assertions.assertEquals("GEOMETRY(" + srid + ")", geometryType.sql());
+      Assertions.assertEquals("geometry(" + srid + ")", geometryType.typeName());
+      Assertions.assertEquals("geometry(" + srid + ")", geometryType.simpleString());
+    });
+  }
+
+  @Test
+  public void geometryTypeWithSpecifiedInvalidCrsTest() {
+    // Invalid CRS values for GEOMETRY.
+    Stream.of("0", "SRID", "SRID:-1", "SRID:4326", "CRS84", "").forEach(crs -> {
+      try {
+        DataTypes.createGeometryType(crs);
+        Assertions.fail("Expected SparkIllegalArgumentException for CRS: " + crs);
+      } catch (SparkIllegalArgumentException e) {
+        Assertions.assertEquals("ST_INVALID_CRS_VALUE", e.getCondition());
+        Assertions.assertEquals(crs, e.getMessageParameters().get("crs"));
+      }
+    });
+  }
+
+  @Test
+  public void geometryTypeWithSpecifiedAnyTest() {
+    // Special string value "ANY" in place of CRS is used to denote a mixed GEOMETRY type.
+    DataType geometryType = DataTypes.createGeometryType("ANY");
+    Assertions.assertEquals("GEOMETRY(ANY)", geometryType.sql());
+    Assertions.assertEquals("geometry(any)", geometryType.typeName());
+    Assertions.assertEquals("geometry(any)", geometryType.simpleString());
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Introduce two new geospatial data types to Java API:
- `GeographyType`
- `GeometryType`

Note that the GEOMETRY and GEOGRAPHY logical types were recently included to Spark SQL as part of: https://github.com/apache/spark/pull/52491.

### Why are the changes needed?
Expanding on GEOMETRY and GEOGRAPHY type support across all of the supported APIs.


### Does this PR introduce _any_ user-facing change?
Yes, two new data types are now available to users of the Java API.


### How was this patch tested?
Added new tests to:
- `JavaGeographyTypeSuite`
- `JavaGeometryTypeSuite`


### Was this patch authored or co-authored using generative AI tooling?
No.
