### PR TITLE
[SPARK-53980][CORE] Add `SparkConf.getAllWithPrefix(String, String => K)` API

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -459,8 +459,9 @@ class SparkConf(loadDefaults: Boolean)
 
   /** Gets all the avro schemas in the configuration used in the generic Avro record serializer */
   def getAvroSchema: Map[Long, String] = {
-    val f = (k: String) => k.substring(avroNamespace.length).toLong
-    getAllWithPrefix(avroNamespace, f).toMap
+    getAll.filter { case (k, v) => k.startsWith(avroNamespace) }
+      .map { case (k, v) => (k.substring(avroNamespace.length).toLong, v) }
+      .toMap
   }
 
   /** Remove a parameter from the configuration */
@@ -503,8 +504,8 @@ class SparkConf(loadDefaults: Boolean)
    * Get all parameters that start with `prefix`
    */
   def getAllWithPrefix(prefix: String): Array[(String, String)] = {
-    val f = (k: String) => k.substring(prefix.length)
-    getAllWithPrefix(prefix, f)
+    getAll.filter { case (k, v) => k.startsWith(prefix) }
+      .map { case (k, v) => (k.substring(prefix.length), v) }
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -459,9 +459,8 @@ class SparkConf(loadDefaults: Boolean)
 
   /** Gets all the avro schemas in the configuration used in the generic Avro record serializer */
   def getAvroSchema: Map[Long, String] = {
-    getAll.filter { case (k, v) => k.startsWith(avroNamespace) }
-      .map { case (k, v) => (k.substring(avroNamespace.length).toLong, v) }
-      .toMap
+    val f = (k: String) => k.substring(avroNamespace.length).toLong
+    getAllWithPrefix(avroNamespace, f).toMap
   }
 
   /** Remove a parameter from the configuration */
@@ -504,8 +503,16 @@ class SparkConf(loadDefaults: Boolean)
    * Get all parameters that start with `prefix`
    */
   def getAllWithPrefix(prefix: String): Array[(String, String)] = {
-    getAll.filter { case (k, v) => k.startsWith(prefix) }
-      .map { case (k, v) => (k.substring(prefix.length), v) }
+    val f = (k: String) => k.substring(prefix.length)
+    getAllWithPrefix(prefix, f)
+  }
+
+  /**
+   * Get all parameters that start with `prefix` and apply f.
+   */
+  def getAllWithPrefix[K](prefix: String, f: String => K): Array[(K, String)] = {
+    getAll.filter { case (k, _) => k.startsWith(prefix) }
+      .map { case (k, v) => (f(k), v) }
   }
 
   /** Get all executor environment variables set on this SparkConf */

--- a/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
@@ -127,6 +127,26 @@ class SparkConfSuite extends SparkFunSuite with LocalSparkContext with ResetSyst
       Set(("main.suffix", "v1"), ("main2.suffix", "v2"), ("main3.extra1.suffix", "v3")))
   }
 
+  test("more flexible getAllWithPrefix") {
+    val prefix = "spark.fs.s3a."
+    val newPrefix = "spark.hadoop.fs.s3a."
+    val conf = new SparkConf(false)
+    conf.set("spark.fs.s3a.config1", "v1")
+    val f = (k: String) => {
+      val keyWithoutPrefix = k.substring(prefix.length)
+      newPrefix + keyWithoutPrefix
+    }
+    assert(conf.getAllWithPrefix(prefix, f).toSet ===
+      Set(("spark.hadoop.fs.s3a.config1", "v1")))
+
+    conf.set("spark.fs.s3a.config1.suffix", "v2")
+    conf.set("spark.fs.s3a.config1.extra.suffix", "v3")
+    conf.set("spark.notMatching.main4", "v4")
+
+    assert(conf.getAllWithPrefix(prefix).toSet ===
+      Set(("config1", "v1"), ("config1.suffix", "v2"), ("config1.extra.suffix", "v3")))
+  }
+
   test("creating SparkContext without master and app name") {
     val conf = new SparkConf(false)
     intercept[SparkException] { sc = new SparkContext(conf) }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to add more flexible `getAllWithPrefix` for `SparkConf`.
We need to set some config related to S3 for our inner Spark.
The requirements are replacing the prefix `spark.fs.s3a` with new prefix `spark.hadoop.fs.s3a` The implementation of the function show below.
```
    val S3A_PREFIX = "spark.fs.s3a"
    val SPARK_HADOOP_S3A_PREFIX = "spark.hadoop.fs.s3a"
    val s3aConf = conf.getAllWithPrefix(S3A_PREFIX)
    val newConf = s3aConf
      .map(
        confPair => {
          val keyWithoutPrefix = confPair._1
          val oldKey = S3A_PREFIX + keyWithoutPrefix
          val newKey = SPARK_HADOOP_S3A_PREFIX + keyWithoutPrefix
          val value = confPair._2
          ((newKey, oldKey), value)
        })
```
Because `getAllWithPrefix` truncated the prefix, developers must concat the suffix and prefix to restore the original key.
The new `getAllWithPrefix` increases the flexibility developers could customize the function as they want.
After this change, the code show above could be improved as follows.
```
    val S3A_PREFIX = "spark.fs.s3a"
    val SPARK_HADOOP_S3A_PREFIX = "spark.hadoop.fs.s3a"
    val f = (k: String) => {
      val keyWithoutPrefix = k.substring(S3A_PREFIX.length)
      val newKey = SPARK_HADOOP_S3A_PREFIX + keyWithoutPrefix
      (newKey, k)
    }
    val newConf = conf.getAllWithPrefix(S3A_PREFIX, f)
```

### Why are the changes needed?
The new API `getAllWithPrefix` could improve the flexibility for `SparkConf`.


### Does this PR introduce _any_ user-facing change?
'No'.
New API.


### How was this patch tested?
GA tests.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
