### PR TITLE
[SPARK-54026][BUILD] Use BOM for AWS Java SDK V2 dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1190,6 +1190,13 @@
         <version>2.14.6</version>
       </dependency>
       <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>${aws.java.sdk.v2.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_${scala.binary.version}</artifactId>
         <version>3.2.19</version>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1189,12 +1189,16 @@ object DependencyOverrides {
   lazy val guavaVersion = sys.props.get("guava.version").getOrElse("33.4.0-jre")
   lazy val jacksonVersion = sys.props.get("fasterxml.jackson.version").getOrElse("2.20.0")
   lazy val jacksonDeps = Bom.dependencies("com.fasterxml.jackson" % "jackson-bom" % jacksonVersion)
-  lazy val settings = jacksonDeps ++ Seq(
+  lazy val awsJavaSdkV2Version = sys.props.get("aws.java.sdk.v2.version").getOrElse("2.29.52")
+  lazy val awsJavaSdkV2Deps =
+    Bom.dependencies("software.amazon.awssdk" % "bom" % awsJavaSdkV2Version)
+  lazy val settings = jacksonDeps ++ awsJavaSdkV2Deps ++ Seq(
     dependencyOverrides += "com.google.guava" % "guava" % guavaVersion,
     dependencyOverrides ++= jacksonDeps.key.value,
     dependencyOverrides += "jline" % "jline" % "2.14.6",
     dependencyOverrides += "org.apache.avro" % "avro" % "1.12.1",
-    dependencyOverrides += "org.slf4j" % "slf4j-api" % "2.0.17")
+    dependencyOverrides += "org.slf4j" % "slf4j-api" % "2.0.17",
+    dependencyOverrides ++= awsJavaSdkV2Deps.key.value)
 }
 
 /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use AWS Java SDK V2 BOM for consistent dependency management.

### Why are the changes needed?
AWS Java SDK V2 expects consistent dependencies (https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/setup-project-maven.html)

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Checked Kinesis ASL works both with maven and SBT


### Was this patch authored or co-authored using generative AI tooling?
No
