### PR TITLE
[SPARK-53972][SS] Fix streaming query recentProgress regression in classic pyspark

### DIFF
--- a/python/pyspark/sql/streaming/query.py
+++ b/python/pyspark/sql/streaming/query.py
@@ -283,7 +283,10 @@ class StreamingQuery:
 
         >>> sq.stop()
         """
-        return [StreamingQueryProgress.fromJObject(p) for p in self._jsq.recentProgress()]
+        return [
+            StreamingQueryProgress.fromJson(json.loads(p.json()))
+            for p in self._jsq.recentProgress()
+        ]
 
     @property
     def lastProgress(self) -> Optional[StreamingQueryProgress]:
@@ -314,7 +317,7 @@ class StreamingQuery:
         """
         lastProgress = self._jsq.lastProgress()
         if lastProgress:
-            return StreamingQueryProgress.fromJObject(lastProgress)
+            return StreamingQueryProgress.fromJson(json.loads(lastProgress.json()))
         else:
             return None
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->
### What changes were proposed in this pull request?

We found a performance regression in recentProgress in pyspark in assigned cluster after version 4.0.  The direct cause of the regression in this [commit](https://github.com/apache/spark/commit/22eb6c4b0a82b9fcf84fc9952b1f6c41dde9bd8d#diff-4d4ed29d139877b160de444add7ee63cfa7a7577d849ab2686f1aa2d5b4aae64), it changes how we load recentProgress `fromJson` to `fromJObject`, and this commit is only included in 4.0. However, when constructing a dict from `JObject`, py4j needs to make multiple RPCs to JVM which result in a long time

### Proposed Fix: 
Use fromJson to load StraemingQueryProgress instead. This will be aligned with the [recentProgress in pyConnect](https://github.com/apache/spark/blob/master/python/pyspark/sql/connect/streaming/query.py#L114-L130) as well

We are also fixing `lastProgress` to load StreamingQueryProgress from json.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Otherwise there is a performance regression in recentProgress. Here is the log of the time it takes to load 70 recent progress:
```
[2025-10-22 06:28:37]Total Time: 0.12269 seconds for getting 1 progress
[2025-10-22 06:28:38]Total Time: 0.199387 seconds for getting 2 progress
[2025-10-22 06:28:39]Total Time: 0.384784 seconds for getting 4 progress
...
[2025-10-22 06:29:27]Total Time: 4.089001 seconds for getting 48 progress
[2025-10-22 06:29:32]Total Time: 4.571433 seconds for getting 53 progress
[2025-10-22 06:29:38]Total Time: 5.024825 seconds for getting 58 progress
[2025-10-22 06:29:45]Total Time: 5.520222 seconds for getting 64 progress
[2025-10-22 06:29:52]Total Time: 6.071674 seconds for getting 71 progress
```
This is generated by adding the following test to test_streaming.py locally
```
def test_recent_progress_regression(self):
        df = self.spark.readStream.format("rate").option("rowsPerSecond", 10).load()
        q = df.writeStream.format("noop").start()
        print("begin waiting for progress")
        numProgress = len(q.recentProgress)
        while numProgress < 70 and q.exception() is None:
            time.sleep(1)
            beforeTime = datetime.now()
            rep = q.recentProgress
            numProgress = len(rep)
            afterTime = datetime.now()
            print("[" + afterTime.strftime("%Y-%m-%d %H:%M:%S") + "]" + "Total Time: " + str((afterTime - beforeTime).total_seconds()) + " seconds for getting " + str(numProgress) + " progress")
        q.stop()
        q.awaitTermination()
        assert(q.exception() is None)
        assert(numProgress == 300) # wrong statement so that we can see the logs
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Run local script with the changes and here is the output log. 
```
2025-10-22 06:23:35]Total Time: 0.001411 seconds for getting 1 progress
[2025-10-22 06:23:36]Total Time: 0.002293 seconds for getting 2 progress
[2025-10-22 06:23:37]Total Time: 0.003163 seconds for getting 3 progress
[2025-10-22 06:23:38]Total Time: 0.003583 seconds for getting 4 progress
[2025-10-22 06:23:39]Total Time: 0.004025 seconds for getting 5 progress
[2025-10-22 06:23:40]Total Time: 0.004954 seconds for getting 6 progress
...
[2025-10-22 06:24:43]Total Time: 0.012729 seconds for getting 69 progress
[2025-10-22 06:24:44]Total Time: 0.01289 seconds for getting 70 progress
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No