### PR TITLE
[SPARK-53968][SQL] Store decimal precision loss conf in arithmetic expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/BinaryArithmeticWithDatetimeResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/BinaryArithmeticWithDatetimeResolver.scala
@@ -106,11 +106,13 @@ object BinaryArithmeticWithDatetimeResolver {
           DateAdd(l, UnaryMinus(ExtractANSIIntervalDays(r), context.evalMode == EvalMode.ANSI))
         case (DateType, _: DayTimeIntervalType) =>
           DatetimeSub(l, r,
-            TimestampAddInterval(Cast(l, TimestampType), UnaryMinus(r, context.evalMode == EvalMode.ANSI)))
+            TimestampAddInterval(Cast(l, TimestampType),
+              UnaryMinus(r, context.evalMode == EvalMode.ANSI)))
         case (DateType, _: YearMonthIntervalType) =>
           DatetimeSub(l, r, DateAddYMInterval(l, UnaryMinus(r, context.evalMode == EvalMode.ANSI)))
         case (TimestampType | TimestampNTZType, _: YearMonthIntervalType) =>
-          DatetimeSub(l, r, TimestampAddYMInterval(l, UnaryMinus(r, context.evalMode == EvalMode.ANSI)))
+          DatetimeSub(l, r, TimestampAddYMInterval(l,
+            UnaryMinus(r, context.evalMode == EvalMode.ANSI)))
         case (CalendarIntervalType, CalendarIntervalType) |
              (_: DayTimeIntervalType, _: DayTimeIntervalType) =>
           s

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/BinaryArithmeticWithDatetimeResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/BinaryArithmeticWithDatetimeResolver.scala
@@ -63,7 +63,7 @@ import org.apache.spark.sql.types.DayTimeIntervalType.DAY
 
 object BinaryArithmeticWithDatetimeResolver {
   def resolve(expr: Expression): Expression = expr match {
-    case a @ Add(l, r, mode) =>
+    case a @ Add(l, r, context) =>
       (l.dataType, r.dataType) match {
         case (DateType, DayTimeIntervalType(DAY, DAY)) => DateAdd(l, ExtractANSIIntervalDays(r))
         case (DateType, _: DayTimeIntervalType) => TimestampAddInterval(Cast(l, TimestampType), r)
@@ -83,7 +83,7 @@ object BinaryArithmeticWithDatetimeResolver {
         case (_: AnsiIntervalType, _: NullType) =>
           a.copy(right = Cast(a.right, a.left.dataType))
         case (DateType, CalendarIntervalType) =>
-          DateAddInterval(l, r, ansiEnabled = mode == EvalMode.ANSI)
+          DateAddInterval(l, r, ansiEnabled = context.evalMode == EvalMode.ANSI)
         case (_: TimeType, _: DayTimeIntervalType) => TimeAddInterval(l, r)
         case (_: DatetimeType, _: NullType) =>
           a.copy(right = Cast(a.right, DayTimeIntervalType.DEFAULT))
@@ -93,24 +93,24 @@ object BinaryArithmeticWithDatetimeResolver {
         case (_, CalendarIntervalType | _: DayTimeIntervalType) =>
           Cast(TimestampAddInterval(l, r), l.dataType)
         case (CalendarIntervalType, DateType) =>
-          DateAddInterval(r, l, ansiEnabled = mode == EvalMode.ANSI)
+          DateAddInterval(r, l, ansiEnabled = context.evalMode == EvalMode.ANSI)
         case (CalendarIntervalType | _: DayTimeIntervalType, _) =>
           Cast(TimestampAddInterval(r, l), r.dataType)
         case (DateType, dt) if dt != StringType => DateAdd(l, r)
         case (dt, DateType) if dt != StringType => DateAdd(r, l)
         case _ => a
       }
-    case s @ Subtract(l, r, mode) =>
+    case s @ Subtract(l, r, context) =>
       (l.dataType, r.dataType) match {
         case (DateType, DayTimeIntervalType(DAY, DAY)) =>
-          DateAdd(l, UnaryMinus(ExtractANSIIntervalDays(r), mode == EvalMode.ANSI))
+          DateAdd(l, UnaryMinus(ExtractANSIIntervalDays(r), context.evalMode == EvalMode.ANSI))
         case (DateType, _: DayTimeIntervalType) =>
           DatetimeSub(l, r,
-            TimestampAddInterval(Cast(l, TimestampType), UnaryMinus(r, mode == EvalMode.ANSI)))
+            TimestampAddInterval(Cast(l, TimestampType), UnaryMinus(r, context.evalMode == EvalMode.ANSI)))
         case (DateType, _: YearMonthIntervalType) =>
-          DatetimeSub(l, r, DateAddYMInterval(l, UnaryMinus(r, mode == EvalMode.ANSI)))
+          DatetimeSub(l, r, DateAddYMInterval(l, UnaryMinus(r, context.evalMode == EvalMode.ANSI)))
         case (TimestampType | TimestampNTZType, _: YearMonthIntervalType) =>
-          DatetimeSub(l, r, TimestampAddYMInterval(l, UnaryMinus(r, mode == EvalMode.ANSI)))
+          DatetimeSub(l, r, TimestampAddYMInterval(l, UnaryMinus(r, context.evalMode == EvalMode.ANSI)))
         case (CalendarIntervalType, CalendarIntervalType) |
              (_: DayTimeIntervalType, _: DayTimeIntervalType) =>
           s
@@ -124,15 +124,15 @@ object BinaryArithmeticWithDatetimeResolver {
             r,
             DateAddInterval(
               l,
-              UnaryMinus(r, mode == EvalMode.ANSI),
-              ansiEnabled = mode == EvalMode.ANSI
+              UnaryMinus(r, context.evalMode == EvalMode.ANSI),
+              ansiEnabled = context.evalMode == EvalMode.ANSI
             )
           )
         case (_: TimeType, _: DayTimeIntervalType) =>
-          DatetimeSub(l, r, TimeAddInterval(l, UnaryMinus(r, mode == EvalMode.ANSI)))
+          DatetimeSub(l, r, TimeAddInterval(l, UnaryMinus(r, context.evalMode == EvalMode.ANSI)))
         case (_, CalendarIntervalType | _: DayTimeIntervalType) =>
           Cast(DatetimeSub(l, r,
-            TimestampAddInterval(l, UnaryMinus(r, mode == EvalMode.ANSI))), l.dataType)
+            TimestampAddInterval(l, UnaryMinus(r, context.evalMode == EvalMode.ANSI))), l.dataType)
         case _
           if AnyTimestampTypeExpression.unapply(l) ||
             AnyTimestampTypeExpression.unapply(r) =>
@@ -142,19 +142,19 @@ object BinaryArithmeticWithDatetimeResolver {
         case (_: TimeType, _: TimeType) => SubtractTimes(l, r)
         case _ => s
       }
-    case m @ Multiply(l, r, mode) =>
+    case m @ Multiply(l, r, context) =>
       (l.dataType, r.dataType) match {
-        case (CalendarIntervalType, _) => MultiplyInterval(l, r, mode == EvalMode.ANSI)
-        case (_, CalendarIntervalType) => MultiplyInterval(r, l, mode == EvalMode.ANSI)
+        case (CalendarIntervalType, _) => MultiplyInterval(l, r, context.evalMode == EvalMode.ANSI)
+        case (_, CalendarIntervalType) => MultiplyInterval(r, l, context.evalMode == EvalMode.ANSI)
         case (_: YearMonthIntervalType, _) => MultiplyYMInterval(l, r)
         case (_, _: YearMonthIntervalType) => MultiplyYMInterval(r, l)
         case (_: DayTimeIntervalType, _) => MultiplyDTInterval(l, r)
         case (_, _: DayTimeIntervalType) => MultiplyDTInterval(r, l)
         case _ => m
       }
-    case d @ Divide(l, r, mode) =>
+    case d @ Divide(l, r, context) =>
       (l.dataType, r.dataType) match {
-        case (CalendarIntervalType, _) => DivideInterval(l, r, mode == EvalMode.ANSI)
+        case (CalendarIntervalType, _) => DivideInterval(l, r, context.evalMode == EvalMode.ANSI)
         case (_: YearMonthIntervalType, _) => DivideYMInterval(l, r)
         case (_: DayTimeIntervalType, _) => DivideDTInterval(l, r)
         case _ => d

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/NumericEvalContext.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/NumericEvalContext.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Encapsulates the evaluation context for expressions, capturing SQL configuration
+ * state at expression construction time.
+ *
+ * This context must be stored as part of the expression's state to ensure deterministic
+ * evaluation. Without it, copying an expression or evaluating it in a different context
+ * (e.g., inside a view) could produce different results due to changed SQL configuration
+ * values.
+ *
+ * @param evalMode                  The error handling mode (LEGACY, ANSI, or TRY) that determines
+ *                                  overflow behavior and exception handling for operations like
+ *                                  arithmetic and casts.
+ * @param allowDecimalPrecisionLoss Whether decimal operations are allowed to lose precision
+ *                                  when the result type cannot represent the full precision.
+ *                                  Corresponds to
+ *                                  spark.sql.decimalOperations.allowPrecisionLoss.
+ */
+case class NumericEvalContext private(
+    evalMode: EvalMode.Value,
+    allowDecimalPrecisionLoss: Boolean
+)
+
+case object NumericEvalContext {
+
+  def apply(
+      evalMode: EvalMode.Value,
+      allowDecimalPrecisionLoss: Boolean = SQLConf.get.decimalOperationsAllowPrecisionLoss
+  ): NumericEvalContext = {
+    new NumericEvalContext(evalMode, allowDecimalPrecisionLoss)
+  }
+
+  def fromSQLConf(conf: SQLConf): NumericEvalContext = {
+    NumericEvalContext(
+      EvalMode.fromSQLConf(conf),
+      conf.decimalOperationsAllowPrecisionLoss)
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
@@ -39,7 +39,9 @@ import org.apache.spark.sql.types._
 case class BitwiseAnd(left: Expression, right: Expression) extends BinaryArithmetic
   with CommutativeExpression {
 
-  protected override val evalMode: EvalMode.Value = EvalMode.LEGACY
+  override def evalMode: EvalMode.Value = EvalMode.LEGACY
+
+  override val evalContext: NumericEvalContext = NumericEvalContext(evalMode)
 
   override def inputType: AbstractDataType = IntegralType
 
@@ -86,7 +88,9 @@ case class BitwiseAnd(left: Expression, right: Expression) extends BinaryArithme
 case class BitwiseOr(left: Expression, right: Expression) extends BinaryArithmetic
   with CommutativeExpression {
 
-  protected override val evalMode: EvalMode.Value = EvalMode.LEGACY
+  override def evalMode: EvalMode.Value = EvalMode.LEGACY
+
+  override val evalContext: NumericEvalContext = NumericEvalContext(evalMode)
 
   override def inputType: AbstractDataType = IntegralType
 
@@ -133,7 +137,9 @@ case class BitwiseOr(left: Expression, right: Expression) extends BinaryArithmet
 case class BitwiseXor(left: Expression, right: Expression) extends BinaryArithmetic
   with CommutativeExpression {
 
-  protected override val evalMode: EvalMode.Value = EvalMode.LEGACY
+  override def evalMode: EvalMode.Value = EvalMode.LEGACY
+
+  override val evalContext: NumericEvalContext = NumericEvalContext(evalMode)
 
   override def inputType: AbstractDataType = IntegralType
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
@@ -933,7 +933,8 @@ class BrokenColumnarAdd(
     left: ColumnarExpression,
     right: ColumnarExpression,
     failOnError: Boolean = false)
-  extends Add(left, right, EvalMode.fromBoolean(failOnError)) with ColumnarExpression {
+  extends Add(left, right, NumericEvalContext(EvalMode.fromBoolean(failOnError)))
+    with ColumnarExpression {
 
   override def supportsColumnar: Boolean = left.supportsColumnar && right.supportsColumnar
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/functions/V2FunctionBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/functions/V2FunctionBenchmark.scala
@@ -23,7 +23,7 @@ import test.org.apache.spark.sql.connector.catalog.functions.JavaLongAdd.{JavaLo
 import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{BinaryArithmetic, EvalMode, Expression}
+import org.apache.spark.sql.catalyst.expressions.{BinaryArithmetic, EvalMode, Expression, NumericEvalContext}
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode._
 import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.classic.ClassicConversions._
@@ -109,7 +109,7 @@ object V2FunctionBenchmark extends SqlBasedBenchmark {
       left: Expression,
       right: Expression,
       override val nullable: Boolean) extends BinaryArithmetic {
-    protected override val evalMode: EvalMode.Value = EvalMode.LEGACY
+    override val evalContext: NumericEvalContext = NumericEvalContext(EvalMode.LEGACY)
     override def inputType: AbstractDataType = NumericType
     override def symbol: String = "+"
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -1338,7 +1338,7 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
     import org.apache.spark.sql.internal.SQLConf
     val partsTableName = "parts_tbl"
     val ordersTableName = "orders_tbl"
-    val viewName = "view_es_1600586"
+    val viewName = "view_spark_53968"
     withTable(partsTableName, ordersTableName) {
       spark.sql(s"""CREATE TABLE $partsTableName (
            | part_number STRING

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -1333,4 +1333,73 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
       }
     }
   }
+
+  test("SPARK-53968 reading the view after allowPrecisionLoss is changed") {
+    import org.apache.spark.sql.internal.SQLConf
+    val partsTableName = "parts_tbl"
+    val ordersTableName = "orders_tbl"
+    val viewName = "view_es_1600586"
+    withTable(partsTableName, ordersTableName) {
+      spark.sql(
+        s"""CREATE TABLE $partsTableName (
+           | part_number STRING
+           |) USING PARQUET
+           |""".stripMargin)
+      spark.sql(s"INSERT INTO $partsTableName VALUES ('part1'), ('part2')")
+
+      spark.sql(
+        s"""CREATE TABLE $ordersTableName
+           |USING PARQUET AS
+           |SELECT * FROM VALUES
+           |('part1', CAST(100 AS DECIMAL(38,18)), CAST(NULL   AS DECIMAL(38,18))),
+           |('part2', CAST(100 AS DECIMAL(38,18)), CAST(0 AS DECIMAL(38,18))),
+           |('part3', CAST(200.23 AS DECIMAL(38,18)), CAST(100 AS DECIMAL(38,18)))
+           |AS t(part_number, unit_price, shipping_price);
+           |""".stripMargin)
+
+      Seq(
+        (true, false),
+        (false, true)
+      ).foreach { case (oldValue, newValue) =>
+        withView(viewName) {
+          withSQLConf(SQLConf.DECIMAL_OPERATIONS_ALLOW_PREC_LOSS.key -> oldValue.toString) {
+            spark.sql(
+              s"""
+                 |CREATE OR REPLACE VIEW $viewName AS
+                 |WITH order_details AS (
+                 |  SELECT
+                 |    orders.part_number,
+                 |    orders.unit_price
+                 |      + COALESCE(orders.shipping_price, CAST(0 AS DECIMAL(38, 18)))
+                 |      AS total_price
+                 |  FROM $ordersTableName orders
+                 |)
+                 |SELECT
+                 |  od.total_price
+                 |FROM order_details od LEFT JOIN $partsTableName pt
+                 |  ON pt.part_number = od.part_number
+                 |ORDER BY od.total_price
+            """.stripMargin)
+
+            val expectedResults = Seq(
+              Row(BigDecimal("100.00000000000000000")),
+              Row(BigDecimal("100.00000000000000000")),
+              Row(BigDecimal("300.23000000000000000")),
+            )
+
+            checkAnswer(
+              spark.sql(s"SELECT * FROM $viewName"),
+              expectedResults)
+
+            // Re-run the query with new value of the config, we should get the same result.
+            withSQLConf(SQLConf.DECIMAL_OPERATIONS_ALLOW_PREC_LOSS.key -> newValue.toString) {
+              checkAnswer(
+                spark.sql(s"SELECT * FROM $viewName"),
+                expectedResults)
+            }
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Currently, arithmetic expressions such as `Add` and `Multiply` use the configuration `spark.sql.decimalOperations.allowPrecisionLoss` to determine their output type when working with decimal values. This approach is problematic because if the expression is transformed or copied, its return type could change depending on the active configuration value.

This issue can happen during view resolution; we can use one value of the config during analysis and different one during query optimization. If a referenced expression changes type and that reference is reused elsewhere in the plan it will trigger a plan validation error.


### Why are the changes needed?
To address this, we should follow a similar approach to what was done for ANSI mode: store the relevant context directly within the expression as part of its state. This ensures the expression remains stable and unaffected by configuration changes when it’s copied or transformed. To make this transition smooth, I’ve generalized the existing EvalMode used for ANSI so that it can be extended to multiple configuration dimensions.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added a new unit test in SQLViewSuite which was failing with plan validation error before.


### Was this patch authored or co-authored using generative AI tooling?
No.
