### PR TITLE
[SPARK-53925][INFRA] Use `MacOS 26` in `build_maven_java21_macos15.yml`

### DIFF
--- a/.github/workflows/build_maven_java21_macos26.yml
+++ b/.github/workflows/build_maven_java21_macos26.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Maven (master, Scala 2.13, Hadoop 3, JDK 21, MacOS-15)"
+name: "Build / Maven (master, Scala 2.13, Hadoop 3, JDK 21, MacOS-26)"
 
 on:
   schedule:
@@ -33,7 +33,7 @@ jobs:
     if: github.repository == 'apache/spark'
     with:
       java: 21
-      os: macos-15
+      os: macos-26
       arch: arm64
       envs: >-
         {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `MacOS` from `15` to `26` in `build_maven_java21_macos15.yml`.

### Why are the changes needed?

To use the latest MacOS as a part of Apache Spark 4.1.0 preparation.
- https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md

### Does this PR introduce _any_ user-facing change?

No, this is an infra-only change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.