### PR TITLE
[SPARK-53940][SQL] Function version() should return full spark version instead of short version

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtils.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtils.java
@@ -183,7 +183,7 @@ public class ExpressionImplUtils {
    *  Space separated version and revision.
    */
   public static UTF8String getSparkVersion() {
-    String shortVersion = VersionUtils.shortVersion(SparkBuildInfo.spark_version());
+    String shortVersion = SparkBuildInfo.spark_version();
     String revision = SparkBuildInfo.spark_revision();
     return UTF8String.fromString(shortVersion + " " + revision);
   }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtils.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtils.java
@@ -35,7 +35,6 @@ import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.GenericArrayData;
 import org.apache.spark.sql.errors.QueryExecutionErrors;
 import org.apache.spark.unsafe.types.UTF8String;
-import org.apache.spark.util.VersionUtils;
 import org.apache.spark.util.random.XORShiftRandom;
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.{SPARK_REVISION, SPARK_VERSION_SHORT}
+import org.apache.spark.{SPARK_REVISION, SPARK_VERSION}
 import org.apache.spark.sql.catalyst.expressions.Hex
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.functions._
@@ -42,7 +42,7 @@ class MiscFunctionsSuite extends QueryTest with SharedSparkSession {
     val df = sql("SELECT version()")
     checkAnswer(
       df,
-      Row(SPARK_VERSION_SHORT + " " + SPARK_REVISION))
+      Row(SPARK_VERSION + " " + SPARK_REVISION))
     assert(df.schema.fieldNames === Seq("version()"))
 
     checkAnswer(df.selectExpr("version()"), df.select(version()))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
As title.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

For example, when executing `select version()` on `spark-4.1.0-preview2-bin-hadoop3`, it returns `4.1.0`, which is misleading.

```
0: jdbc:sc://localhost:15002> select version();
+-------------------------------------------------+
|                    version()                    |
+-------------------------------------------------+
| 4.1.0 c5ff48cc2b2c5a1526789ae414ff4c63b053d3ec  |
+-------------------------------------------------+
```

Another case is that the vendor version usually has a suffix, e.g., `Foo Spark 4.0.1-foo1.2.3`, in this case, `version()` returns only the short version 4.0.1 is misleading.

As a reference, in CDH Hive, `version()` returns the full version.

```
hive> SELECT version()
2.1.1-cdh6.3.2 b3393cf499504df1d2a12d34b4285e5d0c02be11
```

MariaDB `version()`'s result contains vendor info

```
> SELECT version()
11.8.2-MariaDB-ubu2404
```

PostgreSQL `version()`'s result also contains vendor info
```
> SELECT version()
PostgreSQL 17.5 (Debian 17.5-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, for the Apache official release, because all official release versions are same as the short version.

But users would see the full Spark version for preview releases when executing `SELECT version()`

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT is tuned.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.