### PR TITLE
[SPARK-46485][SQL][3.5] V1Write should not add Sort when not needed

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/V1Writes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/V1Writes.scala
@@ -102,8 +102,8 @@ object V1Writes extends Rule[LogicalPlan] with SQLConfHelper {
     val requiredOrdering = write.requiredOrdering.map(_.transform {
       case a: Attribute => attrMap.getOrElse(a, a)
     }.asInstanceOf[SortOrder])
-    val outputOrdering = query.outputOrdering
-    val orderingMatched = isOrderingMatched(requiredOrdering, outputOrdering)
+    val outputOrdering = empty2NullPlan.outputOrdering
+    val orderingMatched = isOrderingMatched(requiredOrdering.map(_.child), outputOrdering)
     if (orderingMatched) {
       empty2NullPlan
     } else {


### PR DESCRIPTION
Backport #44458 to branch-3.5.

Justification: it fixes a hidden bug (until exposed by https://github.com/apache/spark/pull/44429) that has existed since 3.4.

### What changes were proposed in this pull request?

In `V1Writes`, we try to avoid adding Sort if the output ordering always satisfies. However, the code is completely broken with two issues:
- we put `SortOrder` as the child of another `SortOrder` and compare, which always returns false.
- once we add a project to do `empty2null`, we change the query output attribute id and the sort order never matches.

It's not a big issue as we still have QO rules to eliminate useless sorts, but https://github.com/apache/spark/pull/44429 exposes this problem because the way we optimize sort is a bit different. For `V1Writes`, we should always avoid adding sort even if the number of ordering key is less, to not change the user query.

### Why are the changes needed?

fix code mistakes.

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

updated test

### Was this patch authored or co-authored using generative AI tooling?

no

