### PR TITLE
[SPARK-51756][CORE][FOLLOWUP] Avoid the risk of overflow of long

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/checksum/RowBasedChecksum.scala
+++ b/core/src/main/java/org/apache/spark/shuffle/checksum/RowBasedChecksum.scala
@@ -74,7 +74,7 @@ abstract class RowBasedChecksum() extends Serializable with Logging {
 object RowBasedChecksum {
   def getAggregatedChecksumValue(rowBasedChecksums: Array[RowBasedChecksum]): Long = {
     Option(rowBasedChecksums)
-      .map(_.foldLeft(0L)((acc, c) => acc * 31L + c.getValue))
+      .map(_.foldLeft(0L)((acc, c) => (acc * 31L + c.getValue) & Long.MaxValue))
       .getOrElse(0L)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to avoid the risk of overflow of long for `getAggregatedChecksumValue`.
This PR follows up https://github.com/apache/spark/pull/50230


### Why are the changes needed?
I guess the size of `rowBasedChecksums` is very great and row-based checksum could be big one. Then there exists the risk of overflow of long.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
GA tests.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
