### PR TITLE
[SPARK-53446][CORE] Optimize BlockManager remove operations with cached block mappings

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockInfoManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockInfoManager.scala
@@ -149,6 +149,14 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
    */
   private[this] val blockInfoWrappers = new ConcurrentHashMap[BlockId, BlockInfoWrapper]
 
+  // Cache mappings to avoid O(n) scans in remove operations.
+  private[this] val rddToBlockIds =
+    new ConcurrentHashMap[Int, ConcurrentHashMap.KeySetView[BlockId, java.lang.Boolean]]()
+  private[this] val broadcastToBlockIds =
+    new ConcurrentHashMap[Long, ConcurrentHashMap.KeySetView[BlockId, java.lang.Boolean]]()
+  private[this] val sessionToBlockIds =
+    new ConcurrentHashMap[String, ConcurrentHashMap.KeySetView[BlockId, java.lang.Boolean]]()
+
   /**
    * Record invisible rdd blocks stored in the block manager, entries will be removed when blocks
    * are marked as visible or blocks are removed by [[removeBlock()]].
@@ -445,6 +453,7 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
         }
 
         if (previous == null) {
+          addToMapping(blockId)
           // New block lock it for writing.
           val result = lockForWriting(blockId, blocking = false)
           assert(result.isDefined)
@@ -536,6 +545,23 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
   }
 
   /**
+   * Return all blocks belonging to the given RDD.
+   */
+  def rddBlockIds(rddId: Int): Seq[BlockId] = getBlockIdsFromMapping(rddToBlockIds, rddId)
+
+  /**
+   * Return all blocks belonging to the given broadcast.
+   */
+  def broadcastBlockIds(broadcastId: Long): Seq[BlockId] =
+    getBlockIdsFromMapping(broadcastToBlockIds, broadcastId)
+
+  /**
+   * Return cache blocks that might be related to cached local relations.
+   */
+  def sessionBlockIds(sessionUUID: String): Seq[BlockId] =
+    getBlockIdsFromMapping(sessionToBlockIds, sessionUUID)
+
+  /**
    * Removes the given block and releases the write lock on it.
    *
    * This can only be called while holding a write lock on the given block.
@@ -551,6 +577,7 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
       } else {
         invisibleRDDBlocks.synchronized {
           blockInfoWrappers.remove(blockId)
+          removeFromMapping(blockId)
           blockId.asRDDId.foreach(invisibleRDDBlocks.remove)
         }
         info.readerCount = 0
@@ -573,6 +600,9 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
       }
     }
     blockInfoWrappers.clear()
+    rddToBlockIds.clear()
+    broadcastToBlockIds.clear()
+    sessionToBlockIds.clear()
     readLocksByTask.clear()
     writeLocksByTask.clear()
     invisibleRDDBlocks.synchronized {
@@ -580,4 +610,65 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
     }
   }
 
+  /**
+   * Return all blocks in the cache mapping for a given key.
+   */
+  private def getBlockIdsFromMapping[K](
+      map: ConcurrentHashMap[K, ConcurrentHashMap.KeySetView[BlockId, java.lang.Boolean]],
+      key: K): Seq[BlockId] = {
+    Option(map.get(key)).map(_.asScala.toSeq).getOrElse(Seq.empty)
+  }
+
+  /**
+   * Add a block ID to the corresponding cache mapping based on its type.
+   */
+  private def addToMapping(blockId: BlockId): Unit = {
+    blockId match {
+      case rddBlockId: RDDBlockId =>
+        rddToBlockIds
+          .computeIfAbsent(rddBlockId.rddId, _ => ConcurrentHashMap.newKeySet())
+          .add(blockId)
+      case broadcastBlockId: BroadcastBlockId =>
+        broadcastToBlockIds
+          .computeIfAbsent(broadcastBlockId.broadcastId, _ => ConcurrentHashMap.newKeySet())
+          .add(blockId)
+      case cacheId: CacheId =>
+        sessionToBlockIds
+          .computeIfAbsent(cacheId.sessionUUID, _ => ConcurrentHashMap.newKeySet())
+          .add(blockId)
+      case _ => // Do nothing for other block types
+    }
+  }
+
+  /**
+   * Remove a block ID from the corresponding cache mapping based on its type.
+   */
+  private def removeFromMapping(blockId: BlockId): Unit = {
+    def doRemove[K](
+        map: ConcurrentHashMap[K, ConcurrentHashMap.KeySetView[BlockId, java.lang.Boolean]],
+        key: K,
+        block: BlockId): Unit = {
+      map.compute(key,
+        (_, set) => {
+          if (null != set) {
+            set.remove(block)
+            if (set.isEmpty) null else set
+          } else {
+            // missing
+            null
+          }
+        }
+      )
+    }
+
+    blockId match {
+      case rddBlockId: RDDBlockId =>
+        doRemove(rddToBlockIds, rddBlockId.rddId, rddBlockId)
+      case broadcastBlockId: BroadcastBlockId =>
+        doRemove(broadcastToBlockIds, broadcastBlockId.broadcastId, broadcastBlockId)
+      case cacheId: CacheId =>
+        doRemove(sessionToBlockIds, cacheId.sessionUUID, cacheId)
+      case _ => // Do nothing for other block types
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Continue #52210.
Introduced three concurrent hash maps to track block ID associations for optimize BlockManager remove operations by introducing cached mappings to eliminate O(n) linear scans. 


### Why are the changes needed?
Previously, removeRdd(), removeBroadcast(), and removeCache() required scanning all blocks in blockInfoManager.entries to find matches. This approach becomes a serious bottleneck when:

1. Large block counts: In production deployments with millions or even tens of millions of cached blocks, linear scans can be prohibitively slow
2. High cleanup frequency: Workloads that repeatedly create and discard RDDs or broadcast variables accumulate overhead quickly

The original removeRdd() method already contained a TODO noting that an additional mapping would be needed to avoid linear scans. This PR implements that improvement.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
New UT.


### Was this patch authored or co-authored using generative AI tooling?
No.
