### PR TITLE
[SPARK-54034][CORE] Fix `Utils.isBindCollision` to detect port conflict `NativeIoException` correctly

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2302,7 +2302,7 @@ private[spark] object Utils
       case e: MultiException =>
         e.getThrowables.asScala.exists(isBindCollision)
       case e: NativeIoException =>
-        (e.getMessage != null && e.getMessage.startsWith("bind() failed: ")) ||
+        (e.getMessage != null && e.getMessage.matches("bind.*failed.*")) ||
           isBindCollision(e.getCause)
       case e: IOException =>
         (e.getMessage != null && e.getMessage.startsWith("Failed to bind to address")) ||

--- a/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcEnvSuite.scala
@@ -186,3 +186,9 @@ class SslNettyRpcEnvSuite extends NettyRpcEnvSuite with MockitoSugar with TimeLi
     SslTestUtils.updateWithSSLConfig(super.createSparkConf())
   }
 }
+
+class AutoNettyRpcEnvSuite extends NettyRpcEnvSuite with MockitoSugar with TimeLimits {
+  override def createSparkConf(): SparkConf = {
+    super.createSparkConf().set("spark.rpc.io.mode", "AUTO")
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `Utils.isBindCollision` to detect port conflict NativeIoException correctly by using regular expression.

### Why are the changes needed?

Currently, `Utils.isBindCollision` fails to detect port conflicts when we use native Netty transport IO modes, `EPOLL` and `KQUEUE`.

**BEFORE**

```
[info] AutoNettyRpcEnvSuite:
[info] - port conflict *** FAILED *** (7 milliseconds)
[info]   io.netty.channel.unix.Errors$NativeIoException: bind(..) failed with error(-48): Address already in use
```

**AFTER**

```
[info] AutoNettyRpcEnvSuite:
[info] - port conflict (68 milliseconds)
```

### Does this PR introduce _any_ user-facing change?

No, this is a bug fix.

### How was this patch tested?

Pass the CI with the newly added test suite, `AutoNettyRpcEnvSuite`.

### Was this patch authored or co-authored using generative AI tooling?

No.