### PR TITLE
[SPARK-53891][SQL][FOLLOW-UP] Clarify javadocs for case when merge summary metric is not found

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/MergeSummary.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/MergeSummary.java
@@ -28,42 +28,45 @@ import org.apache.spark.annotation.Evolving;
 public interface MergeSummary extends WriteSummary {
 
   /**
-   * Returns the number of target rows copied unmodified because they did not match any action.
+   * Returns the number of target rows copied unmodified because they did not match any action,
+   * or -1 if not found.
    */
   long numTargetRowsCopied();
 
   /**
-   * Returns the number of target rows deleted.
+   * Returns the number of target rows deleted, or -1 if not found.
    */
   long numTargetRowsDeleted();
 
   /**
-   * Returns the number of target rows updated.
+   * Returns the number of target rows updated, or -1 if not found.
    */
   long numTargetRowsUpdated();
 
   /**
-   * Returns the number of target rows inserted.
+   * Returns the number of target rows inserted, or -1 if not found.
    */
   long numTargetRowsInserted();
 
   /**
-   * Returns the number of target rows updated by a matched clause.
+   * Returns the number of target rows updated by a matched clause, or -1 if not found.
    */
   long numTargetRowsMatchedUpdated();
 
   /**
-   * Returns the number of target rows deleted by a matched clause
+   * Returns the number of target rows deleted by a matched clause, or -1 if not found.
    */
   long numTargetRowsMatchedDeleted();
 
   /**
-   * Returns the number of target rows updated by a not matched by source clause.
+   * Returns the number of target rows updated by a not matched by source clause,
+   * or -1 if not found.
    */
   long numTargetRowsNotMatchedBySourceUpdated();
 
   /**
-   * Returns the number of target rows deleted by a not matched by source clause.
+   * Returns the number of target rows deleted by a not matched by source clause,
+   * or -1 if not found.
    */
   long numTargetRowsNotMatchedBySourceDeleted();
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Clarify javadocs to explain situations where the metric is not found.

### Why are the changes needed?
As we begin to handle more write summaries like in https://github.com/apache/spark/pull/52669/, involving more complex walks of the executed plan graph, the code to calculate merge summary may encounter some plan it does not expect and would need to populate -1.  

This was actually called out in https://github.com/apache/spark/pull/52595#discussion_r2427651730 , it was not done as it was not case then, but now I realize it will be possible as this code evolves.  Especially as we plan to still populate MergeSummary in cases where the optimizer rewrites Merge plan to get rid of MergeRowsExec or Join.

As it is more an error-handling case, we don't need to change the model of the MergeSummary to return Long or OptionalLong, so we can put -1 and indicate this in the javadoc.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
No


### Was this patch authored or co-authored using generative AI tooling?
No
