### PR TITLE
[SPARK-53949][CONNECT] Use `Utils.getRootCause` instead of `Throwables.getRootCause`

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -827,6 +827,11 @@ This file is divided into 3 sections:
     <customMessage>Use stackTraceToString of JavaUtils/SparkFileUtils/Utils instead.</customMessage>
   </check>
 
+  <check customId="googleThrowablesGetRootCause" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bThrowables\.getRootCause\b</parameter></parameters>
+    <customMessage>Use getRootCause of SparkErrorUtils or Utils instead</customMessage>
+  </check>
+
   <check customId="preconditionschecknotnull" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">\bPreconditions\.checkNotNull\b</parameter></parameters>
     <customMessage>Use requireNonNull of java.util.Objects instead.</customMessage>

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -24,7 +24,6 @@ import scala.jdk.CollectionConverters._
 import scala.util.Try
 import scala.util.control.NonFatal
 
-import com.google.common.base.Throwables
 import com.google.common.collect.Lists
 import com.google.protobuf.{Any => ProtoAny, ByteString}
 import io.grpc.{Context, Status, StatusRuntimeException}
@@ -1972,7 +1971,7 @@ class SparkConnectPlanner(
       Utils.deserialize[T](fun.getPayload.toByteArray, Utils.getContextOrSparkClassLoader)
     } catch {
       case t: Throwable =>
-        Throwables.getRootCause(t) match {
+        Utils.getRootCause(t) match {
           case nsm: NoSuchMethodException =>
             throw new SparkClassNotFoundException(
               "INTERNAL_ERROR",


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to replace Guava's `Throwables.getRootCause` with the newly added `Utils.getRootCause` in SPARK-53123. 

### Why are the changes needed?
Use the existing utility functions in Spark.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions

### Was this patch authored or co-authored using generative AI tooling?
No