### PR TITLE
[SPARK-54086][CORE][SHUFFLE] Support `IO_URING` Netty IO Mode

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -365,6 +365,12 @@ jobs:
         python3.11 -m pip install 'numpy>=1.22' pyarrow pandas pyyaml scipy unittest-xml-reporting 'lxml==4.9.4' 'grpcio==1.67.0' 'grpcio-status==1.67.0' 'protobuf==5.29.5'
         python3.11 -m pip list
     # Run the tests.
+    - name: Debug
+      env: ${{ fromJSON(inputs.envs) }}
+      run: |
+        uname -a
+        cat /etc/os-release
+        ./build/sbt clean "core/testOnly *ShuffleNettyIoUringSuite"
     - name: Run tests
       env: ${{ fromJSON(inputs.envs) }}
       shell: 'script -q -e -c "bash {0}"'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -370,7 +370,7 @@ jobs:
       run: |
         uname -a
         cat /etc/os-release
-        ./build/sbt clean "core/testOnly *ShuffleNettyIoUringSuite"
+        ./build/sbt clean "core/testOnly *ShuffleNettyIoUringSuite -- -z non-zero"
     - name: Run tests
       env: ${{ fromJSON(inputs.envs) }}
       shell: 'script -q -e -c "bash {0}"'

--- a/common/network-common/pom.xml
+++ b/common/network-common/pom.xml
@@ -53,6 +53,16 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-io_uring</artifactId>
+      <classifier>linux-x86_64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-io_uring</artifactId>
+      <classifier>linux-aarch_64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-kqueue</artifactId>
       <classifier>osx-aarch_64</classifier>
     </dependency>

--- a/common/network-common/src/main/java/org/apache/spark/network/util/IOMode.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/IOMode.java
@@ -30,6 +30,10 @@ public enum IOMode {
    */
   EPOLL,
   /**
+   * Native IO_URING via JNI, Linux only
+   */
+  IO_URING,
+  /**
    * Native KQUEUE via JNI, MacOS/BSD only
    */
   KQUEUE,

--- a/common/network-common/src/main/java/org/apache/spark/network/util/NettyUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/NettyUtils.java
@@ -79,10 +79,10 @@ public class NettyUtils {
       case IO_URING -> IoUringIoHandler.newFactory();
       case KQUEUE -> KQueueIoHandler.newFactory();
       case AUTO -> {
-        if (JavaUtils.isLinux && IoUring.isAvailable()) {
-          yield IoUringIoHandler.newFactory();
-        } else if (JavaUtils.isLinux && Epoll.isAvailable()) {
+        if (JavaUtils.isLinux && Epoll.isAvailable()) {
           yield EpollIoHandler.newFactory();
+        } else if (JavaUtils.isLinux && IoUring.isAvailable()) {
+          yield IoUringIoHandler.newFactory();
         } else if (JavaUtils.isMac && KQueue.isAvailable()) {
           yield KQueueIoHandler.newFactory();
         } else {
@@ -101,10 +101,10 @@ public class NettyUtils {
       case IO_URING -> IoUringSocketChannel.class;
       case KQUEUE -> KQueueSocketChannel.class;
       case AUTO -> {
-        if (JavaUtils.isLinux && IoUring.isAvailable()) {
-          yield IoUringSocketChannel.class;
-        } else if (JavaUtils.isLinux && Epoll.isAvailable()) {
+        if (JavaUtils.isLinux && Epoll.isAvailable()) {
           yield EpollSocketChannel.class;
+        } else if (JavaUtils.isLinux && IoUring.isAvailable()) {
+          yield IoUringSocketChannel.class;
         } else if (JavaUtils.isMac && KQueue.isAvailable()) {
           yield KQueueSocketChannel.class;
         } else {
@@ -122,10 +122,10 @@ public class NettyUtils {
       case IO_URING -> IoUringServerSocketChannel.class;
       case KQUEUE -> KQueueServerSocketChannel.class;
       case AUTO -> {
-        if (JavaUtils.isLinux && IoUring.isAvailable()) {
-          yield IoUringServerSocketChannel.class;
-        } else if (JavaUtils.isLinux && Epoll.isAvailable()) {
+        if (JavaUtils.isLinux && Epoll.isAvailable()) {
           yield EpollServerSocketChannel.class;
+        } else if (JavaUtils.isLinux && IoUring.isAvailable()) {
+          yield IoUringServerSocketChannel.class;
         } else if (JavaUtils.isMac && KQueue.isAvailable()) {
           yield KQueueServerSocketChannel.class;
         } else {

--- a/common/network-common/src/main/java/org/apache/spark/network/util/NettyUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/NettyUtils.java
@@ -32,7 +32,6 @@ import io.netty.channel.kqueue.KQueueSocketChannel;
 import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.channel.uring.IoUring;
 import io.netty.channel.uring.IoUringIoHandler;
 import io.netty.channel.uring.IoUringServerSocketChannel;
 import io.netty.channel.uring.IoUringSocketChannel;

--- a/common/network-common/src/main/java/org/apache/spark/network/util/NettyUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/NettyUtils.java
@@ -81,8 +81,6 @@ public class NettyUtils {
       case AUTO -> {
         if (JavaUtils.isLinux && Epoll.isAvailable()) {
           yield EpollIoHandler.newFactory();
-        } else if (JavaUtils.isLinux && IoUring.isAvailable()) {
-          yield IoUringIoHandler.newFactory();
         } else if (JavaUtils.isMac && KQueue.isAvailable()) {
           yield KQueueIoHandler.newFactory();
         } else {
@@ -103,8 +101,6 @@ public class NettyUtils {
       case AUTO -> {
         if (JavaUtils.isLinux && Epoll.isAvailable()) {
           yield EpollSocketChannel.class;
-        } else if (JavaUtils.isLinux && IoUring.isAvailable()) {
-          yield IoUringSocketChannel.class;
         } else if (JavaUtils.isMac && KQueue.isAvailable()) {
           yield KQueueSocketChannel.class;
         } else {
@@ -124,8 +120,6 @@ public class NettyUtils {
       case AUTO -> {
         if (JavaUtils.isLinux && Epoll.isAvailable()) {
           yield EpollServerSocketChannel.class;
-        } else if (JavaUtils.isLinux && IoUring.isAvailable()) {
-          yield IoUringServerSocketChannel.class;
         } else if (JavaUtils.isMac && KQueue.isAvailable()) {
           yield KQueueServerSocketChannel.class;
         } else {

--- a/common/network-common/src/main/java/org/apache/spark/network/util/NettyUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/NettyUtils.java
@@ -32,6 +32,10 @@ import io.netty.channel.kqueue.KQueueSocketChannel;
 import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.channel.uring.IoUring;
+import io.netty.channel.uring.IoUringIoHandler;
+import io.netty.channel.uring.IoUringServerSocketChannel;
+import io.netty.channel.uring.IoUringSocketChannel;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.internal.PlatformDependent;
 
@@ -72,9 +76,12 @@ public class NettyUtils {
     IoHandlerFactory handlerFactory = switch (mode) {
       case NIO -> NioIoHandler.newFactory();
       case EPOLL -> EpollIoHandler.newFactory();
+      case IO_URING -> IoUringIoHandler.newFactory();
       case KQUEUE -> KQueueIoHandler.newFactory();
       case AUTO -> {
-        if (JavaUtils.isLinux && Epoll.isAvailable()) {
+        if (JavaUtils.isLinux && IoUring.isAvailable()) {
+          yield IoUringIoHandler.newFactory();
+        } else if (JavaUtils.isLinux && Epoll.isAvailable()) {
           yield EpollIoHandler.newFactory();
         } else if (JavaUtils.isMac && KQueue.isAvailable()) {
           yield KQueueIoHandler.newFactory();
@@ -91,9 +98,12 @@ public class NettyUtils {
     return switch (mode) {
       case NIO -> NioSocketChannel.class;
       case EPOLL -> EpollSocketChannel.class;
+      case IO_URING -> IoUringSocketChannel.class;
       case KQUEUE -> KQueueSocketChannel.class;
       case AUTO -> {
-        if (JavaUtils.isLinux && Epoll.isAvailable()) {
+        if (JavaUtils.isLinux && IoUring.isAvailable()) {
+          yield IoUringSocketChannel.class;
+        } else if (JavaUtils.isLinux && Epoll.isAvailable()) {
           yield EpollSocketChannel.class;
         } else if (JavaUtils.isMac && KQueue.isAvailable()) {
           yield KQueueSocketChannel.class;
@@ -109,9 +119,12 @@ public class NettyUtils {
     return switch (mode) {
       case NIO -> NioServerSocketChannel.class;
       case EPOLL -> EpollServerSocketChannel.class;
+      case IO_URING -> IoUringServerSocketChannel.class;
       case KQUEUE -> KQueueServerSocketChannel.class;
       case AUTO -> {
-        if (JavaUtils.isLinux && Epoll.isAvailable()) {
+        if (JavaUtils.isLinux && IoUring.isAvailable()) {
+          yield IoUringServerSocketChannel.class;
+        } else if (JavaUtils.isLinux && Epoll.isAvailable()) {
           yield EpollServerSocketChannel.class;
         } else if (JavaUtils.isMac && KQueue.isAvailable()) {
           yield KQueueServerSocketChannel.class;

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -313,6 +313,16 @@
       <artifactId>netty-transport-native-kqueue</artifactId>
       <classifier>osx-x86_64</classifier>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-io_uring</artifactId>
+      <classifier>linux-x86_64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-io_uring</artifactId>
+      <classifier>linux-aarch_64</classifier>
+    </dependency>
     <!-- Netty End -->
     <dependency>
       <groupId>com.clearspring.analytics</groupId>

--- a/core/src/test/resources/log4j2.properties
+++ b/core/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = info
+rootLogger.level = debug
 rootLogger.appenderRef.file.ref = ${sys:test.appender:-File}
 
 appender.file.type = File

--- a/core/src/test/scala/org/apache/spark/ShuffleNettySuite.scala
+++ b/core/src/test/scala/org/apache/spark/ShuffleNettySuite.scala
@@ -51,6 +51,11 @@ class ShuffleNettyEpollSuite extends ShuffleNettySuite {
   override def ioMode: IOMode = IOMode.EPOLL
 }
 
+class ShuffleNettyIoUringSuite extends ShuffleNettySuite {
+  override def shouldRunTests: Boolean = Utils.isLinux
+  override def ioMode: IOMode = IOMode.IO_URING
+}
+
 class ShuffleNettyKQueueSuite extends ShuffleNettySuite {
   override def shouldRunTests: Boolean = Utils.isMac
   override def ioMode: IOMode = IOMode.KQUEUE

--- a/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
@@ -43,6 +43,7 @@ abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalRootDi
   // Ensure that the DAGScheduler doesn't retry stages whose fetches fail, so that we accurately
   // test that the shuffle works (rather than retrying until all blocks are local to one Executor).
   conf.set(TEST_NO_STAGE_RETRY, true)
+  conf.set("spark.ui.enabled", "false")
 
   test("groupByKey without compression") {
     val myConf = conf.clone().set(config.SHUFFLE_COMPRESS, false)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2657,9 +2657,9 @@ Apart from these, the following properties are also available, and may be useful
   <td>AUTO</td>
   <td>
     The default IO mode for Netty transports.
-    One of <code>NIO</code>, <code>EPOLL</code>, <code>KQUEUE</code>, or <code>AUTO</code>.
+    One of <code>NIO</code>, <code>EPOLL</code>, <code>IO_URING</code>, <code>KQUEUE</code>, or <code>AUTO</code>.
     The default value is <code>AUTO</code> which means to use native Netty libraries if available.
-    In other words, for Linux environments, <code>EPOLL</code> is used if available before using <code>NIO</code>.
+    In other words, for Linux environments, the used mode is decided by the following order: <code>IO_URING</code>, <code>EPOLL</code>, <code>NIO</code>.
     For MacOS/BSD environments, <code>KQUEUE</code> is used if available before using <code>NIO</code>.
   </td>
   <td>4.1.0</td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2657,9 +2657,9 @@ Apart from these, the following properties are also available, and may be useful
   <td>AUTO</td>
   <td>
     The default IO mode for Netty transports.
-    One of <code>NIO</code>, <code>EPOLL</code>, <code>IO_URING</code>, <code>KQUEUE</code>, or <code>AUTO</code>.
+    One of <code>NIO</code>, <code>EPOLL</code>, <code>KQUEUE</code>, or <code>AUTO</code>.
     The default value is <code>AUTO</code> which means to use native Netty libraries if available.
-    In other words, for Linux environments, the used mode is decided by the following order: <code>IO_URING</code>, <code>EPOLL</code>, <code>NIO</code>.
+    In other words, for Linux environments, <code>EPOLL</code> is used if available before using <code>NIO</code>.
     For MacOS/BSD environments, <code>KQUEUE</code> is used if available before using <code>NIO</code>.
   </td>
   <td>4.1.0</td>

--- a/pom.xml
+++ b/pom.xml
@@ -984,6 +984,18 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-io_uring</artifactId>
+        <version>${netty.version}</version>
+        <classifier>linux-x86_64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-io_uring</artifactId>
+        <version>${netty.version}</version>
+        <classifier>linux-aarch_64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-kqueue</artifactId>
         <version>${netty.version}</version>
         <classifier>osx-aarch_64</classifier>


### PR DESCRIPTION


### What changes were proposed in this pull request?

We add support for `IO_URING` Netty IO Mode, https://kernel.dk/io_uring.pdf

IO_URING finished its [incubation](https://github.com/netty/netty-incubator-transport-io_uring) progress and got merged into netty main since 4.2, see also https://mvnrepository.com/artifact/io.netty/netty-transport-native-io_uring
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We could have a better choice for I/O modes while deploying Spark on Linux kernel>5.1


### Does this PR introduce _any_ user-facing change?

Since AUTO is not released yet, making the priority of IO_URING higher than that of EPOLL is not a behavior change
### How was this patch tested?
new tests


### Was this patch authored or co-authored using generative AI tooling?
NO
