### PR TITLE
[SPARK-47836][SQL] Use doubles sketch replace the GK algorithm for ap…

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentileSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentileSuite.scala
@@ -426,12 +426,19 @@ class ApproximatePercentileSuite extends SparkFunSuite {
   }
 
   private def compareEquals(left: PercentileDigest, right: PercentileDigest): Boolean = {
-    val leftSummary = left.quantileSummaries
-    val rightSummary = right.quantileSummaries
-    leftSummary.compressThreshold == rightSummary.compressThreshold &&
-      leftSummary.relativeError == rightSummary.relativeError &&
-      leftSummary.count == rightSummary.count &&
-      leftSummary.sampled.sameElements(rightSummary.sampled)
+    val leftSketch = left.sketchInfo
+    val rightSketch = right.sketchInfo
+    if (leftSketch.isEmpty && rightSketch.isEmpty) {
+      true
+    } else if (leftSketch.isEmpty || rightSketch.isEmpty) {
+      false
+    } else {
+      leftSketch.getK == rightSketch.getK &&
+        leftSketch.getMaxItem == rightSketch.getMaxItem &&
+        leftSketch.getMinItem == rightSketch.getMinItem &&
+        leftSketch.getN == rightSketch.getN &&
+        leftSketch.toByteArray(false).sameElements(rightSketch.toByteArray(false))
+    }
   }
 
   private def assertEqual[T](left: T, right: T): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql
 import java.sql.{Date, Timestamp}
 import java.time.{Duration, LocalDateTime, Period}
 
-import org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile
 import org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile.DEFAULT_PERCENTILE_ACCURACY
 import org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile.PercentileDigest
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -291,18 +290,6 @@ class ApproximatePercentileQuerySuite extends QueryTest with SharedSparkSession 
     }
   }
 
-  test("SPARK-24013: unneeded compress can cause performance issues with sorted input") {
-    val buffer = new PercentileDigest(1.0D / ApproximatePercentile.DEFAULT_PERCENTILE_ACCURACY)
-    var compressCounts = 0
-    (1 to 10000000).foreach { i =>
-      buffer.add(i)
-      if (buffer.isCompressed) compressCounts += 1
-    }
-    assert(compressCounts > 0)
-    buffer.quantileSummaries
-    assert(buffer.isCompressed)
-  }
-
   test("SPARK-32908: maximum target error in percentile_approx") {
     withTempView(table) {
       spark.read
@@ -318,7 +305,7 @@ class ApproximatePercentileQuerySuite extends QueryTest with SharedSparkSession 
              |  percentile_approx(col, 0.77, 100000),
              |  percentile_approx(col, 0.77, 1000000)
              |FROM $table""".stripMargin),
-        Row(18, 17, 17, 17))
+        Row(17, 17, 17, 17))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -1182,8 +1182,8 @@ class DataFrameAggregateSuite extends QueryTest
         approx_percentile(col("earnings"), lit(0.3), lit(1)),
         approx_percentile(col("earnings"), array(lit(0.3), lit(0.6)), lit(1))
       ),
-      Row("Java", 20000.0, Seq(20000.0, 30000.0), 20000.0, Seq(20000.0, 20000.0)) ::
-        Row("dotNET", 5000.0, Seq(5000.0, 10000.0), 5000.0, Seq(5000.0, 5000.0)) :: Nil
+      Row("Java", 20000.0, Seq(20000.0, 30000.0), 20000.0, Seq(20000.0, 30000.0)) ::
+        Row("dotNET", 5000.0, Seq(5000.0, 10000.0), 5000.0, Seq(5000.0, 10000.0)) :: Nil
     )
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
@@ -270,19 +270,29 @@ class DataFrameStatSuite extends QueryTest with SharedSparkSession {
     val Array(s1_1, s2_1) = df.stat.approxQuantile("singles", Array(q1, q2), 1.0)
     val Array(Array(ms1_1, ms2_1), Array(md1_1, md2_1)) =
       df.stat.approxQuantile(Array("singles", "doubles"), Array(q1, q2), 1.0)
+    val errorSingle = 1000 * 1.0
+    val errorDouble = 2.0 * errorSingle
+
+    assert(math.abs(single1_1 - q1 * n) <= errorSingle)
+    assert(math.abs(s1_1 - q1 * n) <= errorSingle)
+    assert(math.abs(s2_1 - q2 * n) <= errorSingle)
+    assert(math.abs(ms1_1 - q1 * n) <= errorSingle)
+    assert(math.abs(ms2_1 - q2 * n) <= errorSingle)
+    assert(math.abs(md1_1 - 2 * q1 * n) <= errorDouble)
+    assert(math.abs(md2_1 - 2 * q2 * n) <= errorDouble)
 
     for (epsilon <- epsilons) {
       val Array(single1) = df.stat.approxQuantile("singles", Array(q1), epsilon)
       val Array(s1, s2) = df.stat.approxQuantile("singles", Array(q1, q2), epsilon)
       val Array(Array(ms1, ms2), Array(md1, md2)) =
         df.stat.approxQuantile(Array("singles", "doubles"), Array(q1, q2), epsilon)
-      assert(single1_1 === single1)
-      assert(s1_1 === s1)
-      assert(s2_1 === s2)
-      assert(ms1_1 === ms1)
-      assert(ms2_1 === ms2)
-      assert(md1_1 === md1)
-      assert(md2_1 === md2)
+      assert(math.abs(single1 - q1 * n) <= errorSingle)
+      assert(math.abs(s1 - q1 * n) <= errorSingle)
+      assert(math.abs(s2 - q2 * n) <= errorSingle)
+      assert(math.abs(ms1 - q1 * n) <= errorSingle)
+      assert(math.abs(ms2 - q2 * n) <= errorSingle)
+      assert(math.abs(md1 - 2 * q1 * n) <= errorDouble)
+      assert(math.abs(md2 - 2 * q2 * n) <= errorDouble)
     }
   }
 


### PR DESCRIPTION
…proximate quantile computation, significantly improving merge performance

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Use datasketches qualifie to replace spark default GK algorithm for speed up ApproximatePercentile performance
https://datasketches.apache.org/
https://github.com/apache/datasketches-java
i found that spark has use datasketches before, but why not replace approximate qualifie with datasketches?

### Why are the changes needed?
https://issues.apache.org/jira/browse/SPARK-47836
https://issues.apache.org/jira/browse/SPARK-46706
https://issues.apache.org/jira/browse/SPARK-40499
multipe issues has reported spark3.x ApproximatePercentile performance problem, which introduce from this bug fix:https://issues.apache.org/jira/browse/SPARK-29336
the performance problem is because GK algorithm is not designed for distruibuted system, it's merge performance is bad, higher upstream stage parallelism leads to worse performance.
<img width="2554" height="1137" alt="image" src="https://github.com/user-attachments/assets/a22b050a-4c42-458f-8ad6-831439e41dcc" />


Use our produce env spark job as example, it deal with 60 billion records as source input, then sample with ratio 0.06, group by key (key has 4 distinct records), then calculate 1 to 100 percentile with accuracy 999 for 40 columns with spark conf spark.sql.shuffle.partitions=2000, each executor memory is 28g cores is 6
run with spark-2.4.3 the final merge stage cost is 5min
run with spark-3.5.2 the final merge stage cost  is 2.8h
<img width="1084" height="143" alt="image" src="https://github.com/user-attachments/assets/fd4195f3-49d2-4dcb-9154-ef7f3bb1e069" />

adjust spark.sql.shuffle.partitions to 500
run with spark-3.5.2 the final merge stage cost  is 11min, but because the data is big, the upstream stage time cost will be increase a lot, and more data is spill to disk
<img width="2471" height="450" alt="image" src="https://github.com/user-attachments/assets/f725f376-1132-40a1-9007-a4a704fdff98" />


when use datasketches qualifie 
run with spark-3.5.2 the final merge stage cost  is less than 1min with conf spark.sql.shuffle.partitions=2000
<img width="1212" height="118" alt="image" src="https://github.com/user-attachments/assets/78db9fe9-3455-4c0b-90cc-86606a02acd1" />


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
var values = (1 to 100).toArray
var percents = (1 to 100).toArray
val all_quantiles = percents.indices.map(i => (i+1).toDouble / percents.length).toArray
val all_quantiles_str = s"ARRAY(${all_quantiles.toList.mkString(",")})"
for (n <- 0 until 5) {
  var df = spark.sparkContext.makeRDD(values).toDF("value").repartition(5)
  df.createOrReplaceTempView("data_table")
  var sql = s"select PERCENTILE_APPROX(cast(value as DOUBLE), $all_quantiles_str, 90) as values from data_table"
  val all_answers = spark.sql(sql).collect
  val all_answered_ranks = all_answers.map(ans => values.indexOf(ans)).toArray
  val error = all_answered_ranks.zipWithIndex.map({ case (answer, expected) => Math.abs(expected - answer) }).toArray
  val max_error = error.max
  print(max_error + "\n")
}
test code above  the max_error is always 1, which is good than expect

var values = (1 to 10000).toArray
var percents = (1 to 100).toArray
val all_quantiles = percents.indices.map(i => (i+1).toDouble / percents.length).toArray
val all_quantiles_str = s"ARRAY(${all_quantiles.toList.mkString(",")})"
for (n <- 0 until 5) {
  var df = spark.sparkContext.makeRDD(values).toDF("value").repartition(5)
  df.createOrReplaceTempView("data_table")
  var sql = s"select PERCENTILE_APPROX(cast(value as DOUBLE), $all_quantiles_str, 9999) as values from data_table"
  val all_answers = spark.sql(sql).collect
  val all_answered_ranks = all_answers.map(ans => values.indexOf(ans)).toArray
  val error = all_answered_ranks.zipWithIndex.map({ case (answer, expected) => Math.abs(expected*100 - answer) }).toArray
  val max_error = error.max
  print(max_error + "\n")
}

test code above  the max_error is always 1, which is as expect

also test with user produce env job for performance check


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No