### PR TITLE
[SPARK-53760][Geo][SQL][FOLLOWUP] Fix error message and comment for Spatial types

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5561,7 +5561,7 @@
   },
   "ST_INVALID_SRID_VALUE" : {
     "message" : [
-      "Invalid or unsupported SRID (spatial reference identifier) value: <srid>"
+      "Invalid or unsupported SRID (spatial reference identifier) value: <srid>."
     ],
     "sqlState" : "22023"
   },

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/SpatialType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/SpatialType.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.types.AbstractDataType
 trait SpatialType extends AbstractDataType {
 
   /**
-   * Mixed SRID value and the corresponding CRS for geospatial types (Geometry and Geography)
+   * Mixed SRID value and the corresponding CRS for geospatial types (Geometry and Geography).
    * These values represent a geospatial type that can hold different SRID values per row.
    */
   final val MIXED_SRID: Int = -1


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

- Fix the `ST_INVALID_SRID_VALUE` error message.
- Fix the `SpatialType` doc comment.


### Why are the changes needed?
Followup PR to clean up original issues introduced in: https://github.com/apache/spark/pull/52491.


### Does this PR introduce _any_ user-facing change?
Yes, the `ST_INVALID_SRID_VALUE` error message is updated.


### How was this patch tested?
Existing tests are sufficient.


### Was this patch authored or co-authored using generative AI tooling?
No.
