### PR TITLE
[SPARK-53941][SS] Support AQE in stateless streaming workloads

### DIFF
--- a/common/utils-java/src/main/java/org/apache/spark/internal/LogKeys.java
+++ b/common/utils-java/src/main/java/org/apache/spark/internal/LogKeys.java
@@ -44,6 +44,7 @@ public enum LogKeys implements LogKey {
   APP_ID,
   APP_NAME,
   APP_STATE,
+  AQE_PLAN,
   ARCHIVE_NAME,
   ARGS,
   ARTIFACTS,

--- a/docs/streaming/ss-migration-guide.md
+++ b/docs/streaming/ss-migration-guide.md
@@ -23,6 +23,10 @@ Note that this migration guide describes the items specific to Structured Stream
 Many items of SQL migration can be applied when migrating Structured Streaming to higher versions.
 Please refer [Migration Guide: SQL, Datasets and DataFrame](../sql-migration-guide.html).
 
+## Upgrading from Structured Streaming 4.0 to 4.1
+
+- Since Spark 4.1, AQE is supported for stateless workloads, and it could affect the behavior of the query after upgrade (especially that AQE is turned on by default). Generally it works better, but you can turn off AQE via changing `spark.sql.adaptive.enabled` to `false` to restore the behavior if you see regression.
+
 ## Upgrading from Structured Streaming 3.5 to 4.0
 
 - Since Spark 4.0, Spark falls back to single batch execution if any source in the query does not support `Trigger.AvailableNow`. This is to avoid any possible correctness, duplication, and dataloss issue due to incompatibility between source and wrapper implementation. (See [SPARK-45178](https://issues.apache.org/jira/browse/SPARK-45178) for more details.)

--- a/docs/streaming/ss-migration-guide.md
+++ b/docs/streaming/ss-migration-guide.md
@@ -25,7 +25,7 @@ Please refer [Migration Guide: SQL, Datasets and DataFrame](../sql-migration-gui
 
 ## Upgrading from Structured Streaming 4.0 to 4.1
 
-- Since Spark 4.1, AQE is supported for stateless workloads, and it could affect the behavior of the query after upgrade (especially that AQE is turned on by default). Generally it works better, but you can turn off AQE via changing `spark.sql.adaptive.enabled` to `false` to restore the behavior if you see regression.
+- Since Spark 4.1, AQE is supported for stateless workloads, and it could affect the behavior of the query after upgrade (especially since AQE is turned on by default). In general, it helps to achieve better performance including resolution of skewed partition, but you can turn off AQE via changing `spark.sql.adaptive.enabled` to `false` to restore the behavior if you see regression.
 
 ## Upgrading from Structured Streaming 3.5 to 4.0
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanner.scala
@@ -52,7 +52,9 @@ class SparkPlanner(val session: SparkSession, val experimentalMethods: Experimen
       InMemoryScans ::
       SparkScripts ::
       Pipelines ::
-      BasicOperators :: Nil)
+      BasicOperators ::
+      // Need to be here since users can specify withWatermark in stateless streaming query.
+      EventTimeWatermarkStrategy :: Nil)
 
   /**
    * Override to add extra planning strategies to the planner. These strategies are tried after

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -427,6 +427,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
 
       case EventTimeWatermark(nodeId, columnName, delay, child) =>
         EventTimeWatermarkExec(nodeId, columnName, delay, planLater(child)) :: Nil
+
       case UpdateEventTimeWatermarkColumn(columnName, delay, child) =>
         // we expect watermarkDelay to be resolved before physical planning.
         if (delay.isEmpty) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
@@ -56,7 +56,7 @@ case class InsertAdaptiveSparkPlan(
     case c: DataWritingCommandExec
         if !c.cmd.isInstanceOf[V1WriteCommand] || !conf.plannedWriteEnabled =>
       c.copy(child = apply(c.child))
-    // SPARK-XXXXX: Do not apply AQE for stateful streaming workloads. From recent change of shuffle
+    // SPARK-53941: Do not apply AQE for stateful streaming workloads. From recent change of shuffle
     // origin for shuffle being added from stateful operator, we anticipate stateful operator to
     // work with AQE. But we want to make the adoption of AQE be gradual, to have a risk under
     // control. Note that we will disable the value of AQE config explicitly in streaming engine,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.adaptive
 
 import scala.collection.mutable
+
 import org.apache.spark.internal.LogKeys.{CONFIG, SUB_QUERY}
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions.{DynamicPruningSubquery, ListQuery, SubqueryExpression}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
@@ -124,9 +124,7 @@ case class InsertAdaptiveSparkPlan(
   }
 
   private def supportAdaptive(plan: SparkPlan): Boolean = {
-    sanityCheck(plan) &&
-      !plan.logicalLink.exists(_.isStreaming) &&
-    plan.children.forall(supportAdaptive)
+    sanityCheck(plan) && plan.children.forall(supportAdaptive)
   }
 
   private def sanityCheck(plan: SparkPlan): Boolean =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingQueryPlanTraverseHelper.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingQueryPlanTraverseHelper.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming
+
+import org.apache.spark.internal.{Logging, LogKeys, MDC}
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
+import org.apache.spark.sql.execution.adaptive.QueryStageExec
+import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
+
+/**
+ * This is an utility object placing methods to traverse the query plan for streaming query.
+ * This is used for patterns of traversal which are repeated in multiple places.
+ */
+object StreamingQueryPlanTraverseHelper extends Logging {
+  def collectFromUnfoldedPlan[B](
+      executedPlan: SparkPlan)(
+      pf: PartialFunction[SparkPlan, B]): Seq[B] = {
+    executedPlan.flatMap {
+      // InMemoryTableScanExec is a node to represent a cached plan. The node has underlying
+      // actual executed plan, which we should traverse to collect the required information.
+      case s: InMemoryTableScanExec => collectFromUnfoldedPlan(s.relation.cachedPlan)(pf)
+
+      // AQE physical node contains the executed plan, pick the plan.
+      // In most cases, AQE physical node is expected to contain the final plan, which is
+      // appropriate for the caller.
+      // Even it does not contain the final plan (in whatever reason), we just provide the
+      // plan as best effort, as there is no better way around.
+      case a: AdaptiveSparkPlanExec =>
+        if (!a.isFinalPlan) {
+          logWarning(log"AQE plan is captured, but the executed plan in AQE plan is not" +
+            log"the final one. Providing incomplete executed plan. AQE plan: ${MDC(
+              LogKeys.AQE_PLAN, a)}")
+        }
+        collectFromUnfoldedPlan(a.executedPlan)(pf)
+
+      // There are several AQE-specific leaf nodes which covers shuffle. We should pick the
+      // underlying plan of these nodes, since the underlying plan has the actual executed
+      // nodes which we want to collect metrics.
+      case e: QueryStageExec => collectFromUnfoldedPlan(e.plan)(pf)
+
+      case p if pf.isDefinedAt(p) => Seq(pf(p))
+      case _ => Seq.empty[B]
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingQueryPlanTraverseHelper.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingQueryPlanTraverseHelper.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.streaming
 
-import org.apache.spark.internal.{Logging, LogKeys, MDC}
+import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.execution.adaptive.QueryStageExec

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/IncrementalExecution.scala
@@ -19,8 +19,11 @@ package org.apache.spark.sql.execution.streaming.runtime
 
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
+
 import scala.collection.mutable.{Map => MutableMap}
+
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{BATCH_TIMESTAMP, ERROR}
 import org.apache.spark.sql.catalyst.QueryPlanningTracker
@@ -30,14 +33,14 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.execution.{CommandExecutionMode, LocalLimitExec, QueryExecution, SerializeFromObjectExec, SparkPlan, SparkPlanner, UnaryExecNode, SparkStrategy => Strategy}
+import org.apache.spark.sql.execution.{CommandExecutionMode, LocalLimitExec, QueryExecution, SerializeFromObjectExec, SparkPlan, SparkPlanner, SparkStrategy => Strategy, UnaryExecNode}
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, MergingSessionsExec, ObjectHashAggregateExec, SortAggregateExec, UpdatingSessionsExec}
 import org.apache.spark.sql.execution.datasources.v2.state.metadata.StateMetadataPartitionReader
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeLike
 import org.apache.spark.sql.execution.python.streaming.{FlatMapGroupsInPandasWithStateExec, TransformWithStateInPySparkExec}
 import org.apache.spark.sql.execution.streaming.StreamingQueryPlanTraverseHelper
 import org.apache.spark.sql.execution.streaming.checkpointing.{CheckpointFileManager, OffsetSeqMetadata}
-import org.apache.spark.sql.execution.streaming.operators.stateful.{SessionWindowStateStoreRestoreExec, SessionWindowStateStoreSaveExec, StateStoreRestoreExec, StateStoreSaveExec, StateStoreWriter, StatefulOperator, StatefulOperatorStateInfo, StreamingDeduplicateExec, StreamingDeduplicateWithinWatermarkExec, StreamingGlobalLimitExec, StreamingLocalLimitExec, UpdateEventTimeColumnExec}
+import org.apache.spark.sql.execution.streaming.operators.stateful.{SessionWindowStateStoreRestoreExec, SessionWindowStateStoreSaveExec, StatefulOperator, StatefulOperatorStateInfo, StateStoreRestoreExec, StateStoreSaveExec, StateStoreWriter, StreamingDeduplicateExec, StreamingDeduplicateWithinWatermarkExec, StreamingGlobalLimitExec, StreamingLocalLimitExec, UpdateEventTimeColumnExec}
 import org.apache.spark.sql.execution.streaming.operators.stateful.flatmapgroupswithstate.FlatMapGroupsWithStateExec
 import org.apache.spark.sql.execution.streaming.operators.stateful.join.{StreamingSymmetricHashJoinExec, StreamingSymmetricHashJoinHelper}
 import org.apache.spark.sql.execution.streaming.operators.stateful.transformwithstate.TransformWithStateExec

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -346,8 +346,7 @@ class MicroBatchExecution(
     populateStartOffsets(execCtx, sparkSessionForStream)
 
     // SPARK-53941: This code path is executed for the first batch, regardless of whether it's a
-    // fresh new run or restart, and whether it's a single uncommitted batch or multiple
-    // uncommitted batches.
+    // fresh new run or restart.
     disableAQESupportInStatelessIfUnappropriated(sparkSessionForStream)
 
     logInfo(log"Stream started from ${MDC(LogKeys.STREAMING_OFFSETS_START, execCtx.startOffsets)}")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -20,7 +20,9 @@ package org.apache.spark.sql.execution.streaming.runtime
 import scala.collection.mutable.{Map => MutableMap}
 import scala.collection.mutable
 import scala.util.control.NonFatal
+
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.internal.LogKeys
 import org.apache.spark.internal.LogKeys.BATCH_ID
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
@@ -32,14 +34,14 @@ import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.classic.{Dataset, SparkSession}
 import org.apache.spark.sql.classic.ClassicConversions.castToImpl
 import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, TableCapability}
-import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, ReadLimit, SparkDataStream, SupportsAdmissionControl, SupportsTriggerAvailableNow, Offset => OffsetV2}
+import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, Offset => OffsetV2, ReadLimit, SparkDataStream, SupportsAdmissionControl, SupportsTriggerAvailableNow}
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.execution.{SQLExecution, SparkPlan}
+import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
-import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, StreamWriterCommitProgress, StreamingDataSourceV2Relation, StreamingDataSourceV2ScanRelation, WriteToDataSourceV2Exec}
+import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, StreamingDataSourceV2Relation, StreamingDataSourceV2ScanRelation, StreamWriterCommitProgress, WriteToDataSourceV2Exec}
 import org.apache.spark.sql.execution.streaming.{AvailableNowTrigger, Offset, OneTimeTrigger, ProcessingTimeTrigger, Sink, Source}
 import org.apache.spark.sql.execution.streaming.checkpointing.{CheckpointFileManager, CommitMetadata, OffsetSeq, OffsetSeqMetadata}
-import org.apache.spark.sql.execution.streaming.operators.stateful.{StateStoreWriter, StatefulOpStateStoreCheckpointInfo, StatefulOperatorStateInfo}
+import org.apache.spark.sql.execution.streaming.operators.stateful.{StatefulOperatorStateInfo, StatefulOpStateStoreCheckpointInfo, StateStoreWriter}
 import org.apache.spark.sql.execution.streaming.runtime.AcceptsLatestSeenOffsetHandler
 import org.apache.spark.sql.execution.streaming.runtime.StreamingCheckpointConstants.{DIR_NAME_COMMITS, DIR_NAME_OFFSETS, DIR_NAME_STATE}
 import org.apache.spark.sql.execution.streaming.sources.{ForeachBatchSink, WriteToMicroBatchDataSource, WriteToMicroBatchDataSourceV1}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -345,7 +345,7 @@ class MicroBatchExecution(
 
     populateStartOffsets(execCtx, sparkSessionForStream)
 
-    // SPARK-XXXXX: This code path is executed for the first batch, regardless of whether it's a
+    // SPARK-53941: This code path is executed for the first batch, regardless of whether it's a
     // fresh new run or restart, and whether it's a single uncommitted batch or multiple
     // uncommitted batches.
     disableAQESupportInStatelessIfUnappropriated(sparkSessionForStream)
@@ -373,7 +373,7 @@ class MicroBatchExecution(
     }
 
     if (containsStatefulOperator(analyzedPlan)) {
-      // SPARK-XXXXX: We disable AQE for stateful workloads as of now.
+      // SPARK-53941: We disable AQE for stateful workloads as of now.
       logWarning(log"Disabling AQE since AQE is not supported in stateful workloads.")
       sparkSessionToRunBatches.conf.set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
@@ -315,7 +315,7 @@ abstract class StreamExecution(
           "false")
 
         if (trigger.isInstanceOf[ContinuousTrigger]) {
-          // SPARK-XXXXX: AQE does not make sense for continuous processing, disable it.
+          // SPARK-53941: AQE does not make sense for continuous processing, disable it.
           logWarning("Disabling AQE since the query runs with continuous mode.")
           sparkSessionForStream.conf.set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala
@@ -20,15 +20,18 @@ package org.apache.spark.sql.execution.streaming.runtime
 import java.io.{InterruptedIOException, UncheckedIOException}
 import java.nio.channels.ClosedByInterruptException
 import java.util.UUID
-import java.util.concurrent.{CountDownLatch, ExecutionException, TimeUnit, TimeoutException}
+import java.util.concurrent.{CountDownLatch, ExecutionException, TimeoutException, TimeUnit}
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
+
 import scala.collection.mutable.{Map => MutableMap}
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
+
 import com.google.common.util.concurrent.UncheckedExecutionException
 import org.apache.hadoop.fs.Path
 import org.apache.logging.log4j.CloseableThreadContext
+
 import org.apache.spark.{JobArtifactSet, SparkContext, SparkException, SparkThrowable}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{CHECKPOINT_PATH, CHECKPOINT_ROOT, LOGICAL_PLAN, PATH, PRETTY_ID_STRING, QUERY_ID, RUN_ID, SPARK_DATA_STREAM}
@@ -36,13 +39,13 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes._
 import org.apache.spark.sql.classic.{SparkSession, StreamingQuery}
 import org.apache.spark.sql.connector.catalog.{SupportsWrite, Table}
-import org.apache.spark.sql.connector.read.streaming.{ReadLimit, SparkDataStream, Offset => OffsetV2}
+import org.apache.spark.sql.connector.read.streaming.{Offset => OffsetV2, ReadLimit, SparkDataStream}
 import org.apache.spark.sql.connector.write.{LogicalWriteInfoImpl, SupportsTruncate, Write}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.command.StreamingExplainCommand
 import org.apache.spark.sql.execution.streaming.ContinuousTrigger
 import org.apache.spark.sql.execution.streaming.checkpointing.{CheckpointFileManager, CommitLog, OffsetSeqLog, OffsetSeqMetadata}
-import org.apache.spark.sql.execution.streaming.operators.stateful.{StateStoreWriter, StatefulOperator}
+import org.apache.spark.sql.execution.streaming.operators.stateful.{StatefulOperator, StateStoreWriter}
 import org.apache.spark.sql.execution.streaming.sources.{ForeachBatchUserFuncException, ForeachUserFuncException}
 import org.apache.spark.sql.execution.streaming.state.OperatorStateMetadataV2FileManager
 import org.apache.spark.sql.internal.SQLConf

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/WatermarkPropagator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/WatermarkPropagator.scala
@@ -18,7 +18,9 @@
 package org.apache.spark.sql.execution.streaming.runtime
 
 import java.{util => jutil}
+
 import scala.collection.mutable
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.execution.SparkPlan

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/WatermarkPropagator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/WatermarkPropagator.scala
@@ -213,7 +213,6 @@ class PropagateWatermarkSimulator extends WatermarkPropagator with Logging {
           }
 
           nodeToOutputWatermark.put(node.id, Some(originWatermark))
-          node
 
         case node: StateStoreWriter =>
           val stOpId = node.stateInfo.get.operatorId
@@ -233,7 +232,6 @@ class PropagateWatermarkSimulator extends WatermarkPropagator with Logging {
           }
           nodeToOutputWatermark.put(node.id, outputWatermarkMs)
           nextStatefulOperatorToWatermark.put(stOpId, finalInputWatermarkMs)
-          node
 
         case node =>
           // pass-through, but also consider multiple children like the case of union
@@ -245,7 +243,6 @@ class PropagateWatermarkSimulator extends WatermarkPropagator with Logging {
           }
 
           nodeToOutputWatermark.put(node.id, finalInputWatermarkMs)
-          node
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/WatermarkTracker.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/WatermarkTracker.scala
@@ -18,7 +18,9 @@
 package org.apache.spark.sql.execution.streaming.runtime
 
 import java.util.{Locale, UUID}
+
 import scala.collection.mutable
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.sql.RuntimeConfig

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
@@ -87,7 +87,7 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("ordered distribution and sort with same exprs: micro-batch append") {
-    // SPARK-XXXXX: Once AQE is enabled, the optimization kicks in and the write distribution
+    // SPARK-53941: Once AQE is enabled, the optimization kicks in and the write distribution
     // can be adjusted by AQE. There is a logic for batch query to consider the AQE optimization
     // while verifying the write distribution, but that seems to be quite complicated and we
     // should not block the code change by updating the tests to deal with AQE optimization.
@@ -98,7 +98,7 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("ordered distribution and sort with same exprs: micro-batch update") {
-    // SPARK-XXXXX: Once AQE is enabled, the optimization kicks in and the write distribution
+    // SPARK-53941: Once AQE is enabled, the optimization kicks in and the write distribution
     // can be adjusted by AQE. There is a logic for batch query to consider the AQE optimization
     // while verifying the write distribution, but that seems to be quite complicated and we
     // should not block the code change by updating the tests to deal with AQE optimization.
@@ -201,7 +201,7 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("clustered distribution and sort with same exprs: micro-batch append") {
-    // SPARK-XXXXX: Once AQE is enabled, the optimization kicks in and the write distribution
+    // SPARK-53941: Once AQE is enabled, the optimization kicks in and the write distribution
     // can be adjusted by AQE. There is a logic for batch query to consider the AQE optimization
     // while verifying the write distribution, but that seems to be quite complicated and we
     // should not block the code change by updating the tests to deal with AQE optimization.
@@ -212,7 +212,7 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("clustered distribution and sort with same exprs: micro-batch update") {
-    // SPARK-XXXXX: Once AQE is enabled, the optimization kicks in and the write distribution
+    // SPARK-53941: Once AQE is enabled, the optimization kicks in and the write distribution
     // can be adjusted by AQE. There is a logic for batch query to consider the AQE optimization
     // while verifying the write distribution, but that seems to be quite complicated and we
     // should not block the code change by updating the tests to deal with AQE optimization.
@@ -321,7 +321,7 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("clustered distribution and sort with extended exprs: micro-batch append") {
-    // SPARK-XXXXX: Once AQE is enabled, the optimization kicks in and the write distribution
+    // SPARK-53941: Once AQE is enabled, the optimization kicks in and the write distribution
     // can be adjusted by AQE. There is a logic for batch query to consider the AQE optimization
     // while verifying the write distribution, but that seems to be quite complicated and we
     // should not block the code change by updating the tests to deal with AQE optimization.
@@ -332,7 +332,7 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("clustered distribution and sort with extended exprs: micro-batch update") {
-    // SPARK-XXXXX: Once AQE is enabled, the optimization kicks in and the write distribution
+    // SPARK-53941: Once AQE is enabled, the optimization kicks in and the write distribution
     // can be adjusted by AQE. There is a logic for batch query to consider the AQE optimization
     // while verifying the write distribution, but that seems to be quite complicated and we
     // should not block the code change by updating the tests to deal with AQE optimization.

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
@@ -87,11 +87,25 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("ordered distribution and sort with same exprs: micro-batch append") {
-    checkOrderedDistributionAndSortWithSameExprs(microBatchPrefix + "append")
+    // SPARK-XXXXX: Once AQE is enabled, the optimization kicks in and the write distribution
+    // can be adjusted by AQE. There is a logic for batch query to consider the AQE optimization
+    // while verifying the write distribution, but that seems to be quite complicated and we
+    // should not block the code change by updating the tests to deal with AQE optimization.
+    // TODO: Update the test to reflect optimization from AQE.
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      checkOrderedDistributionAndSortWithSameExprs(microBatchPrefix + "append")
+    }
   }
 
   test("ordered distribution and sort with same exprs: micro-batch update") {
-    checkOrderedDistributionAndSortWithSameExprs(microBatchPrefix + "update")
+    // SPARK-XXXXX: Once AQE is enabled, the optimization kicks in and the write distribution
+    // can be adjusted by AQE. There is a logic for batch query to consider the AQE optimization
+    // while verifying the write distribution, but that seems to be quite complicated and we
+    // should not block the code change by updating the tests to deal with AQE optimization.
+    // TODO: Update the test to reflect optimization from AQE.
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      checkOrderedDistributionAndSortWithSameExprs(microBatchPrefix + "update")
+    }
   }
 
   test("ordered distribution and sort with same exprs: micro-batch complete") {
@@ -187,11 +201,25 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("clustered distribution and sort with same exprs: micro-batch append") {
-    checkClusteredDistributionAndSortWithSameExprs(microBatchPrefix + "append")
+    // SPARK-XXXXX: Once AQE is enabled, the optimization kicks in and the write distribution
+    // can be adjusted by AQE. There is a logic for batch query to consider the AQE optimization
+    // while verifying the write distribution, but that seems to be quite complicated and we
+    // should not block the code change by updating the tests to deal with AQE optimization.
+    // TODO: Update the test to reflect optimization from AQE.
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      checkClusteredDistributionAndSortWithSameExprs(microBatchPrefix + "append")
+    }
   }
 
   test("clustered distribution and sort with same exprs: micro-batch update") {
-    checkClusteredDistributionAndSortWithSameExprs(microBatchPrefix + "update")
+    // SPARK-XXXXX: Once AQE is enabled, the optimization kicks in and the write distribution
+    // can be adjusted by AQE. There is a logic for batch query to consider the AQE optimization
+    // while verifying the write distribution, but that seems to be quite complicated and we
+    // should not block the code change by updating the tests to deal with AQE optimization.
+    // TODO: Update the test to reflect optimization from AQE.
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      checkClusteredDistributionAndSortWithSameExprs(microBatchPrefix + "update")
+    }
   }
 
   test("clustered distribution and sort with same exprs: micro-batch complete") {
@@ -293,11 +321,25 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("clustered distribution and sort with extended exprs: micro-batch append") {
-    checkClusteredDistributionAndSortWithExtendedExprs(microBatchPrefix + "append")
+    // SPARK-XXXXX: Once AQE is enabled, the optimization kicks in and the write distribution
+    // can be adjusted by AQE. There is a logic for batch query to consider the AQE optimization
+    // while verifying the write distribution, but that seems to be quite complicated and we
+    // should not block the code change by updating the tests to deal with AQE optimization.
+    // TODO: Update the test to reflect optimization from AQE.
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      checkClusteredDistributionAndSortWithExtendedExprs(microBatchPrefix + "append")
+    }
   }
 
   test("clustered distribution and sort with extended exprs: micro-batch update") {
-    checkClusteredDistributionAndSortWithExtendedExprs(microBatchPrefix + "update")
+    // SPARK-XXXXX: Once AQE is enabled, the optimization kicks in and the write distribution
+    // can be adjusted by AQE. There is a logic for batch query to consider the AQE optimization
+    // while verifying the write distribution, but that seems to be quite complicated and we
+    // should not block the code change by updating the tests to deal with AQE optimization.
+    // TODO: Update the test to reflect optimization from AQE.
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      checkClusteredDistributionAndSortWithExtendedExprs(microBatchPrefix + "update")
+    }
   }
 
   test("clustered distribution and sort with extended exprs: micro-batch complete") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -1071,7 +1071,8 @@ class AdaptiveQueryExecSuite
           case _: AdaptiveSparkPlanExec | _: QueryStageExec => true
           case _ => false
         }
-        assert(ret.nonEmpty)
+        assert(ret.nonEmpty,
+          s"expected AQE to take effect but can't find AQE node, plan: $plan")
         // aqe config should still be enabled
         assert(query.sparkSession.sessionState.conf.adaptiveExecutionEnabled)
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -33,7 +33,7 @@ import org.scalatest.time.SpanSugar._
 import org.apache.spark.{SparkConf, SparkContext, TaskContext, TestUtils}
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart}
 import org.apache.spark.sql.{AnalysisException, Encoders, Row, SQLContext, TestStrategy}
-import org.apache.spark.sql.catalyst.plans.logical.{Range, RepartitionByExpression}
+import org.apache.spark.sql.catalyst.plans.logical.Range
 import org.apache.spark.sql.catalyst.streaming.{InternalOutputModes, StreamingRelationV2}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.catalyst.util.DateTimeUtils

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -1116,7 +1116,7 @@ class StreamSuite extends StreamTest {
       )
       require(execPlan != null)
 
-      val localLimits = execPlan.collect {
+      val localLimits = StreamingQueryPlanTraverseHelper.collectFromUnfoldedPlan(execPlan) {
         case l: LocalLimitExec => l
         case l: StreamingLocalLimitExec => l
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -1299,37 +1299,6 @@ class StreamSuite extends StreamTest {
     }
   }
 
-  test("SPARK-34482: correct active SparkSession for logicalPlan") {
-    withSQLConf(
-      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
-      SQLConf.COALESCE_PARTITIONS_INITIAL_PARTITION_NUM.key -> "10") {
-      val df = spark.readStream.format(classOf[FakeDefaultSource].getName).load()
-      var query: StreamExecution = null
-      try {
-        query =
-          df.repartition($"a")
-            .writeStream
-            .format("memory")
-            .queryName("memory")
-            .start()
-            .asInstanceOf[StreamingQueryWrapper]
-            .streamingQuery
-        query.awaitInitialization(streamingTimeout.toMillis)
-        val plan = query.logicalPlan
-        val numPartition = plan
-          .find { _.isInstanceOf[RepartitionByExpression] }
-          .map(_.asInstanceOf[RepartitionByExpression].numPartitions)
-        // Before the fix of SPARK-34482, the numPartition is the value of
-        // `COALESCE_PARTITIONS_INITIAL_PARTITION_NUM`.
-        assert(numPartition.get === spark.sessionState.conf.getConf(SQLConf.SHUFFLE_PARTITIONS))
-      } finally {
-        if (query != null) {
-          query.stop()
-        }
-      }
-    }
-  }
-
   test("isInterruptionException should correctly unwrap classic py4j InterruptedException") {
     val e1 = new py4j.Py4JException(
       """

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -627,7 +627,10 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
         // The number of leaves in the trigger's logical plan should be same as the executed plan.
         require(
           q.lastExecution.logical.collectLeaves().length ==
-            q.lastExecution.executedPlan.collectLeaves().length)
+            StreamingQueryPlanTraverseHelper
+              .collectFromUnfoldedPlan(q.lastExecution.executedPlan) {
+                case n if n.children.isEmpty => n
+              }.length)
 
         val lastProgress = getLastProgressWithData(q)
         assert(lastProgress.nonEmpty)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to support AQE in stateless streaming workloads. We have been disabling it due to the incompatibility with stateful operator, but it's arguably too restricted given shuffles are still triggered in stateless streaming workloads and stream-static join can benefit with it.

Note that AQE performs re-optimization which replans via reapplying optimization and physical planning against a logical link (optimized plan) for stage. IncrementalExecution instance may not be available during AQE re-optimization (e.g. ForeachBatch sink), hence streaming specific physical planning rules aren't compatible with AQE re-optimization. These rules are reserved for initializing stateful operators, hence stateless workloads are still safe to apply full phase of AQE.

Worth mentioning that AQE is not enabled for 1) continuous mode (and upcoming real time mode) 2) stateful workloads. 

* continuous mode (and real time mode): AQE doesn't make sense for continuous and real time mode since stages run concurrently.
* stateful workloads: AQE can't change the number of partitions in stateful operator, and even if it's changeable, repartitioning state would cost a lot and we shouldn't decide it per batch based on specific batch's data distribution.

### Why are the changes needed?

There are still various cases where stateless operators trigger shuffle (e.g. stream-static join), and these operators have the same characteristic with batch query which AQE has been battle tested and proved its usefulness for a long time.

### Does this PR introduce _any_ user-facing change?

Yes, AQE will be enabled in stateless streaming workloads. Given that AQE is set to true by default, stateless streaming queries will take effect, regardless whether the query starts with new Spark version, or being upgraded from old Spark version. This PR also updates this to the migration guide.

### How was this patch tested?

Existing tests will run with AQE enabled if the query is stateless.

### Was this patch authored or co-authored using generative AI tooling?

No.