### PR TITLE
[SPARK-54060][Geo][SQL] Introduce Geometry and Geography in-memory wrapper formats

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geo.java
@@ -21,6 +21,9 @@ import java.nio.ByteOrder;
 // Helper interface for the APIs expected from top-level GEOMETRY and GEOGRAPHY classes.
 interface Geo {
 
+  // The default endianness for in-memory geo objects is Little Endian (NDR).
+  ByteOrder DEFAULT_ENDIANNESS = ByteOrder.LITTLE_ENDIAN;
+
   /**
    * In-memory representation of a geospatial object:
    * +------------------------------+

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geo.java
@@ -16,13 +16,47 @@
  */
 package org.apache.spark.sql.catalyst.util;
 
+import java.nio.ByteOrder;
+
 // Helper interface for the APIs expected from top-level GEOMETRY and GEOGRAPHY classes.
 interface Geo {
+
+  /**
+   * In-memory representation of a geospatial object:
+   * +------------------------------+
+   * |          Geo Object          |
+   * +------------------------------+
+   * | Header          (Fixed Size) |
+   * | +--------------------------+ |
+   * | | SRID           [4 bytes] | |
+   * | +--------------------------+ |
+   * |                              |
+   * | Payload      (Variable Size) |
+   * | +--------------------------+ |
+   * | | WKB         [byte array] | |
+   * | +--------------------------+ |
+   * +------------------------------+
+   * Byte order: Little Endian (NDR).
+   */
+
+  // Constant defining the size of the header in the geo object in-memory representation.
+  int HEADER_SIZE = 4;
+
+  /** Header offsets. */
+
+  // Constant defining the offset of the Spatial Reference System Identifier (SRID) value.
+  int SRID_OFFSET = 0;
+
+  /** Payload offsets. */
+
+  // Constant defining the offset of the Well-Known Binary (WKB) representation value.
+  int WKB_OFFSET = HEADER_SIZE;
 
   /** Binary converters. */
 
   // Returns the Well-Known Binary (WKB) representation of the geo object.
   byte[] toWkb();
+  byte[] toWkb(ByteOrder endianness);
 
   // Returns the Extended Well-Known Binary (EWKB) representation of the geo object.
   byte[] toEwkb();

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geo.java
@@ -60,6 +60,7 @@ interface Geo {
 
   // Returns the Extended Well-Known Binary (EWKB) representation of the geo object.
   byte[] toEwkb();
+  byte[] toEwkb(ByteOrder endianness);
 
   /** Textual converters. */
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geography.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geography.java
@@ -153,7 +153,7 @@ public final class Geography implements Geo {
 
   @Override
   public int srid() {
-    // This method gets the SRID value from the in-memory Geometry representation header.
+    // This method gets the SRID value from the in-memory Geography representation header.
     return ByteBuffer.wrap(getBytes()).order(ByteOrder.LITTLE_ENDIAN).getInt(SRID_OFFSET);
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geography.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geography.java
@@ -22,8 +22,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 
-import java.util.Arrays;
-
 // Catalyst-internal server-side execution wrapper for GEOGRAPHY.
 public final class Geography implements Geo {
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geography.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geography.java
@@ -131,8 +131,12 @@ public final class Geography implements Geo {
 
   @Override
   public byte[] toEwkb() {
-    // Once EWKB conversion is implemented, it should support NDR and XDR endianness.
     throw new UnsupportedOperationException("Geography EWKB conversion is not yet supported.");
+  }
+
+  @Override
+  public byte[] toEwkb(ByteOrder endianness) {
+    throw new UnsupportedOperationException("Geography EWKB endianness is not yet supported.");
   }
 
   /** Geography textual standard format converters: WKT and EWKT. */

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geography.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geography.java
@@ -122,7 +122,8 @@ public final class Geography implements Geo {
 
   @Override
   public byte[] toWkb(ByteOrder endianness) {
-    if (endianness == ByteOrder.LITTLE_ENDIAN) {
+    // The default endianness is Little Endian (NDR).
+    if (endianness == DEFAULT_ENDIANNESS) {
       return toWkb();
     } else {
       throw new UnsupportedOperationException("Geography WKB endianness is not yet supported.");
@@ -158,7 +159,7 @@ public final class Geography implements Geo {
   @Override
   public int srid() {
     // This method gets the SRID value from the in-memory Geography representation header.
-    return ByteBuffer.wrap(getBytes()).order(ByteOrder.LITTLE_ENDIAN).getInt(SRID_OFFSET);
+    return ByteBuffer.wrap(getBytes()).order(DEFAULT_ENDIANNESS).getInt(SRID_OFFSET);
   }
 
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geometry.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geometry.java
@@ -131,8 +131,12 @@ public final class Geometry implements Geo {
 
   @Override
   public byte[] toEwkb() {
-    // Once EWKB conversion is implemented, it should support NDR and XDR endianness.
     throw new UnsupportedOperationException("Geometry EWKB conversion is not yet supported.");
+  }
+
+  @Override
+  public byte[] toEwkb(ByteOrder endianness) {
+    throw new UnsupportedOperationException("Geometry EWKB endianness is not yet supported.");
   }
 
   /** Geometry textual standard format converters: WKT and EWKT. */

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geometry.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geometry.java
@@ -122,7 +122,8 @@ public final class Geometry implements Geo {
 
   @Override
   public byte[] toWkb(ByteOrder endianness) {
-    if (endianness == ByteOrder.LITTLE_ENDIAN) {
+    // The default endianness is Little Endian (NDR).
+    if (endianness == DEFAULT_ENDIANNESS) {
       return toWkb();
     } else {
       throw new UnsupportedOperationException("Geometry WKB endianness is not yet supported.");
@@ -158,7 +159,7 @@ public final class Geometry implements Geo {
   @Override
   public int srid() {
     // This method gets the SRID value from the in-memory Geometry representation header.
-    return ByteBuffer.wrap(getBytes()).order(ByteOrder.LITTLE_ENDIAN).getInt(SRID_OFFSET);
+    return ByteBuffer.wrap(getBytes()).order(DEFAULT_ENDIANNESS).getInt(SRID_OFFSET);
   }
 
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/GeographyExecutionSuite.java
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/GeographyExecutionSuite.java
@@ -186,6 +186,26 @@ class GeographyExecutionTest {
     assertEquals("Geography EWKB conversion is not yet supported.", exception.getMessage());
   }
 
+  @Test
+  void testToEwkbEndiannessXDRUnsupported() {
+    Geography geography = Geography.fromBytes(testGeographyVal);
+    UnsupportedOperationException exception = assertThrows(
+      UnsupportedOperationException.class,
+      () -> geography.toEwkb(ByteOrder.BIG_ENDIAN)
+    );
+    assertEquals("Geography EWKB endianness is not yet supported.", exception.getMessage());
+  }
+
+  @Test
+  void testToEwkbEndiannessNDRUnsupported() {
+    Geography geography = Geography.fromBytes(testGeographyVal);
+    UnsupportedOperationException exception = assertThrows(
+      UnsupportedOperationException.class,
+      () -> geography.toEwkb(ByteOrder.LITTLE_ENDIAN)
+    );
+    assertEquals("Geography EWKB endianness is not yet supported.", exception.getMessage());
+  }
+
   /** Tests for Geography WKT and EWKT converters. */
 
   @Test

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/GeometryExecutionSuite.java
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/GeometryExecutionSuite.java
@@ -20,6 +20,9 @@ package org.apache.spark.sql.catalyst.util;
 import org.apache.spark.unsafe.types.GeometryVal;
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteOrder;
+import java.util.HexFormat;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 
@@ -28,13 +31,15 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class GeometryExecutionTest {
 
-  // A sample Geometry byte array for testing purposes.
+  // A sample Geometry byte array for testing purposes, representing a POINT(1 2) with SRID 4326.
   private final byte[] testGeometryVal = new byte[] {
+    (byte)0xE6, 0x10, 0x00, 0x00,
     0x01, 0x01, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, (byte)0xF0,
     0x3F, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x40
+    0x00, 0x00, 0x00, 0x00,
+    0x40
   };
 
   /** Tests for Geometry factory methods and getters. */
@@ -146,13 +151,29 @@ class GeometryExecutionTest {
   /** Tests for Geometry WKB and EWKB converters. */
 
   @Test
-  void testToWkbUnsupported() {
+  void testToWkb() {
+    Geometry geometry = Geometry.fromBytes(testGeometryVal);
+    // WKB value (endianness: NDR) corresponding to WKT: POINT(1 2).
+    byte[] wkb = HexFormat.of().parseHex("0101000000000000000000f03f0000000000000040");
+    assertArrayEquals(wkb, geometry.toWkb());
+  }
+
+  @Test
+  void testToWkbEndiannessNDR() {
+    Geometry geometry = Geometry.fromBytes(testGeometryVal);
+    // WKB value (endianness: NDR) corresponding to WKT: POINT(1 2).
+    byte[] wkb = HexFormat.of().parseHex("0101000000000000000000f03f0000000000000040");
+    assertArrayEquals(wkb, geometry.toWkb(ByteOrder.LITTLE_ENDIAN));
+  }
+
+  @Test
+  void testToWkbEndiannessXDR() {
     Geometry geometry = Geometry.fromBytes(testGeometryVal);
     UnsupportedOperationException exception = assertThrows(
       UnsupportedOperationException.class,
-      geometry::toWkb
+      () -> geometry.toWkb(ByteOrder.BIG_ENDIAN)
     );
-    assertEquals("Geometry WKB conversion is not yet supported.", exception.getMessage());
+    assertEquals("Geometry WKB endianness is not yet supported.", exception.getMessage());
   }
 
   @Test
@@ -190,12 +211,8 @@ class GeometryExecutionTest {
   /** Tests for other Geometry methods. */
 
   @Test
-  void testSridUnsupported() {
+  void testSrid() {
     Geometry geometry = Geometry.fromBytes(testGeometryVal);
-    UnsupportedOperationException exception = assertThrows(
-      UnsupportedOperationException.class,
-      geometry::srid
-    );
-    assertEquals("Geometry SRID is not yet supported.", exception.getMessage());
+    assertEquals(4326, geometry.srid());
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/GeometryExecutionSuite.java
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/GeometryExecutionSuite.java
@@ -186,6 +186,26 @@ class GeometryExecutionTest {
     assertEquals("Geometry EWKB conversion is not yet supported.", exception.getMessage());
   }
 
+  @Test
+  void testToEwkbEndiannessXDRUnsupported() {
+    Geometry geometry = Geometry.fromBytes(testGeometryVal);
+    UnsupportedOperationException exception = assertThrows(
+      UnsupportedOperationException.class,
+      () -> geometry.toEwkb(ByteOrder.BIG_ENDIAN)
+    );
+    assertEquals("Geometry EWKB endianness is not yet supported.", exception.getMessage());
+  }
+
+  @Test
+  void testToEwkbEndiannessNDRUnsupported() {
+    Geometry geometry = Geometry.fromBytes(testGeometryVal);
+    UnsupportedOperationException exception = assertThrows(
+      UnsupportedOperationException.class,
+      () -> geometry.toEwkb(ByteOrder.LITTLE_ENDIAN)
+    );
+    assertEquals("Geometry EWKB endianness is not yet supported.", exception.getMessage());
+  }
+
   /** Tests for Geometry WKT and EWKT converters. */
 
   @Test


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Introduce the catalyst-internal geospatial in-memory layout for Geometry and Geography: `SRID` (integer value) header + `WKB` (byte array) payload, and add core conversion API to retrieve these values from the server-side execution wrappers.


### Why are the changes needed?
Establish a consistent representation/encoding for geospatial types, with a clear contract towards `Geometry` and `Geography` classes. This also provides minimal safe SRID & WKB extraction in execution and lays the groundwork for standard format support, conversions, etc.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Added the appropriate unit tests to validate SRID and WKB extraction from the in-memory data formats:
- `GeographyExecutionSuite`
- `GeometryExecutionSuite`


### Was this patch authored or co-authored using generative AI tooling?
No.
