### PR TITLE
[SPARK-53977][PYTHON] Support logging in UDTFs

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonUDTFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonUDTFExec.scala
@@ -53,6 +53,12 @@ case class ArrowEvalPythonUDTFExec(
   private val largeVarTypes = conf.arrowUseLargeVarTypes
   private val pythonRunnerConf = ArrowPythonRunner.getPythonRunnerConfMap(conf)
   private[this] val jobArtifactUUID = JobArtifactSet.getCurrentJobArtifactState.map(_.uuid)
+  private[this] val sessionUUID = {
+    Option(session).collect {
+      case session if session.sessionState.conf.pythonWorkerLoggingEnabled =>
+        session.sessionUUID
+    }
+  }
 
   override protected def evaluate(
       argMetas: Array[ArgumentMetadata],
@@ -75,7 +81,8 @@ case class ArrowEvalPythonUDTFExec(
       largeVarTypes,
       pythonRunnerConf,
       pythonMetrics,
-      jobArtifactUUID).compute(batchIter, context.partitionId(), context)
+      jobArtifactUUID,
+      sessionUUID).compute(batchIter, context.partitionId(), context)
 
     columnarBatchIter.map { batch =>
       // UDTF returns a StructType column in ColumnarBatch. Flatten the columnar batch here.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonUDFRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonUDFRunner.scala
@@ -36,7 +36,7 @@ abstract class BasePythonUDFRunner(
     argOffsets: Array[Array[Int]],
     pythonMetrics: Map[String, SQLMetric],
     jobArtifactUUID: Option[String],
-    sessionUUID: Option[String] = None)
+    sessionUUID: Option[String])
   extends BasePythonRunner[Array[Byte], Array[Byte]](
     funcs.map(_._1), evalType, argOffsets, jobArtifactUUID, pythonMetrics) {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Supports logging in UDTFs.

### Why are the changes needed?

The basic logging infrastructure was introduced in https://github.com/apache/spark/pull/52689, and UDTFs should also support logging.

Here adding support for UDTFs.

### Does this PR introduce _any_ user-facing change?

Yes, the logging feature will be available in UDTFs.

### How was this patch tested?

Added the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
