### PR TITLE
[SPARK-54005][CORE][TESTS] Remove no-op `spark.shuffle.blockTransferService` configuration

### DIFF
--- a/core/src/test/scala/org/apache/spark/ShuffleNettySuite.scala
+++ b/core/src/test/scala/org/apache/spark/ShuffleNettySuite.scala
@@ -31,7 +31,6 @@ abstract class ShuffleNettySuite extends ShuffleSuite with BeforeAndAfterAll {
   def shouldRunTests: Boolean = true
   override def beforeAll(): Unit = {
     super.beforeAll()
-    conf.set("spark.shuffle.blockTransferService", "netty")
     conf.set("spark.shuffle.io.mode", ioMode.toString)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove no-op `spark.shuffle.blockTransferService` configuration from Apache Spark code based.

### Why are the changes needed?

The configuration was removed at Apache Spark 1.6.0.
- #8161 

### Does this PR introduce _any_ user-facing change?

No, this is a clean up of unused test code.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.