### PR TITLE
[SPARK-53941][FOLLOWUP][SS] Introduce a SQL config to control AQE for stateless streaming workload specifically

### DIFF
--- a/docs/streaming/ss-migration-guide.md
+++ b/docs/streaming/ss-migration-guide.md
@@ -25,7 +25,7 @@ Please refer [Migration Guide: SQL, Datasets and DataFrame](../sql-migration-gui
 
 ## Upgrading from Structured Streaming 4.0 to 4.1
 
-- Since Spark 4.1, AQE is supported for stateless workloads, and it could affect the behavior of the query after upgrade (especially since AQE is turned on by default). In general, it helps to achieve better performance including resolution of skewed partition, but you can turn off AQE via changing `spark.sql.adaptive.enabled` to `false` to restore the behavior if you see regression.
+- Since Spark 4.1, AQE is supported for stateless workloads, and it could affect the behavior of the query after upgrade (especially since AQE is turned on by default). In general, it helps to achieve better performance including resolution of skewed partition, but you can turn off AQE via changing `spark.sql.adaptive.streaming.stateless.enabled` to `false` to restore the behavior if you see regression.
 
 ## Upgrading from Structured Streaming 3.5 to 4.0
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -922,6 +922,14 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val ADAPTIVE_EXECUTION_ENABLED_IN_STATELESS_STREAMING =
+    buildConf("spark.sql.adaptive.streaming.stateless.enabled")
+      .doc("When true, enable adaptive query execution for stateless streaming query. To " +
+        "enable this config, `spark.sql.adaptive.enabled` needs to be also enabled.")
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val ADAPTIVE_EXECUTION_FORCE_APPLY = buildConf("spark.sql.adaptive.forceApply")
     .internal()
     .doc("Adaptive query execution is skipped when the query does not have exchanges or " +
@@ -6807,6 +6815,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def trimCollationEnabled: Boolean = getConf(TRIM_COLLATION_ENABLED)
 
   def adaptiveExecutionEnabled: Boolean = getConf(ADAPTIVE_EXECUTION_ENABLED)
+
+  def adaptiveExecutionEnabledInStatelessStreaming: Boolean =
+    getConf(ADAPTIVE_EXECUTION_ENABLED_IN_STATELESS_STREAMING)
 
   def adaptiveExecutionLogLevel: Level = getConf(ADAPTIVE_EXECUTION_LOG_LEVEL)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
@@ -56,6 +56,9 @@ case class InsertAdaptiveSparkPlan(
     case c: DataWritingCommandExec
         if !c.cmd.isInstanceOf[V1WriteCommand] || !conf.plannedWriteEnabled =>
       c.copy(child = apply(c.child))
+    // SPARK-53941: if AQE for stateless streaming is disabled specifically, we disable it here.
+    case _ if !conf.adaptiveExecutionEnabledInStatelessStreaming &&
+      plan.logicalLink.exists(_.isStreaming) => plan
     // SPARK-53941: Do not apply AQE for stateful streaming workloads. From recent change of shuffle
     // origin for shuffle being added from stateful operator, we anticipate stateful operator to
     // work with AQE. But we want to make the adoption of AQE be gradual, to have a risk under


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to introduce a new SQL config to control AQE for stateless streaming workload. 

### Why are the changes needed?

We had a post review comment about the impact of turning off AQE config across batch and streaming.
https://github.com/apache/spark/pull/52642#discussion_r2463840301

To reduce the side effect of turning off AQE for stateless streaming workload, we demand a new SQL config to control only to stateless streaming workload while leaving the AQE for batch query.

### Does this PR introduce _any_ user-facing change?

Yes, new config is proposed to control the AQE enablement for stateless streaming query.

### How was this patch tested?

New UT.

### Was this patch authored or co-authored using generative AI tooling?

No.