### PR TITLE
[SPARK-54027] Kafka Source RTM support

### DIFF
--- a/common/utils-java/src/main/java/org/apache/spark/internal/LogKeys.java
+++ b/common/utils-java/src/main/java/org/apache/spark/internal/LogKeys.java
@@ -823,6 +823,7 @@ public enum LogKeys implements LogKey {
   TIMEOUT,
   TIMER,
   TIMESTAMP,
+  TIMESTAMP_COLUMN_NAME,
   TIME_UNITS,
   TIP,
   TOKEN,

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaBatchPartitionReader.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaBatchPartitionReader.scala
@@ -19,15 +19,19 @@ package org.apache.spark.sql.kafka010
 
 import java.{util => ju}
 
+import org.apache.kafka.common.record.TimestampType
+
 import org.apache.spark.TaskContext
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.connector.metric.CustomTaskMetric
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
+import org.apache.spark.sql.connector.read.streaming.SupportsRealTimeRead
+import org.apache.spark.sql.connector.read.streaming.SupportsRealTimeRead.RecordStatus
 import org.apache.spark.sql.execution.streaming.runtime.{MicroBatchExecution, StreamExecution}
-import org.apache.spark.sql.kafka010.consumer.KafkaDataConsumer
+import org.apache.spark.sql.kafka010.consumer.{KafkaDataConsumer, KafkaDataConsumerIterator}
 
 /** A [[InputPartition]] for reading Kafka data in a batch based streaming query. */
 private[kafka010] case class KafkaBatchInputPartition(
@@ -67,7 +71,8 @@ private case class KafkaBatchPartitionReader(
     executorKafkaParams: ju.Map[String, Object],
     pollTimeoutMs: Long,
     failOnDataLoss: Boolean,
-    includeHeaders: Boolean) extends PartitionReader[InternalRow] with Logging {
+    includeHeaders: Boolean)
+  extends SupportsRealTimeRead[InternalRow] with Logging {
 
   private val consumer = KafkaDataConsumer.acquire(offsetRange.topicPartition, executorKafkaParams)
 
@@ -77,6 +82,12 @@ private case class KafkaBatchPartitionReader(
 
   private var nextOffset = rangeToRead.fromOffset
   private var nextRow: UnsafeRow = _
+  private var iteratorForRealTimeMode: Option[KafkaDataConsumerIterator] = None
+
+  // Boolean flag that indicates whether we have logged the type of timestamp (i.e. create time,
+  // log-append time, etc.) for the Kafka source. We log upon reading the first record, and we
+  // then skip logging for subsequent records.
+  private var timestampTypeLogged = false
 
   override def next(): Boolean = {
     if (nextOffset < rangeToRead.untilOffset) {
@@ -91,6 +102,38 @@ private case class KafkaBatchPartitionReader(
     } else {
       false
     }
+  }
+
+  override def nextWithTimeout(timeoutMs: java.lang.Long): RecordStatus = {
+    if (!iteratorForRealTimeMode.isDefined) {
+      logInfo(s"Getting a new kafka consuming iterator for ${offsetRange.topicPartition} " +
+        s"starting from ${nextOffset}, timeoutMs ${timeoutMs}")
+      iteratorForRealTimeMode = Some(consumer.getIterator(nextOffset))
+    }
+    assert(iteratorForRealTimeMode.isDefined)
+    val nextRecord = iteratorForRealTimeMode.get.nextWithTimeout(timeoutMs)
+    nextRecord.foreach { record =>
+
+      nextRow = unsafeRowProjector(record)
+      nextOffset = record.offset + 1
+      if (record.timestampType() == TimestampType.LOG_APPEND_TIME ||
+        record.timestampType() == TimestampType.CREATE_TIME) {
+        if (!timestampTypeLogged) {
+          logInfo(log"Kafka source record timestamp type is " +
+            log"${MDC(LogKeys.TIMESTAMP_COLUMN_NAME, record.timestampType())}")
+          timestampTypeLogged = true
+        }
+
+        RecordStatus.newStatusWithArrivalTimeMs(record.timestamp())
+      } else {
+        RecordStatus.newStatusWithoutArrivalTime(true)
+      }
+    }
+    RecordStatus.newStatusWithoutArrivalTime(nextRecord.isDefined)
+  }
+
+  override def getOffset(): KafkaSourcePartitionOffset = {
+    KafkaSourcePartitionOffset(offsetRange.topicPartition, nextOffset)
   }
 
   override def get(): UnsafeRow = {

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
@@ -345,7 +345,6 @@ private[kafka010] class KafkaMicroBatchStream(
   override def toString(): String = s"KafkaV2[$kafkaOffsetReader]"
 
   override def metrics(latestConsumedOffset: Optional[Offset]): ju.Map[String, String] = {
-    var rtmFetchLatestOffsetsTimeMs = Option.empty[Long]
     val reCalculatedLatestPartitionOffsets =
       if (inRealTimeMode) {
         if (!latestConsumedOffset.isPresent) {
@@ -353,12 +352,8 @@ private[kafka010] class KafkaMicroBatchStream(
           None
         } else {
           Some {
-            val startTime = System.currentTimeMillis()
-            val latestOffsets = kafkaOffsetReader.fetchLatestOffsets(
+            kafkaOffsetReader.fetchLatestOffsets(
               Some(latestConsumedOffset.get.asInstanceOf[KafkaSourceOffset].partitionToOffsets))
-            val endTime = System.currentTimeMillis()
-            rtmFetchLatestOffsetsTimeMs = Some(endTime - startTime)
-            latestOffsets
           }
         }
       } else {

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
@@ -299,6 +299,14 @@ private[kafka010] class KafkaMicroBatchStream(
         }
       }
 
+      val deletedPartitions = startPartitionOffsets.keySet.diff(latestTopicPartitions)
+      if (deletedPartitions.nonEmpty) {
+        reportDataLoss(
+          s"$deletedPartitions are gone. Some data may have been missed",
+          () =>
+            KafkaExceptions.partitionsDeleted(deletedPartitions, None))
+      }
+
       startPartitionOffsets ++ newPartitionOffsets
     }
 

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
@@ -357,10 +357,7 @@ private[kafka010] class KafkaMicroBatchStream(
           }
         }
       } else {
-        // If we are in micro-batch mode, we need to get the latest partition offsets at the
-        // start of the batch and recalculate the latest offsets at the end for backlog
-        // estimation.
-        Some(kafkaOffsetReader.fetchLatestOffsets(Some(latestPartitionOffsets)))
+        Some(latestPartitionOffsets)
       }
 
       KafkaMicroBatchStream.metrics(latestConsumedOffset, reCalculatedLatestPartitionOffsets)

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/consumer/KafkaDataConsumer.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/consumer/KafkaDataConsumer.scala
@@ -300,15 +300,15 @@ private[kafka010] class KafkaDataConsumer(
    * out-of-bound check in this function. Since there is no endOffset given, we assume anything
    * record is valid to return as long as it is at or after `offset`.
    *
-   * @param startOffsets, the starting positions to read from, inclusive.
+   * @param startOffset, the starting positions to read from, inclusive.
    */
-  def getIterator(offset: Long): KafkaDataConsumerIterator = {
+  def getIterator(startOffset: Long): KafkaDataConsumerIterator = {
     new KafkaDataConsumerIterator {
       private var fetchedRecordList
           : Option[ju.ListIterator[ConsumerRecord[Array[Byte], Array[Byte]]]] = None
       private val consumer = getOrRetrieveConsumer()
       private var firstRecord = true
-      private var _currentOffset: Long = offset - 1
+      private var _currentOffset: Long = startOffset - 1
 
       private def fetchedRecordListHasNext(): Boolean = {
         fetchedRecordList.map(_.hasNext).getOrElse(false)
@@ -330,7 +330,7 @@ private[kafka010] class KafkaDataConsumer(
 
         if (firstRecord) {
           timeAndDeductFromTimeLeftMs {
-            consumer.seek(offset)
+            consumer.seek(startOffset)
             firstRecord = false
           }
         }
@@ -349,8 +349,8 @@ private[kafka010] class KafkaDataConsumer(
                   throw ex
                 } else {
                   Thread.sleep(10) // retry until the source partition is populated
-                  assert(offset == 0)
-                  consumer.seek(offset)
+                  assert(startOffset == 0)
+                  consumer.seek(startOffset)
                 }
             }
           }

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -1839,20 +1839,20 @@ abstract class KafkaMicroBatchV2SourceSuite extends KafkaMicroBatchSourceSuiteBa
     val latestOffset = Map[TopicPartition, Long]((topicPartition1, 3L), (topicPartition2, 6L))
 
     // test empty offset.
-    assert(KafkaMicroBatchStream.metrics(Optional.ofNullable(null), latestOffset).isEmpty)
+    assert(KafkaMicroBatchStream.metrics(Optional.ofNullable(null), Some(latestOffset)).isEmpty)
 
     // test valid offsetsBehindLatest
     val offset = KafkaSourceOffset(
       Map[TopicPartition, Long]((topicPartition1, 1L), (topicPartition2, 2L)))
     assert(
-      KafkaMicroBatchStream.metrics(Optional.ofNullable(offset), latestOffset) ===
+      KafkaMicroBatchStream.metrics(Optional.ofNullable(offset), Some(latestOffset)) ===
         Map[String, String](
           "minOffsetsBehindLatest" -> "2",
           "maxOffsetsBehindLatest" -> "4",
           "avgOffsetsBehindLatest" -> "3.0").asJava)
 
     // test null latestAvailablePartitionOffsets
-    assert(KafkaMicroBatchStream.metrics(Optional.ofNullable(offset), null).isEmpty)
+    assert(KafkaMicroBatchStream.metrics(Optional.ofNullable(offset), None).isEmpty)
   }
 }
 

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRealTimeIntegrationSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRealTimeIntegrationSuite.scala
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.spark.sql.kafka010
+
+import java.nio.file.Files
+import java.util.Properties
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+import org.apache.kafka.clients.producer.{KafkaProducer, Producer, ProducerRecord}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.SpanSugar._
+
+import org.apache.spark.{SparkContext, ThreadAudit}
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
+import org.apache.spark.sql.execution.streaming.RealTimeTrigger
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.streaming.{OutputMode, ResultsCollector, StreamingQuery, StreamRealTimeModeE2ESuiteBase, StreamRealTimeModeSuiteBase}
+import org.apache.spark.sql.test.TestSparkSession
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+
+class KafkaRealTimeModeE2ESuite extends KafkaSourceTest with StreamRealTimeModeE2ESuiteBase {
+
+  override protected val defaultTrigger: RealTimeTrigger = RealTimeTrigger.apply("5 seconds")
+
+  override protected def createSparkSession =
+    new TestSparkSession(
+      new SparkContext(
+        "local[15]",
+        "streaming-key-cuj",
+      )
+    )
+
+  override def beforeEach(): Unit = {
+    super[KafkaSourceTest].beforeEach()
+    super[StreamRealTimeModeE2ESuiteBase].beforeEach()
+  }
+
+  def getKafkaConsumerProperties: Properties = {
+    val props: Properties = new Properties()
+    props.put("bootstrap.servers", testUtils.brokerAddress)
+    props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer")
+    props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer")
+    props.put("compression.type", "snappy")
+
+    props
+  }
+
+  test("Union two kafka streams, for each write to sink") {
+    var q: StreamingQuery = null
+    try {
+      val topic1 = newTopic()
+      val topic2 = newTopic()
+      testUtils.createTopic(topic1, partitions = 2)
+      testUtils.createTopic(topic2, partitions = 2)
+
+      val props: Properties = getKafkaConsumerProperties
+      val producer1: Producer[String, String] = new KafkaProducer[String, String](props)
+      val producer2: Producer[String, String] = new KafkaProducer[String, String](props)
+
+      val readStream1 = spark.readStream
+        .format("kafka")
+        .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+        .option("subscribe", topic1)
+        .load()
+
+      val readStream2 = spark.readStream
+        .format("kafka")
+        .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+        .option("subscribe", topic2)
+        .load()
+
+      val df = readStream1
+        .union(readStream2)
+        .selectExpr("CAST(key AS STRING) AS key", "CAST(value AS STRING) AS value")
+        .selectExpr("key || ',' || value")
+        .toDF()
+
+      q = runStreamingQuery("union-kafka", df)
+
+      waitForTasksToStart(4)
+
+      val expectedResults = new mutable.ListBuffer[String]()
+      for (batch <- 0 until 3) {
+        (1 to 100).foreach(i => {
+          producer1
+            .send(
+              new ProducerRecord[String, String](
+                topic1,
+                java.lang.Long.toString(i),
+                s"input1-${batch}-${i}"
+              )
+            )
+            .get()
+          producer2
+            .send(
+              new ProducerRecord[String, String](
+                topic2,
+                java.lang.Long.toString(i),
+                s"input2-${batch}-${i}"
+              )
+            )
+            .get()
+        })
+        producer1.flush()
+        producer2.flush()
+
+        expectedResults ++= (1 to 100)
+          .flatMap(v => {
+            Seq(
+              s"${v},input1-${batch}-${v}",
+              s"${v},input2-${batch}-${v}"
+            )
+          })
+          .toList
+
+        eventually(timeout(60.seconds)) {
+          ResultsCollector
+            .get(sinkName)
+            .toArray(new Array[String](ResultsCollector.get(sinkName).size()))
+            .toList
+            .sorted should equal(expectedResults.sorted)
+        }
+      }
+    } finally {
+      if (q != null) {
+        q.stop()
+      }
+    }
+  }
+}
+
+
+/**
+ * Kafka Real-Time Integration test suite.
+ * Tests with a distributed spark cluster with
+ * separate executors processes deployed.
+ */
+class KafkaRealTimeIntegrationSuite
+  extends KafkaSourceTest
+    with StreamRealTimeModeSuiteBase
+    with ThreadAudit
+    with BeforeAndAfterEach
+    with Matchers {
+
+  override protected def createSparkSession =
+    new TestSparkSession(
+      new SparkContext(
+        "local-cluster[3, 5, 1024]", // Ensure we have enough for both stages.
+        "microbatch-context",
+        sparkConf
+          .set("spark.sql.testkey", "true")
+          .set("spark.scheduler.mode", "FAIR")
+          .set("spark.executor.extraJavaOptions", "-Dio.netty.leakDetection.level=paranoid")
+      )
+    )
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    // testing to make sure the cluster is usable
+    testUtils.createTopic("_test")
+    testUtils.sendMessage(new ProducerRecord[String, String]("_test", "", ""))
+    testUtils.deleteTopic("_test")
+    logInfo("Kafka cluster setup complete....")
+
+    eventually(timeout(10.seconds)) {
+      val executors = sparkContext.getExecutorIds()
+      assert(executors.size == 3, s"executors: ${executors}}")
+    }
+  }
+
+  test("e2e stateless") {
+    var query: StreamingQuery = null
+    try {
+      val inputTopic = newTopic()
+      testUtils.createTopic(inputTopic, partitions = 5)
+
+      val outputTopic = newTopic()
+      testUtils.createTopic(outputTopic, partitions = 5)
+
+      val props: Properties = new Properties()
+
+      props.put("bootstrap.servers", testUtils.brokerAddress)
+      props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+      props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+      props.put("compression.type", "snappy")
+
+      val producer: Producer[String, String] = new KafkaProducer[String, String](props)
+
+      query = spark.readStream
+        .format("kafka")
+        .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+        .option("kafka.metadata.max.age.ms", "1")
+        .option("startingOffsets", "earliest")
+        .option("subscribe", inputTopic)
+        .option("kafka.fetch.max.wait.ms", 10)
+        .load()
+        .withColumn("value", substring(col("value"), 0, 500 * 1000))
+        .withColumn("value", base64(col("value")))
+        .withColumn(
+          "headers",
+          array(
+            struct(
+              lit("source-timestamp") as "key",
+              unix_millis(col("timestamp")).cast("STRING").cast("BINARY") as "value"
+            )
+          )
+        )
+        .drop(col("timestamp"))
+        .writeStream
+        .format("kafka")
+        .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+        .option("topic", outputTopic)
+        .option("checkpointLocation", Files.createTempDirectory("some-prefix").toFile.getName)
+        .option("kafka.max.block.ms", "100")
+        .trigger(RealTimeTrigger.apply("5 minutes"))
+        .outputMode(OutputMode.Update())
+        .start()
+
+      waitForTasksToStart(5)
+
+      var expectedResults: ListBuffer[GenericRowWithSchema] = new ListBuffer
+      for (i <- 0 until 3) {
+        (1 to 100).foreach(i => {
+          producer
+            .send(
+              new ProducerRecord[String, String](
+                inputTopic,
+                java.lang.Long.toString(i),
+                s"payload-${i}"
+              )
+            )
+            .get()
+        })
+
+        producer.flush()
+
+        val kafkaSinkData = spark.read
+          .format("kafka")
+          .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+          .option("subscribe", outputTopic)
+          .option("includeHeaders", "true")
+          .option("startingOffsets", "earliest")
+          .load()
+          .withColumn("value", unbase64(col("value")).cast("STRING"))
+          .withColumn("headers-map", map_from_entries(col("headers")))
+          .withColumn("source-timestamp", conv(hex(col("headers-map.source-timestamp")), 16, 10))
+          .withColumn("sink-timestamp", unix_millis(col("timestamp")))
+
+        // Check the answers
+        val newResults = (1 to 100)
+          .map(v => {
+            new GenericRowWithSchema(
+              Array(s"payload-${v}"),
+              schema = new StructType().add(StructField("value", StringType))
+            )
+          })
+          .toList
+
+        expectedResults ++= newResults
+        expectedResults =
+          expectedResults.sorted((x: GenericRowWithSchema, y: GenericRowWithSchema) => {
+            x.getString(0).compareTo(y.getString(0))
+          })
+
+        eventually(timeout(1.minute)) {
+          checkAnswer(kafkaSinkData.select("value"), expectedResults.toSeq)
+        }
+      }
+    } finally {
+      if (query != null) {
+        query.stop()
+      }
+    }
+  }
+}

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRealTimeIntegrationSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRealTimeIntegrationSuite.scala
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.spark.sql.kafka010
 
 import java.nio.file.Files
@@ -45,7 +44,7 @@ class KafkaRealTimeModeE2ESuite extends KafkaSourceTest with StreamRealTimeModeE
     new TestSparkSession(
       new SparkContext(
         "local[15]",
-        "streaming-key-cuj",
+        "streaming-key-cuj"
       )
     )
 

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRealTimeModeSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRealTimeModeSuite.scala
@@ -1,0 +1,681 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.kafka010
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.SpanSugar._
+
+import org.apache.spark.{SparkConf, SparkContext, SparkIllegalStateException}
+import org.apache.spark.sql.execution.datasources.v2.LowLatencyClock
+import org.apache.spark.sql.execution.streaming._
+import org.apache.spark.sql.execution.streaming.sources.ContinuousMemorySink
+import org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.streaming.{StreamingQuery, Trigger}
+import org.apache.spark.sql.streaming.OutputMode.Update
+import org.apache.spark.sql.streaming.util.GlobalSingletonManualClock
+import org.apache.spark.sql.test.TestSparkSession
+import org.apache.spark.util.SystemClock
+
+class KafkaRealTimeModeSuite
+  extends KafkaSourceTest
+    with Matchers {
+
+  override protected val defaultTrigger = RealTimeTrigger.apply("3 seconds")
+
+  override protected def sparkConf: SparkConf = {
+    // Should turn to use StreamingShuffleManager when it is ready.
+    super.sparkConf
+      .set("spark.databricks.streaming.realTimeMode.enabled", "true")
+      .set(
+        SQLConf.STATE_STORE_PROVIDER_CLASS,
+        classOf[RocksDBStateStoreProvider].getName)
+  }
+
+  override protected def createSparkSession = new TestSparkSession(
+    new SparkContext(
+      "local[8]", // Ensure enough number of cores to ensure concurrent schedule of all tasks.
+      "streaming-rtm-context",
+      sparkConf.set("spark.sql.testkey", "true")))
+
+
+  import testImplicits._
+
+  val sleepOneSec = new ExternalAction() {
+    override def runAction(): Unit = {
+      Thread.sleep(1000)
+    }
+  }
+
+  var clock = new GlobalSingletonManualClock()
+
+  private def advanceRealTimeClock(timeMs: Int) = new ExternalAction {
+    override def runAction(): Unit = {
+      clock.advance(timeMs)
+    }
+
+    override def toString(): String = {
+      s"advanceRealTimeClock($timeMs)"
+    }
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.conf.set(
+      SQLConf.STREAMING_REAL_TIME_MODE_MIN_BATCH_DURATION,
+      defaultTrigger.batchDurationMs
+    )
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    GlobalSingletonManualClock.reset()
+  }
+
+  override def afterEach(): Unit = {
+    LowLatencyClock.setClock(new SystemClock)
+    super.afterEach()
+  }
+
+  def waitUntilBatchStartedOrProcessed(q: StreamingQuery, batchId: Long): Unit = {
+    eventually(timeout(60.seconds)) {
+      val tasksRunning =
+        spark.sparkContext.statusTracker.getExecutorInfos.map(_.numRunningTasks()).sum
+      val lastBatch = {
+        if (q.lastProgress == null) {
+          -1
+        } else {
+          q.lastProgress.batchId
+        }
+      }
+      val batchStarted = tasksRunning >= 1 && lastBatch >= batchId - 1
+      val batchProcessed = lastBatch >= batchId
+      assert(batchStarted || batchProcessed,
+        s"tasksRunning: ${tasksRunning} lastBatch: ${lastBatch}")
+    }
+  }
+
+  // A simple unit test that reads from Kakfa source, does a simple map and writes to memory
+  // sink.
+  test("simple map") {
+    val topic = newTopic()
+    testUtils.createTopic(topic, partitions = 2)
+
+    testUtils.sendMessages(topic, Array("1", "2"), Some(0))
+    testUtils.sendMessages(topic, Array("3"), Some(1))
+
+    val reader = spark
+      .readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+      .option("subscribe", topic)
+      .option("startingOffsets", "earliest")
+      .load()
+      .selectExpr("CAST(value AS STRING)")
+      .as[String]
+      .map(_.toInt)
+      .map(_ + 1)
+
+    testStream(reader, Update, sink = new ContinuousMemorySink())(
+      StartStream(),
+      CheckAnswerWithTimeout(60000, 2, 3, 4),
+      sleepOneSec,
+      sleepOneSec,
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.sendMessages(topic, Array("4", "5"), Some(0))
+          testUtils.sendMessages(topic, Array("6"), Some(1))
+        }
+      },
+      CheckAnswerWithTimeout(5000, 2, 3, 4, 5, 6, 7),
+      WaitUntilCurrentBatchProcessed,
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.sendMessages(topic, Array("7"), Some(1))
+        }
+      },
+      CheckAnswerWithTimeout(5000, 2, 3, 4, 5, 6, 7, 8),
+      WaitUntilCurrentBatchProcessed,
+      StopStream,
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.sendMessages(topic, Array("8"), Some(0))
+          testUtils.sendMessages(topic, Array("9"), Some(1))
+        }
+      },
+      StartStream(),
+      CheckAnswerWithTimeout(5000, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+      WaitUntilCurrentBatchProcessed)
+  }
+
+  // A simple unit test that reads from Kakfa source, does a simple map and writes to memory
+  // sink. Make sure there is no data for a whole batch. Also, after restart the first batch
+  // has no data.
+  test("simple map with empty batch") {
+    val topic = newTopic()
+    testUtils.createTopic(topic, partitions = 2)
+
+    val reader = spark.readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+      .option("subscribe", topic)
+      .option("startingOffsets", "earliest")
+      .load()
+      .selectExpr("CAST(value AS STRING)")
+      .as[String]
+      .map(_.toInt)
+      .map(_ + 1)
+
+    testStream(reader, Update, sink = new ContinuousMemorySink())(
+      StartStream(),
+      WaitUntilBatchProcessed(0),
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.sendMessages(topic, Array("1"), Some(0))
+          testUtils.sendMessages(topic, Array("2"), Some(1))
+        }
+      },
+      CheckAnswerWithTimeout(5000, 2, 3),
+      WaitUntilCurrentBatchProcessed,
+      WaitUntilCurrentBatchProcessed,
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.sendMessages(topic, Array("3"), Some(1))
+        }
+      },
+      WaitUntilCurrentBatchProcessed,
+      CheckAnswerWithTimeout(5000, 2, 3, 4),
+      StopStream,
+      StartStream(),
+      WaitUntilCurrentBatchProcessed,
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.sendMessages(topic, Array("4"), Some(0))
+          testUtils.sendMessages(topic, Array("5"), Some(1))
+        }
+      },
+      CheckAnswerWithTimeout(5000, 2, 3, 4, 5, 6),
+      WaitUntilCurrentBatchProcessed
+    )
+  }
+
+  // A simple unit test that reads from Kakfa source, does a simple map and writes to memory
+  // sink.
+  test("add partition") {
+    val topic = newTopic()
+    testUtils.createTopic(topic, partitions = 1)
+
+    testUtils.sendMessages(topic, Array("1", "2", "3"), Some(0))
+
+    val reader = spark.readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+      .option("subscribe", topic)
+      .option("startingOffsets", "earliest")
+      .load()
+      .selectExpr("CAST(value AS STRING)")
+      .as[String]
+      .map(_.toInt)
+      .map(_ + 1)
+
+    testStream(reader, Update, sink = new ContinuousMemorySink())(
+      StartStream(),
+      CheckAnswerWithTimeout(60000, 2, 3, 4),
+      sleepOneSec,
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.addPartitions(topic, 2)
+          testUtils.sendMessages(topic, Array("4", "5"), Some(0))
+          testUtils.sendMessages(topic, Array("6"), Some(1))
+        }
+      },
+      CheckAnswerWithTimeout(15000, 2, 3, 4, 5, 6, 7),
+      WaitUntilCurrentBatchProcessed,
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.addPartitions(topic, 4)
+          testUtils.sendMessages(topic, Array("7"), Some(2))
+        }
+      },
+      CheckAnswerWithTimeout(15000, 2, 3, 4, 5, 6, 7, 8),
+      WaitUntilCurrentBatchProcessed,
+      StopStream,
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.sendMessages(topic, Array("8"), Some(3))
+          testUtils.sendMessages(topic, Array("9"), Some(2))
+        }
+      },
+      StartStream(),
+      CheckAnswerWithTimeout(15000, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+      WaitUntilCurrentBatchProcessed
+    )
+  }
+
+  test("Real-Time Mode fetches latestOffset again at end of the batch") {
+    // LowLatencyClock does not affect the wait time of kafka iterator, so advancing the clock
+    // does not affect the test finish time. The purpose of using it is to make the query start
+    // time consistent, so the test behaves the same.
+    LowLatencyClock.setClock(clock)
+    val topic = newTopic()
+    testUtils.createTopic(topic, partitions = 1)
+
+    val reader = spark.readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+      .option("subscribe", topic)
+      .option("startingOffsets", "earliest")
+      // extra large number to make sure fetch does
+      // not return within batch duration
+      .option("kafka.fetch.max.wait.ms", "20000000")
+      .option("kafka.fetch.min.bytes", "20000000")
+      .load()
+      .selectExpr("CAST(value AS STRING)")
+      .as[String]
+      .map(_.toInt)
+      .map(_ + 1)
+
+    testStream(reader, Update, sink = new ContinuousMemorySink())(
+      StartStream(Trigger.RealTime(10000)),
+      advanceRealTimeClock(2000),
+      Execute { q =>
+        waitUntilBatchStartedOrProcessed(q, 0)
+        testUtils.sendMessages(topic, Array("1"), Some(0))
+      },
+      advanceRealTimeClock(8000),
+      WaitUntilBatchProcessed(0),
+      Execute { q =>
+        val expectedMetrics = Map(
+          "minOffsetsBehindLatest" -> "1",
+          "maxOffsetsBehindLatest" -> "1",
+          "avgOffsetsBehindLatest" -> "1.0",
+          "estimatedTotalBytesBehindLatest" -> null
+        )
+        eventually(timeout(60.seconds)) {
+          expectedMetrics.foreach { case (metric, expectedValue) =>
+            assert(q.lastProgress.sources(0).metrics.get(metric) === expectedValue)
+          }
+        }
+      },
+      advanceRealTimeClock(2000),
+      Execute { q =>
+        waitUntilBatchStartedOrProcessed(q, 1)
+        testUtils.sendMessages(topic, Array("2", "3"), Some(0))
+      },
+      advanceRealTimeClock(8000),
+      WaitUntilBatchProcessed(1),
+      Execute { q =>
+        val expectedMetrics = Map(
+          "minOffsetsBehindLatest" -> "3",
+          "maxOffsetsBehindLatest" -> "3",
+          "avgOffsetsBehindLatest" -> "3.0",
+          "estimatedTotalBytesBehindLatest" -> null
+        )
+        eventually(timeout(60.seconds)) {
+          expectedMetrics.foreach { case (metric, expectedValue) =>
+            assert(q.lastProgress.sources(0).metrics.get(metric) === expectedValue)
+          }
+        }
+      }
+    )
+  }
+
+  // Validate the query fails with minOffsetPerTrigger option set.
+  Seq(
+    "maxoffsetspertrigger",
+    "minoffsetspertrigger",
+    "minpartitions",
+    "endingtimestamp",
+    "maxtriggerdelay").foreach { opt =>
+    test(s"$opt incompatible") {
+      val topic = newTopic()
+      testUtils.createTopic(topic, partitions = 2)
+
+      val reader = spark.readStream
+        .format("kafka")
+        .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+        .option("subscribe", topic)
+        .option("startingOffsets", "earliest")
+        .option(opt, "5")
+        .load()
+      testStream(reader, Update, sink = new ContinuousMemorySink())(
+        StartStream(),
+        ExpectFailure[UnsupportedOperationException] { (t: Throwable) => {
+          assert(t.getMessage.toLowerCase().contains(opt))
+        }
+        }
+      )
+    }
+  }
+
+  test("union 2 dataframes after projection") {
+    val topic = newTopic()
+    testUtils.createTopic(topic, partitions = 2)
+
+    val topic1 = newTopic()
+    testUtils.createTopic(topic1, partitions = 2)
+
+    testUtils.sendMessages(topic, Array("1", "2"), Some(0))
+    testUtils.sendMessages(topic, Array("3"), Some(1))
+
+    testUtils.sendMessages(topic1, Array("11", "12"), Some(0))
+    testUtils.sendMessages(topic1, Array("13"), Some(1))
+
+    val reader1 = spark
+      .readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+      .option("subscribe", topic)
+      .option("startingOffsets", "earliest")
+      .load()
+      .selectExpr("CAST(value AS STRING)")
+      .as[String]
+      .map(_.toInt)
+      .map(_ + 1)
+
+    val reader2 = spark
+      .readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+      .option("subscribe", topic1)
+      .option("startingOffsets", "earliest")
+      .load()
+      .selectExpr("CAST(value AS STRING)")
+      .as[String]
+      .map(_.toInt)
+      .map(_ + 1)
+
+    val unionedReader = reader1.union(reader2)
+
+    testStream(unionedReader, Update, sink = new ContinuousMemorySink())(
+      StartStream(),
+      CheckAnswerWithTimeout(60000, 2, 3, 4, 12, 13, 14),
+      sleepOneSec,
+      sleepOneSec,
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.sendMessages(topic, Array("4", "5"), Some(0))
+          testUtils.sendMessages(topic, Array("6"), Some(1))
+          testUtils.sendMessages(topic1, Array("14", "15"), Some(0))
+          testUtils.sendMessages(topic1, Array("16"), Some(1))
+        }
+      },
+      CheckAnswerWithTimeout(5000, 2, 3, 4, 12, 13, 14, 5, 6, 7, 15, 16, 17),
+      WaitUntilCurrentBatchProcessed,
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.sendMessages(topic, Array("7"), Some(1))
+        }
+      },
+      CheckAnswerWithTimeout(5000, 2, 3, 4, 12, 13, 14, 5, 6, 7, 15, 16, 17, 8),
+      WaitUntilCurrentBatchProcessed,
+      StopStream,
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.sendMessages(topic, Array("8"), Some(0))
+          testUtils.sendMessages(topic, Array("9"), Some(1))
+          testUtils.sendMessages(topic1, Array("19"), Some(1))
+        }
+      },
+      StartStream(),
+      CheckAnswerWithTimeout(5000, 2, 3, 4, 12, 13, 14, 5, 6, 7, 15, 16, 17, 8, 9, 10, 20),
+      WaitUntilCurrentBatchProcessed)
+  }
+
+  test("union 3 dataframes with and without maxPartitions") {
+    val topic = newTopic()
+    testUtils.createTopic(topic, partitions = 2)
+
+    val topic1 = newTopic()
+    testUtils.createTopic(topic1, partitions = 2)
+
+    val topic2 = newTopic()
+    testUtils.createTopic(topic2, partitions = 2)
+
+    testUtils.sendMessages(topic, Array("1", "2"), Some(0))
+    testUtils.sendMessages(topic, Array("3"), Some(1))
+
+    testUtils.sendMessages(topic1, Array("11", "12"), Some(0))
+    testUtils.sendMessages(topic1, Array("13"), Some(1))
+
+    testUtils.sendMessages(topic2, Array("21", "22"), Some(0))
+    testUtils.sendMessages(topic2, Array("23"), Some(1))
+
+    val reader1 = spark
+      .readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+      .option("subscribe", topic)
+      .option("startingOffsets", "earliest")
+      .option("maxPartitions", "1")
+      .load()
+
+    val reader2 = spark
+      .readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+      .option("subscribe", topic1)
+      .option("startingOffsets", "earliest")
+      .load()
+
+    val reader3 = spark
+      .readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+      .option("subscribe", topic2)
+      .option("startingOffsets", "earliest")
+      .option("maxPartitions", "3")
+      .load()
+
+    val unionedReader = reader1.union(reader2).union(reader3)
+      .selectExpr("CAST(value AS STRING)")
+      .as[String]
+      .map(_.toInt)
+      .map(_ + 1)
+
+    testStream(unionedReader, Update, sink = new ContinuousMemorySink())(
+      StartStream(),
+      CheckAnswerWithTimeout(10000, 2, 3, 4, 12, 13, 14, 22, 23, 24),
+      sleepOneSec,
+      sleepOneSec,
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.sendMessages(topic, Array("4"), Some(0))
+          testUtils.sendMessages(topic, Array("5"), Some(1))
+          testUtils.sendMessages(topic1, Array("14", "15"), Some(0))
+          testUtils.sendMessages(topic2, Array("24"), Some(0))
+        }
+      },
+      CheckAnswerWithTimeout(5000, 2, 3, 4, 12, 13, 14, 22, 23, 24, 5, 6, 15, 16, 25),
+      WaitUntilCurrentBatchProcessed,
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.sendMessages(topic, Array("6"), Some(1))
+          testUtils.sendMessages(topic2, Array("25"), Some(1))
+        }
+      },
+      CheckAnswerWithTimeout(5000, 2, 3, 4, 12, 13, 14, 22, 23, 24, 5, 6, 15, 16, 25, 7, 26),
+      WaitUntilCurrentBatchProcessed,
+      StopStream,
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.sendMessages(topic1, Array("16"), Some(1))
+        }
+      },
+      StartStream(),
+      CheckAnswerWithTimeout(5000, 2, 3, 4, 12, 13, 14, 22, 23, 24, 5, 6, 15, 16, 25, 7, 26, 17),
+      WaitUntilCurrentBatchProcessed)
+  }
+
+  test("self union workaround") {
+    val topic = newTopic()
+    testUtils.createTopic(topic, partitions = 2)
+
+    testUtils.sendMessages(topic, Array("1", "2"), Some(0))
+    testUtils.sendMessages(topic, Array("3"), Some(1))
+
+    val reader1 = spark
+      .readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+      .option("subscribe", topic)
+      .option("startingOffsets", "earliest")
+      .load()
+
+
+    val reader2 = spark
+      .readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+      .option("subscribe", topic)
+      .option("startingOffsets", "earliest")
+      .load()
+
+    val unionedReader = reader1.union(reader2)
+      .selectExpr("CAST(value AS STRING)")
+      .as[String]
+      .map(_.toInt)
+      .map(_ + 1)
+
+    testStream(unionedReader, Update, sink = new ContinuousMemorySink())(
+      StartStream(),
+      CheckAnswerWithTimeout(60000, 2, 3, 4, 2, 3, 4),
+      sleepOneSec,
+      sleepOneSec,
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.sendMessages(topic, Array("4", "5"), Some(0))
+          testUtils.sendMessages(topic, Array("6"), Some(1))
+        }
+      },
+      CheckAnswerWithTimeout(5000, 2, 3, 4, 2, 3, 4, 5, 6, 7, 5, 6, 7),
+      WaitUntilCurrentBatchProcessed,
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.sendMessages(topic, Array("7"), Some(1))
+        }
+      },
+      CheckAnswerWithTimeout(5000, 2, 3, 4, 2, 3, 4, 5, 6, 7, 5, 6, 7, 8, 8),
+      WaitUntilCurrentBatchProcessed,
+      StopStream,
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.sendMessages(topic, Array("8"), Some(0))
+          testUtils.sendMessages(topic, Array("9"), Some(1))
+        }
+      },
+      StartStream(),
+      CheckAnswerWithTimeout(5000, 2, 3, 4, 2, 3, 4, 5, 6, 7, 5, 6, 7, 8, 8, 9, 10, 9, 10),
+      WaitUntilCurrentBatchProcessed)
+  }
+
+  test("union 2 different sources - Kafka and LowLatencyMemoryStream") {
+    import testImplicits._
+    val topic = newTopic()
+    testUtils.createTopic(topic, partitions = 2)
+
+    val memoryStreamRead = LowLatencyMemoryStream[String](2)
+
+    testUtils.sendMessages(topic, Array("1", "2"), Some(0))
+    testUtils.sendMessages(topic, Array("3"), Some(1))
+    memoryStreamRead.addData("11", "12", "13")
+
+    val reader1 = spark
+      .readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+      .option("subscribe", topic)
+      .option("startingOffsets", "earliest")
+      .load()
+      .selectExpr("CAST(value AS STRING)")
+      .as[String]
+
+
+    val reader2 = memoryStreamRead.toDF()
+      .selectExpr("CAST(value AS STRING)")
+      .as[String]
+
+    val unionedReader = reader1.union(reader2)
+      .map(_.toInt)
+      .map(_ + 1)
+
+    testStream(unionedReader, Update, sink = new ContinuousMemorySink())(
+      StartStream(),
+      CheckAnswerWithTimeout(60000, 2, 3, 4, 12, 13, 14),
+      sleepOneSec,
+      sleepOneSec,
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.sendMessages(topic, Array("4", "5"), Some(0))
+          testUtils.sendMessages(topic, Array("6"), Some(1))
+          memoryStreamRead.addData("14")
+        }
+      },
+      CheckAnswerWithTimeout(5000, 2, 3, 4, 12, 13, 14, 5, 6, 7, 15),
+      WaitUntilCurrentBatchProcessed,
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.sendMessages(topic, Array("7"), Some(1))
+        }
+      },
+      CheckAnswerWithTimeout(5000, 2, 3, 4, 12, 13, 14, 5, 6, 7, 15, 8),
+      WaitUntilCurrentBatchProcessed,
+      StopStream,
+      new ExternalAction() {
+        override def runAction(): Unit = {
+          testUtils.sendMessages(topic, Array("8"), Some(0))
+          testUtils.sendMessages(topic, Array("9"), Some(1))
+          memoryStreamRead.addData("15", "16", "17")
+        }
+      },
+      StartStream(),
+      CheckAnswerWithTimeout(5000, 2, 3, 4, 12, 13, 14, 5, 6, 7, 15, 8, 9, 10, 16, 17, 18),
+      WaitUntilCurrentBatchProcessed)
+  }
+
+  test("self union - not allowed") {
+    val topic = newTopic()
+    testUtils.createTopic(topic, partitions = 2)
+
+    val reader = spark
+      .readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+      .option("subscribe", topic)
+      .option("startingOffsets", "earliest")
+      .load()
+
+    val unionedReader = reader.union(reader)
+      .selectExpr("CAST(value AS STRING)")
+      .as[String]
+      .map(_.toInt)
+      .map(_ + 1)
+
+      testStream(unionedReader, Update, sink = new ContinuousMemorySink())(
+        StartStream(),
+        ExpectFailure[SparkIllegalStateException] { ex =>
+          checkErrorMatchPVals(
+            ex.asInstanceOf[SparkIllegalStateException],
+            "STREAMING_REAL_TIME_MODE.IDENTICAL_SOURCES_IN_UNION_NOT_SUPPORTED",
+            parameters =
+              Map("sources" -> "(?s).*")
+          )
+        }
+      )
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeSuiteBase.scala
@@ -17,11 +17,18 @@
 
 package org.apache.spark.sql.streaming
 
+import java.util.concurrent.{ConcurrentHashMap, ConcurrentLinkedQueue}
+
+import scala.collection.mutable
+
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.ForeachWriter
 import org.apache.spark.sql.execution.datasources.v2.LowLatencyClock
-import org.apache.spark.sql.execution.streaming.RealTimeTrigger
+import org.apache.spark.sql.execution.streaming.{LowLatencyMemoryStream, RealTimeTrigger}
+import org.apache.spark.sql.execution.streaming.runtime.StreamingQueryWrapper
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.util.GlobalSingletonManualClock
 import org.apache.spark.sql.test.TestSparkSession
@@ -43,6 +50,124 @@ trait StreamRealTimeModeSuiteBase extends StreamTest with Matchers {
       "local[10]", // Ensure enough number of cores to ensure concurrent schedule of all tasks.
       "streaming-rtm-context",
       sparkConf.set("spark.sql.testkey", "true")))
+
+  /**
+   * Should only be used in real-time mode where the batch duration is long enough to ensure
+   * eventually does not skip the batch due to long refresh interval.
+   */
+  def waitForTasksToStart(numTasks: Int): Unit = {
+    eventually(timeout(60.seconds)) {
+      val tasksRunning = spark.sparkContext.statusTracker
+        .getExecutorInfos.map(_.numRunningTasks()).sum
+      assert(tasksRunning == numTasks, s"tasksRunning: ${tasksRunning}")
+    }
+  }
+}
+
+/**
+ * Must be a singleton object to ensure serializable when used in ForeachWriter.
+ * Users must make sure different test suites use different sink names to avoid race conditions.
+ */
+object ResultsCollector extends ConcurrentHashMap[String, ConcurrentLinkedQueue[String]] {
+  def reset(): Unit = {
+    clear()
+  }
+}
+
+/**
+ * Base class that contains helper methods to test Real-Time Mode streaming queries.
+ *
+ * The general procedure to use this suite is as follows:
+ * 1. Call createMemoryStream to create a memory stream with manual clock.
+ * 2. Call runStreamingQuery to start a streaming query with custom logic.
+ * 3. Call processBatches to add data to the memory stream and validate results.
+ *
+ * It uses foreach to collect results into [[ResultsCollector]]. It also tests whether
+ * results are emitted in real-time by having longer batch durations than the waiting time.
+ */
+trait StreamRealTimeModeE2ESuiteBase extends StreamRealTimeModeSuiteBase {
+  import testImplicits._
+
+  override protected val defaultTrigger = RealTimeTrigger.apply("300 seconds")
+
+  protected final def sinkName: String = getClass.getName + "Sink"
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    ResultsCollector.reset()
+  }
+
+  // Create a ForeachWriter that collects results into ResultsCollector.
+  def foreachWriter(sinkName: String): ForeachWriter[String] = new ForeachWriter[String] {
+    override def open(partitionId: Long, epochId: Long): Boolean = {
+      true
+    }
+
+    override def process(value: String): Unit = {
+      val collector =
+        ResultsCollector.computeIfAbsent(sinkName, (_) => new ConcurrentLinkedQueue[String]())
+      collector.add(value)
+    }
+
+    override def close(errorOrNull: Throwable): Unit = {}
+  }
+
+  def createMemoryStream(numPartitions: Int = 5)
+      : (LowLatencyMemoryStream[(String, Int)], GlobalSingletonManualClock) = {
+    val clock = new GlobalSingletonManualClock()
+    LowLatencyClock.setClock(clock)
+    val read = LowLatencyMemoryStream[(String, Int)](numPartitions)
+    (read, clock)
+  }
+
+  def runStreamingQuery(queryName: String, df: org.apache.spark.sql.DataFrame): StreamingQuery = {
+    df.as[String]
+      .writeStream
+      .outputMode(OutputMode.Update())
+      .foreach(foreachWriter(sinkName))
+      .queryName(queryName)
+      .trigger(defaultTrigger)
+      .start()
+  }
+
+  // Add test data to the memory source and validate results
+  def processBatches(
+      query: StreamingQuery,
+      read: LowLatencyMemoryStream[(String, Int)],
+      clock: GlobalSingletonManualClock,
+      numRowsPerBatch: Int,
+      numBatches: Int,
+      expectedResultsGenerator: (String, Int) => Array[String]): Unit = {
+    val expectedResults = mutable.ListBuffer[String]()
+    for (i <- 0 until numBatches) {
+      for (key <- List("a", "b", "c")) {
+        for (j <- 1 to numRowsPerBatch) {
+          val value = i * numRowsPerBatch + j
+          read.addData((key, value))
+          expectedResults ++= expectedResultsGenerator(key, value)
+        }
+      }
+
+      eventually(timeout(60.seconds)) {
+        ResultsCollector
+          .get(sinkName)
+          .toArray(new Array[String](ResultsCollector.get(sinkName).size()))
+          .toList
+          .sorted should equal(expectedResults.sorted)
+      }
+
+      clock.advance(defaultTrigger.batchDurationMs)
+
+      eventually(timeout(60.seconds)) {
+        query
+          .asInstanceOf[StreamingQueryWrapper]
+          .streamingQuery
+          .getLatestExecutionContext()
+          .batchId should be(i + 1)
+        query.lastProgress.sources(0).numInputRows should be(numRowsPerBatch * 3)
+      }
+    }
+  }
 }
 
 abstract class StreamRealTimeModeManualClockSuiteBase extends StreamRealTimeModeSuiteBase {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add support for Real-time Mode in the Kafka Source.  Which means KafkaMicroBatchStream needs to implement the SupportsRealTimeMode interface and the KakfaPartitionBatchReader needs to extend SupportRealTimeRead interface.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

So that Kafka source and sink can be used by Real-time Mode queries


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, Kafka source and sink can be used by Real-time Mode queries


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Many tests added


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
