### PR TITLE
[SPARK-54052][PYTHON] Add a bridge object to workaround Py4J limitation

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonErrorUtils.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonErrorUtils.scala
@@ -30,6 +30,7 @@ import org.apache.spark.{BreakingChangeInfo, QueryContext, SparkThrowable}
  * with default methods.
  */
 private[spark] object PythonErrorUtils {
+  def getCondition(e: SparkThrowable): String = e.getCondition
   def getErrorClass(e: SparkThrowable): String = e.getCondition
   def getSqlState(e: SparkThrowable): String = e.getSqlState
   def isInternalError(e: SparkThrowable): Boolean = e.isInternalError

--- a/core/src/main/scala/org/apache/spark/api/python/PythonErrorUtils.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonErrorUtils.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.api.python
+
+import java.util
+
+import org.apache.spark.{BreakingChangeInfo, QueryContext, SparkThrowable}
+
+/**
+ * Utility object that provides convenient accessors for extracting
+ * detailed information from a [[SparkThrowable]] instance.
+ *
+ * This object is primarily used in PySpark
+ * to retrieve structured error metadata because Py4J does not work
+ * with default methods.
+ */
+private[spark] object PythonErrorUtils {
+  def getErrorClass(e: SparkThrowable): String = e.getCondition
+  def getSqlState(e: SparkThrowable): String = e.getSqlState
+  def isInternalError(e: SparkThrowable): Boolean = e.isInternalError
+  def getBreakingChangeInfo(e: SparkThrowable): BreakingChangeInfo = e.getBreakingChangeInfo
+  def getMessageParameters(e: SparkThrowable): util.Map[String, String] = e.getMessageParameters
+  def getDefaultMessageTemplate(e: SparkThrowable): String = e.getDefaultMessageTemplate
+  def getQueryContext(e: SparkThrowable): Array[QueryContext] = e.getQueryContext
+}

--- a/core/src/test/scala/org/apache/spark/deploy/PythonRunnerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/PythonRunnerSuite.scala
@@ -66,11 +66,11 @@ class PythonRunnerSuite extends SparkFunSuite {
     intercept[IllegalArgumentException] { PythonRunner.formatPaths("foo.py,hdfs:/some.py") }
   }
 
-  test("PythonErrorUtils should have corresponding methods for default methods in SparkThrowable") {
+  test("SPARK-54052: PythonErrorUtils should have corresponding methods in SparkThrowable") {
     // Find default methods in SparkThrowable
     val defaultMethods = classOf[SparkThrowable]
       .getMethods
-      .filter(m => m.getDeclaringClass == classOf[SparkThrowable] && m.isDefault)
+      .filter(m => m.getDeclaringClass == classOf[SparkThrowable])
       .map(_.getName)
       .toSet
 

--- a/core/src/test/scala/org/apache/spark/deploy/PythonRunnerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/PythonRunnerSuite.scala
@@ -17,7 +17,8 @@
 
 package org.apache.spark.deploy
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkFunSuite, SparkThrowable}
+import org.apache.spark.api.python.PythonErrorUtils
 import org.apache.spark.util.Utils
 
 class PythonRunnerSuite extends SparkFunSuite {
@@ -63,5 +64,32 @@ class PythonRunnerSuite extends SparkFunSuite {
     intercept[IllegalArgumentException] { PythonRunner.formatPaths("two,three,four:five:six") }
     intercept[IllegalArgumentException] { PythonRunner.formatPaths("hdfs:/some.py,foo.py") }
     intercept[IllegalArgumentException] { PythonRunner.formatPaths("foo.py,hdfs:/some.py") }
+  }
+
+  test("PythonErrorUtils should have corresponding methods for default methods in SparkThrowable") {
+    // Find default methods in SparkThrowable
+    val defaultMethods = classOf[SparkThrowable]
+      .getMethods
+      .filter(m => m.getDeclaringClass == classOf[SparkThrowable] && m.isDefault)
+      .map(_.getName)
+      .toSet
+
+    // Find methods defined in PythonErrorUtils object
+    val utilsMethods = PythonErrorUtils.getClass
+      .getDeclaredMethods
+      .filterNot(_.isSynthetic)
+      .map(_.getName)
+      .filterNot(_.contains("$"))
+      .toSet
+
+    // Compare
+    assert(
+      utilsMethods == defaultMethods,
+      s"""
+         |PythonErrorUtils methods and SparkThrowable default methods differ!
+         |Missing in PythonErrorUtils: ${defaultMethods.diff(utilsMethods).mkString(", ")}
+         |Extra in PythonErrorUtils: ${utilsMethods.diff(defaultMethods).mkString(", ")}
+         |""".stripMargin
+    )
   }
 }

--- a/python/pyspark/errors/exceptions/captured.py
+++ b/python/pyspark/errors/exceptions/captured.py
@@ -107,7 +107,8 @@ class CapturedException(PySparkException):
         if self._origin is not None and is_instance_of(
             gw, self._origin, "org.apache.spark.SparkThrowable"
         ):
-            return SparkContext._jvm.PythonErrorUtils.getCondition(self._origin)
+            utils = SparkContext._jvm.PythonErrorUtils  # type: ignore[union-attr]
+            return utils.getCondition(self._origin)
         else:
             return None
 
@@ -125,7 +126,8 @@ class CapturedException(PySparkException):
         if self._origin is not None and is_instance_of(
             gw, self._origin, "org.apache.spark.SparkThrowable"
         ):
-            return dict(SparkContext._jvm.PythonErrorUtils.getMessageParameters(self._origin))
+            utils = SparkContext._jvm.PythonErrorUtils  # type: ignore[union-attr]
+            return dict(utils.getMessageParameters(self._origin))
         else:
             return None
 
@@ -138,7 +140,8 @@ class CapturedException(PySparkException):
         if self._origin is not None and is_instance_of(
             gw, self._origin, "org.apache.spark.SparkThrowable"
         ):
-            return SparkContext._jvm.PythonErrorUtils.getSqlState(self._origin)
+            utils = SparkContext._jvm.PythonErrorUtils  # type: ignore[union-attr]
+            return utils.getSqlState(self._origin)
         else:
             return None
 
@@ -152,10 +155,9 @@ class CapturedException(PySparkException):
         if self._origin is not None and is_instance_of(
             gw, self._origin, "org.apache.spark.SparkThrowable"
         ):
-            errorClass = SparkContext._jvm.PythonErrorUtils.getCondition(self._origin)
-            messageParameters = SparkContext._jvm.PythonErrorUtils.getMessageParameters(
-                self._origin
-            )
+            utils = SparkContext._jvm.PythonErrorUtils  # type: ignore[union-attr]
+            errorClass = utils.getCondition(self._origin)
+            messageParameters = utils.getMessageParameters(self._origin)
 
             error_message = getattr(gw.jvm, "org.apache.spark.SparkThrowableHelper").getMessage(
                 errorClass, messageParameters
@@ -176,7 +178,8 @@ class CapturedException(PySparkException):
             gw, self._origin, "org.apache.spark.SparkThrowable"
         ):
             contexts: List[BaseQueryContext] = []
-            for q in SparkContext._jvm.PythonErrorUtils.getQueryContext(self._origin):
+            utils = SparkContext._jvm.PythonErrorUtils  # type: ignore[union-attr]
+            for q in utils.getQueryContext(self._origin):
                 if q.contextType().toString() == "SQL":
                     contexts.append(SQLQueryContext(q))
                 else:

--- a/python/pyspark/errors/exceptions/captured.py
+++ b/python/pyspark/errors/exceptions/captured.py
@@ -153,7 +153,9 @@ class CapturedException(PySparkException):
             gw, self._origin, "org.apache.spark.SparkThrowable"
         ):
             errorClass = SparkContext._jvm.PythonErrorUtils.getCondition(self._origin)
-            messageParameters = SparkContext._jvm.PythonErrorUtils.getMessageParameters(self._origin)
+            messageParameters = SparkContext._jvm.PythonErrorUtils.getMessageParameters(
+                self._origin
+            )
 
             error_message = getattr(gw.jvm, "org.apache.spark.SparkThrowableHelper").getMessage(
                 errorClass, messageParameters

--- a/python/pyspark/errors/exceptions/captured.py
+++ b/python/pyspark/errors/exceptions/captured.py
@@ -107,7 +107,7 @@ class CapturedException(PySparkException):
         if self._origin is not None and is_instance_of(
             gw, self._origin, "org.apache.spark.SparkThrowable"
         ):
-            return self._origin.getCondition()
+            return SparkContext._jvm.PythonErrorUtils.getCondition(self._origin)
         else:
             return None
 
@@ -138,7 +138,7 @@ class CapturedException(PySparkException):
         if self._origin is not None and is_instance_of(
             gw, self._origin, "org.apache.spark.SparkThrowable"
         ):
-            return dict(SparkContext._jvm.PythonErrorUtils.getSqlState(self._origin))
+            return SparkContext._jvm.PythonErrorUtils.getSqlState(self._origin)
         else:
             return None
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add PythonErrorUtils object to workaround Py4J limitation. Py4J does not support default method access.

### Why are the changes needed?

To make the change easier and non error prone

### Does this PR introduce _any_ user-facing change?

No. Virtually a refactoring change.

### How was this patch tested?

Unittest was added.

### Was this patch authored or co-authored using generative AI tooling?

No.
