### PR TITLE
[SPARK-54023][CORE] Support `AUTO` IO Mode

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/IOMode.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/IOMode.java
@@ -32,5 +32,9 @@ public enum IOMode {
   /**
    * Native KQUEUE via JNI, MacOS/BSD only
    */
-  KQUEUE
+  KQUEUE,
+  /**
+   * Prefer to use native EPOLL on Linux (or KQUEUE on MacOS) if available. Then, fallback to NIO.
+   */
+  AUTO
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -87,7 +87,7 @@ public class TransportConf {
     return module;
   }
 
-  /** IO mode: NIO, EPOLL, or KQUEUE */
+  /** IO mode: NIO, EPOLL, KQUEUE, or AUTO */
   public String ioMode() {
     String defaultIOMode = conf.get(SPARK_NETWORK_DEFAULT_IO_MODE_KEY, "NIO");
     return conf.get(SPARK_NETWORK_IO_MODE_KEY, defaultIOMode).toUpperCase(Locale.ROOT);

--- a/core/src/test/scala/org/apache/spark/ShuffleNettySuite.scala
+++ b/core/src/test/scala/org/apache/spark/ShuffleNettySuite.scala
@@ -55,3 +55,7 @@ class ShuffleNettyKQueueSuite extends ShuffleNettySuite {
   override def shouldRunTests: Boolean = Utils.isMac
   override def ioMode: IOMode = IOMode.KQUEUE
 }
+
+class ShuffleNettyAutoSuite extends ShuffleNettySuite {
+  override def ioMode: IOMode = IOMode.AUTO
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support a new Netty IO Mode, `AUTO`, on top of the existing `NIO`, `EPOLL`, and `KQUEUE`.

`AUTO` mode prefers to use native `EPOLL` mode on Linux and `KQUEUE` mode on MacOS if available. Then, it fallbacks to `NIO` mode.

### Why are the changes needed?

To help a user to try to use native IO mode more easily.

### Does this PR introduce _any_ user-facing change?

No, this is a new IO mode.

### How was this patch tested?

Pass the CIs with newly added test suite, `ShuffleNettyAutoSuite`.

### Was this patch authored or co-authored using generative AI tooling?

No.