### PR TITLE
[SPARK-54007][CORE][SQL] Use Java `Set.of` instead of `Collections.emptySet`

### DIFF
--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/CleanupNonShuffleServiceServedFilesSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/CleanupNonShuffleServiceServedFilesSuite.java
@@ -67,7 +67,7 @@ public class CleanupNonShuffleServiceServedFilesSuite {
 
   @Test
   public void cleanupOnRemovedExecutorWithoutFilesToKeep() throws IOException {
-    cleanupOnRemovedExecutor(false, getConf(true), Collections.emptySet());
+    cleanupOnRemovedExecutor(false, getConf(true), Set.of());
   }
 
   private void cleanupOnRemovedExecutor(
@@ -124,7 +124,7 @@ public class CleanupNonShuffleServiceServedFilesSuite {
 
   @Test
   public void cleanupOnlyRemovedExecutorWithoutFilesToKeep() throws IOException {
-    cleanupOnlyRemovedExecutor(false, getConf(true) , Collections.emptySet());
+    cleanupOnlyRemovedExecutor(false, getConf(true) , Set.of());
   }
 
   private void cleanupOnlyRemovedExecutor(
@@ -170,7 +170,7 @@ public class CleanupNonShuffleServiceServedFilesSuite {
 
   @Test
   public void cleanupOnlyRegisteredExecutorWithoutFilesToKeep() throws IOException {
-    cleanupOnlyRegisteredExecutor(false, getConf(true), Collections.emptySet());
+    cleanupOnlyRegisteredExecutor(false, getConf(true), Set.of());
   }
 
   private void cleanupOnlyRegisteredExecutor(

--- a/common/utils-java/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/utils-java/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -367,7 +367,7 @@ public class JavaUtils {
 
   public static Set<Path> listPaths(File dir) throws IOException {
     if (dir == null) throw new IllegalArgumentException("Input directory is null");
-    if (!dir.exists() || !dir.isDirectory()) return Collections.emptySet();
+    if (!dir.exists() || !dir.isDirectory()) return Set.of();
     try (var stream = Files.walk(dir.toPath(), FileVisitOption.FOLLOW_LINKS)) {
       return stream.filter(Files::isRegularFile).collect(Collectors.toCollection(HashSet::new));
     }
@@ -375,7 +375,7 @@ public class JavaUtils {
 
   public static Set<File> listFiles(File dir) throws IOException {
     if (dir == null) throw new IllegalArgumentException("Input directory is null");
-    if (!dir.exists() || !dir.isDirectory()) return Collections.emptySet();
+    if (!dir.exists() || !dir.isDirectory()) return Set.of();
     try (var stream = Files.walk(dir.toPath(), FileVisitOption.FOLLOW_LINKS)) {
       return stream
         .filter(Files::isRegularFile)

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.avro
 
 import java.util
-import java.util.Collections
+import java.util.Set
 
 import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericData, GenericRecordBuilder}
@@ -329,7 +329,7 @@ class AvroCatalystDataConversionSuite extends SparkFunSuite
       checkDeserialization(avroSchema, reEncoded, Some(expected))
     }
 
-    validateDeserialization(Collections.emptySet())
+    validateDeserialization(Set.of())
     validateDeserialization(util.Arrays.asList(1, null, 3))
   }
 

--- a/connector/spark-ganglia-lgpl/src/main/java/com/codahale/metrics/ganglia/GangliaReporter.java
+++ b/connector/spark-ganglia-lgpl/src/main/java/com/codahale/metrics/ganglia/GangliaReporter.java
@@ -61,7 +61,7 @@ public class GangliaReporter extends ScheduledReporter {
         private MetricFilter filter;
         private ScheduledExecutorService executor;
         private boolean shutdownExecutorOnStop;
-        private Set<MetricAttribute> disabledMetricAttributes = Collections.emptySet();
+        private Set<MetricAttribute> disabledMetricAttributes = Set.of();
 
         private Builder(MetricRegistry registry) {
             this.registry = registry;

--- a/core/src/main/scala/org/apache/spark/storage/BlockInfoManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockInfoManager.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.storage
 
 import java.util
-import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.{Condition, Lock}
 
@@ -478,7 +477,7 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
   def releaseAllLocksForTask(taskAttemptId: TaskAttemptId): Seq[BlockId] = {
     val blocksWithReleasedLocks = mutable.ArrayBuffer[BlockId]()
 
-    val writeLocks = Option(writeLocksByTask.remove(taskAttemptId)).getOrElse(Collections.emptySet)
+    val writeLocks = Option(writeLocksByTask.remove(taskAttemptId)).getOrElse(util.Set.of())
     writeLocks.forEach { blockId =>
       blockInfo(blockId) { (info, condition) =>
         assert(info.writerTask == taskAttemptId)

--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -283,6 +283,10 @@
             <property name="message" value="Use Set.of instead." />
         </module>
         <module name="RegexpSinglelineJava">
+            <property name="format" value="Collections\.emptySet"/>
+            <property name="message" value="Use Set.of() instead." />
+        </module>
+        <module name="RegexpSinglelineJava">
             <property name="format" value="Throwables\.getStackTraceAsString"/>
             <property name="message" value="Use stackTraceToString of JavaUtils/SparkFileUtils/Utils instead." />
         </module>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -797,6 +797,11 @@ This file is divided into 3 sections:
     <customMessage>Use java.util.Set.of instead.</customMessage>
   </check>
 
+  <check customId="emptySet" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bCollections\.emptySet\b</parameter></parameters>
+    <customMessage>Use java.util.Set.of() instead.</customMessage>
+  </check>
+
   <check customId="maputils" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">org\.apache\.commons\.collections4\.MapUtils\b</parameter></parameters>
     <customMessage>Use org.apache.spark.util.collection.Utils instead.</customMessage>

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableCatalog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableCatalog.java
@@ -27,7 +27,6 @@ import org.apache.spark.sql.errors.QueryExecutionErrors;
 import org.apache.spark.sql.types.StructType;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -96,7 +95,7 @@ public interface TableCatalog extends CatalogPlugin {
   /**
    * @return the set of capabilities for this TableCatalog
    */
-  default Set<TableCatalogCapability> capabilities() { return Collections.emptySet(); }
+  default Set<TableCatalogCapability> capabilities() { return Set.of(); }
 
   /**
    * List the tables in a namespace from the catalog.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -67,7 +67,7 @@ object SQLConf {
   private[this] val staticConfKeysUpdateLock = new Object
 
   @volatile
-  private[this] var staticConfKeys: java.util.Set[String] = util.Collections.emptySet()
+  private[this] var staticConfKeys: util.Set[String] = util.Set.of()
 
   private def register(entry: ConfigEntry[_]): Unit = sqlConfEntriesUpdateLock.synchronized {
     require(!sqlConfEntries.containsKey(entry.key),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/EnumTypeSetBenchmark.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/EnumTypeSetBenchmark.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.connector.catalog
 
 import java.util
-import java.util.Collections
 
 import scala.jdk.CollectionConverters._
 
@@ -38,7 +37,7 @@ import org.apache.spark.sql.connector.catalog.TableCapability._
  */
 object EnumTypeSetBenchmark extends BenchmarkBase {
 
-  def emptyHashSet(): util.Set[TableCapability] = Collections.emptySet()
+  def emptyHashSet(): util.Set[TableCapability] = util.Set.of()
 
   def emptyEnumSet(): util.Set[TableCapability] =
     util.EnumSet.noneOf(classOf[TableCapability])

--- a/streaming/src/test/java/org/apache/spark/streaming/JavaMapWithStateSuite.java
+++ b/streaming/src/test/java/org/apache/spark/streaming/JavaMapWithStateSuite.java
@@ -105,18 +105,18 @@ public class JavaMapWithStateSuite extends LocalJavaStreamingContext implements 
     );
 
     List<Set<Integer>> outputData = Arrays.asList(
-        Collections.emptySet(),
+        Set.of(),
         Set.of(1),
         Set.of(2, 1),
         Set.of(3, 2, 1),
         Set.of(4, 3),
         Set.of(5),
-        Collections.emptySet()
+        Set.of()
     );
 
     @SuppressWarnings("unchecked")
     List<Set<Tuple2<String, Integer>>> stateData = Arrays.asList(
-        Collections.emptySet(),
+        Set.of(),
         Set.of(new Tuple2<>("a", 1)),
         Set.of(new Tuple2<>("a", 2), new Tuple2<>("b", 1)),
         Set.of(new Tuple2<>("a", 3), new Tuple2<>("b", 2), new Tuple2<>("c", 1)),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java 9+ `Set.of()` API instead of `Collections.emptySet()` and add Scalastyle and Checkstyle rules.

### Why are the changes needed?

Like `TableCatalog.java` example of this PR, we had better use `Set` simply and uniformly from Apache Spark 4.1.0.

```
- import java.util.Collections;
...
- default Set<TableCatalogCapability> capabilities() { return Collections.emptySet(); }
+ default Set<TableCatalogCapability> capabilities() { return Set.of(); }
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.