### PR TITLE
[SPARK-53921][Geo][PYTHON][FOLLOWUP] Add GeographyType and GeometryType to `__all__` in types

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -101,6 +101,8 @@ __all__ = [
     "StructType",
     "VariantType",
     "VariantVal",
+    "GeographyType",
+    "GeometryType",
 ]
 
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR follows up on https://github.com/apache/spark/pull/52627, and addresses a gap - `GeographyType` and `GeometryType` should be included in `__all__`.


### Why are the changes needed?
Include geospatial types in __all__ for `types.py`.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing tests suffice.


### Was this patch authored or co-authored using generative AI tooling?
No.
