### PR TITLE
[SPARK-54047][PYTHON] Use a difference error when kill-on-idle-timeout

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -119,6 +119,18 @@ private[spark] object BasePythonRunner extends Logging {
     new File(faultHandlerLogDir, pid.toString).toPath
   }
 
+  private[spark] def tryReadFaultHandlerLog(
+      faultHandlerEnabled: Boolean, pid: Option[Int]): Option[String] = {
+    if (faultHandlerEnabled) {
+      pid.map(faultHandlerLogPath).collect {
+        case path if JavaFiles.exists(path) =>
+          val error = String.join("\n", JavaFiles.readAllLines(path)) + "\n"
+          JavaFiles.deleteIfExists(path)
+          error
+      }
+    } else None
+  }
+
   private[spark] def pythonWorkerStatusMessageWithContext(
       handle: Option[ProcessHandle],
       worker: PythonWorker,
@@ -318,7 +330,8 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
 
     // Return an iterator that read lines from the process's stdout
     val dataIn = new DataInputStream(new BufferedInputStream(
-      new ReaderInputStream(worker, writer, handle, idleTimeoutSeconds, killOnIdleTimeout),
+      new ReaderInputStream(worker, writer, handle,
+        faultHandlerEnabled, idleTimeoutSeconds, killOnIdleTimeout),
       bufferSize))
     val stdoutIterator = newReaderIterator(
       dataIn, writer, startTime, env, worker, handle.map(_.pid.toInt), releasedOrClosed, context)
@@ -648,13 +661,6 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
         logError("This may have been caused by a prior exception:", writer.exception.get)
         throw writer.exception.get
 
-      case e: IOException if faultHandlerEnabled && pid.isDefined &&
-          JavaFiles.exists(faultHandlerLogPath(pid.get)) =>
-        val path = faultHandlerLogPath(pid.get)
-        val error = String.join("\n", JavaFiles.readAllLines(path)) + "\n"
-        JavaFiles.deleteIfExists(path)
-        throw new SparkException(s"Python worker exited unexpectedly (crashed): $error", e)
-
       case e: IOException if !faultHandlerEnabled =>
         throw new SparkException(
           s"Python worker exited unexpectedly (crashed). " +
@@ -663,7 +669,11 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
             "the better Python traceback.", e)
 
       case e: IOException =>
-        throw new SparkException("Python worker exited unexpectedly (crashed)", e)
+        val base = "Python worker exited unexpectedly (crashed)"
+        val msg = tryReadFaultHandlerLog(faultHandlerEnabled, pid)
+          .map(error => s"$base: $error")
+          .getOrElse(base)
+        throw new SparkException(msg, e)
     }
   }
 
@@ -721,6 +731,7 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
       worker: PythonWorker,
       writer: Writer,
       handle: Option[ProcessHandle],
+      faultHandlerEnabled: Boolean,
       idleTimeoutSeconds: Long,
       killOnIdleTimeout: Boolean) extends InputStream {
     private[this] var writerIfbhThreadLocalValue: Object = null
@@ -856,6 +867,14 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
             }
           }
         }
+      }
+      if (n == -1 && pythonWorkerKilled) {
+        val base = "Python worker process terminated due to idle timeout " +
+          s"(timeout: $idleTimeoutSeconds seconds)"
+        val msg = tryReadFaultHandlerLog(faultHandlerEnabled, handle.map(_.pid.toInt))
+          .map(error => s"$base: $error")
+          .getOrElse(base)
+        throw new SparkException(msg)
       }
       n
     }

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -874,7 +874,7 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
         val msg = tryReadFaultHandlerLog(faultHandlerEnabled, handle.map(_.pid.toInt))
           .map(error => s"$base: $error")
           .getOrElse(base)
-        throw new SparkException(msg)
+        throw new PythonWorkerException(msg)
       }
       n
     }
@@ -1026,6 +1026,12 @@ private[spark] class PythonRunner(
       }
     }
   }
+}
+
+class PythonWorkerException(msg: String, cause: Throwable)
+  extends SparkException(msg, cause) {
+
+  def this(msg: String) = this(msg, cause = null)
 }
 
 private[spark] object SpecialLengths {

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -1248,7 +1248,10 @@ class BaseUDFTestsMixin(object):
                 time.sleep(2)
                 return str(x)
 
-            with self.assertRaisesRegex(Exception, "Python worker exited unexpectedly"):
+            with self.assertRaisesRegex(
+                Exception,
+                "Python worker process terminated due to idle timeout \\(timeout: 1 seconds\\)",
+            ):
                 self.spark.range(1).select(f("id")).show()
 
     def test_err_udf_init(self):

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -2987,7 +2987,7 @@ class BaseUDTFTestsMixin:
                 self._check_result_or_exception(
                     TestUDTF,
                     "x: string",
-                    "Python worker exited unexpectedly",
+                    "Python worker process terminated due to idle timeout \\(timeout: 1 seconds\\)",
                     err_type=Exception,
                 )
 
@@ -3005,7 +3005,7 @@ class BaseUDTFTestsMixin:
                 self._check_result_or_exception(
                     TestUDTFWithAnalyze,
                     None,
-                    "Python worker exited unexpectedly",
+                    "Python worker process terminated due to idle timeout \\(timeout: 1 seconds\\)",
                     err_type=Exception,
                 )
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonPlannerRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonPlannerRunner.scala
@@ -28,7 +28,7 @@ import scala.jdk.CollectionConverters._
 import net.razorvine.pickle.Pickler
 
 import org.apache.spark.{JobArtifactSet, SparkEnv, SparkException}
-import org.apache.spark.api.python.{BasePythonRunner, PythonFunction, PythonWorker, PythonWorkerUtils, SpecialLengths}
+import org.apache.spark.api.python.{BasePythonRunner, PythonFunction, PythonWorker, PythonWorkerException, PythonWorkerUtils, SpecialLengths}
 import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.internal.config.BUFFER_SIZE
 import org.apache.spark.internal.config.Python._
@@ -246,7 +246,7 @@ abstract class PythonPlannerRunner[T](func: PythonFunction) extends Logging {
         val msg = tryReadFaultHandlerLog(faultHandlerEnabled, handle.map(_.pid.toInt))
           .map(error => s"$base: $error")
           .getOrElse(base)
-        throw new SparkException(msg)
+        throw new PythonWorkerException(msg)
       }
       n
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Uses a difference error message when kill-on-idle-timeout.

### Why are the changes needed?

Currently the error message when kill-on-idle-timeout is same as when the Python worker crashes.

```py
>>> from pyspark.sql.functions import udf
>>> import time
>>>
>>> @udf
... def f(x):
...   time.sleep(2)
...   return str(x)
...
>>> spark.conf.set("spark.sql.execution.pyspark.udf.idleTimeoutSeconds", "1s")
>>> spark.conf.set("spark.sql.execution.pyspark.udf.killOnIdleTimeout", "true")
>>>
>>> spark.range(1).select(f("id")).show()
25/10/27 16:31:16 WARN PythonUDFWithNamedArgumentsRunner: Idle timeout reached for Python worker (timeout: 1 seconds). No data received from the worker process: handle.map(_.isAlive) = Some(true), channel.isConnected = true, channel.isBlocking = false, selector.isOpen = true, selectionKey.isValid = true, selectionKey.interestOps = 1, hasInputs = false
25/10/27 16:31:16 WARN PythonUDFWithNamedArgumentsRunner: Terminating Python worker process due to idle timeout (timeout: 1 seconds)
25/10/27 16:31:16 ERROR Executor: Exception in task 15.0 in stage 0.0 (TID 15)
org.apache.spark.SparkException: Python worker exited unexpectedly (crashed). Consider setting 'spark.sql.execution.pyspark.udf.faulthandler.enabled' or'spark.python.worker.faulthandler.enabled' configuration to 'true' for the better Python traceback.
...
```

It should show a different message to distinguish the cause:

```py
25/10/27 16:34:55 WARN PythonUDFWithNamedArgumentsRunner: Idle timeout reached for Python worker (timeout: 1 seconds). No data received from the worker process: handle.map(_.isAlive) = Some(true), channel.isConnected = true, channel.isBlocking = false, selector.isOpen = true, selectionKey.isValid = true, selectionKey.interestOps = 1, hasInputs = false
25/10/27 16:34:55 WARN PythonUDFWithNamedArgumentsRunner: Terminating Python worker process due to idle timeout (timeout: 1 seconds)
25/10/27 16:34:55 ERROR Executor: Exception in task 15.0 in stage 0.0 (TID 15)
org.apache.spark.api.python.PythonWorkerException: Python worker process terminated due to idle timeout (timeout: 1 seconds)
...
```

### Does this PR introduce _any_ user-facing change?

Yes, the error message when kill-on-idle-timeout is different.

### How was this patch tested?

Modified the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.