### PR TITLE
[SPARK-54054][CONNECT] Support row position for SparkConnectResultSet

### DIFF
--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
@@ -37,7 +37,7 @@ class SparkConnectResultSet(
 
   // cursor is 1-based, range in [0, length + 1]
   // - 0 means beforeFirstRow
-  // - [1, length] means the row number
+  // - value in [1, length] means the row number
   // - length + 1 means afterLastRow
   private var cursor: Int = 0
 

--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
@@ -265,7 +265,7 @@ class SparkConnectResultSet(
 
   override def isBeforeFirst: Boolean = {
     checkOpen()
-    cursor < 1
+    cursor < 1 && sparkResult.length > 0
   }
 
   override def isFirst: Boolean = {

--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
@@ -25,6 +25,7 @@ import java.util.Calendar
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.connect.client.SparkResult
+import org.apache.spark.sql.connect.client.jdbc.util.JdbcErrorUtils
 
 class SparkConnectResultSet(
     sparkResult: SparkResult[Row],
@@ -34,16 +35,25 @@ class SparkConnectResultSet(
 
   private var currentRow: Row = _
 
-  private var _wasNull: Boolean = false
+  // cursor is 1-based, range in [0, length + 1]
+  // - 0 means beforeFirstRow
+  // - [1, length] means the row number
+  // - length + 1 means afterLastRow
+  private var cursor: Int = 0
 
+  private var _wasNull: Boolean = false
   override def wasNull: Boolean = _wasNull
 
   override def next(): Boolean = {
     val hasNext = iterator.hasNext
     if (hasNext) {
       currentRow = iterator.next()
+      cursor += 1
     } else {
       currentRow = null
+      if (cursor > 0 && cursor == sparkResult.length) {
+        cursor += 1
+      }
     }
     hasNext
   }
@@ -253,13 +263,25 @@ class SparkConnectResultSet(
   override def getBigDecimal(columnLabel: String): java.math.BigDecimal =
     throw new SQLFeatureNotSupportedException
 
-  override def isBeforeFirst: Boolean = throw new SQLFeatureNotSupportedException
+  override def isBeforeFirst: Boolean = {
+    checkOpen()
+    cursor < 1
+  }
 
-  override def isAfterLast: Boolean = throw new SQLFeatureNotSupportedException
+  override def isFirst: Boolean = {
+    checkOpen()
+    cursor == 1
+  }
 
-  override def isFirst: Boolean = throw new SQLFeatureNotSupportedException
+  override def isLast: Boolean = {
+    checkOpen()
+    cursor > 0 && cursor == sparkResult.length
+  }
 
-  override def isLast: Boolean = throw new SQLFeatureNotSupportedException
+  override def isAfterLast: Boolean = {
+    checkOpen()
+    cursor > 0 && cursor > sparkResult.length
+  }
 
   override def beforeFirst(): Unit = throw new SQLFeatureNotSupportedException
 
@@ -269,7 +291,15 @@ class SparkConnectResultSet(
 
   override def last(): Boolean = throw new SQLFeatureNotSupportedException
 
-  override def getRow: Int = throw new SQLFeatureNotSupportedException
+  override def getRow: Int = {
+    checkOpen()
+
+    if (cursor < 1 || cursor > sparkResult.length) {
+      0
+    } else {
+      cursor
+    }
+  }
 
   override def absolute(row: Int): Boolean = throw new SQLFeatureNotSupportedException
 
@@ -277,11 +307,21 @@ class SparkConnectResultSet(
 
   override def previous(): Boolean = throw new SQLFeatureNotSupportedException
 
-  override def setFetchDirection(direction: Int): Unit =
-    throw new SQLFeatureNotSupportedException
+  override def setFetchDirection(direction: Int): Unit = {
+    checkOpen()
+    assert(this.getType == ResultSet.TYPE_FORWARD_ONLY)
 
-  override def getFetchDirection: Int =
-    throw new SQLFeatureNotSupportedException
+    if (direction != ResultSet.FETCH_FORWARD) {
+      throw new SQLException(
+        s"Fetch direction ${JdbcErrorUtils.stringifyFetchDirection(direction)} is not supported " +
+          s"for ${JdbcErrorUtils.stringifyResultSetType(ResultSet.TYPE_FORWARD_ONLY)} result set.")
+    }
+  }
+
+  override def getFetchDirection: Int = {
+    checkOpen()
+    ResultSet.FETCH_FORWARD
+  }
 
   override def setFetchSize(rows: Int): Unit =
     throw new SQLFeatureNotSupportedException

--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/util/JdbcErrorUtils.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/util/JdbcErrorUtils.scala
@@ -37,4 +37,20 @@ private[jdbc] object JdbcErrorUtils {
     case _ =>
       throw new IllegalArgumentException(s"Invalid holdability: $holdability")
   }
+
+  def stringifyResultSetType(typ: Int): String = typ match {
+    case ResultSet.TYPE_FORWARD_ONLY => "FORWARD_ONLY"
+    case ResultSet.TYPE_SCROLL_INSENSITIVE => "SCROLL_INSENSITIVE"
+    case ResultSet.TYPE_SCROLL_SENSITIVE => "SCROLL_SENSITIVE"
+    case _ =>
+      throw new IllegalArgumentException(s"Invalid ResultSet type: $typ")
+  }
+
+  def stringifyFetchDirection(direction: Int): String = direction match {
+    case ResultSet.FETCH_FORWARD => "FETCH_FORWARD"
+    case ResultSet.FETCH_REVERSE => "FETCH_REVERSE"
+    case ResultSet.FETCH_UNKNOWN => "FETCH_UNKNOWN"
+    case _ =>
+      throw new IllegalArgumentException(s"Invalid fetch direction: $direction")
+  }
 }

--- a/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSetSuite.scala
+++ b/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSetSuite.scala
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.client.jdbc
+
+import java.sql.{Array => _, _}
+
+import org.apache.spark.sql.connect.client.jdbc.test.JdbcHelper
+import org.apache.spark.sql.connect.test.{ConnectFunSuite, RemoteSparkSession}
+
+class SparkConnectResultSetSuite extends ConnectFunSuite with RemoteSparkSession
+  with JdbcHelper {
+
+  def jdbcUrl: String = s"jdbc:sc://localhost:$serverPort"
+
+  test("type, concurrency, fetch direction of result set") {
+    withExecuteQuery("SELECT 1") { rs =>
+      rs.getType === ResultSet.TYPE_FORWARD_ONLY
+      rs.getConcurrency === ResultSet.CONCUR_READ_ONLY
+      rs.getFetchDirection === ResultSet.FETCH_FORWARD
+      Seq(ResultSet.FETCH_FORWARD, ResultSet.FETCH_REVERSE,
+        ResultSet.FETCH_UNKNOWN).foreach { direction =>
+        if (direction == ResultSet.FETCH_FORWARD) {
+          rs.setFetchDirection(direction)
+        } else {
+          intercept[SQLException] {
+            rs.setFetchDirection(direction)
+          }
+        }
+      }
+    }
+  }
+
+  test("row position for empty result set") {
+    withExecuteQuery("SELECT * FROM range(0)") { rs =>
+      assert(rs.getRow === 0)
+      assert(rs.isBeforeFirst)
+      assert(!rs.isFirst)
+      assert(!rs.isLast)
+      assert(!rs.isAfterLast)
+
+      assert(!rs.next())
+
+      assert(rs.getRow === 0)
+      assert(rs.isBeforeFirst)
+      assert(!rs.isFirst)
+      assert(!rs.isLast)
+      assert(!rs.isAfterLast)
+    }
+  }
+
+  test("row position for one row result set") {
+    withExecuteQuery("SELECT * FROM range(1)") { rs =>
+      assert(rs.getRow === 0)
+      assert(rs.isBeforeFirst)
+      assert(!rs.isFirst)
+      assert(!rs.isLast)
+      assert(!rs.isAfterLast)
+
+      assert(rs.next())
+
+      assert(rs.getRow === 1)
+      assert(!rs.isBeforeFirst)
+      assert(rs.isFirst)
+      assert(rs.isLast)
+      assert(!rs.isAfterLast)
+
+      assert(!rs.next())
+
+      assert(rs.getRow === 0)
+      assert(!rs.isBeforeFirst)
+      assert(!rs.isFirst)
+      assert(!rs.isLast)
+      assert(rs.isAfterLast)
+    }
+  }
+
+  test("row position for multiple rows result set") {
+    withExecuteQuery("SELECT * FROM range(2)") { rs =>
+      assert(rs.getRow === 0)
+      assert(rs.isBeforeFirst)
+      assert(!rs.isFirst)
+      assert(!rs.isLast)
+      assert(!rs.isAfterLast)
+
+      assert(rs.next())
+
+      assert(rs.getRow === 1)
+      assert(!rs.isBeforeFirst)
+      assert(rs.isFirst)
+      assert(!rs.isLast)
+      assert(!rs.isAfterLast)
+
+      assert(rs.next())
+
+      assert(rs.getRow === 2)
+      assert(!rs.isBeforeFirst)
+      assert(!rs.isFirst)
+      assert(rs.isLast)
+      assert(!rs.isAfterLast)
+
+      assert(!rs.next())
+
+      assert(rs.getRow === 0)
+      assert(!rs.isBeforeFirst)
+      assert(!rs.isFirst)
+      assert(!rs.isLast)
+      assert(rs.isAfterLast)
+    }
+  }
+}

--- a/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSetSuite.scala
+++ b/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSetSuite.scala
@@ -48,7 +48,7 @@ class SparkConnectResultSetSuite extends ConnectFunSuite with RemoteSparkSession
   test("row position for empty result set") {
     withExecuteQuery("SELECT * FROM range(0)") { rs =>
       assert(rs.getRow === 0)
-      assert(rs.isBeforeFirst)
+      assert(!rs.isBeforeFirst)
       assert(!rs.isFirst)
       assert(!rs.isLast)
       assert(!rs.isAfterLast)
@@ -56,7 +56,7 @@ class SparkConnectResultSetSuite extends ConnectFunSuite with RemoteSparkSession
       assert(!rs.next())
 
       assert(rs.getRow === 0)
-      assert(rs.isBeforeFirst)
+      assert(!rs.isBeforeFirst)
       assert(!rs.isFirst)
       assert(!rs.isLast)
       assert(!rs.isAfterLast)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR implements below methods of the `java.sql.ResultSet` interface for `SparkConnectResultSet`

```
boolean isBeforeFirst() throws SQLException;
boolean isAfterLast() throws SQLException;
boolean isFirst() throws SQLException;
boolean isLast() throws SQLException;
int getRow() throws SQLException;
void setFetchDirection(int direction) throws SQLException;
int getFetchDirection() throws SQLException;
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Implement more JDBC APIs.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, it's new feature.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New UTs are added.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
