### PR TITLE
[SPARK-54061] Wrap IllegalArgumentException with proper error code for invalid datetime patterns

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
@@ -572,7 +572,9 @@ object TimestampFormatter {
         e match {
           case _: SparkIllegalArgumentException => throw e
           case _ =>
-            throw ExecutionErrors.failToRecognizePatternError(format.getOrElse(defaultPattern()), e)
+            throw ExecutionErrors.failToRecognizePatternError(
+              format.getOrElse(defaultPattern()),
+              e)
         }
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -90,9 +90,9 @@ trait TimestampFormatterHelper extends TimeZoneAwareExpression {
 
   @transient final protected lazy val formatterOption: Option[TimestampFormatter] =
     if (formatString.foldable) {
-      Option(formatString.eval()).flatMap { fmt =>
+      Option(formatString.eval()).map { fmt =>
         try {
-          Some(getFormatter(fmt.toString))
+          getFormatter(fmt.toString)
         } catch {
           case e: IllegalArgumentException =>
             // Wrap Java's IllegalArgumentException with proper error code.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.catalyst.util.{DateTimeUtils, LegacyDateFormats, Tim
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils._
 import org.apache.spark.sql.catalyst.util.LegacyDateFormats.SIMPLE_DATE_FORMAT
-import org.apache.spark.sql.errors.{ExecutionErrors, QueryCompilationErrors, QueryExecutionErrors}
+import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.types.StringTypeWithCollation
 import org.apache.spark.sql.types._
@@ -90,19 +90,7 @@ trait TimestampFormatterHelper extends TimeZoneAwareExpression {
 
   @transient final protected lazy val formatterOption: Option[TimestampFormatter] =
     if (formatString.foldable) {
-      Option(formatString.eval()).map { fmt =>
-        try {
-          getFormatter(fmt.toString)
-        } catch {
-          case e: IllegalArgumentException =>
-            // Wrap Java's IllegalArgumentException with proper error code.
-            // Spark's SparkIllegalArgumentException should pass through unchanged.
-            e match {
-              case _: SparkIllegalArgumentException => throw e
-              case _ => throw ExecutionErrors.failToRecognizePatternError(fmt.toString, e)
-            }
-        }
-      }
+      Option(formatString.eval()).map(fmt => getFormatter(fmt.toString))
     } else None
 
   final protected def getFormatter(fmt: String): TimestampFormatter = {

--- a/sql/core/src/test/resources/sql-tests/results/datetime-formatting-invalid.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/datetime-formatting-invalid.sql.out
@@ -306,8 +306,15 @@ select date_format('2018-11-17 13:33:33.333', 'V')
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
-Pattern letter count must be 2: V
+org.apache.spark.SparkRuntimeException
+{
+  "errorClass" : "INVALID_DATETIME_PATTERN.WITH_SUGGESTION",
+  "sqlState" : "22007",
+  "messageParameters" : {
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "pattern" : "'V'"
+  }
+}
 
 
 -- !query
@@ -332,8 +339,15 @@ select date_format('2018-11-17 13:33:33.333', 'XXXXXX')
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
-Too many pattern letters: X
+org.apache.spark.SparkRuntimeException
+{
+  "errorClass" : "INVALID_DATETIME_PATTERN.WITH_SUGGESTION",
+  "sqlState" : "22007",
+  "messageParameters" : {
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "pattern" : "'XXXXXX'"
+  }
+}
 
 
 -- !query
@@ -358,8 +372,15 @@ select date_format('2018-11-17 13:33:33.333', 'OO')
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
-Pattern letter count must be 1 or 4: O
+org.apache.spark.SparkRuntimeException
+{
+  "errorClass" : "INVALID_DATETIME_PATTERN.WITH_SUGGESTION",
+  "sqlState" : "22007",
+  "messageParameters" : {
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "pattern" : "'OO'"
+  }
+}
 
 
 -- !query
@@ -367,8 +388,15 @@ select date_format('2018-11-17 13:33:33.333', 'xxxxxx')
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
-Too many pattern letters: x
+org.apache.spark.SparkRuntimeException
+{
+  "errorClass" : "INVALID_DATETIME_PATTERN.WITH_SUGGESTION",
+  "sqlState" : "22007",
+  "messageParameters" : {
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "pattern" : "'xxxxxx'"
+  }
+}
 
 
 -- !query
@@ -554,8 +582,15 @@ select date_format('2018-11-17 13:33:33.333', 'C')
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
-Unknown pattern letter: C
+org.apache.spark.SparkRuntimeException
+{
+  "errorClass" : "INVALID_DATETIME_PATTERN.WITH_SUGGESTION",
+  "sqlState" : "22007",
+  "messageParameters" : {
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "pattern" : "'C'"
+  }
+}
 
 
 -- !query
@@ -563,5 +598,12 @@ select date_format('2018-11-17 13:33:33.333', 'I')
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
-Unknown pattern letter: I
+org.apache.spark.SparkRuntimeException
+{
+  "errorClass" : "INVALID_DATETIME_PATTERN.WITH_SUGGESTION",
+  "sqlState" : "22007",
+  "messageParameters" : {
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "pattern" : "'I'"
+  }
+}

--- a/sql/core/src/test/resources/sql-tests/results/datetime-formatting-legacy.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/datetime-formatting-legacy.sql.out
@@ -47,8 +47,15 @@ select col, date_format(col, 'q qq'), to_char(col, 'q qq'), to_varchar(col, 'q q
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
-Illegal pattern character 'q'
+org.apache.spark.SparkRuntimeException
+{
+  "errorClass" : "INVALID_DATETIME_PATTERN.WITH_SUGGESTION",
+  "sqlState" : "22007",
+  "messageParameters" : {
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "pattern" : "'q qq'"
+  }
+}
 
 
 -- !query
@@ -56,8 +63,15 @@ select col, date_format(col, 'Q QQ QQQ QQQQ'), to_char(col, 'Q QQ QQQ QQQQ'), to
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
-Illegal pattern character 'Q'
+org.apache.spark.SparkRuntimeException
+{
+  "errorClass" : "INVALID_DATETIME_PATTERN.WITH_SUGGESTION",
+  "sqlState" : "22007",
+  "messageParameters" : {
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "pattern" : "'Q QQ QQQ QQQQ'"
+  }
+}
 
 
 -- !query
@@ -269,8 +283,15 @@ select col, date_format(col, 'VV'), to_char(col, 'VV'), to_varchar(col, 'VV') fr
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
-Illegal pattern character 'V'
+org.apache.spark.SparkRuntimeException
+{
+  "errorClass" : "INVALID_DATETIME_PATTERN.WITH_SUGGESTION",
+  "sqlState" : "22007",
+  "messageParameters" : {
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "pattern" : "'VV'"
+  }
+}
 
 
 -- !query
@@ -306,8 +327,15 @@ select col, date_format(col, 'XXXX XXXXX'), to_char(col, 'XXXX XXXXX'), to_varch
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
-invalid ISO 8601 format: length=4
+org.apache.spark.SparkRuntimeException
+{
+  "errorClass" : "INVALID_DATETIME_PATTERN.WITH_SUGGESTION",
+  "sqlState" : "22007",
+  "messageParameters" : {
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "pattern" : "'XXXX XXXXX'"
+  }
+}
 
 
 -- !query
@@ -329,8 +357,15 @@ select col, date_format(col, 'O OOOO'), to_char(col, 'O OOOO'), to_varchar(col, 
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
-Illegal pattern character 'O'
+org.apache.spark.SparkRuntimeException
+{
+  "errorClass" : "INVALID_DATETIME_PATTERN.WITH_SUGGESTION",
+  "sqlState" : "22007",
+  "messageParameters" : {
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "pattern" : "'O OOOO'"
+  }
+}
 
 
 -- !query
@@ -338,8 +373,15 @@ select col, date_format(col, 'x xx xxx xxxx xxxx xxxxx'), to_char(col, 'x xx xxx
 -- !query schema
 struct<>
 -- !query output
-java.lang.IllegalArgumentException
-Illegal pattern character 'x'
+org.apache.spark.SparkRuntimeException
+{
+  "errorClass" : "INVALID_DATETIME_PATTERN.WITH_SUGGESTION",
+  "sqlState" : "22007",
+  "messageParameters" : {
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "pattern" : "'x xx xxx xxxx xxxx xxxxx'"
+  }
+}
 
 
 -- !query

--- a/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
@@ -23,7 +23,7 @@ import java.time.{Instant, LocalDateTime, ZoneId}
 import java.util.{Locale, TimeZone}
 import java.util.concurrent.TimeUnit
 
-import org.apache.spark.{SPARK_DOC_ROOT, SparkConf, SparkUpgradeException}
+import org.apache.spark.{SPARK_DOC_ROOT, SparkConf, SparkRuntimeException, SparkUpgradeException}
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{CEST, LA}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.functions._
@@ -967,8 +967,9 @@ class DateFunctionsSuite extends QueryTest with SharedSparkSession {
           Row(secs(ts5.getTime)), Row(null)))
 
         // invalid format
+        // Intercept to SparkRuntimeException to check for proper exception handling
         val invalid = df1.selectExpr(s"to_unix_timestamp(x, 'yyyy-MM-dd bb:HH:ss')")
-        val e = intercept[IllegalArgumentException](invalid.collect())
+        val e = intercept[SparkRuntimeException](invalid.collect())
         assert(e.getMessage.contains('b'))
 
         val df3 = Seq("2016-04-08").toDF("a")

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
@@ -287,8 +287,6 @@ class QueryExecutionAnsiErrorsSuite extends QueryTest
   }
 
   test("INVALID_DATETIME_PATTERN with non-constant pattern") {
-    // Test that invalid patterns are properly wrapped when the pattern is NOT a constant
-    // This ensures the runtime getFormatter() path is exercised, not constant folding.
     withTable("patterns") {
       sql("create table patterns(pattern string) using parquet")
       sql("insert into patterns values ('yyyyMMddHHMIss')")

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
@@ -288,9 +288,10 @@ class QueryExecutionAnsiErrorsSuite extends QueryTest
 
   test("INVALID_DATETIME_PATTERN with non-constant pattern") {
     // Test that invalid patterns are properly wrapped when the pattern is NOT a constant
-    // (e.g., from a column or variable). This exercises the runtime getFormatter() path.
-    withTempView("patterns") {
-      sql("select 'yyyyMMddHHMIss' as pattern").createOrReplaceTempView("patterns")
+    // This ensures the runtime getFormatter() path is exercised, not constant folding.
+    withTable("patterns") {
+      sql("create table patterns(pattern string) using parquet")
+      sql("insert into patterns values ('yyyyMMddHHMIss')")
       checkError(
         exception = intercept[SparkRuntimeException] {
           sql("select to_timestamp('20231225143045', pattern) from patterns").collect()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added exception handling in the formatterOption lazy val to catch `IllegalArgumentException` and wrap it with `ExecutionErrors.failToRecognizePatternError`, ensuring consistent error reporting with `INVALID_DATETIME_PATTERN.WITH_SUGGESTION` error class and `SQLSTATE 22007`.


### Why are the changes needed?
When `TO_TIMESTAMP` is called with an invalid datetime pattern (e.g., `'yyyyMMddHHMIss'` with invalid letter `'I'`), the `IllegalArgumentException` from Java's `DateTimeFormatterBuilder` escapes during constant folding optimization, resulting in a raw exception without proper error codes or `SQLSTATE`.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added test case in `QueryExecutionAnsiErrorsSuite`.


### Was this patch authored or co-authored using generative AI tooling?
No
