### PR TITLE
[SPARK-54101][Geo][SQL] Introduce the framework for adding ST functions in Scala

### DIFF
--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -80,6 +80,10 @@ class FunctionsTestsMixin:
 
         missing_in_py = jvm_fn_set.difference(py_fn_set)
 
+        # Temporarily disable Scala/Python parity check for ST geospatial functions, while the
+        # feature is under development. Once the geospatial module is stable, remove this.
+        missing_in_py = {fn for fn in missing_in_py if not fn.startswith("st_")}
+
         # Functions that we expect to be missing in python until they are added to pyspark
         expected_missing_in_py = set()
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -71,6 +71,7 @@ import org.apache.spark.util.SparkClassUtils
  * @groupname array_funcs Array functions
  * @groupname map_funcs Map functions
  * @groupname struct_funcs Struct functions
+ * @groupname st_funcs ST geospatial functions
  * @groupname csv_funcs CSV functions
  * @groupname json_funcs JSON functions
  * @groupname variant_funcs VARIANT functions
@@ -9138,6 +9139,37 @@ object functions {
   }
 
    */
+
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  // ST geospatial functions
+  //////////////////////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * Returns the input GEOGRAPHY or GEOMETRY value in WKB format.
+   *
+   * @group st_funcs
+   * @since 4.1.0
+   */
+  def st_asbinary(geo: Column): Column =
+    Column.fn("st_asbinary", geo)
+
+  /**
+   * Parses the WKB description of a geography and returns the corresponding GEOGRAPHY value.
+   *
+   * @group st_funcs
+   * @since 4.1.0
+   */
+  def st_geogfromwkb(wkb: Column): Column =
+    Column.fn("st_geogfromwkb", wkb)
+
+  /**
+   * Parses the WKB description of a geometry and returns the corresponding GEOMETRY value.
+   *
+   * @group st_funcs
+   * @since 4.1.0
+   */
+  def st_geomfromwkb(wkb: Column): Column =
+    Column.fn("st_geomfromwkb", wkb)
 
   //////////////////////////////////////////////////////////////////////////////////////////////
   // Scala UDF functions

--- a/sql/core/src/test/scala/org/apache/spark/sql/STFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/STFunctionsSuite.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.test.SharedSparkSession
+
+class STFunctionsSuite extends QueryTest with SharedSparkSession {
+  import testImplicits._
+
+  /** ST reader/writer expressions. */
+
+  test("st_asbinary") {
+    // Test data: Well-Known Binary (WKB) representations.
+    val df = Seq[(String)](
+      (
+        "0101000000000000000000f03f0000000000000040",
+      )
+    ).toDF("wkb")
+    // ST_GeogFromWKB/ST_GeomFromWKB and ST_AsBinary.
+    checkAnswer(
+      df.select(
+        lower(hex(st_asbinary(st_geogfromwkb(unhex($"wkb"))))).as("col0"),
+        lower(hex(st_asbinary(st_geomfromwkb(unhex($"wkb"))))).as("col1"),
+      ),
+      Row(
+        "0101000000000000000000f03f0000000000000040",
+        "0101000000000000000000f03f0000000000000040",
+      )
+    )
+  }
+
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/STFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/STFunctionsSuite.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
 
 class STFunctionsSuite extends QueryTest with SharedSparkSession {
+
   import testImplicits._
 
   /** ST reader/writer expressions. */
@@ -29,20 +30,16 @@ class STFunctionsSuite extends QueryTest with SharedSparkSession {
     // Test data: Well-Known Binary (WKB) representations.
     val df = Seq[(String)](
       (
-        "0101000000000000000000f03f0000000000000040",
-      )
-    ).toDF("wkb")
+        "0101000000000000000000f03f0000000000000040"
+      )).toDF("wkb")
     // ST_GeogFromWKB/ST_GeomFromWKB and ST_AsBinary.
     checkAnswer(
       df.select(
         lower(hex(st_asbinary(st_geogfromwkb(unhex($"wkb"))))).as("col0"),
-        lower(hex(st_asbinary(st_geomfromwkb(unhex($"wkb"))))).as("col1"),
-      ),
+        lower(hex(st_asbinary(st_geomfromwkb(unhex($"wkb"))))).as("col1")),
       Row(
         "0101000000000000000000f03f0000000000000040",
-        "0101000000000000000000f03f0000000000000040",
-      )
-    )
+        "0101000000000000000000f03f0000000000000040"))
   }
 
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR adds rudimentary WKB read/write ST geospatial functions in Scala API, and registers the new Scala functions under the new `st_funcs` group.

Note that a similar framework was already implemented in Catalyst, as part of: https://github.com/apache/spark/pull/52784.


### Why are the changes needed?
Establish a minimal ST function framework in Scala API, setting the foundations for expanding geospatial function support in the near future.


### Does this PR introduce _any_ user-facing change?
Yes, this PR introduces 3 new Scala functions: `st_asbinary`, `st_geogfromwkb`, `st_geomfromwkb`.


### How was this patch tested?
Added new Scala unit test suites:
- `STFunctionsSuite.scala`


### Was this patch authored or co-authored using generative AI tooling?
No.
