### PR TITLE
[SPARK-53938][PYTHON][CONNECT] Fix decimal rescaling in LocalDataToArrowConversion

### DIFF
--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -322,7 +322,7 @@ class LocalDataToArrowConversion:
                         if not nullable:
                             raise PySparkValueError(f"input for {dataType} must not be None")
                         return None
-                    return round(value, dataType.scale)
+                    return round(value, dataType.scale).normalize()
 
             return convert_decimal
 

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -80,6 +80,7 @@ class LocalDataToArrowConversion:
             return True
         elif isinstance(dataType, DecimalType):
             # Convert Decimal('NaN') to None
+            # Rescale Decimal values
             return True
         elif isinstance(dataType, StringType):
             # Coercion to StringType is allowed
@@ -321,7 +322,7 @@ class LocalDataToArrowConversion:
                         if not nullable:
                             raise PySparkValueError(f"input for {dataType} must not be None")
                         return None
-                    return value
+                    return round(value, dataType.scale)
 
             return convert_decimal
 

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -118,8 +118,6 @@ class LocalDataToArrowConversion:
         none_on_identity: bool = False,
         int_to_decimal_coercion_enabled: bool = False,
     ) -> Optional[Callable]:
-        import pyarrow as pa
-
         assert dataType is not None and isinstance(dataType, DataType)
         assert isinstance(nullable, bool)
 

--- a/python/pyspark/sql/tests/test_creation.py
+++ b/python/pyspark/sql/tests/test_creation.py
@@ -167,6 +167,11 @@ class DataFrameCreationTestsMixin:
         with self.assertRaises(PySparkValueError):
             self.spark.createDataFrame(data=data, schema=schema)
 
+    def test_decimal_round(self):
+        df = self.spark.createDataFrame([(Decimal(1.234),)], ["d"])
+        rounded = df.first().d
+        self.assertEqual(rounded, Decimal("1.233999999999999986"))
+
     def test_invalid_argument_create_dataframe(self):
         with self.assertRaises(PySparkTypeError) as pe:
             self.spark.createDataFrame([(1, 2)], schema=123)

--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -20,7 +20,7 @@ import tempfile
 import unittest
 from datetime import datetime
 from decimal import Decimal
-from typing import Callable, Iterable, List, Union
+from typing import Callable, Iterable, List, Union, Iterator, Tuple
 
 from pyspark.errors import AnalysisException, PythonException
 from pyspark.sql.datasource import (
@@ -48,7 +48,7 @@ from pyspark.sql.datasource import (
 )
 from pyspark.sql.functions import spark_partition_id
 from pyspark.sql.session import SparkSession
-from pyspark.sql.types import Row, StructType, VariantVal
+from pyspark.sql.types import Row, StructField, StructType, IntegerType, DecimalType, VariantVal
 from pyspark.testing import assertDataFrameEqual
 from pyspark.testing.sqlutils import (
     SPARK_HOME,
@@ -754,6 +754,31 @@ class BasePythonDataSourceTestsMixin:
             r"\[DATA_SOURCE_TYPE_MISMATCH\] Expected an instance of DataSourceWriter",
         ):
             df.write.format("test").mode("append").saveAsTable("test_table")
+
+    def test_decimal_round(self):
+        class SimpleDataSource(DataSource):
+            @classmethod
+            def name(cls) -> str:
+                return "simple_decimal"
+
+            def schema(self) -> StructType:
+                return StructType(
+                    [
+                        StructField("i", IntegerType()),
+                        StructField("d", DecimalType(38, 18)),
+                    ]
+                )
+
+            def reader(self, schema: StructType) -> DataSourceReader:
+                return SimpleDataSourceReader()
+
+        class SimpleDataSourceReader(DataSourceReader):
+            def read(self, partition: InputPartition) -> Iterator[Tuple]:
+                yield (1, Decimal(1.234))
+
+        self.spark.dataSource.register(SimpleDataSource)
+        df = self.spark.read.format("simple_decimal").load()
+        self.assertEqual(df.select("d").first().d, Decimal("1.233999999999999986"))
 
     @unittest.skipIf(
         "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"

--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -778,7 +778,9 @@ class BasePythonDataSourceTestsMixin:
 
         self.spark.dataSource.register(SimpleDataSource)
         df = self.spark.read.format("simple_decimal").load()
-        self.assertEqual(df.select("d").first().d, Decimal("1.233999999999999986"))
+
+        rounded = df.select("d").first().d
+        self.assertEqual(rounded, Decimal("1.233999999999999986"))
 
     @unittest.skipIf(
         "pypy" in platform.python_implementation().lower(), "cannot run in environment pypy"

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -194,13 +194,15 @@ class BaseUDFTestsMixin(object):
 
     def test_chained_udf(self):
         self.spark.catalog.registerFunction("double_int", lambda x: x + x, IntegerType())
-        [row] = self.spark.sql("SELECT double_int(1)").collect()
-        self.assertEqual(row[0], 2)
-        [row] = self.spark.sql("SELECT double_int(double_int(1))").collect()
-        self.assertEqual(row[0], 4)
-        [row] = self.spark.sql("SELECT double_int(double_int(1) + 1)").collect()
-        self.assertEqual(row[0], 6)
-        self.spark.sql("DROP TEMPORARY FUNCTION IF EXISTS double_int")
+        try:
+            [row] = self.spark.sql("SELECT double_int(1)").collect()
+            self.assertEqual(row[0], 2)
+            [row] = self.spark.sql("SELECT double_int(double_int(1))").collect()
+            self.assertEqual(row[0], 4)
+            [row] = self.spark.sql("SELECT double_int(double_int(1) + 1)").collect()
+            self.assertEqual(row[0], 6)
+        finally:
+            self.spark.sql("DROP TEMPORARY FUNCTION IF EXISTS double_int")
 
     def test_single_udf_with_repeated_argument(self):
         # regression test for SPARK-20685

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -193,13 +193,14 @@ class BaseUDFTestsMixin(object):
             df.agg(sum(udf_random_col())).collect()
 
     def test_chained_udf(self):
-        self.spark.catalog.registerFunction("double", lambda x: x + x, IntegerType())
-        [row] = self.spark.sql("SELECT double(1)").collect()
+        self.spark.catalog.registerFunction("double_int", lambda x: x + x, IntegerType())
+        [row] = self.spark.sql("SELECT double_int(1)").collect()
         self.assertEqual(row[0], 2)
-        [row] = self.spark.sql("SELECT double(double(1))").collect()
+        [row] = self.spark.sql("SELECT double_int(double_int(1))").collect()
         self.assertEqual(row[0], 4)
-        [row] = self.spark.sql("SELECT double(double(1) + 1)").collect()
+        [row] = self.spark.sql("SELECT double_int(double_int(1) + 1)").collect()
         self.assertEqual(row[0], 6)
+        self.spark.sql("DROP TEMPORARY FUNCTION IF EXISTS double_int")
 
     def test_single_udf_with_repeated_argument(self):
         # regression test for SPARK-20685


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix decimal rescaling in LocalDataToArrowConversion for:

- createDataFrame
- arrow-optimized udf (without legacy pandas conversion)
- arrow-optimized utdf (without legacy pandas conversion)
- python data source

### Why are the changes needed?
this query works in classic, but fails in connect

classic
```py
In [1]: import decimal

In [2]: df = spark.createDataFrame([(decimal.Decimal(1.234),)], ["d"])

In [3]: df
Out[3]: DataFrame[d: decimal(38,18)]

In [4]: df.show()
+--------------------+
|                   d|
+--------------------+
|1.233999999999999986|
+--------------------+
```

connect
```py
In [1]: import decimal

In [2]: df = spark.createDataFrame([(decimal.Decimal(1.234),)], ["d"])
---------------------------------------------------------------------------
ArrowInvalid                              Traceback (most recent call last)
Cell In[1], line 2
      1 import decimal
----> 2 spark.createDataFrame([(decimal.Decimal(1.234),)], ["d"])

File ~/spark/python/pyspark/sql/connect/session.py:740, in SparkSession.createDataFrame(self, data, schema, samplingRatio, verifySchema)
    733     from pyspark.sql.conversion import (
    734         LocalDataToArrowConversion,
    735     )
    737     # Spark Connect will try its best to build the Arrow table with the
    738     # inferred schema in the client side, and then rename the columns and
    739     # cast the datatypes in the server side.
--> 740     _table = LocalDataToArrowConversion.convert(_data, _schema, prefers_large_types)

...

ArrowInvalid: Rescaling Decimal value would cause data loss
```

The root cause is the data loss in arrow conversion
```py
In [13]: d = decimal.Decimal(1.234)

In [14]: d
Out[14]: Decimal('1.2339999999999999857891452847979962825775146484375')

In [15]: pa.scalar(d)
Out[15]: <pyarrow.Decimal256Scalar: Decimal('1.2339999999999999857891452847979962825775146484375')>

In [16]: pa.scalar(d).cast(pa.decimal128(38, 18))
---------------------------------------------------------------------------
ArrowInvalid                              Traceback (most recent call last)
Cell In[10], line 1
----> 1 pa.scalar(d).cast(pa.decimal128(38, 18))

...

ArrowInvalid: Rescaling Decimal value would cause data loss
```


### Does this PR introduce _any_ user-facing change?
yes, the query works after this PR


### How was this patch tested?
added test


### Was this patch authored or co-authored using generative AI tooling?
no