### PR TITLE
[SPARK-54075] [SQL] Make `ResolvedCollation` evaluable

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collationExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collationExpressions.scala
@@ -125,7 +125,7 @@ case class UnresolvedCollation(collationName: Seq[String])
 /**
  * An expression that represents a resolved collation name.
  */
-case class ResolvedCollation(collationName: String) extends LeafExpression with Unevaluable {
+case class ResolvedCollation(collationName: String) extends LeafExpression {
   override def nullable: Boolean = false
 
   override def dataType: DataType = StringType(CollationFactory.collationNameToId(collationName))
@@ -133,6 +133,15 @@ case class ResolvedCollation(collationName: String) extends LeafExpression with 
   override def toString: String = collationName
 
   override def sql: String = collationName
+
+  override def eval(input: InternalRow): Any = Literal.create(collationName, dataType).eval(input)
+
+  /** Just a simple passthrough for code generation. */
+  override def genCode(ctx: CodegenContext): ExprCode =
+    Literal.create(collationName, dataType).genCode(ctx)
+  override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    throw SparkException.internalError("ResolvedCollation.doGenCode should not be called.")
+  }
 }
 
 // scalastyle:off line.contains.tab


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR I propose to make `ResolvedCollation` evaluable. By making `ResolvedCollation` evaluable, it can now pass the `canEvaluateWithinJoin` check, allowing the optimizer to use efficient hash joins for queries with inline COLLATE in join conditions (before this change we would fallback to `BroadcastNestedLoopJoin`).

### Why are the changes needed?
To improve performance of specific queries (see added tests).

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added tests.

### Was this patch authored or co-authored using generative AI tooling?
No.