### PR TITLE
[SPARK-53930][PYTHON] Support TIME in the make_timestamp function in PySpark

### DIFF
--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -3945,6 +3945,7 @@ def make_time(hour: "ColumnOrName", minute: "ColumnOrName", second: "ColumnOrNam
 make_time.__doc__ = pysparkfuncs.make_time.__doc__
 
 
+@overload
 def make_timestamp(
     years: "ColumnOrName",
     months: "ColumnOrName",
@@ -3952,16 +3953,79 @@ def make_timestamp(
     hours: "ColumnOrName",
     mins: "ColumnOrName",
     secs: "ColumnOrName",
-    timezone: Optional["ColumnOrName"] = None,
+    timezone: Optional["ColumnOrName"] = None
 ) -> Column:
-    if timezone is not None:
-        return _invoke_function_over_columns(
-            "make_timestamp", years, months, days, hours, mins, secs, timezone
-        )
+    ...
+
+
+@overload
+def make_timestamp(
+    *,
+    date: "ColumnOrName",
+    time: "ColumnOrName",
+    timezone: Optional["ColumnOrName"] = None
+) -> Column:
+    ...
+
+
+def make_timestamp(
+    years: Optional["ColumnOrName"] = None,
+    months: Optional["ColumnOrName"] = None,
+    days: Optional["ColumnOrName"] = None,
+    hours: Optional["ColumnOrName"] = None,
+    mins: Optional["ColumnOrName"] = None,
+    secs: Optional["ColumnOrName"] = None,
+    *,
+    date: Optional["ColumnOrName"] = None,
+    time: Optional["ColumnOrName"] = None,
+    timezone: Optional["ColumnOrName"] = None
+) -> Column:
+    if years is not None:
+        if any(arg is not None for arg in [date, time]):
+            raise PySparkValueError(
+                errorClass="CANNOT_SET_TOGETHER",
+                messageParameters={"arg_list": "years|months|days|hours|mins|secs and date|time"},
+            )
+        if timezone is not None:
+            return _invoke_function_over_columns(
+                "make_timestamp",
+                cast("ColumnOrName", years),
+                cast("ColumnOrName", months),
+                cast("ColumnOrName", days),
+                cast("ColumnOrName", hours),
+                cast("ColumnOrName", mins),
+                cast("ColumnOrName", secs),
+                cast("ColumnOrName", timezone)
+            )
+        else:
+            return _invoke_function_over_columns(
+                "make_timestamp",
+                cast("ColumnOrName", years),
+                cast("ColumnOrName", months),
+                cast("ColumnOrName", days),
+                cast("ColumnOrName", hours),
+                cast("ColumnOrName", mins),
+                cast("ColumnOrName", secs)
+            )
     else:
-        return _invoke_function_over_columns(
-            "make_timestamp", years, months, days, hours, mins, secs
-        )
+        if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
+            raise PySparkValueError(
+                errorClass="CANNOT_SET_TOGETHER",
+                messageParameters={"arg_list": "years|months|days|hours|mins|secs and date|time"},
+            )
+        if timezone is not None:
+            return _invoke_function_over_columns(
+                "make_timestamp",
+                cast("ColumnOrName", date),
+                cast("ColumnOrName", time),
+                cast("ColumnOrName", timezone)
+            )
+        else:
+            return _invoke_function_over_columns(
+                "make_timestamp",
+                cast("ColumnOrName", date),
+                cast("ColumnOrName", time)
+            )
 
 
 make_timestamp.__doc__ = pysparkfuncs.make_timestamp.__doc__

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -3990,7 +3990,6 @@ def make_timestamp(
     mins: Optional["ColumnOrName"] = None,
     secs: Optional["ColumnOrName"] = None,
     timezone: Optional["ColumnOrName"] = None,
-    *,
     date: Optional["ColumnOrName"] = None,
     time: Optional["ColumnOrName"] = None,
 ) -> Column:

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -3953,17 +3953,31 @@ def make_timestamp(
     hours: "ColumnOrName",
     mins: "ColumnOrName",
     secs: "ColumnOrName",
-    timezone: Optional["ColumnOrName"] = None
 ) -> Column:
     ...
 
 
 @overload
 def make_timestamp(
-    *,
-    date: "ColumnOrName",
-    time: "ColumnOrName",
-    timezone: Optional["ColumnOrName"] = None
+    years: "ColumnOrName",
+    months: "ColumnOrName",
+    days: "ColumnOrName",
+    hours: "ColumnOrName",
+    mins: "ColumnOrName",
+    secs: "ColumnOrName",
+    timezone: "ColumnOrName",
+) -> Column:
+    ...
+
+
+@overload
+def make_timestamp(*, date: "ColumnOrName", time: "ColumnOrName") -> Column:
+    ...
+
+
+@overload
+def make_timestamp(
+    *, date: "ColumnOrName", time: "ColumnOrName", timezone: "ColumnOrName"
 ) -> Column:
     ...
 
@@ -3975,10 +3989,10 @@ def make_timestamp(
     hours: Optional["ColumnOrName"] = None,
     mins: Optional["ColumnOrName"] = None,
     secs: Optional["ColumnOrName"] = None,
+    timezone: Optional["ColumnOrName"] = None,
     *,
     date: Optional["ColumnOrName"] = None,
     time: Optional["ColumnOrName"] = None,
-    timezone: Optional["ColumnOrName"] = None
 ) -> Column:
     if years is not None:
         if any(arg is not None for arg in [date, time]):
@@ -3995,7 +4009,7 @@ def make_timestamp(
                 cast("ColumnOrName", hours),
                 cast("ColumnOrName", mins),
                 cast("ColumnOrName", secs),
-                cast("ColumnOrName", timezone)
+                cast("ColumnOrName", timezone),
             )
         else:
             return _invoke_function_over_columns(
@@ -4005,7 +4019,7 @@ def make_timestamp(
                 cast("ColumnOrName", days),
                 cast("ColumnOrName", hours),
                 cast("ColumnOrName", mins),
-                cast("ColumnOrName", secs)
+                cast("ColumnOrName", secs),
             )
     else:
         if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
@@ -4018,13 +4032,11 @@ def make_timestamp(
                 "make_timestamp",
                 cast("ColumnOrName", date),
                 cast("ColumnOrName", time),
-                cast("ColumnOrName", timezone)
+                cast("ColumnOrName", timezone),
             )
         else:
             return _invoke_function_over_columns(
-                "make_timestamp",
-                cast("ColumnOrName", date),
-                cast("ColumnOrName", time)
+                "make_timestamp", cast("ColumnOrName", date), cast("ColumnOrName", time)
             )
 
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -24827,6 +24827,7 @@ def make_timestamp(
     ...
 
 
+@_try_remote_functions
 def make_timestamp(
     years: Optional["ColumnOrName"] = None,
     months: Optional["ColumnOrName"] = None,

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -24816,14 +24816,12 @@ def make_timestamp(
 
 
 @overload
-def make_timestamp(*, date: "ColumnOrName", time: "ColumnOrName") -> Column:
+def make_timestamp(date: "ColumnOrName", time: "ColumnOrName") -> Column:
     ...
 
 
 @overload
-def make_timestamp(
-    *, date: "ColumnOrName", time: "ColumnOrName", timezone: "ColumnOrName"
-) -> Column:
+def make_timestamp(date: "ColumnOrName", time: "ColumnOrName", timezone: "ColumnOrName") -> Column:
     ...
 
 
@@ -24835,7 +24833,6 @@ def make_timestamp(
     mins: Optional["ColumnOrName"] = None,
     secs: Optional["ColumnOrName"] = None,
     timezone: Optional["ColumnOrName"] = None,
-    *,
     date: Optional["ColumnOrName"] = None,
     time: Optional["ColumnOrName"] = None,
 ) -> Column:
@@ -24880,6 +24877,8 @@ def make_timestamp(
         to 0 and 1 minute is added to the final timestamp.
         Required when creating timestamps from individual components.
         Must be used with years, months, days, hours, and mins.
+    timezone : :class:`~pyspark.sql.Column` or column name, optional
+        The time zone identifier. For example, CET, UTC, and etc.
     date : :class:`~pyspark.sql.Column` or column name, optional
         The date to represent, in valid DATE format.
         Required when creating timestamps from date and time components.
@@ -24888,8 +24887,6 @@ def make_timestamp(
         The time to represent, in valid TIME format.
         Required when creating timestamps from date and time components.
         Must be used with date parameter only.
-    timezone : :class:`~pyspark.sql.Column` or column name, optional
-        The time zone identifier. For example, CET, UTC and etc.
 
     Returns
     -------

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -24816,12 +24816,14 @@ def make_timestamp(
 
 
 @overload
-def make_timestamp(date: "ColumnOrName", time: "ColumnOrName") -> Column:
+def make_timestamp(*, date: "ColumnOrName", time: "ColumnOrName") -> Column:
     ...
 
 
 @overload
-def make_timestamp(date: "ColumnOrName", time: "ColumnOrName", timezone: "ColumnOrName") -> Column:
+def make_timestamp(
+    *, date: "ColumnOrName", time: "ColumnOrName", timezone: "ColumnOrName"
+) -> Column:
     ...
 
 

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -849,6 +849,283 @@ class FunctionsTestsMixin:
         self.assertIsInstance(row_from_name[0], datetime.time)
         self.assertEqual(row_from_name[0], result)
 
+    def test_make_timestamp(self):
+        """Comprehensive test cases for make_timestamp with various arguments and edge cases."""
+
+        # Common input dataframe setup for multiple test cases (with various arguments).
+        df = self.spark.createDataFrame(
+            [(2024, 5, 22, 10, 30, 0, "CET")],
+            ["year", "month", "day", "hour", "minute", "second", "timezone"]
+        )
+        df_frac = self.spark.createDataFrame(
+            [(2024, 5, 22, 10, 30, 45.123, "CET")],
+            ["year", "month", "day", "hour", "minute", "second", "timezone"]
+        )
+        df_dt = self.spark.range(1).select(
+            F.lit(datetime.date(2024, 5, 22)).alias("date"),
+            F.lit(datetime.time(10, 30, 0)).alias("time"),
+            F.lit("CET").alias("timezone")
+        )
+        df_dt_frac = self.spark.range(1).select(
+            F.lit(datetime.date(2024, 5, 22)).alias("date"),
+            F.lit(datetime.time(10, 30, 45, 123000)).alias("time"),
+            F.lit("CET").alias("timezone")
+        )
+        # Expected results for comparison in different scenarios.
+        result_no_tz = datetime.datetime(2024, 5, 22, 10, 30)
+        result_with_tz = datetime.datetime(2024, 5, 22, 1, 30)
+        result_frac_no_tz = datetime.datetime(2024, 5, 22, 10, 30, 45, 123000)
+        result_frac_with_tz = datetime.datetime(2024, 5, 22, 1, 30, 45, 123000)
+
+        # Test 1A: Basic 6 positional arguments (years, months, days, hours, mins, secs).
+        actual = df.select(
+            F.make_timestamp(df.year, df.month, df.day, df.hour, df.minute, df.second)
+        )
+        assertDataFrameEqual(actual, [Row(result_no_tz)])
+
+        # Test 1B: Basic 7 positional arguments (years, months, days, hours, mins, secs, timezone).
+        actual = df.select(
+            F.make_timestamp(df.year, df.month, df.day, df.hour, df.minute, df.second, df.timezone)
+        )
+        assertDataFrameEqual(actual, [Row(result_with_tz)])
+
+        # Test 2A: Basic 6 keyword arguments (years, months, days, hours, mins, secs).
+        actual = df.select(
+            F.make_timestamp(
+                years=df.year,
+                months=df.month,
+                days=df.day,
+                hours=df.hour,
+                mins=df.minute,
+                secs=df.second
+            )
+        )
+        assertDataFrameEqual(actual, [Row(result_no_tz)])
+
+        # Test 2B: Basic 7 keyword arguments (years, months, days, hours, mins, secs, timezone).
+        actual = df.select(
+            F.make_timestamp(
+                years=df.year,
+                months=df.month,
+                days=df.day,
+                hours=df.hour,
+                mins=df.minute,
+                secs=df.second,
+                timezone=df.timezone
+            )
+        )
+        assertDataFrameEqual(actual, [Row(result_with_tz)])
+
+        # Test 3A: Alternative 2 keyword arguments (date, time).
+        actual = df_dt.select(
+            F.make_timestamp(date=df_dt.date, time=df_dt.time)
+        )
+        assertDataFrameEqual(actual, [Row(result_no_tz)])
+
+        # Test 3B: Alternative 3 keyword arguments (date, time, timezone).
+        actual = df_dt.select(
+            F.make_timestamp(date=df_dt.date, time=df_dt.time, timezone=df_dt.timezone)
+        )
+        assertDataFrameEqual(actual, [Row(result_with_tz)])
+
+        # Test 4A: Fractional seconds with positional arguments (without timezone).
+        actual = df_frac.select(
+            F.make_timestamp(
+                df_frac.year,
+                df_frac.month,
+                df_frac.day,
+                df_frac.hour,
+                df_frac.minute,
+                df_frac.second
+            )
+        )
+        assertDataFrameEqual(actual, [Row(result_frac_no_tz)])
+
+        # Test 4B: Fractional seconds with positional arguments (with timezone).
+        actual = df_frac.select(
+            F.make_timestamp(
+                df_frac.year,
+                df_frac.month,
+                df_frac.day,
+                df_frac.hour,
+                df_frac.minute,
+                df_frac.second,
+                df_frac.timezone
+            )
+        )
+        assertDataFrameEqual(actual, [Row(result_frac_with_tz)])
+
+        # Test 5A: Fractional seconds with keyword arguments (without timezone).
+        actual = df_frac.select(
+            F.make_timestamp(
+                years=df_frac.year,
+                months=df_frac.month,
+                days=df_frac.day,
+                hours=df_frac.hour,
+                mins=df_frac.minute,
+                secs=df_frac.second
+            )
+        )
+        assertDataFrameEqual(actual, [Row(result_frac_no_tz)])
+
+        # Test 5B: Fractional seconds with keyword arguments (with timezone).
+        actual = df_frac.select(
+            F.make_timestamp(
+                years=df_frac.year,
+                months=df_frac.month,
+                days=df_frac.day,
+                hours=df_frac.hour,
+                mins=df_frac.minute,
+                secs=df_frac.second,
+                timezone=df_frac.timezone
+            )
+        )
+        assertDataFrameEqual(actual, [Row(result_frac_with_tz)])
+
+        # Test 6A: Fractional seconds with date/time arguments (without timezone).
+        actual = df_dt_frac.select(
+            F.make_timestamp(
+                date=df_dt_frac.date,
+                time=df_dt_frac.time
+            )
+        )
+        assertDataFrameEqual(actual, [Row(result_frac_no_tz)])
+
+        # Test 6B: Fractional seconds with date/time arguments (with timezone).
+        actual = df_dt_frac.select(
+            F.make_timestamp(
+                date=df_dt_frac.date,
+                time=df_dt_frac.time,
+                timezone=df_dt_frac.timezone
+            )
+        )
+        assertDataFrameEqual(actual, [Row(result_frac_with_tz)])
+
+        # Test 7: Edge case - February 29 in leap year.
+        df_leap = self.spark.createDataFrame(
+            [(2024, 2, 29, 0, 0, 0)],
+            ["year", "month", "day", "hour", "minute", "second"]
+        )
+        expected_leap = datetime.datetime(2024, 2, 29, 0, 0, 0)
+        actual = df_leap.select(
+            F.make_timestamp(
+                df_leap.year,
+                df_leap.month,
+                df_leap.day,
+                df_leap.hour,
+                df_leap.minute,
+                df_leap.second
+            )
+        )
+        assertDataFrameEqual(actual, [Row(expected_leap)])
+
+        # Test 8: Edge case - Maximum valid positional argument values.
+        df_max = self.spark.createDataFrame(
+            [(2024, 12, 31, 23, 59, 59)],
+            ["year", "month", "day", "hour", "minute", "second"]
+        )
+        expected_max = datetime.datetime(2024, 12, 31, 23, 59, 59)
+        actual = df_max.select(
+            F.make_timestamp(
+                df_max.year, df_max.month, df_max.day, df_max.hour, df_max.minute, df_max.second
+            )
+        )
+        assertDataFrameEqual(actual, [Row(expected_max)])
+
+        # Test 9: Edge case - Minimum valid positional argument values.
+        df_min = self.spark.createDataFrame(
+            [(1, 1, 1, 0, 0, 0)], ["year", "month", "day", "hour", "minute", "second"]
+        )
+        expected_min = datetime.datetime(1, 1, 1, 0, 0, 0)
+        actual = df_min.select(
+            F.make_timestamp(
+                df_min.year, df_min.month, df_min.day, df_min.hour, df_min.minute, df_min.second
+            )
+        )
+        assertDataFrameEqual(actual, [Row(expected_min)])
+
+        # Test 10: Mixed positional and keyword (should work for valid combinations).
+        actual = df.select(
+            F.make_timestamp(
+                df.year, df.month, df.day, hours=df.hour, mins=df.minute, secs=df.second
+            )
+        )
+        assertDataFrameEqual(actual, [Row(result_no_tz)])
+
+        # Test 11A: Using literal values for positional arguments (without timezone).
+        actual = self.spark.range(1).select(
+            F.make_timestamp(
+                F.lit(2024), F.lit(5), F.lit(22), F.lit(10), F.lit(30), F.lit(0)
+            )
+        )
+        assertDataFrameEqual(actual, [Row(result_no_tz)])
+
+        # Test 11B: Using literal values for positional arguments (with timezone).
+        actual = self.spark.range(1).select(
+            F.make_timestamp(
+                F.lit(2024), F.lit(5), F.lit(22), F.lit(10), F.lit(30), F.lit(0), F.lit("CET")
+            )
+        )
+        assertDataFrameEqual(actual, [Row(result_with_tz)])
+
+        # Test 12A: Using literal values for date/time arguments (without timezone).
+        actual = self.spark.range(1).select(
+            F.make_timestamp(
+                date=F.lit(datetime.date(2024, 5, 22)),
+                time=F.lit(datetime.time(10, 30, 0))
+            )
+        )
+        assertDataFrameEqual(actual, [Row(result_no_tz)])
+
+        # Test 12B: Using literal values for date/time arguments (with timezone).
+        actual = self.spark.range(1).select(
+            F.make_timestamp(
+                date=F.lit(datetime.date(2024, 5, 22)),
+                time=F.lit(datetime.time(10, 30, 0)),
+                timezone=F.lit("CET")
+            )
+        )
+        assertDataFrameEqual(actual, [Row(result_with_tz)])
+
+        # Error handling tests.
+
+        # Test 13: Mixing timestamp and date/time keyword arguments - should raise Exception.
+        with self.assertRaises(PySparkValueError) as context:
+            df_dt.select(
+                F.make_timestamp(years=df.year, date=df_dt.date, time=df_dt.time)
+            ).collect()
+        error_msg = str(context.exception)
+        self.assertIn("CANNOT_SET_TOGETHER", error_msg)
+        self.assertIn("years|months|days|hours|mins|secs and date|time", error_msg)
+
+        with self.assertRaises(PySparkValueError) as context:
+            df_dt.select(
+                F.make_timestamp(hours=df.hour, time=df_dt.time, timezone=df_dt.timezone)
+            ).collect()
+        error_msg = str(context.exception)
+        self.assertIn("CANNOT_SET_TOGETHER", error_msg)
+        self.assertIn("years|months|days|hours|mins|secs and date|time", error_msg)
+
+        # Test 14: Incomplete keyword arguments - should raise Exception for None values.
+        with self.assertRaises(Exception):
+            F.make_timestamp(years=df.year)
+        with self.assertRaises(Exception):
+            F.make_timestamp(secs=df.second)
+        with self.assertRaises(Exception):
+            F.make_timestamp(years=df.year, months=df.month, days=df.day)
+        with self.assertRaises(Exception):
+            F.make_timestamp(days=df.day, timezone=df.timezone)
+        with self.assertRaises(Exception):
+            F.make_timestamp(hours=df.hour, mins=df.minute, secs=df.second, timezone=df.timezone)
+        with self.assertRaises(Exception):
+            F.make_timestamp(date=df_dt.date)
+        with self.assertRaises(Exception):
+            F.make_timestamp(time=df_dt.time, timezone=df_dt.timezone)
+        with self.assertRaises(Exception):
+            F.make_timestamp(timezone=df.timezone)
+        with self.assertRaises(Exception):
+            F.make_timestamp(timezone=df_dt.timezone)
+
     def test_make_timestamp_ntz(self):
         """Comprehensive test cases for make_timestamp_ntz with various arguments and edge cases."""
 

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -873,9 +873,9 @@ class FunctionsTestsMixin:
         )
         # Expected results for comparison in different scenarios.
         result_no_tz = datetime.datetime(2024, 5, 22, 10, 30)
-        result_with_tz = datetime.datetime(2024, 5, 22, 10, 30)
+        result_with_tz = datetime.datetime(2024, 5, 22, 8, 30)
         result_frac_no_tz = datetime.datetime(2024, 5, 22, 10, 30, 45, 123000)
-        result_frac_with_tz = datetime.datetime(2024, 5, 22, 10, 30, 45, 123000)
+        result_frac_with_tz = datetime.datetime(2024, 5, 22, 8, 30, 45, 123000)
 
         # Test 1A: Basic 6 positional arguments (years, months, days, hours, mins, secs).
         actual = df.select(

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -855,27 +855,27 @@ class FunctionsTestsMixin:
         # Common input dataframe setup for multiple test cases (with various arguments).
         df = self.spark.createDataFrame(
             [(2024, 5, 22, 10, 30, 0, "CET")],
-            ["year", "month", "day", "hour", "minute", "second", "timezone"]
+            ["year", "month", "day", "hour", "minute", "second", "timezone"],
         )
         df_frac = self.spark.createDataFrame(
             [(2024, 5, 22, 10, 30, 45.123, "CET")],
-            ["year", "month", "day", "hour", "minute", "second", "timezone"]
+            ["year", "month", "day", "hour", "minute", "second", "timezone"],
         )
         df_dt = self.spark.range(1).select(
             F.lit(datetime.date(2024, 5, 22)).alias("date"),
             F.lit(datetime.time(10, 30, 0)).alias("time"),
-            F.lit("CET").alias("timezone")
+            F.lit("CET").alias("timezone"),
         )
         df_dt_frac = self.spark.range(1).select(
             F.lit(datetime.date(2024, 5, 22)).alias("date"),
             F.lit(datetime.time(10, 30, 45, 123000)).alias("time"),
-            F.lit("CET").alias("timezone")
+            F.lit("CET").alias("timezone"),
         )
         # Expected results for comparison in different scenarios.
         result_no_tz = datetime.datetime(2024, 5, 22, 10, 30)
-        result_with_tz = datetime.datetime(2024, 5, 22, 1, 30)
+        result_with_tz = datetime.datetime(2024, 5, 22, 10, 30)
         result_frac_no_tz = datetime.datetime(2024, 5, 22, 10, 30, 45, 123000)
-        result_frac_with_tz = datetime.datetime(2024, 5, 22, 1, 30, 45, 123000)
+        result_frac_with_tz = datetime.datetime(2024, 5, 22, 10, 30, 45, 123000)
 
         # Test 1A: Basic 6 positional arguments (years, months, days, hours, mins, secs).
         actual = df.select(
@@ -897,7 +897,7 @@ class FunctionsTestsMixin:
                 days=df.day,
                 hours=df.hour,
                 mins=df.minute,
-                secs=df.second
+                secs=df.second,
             )
         )
         assertDataFrameEqual(actual, [Row(result_no_tz)])
@@ -911,15 +911,13 @@ class FunctionsTestsMixin:
                 hours=df.hour,
                 mins=df.minute,
                 secs=df.second,
-                timezone=df.timezone
+                timezone=df.timezone,
             )
         )
         assertDataFrameEqual(actual, [Row(result_with_tz)])
 
         # Test 3A: Alternative 2 keyword arguments (date, time).
-        actual = df_dt.select(
-            F.make_timestamp(date=df_dt.date, time=df_dt.time)
-        )
+        actual = df_dt.select(F.make_timestamp(date=df_dt.date, time=df_dt.time))
         assertDataFrameEqual(actual, [Row(result_no_tz)])
 
         # Test 3B: Alternative 3 keyword arguments (date, time, timezone).
@@ -936,7 +934,7 @@ class FunctionsTestsMixin:
                 df_frac.day,
                 df_frac.hour,
                 df_frac.minute,
-                df_frac.second
+                df_frac.second,
             )
         )
         assertDataFrameEqual(actual, [Row(result_frac_no_tz)])
@@ -950,7 +948,7 @@ class FunctionsTestsMixin:
                 df_frac.hour,
                 df_frac.minute,
                 df_frac.second,
-                df_frac.timezone
+                df_frac.timezone,
             )
         )
         assertDataFrameEqual(actual, [Row(result_frac_with_tz)])
@@ -963,7 +961,7 @@ class FunctionsTestsMixin:
                 days=df_frac.day,
                 hours=df_frac.hour,
                 mins=df_frac.minute,
-                secs=df_frac.second
+                secs=df_frac.second,
             )
         )
         assertDataFrameEqual(actual, [Row(result_frac_no_tz)])
@@ -977,34 +975,26 @@ class FunctionsTestsMixin:
                 hours=df_frac.hour,
                 mins=df_frac.minute,
                 secs=df_frac.second,
-                timezone=df_frac.timezone
+                timezone=df_frac.timezone,
             )
         )
         assertDataFrameEqual(actual, [Row(result_frac_with_tz)])
 
         # Test 6A: Fractional seconds with date/time arguments (without timezone).
-        actual = df_dt_frac.select(
-            F.make_timestamp(
-                date=df_dt_frac.date,
-                time=df_dt_frac.time
-            )
-        )
+        actual = df_dt_frac.select(F.make_timestamp(date=df_dt_frac.date, time=df_dt_frac.time))
         assertDataFrameEqual(actual, [Row(result_frac_no_tz)])
 
         # Test 6B: Fractional seconds with date/time arguments (with timezone).
         actual = df_dt_frac.select(
             F.make_timestamp(
-                date=df_dt_frac.date,
-                time=df_dt_frac.time,
-                timezone=df_dt_frac.timezone
+                date=df_dt_frac.date, time=df_dt_frac.time, timezone=df_dt_frac.timezone
             )
         )
         assertDataFrameEqual(actual, [Row(result_frac_with_tz)])
 
         # Test 7: Edge case - February 29 in leap year.
         df_leap = self.spark.createDataFrame(
-            [(2024, 2, 29, 0, 0, 0)],
-            ["year", "month", "day", "hour", "minute", "second"]
+            [(2024, 2, 29, 0, 0, 0)], ["year", "month", "day", "hour", "minute", "second"]
         )
         expected_leap = datetime.datetime(2024, 2, 29, 0, 0, 0)
         actual = df_leap.select(
@@ -1014,37 +1004,12 @@ class FunctionsTestsMixin:
                 df_leap.day,
                 df_leap.hour,
                 df_leap.minute,
-                df_leap.second
+                df_leap.second,
             )
         )
         assertDataFrameEqual(actual, [Row(expected_leap)])
 
-        # Test 8: Edge case - Maximum valid positional argument values.
-        df_max = self.spark.createDataFrame(
-            [(2024, 12, 31, 23, 59, 59)],
-            ["year", "month", "day", "hour", "minute", "second"]
-        )
-        expected_max = datetime.datetime(2024, 12, 31, 23, 59, 59)
-        actual = df_max.select(
-            F.make_timestamp(
-                df_max.year, df_max.month, df_max.day, df_max.hour, df_max.minute, df_max.second
-            )
-        )
-        assertDataFrameEqual(actual, [Row(expected_max)])
-
-        # Test 9: Edge case - Minimum valid positional argument values.
-        df_min = self.spark.createDataFrame(
-            [(1, 1, 1, 0, 0, 0)], ["year", "month", "day", "hour", "minute", "second"]
-        )
-        expected_min = datetime.datetime(1, 1, 1, 0, 0, 0)
-        actual = df_min.select(
-            F.make_timestamp(
-                df_min.year, df_min.month, df_min.day, df_min.hour, df_min.minute, df_min.second
-            )
-        )
-        assertDataFrameEqual(actual, [Row(expected_min)])
-
-        # Test 10: Mixed positional and keyword (should work for valid combinations).
+        # Test 8: Mixed positional and keyword (should work for valid combinations).
         actual = df.select(
             F.make_timestamp(
                 df.year, df.month, df.day, hours=df.hour, mins=df.minute, secs=df.second
@@ -1052,15 +1017,13 @@ class FunctionsTestsMixin:
         )
         assertDataFrameEqual(actual, [Row(result_no_tz)])
 
-        # Test 11A: Using literal values for positional arguments (without timezone).
+        # Test 9A: Using literal values for positional arguments (without timezone).
         actual = self.spark.range(1).select(
-            F.make_timestamp(
-                F.lit(2024), F.lit(5), F.lit(22), F.lit(10), F.lit(30), F.lit(0)
-            )
+            F.make_timestamp(F.lit(2024), F.lit(5), F.lit(22), F.lit(10), F.lit(30), F.lit(0))
         )
         assertDataFrameEqual(actual, [Row(result_no_tz)])
 
-        # Test 11B: Using literal values for positional arguments (with timezone).
+        # Test 9B: Using literal values for positional arguments (with timezone).
         actual = self.spark.range(1).select(
             F.make_timestamp(
                 F.lit(2024), F.lit(5), F.lit(22), F.lit(10), F.lit(30), F.lit(0), F.lit("CET")
@@ -1068,28 +1031,27 @@ class FunctionsTestsMixin:
         )
         assertDataFrameEqual(actual, [Row(result_with_tz)])
 
-        # Test 12A: Using literal values for date/time arguments (without timezone).
+        # Test 10A: Using literal values for date/time arguments (without timezone).
         actual = self.spark.range(1).select(
             F.make_timestamp(
-                date=F.lit(datetime.date(2024, 5, 22)),
-                time=F.lit(datetime.time(10, 30, 0))
+                date=F.lit(datetime.date(2024, 5, 22)), time=F.lit(datetime.time(10, 30, 0))
             )
         )
         assertDataFrameEqual(actual, [Row(result_no_tz)])
 
-        # Test 12B: Using literal values for date/time arguments (with timezone).
+        # Test 10B: Using literal values for date/time arguments (with timezone).
         actual = self.spark.range(1).select(
             F.make_timestamp(
                 date=F.lit(datetime.date(2024, 5, 22)),
                 time=F.lit(datetime.time(10, 30, 0)),
-                timezone=F.lit("CET")
+                timezone=F.lit("CET"),
             )
         )
         assertDataFrameEqual(actual, [Row(result_with_tz)])
 
         # Error handling tests.
 
-        # Test 13: Mixing timestamp and date/time keyword arguments - should raise Exception.
+        # Test 11: Mixing timestamp and date/time keyword arguments - should raise Exception.
         with self.assertRaises(PySparkValueError) as context:
             df_dt.select(
                 F.make_timestamp(years=df.year, date=df_dt.date, time=df_dt.time)
@@ -1106,7 +1068,7 @@ class FunctionsTestsMixin:
         self.assertIn("CANNOT_SET_TOGETHER", error_msg)
         self.assertIn("years|months|days|hours|mins|secs and date|time", error_msg)
 
-        # Test 14: Incomplete keyword arguments - should raise Exception for None values.
+        # Test 12: Incomplete keyword arguments - should raise Exception for None values.
         with self.assertRaises(Exception):
             F.make_timestamp(years=df.year)
         with self.assertRaises(Exception):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Implement the support for TIME type in `make_timestamp` function in PySpark API.


### Why are the changes needed?
Expand API support for the `MakeTimestamp` expression.


### Does this PR introduce _any_ user-facing change?
Yes, the new function is now available in PySpark API.


### How was this patch tested?
Added appropriate Python functions tests and examples.


### Was this patch authored or co-authored using generative AI tooling?
No.
