### PR TITLE
[SPARK-54003][SQL] Use the staging directory as the output path then move to final path.

### DIFF
--- a/core/src/test/scala/org/apache/spark/internal/io/FileCommitProtocolInstantiationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/io/FileCommitProtocolInstantiationSuite.scala
@@ -119,16 +119,16 @@ private class ClassicConstructorCommitProtocol(arg1: String, arg2: String)
 private class FullConstructorCommitProtocol(
   arg1: String,
   arg2: String,
-  b: Boolean,
+  arg3: String,
   val argCount: Int)
-  extends HadoopMapReduceCommitProtocol(arg1, arg2, b) {
+  extends HadoopMapReduceCommitProtocol(arg1, arg2, arg3) {
 
   def this(arg1: String, arg2: String) = {
-    this(arg1, arg2, false, 2)
+    this(arg1, arg2, "", 2)
   }
 
-  def this(arg1: String, arg2: String, b: Boolean) = {
-    this(arg1, arg2, false, 3)
+  def this(arg1: String, arg2: String, args: String) = {
+    this(arg1, arg2, "", 3)
   }
 }
 

--- a/hadoop-cloud/src/main/scala/org/apache/spark/internal/io/cloud/PathOutputCommitProtocol.scala
+++ b/hadoop-cloud/src/main/scala/org/apache/spark/internal/io/cloud/PathOutputCommitProtocol.scala
@@ -23,8 +23,7 @@ import org.apache.hadoop.fs.{Path, StreamCapabilities}
 import org.apache.hadoop.mapreduce.TaskAttemptContext
 import org.apache.hadoop.mapreduce.lib.output.{FileOutputCommitter, PathOutputCommitter, PathOutputCommitterFactory}
 
-import org.apache.spark.internal.io.FileNameSpec
-import org.apache.spark.internal.io.HadoopMapReduceCommitProtocol
+import org.apache.spark.internal.io.{FileNameSpec, HadoopMapReduceCommitProtocol}
 
 /**
  * Spark Commit protocol for Path Output Committers.
@@ -57,12 +56,9 @@ import org.apache.spark.internal.io.HadoopMapReduceCommitProtocol
 class PathOutputCommitProtocol(
     jobId: String,
     dest: String,
-    dynamicPartitionOverwrite: Boolean = false)
-  extends HadoopMapReduceCommitProtocol(jobId, dest, dynamicPartitionOverwrite)
+    mode: String = "")
+  extends HadoopMapReduceCommitProtocol(jobId, dest, mode)
     with Serializable {
-
-  /** The committer created. */
-  @transient private var committer: PathOutputCommitter = _
 
   require(dest != null, "Null destination specified")
 
@@ -127,7 +123,7 @@ class PathOutputCommitProtocol(
         }
       }
     }
-    committer
+    committer.asInstanceOf[PathOutputCommitter]
   }
 
 
@@ -155,7 +151,7 @@ class PathOutputCommitProtocol(
       dir: Option[String],
       spec: FileNameSpec): String = {
 
-    val workDir = committer.getWorkPath
+    val workDir = committer.asInstanceOf[PathOutputCommitter].getWorkPath
     val parent = dir.map {
       d => new Path(workDir, d)
     }.getOrElse(workDir)
@@ -186,6 +182,8 @@ class PathOutputCommitProtocol(
         s" by committer $committer")
     }
   }
+
+  override def useStagingDir(): Boolean = false
 }
 
 object PathOutputCommitProtocol {

--- a/hadoop-cloud/src/test/scala/org/apache/spark/internal/io/cloud/CommitterBindingSuite.scala
+++ b/hadoop-cloud/src/test/scala/org/apache/spark/internal/io/cloud/CommitterBindingSuite.scala
@@ -110,7 +110,7 @@ class CommitterBindingSuite extends SparkFunSuite {
     val tempDir = File.createTempFile("ser", ".bin")
 
     tempDir.delete()
-    val committer = new PathOutputCommitProtocol(jobId, tempDir.toURI.toString, false)
+    val committer = new PathOutputCommitProtocol(jobId, tempDir.toURI.toString)
 
     val serData = File.createTempFile("ser", ".bin")
     var out: ObjectOutputStream = null

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatDataWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatDataWriter.scala
@@ -172,6 +172,7 @@ class SingleDirectoryDataWriter(
     val currentPath = committer.newTaskTempFile(
       taskAttemptContext,
       None,
+      None,
       FileNameSpec("", f"-c$fileCounter%03d" + ext))
 
     currentWriter = description.outputWriterFactory.newInstance(
@@ -306,9 +307,10 @@ abstract class BaseDynamicPartitionDataWriter(
       description.customPartitionLocations.get(PartitioningUtils.parsePathFragment(dir))
     }
     val currentPath = if (customPath.isDefined) {
-      committer.newTaskTempFileAbsPath(taskAttemptContext, customPath.get, fileNameSpec)
+      assert(partDir.isDefined, "partDir must be defined when using customPath")
+      committer.newTaskTempFile(taskAttemptContext, partDir, customPath, fileNameSpec)
     } else {
-      committer.newTaskTempFile(taskAttemptContext, partDir, fileNameSpec)
+      committer.newTaskTempFile(taskAttemptContext, partDir, None, fileNameSpec)
     }
 
     currentWriter = description.outputWriterFactory.newInstance(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
@@ -149,7 +149,7 @@ abstract class PartitioningAwareFileIndex(
     files.filter(matchPathPattern)
   }
 
-  protected def inferPartitioning(): PartitionSpec = {
+  def inferPartitioning(): PartitionSpec = {
     if (recursiveFileLookup) {
       PartitionSpec.emptySpec
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SQLHadoopMapReduceCommitProtocol.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SQLHadoopMapReduceCommitProtocol.scala
@@ -17,13 +17,20 @@
 
 package org.apache.spark.sql.execution.datasources
 
-import org.apache.hadoop.fs.Path
-import org.apache.hadoop.mapreduce.{OutputCommitter, TaskAttemptContext}
-import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter
+import java.io.IOException
+
+import scala.collection.mutable
+
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.mapreduce.{JobContext, OutputCommitter, TaskAttemptContext}
+import org.apache.hadoop.mapreduce.lib.output.{FileOutputCommitter, FileOutputFormat}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.CLASS_NAME
-import org.apache.spark.internal.io.HadoopMapReduceCommitProtocol
+import org.apache.spark.internal.io.{FileNameSpec, HadoopMapReduceCommitProtocol}
+import org.apache.spark.internal.io.FileCommitProtocol.{DYNAMIC_PARTITION_OVERWRITE, TaskCommitMessage}
+import org.apache.spark.mapred.SparkHadoopMapRedUtil
+import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -33,11 +40,27 @@ import org.apache.spark.sql.internal.SQLConf
 class SQLHadoopMapReduceCommitProtocol(
     jobId: String,
     path: String,
-    dynamicPartitionOverwrite: Boolean = false)
-  extends HadoopMapReduceCommitProtocol(jobId, path, dynamicPartitionOverwrite)
+    mode: String = "")
+  extends HadoopMapReduceCommitProtocol(jobId, path, mode)
     with Serializable with Logging {
 
+  @transient private var addedAbsPath: mutable.Map[String, String] = null
+
+  // For Hive serde, we just need to put the results into the staging directory and
+  // wait for the load partition, so mode is None.
+  protected val saveMode: Option[SaveMode] = mode match {
+    case null | "" => None
+    case m if m.equalsIgnoreCase(DYNAMIC_PARTITION_OVERWRITE) => Some(SaveMode.Overwrite)
+    case m => Some(SaveMode.valueOf(m))
+  }
+
+  override def setupTask(taskContext: TaskAttemptContext): Unit = {
+    super.setupTask(taskContext)
+    addedAbsPath = mutable.Map[String, String]()
+  }
+
   override protected def setupCommitter(context: TaskAttemptContext): OutputCommitter = {
+    saveMode.map(_ => context.getConfiguration().set(FileOutputFormat.OUTDIR, stagingDir.toString))
     var committer = super.setupCommitter(context)
 
     val configuration = context.getConfiguration
@@ -57,7 +80,10 @@ class SQLHadoopMapReduceCommitProtocol(
         // The specified output committer is a FileOutputCommitter.
         // So, we will use the FileOutputCommitter-specified constructor.
         val ctor = clazz.getDeclaredConstructor(classOf[Path], classOf[TaskAttemptContext])
-        val committerOutputPath = if (dynamicPartitionOverwrite) stagingDir else new Path(path)
+        val committerOutputPath = committer match {
+          case f: FileOutputCommitter => f.getOutputPath()
+          case _ => new Path(path)
+        }
         committer = ctor.newInstance(committerOutputPath, context)
       } else {
         // The specified output committer is just an OutputCommitter.
@@ -69,5 +95,145 @@ class SQLHadoopMapReduceCommitProtocol(
     logInfo(log"Using output committer class " +
       log"${MDC(CLASS_NAME, committer.getClass.getCanonicalName)}")
     committer
+  }
+
+  override def newTaskTempFile(taskContext: TaskAttemptContext,
+                               partDir: Option[String],
+                               customPath: Option[String],
+                               spec: FileNameSpec): String = {
+    // For hive serde, we should not move staging file to final location.
+    // We should wait for load partition to do that. So there is no need to
+    // add to addedAbsPath.
+    saveMode.map { _ =>
+      val srcDir = partDir.map { d =>
+        new Path(stagingDir, d).toString
+      }.getOrElse {
+        stagingDir.toString
+      }
+      // For custom partition directory
+      val dstDir = customPath.getOrElse {
+        partDir.map { d =>
+          new Path(path, d).toString
+        }.getOrElse {
+          path
+        }
+      }
+      addedAbsPath(srcDir) = dstDir
+    }
+
+    super.newTaskTempFile(
+      taskContext,
+      partDir,
+      customPath,
+      spec)
+  }
+
+  override def commitTask(taskContext: TaskAttemptContext): TaskCommitMessage = {
+    val attemptId = taskContext.getTaskAttemptID
+    logTrace(s"Commit task ${attemptId}")
+    SparkHadoopMapRedUtil.commitTask(
+      committer, taskContext, attemptId.getJobID.getId, attemptId.getTaskID.getId)
+    new TaskCommitMessage(addedAbsPath.toMap)
+  }
+
+  private def isSubDir(qualifiedPathParent: Path, qualifiedPathChild: Path): Boolean = {
+    Iterator
+      .iterate(qualifiedPathChild)(_.getParent)
+      .takeWhile(_ != null)
+      .exists(_.equals(qualifiedPathParent))
+  }
+
+  private def isDataPath(path: Path): Boolean = {
+    val name = path.getName
+    !(name.equals(FileOutputCommitter.SUCCEEDED_FILE_NAME) || name.startsWith("."))
+  }
+
+  def moveStagedFilesToFinalLocation(fs: FileSystem, stagingPath: Path, finalPath: Path): Unit = {
+    for (file <- fs.listStatus(stagingPath).map(_.getPath)) {
+      val dest = new Path(finalPath, file.getName)
+      if(isDataPath(file) && !fs.rename(file, dest)) {
+        throw new IOException(s"Failed to rename($file, $dest)")
+      }
+    }
+  }
+
+  override def commitJob(jobContext: JobContext, taskCommits: Seq[TaskCommitMessage]): Unit = {
+    committer.commitJob(jobContext)
+
+    if (hasValidPath) {
+      val allAbsPath = taskCommits.map(_.obj.asInstanceOf[Map[String, String]])
+      val fs = stagingDir.getFileSystem(jobContext.getConfiguration)
+
+      val dirToMove = allAbsPath.foldLeft(Map[String, String]())(_ ++ _)
+      logDebug(s"Committing directory staged for absolute locations $dirToMove")
+
+      for ((src, dst) <- dirToMove) {
+        val stagingPath = new Path(src)
+        val finalPath = new Path(dst)
+        assert(!isSubDir(stagingPath, finalPath), "staging path cannot be a parent of final path")
+        val finalPathEmpty = fs.exists(finalPath) match {
+          // final path must be directory if it exists
+          case true => fs.listStatus(finalPath).map(_.getPath).filter(isDataPath(_)).isEmpty
+          case false => true
+        }
+        saveMode match {
+          case Some(SaveMode.ErrorIfExists) if !finalPathEmpty =>
+            throw new IOException(s"Path $finalPath already exists.")
+          case Some(SaveMode.Ignore) if !finalPathEmpty =>
+            logInfo(s"Skip for existing Path $finalPath.")
+          case None => logInfo(s"Skip for hive serde mode.")
+          case Some(SaveMode.Append) if !finalPathEmpty =>
+            // Move staged files to their final locations
+            moveStagedFilesToFinalLocation(fs, stagingPath, finalPath)
+          case _ =>
+            if (isSubDir(finalPath, stagingDir)) {
+              // For non-partitioned data, the stagingDir will be a subdirectory of finalPath.
+              // Firstly, delete all path except non-data path(including staging dir) under
+              // finalPath
+              for (fileStatus <- fs.listStatus(finalPath)) {
+                val childPath = fileStatus.getPath
+                if (isDataPath(childPath) && !isSubDir(childPath, stagingPath)) {
+                  fs.delete(childPath, true)
+                }
+              }
+              // Secondly, move all files from stagingDir to finalPath
+              moveStagedFilesToFinalLocation(fs, stagingPath, finalPath)
+            } else {
+              // According to the official hadoop FileSystem API spec, delete op should assume
+              // the destination is no longer present regardless of return value, thus we do not
+              // need to double check if finalPartPath exists before rename.
+              // Also in our case, based on the spec, delete returns false only when finalPartPath
+              // does not exist. When this happens, we need to take action if parent of
+              // finalPartPath also does not exist(e.g. the scenario described on SPARK-23815),
+              // because FileSystem API spec on rename op says the rename dest(finalPartPath) must
+              // have a parent that exists, otherwise we may get unexpected result on the rename.
+              if (!fs.delete(finalPath, true) && !fs.exists(finalPath.getParent)) {
+                fs.mkdirs(finalPath.getParent)
+              }
+              fs.rename(stagingPath, finalPath)
+            }
+        }
+      }
+      fs.delete(stagingDir, true)
+    }
+  }
+
+  override def abortTask(taskContext: TaskAttemptContext): Unit = {
+    try {
+      committer.abortTask(taskContext)
+    } catch {
+      case e: IOException =>
+        logWarning(s"Exception while aborting ${taskContext.getTaskAttemptID}", e)
+    }
+    // best effort cleanup of other staged files
+    try {
+      for ((src, _) <- addedAbsPath) {
+        val tmp = new Path(src)
+        tmp.getFileSystem(taskContext.getConfiguration).delete(tmp, true)
+      }
+    } catch {
+      case e: IOException =>
+        logWarning(s"Exception while aborting ${taskContext.getTaskAttemptID}", e)
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -1002,8 +1002,8 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
 case class CustomFileCommitProtocol(
     jobId: String,
     path: String,
-    dynamicPartitionOverwrite: Boolean = false)
-  extends SQLHadoopMapReduceCommitProtocol(jobId, path, dynamicPartitionOverwrite) {
+    mode: String = "")
+  extends SQLHadoopMapReduceCommitProtocol(jobId, path, mode) {
   override def commitTask(
       taskContext: TaskAttemptContext): FileCommitProtocol.TaskCommitMessage = {
     Thread.sleep(100)

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
@@ -260,8 +260,8 @@ class PartitionedWriteSuite extends QueryTest with SharedSparkSession {
 private class PartitionFileExistCommitProtocol(
     jobId: String,
     path: String,
-    dynamicPartitionOverwrite: Boolean)
-  extends SQLHadoopMapReduceCommitProtocol(jobId, path, dynamicPartitionOverwrite) {
+    mode: String = "")
+  extends SQLHadoopMapReduceCommitProtocol(jobId, path, mode) {
   override def setupJob(jobContext: JobContext): Unit = {
     super.setupJob(jobContext)
     val stagingDir = new File(new Path(path).toUri.getPath, s".spark-staging-$jobId")

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/SaveLoadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/SaveLoadSuite.scala
@@ -85,7 +85,6 @@ class SaveLoadSuite extends DataSourceTest with SharedSparkSession with BeforeAn
 
   test("save with string mode and path, and load") {
     spark.conf.set(SQLConf.DEFAULT_DATA_SOURCE_NAME.key, "org.apache.spark.sql.json")
-    path.createNewFile()
     df.write.mode("overwrite").save(path.toString)
     checkLoad()
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

The key modifications are as follows: 

* Force to use staging directory in `SQLHadoopMapReduceCommitProtocol` except `PathOutputCommitProtocol` and perform a rename from the source directory to the destination directory during the commit job phase. `Dynamic partition overwrite` and `custom partition path` have also been integrated into this process. And Handle paths according to `SaveMode`.

* Avoid deleting partitions before task runs and implement dynamic overwrite in `SQLHadoopMapReduceCommitProtocol`. To maintain compatibility with static mode, the corresponding partition files need to be deleted after the job is done.

> Note: For ease of review, some code in `HadoopMapReduceCommitProtocol` has been retained. In fact, I think the parameter `dynamicPartitionOverwrite` and the code for renaming partition directories during the commit job phase are no longer meaningful and should be removed.

### Why are the changes needed?

SparkSQL uses the partition location or table location as the commit path (except in `dynamic partition overwrite` mode and `custom partition path` mode). This has at least the following issues:

* As described in [SPARK-37210](https://issues.apache.org/jira/browse/SPARK-37210), conflicts can occur when multiple partitions job of the same table are run concurrently. Using a staging directory can avoid this issue.
* As described in [SPARK-53937](https://issues.apache.org/jira/browse/SPARK-53937), using a staging directory allows for near-atomic operations.

`Dynamic partition overwrite` mode and `custom partition path` mode already use the staging directory. And `dynamic partition overwrite` mode and `custom partition path` are implemented differently, which can be simplified into a unified process. And in https://github.com/apache/spark/pull/29000, reset the staging directory as the output directory of FileOutputCommitter. This way is more safer. It should be modified to this way.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Existing unit tests and newly added unit tests
