### PR TITLE
[SPARK-53610][PYTHON] Limit Arrow batch sizes in CoGrouped applyInPandas and applyInArrow

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -1302,16 +1302,16 @@ class CogroupPandasUDFSerializer(ArrowStreamPandasUDFSerializer):
             dataframes_in_group = read_int(stream)
 
             if dataframes_in_group == 2:
-                batch1 = [batch for batch in ArrowStreamSerializer.load_stream(self, stream)]
-                batch2 = [batch for batch in ArrowStreamSerializer.load_stream(self, stream)]
+                batches1 = [batch for batch in ArrowStreamSerializer.load_stream(self, stream)]
+                batches2 = [batch for batch in ArrowStreamSerializer.load_stream(self, stream)]
                 yield (
                     [
                         self.arrow_to_pandas(c, i)
-                        for i, c in enumerate(pa.Table.from_batches(batch1).itercolumns())
+                        for i, c in enumerate(pa.Table.from_batches(batches1).itercolumns())
                     ],
                     [
                         self.arrow_to_pandas(c, i)
-                        for i, c in enumerate(pa.Table.from_batches(batch2).itercolumns())
+                        for i, c in enumerate(pa.Table.from_batches(batches2).itercolumns())
                     ],
                 )
 

--- a/python/pyspark/sql/tests/arrow/test_arrow_cogrouped_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_cogrouped_map.py
@@ -335,6 +335,8 @@ class CogroupedMapInArrowTestsMixin:
                 }
             )
 
+        schema = "key long, left_rows long, left_columns long, right_rows long, right_columns long"
+
         expected = [
             Row(key=0, left_rows=5000000, left_columns=12, right_rows=25000, right_columns=22),
             Row(key=1, left_rows=5000000, left_columns=12, right_rows=25000, right_columns=22),
@@ -353,10 +355,7 @@ class CogroupedMapInArrowTestsMixin:
                     result = (
                         df1.groupby("key")
                         .cogroup(df2.groupby("key"))
-                        .applyInArrow(
-                            summarize,
-                            schema="key long, left_rows long, left_columns long, right_rows long, right_columns long",
-                        )
+                        .applyInArrow(summarize, schema=schema)
                         .sort("key")
                         .collect()
                     )

--- a/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
@@ -682,6 +682,8 @@ class CogroupedApplyInPandasTestsMixin:
                 }
             )
 
+        schema = "key long, left_rows long, left_columns long, right_rows long, right_columns long"
+
         expected = [
             Row(key=0, left_rows=5000000, left_columns=12, right_rows=25000, right_columns=22),
             Row(key=1, left_rows=5000000, left_columns=12, right_rows=25000, right_columns=22),
@@ -700,10 +702,7 @@ class CogroupedApplyInPandasTestsMixin:
                     result = (
                         df1.groupby("key")
                         .cogroup(df2.groupby("key"))
-                        .applyInPandas(
-                            summarize,
-                            schema="key long, left_rows long, left_columns long, right_rows long, right_columns long",
-                        )
+                        .applyInPandas(summarize, schema=schema)
                         .sort("key")
                         .collect()
                     )

--- a/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
@@ -18,7 +18,8 @@
 import unittest
 from typing import cast
 
-from pyspark.sql.functions import array, explode, col, lit, udf, pandas_udf, sum
+from pyspark.sql import functions as sf
+from pyspark.sql.functions import pandas_udf, udf
 from pyspark.sql.types import (
     ArrayType,
     DoubleType,
@@ -55,9 +56,9 @@ class CogroupedApplyInPandasTestsMixin:
     def data1(self):
         return (
             self.spark.range(10)
-            .withColumn("ks", array([lit(i) for i in range(20, 30)]))
-            .withColumn("k", explode(col("ks")))
-            .withColumn("v", col("k") * 10)
+            .withColumn("ks", sf.array([sf.lit(i) for i in range(20, 30)]))
+            .withColumn("k", sf.explode(sf.col("ks")))
+            .withColumn("v", sf.col("k") * 10)
             .drop("ks")
         )
 
@@ -65,9 +66,9 @@ class CogroupedApplyInPandasTestsMixin:
     def data2(self):
         return (
             self.spark.range(10)
-            .withColumn("ks", array([lit(i) for i in range(20, 30)]))
-            .withColumn("k", explode(col("ks")))
-            .withColumn("v2", col("k") * 100)
+            .withColumn("ks", sf.array([sf.lit(i) for i in range(20, 30)]))
+            .withColumn("k", sf.explode(sf.col("ks")))
+            .withColumn("v2", sf.col("k") * 100)
             .drop("ks")
         )
 
@@ -75,15 +76,15 @@ class CogroupedApplyInPandasTestsMixin:
         self._test_merge(self.data1, self.data2)
 
     def test_left_group_empty(self):
-        left = self.data1.where(col("id") % 2 == 0)
+        left = self.data1.where(sf.col("id") % 2 == 0)
         self._test_merge(left, self.data2)
 
     def test_right_group_empty(self):
-        right = self.data2.where(col("id") % 2 == 0)
+        right = self.data2.where(sf.col("id") % 2 == 0)
         self._test_merge(self.data1, right)
 
     def test_different_schemas(self):
-        right = self.data2.withColumn("v3", lit("a"))
+        right = self.data2.withColumn("v3", sf.lit("a"))
         self._test_merge(
             self.data1, right, output_schema="id long, k int, v int, v2 int, v3 string"
         )
@@ -116,9 +117,9 @@ class CogroupedApplyInPandasTestsMixin:
 
         right = pd.DataFrame.from_dict({"id": [11, 12, 13], "k": [5, 6, 7], "v2": [90, 100, 110]})
 
-        left_gdf = self.spark.createDataFrame(left).groupby(col("id") % 2 == 0)
+        left_gdf = self.spark.createDataFrame(left).groupby(sf.col("id") % 2 == 0)
 
-        right_gdf = self.spark.createDataFrame(right).groupby(col("id") % 2 == 0)
+        right_gdf = self.spark.createDataFrame(right).groupby(sf.col("id") % 2 == 0)
 
         def merge_pandas(lft, rgt):
             return pd.merge(lft[["k", "v"]], rgt[["k", "v2"]], on=["k"])
@@ -354,11 +355,11 @@ class CogroupedApplyInPandasTestsMixin:
         self._test_with_key(self.data1, self.data1, isLeft=False)
 
     def test_with_key_left_group_empty(self):
-        left = self.data1.where(col("id") % 2 == 0)
+        left = self.data1.where(sf.col("id") % 2 == 0)
         self._test_with_key(left, self.data1, isLeft=True)
 
     def test_with_key_right_group_empty(self):
-        right = self.data1.where(col("id") % 2 == 0)
+        right = self.data1.where(sf.col("id") % 2 == 0)
         self._test_with_key(self.data1, right, isLeft=False)
 
     def test_with_key_complex(self):
@@ -366,8 +367,8 @@ class CogroupedApplyInPandasTestsMixin:
             return lft.assign(key=key[0])
 
         result = (
-            self.data1.groupby(col("id") % 2 == 0)
-            .cogroup(self.data2.groupby(col("id") % 2 == 0))
+            self.data1.groupby(sf.col("id") % 2 == 0)
+            .cogroup(self.data2.groupby(sf.col("id") % 2 == 0))
             .applyInPandas(left_assign_key, "id long, k int, v int, key boolean")
             .sort(["id", "k"])
             .toPandas()
@@ -456,7 +457,9 @@ class CogroupedApplyInPandasTestsMixin:
         left_df = df.withColumnRenamed("value", "left").repartition(parts).cache()
         # SPARK-42132: this bug requires us to alias all columns from df here
         right_df = (
-            df.select(col("id").alias("id"), col("day").alias("day"), col("value").alias("right"))
+            df.select(
+                sf.col("id").alias("id"), sf.col("day").alias("day"), sf.col("value").alias("right")
+            )
             .repartition(parts)
             .cache()
         )
@@ -465,9 +468,9 @@ class CogroupedApplyInPandasTestsMixin:
         window = Window.partitionBy("day", "id")
 
         left_grouped_df = left_df.groupBy("id", "day")
-        right_grouped_df = right_df.withColumn("day_sum", sum(col("day")).over(window)).groupBy(
-            "id", "day"
-        )
+        right_grouped_df = right_df.withColumn(
+            "day_sum", sf.sum(sf.col("day")).over(window)
+        ).groupBy("id", "day")
 
         def cogroup(left: pd.DataFrame, right: pd.DataFrame) -> pd.DataFrame:
             return pd.DataFrame(
@@ -652,6 +655,60 @@ class CogroupedApplyInPandasTestsMixin:
         # Test fn as is, cf. _test_merge_error
         with self.assertRaisesRegex(errorClass, error_message_regex):
             self.__test_merge(left, right, by, fn, output_schema)
+
+    def test_arrow_batch_slicing(self):
+        df1 = self.spark.range(10000000).select(
+            (sf.col("id") % 2).alias("key"), sf.col("id").alias("v")
+        )
+        cols = {f"col_{i}": sf.col("v") + i for i in range(10)}
+        df1 = df1.withColumns(cols)
+
+        df2 = self.spark.range(100000).select(
+            (sf.col("id") % 4).alias("key"), sf.col("id").alias("v")
+        )
+        cols = {f"col_{i}": sf.col("v") + i for i in range(20)}
+        df2 = df2.withColumns(cols)
+
+        def summarize(key, left, right):
+            assert len(left) == 10000000 / 2 or len(left) == 0, len(left)
+            assert len(right) == 100000 / 4, len(right)
+            return pd.DataFrame(
+                {
+                    "key": [key[0]],
+                    "left_rows": [len(left)],
+                    "left_columns": [len(left.columns)],
+                    "right_rows": [len(right)],
+                    "right_columns": [len(right.columns)],
+                }
+            )
+
+        expected = [
+            Row(key=0, left_rows=5000000, left_columns=12, right_rows=25000, right_columns=22),
+            Row(key=1, left_rows=5000000, left_columns=12, right_rows=25000, right_columns=22),
+            Row(key=2, left_rows=0, left_columns=12, right_rows=25000, right_columns=22),
+            Row(key=3, left_rows=0, left_columns=12, right_rows=25000, right_columns=22),
+        ]
+
+        for maxRecords, maxBytes in [(1000, 2**31 - 1), (0, 1048576), (1000, 1048576)]:
+            with self.subTest(maxRecords=maxRecords, maxBytes=maxBytes):
+                with self.sql_conf(
+                    {
+                        "spark.sql.execution.arrow.maxRecordsPerBatch": maxRecords,
+                        "spark.sql.execution.arrow.maxBytesPerBatch": maxBytes,
+                    }
+                ):
+                    result = (
+                        df1.groupby("key")
+                        .cogroup(df2.groupby("key"))
+                        .applyInPandas(
+                            summarize,
+                            schema="key long, left_rows long, left_columns long, right_rows long, right_columns long",
+                        )
+                        .sort("key")
+                        .collect()
+                    )
+
+                    self.assertEqual(expected, result)
 
 
 class CogroupedApplyInPandasTests(CogroupedApplyInPandasTestsMixin, ReusedSQLTestCase):

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/CoGroupedArrowPythonRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/CoGroupedArrowPythonRunner.scala
@@ -134,14 +134,14 @@ class CoGroupedArrowPythonRunner(
           }
         }
 
-        var numRowsWrittenInArrowBatch: Int = 0
+        var numRowsInBatch: Int = 0
         if (nextBatchInLeftGroup != null) {
           if (leftGroupArrowWriter == null) {
             leftGroupArrowWriter = ArrowWriterWrapper.createAndStartArrowWriter(leftSchema,
               timeZoneId, pythonExec + " (left)", errorOnDuplicatedFieldNames = true,
               largeVarTypes, dataOut, context)
           }
-          numRowsWrittenInArrowBatch = BatchedPythonArrowInput.writeSizedBatch(
+          numRowsInBatch = BatchedPythonArrowInput.writeSizedBatch(
             leftGroupArrowWriter.arrowWriter,
             leftGroupArrowWriter.streamWriter,
             nextBatchInLeftGroup,
@@ -159,7 +159,7 @@ class CoGroupedArrowPythonRunner(
               timeZoneId, pythonExec + " (right)", errorOnDuplicatedFieldNames = true,
               largeVarTypes, dataOut, context)
           }
-          numRowsWrittenInArrowBatch = BatchedPythonArrowInput.writeSizedBatch(
+          numRowsInBatch = BatchedPythonArrowInput.writeSizedBatch(
             rightGroupArrowWriter.arrowWriter,
             rightGroupArrowWriter.streamWriter,
             nextBatchInRightGroup,
@@ -176,7 +176,7 @@ class CoGroupedArrowPythonRunner(
 
         // With CoGroupedIterator, we can have empty groups for one of the sides if a grouping
         // key exists in one side but not in the other side.
-        assert(numRowsWrittenInArrowBatch <= maxRecordsPerBatch)
+        assert(0 <= numRowsInBatch && numRowsInBatch <= maxRecordsPerBatch, numRowsInBatch)
         val deltaData = dataOut.size() - startData
         pythonMetrics("pythonDataSent") += deltaData
         true

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/CoGroupedArrowPythonRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/CoGroupedArrowPythonRunner.scala
@@ -19,17 +19,13 @@ package org.apache.spark.sql.execution.python
 
 import java.io.DataOutputStream
 
-import org.apache.arrow.vector.VectorSchemaRoot
-import org.apache.arrow.vector.ipc.ArrowStreamWriter
-
 import org.apache.spark.{SparkEnv, TaskContext}
 import org.apache.spark.api.python.{BasePythonRunner, ChainedPythonFunctions, PythonRDD, PythonWorker}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.execution.arrow.ArrowWriter
+import org.apache.spark.sql.execution.arrow.ArrowWriterWrapper
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.util.ArrowUtils
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.Utils
 
@@ -68,6 +64,12 @@ class CoGroupedArrowPythonRunner(
   override val hideTraceback: Boolean = SQLConf.get.pysparkHideTraceback
   override val simplifiedTraceback: Boolean = SQLConf.get.pysparkSimplifiedTraceback
 
+  private val maxRecordsPerBatch: Int = {
+    val v = SQLConf.get.arrowMaxRecordsPerBatch
+    if (v > 0) v else Int.MaxValue
+  }
+  private val maxBytesPerBatch: Long = SQLConf.get.arrowMaxBytesPerBatch
+
   protected def newWriter(
       env: SparkEnv,
       worker: PythonWorker,
@@ -76,6 +78,11 @@ class CoGroupedArrowPythonRunner(
       context: TaskContext): Writer = {
 
     new Writer(env, worker, inputIterator, partitionIndex, context) {
+
+      private var nextBatchInLeftGroup: Iterator[InternalRow] = null
+      private var nextBatchInRightGroup: Iterator[InternalRow] = null
+      private var leftGroupArrowWriter: ArrowWriterWrapper = null
+      private var rightGroupArrowWriter: ArrowWriterWrapper = null
 
       protected override def writeCommand(dataOut: DataOutputStream): Unit = {
 
@@ -89,52 +96,90 @@ class CoGroupedArrowPythonRunner(
         PythonUDFRunner.writeUDFs(dataOut, funcs, argOffsets, profiler)
       }
 
-      override def writeNextInputToStream(dataOut: DataOutputStream): Boolean = {
-        // For each we first send the number of dataframes in each group then send
-        // first df, then send second df.  End of data is marked by sending 0.
-        if (inputIterator.hasNext) {
-          val startData = dataOut.size()
-          dataOut.writeInt(2)
-          val (nextLeft, nextRight) = inputIterator.next()
-          writeGroup(nextLeft, leftSchema, dataOut, "left")
-          writeGroup(nextRight, rightSchema, dataOut, "right")
-
-          val deltaData = dataOut.size() - startData
-          pythonMetrics("pythonDataSent") += deltaData
-          true
-        } else {
-          dataOut.writeInt(0)
-          false
+      private def writeFooterAndCloseArrowWriter(writer: ArrowWriterWrapper): Unit = {
+        Utils.tryWithSafeFinally {
+          // end writes footer to the output stream and doesn't clean any resources.
+          // It could throw exception if the output stream is closed, so it should be
+          // in the try block.
+          writer.streamWriter.end()
+        } {
+          writer.close()
         }
       }
 
-      private def writeGroup(
-          group: Iterator[InternalRow],
-          schema: StructType,
-          dataOut: DataOutputStream,
-          name: String): Unit = {
-        val arrowSchema =
-          ArrowUtils.toArrowSchema(
-            schema, timeZoneId, errorOnDuplicatedFieldNames = true, largeVarTypes = largeVarTypes)
-        val allocator = ArrowUtils.rootAllocator.newChildAllocator(
-          s"stdout writer for $pythonExec ($name)", 0, Long.MaxValue)
-        val root = VectorSchemaRoot.create(arrowSchema, allocator)
-
-        Utils.tryWithSafeFinally {
-          val writer = new ArrowStreamWriter(root, null, dataOut)
-          val arrowWriter = ArrowWriter.create(root)
-          writer.start()
-
-          while (group.hasNext) {
-            arrowWriter.write(group.next())
+      /**
+       * Writes the input iterator to the Arrow stream. We slice the input iterator into multiple
+       * small batches contain at most `arrowMaxRecordsPerBatch` records.
+       */
+      override def writeNextInputToStream(dataOut: DataOutputStream): Boolean = {
+        val startData = dataOut.size()
+        // We use null checks for nextBatchInLeftGroup and nextBatchInRightGroup as a way
+        // to indicate that the iterator has been consumed.
+        // This is because the inputIterator can output empty iterators that need to be
+        // written to the stream.
+        if (nextBatchInLeftGroup == null && nextBatchInRightGroup == null) {
+          if (inputIterator.hasNext) {
+            // For each cogroup,
+            // first send the number of dataframes in each group,
+            // then send first df, then send second df.
+            // End of data is marked by sending 0.
+            dataOut.writeInt(2)
+            val (nextLeft, nextRight) = inputIterator.next()
+            nextBatchInLeftGroup = nextLeft
+            nextBatchInRightGroup = nextRight
+          } else {
+            // All the input has been consumed.
+            dataOut.writeInt(0)
+            return false
           }
-          arrowWriter.finish()
-          writer.writeBatch()
-          writer.end()
-        }{
-          root.close()
-          allocator.close()
         }
+
+        var numRowsWrittenInArrowBatch: Int = 0
+        if (nextBatchInLeftGroup != null) {
+          if (leftGroupArrowWriter == null) {
+            leftGroupArrowWriter = ArrowWriterWrapper.createAndStartArrowWriter(leftSchema,
+              timeZoneId, pythonExec + " (left)", errorOnDuplicatedFieldNames = true,
+              largeVarTypes, dataOut, context)
+          }
+          numRowsWrittenInArrowBatch = BatchedPythonArrowInput.writeSizedBatch(
+            leftGroupArrowWriter.arrowWriter,
+            leftGroupArrowWriter.streamWriter,
+            nextBatchInLeftGroup,
+            maxBytesPerBatch,
+            maxRecordsPerBatch)
+
+          if (!nextBatchInLeftGroup.hasNext) {
+            writeFooterAndCloseArrowWriter(leftGroupArrowWriter)
+            nextBatchInLeftGroup = null
+            leftGroupArrowWriter = null
+          }
+        } else if (nextBatchInRightGroup != null) {
+          if (rightGroupArrowWriter == null) {
+            rightGroupArrowWriter = ArrowWriterWrapper.createAndStartArrowWriter(rightSchema,
+              timeZoneId, pythonExec + " (right)", errorOnDuplicatedFieldNames = true,
+              largeVarTypes, dataOut, context)
+          }
+          numRowsWrittenInArrowBatch = BatchedPythonArrowInput.writeSizedBatch(
+            rightGroupArrowWriter.arrowWriter,
+            rightGroupArrowWriter.streamWriter,
+            nextBatchInRightGroup,
+            maxBytesPerBatch,
+            maxRecordsPerBatch)
+          if (!nextBatchInRightGroup.hasNext) {
+            writeFooterAndCloseArrowWriter(rightGroupArrowWriter)
+            nextBatchInRightGroup = null
+            rightGroupArrowWriter = null
+          }
+        } else {
+          assert(assertion = false, "Either left or right iterator must be non-empty.")
+        }
+
+        // With CoGroupedIterator, we can have empty groups for one of the sides if a grouping
+        // key exists in one side but not in the other side.
+        assert(numRowsWrittenInArrowBatch <= maxRecordsPerBatch)
+        val deltaData = dataOut.size() - startData
+        pythonMetrics("pythonDataSent") += deltaData
+        true
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonArrowInput.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonArrowInput.scala
@@ -170,6 +170,7 @@ private[python] trait BatchedPythonArrowInput extends BasicPythonArrowInput {
 
       val numRowsInBatch = BatchedPythonArrowInput.writeSizedBatch(
         arrowWriter, writer, nextBatchStart, maxBytesPerBatch, maxRecordsPerBatch)
+      assert(0 < numRowsInBatch && numRowsInBatch <= maxRecordsPerBatch, numRowsInBatch)
 
       val deltaData = dataOut.size() - startData
       pythonMetrics("pythonDataSent") += deltaData
@@ -219,12 +220,8 @@ private[python] object BatchedPythonArrowInput {
       arrowWriter.write(rowIter.next())
       numRowsInBatch += 1
     }
-
-    assert(numRowsInBatch > 0)
-    assert(numRowsInBatch <= maxRecordsPerBatch)
     arrowWriter.finish()
     writer.writeBatch()
-
     arrowWriter.reset()
     numRowsInBatch
   }
@@ -271,8 +268,7 @@ private[python] trait GroupedPythonArrowInput { self: RowInputArrowPythonRunner 
             // the TaskCompletionListener.
             writer.close()
           }
-          assert(numRowsInBatch > 0)
-          assert(numRowsInBatch <= maxRecordsPerBatch)
+          assert(0 < numRowsInBatch && numRowsInBatch <= maxRecordsPerBatch, numRowsInBatch)
           val deltaData = dataOut.size() - startData
           pythonMetrics("pythonDataSent") += deltaData
           true


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Limit Arrow batch sizes in CoGrouped applyInPandas and applyInArrow


### Why are the changes needed?
to mitigate JVM side OOM


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
added test

### Was this patch authored or co-authored using generative AI tooling?
No