### PR TITLE
[SPARK-54032][CORE] Prefer to use native Netty transports by default

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -89,7 +89,7 @@ public class TransportConf {
 
   /** IO mode: NIO, EPOLL, KQUEUE, or AUTO */
   public String ioMode() {
-    String defaultIOMode = conf.get(SPARK_NETWORK_DEFAULT_IO_MODE_KEY, "NIO");
+    String defaultIOMode = conf.get(SPARK_NETWORK_DEFAULT_IO_MODE_KEY, "AUTO");
     return conf.get(SPARK_NETWORK_IO_MODE_KEY, defaultIOMode).toUpperCase(Locale.ROOT);
   }
 

--- a/common/network-common/src/test/java/org/apache/spark/network/TransportConfSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/TransportConfSuite.java
@@ -91,7 +91,7 @@ public class TransportConfSuite {
   @Test
   public void testDefaultIOMode() {
     TransportConf c1 = new TransportConf("m1", new MapConfigProvider(Map.of()));
-    assertEquals("NIO", c1.ioMode());
+    assertEquals("AUTO", c1.ioMode());
 
     TransportConf c2 = new TransportConf("m1",
       new MapConfigProvider(Map.of("spark.io.mode.default", "KQUEUE")));

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2653,6 +2653,18 @@ Apart from these, the following properties are also available, and may be useful
   <td>4.1.0</td>
 </tr>
 <tr>
+  <td><code>spark.io.mode.default</code></td>
+  <td>AUTO</td>
+  <td>
+    The default IO mode for Netty transports.
+    One of <code>NIO</code>, <code>EPOLL</code>, <code>KQUEUE</code>, or <code>AUTO</code>.
+    The default value is <code>AUTO</code> which means to use native Netty libraries if available.
+    In other words, for Linux environments, <code>EPOLL</code> is used if available before using <code>NIO</code>.
+    For MacOS/BSD environments, <code>KQUEUE</code> is used if available before using <code>NIO</code>.
+  </td>
+  <td>4.1.0</td>
+</tr>
+<tr>
   <td><code>spark.rpc.io.backLog</code></td>
   <td>64</td>
   <td>

--- a/docs/core-migration-guide.md
+++ b/docs/core-migration-guide.md
@@ -30,6 +30,7 @@ license: |
 - Since Spark 4.1, `java.lang.InternalError` encountered during file reading will no longer fail the task if the configuration `spark.sql.files.ignoreCorruptFiles` or the data source option `ignoreCorruptFiles` is set to `true`. 
 - Since Spark 4.1, Spark ignores `*.blacklist.*` alternative configuration names. To restore the behavior before Spark 4.1, you can use the corresponding configuration names instead which exists since Spark 3.1.0.
 - Since Spark 4.1, Spark will use multiple threads for LZF compression to compress data in parallel. To restore the behavior before Spark 4.1, you can set `spark.io.compression.lzf.parallel.enabled` to `false`.
+- Since Spark 4.1, Spark uses native Netty IO mode by default. To restore the behavior before Spark 4.1, you can set `spark.io.mode.default` to `NIO`.
 
 ## Upgrading from Core 3.5 to 4.0
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to prefer to use native Netty transports by default for Apache Spark 4.1.0.

### Why are the changes needed?

To help users configure Netty transport libraries easily.
- https://netty.io/wiki/native-transports.html

> Netty provides the following platform specific JNI transports:
> - Linux (since 4.0.16)
> - MacOS/BSD (since 4.1.11)
> 
> These JNI transports add features specific to a particular platform, generate less garbage, and generally improve performance when compared to the NIO based transport.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.