### PR TITLE
[SPARK-54024][BUILD] Add sbt-dependency-tree to SBT plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -46,3 +46,5 @@ addSbtPlugin("com.github.sbt.junit" % "sbt-jupiter-interface" % "0.17.0")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.7")
 
 addSbtPlugin("com.here.platform" % "sbt-bom" % "1.0.29")
+
+addDependencyTreePlugin


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `sbt-dependency-tree` to SBT plugins

### Why are the changes needed?
The [plugin](https://www.scala-sbt.org/sbt-dependency-graph/tasks/index.html) provides several options on top of plain ASCII `dependencyTree` SBT command:
- dependencyBrowseGraph
- dependencyBrowseTree
- dependencyGraphML
- dependencyLicenseInfo

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Invoked `dependencyBrowseTree`

### Was this patch authored or co-authored using generative AI tooling?
No