### PR TITLE
[SPARK-54099][SQL] XML variant parser should fall back to string on decimal parsing errors

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
@@ -1290,7 +1290,7 @@ object StaxXmlParser {
       }
     } catch {
       case NonFatal(_) =>
-        // Ignore the exception and parse it as a string later
+        // Ignore the exception and parse it as a string below
     }
 
     // If the character is of other primitive types, parse it as a string

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
@@ -1008,7 +1008,7 @@ class XmlTokenizer(
   }
 }
 
-object StaxXmlParser extends Logging{
+object StaxXmlParser extends Logging {
   /**
    * Parses a stream that contains CSV strings and turns it into an iterator of tokens.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
@@ -1008,7 +1008,7 @@ class XmlTokenizer(
   }
 }
 
-object StaxXmlParser extends Logging {
+object StaxXmlParser {
   /**
    * Parses a stream that contains CSV strings and turns it into an iterator of tokens.
    */
@@ -1279,23 +1279,18 @@ object StaxXmlParser extends Logging {
     // Try parsing the value as decimal
     val decimalParser = ExprUtils.getDecimalParser(options.locale)
     try {
-      allCatch opt decimalParser(value) match {
-        case Some(decimalValue) =>
-          var d = decimalValue
-          if (d.scale() < 0) {
-            d = d.setScale(0)
-          }
-          if (d.scale <= VariantUtil.MAX_DECIMAL16_PRECISION &&
-            d.precision <= VariantUtil.MAX_DECIMAL16_PRECISION) {
-            builder.appendDecimal(d)
-            return
-          }
-        case _ =>
+      var d = decimalParser(value)
+      if (d.scale() < 0) {
+        d = d.setScale(0)
+      }
+      if (d.scale <= VariantUtil.MAX_DECIMAL16_PRECISION &&
+        d.precision <= VariantUtil.MAX_DECIMAL16_PRECISION) {
+        builder.appendDecimal(d)
+        return
       }
     } catch {
-      case NonFatal(e) =>
+      case NonFatal(_) =>
         // Ignore the exception and parse it as a string later
-        logWarning("Failed to parse XML character as decimal.", e)
     }
 
     // If the character is of other primitive types, parse it as a string


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
When parsing XML data with `parse_xml` that contains decimal numbers with very large 
exponents (e.g., "1E+2147483647"), the conversion to Variant type fails with:
```
java.lang.ArithmeticException: BigInteger would overflow supported range
    at java.base/java.math.BigDecimal.setScale(BigDecimal.java:3000)
    at org.apache.spark.sql.catalyst.xml.StaxXmlParser$.org$apache$spark$sql$catalyst$xml$StaxXmlParser$$appendXMLCharacterToVariant(StaxXmlParser.scala:1335)
```

It's because the parser calls `setScale(0)` to normalize the decimal. When the scale is extremely negative (e.g., -2147483647), `setScale(0)` attempts to 
multiply the unscaled value by 10^2147483647, causing BigInteger overflow.

This PR will catch all errors when parsing strings as decimal in the XML variant parser and fall back to string.


### Why are the changes needed?
Bug fix.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
New UT.


### Was this patch authored or co-authored using generative AI tooling?
No.