### PR TITLE
[SPARK-53966][CORE][FOLLOWUP] Support `is(Serial|Parallel)GC`

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -3136,6 +3136,16 @@ private[spark] object Utils
   }
 
   /**
+   * Return whether we are using SerialGC or not
+   */
+  lazy val isSerialGC: Boolean = checkUseGC("UseSerialGC")
+
+  /**
+   * Return whether we are using ParallelGC or not
+   */
+  lazy val isParallelGC: Boolean = checkUseGC("UseParallelGC")
+
+  /**
    * Return whether we are using G1GC or not
    */
   lazy val isG1GC: Boolean = checkUseGC("UseG1GC")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `isSerialGC` and `isParallelGC` additionally as a follow-up of the following PR.
- #52678 

### Why are the changes needed?

- To be exhaustive (up to Java 25 environment)
- Note that `UseEpsilonGC` is excluded because it's not a production-purpose GC.

### Does this PR introduce _any_ user-facing change?

No, these are new APIs.

### How was this patch tested?

Pass the CIs and manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.