### PR TITLE
[SPARK-53967][PYTHON] Avoid intermediate pandas dataframe creation in `df.toPandas`

### DIFF
--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -115,11 +115,13 @@ class PandasConversionMixin:
                     self_destruct = jconf.arrowPySparkSelfDestructEnabled()
                     batches = self._collect_as_arrow(split_batches=self_destruct)
 
+                    # Rename columns to avoid duplicated column names.
+                    temp_col_names = [f"col_{i}" for i in range(len(self.columns))]
                     if len(batches) > 0:
-                        table = pa.Table.from_batches(batches)
+                        table = pa.Table.from_batches(batches).rename_columns(temp_col_names)
                     else:
                         # empty dataset
-                        table = arrow_schema.empty_table()
+                        table = arrow_schema.empty_table().rename_columns(temp_col_names)
 
                     # Ensure only the table has a reference to the batches, so that
                     # self_destruct (if enabled) is effective


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Avoid intermediate pandas dataframe creation in `df.toPandas`

before: batches -> table -> intermediate pdf -> result pdf (based on `pa.Table.to_pandas`)

 
after: batches -> table -> result pdf (based on `pa.ChunkedArray.to_pandas`)



### Why are the changes needed?
the intermediate pandas dataframe can be skipped

simple benchmark in my local
```

spark.conf.set("spark.sql.execution.arrow.pyspark.enabled", "true")
spark.conf.set("spark.sql.execution.arrow.pyspark.fallback.enabled", "false")
spark.conf.set("spark.sql.execution.arrow.pyspark.selfDestruct.enabled", "true")

import time
from pyspark.sql import functions as sf


df = spark.range(1000000).select(
    (sf.col("id") % 2).alias("key"), sf.col("id").alias("v")
)
cols = {f"col_{i}": sf.lit(f"c{i}") for i in range(100)}
df = df.withColumns(cols)
df.cache()
df.count()



pdf = df.toPandas() # warm up


start_arrow = time.perf_counter()
for i in range(100):
    pdf = df.toPandas()

time.perf_counter() - start_arrow
```

master: 304.49954012501985 secs
this PR: 285.2997682078276 secs


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
existing tests


### Was this patch authored or co-authored using generative AI tooling?
no