### PR TITLE
[SPARK-53945][BUILD] Upgrade `semanticdb-shared` to `4.13.10`

### DIFF
--- a/sql/connect/client/jvm/pom.xml
+++ b/sql/connect/client/jvm/pom.xml
@@ -86,6 +86,9 @@
       <version>${guava.failureaccess.version}</version>
       <scope>compile</scope>
     </dependency>
+    <!--
+      When upgrading ammonite, consider upgrading semanticdb-shared too.
+    -->
     <dependency>
       <groupId>com.lihaoyi</groupId>
       <artifactId>ammonite_${scala.version}</artifactId>
@@ -104,7 +107,7 @@
     <dependency>
       <groupId>org.scalameta</groupId>
       <artifactId>semanticdb-shared_${scala.binary.version}</artifactId>
-      <version>4.13.1.1</version>
+      <version>4.13.10</version>
       <exclusions>
         <exclusion>
           <groupId>org.scala-lang</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to `semanticdb-shared` to `4.13.10`.

### Why are the changes needed?
SPARK-53879 upgraded Ammonite to `3.0.3` so `semanticdb-shared` should be upgraded correspondingly.
https://mvnrepository.com/artifact/com.lihaoyi/ammonite-interp-3.3.6_3.3.6/3.0.3

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
No.
