### PR TITLE
[SPARK-54011][CORE] Switch direct ctors to IoHandlerFactories for EventLoopGroups

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/NettyUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/NettyUtils.java
@@ -20,16 +20,14 @@ package org.apache.spark.network.util;
 import java.util.concurrent.ThreadFactory;
 
 import io.netty.buffer.PooledByteBufAllocator;
-import io.netty.channel.Channel;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.ServerChannel;
-import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.*;
+import io.netty.channel.epoll.EpollIoHandler;
 import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.epoll.EpollSocketChannel;
-import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.kqueue.KQueueIoHandler;
 import io.netty.channel.kqueue.KQueueServerSocketChannel;
 import io.netty.channel.kqueue.KQueueSocketChannel;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -69,11 +67,12 @@ public class NettyUtils {
   public static EventLoopGroup createEventLoop(IOMode mode, int numThreads, String threadPrefix) {
     ThreadFactory threadFactory = createThreadFactory(threadPrefix);
 
-    return switch (mode) {
-      case NIO -> new NioEventLoopGroup(numThreads, threadFactory);
-      case EPOLL -> new EpollEventLoopGroup(numThreads, threadFactory);
-      case KQUEUE ->  new KQueueEventLoopGroup(numThreads, threadFactory);
+    IoHandlerFactory handlerFactory = switch (mode) {
+      case NIO -> NioIoHandler.newFactory();
+      case EPOLL -> EpollIoHandler.newFactory();
+      case KQUEUE -> KQueueIoHandler.newFactory();
     };
+    return new MultiThreadIoEventLoopGroup(numThreads, threadFactory, handlerFactory);
   }
 
   /** Returns the correct (client) SocketChannel class based on IOMode. */


### PR DESCRIPTION


### What changes were proposed in this pull request?
Use IoHandlerFactories for EventLoopGroups instead of deprecated ctors


### Why are the changes needed?
Follow https://netty.io/wiki/netty-4.2-migration-guide.html#new-best-practices

### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?
Passing existing tests


### Was this patch authored or co-authored using generative AI tooling?
no
