### PR TITLE
[SPARK-49644][SQL] Support drop multi-level partition V2 table with partial partition spec

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -1364,6 +1364,7 @@ case class DropPartitions(
     parts: Seq[PartitionSpec],
     ifExists: Boolean,
     purge: Boolean) extends V2PartitionCommand {
+  override def allowPartialPartitionSpec: Boolean = true
   override protected def withNewChildInternal(newChild: LogicalPlan): DropPartitions =
     copy(table = newChild)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DropPartitionExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DropPartitionExec.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
+import scala.collection.mutable
+
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{NoSuchPartitionsException, ResolvedPartitionSpec}
 import org.apache.spark.sql.catalyst.expressions.Attribute
@@ -37,15 +39,23 @@ case class DropPartitionExec(
   override def output: Seq[Attribute] = Seq.empty
 
   override protected def run(): Seq[InternalRow] = {
-    val (existsPartIdents, notExistsPartIdents) =
-      partSpecs.map(_.ident).partition(table.partitionExists)
+    val existsPartIdents = mutable.Set[InternalRow]()
+    val notExistsPartIdents = mutable.Set[InternalRow]()
+    partSpecs.foreach { partSpec =>
+      val partIdents = table.listPartitionIdentifiers(partSpec.names.toArray, partSpec.ident)
+      if (partIdents.nonEmpty) {
+        existsPartIdents.addAll(partIdents)
+      } else {
+        notExistsPartIdents.add(partSpec.ident)
+      }
+    }
 
     if (notExistsPartIdents.nonEmpty && !ignoreIfNotExists) {
       throw new NoSuchPartitionsException(
-        table.name(), notExistsPartIdents, table.partitionSchema())
+        table.name(), notExistsPartIdents.toSeq, table.partitionSchema())
     }
 
-    val isTableAltered = existsPartIdents match {
+    val isTableAltered = existsPartIdents.toSeq match {
       case Seq() => false // Nothing will be done
       case Seq(partIdent) =>
         if (purge) table.purgePartition(partIdent) else table.dropPartition(partIdent)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -3042,6 +3042,37 @@ class DataSourceV2SQLSuiteV1Filter
     }
   }
 
+  test("Drop multi-level partition table with partial partition spec") {
+    val t = "testpart.tbl"
+    withTable(t) {
+      sql(s"CREATE TABLE $t (id string) USING foo PARTITIONED BY (p1 int, p2 int, p3 int)")
+      sql(s"INSERT INTO $t VALUES ('a', 1, 11, 111), ('b', 1, 22, 222), ('c', 2, 22, 333)")
+
+      checkAnswer(
+        sql(s"SHOW PARTITIONS $t"),
+        Seq(Row("p1=1/p2=11/p3=111"), Row("p1=1/p2=22/p3=222"), Row("p1=2/p2=22/p3=333")))
+
+      sql(s"ALTER TABLE $t DROP PARTITION (p1=1)")
+      checkAnswer(
+        sql(s"SHOW PARTITIONS $t"),
+        Seq(Row("p1=2/p2=22/p3=333")))
+
+      checkError(exception = intercept[AnalysisException] {
+        sql(s"ALTER TABLE $t DROP PARTITION (p1=4)")
+      },
+        condition = "PARTITIONS_NOT_FOUND",
+        sqlState = Some("428FT"),
+        parameters = Map(
+          "partitionList" -> "PARTITION (`p1` = 4)",
+          "tableName" -> t.split("\\.").map(part => s"`$part`").mkString(".")))
+
+      sql(s"ALTER TABLE $t DROP IF EXISTS PARTITION (p1=4)")
+      checkAnswer(
+        sql(s"SHOW PARTITIONS $t"),
+        Seq(Row("p1=2/p2=22/p3=333")))
+    }
+  }
+
   test("Check HasPartitionStatistics from InMemoryPartitionTable") {
     val t = "testpart.tbl"
     withTable(t) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Support drop multi-level partition V2 table with partial partition spec, e.g.
```
CREATE TABLE t (id string) USING DSV2 PARTITIONED BY (p1 int, p2 int, p3 int)
ALTER TABLE t DROP PARTITION (p1=1)
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This feature is useful when the user has a lot of secondary partitions and wants to delete all of them by specifying a primary partition.
v1 table support this now, v2 can support too.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Support drop multi-level partition V2 table with partial partition spec

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
add test case

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No