### PR TITLE
[SPARK-54015][PYTHON] Relax Py4J requirement to py4j>=0.10.9.7,<0.10.9.10

### DIFF
--- a/python/packaging/classic/setup.py
+++ b/python/packaging/classic/setup.py
@@ -346,7 +346,7 @@ try:
         license="Apache-2.0",
         # Don't forget to update python/docs/source/getting_started/install.rst
         # if you're updating the versions or dependencies.
-        install_requires=["py4j==0.10.9.9"],
+        install_requires=["py4j>=0.10.9.7,<0.10.9.10"],
         extras_require={
             "ml": ["numpy>=%s" % _minimum_numpy_version],
             "mllib": ["numpy>=%s" % _minimum_numpy_version],


### PR DESCRIPTION
### What changes were proposed in this pull request?

Py4J py4j>=0.10.9.7,<0.10.9.10 is JVM compatible so we can actually use older versions as well (I released those Py4J versions). To make it easier to migrate to higher versions of Spark, this PR proposes the range.

### Why are the changes needed?

To make it easier for legacy users to migrate to higher versions of Spark.

### Does this PR introduce _any_ user-facing change?

Virtually no.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.