### PR TITLE
[SPARK-53959][CONNECT] Throw a client-side error when creating a dataframe from a pandas dataframe with an index but no data

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -578,6 +578,11 @@ class SparkSession:
                             spark_type = from_arrow_type(field_type)
                         struct.add(field.name, spark_type, nullable=field.nullable)
                     schema = struct
+                    if len(schema) == 0:
+                        raise PySparkValueError(
+                            errorClass="CANNOT_INFER_EMPTY_SCHEMA",
+                            messageParameters={},
+                        )
             elif isinstance(schema, (list, tuple)) and cast(int, _num_cols) < len(data.columns):
                 assert isinstance(_cols, list)
                 _cols.extend([f"_{i + 1}" for i in range(cast(int, _num_cols), len(data.columns))])

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -557,6 +557,11 @@ class SparkSession:
             # If no schema supplied by user then get the names of columns only
             if schema is None:
                 _cols = [str(x) if not isinstance(x, str) else x for x in data.columns]
+                if len(_cols) == 0:
+                    raise PySparkValueError(
+                        errorClass="CANNOT_INFER_EMPTY_SCHEMA",
+                        messageParameters={},
+                    )
                 infer_pandas_dict_as_map = (
                     configs["spark.sql.execution.pandas.inferPandasDictAsMap"] == "true"
                 )
@@ -578,11 +583,6 @@ class SparkSession:
                             spark_type = from_arrow_type(field_type)
                         struct.add(field.name, spark_type, nullable=field.nullable)
                     schema = struct
-                    if len(schema) == 0:
-                        raise PySparkValueError(
-                            errorClass="CANNOT_INFER_EMPTY_SCHEMA",
-                            messageParameters={},
-                        )
             elif isinstance(schema, (list, tuple)) and cast(int, _num_cols) < len(data.columns):
                 assert isinstance(_cols, list)
                 _cols.extend([f"_{i + 1}" for i in range(cast(int, _num_cols), len(data.columns))])

--- a/python/pyspark/sql/tests/connect/test_connect_creation.py
+++ b/python/pyspark/sql/tests/connect/test_connect_creation.py
@@ -54,10 +54,21 @@ class SparkConnectCreationTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
         self.assertEqual(rows[0][0], 3)
         self.assertEqual(rows[0][1], "c")
 
-        # Check correct behavior for empty DataFrame
-        pdf = pd.DataFrame({"a": []})
-        with self.assertRaises(ValueError):
-            self.connect.createDataFrame(pdf)
+    def test_from_empty_pandas_dataframe(self):
+        dfs = [
+            pd.DataFrame(),
+            pd.DataFrame({"a": []}),
+            pd.DataFrame(index=range(5)),
+        ]
+
+        for df in dfs:
+            with self.assertRaises(PySparkValueError) as pe:
+                self.connect.createDataFrame(df)
+            self.check_error(
+                exception=pe.exception,
+                errorClass="CANNOT_INFER_EMPTY_SCHEMA",
+                messageParameters={},
+            )
 
     def test_with_local_ndarray(self):
         """SPARK-41446: Test creating a dataframe using local list"""


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Spark Connect Python client does not throw a proper error when creating a dataframe from a pandas dataframe with a index and empty data.
Generally, spark connect client throws a client-side error `[CANNOT_INFER_EMPTY_SCHEMA] Can not infer schema from an empty dataset`. when creating a dataframe without data, for example via
```
spark.createDataFrame([]).show()
```
or
```
df = pd.DataFrame()
spark.createDataFrame(df).show()
```
or
```
df = pd.DataFrame({"a": []})
spark.createDataFrame(df).show()
```

This does not happen when pandas dataframe has an index but no data, e.g.
```
df = pd.DataFrame(index=range(5))
spark.createDataFrame(df).show()
```
What happens instead is that the dataframe is successfully converted to a LocalRelation on the client, is sent to the server, but the server then throws the following exception: `INTERNAL_ERROR: Input data for LocalRelation does not produce a schema. SQLSTATE: XX000`. XX000 is an internal error sql state and the error is not actionable enough for the user.

This PR fixes this problem by throwing `CANNOT_INFER_EMPTY_SCHEMA` in case the dataframe has rows (because of the index), but does not have columns.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently the error is thrown as a server-side internal error and the error message is not actionable enough for the user.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Creating a spark connect dataframe from an pandas dataframe with an index but no data will now throw a client-side error `[CANNOT_INFER_EMPTY_SCHEMA] Can not infer schema from an empty dataset` instead of the server-side `INTERNAL_ERROR: Input data for LocalRelation does not produce a schema. SQLSTATE: XX000`.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit test.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
