### PR TITLE
[SPARK-52134][SQL][FOLLOW UP] SQL Script execution code - refactor follow up

### DIFF
--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
@@ -1795,8 +1795,7 @@ class ClientE2ETestSuite
 
   // SQL Scripting tests
   test("SQL Script result") {
-    val df = spark.sql(
-      """BEGIN
+    val df = spark.sql("""BEGIN
         |  IF 1=1 THEN
         |    SELECT 1;
         |  ELSE
@@ -1809,40 +1808,39 @@ class ClientE2ETestSuite
 
   test("SQL Script schema") {
     withTable("script_tbl") {
-      val df = spark.sql(
-        """BEGIN
+      val df = spark.sql("""BEGIN
           |  CREATE TABLE script_tbl (a INT, b STRING);
           |  INSERT INTO script_tbl VALUES (1, 'Hello'), (2, 'World');
           |  SELECT * FROM script_tbl;
           |END
           |""".stripMargin)
-      assert(df.schema == StructType(
-        StructField("a", IntegerType, nullable = true)
-          :: StructField("b", StringType, nullable = true)
-          :: Nil))
+      assert(
+        df.schema == StructType(
+          StructField("a", IntegerType, nullable = true)
+            :: StructField("b", StringType, nullable = true)
+            :: Nil))
     }
   }
 
   test("SQL Script empty result") {
     withTable("script_tbl") {
-      val df = spark.sql(
-        """BEGIN
+      val df = spark.sql("""BEGIN
           |  CREATE TABLE script_tbl (a INT, b STRING);
           |  SELECT * FROM script_tbl;
           |END
           |""".stripMargin)
-      assert(df.schema == StructType(
-        StructField("a", IntegerType, nullable = true)
-          :: StructField("b", StringType, nullable = true)
-          :: Nil))
+      assert(
+        df.schema == StructType(
+          StructField("a", IntegerType, nullable = true)
+            :: StructField("b", StringType, nullable = true)
+            :: Nil))
       checkAnswer(df, Seq.empty)
     }
   }
 
   test("SQL Script no result") {
     withTable("script_tbl") {
-      val df = spark.sql(
-        """BEGIN
+      val df = spark.sql("""BEGIN
           |  CREATE TABLE script_tbl (a INT, b STRING);
           |END
           |""".stripMargin)

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
@@ -1792,6 +1792,64 @@ class ClientE2ETestSuite
     assert(result.length === 1)
     assert(result(0).getAs[Array[Integer]]("arr_col") === Array(1, null))
   }
+
+  // SQL Scripting tests
+  test("SQL Script result") {
+    val df = spark.sql(
+      """BEGIN
+        |  IF 1=1 THEN
+        |    SELECT 1;
+        |  ELSE
+        |    SELECT 3;
+        |  END IF;
+        |END
+        |""".stripMargin)
+    checkAnswer(df, Seq(Row(1)))
+  }
+
+  test("SQL Script schema") {
+    withTable("script_tbl") {
+      val df = spark.sql(
+        """BEGIN
+          |  CREATE TABLE script_tbl (a INT, b STRING);
+          |  INSERT INTO script_tbl VALUES (1, 'Hello'), (2, 'World');
+          |  SELECT * FROM script_tbl;
+          |END
+          |""".stripMargin)
+      assert(df.schema == StructType(
+        StructField("a", IntegerType, nullable = true)
+          :: StructField("b", StringType, nullable = true)
+          :: Nil))
+    }
+  }
+
+  test("SQL Script empty result") {
+    withTable("script_tbl") {
+      val df = spark.sql(
+        """BEGIN
+          |  CREATE TABLE script_tbl (a INT, b STRING);
+          |  SELECT * FROM script_tbl;
+          |END
+          |""".stripMargin)
+      assert(df.schema == StructType(
+        StructField("a", IntegerType, nullable = true)
+          :: StructField("b", StringType, nullable = true)
+          :: Nil))
+      checkAnswer(df, Seq.empty)
+    }
+  }
+
+  test("SQL Script no result") {
+    withTable("script_tbl") {
+      val df = spark.sql(
+        """BEGIN
+          |  CREATE TABLE script_tbl (a INT, b STRING);
+          |END
+          |""".stripMargin)
+      assert(df.schema == StructType(Nil))
+      checkAnswer(df, Seq.empty)
+    }
+  }
 }
 
 private[sql] case class ClassData(a: String, b: Int)

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -52,7 +52,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.parser.{NamedParameterContext, ParameterContext, ParseException, ParserUtils, PositionalParameterContext}
 import org.apache.spark.sql.catalyst.plans.{Cross, FullOuter, Inner, JoinType, LeftAnti, LeftOuter, LeftSemi, RightOuter, UsingJoin}
 import org.apache.spark.sql.catalyst.plans.logical
-import org.apache.spark.sql.catalyst.plans.logical.{AppendColumns, Assignment, CoGroup, CollectMetrics, CommandResult, CompoundBody, Deduplicate, DeduplicateWithinWatermark, DeleteAction, DeserializeToObject, Except, FlatMapGroupsWithState, InsertAction, InsertStarAction, Intersect, JoinWith, LocalRelation, LogicalGroupState, LogicalPlan, MapGroups, MapPartitions, MergeAction, Project, Sample, SerializeFromObject, Sort, SubqueryAlias, TimeModes, TransformWithState, TypedFilter, Union, Unpivot, UnresolvedHint, UpdateAction, UpdateEventTimeWatermarkColumn, UpdateStarAction}
+import org.apache.spark.sql.catalyst.plans.logical.{AppendColumns, Assignment, CoGroup, CollectMetrics, CommandResult, Deduplicate, DeduplicateWithinWatermark, DeleteAction, DeserializeToObject, Except, FlatMapGroupsWithState, InsertAction, InsertStarAction, Intersect, JoinWith, LocalRelation, LogicalGroupState, LogicalPlan, MapGroups, MapPartitions, MergeAction, Project, Sample, SerializeFromObject, Sort, SubqueryAlias, TimeModes, TransformWithState, TypedFilter, Union, Unpivot, UnresolvedHint, UpdateAction, UpdateEventTimeWatermarkColumn, UpdateStarAction}
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes
 import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin, TreePattern}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -2975,7 +2975,7 @@ class SparkConnectPlanner(
 
     // Check if command or SQL Script has been executed.
     val isCommand = df.queryExecution.commandExecuted.isInstanceOf[CommandResult]
-    val isSqlScript = df.queryExecution.logical.isInstanceOf[CompoundBody]
+    val isSqlScript = df.queryExecution.isSqlScript
     val rows = df.logicalPlan match {
       case lr: LocalRelation => lr.data
       case cr: CommandResult => cr.rows

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/SparkConnectServerTest.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/SparkConnectServerTest.scala
@@ -16,19 +16,16 @@
  */
 package org.apache.spark.sql.connect
 
-import java.io.ByteArrayInputStream
 import java.util.{TimeZone, UUID}
 
 import scala.reflect.runtime.universe.TypeTag
 
 import org.apache.arrow.memory.RootAllocator
-import org.apache.arrow.vector.ipc.ArrowStreamReader
 import org.scalatest.concurrent.{Eventually, TimeLimits}
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.connect.proto
-import org.apache.spark.connect.proto.ExecutePlanResponse
 import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.connect.client.{CloseableIterator, CustomSparkConnectBlockingStub, ExecutePlanResponseReattachableIterator, RetryPolicy, SparkConnectClient, SparkConnectStubState}
 import org.apache.spark.sql.connect.client.arrow.ArrowSerializer
@@ -322,44 +319,5 @@ trait SparkConnectServerTest extends SharedSparkSession {
   protected def runQuery(query: String, queryTimeout: Span, iterSleep: Long = 0): Unit = {
     val plan = buildPlan(query)
     runQuery(plan, queryTimeout, iterSleep)
-  }
-
-  protected def checkSqlCommandResponse(
-      result: ExecutePlanResponse.SqlCommandResult,
-      expected: Seq[Seq[Any]]): Unit = {
-    // Extract the serialized Arrow data as a byte array.
-    val dataBytes = result.getRelation.getLocalRelation.getData.toByteArray
-
-    // Create an ArrowStreamReader to deserialize the data.
-    val allocator = new RootAllocator(Long.MaxValue)
-    val inputStream = new ByteArrayInputStream(dataBytes)
-    val reader = new ArrowStreamReader(inputStream, allocator)
-
-    try {
-      // Read the schema and data.
-      val root = reader.getVectorSchemaRoot
-      // Load the first batch of data.
-      reader.loadNextBatch()
-
-      // Get dimensions.
-      val rowCount = root.getRowCount
-      val colCount = root.getFieldVectors.size
-      assert(rowCount == expected.length, "Row count mismatch")
-      assert(colCount == expected.head.length, "Column count mismatch")
-
-      // Compare to expected.
-      for (i <- 0 until rowCount) {
-        for (j <- 0 until colCount) {
-          val col = root.getFieldVectors.get(j)
-          val value = col.getObject(i)
-          print(value)
-          assert(value == expected(i)(j), s"Value mismatch at ($i, $j)")
-        }
-      }
-    } finally {
-      // Clean up resources.
-      reader.close()
-      allocator.close()
-    }
   }
 }

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceE2ESuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceE2ESuite.scala
@@ -33,27 +33,6 @@ class SparkConnectServiceE2ESuite extends SparkConnectServerTest {
   // were all already in the buffer.
   val BIG_ENOUGH_QUERY = "select * from range(1000000)"
 
-  test("SQL Script over Spark Connect.") {
-    val sessionId = UUID.randomUUID.toString()
-    val userId = "ScriptUser"
-    val sqlScriptText =
-      """BEGIN
-        |IF 1 = 1 THEN
-        |  SELECT 1;
-        |ELSE
-        |  SELECT 2;
-        |END IF;
-        |END
-        """.stripMargin
-    withClient(sessionId = sessionId, userId = userId) { client =>
-      // this will create the session, and then ReleaseSession at the end of withClient.
-      val enableSqlScripting = client.execute(buildPlan("SET spark.sql.scripting.enabled=true"))
-      enableSqlScripting.hasNext // trigger execution
-      val query = client.execute(buildSqlCommandPlan(sqlScriptText))
-      checkSqlCommandResponse(query.next().getSqlCommandResult, Seq(Seq(1)))
-    }
-  }
-
   test("Execute is sent eagerly to the server upon iterator creation") {
     // This behavior changed with grpc upgrade from 1.56.0 to 1.59.0.
     // Testing to be aware of future changes.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -72,6 +72,12 @@ class QueryExecution(
   // TODO: Move the planner an optimizer into here from SessionState.
   protected def planner = sparkSession.sessionState.planner
 
+  /**
+   * Check whether the query represented by this QueryExecution is a SQL script.
+   * @return True if the query is a SQL script, False otherwise.
+   */
+  def isSqlScript: Boolean = QueryExecution.isUnresolvedPlanSqlScript(logical)
+
   lazy val isLazyAnalysis: Boolean = {
     // Only check the main query as subquery expression can be resolved now with the main query.
     logical.exists(_.expressions.exists(_.exists(_.isInstanceOf[LazyExpression])))
@@ -95,27 +101,46 @@ class QueryExecution(
     }
   }
 
-  private val lazyAnalyzed = LazyTry {
-    val withScriptExecuted = logical match {
-      // Execute the SQL script. Script doesn't need to go through the analyzer as Spark will run
-      // each statement as individual query.
+  /**
+   * Execute the SQL script if the logical plan is a SQL script.
+   * There are multiple cases, and they are originating from:
+   *   - SparkSession.sql() - Spark and Spark Connect case
+   *   - QueryRuntimePredictionUtils.getParsedPlanWithTracking() - DBSQL case
+   */
+  private val lazySqlScriptExecuted = LazyTry {
+    logical match {
       case NameParameterizedQuery(compoundBody: CompoundBody, argNames, argValues) =>
-        val args = argNames.zip(argValues).toMap
-        SqlScriptingExecution.executeSqlScript(sparkSession, compoundBody, args)
+        SqlScriptingExecution.executeSqlScript(
+          session = sparkSession,
+          script = compoundBody,
+          args = argNames.zip(argValues).toMap)
       case compoundBody: CompoundBody =>
-        SqlScriptingExecution.executeSqlScript(sparkSession, compoundBody)
+        SqlScriptingExecution.executeSqlScript(
+          session = sparkSession,
+          script = compoundBody)
       case _ => logical
     }
+  }
+
+  private def sqlScriptExecuted: LogicalPlan = lazySqlScriptExecuted.get
+
+  private def assertSqlScriptExecuted(): Unit = sqlScriptExecuted
+
+  private val lazyAnalyzed = LazyTry {
+    // Execute the SQL script. Script doesn't need to go through the analyzer as Spark
+    //   will run each statement as individual query.
+    assertSqlScriptExecuted()
+
     try {
       val plan = executePhase(QueryPlanningTracker.ANALYSIS) {
         // We can't clone `logical` here, which will reset the `_analyzed` flag.
-        sparkSession.sessionState.analyzer.executeAndCheck(withScriptExecuted, tracker)
+        sparkSession.sessionState.analyzer.executeAndCheck(sqlScriptExecuted, tracker)
       }
       tracker.setAnalyzed(plan)
       plan
     } catch {
       case NonFatal(e) =>
-        tracker.setAnalysisFailed(withScriptExecuted)
+        tracker.setAnalysisFailed(sqlScriptExecuted)
         throw e
     }
   }
@@ -697,6 +722,19 @@ object QueryExecution {
       RemoveShuffleFiles
     } else {
       DoNotCleanup
+    }
+  }
+
+  /**
+   * Determines whether the given unresolved plan is a SQL script.
+   * @param plan Logical plan to check.
+   * @return True if the plan is a SQL script, False otherwise.
+   */
+  def isUnresolvedPlanSqlScript(plan: LogicalPlan): Boolean = {
+    plan match {
+      case _: CompoundBody => true
+      case NameParameterizedQuery(_: CompoundBody, _, _) => true
+      case _ => false
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Original change was introduced in https://github.com/apache/spark/pull/50895. This change is a follow-up to:
1. Restructure the code better.
2. Add more meaningful Spark Connect tests and move them to a better suite.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  3. If you fix a bug, you can clarify why it is a bug.
-->
Cleaner and more consistent code. No functional changes.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
There shouldn't be any functional changes. Currently existing tests should be enough to confirm that change works as expected.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.