### PR TITLE
[SPARK-53929][SQL] Support TIME in the make_timestamp and try_make_timestamp functions in Scala

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -8796,6 +8796,24 @@ object functions {
     Column.fn("make_timestamp", years, months, days, hours, mins, secs)
 
   /**
+   * Create a local date-time from date, time, and timezone fields.
+   *
+   * @group datetime_funcs
+   * @since 4.1.0
+   */
+  def make_timestamp(date: Column, time: Column, timezone: Column): Column =
+    Column.fn("make_timestamp", date, time, timezone)
+
+  /**
+   * Create a local date-time from date and time fields.
+   *
+   * @group datetime_funcs
+   * @since 4.1.0
+   */
+  def make_timestamp(date: Column, time: Column): Column =
+    Column.fn("make_timestamp", date, time)
+
+  /**
    * Try to create a timestamp from years, months, days, hours, mins, secs and timezone fields.
    * The result data type is consistent with the value of configuration `spark.sql.timestampType`.
    * The function returns NULL on invalid inputs.
@@ -8829,6 +8847,24 @@ object functions {
       mins: Column,
       secs: Column): Column =
     Column.fn("try_make_timestamp", years, months, days, hours, mins, secs)
+
+  /**
+   * Try to create a local date-time from date, time, and timezone fields.
+   *
+   * @group datetime_funcs
+   * @since 4.1.0
+   */
+  def try_make_timestamp(date: Column, time: Column, timezone: Column): Column =
+    Column.fn("try_make_timestamp", date, time, timezone)
+
+  /**
+   * Try to create a local date-time from date and time fields.
+   *
+   * @group datetime_funcs
+   * @since 4.1.0
+   */
+  def try_make_timestamp(date: Column, time: Column): Column =
+    Column.fn("try_make_timestamp", date, time)
 
   /**
    * Create the current timestamp with local time zone from years, months, days, hours, mins, secs


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Implement the `make_timestamp` and `try_make_timestamp` functions in Scala API.


### Why are the changes needed?
Expand API support for the `MakeTimestamp` and `TryMakeTimestamp` expressions.


### Does this PR introduce _any_ user-facing change?
Yes, the new functions are now available in Scala API.


### How was this patch tested?
Added appropriate Scala functions tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
