### PR TITLE
[SPARK-54069][PYTHON][TESTS] Skip `test_to_feather` in Python 3.14

### DIFF
--- a/python/pyspark/pandas/tests/io/test_feather.py
+++ b/python/pyspark/pandas/tests/io/test_feather.py
@@ -17,6 +17,7 @@
 import unittest
 
 import pandas as pd
+import sys
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
@@ -34,6 +35,7 @@ class FeatherMixin:
     def psdf(self):
         return ps.from_pandas(self.pdf)
 
+    @unittest.skipIf(sys.version_info > (3, 13), "SPARK-54068")
     def test_to_feather(self):
         with self.temp_dir() as dirpath:
             path1 = f"{dirpath}/file1.feather"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to skip `test_to_feather` in Python 3.14 test until SPARK-54068 fixes it in the `Connect` mode.

### Why are the changes needed?

We have `test_to_feather` test coverage for both `classic` and `connect` mode, but only `connect` mode fails currently in `Python 3.14`.
- https://github.com/apache/spark/actions/workflows/build_python_3.14.yml
  - https://github.com/apache/spark/actions/runs/18864049006/job/53876343283

We had better focus on `classic` first by skipping this now. SPARK-54068 is created to track it for `connect` mode.

### Does this PR introduce _any_ user-facing change?

No, this is a test only change.

### How was this patch tested?

Pass the CIs and manually test.

```
$ python/run-tests --parallelism 1 --testnames pyspark.pandas.tests.connect.io.test_parity_feather --python-executables python3
Running PySpark tests. Output is in /Users/dongjoon/APACHE/spark-merge/python/unit-tests.log
Will test against the following Python executables: ['python3']
Will test the following Python tests: ['pyspark.pandas.tests.connect.io.test_parity_feather']
python3 python_implementation is CPython
python3 version is: Python 3.14.0
Starting test(python3): pyspark.pandas.tests.connect.io.test_parity_feather (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/4d8b6c19-57bf-49af-a582-43bc4c056c78/python3__pyspark.pandas.tests.connect.io.test_parity_feather__h5rneuu6.log)
Finished test(python3): pyspark.pandas.tests.connect.io.test_parity_feather (4s) ... 1 tests were skipped
Tests passed in 4 seconds

Skipped tests in pyspark.pandas.tests.connect.io.test_parity_feather with python3:
      test_to_feather (pyspark.pandas.tests.connect.io.test_parity_feather.FeatherParityTests.test_to_feather) ... skip (0.000s)
```

### Was this patch authored or co-authored using generative AI tooling?

No.