### PR TITLE
[SPARK-54100][BUILD] Remove `ignore.symbol.file` Javac option

### DIFF
--- a/common/sketch/pom.xml
+++ b/common/sketch/pom.xml
@@ -60,12 +60,6 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <configuration>
-          <javacArgs combine.children="append">
-            <!-- This option is needed to suppress warnings from sun.misc.Unsafe usage -->
-            <javacArg>-XDignore.symbol.file</javacArg>
-          </javacArgs>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/common/unsafe/pom.xml
+++ b/common/unsafe/pom.xml
@@ -135,12 +135,6 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <configuration>
-          <javacArgs combine.children="append">
-            <!-- This option is needed to suppress warnings from sun.misc.Unsafe usage -->
-            <javacArg>-XDignore.symbol.file</javacArg>
-          </javacArgs>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/common/variant/pom.xml
+++ b/common/variant/pom.xml
@@ -69,12 +69,6 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <configuration>
-          <javacArgs combine.children="append">
-            <!-- This option is needed to suppress warnings from sun.misc.Unsafe usage -->
-            <javacArg>-XDignore.symbol.file</javacArg>
-          </javacArgs>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1075,10 +1075,7 @@ object SparkProtobuf {
 }
 
 object Unsafe {
-  lazy val settings = Seq(
-    // This option is needed to suppress warnings from sun.misc.Unsafe usage
-    (Compile / javacOptions) += "-XDignore.symbol.file"
-  )
+  lazy val settings = Seq()
 }
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `ignore.symbol.file` Javac option.

### Why are the changes needed?

Since Apache Spark 4.0.0, we are building with `-release` which means `Javac` always uses `ct.sym`, a stripped-down version of the standard library (like rt.jar in older JDKs) containing only the necessary class stubs and signature data for the documented APIs of a specific Java release. In other words, `ignore.symbol.file` option is ignored now and we can remove it safely.
- https://github.com/apache/spark/pull/45716

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

**BEFORE**

```
$ git grep ignore.symbol.file | wc -l
       4
```

**AFTER**

```
$ git grep ignore.symbol.file | wc -l
       0
```

### Was this patch authored or co-authored using generative AI tooling?

No.