### PR TITLE
[SPARK-53976][PYTHON] Support logging in Pandas/Arrow UDFs

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_cogrouped_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_cogrouped_map.py
@@ -17,6 +17,7 @@
 import os
 import time
 import unittest
+import logging
 
 from pyspark.errors import PythonException
 from pyspark.sql import Row
@@ -26,6 +27,8 @@ from pyspark.testing.sqlutils import (
     have_pyarrow,
     pyarrow_requirement_message,
 )
+from pyspark.testing.utils import assertDataFrameEqual
+from pyspark.util import is_remote_only
 
 if have_pyarrow:
     import pyarrow as pa
@@ -366,6 +369,49 @@ class CogroupedMapInArrowTestsMixin:
         for batch_size in [0, -1]:
             with self.sql_conf({"spark.sql.execution.arrow.maxRecordsPerBatch": batch_size}):
                 CogroupedMapInArrowTestsMixin.test_apply_in_arrow(self)
+
+    @unittest.skipIf(is_remote_only(), "Requires JVM access")
+    def test_cogroup_apply_in_arrow_with_logging(self):
+        import pyarrow as pa
+
+        def func_with_logging(left, right):
+            assert isinstance(left, pa.Table)
+            assert isinstance(right, pa.Table)
+            logger = logging.getLogger("test_arrow_cogrouped_map")
+            logger.warning(
+                "arrow cogrouped map: "
+                + f"{dict(v1=left['v1'].to_pylist(), v2=right['v2'].to_pylist())}"
+            )
+            return left.join(right, keys="id", join_type="inner")
+
+        left_df = self.spark.createDataFrame([(1, 10), (2, 20), (1, 30)], ["id", "v1"])
+        right_df = self.spark.createDataFrame([(1, 100), (2, 200), (1, 300)], ["id", "v2"])
+
+        grouped_left = left_df.groupBy("id")
+        grouped_right = right_df.groupBy("id")
+        cogrouped_df = grouped_left.cogroup(grouped_right)
+
+        with self.sql_conf({"spark.sql.pyspark.worker.logging.enabled": "true"}):
+            assertDataFrameEqual(
+                cogrouped_df.applyInArrow(func_with_logging, "id long, v1 long, v2 long"),
+                [Row(id=1, v1=v1, v2=v2) for v1 in [10, 30] for v2 in [100, 300]]
+                + [Row(id=2, v1=20, v2=200)],
+            )
+
+        logs = self.spark.table("system.session.python_worker_logs")
+
+        assertDataFrameEqual(
+            logs.select("level", "msg", "context", "logger"),
+            [
+                Row(
+                    level="WARNING",
+                    msg=f"arrow cogrouped map: {dict(v1=v1, v2=v2)}",
+                    context={"func_name": func_with_logging.__name__},
+                    logger="test_arrow_cogrouped_map",
+                )
+                for v1, v2 in [([10, 30], [100, 300]), ([20], [200])]
+            ],
+        )
 
 
 class CogroupedMapInArrowTests(CogroupedMapInArrowTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_python_udf.py
@@ -60,18 +60,6 @@ class ArrowPythonUDFTestsMixin(BaseUDFTestsMixin):
     def test_register_java_udaf(self):
         super(ArrowPythonUDFTests, self).test_register_java_udaf()
 
-    @unittest.skip(
-        "TODO(SPARK-53976): Python worker logging is not supported for Arrow Python UDFs."
-    )
-    def test_udf_with_logging(self):
-        super().test_udf_with_logging()
-
-    @unittest.skip(
-        "TODO(SPARK-53976): Python worker logging is not supported for Arrow Python UDFs."
-    )
-    def test_multiple_udfs_with_logging(self):
-        super().test_multiple_udfs_with_logging()
-
     def test_complex_input_types(self):
         row = (
             self.spark.range(1)

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -17,6 +17,7 @@
 
 import datetime
 import unittest
+import logging
 
 from collections import OrderedDict
 from decimal import Decimal
@@ -60,6 +61,8 @@ from pyspark.testing.sqlutils import (
     pandas_requirement_message,
     pyarrow_requirement_message,
 )
+from pyspark.testing.utils import assertDataFrameEqual
+from pyspark.util import is_remote_only
 
 if have_pandas:
     import pandas as pd
@@ -984,6 +987,42 @@ class ApplyInPandasTestsMixin:
         for batch_size in [0, -1]:
             with self.sql_conf({"spark.sql.execution.arrow.maxRecordsPerBatch": batch_size}):
                 ApplyInPandasTestsMixin.test_complex_groupby(self)
+
+    @unittest.skipIf(is_remote_only(), "Requires JVM access")
+    def test_apply_in_pandas_with_logging(self):
+        import pandas as pd
+
+        def func_with_logging(pdf):
+            assert isinstance(pdf, pd.DataFrame)
+            logger = logging.getLogger("test_pandas_grouped_map")
+            logger.warning(
+                f"pandas grouped map: {dict(id=list(pdf['id']), value=list(pdf['value']))}"
+            )
+            return pdf
+
+        df = self.spark.range(9).withColumn("value", col("id") * 10)
+        grouped_df = df.groupBy((col("id") % 2).cast("int"))
+
+        with self.sql_conf({"spark.sql.pyspark.worker.logging.enabled": "true"}):
+            assertDataFrameEqual(
+                grouped_df.applyInPandas(func_with_logging, "id long, value long"),
+                df,
+            )
+
+        logs = self.spark.table("system.session.python_worker_logs")
+
+        assertDataFrameEqual(
+            logs.select("level", "msg", "context", "logger"),
+            [
+                Row(
+                    level="WARNING",
+                    msg=f"pandas grouped map: {dict(id=lst, value=[v*10 for v in lst])}",
+                    context={"func_name": func_with_logging.__name__},
+                    logger="test_pandas_grouped_map",
+                )
+                for lst in [[0, 2, 4, 6, 8], [1, 3, 5, 7]]
+            ],
+        )
 
 
 class ApplyInPandasTests(ApplyInPandasTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_window.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_window.py
@@ -16,6 +16,7 @@
 #
 
 import unittest
+import logging
 from typing import cast
 from decimal import Decimal
 
@@ -38,6 +39,8 @@ from pyspark.testing.sqlutils import (
     pyarrow_requirement_message,
 )
 from pyspark.testing.utils import assertDataFrameEqual
+from pyspark.sql import Row
+from pyspark.util import is_remote_only
 
 if have_pandas:
     from pandas.testing import assert_frame_equal
@@ -632,6 +635,49 @@ class WindowPandasUDFTestsMixin:
                         .collect()
                     )
                     self.assertEqual(expected2, result2)
+
+    @unittest.skipIf(is_remote_only(), "Requires JVM access")
+    def test_window_pandas_udf_with_logging(self):
+        import pandas as pd
+
+        @pandas_udf("double", PandasUDFType.GROUPED_AGG)
+        def my_window_pandas_udf(x):
+            assert isinstance(x, pd.Series)
+            logger = logging.getLogger("test_window_pandas")
+            logger.warning(f"window pandas udf: {list(x)}")
+            return x.sum()
+
+        df = self.spark.createDataFrame(
+            [(1, 1.0), (1, 2.0), (2, 3.0), (2, 5.0), (2, 10.0)], ("id", "v")
+        )
+        w = Window.partitionBy("id").orderBy("v").rangeBetween(Window.unboundedPreceding, 0)
+
+        with self.sql_conf({"spark.sql.pyspark.worker.logging.enabled": "true"}):
+            assertDataFrameEqual(
+                df.select("id", my_window_pandas_udf("v").over(w).alias("result")),
+                [
+                    Row(id=1, result=1.0),
+                    Row(id=1, result=3.0),
+                    Row(id=2, result=3.0),
+                    Row(id=2, result=8.0),
+                    Row(id=2, result=18.0),
+                ],
+            )
+
+        logs = self.spark.table("system.session.python_worker_logs")
+
+        assertDataFrameEqual(
+            logs.select("level", "msg", "context", "logger"),
+            [
+                Row(
+                    level="WARNING",
+                    msg=f"window pandas udf: {lst}",
+                    context={"func_name": my_window_pandas_udf.__name__},
+                    logger="test_window_pandas",
+                )
+                for lst in [[1.0], [1.0, 2.0], [3.0], [3.0, 5.0], [3.0, 5.0, 10.0]]
+            ],
+        )
 
 
 class WindowPandasUDFTests(WindowPandasUDFTestsMixin, ReusedSQLTestCase):

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/UserDefinedPythonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/UserDefinedPythonDataSource.scala
@@ -170,7 +170,8 @@ case class UserDefinedPythonDataSource(dataSourceCls: PythonFunction) {
       conf.arrowUseLargeVarTypes,
       pythonRunnerConf,
       metrics,
-      jobArtifactUUID)
+      jobArtifactUUID,
+      None) // TODO: Python worker logging
   }
 
   def createPythonMetrics(): Array[CustomMetric] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowAggregatePythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowAggregatePythonExec.scala
@@ -144,6 +144,12 @@ case class ArrowAggregatePythonExec(
 
 
     val jobArtifactUUID = JobArtifactSet.getCurrentJobArtifactState.map(_.uuid)
+    val sessionUUID = {
+      Option(session).collect {
+        case session if session.sessionState.conf.pythonWorkerLoggingEnabled =>
+          session.sessionUUID
+      }
+    }
 
     // Map grouped rows to ArrowPythonRunner results, Only execute if partition is not empty
     inputRDD.mapPartitionsInternal { iter => if (iter.isEmpty) iter else {
@@ -190,6 +196,7 @@ case class ArrowAggregatePythonExec(
         pythonRunnerConf,
         pythonMetrics,
         jobArtifactUUID,
+        sessionUUID,
         conf.pythonUDFProfiler) with GroupedPythonArrowInput
 
       val columnarBatchIter = runner.compute(projectedRowIter, context.partitionId(), context)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowWindowPythonEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowWindowPythonEvaluatorFactory.scala
@@ -45,6 +45,7 @@ class ArrowWindowPythonEvaluatorFactory(
     val evalType: Int,
     val spillSize: SQLMetric,
     pythonMetrics: Map[String, SQLMetric],
+    sessionUUID: Option[String],
     profiler: Option[String])
   extends PartitionEvaluatorFactory[InternalRow, InternalRow] with WindowEvaluatorFactoryBase {
 
@@ -378,6 +379,7 @@ class ArrowWindowPythonEvaluatorFactory(
         pythonRunnerConf,
         pythonMetrics,
         jobArtifactUUID,
+        sessionUUID,
         profiler) with GroupedPythonArrowInput
 
       val windowFunctionResult = runner.compute(pythonInput, context.partitionId(), context)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowWindowPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowWindowPythonExec.scala
@@ -91,6 +91,13 @@ case class ArrowWindowPythonExec(
     "spillSize" -> SQLMetrics.createSizeMetric(sparkContext, "spill size")
   )
 
+  private[this] val sessionUUID = {
+    Option(session).collect {
+      case session if session.sessionState.conf.pythonWorkerLoggingEnabled =>
+        session.sessionUUID
+    }
+  }
+
   protected override def doExecute(): RDD[InternalRow] = {
     val evaluatorFactory =
       new ArrowWindowPythonEvaluatorFactory(
@@ -101,6 +108,7 @@ case class ArrowWindowPythonExec(
         evalType,
         longMetric("spillSize"),
         pythonMetrics,
+        sessionUUID,
         conf.pythonUDFProfiler)
 
     // Start processing.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInBatchExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInBatchExec.scala
@@ -48,6 +48,12 @@ trait FlatMapGroupsInBatchExec extends SparkPlan with UnaryExecNode with PythonS
   private val chainedFunc =
     Seq((ChainedPythonFunctions(Seq(pythonFunction)), pythonUDF.resultId.id))
   private[this] val jobArtifactUUID = JobArtifactSet.getCurrentJobArtifactState.map(_.uuid)
+  private[this] val sessionUUID = {
+    Option(session).collect {
+      case session if session.sessionState.conf.pythonWorkerLoggingEnabled =>
+        session.sessionUUID
+    }
+  }
 
   override def producedAttributes: AttributeSet = AttributeSet(output)
 
@@ -92,6 +98,7 @@ trait FlatMapGroupsInBatchExec extends SparkPlan with UnaryExecNode with PythonS
         pythonRunnerConf,
         pythonMetrics,
         jobArtifactUUID,
+        sessionUUID,
         conf.pythonUDFProfiler) with GroupedPythonArrowInput
 
       executePython(data, output, runner)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
@@ -40,7 +40,8 @@ class MapInBatchEvaluatorFactory(
     largeVarTypes: Boolean,
     pythonRunnerConf: Map[String, String],
     val pythonMetrics: Map[String, SQLMetric],
-    jobArtifactUUID: Option[String])
+    jobArtifactUUID: Option[String],
+    sessionUUID: Option[String])
   extends PartitionEvaluatorFactory[InternalRow, InternalRow] {
 
   override def createEvaluator(): PartitionEvaluator[InternalRow, InternalRow] =
@@ -72,6 +73,7 @@ class MapInBatchEvaluatorFactory(
         pythonRunnerConf,
         pythonMetrics,
         jobArtifactUUID,
+        sessionUUID,
         None) with BatchedPythonArrowInput
       val columnarBatchIter = pyRunner.compute(batchIter, context.partitionId(), context)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchExec.scala
@@ -44,6 +44,12 @@ trait MapInBatchExec extends UnaryExecNode with PythonSQLMetrics {
   override def producedAttributes: AttributeSet = AttributeSet(output)
 
   private[this] val jobArtifactUUID = JobArtifactSet.getCurrentJobArtifactState.map(_.uuid)
+  private[this] val sessionUUID = {
+    Option(session).collect {
+      case session if session.sessionState.conf.pythonWorkerLoggingEnabled =>
+        session.sessionUUID
+    }
+  }
 
   override def outputPartitioning: Partitioning = child.outputPartitioning
 
@@ -63,7 +69,8 @@ trait MapInBatchExec extends UnaryExecNode with PythonSQLMetrics {
       conf.arrowUseLargeVarTypes,
       pythonRunnerConf,
       pythonMetrics,
-      jobArtifactUUID)
+      jobArtifactUUID,
+      sessionUUID)
 
     val rdd = if (isBarrier) {
       val rddBarrier = child.execute().barrier()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Supports logging in Pandas/Arrow UDFs.

### Why are the changes needed?

The basic logging infrastructure was introduced in https://github.com/apache/spark/pull/52689, and other UDF types should also support logging.

Here adding support for Pandas and Arrow UDFs.

### Does this PR introduce _any_ user-facing change?

Yes, the logging feature will be available in Pandas/Arrow UDFs.

### How was this patch tested?

Added the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
