### PR TITLE
[SPARK-53923][CORE] Rename `spark.executor.(log -> logs).redirectConsoleOutputs`

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2889,7 +2889,7 @@ package object config {
       .createWithDefault(Seq("stdout", "stderr"))
 
   private[spark] val EXEC_REDIRECT_CONSOLE_OUTPUTS =
-    ConfigBuilder("spark.executor.log.redirectConsoleOutputs")
+    ConfigBuilder("spark.executor.logs.redirectConsoleOutputs")
       .doc("Comma-separated list of the console output kind for executor that needs to redirect " +
         "to logging system. Supported values are `stdout`, `stderr`. It only takes affect when " +
         s"`${PLUGINS.key}` is configured with `org.apache.spark.deploy.RedirectConsolePlugin`.")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to rename `spark.executor.log.redirectConsoleOutputs` to `spark.executor.logs.redirectConsoleOutputs` to be consistent with the existing executor log configurations like the following.

```
spark.executor.logs.rolling.strategy
spark.executor.logs.rolling.time.interval
spark.executor.logs.rolling.maxSize
spark.executor.logs.rolling.maxRetainedFiles
spark.executor.logs.rolling.enableCompression
spark.executor.logs.redirectConsoleOutputs
```

### Why are the changes needed?

Although SPARK-52426 introduced two configurations consistently in the PR, Apache Spark has different namespaces for Driver and Executor which are `spark.driver.log.*` and `spark.executor.logs.*` respectively. Instead of introducing a new config namespace, `spark.executor.log`, for this single new configuration, we had better follow the existing naming rule.
- https://github.com/apache/spark/pull/51130

```
spark.driver.log.redirectConsoleOutputs
spark.executor.log.redirectConsoleOutputs
```

### Does this PR introduce _any_ user-facing change?

No this is not released yet.

### How was this patch tested?

Pass the CIs. Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.