### PR TITLE
[MINOR][CORE] Remove invalid `NioBlockTransferService` comment

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -2184,7 +2184,7 @@ private[spark] class BlockManager(
     decommissioner.foreach(_.stop())
     blockTransferService.close()
     if (blockStoreClient ne blockTransferService) {
-      // Closing should be idempotent, but maybe not for the NioBlockTransferService.
+      // Closing should be idempotent
       blockStoreClient.close()
     }
     remoteBlockTempFileManager.stop()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove invalid comment about `NioBlockTransferService`.

### Why are the changes needed?

`NioBlockTransferService` was deprecated at Apache Spark 1.5.0 and removed at 1.6.0.

### Does this PR introduce _any_ user-facing change?

No, this is a removal of comment.

### How was this patch tested?

Manual review.

**BEFORE**

```
$ git grep -i NioBlockTransferService | wc -l
       1
```

**AFTER**

```
$ git grep -i NioBlockTransferService | wc -l
       0
```

### Was this patch authored or co-authored using generative AI tooling?

No.