### PR TITLE
[SPARK-53905][SQL] Refactor RelationResolution to enable code reuse

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
+import scala.collection.mutable
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.SQLConfHelper
@@ -49,7 +51,12 @@ class RelationResolution(override val catalogManager: CatalogManager)
     with Logging
     with LookupCatalog
     with SQLConfHelper {
+
+  type CacheKey = (Seq[String], Option[TimeTravelSpec])
+
   val v1SessionCatalog = catalogManager.v1SessionCatalog
+
+  private def relationCache: mutable.Map[CacheKey, LogicalPlan] = AnalysisContext.get.relationCache
 
   /**
    * If we are resolving database objects (relations, functions, etc.) inside views, we may need to
@@ -109,12 +116,9 @@ class RelationResolution(override val catalogManager: CatalogManager)
     }.orElse {
       expandIdentifier(u.multipartIdentifier) match {
         case CatalogAndIdentifier(catalog, ident) =>
-          val key =
-            (
-              (catalog.name +: ident.namespace :+ ident.name).toImmutableArraySeq,
-              finalTimeTravelSpec
-            )
-          AnalysisContext.get.relationCache
+          val key = toCacheKey(catalog, ident, finalTimeTravelSpec)
+          val planId = u.getTagValue(LogicalPlan.PLAN_ID_TAG)
+          relationCache
             .get(key)
             .map { cache =>
               val cachedRelation = cache.transform {
@@ -123,13 +127,7 @@ class RelationResolution(override val catalogManager: CatalogManager)
                   newRelation.copyTagsFrom(multi)
                   newRelation
               }
-              u.getTagValue(LogicalPlan.PLAN_ID_TAG)
-                .map { planId =>
-                  val cachedConnectRelation = cachedRelation.clone()
-                  cachedConnectRelation.setTagValue(LogicalPlan.PLAN_ID_TAG, planId)
-                  cachedConnectRelation
-                }
-                .getOrElse(cachedRelation)
+              cloneWithPlanId(cachedRelation, planId)
             }
             .orElse {
               val writePrivilegesString =
@@ -144,16 +142,8 @@ class RelationResolution(override val catalogManager: CatalogManager)
                 u.isStreaming,
                 finalTimeTravelSpec
               )
-              loaded.foreach(AnalysisContext.get.relationCache.update(key, _))
-              u.getTagValue(LogicalPlan.PLAN_ID_TAG)
-                .map { planId =>
-                  loaded.map { loadedRelation =>
-                    val loadedConnectRelation = loadedRelation.clone()
-                    loadedConnectRelation.setTagValue(LogicalPlan.PLAN_ID_TAG, planId)
-                    loadedConnectRelation
-                  }
-                }
-                .getOrElse(loaded)
+              loaded.foreach(relationCache.update(key, _))
+              loaded.map(cloneWithPlanId(_, planId))
             }
         case _ => None
       }
@@ -262,5 +252,23 @@ class RelationResolution(override val catalogManager: CatalogManager)
           PythonWorkerLogs.viewDefinition()
       }
     } else None
+  }
+
+  private def toCacheKey(
+      catalog: CatalogPlugin,
+      ident: Identifier,
+      timeTravelSpec: Option[TimeTravelSpec] = None): CacheKey = {
+    ((catalog.name +: ident.namespace :+ ident.name).toImmutableArraySeq, timeTravelSpec)
+  }
+
+  private def cloneWithPlanId(plan: LogicalPlan, planId: Option[Long]): LogicalPlan = {
+    planId match {
+      case Some(id) =>
+        val clone = plan.clone()
+        clone.setTagValue(LogicalPlan.PLAN_ID_TAG, id)
+        clone
+      case None =>
+        plan
+    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR refactor RelationResolution to enable code reuse.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

These changes are needed to simplify subsequent PRs.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing tests in `PlanResolutionSuite` already cover plan ID cloning and cache hits.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.