### PR TITLE
[SPARK-54103][Geo][SQL] Introduce client-side Geography and Geometry classes

### DIFF
--- a/sql/api/src/main/java/org/apache/spark/sql/types/Geography.java
+++ b/sql/api/src/main/java/org/apache/spark/sql/types/Geography.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+// This class represents the Geography data for clients.
+public final class Geography implements Serializable {
+  // The GEOGRAPHY type is implemented as WKB bytes + SRID integer stored in class itself.
+  protected final byte[] value;
+
+  protected final int srid;
+
+  // We make the constructor private. We should use `fromWKB` to create new instances.
+  private Geography(byte[] value, int srid) {
+    this.value = value;
+    this.srid = srid;
+  }
+
+  // We provide `getBytes` and `fromBytes` methods to access GEOGRAPHY data.
+
+  public byte[] getBytes() {
+    return value;
+  }
+
+  public int getSrid() {
+    return srid;
+  }
+
+  // Default SRID value for the Geography client class.
+  public static final int DEFAULT_SRID = 4326;
+
+  // Factory methods to create new Geography instances from WKB bytes and optional SRID.
+
+  public static Geography fromWKB(byte[] bytes, int srid) {
+    return new Geography(bytes, srid);
+  }
+
+  public static Geography fromWKB(byte[] bytes) {
+    return new Geography(bytes, DEFAULT_SRID);
+  }
+
+  // Overrides for `equals` and `hashCode` methods.
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    Geography other = (Geography) obj;
+    return srid == other.srid && java.util.Arrays.equals(value, other.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * Arrays.hashCode(value) + Integer.hashCode(srid);
+  }
+}

--- a/sql/api/src/main/java/org/apache/spark/sql/types/Geometry.java
+++ b/sql/api/src/main/java/org/apache/spark/sql/types/Geometry.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+// This class represents the Geometry data for clients.
+public final class Geometry implements Serializable {
+  // The GEOMETRY type is implemented as WKB bytes + SRID integer stored in class itself.
+  protected final byte[] value;
+
+  protected final int srid;
+
+  // We make the constructor private. We should use `fromWKB` to create new instances.
+  private Geometry(byte[] value, int srid) {
+    this.value = value;
+    this.srid = srid;
+  }
+
+  // We provide `getBytes` and `fromBytes` methods to access GEOMETRY data.
+
+  public byte[] getBytes() {
+    return value;
+  }
+
+  public int getSrid() {
+    return srid;
+  }
+
+  // Default SRID value for the Geometry client class.
+  public static final int DEFAULT_SRID = 0;
+
+  // Factory methods to create new Geometry instances from WKB bytes and optional SRID.
+
+  public static Geometry fromWKB(byte[] bytes, int srid) {
+    return new Geometry(bytes, srid);
+  }
+
+  public static Geometry fromWKB(byte[] bytes) {
+    return new Geometry(bytes, DEFAULT_SRID);
+  }
+
+  // Overrides for `equals` and `hashCode` methods.
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    Geometry other = (Geometry) obj;
+    return srid == other.srid && java.util.Arrays.equals(value, other.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * Arrays.hashCode(value) + Integer.hashCode(srid);
+  }
+}

--- a/sql/core/src/test/java/org/apache/spark/sql/types/GeographyClientSuite.java
+++ b/sql/core/src/test/java/org/apache/spark/sql/types/GeographyClientSuite.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+/**
+ * Test suite for the Geography client-side class.
+ */
+class GeographyClientSuite {
+
+  // A sample Geography WKB array for testing purposes, representing a POINT(1 2).
+  private final byte[] testGeographyWkb = new byte[] { 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, (byte)0xF0, 0x3F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40 };
+  private final int testGeographySrid = 4326;
+
+  /** Tests for Geography factory methods and getters. */
+
+  @Test
+  void testFromWkb() {
+    Geography geography = Geography.fromWKB(testGeographyWkb);
+    assertNotNull(geography);
+    assertArrayEquals(testGeographyWkb, geography.getBytes());
+    assertEquals(Geography.DEFAULT_SRID, geography.getSrid());
+  }
+
+  @Test
+  void testFromWkbSrid() {
+    Geography geography = Geography.fromWKB(testGeographyWkb, testGeographySrid);
+    assertNotNull(geography);
+    assertArrayEquals(testGeographyWkb, geography.getBytes());
+    assertEquals(testGeographySrid, geography.getSrid());
+  }
+
+  /** Tests for Geography constants. */
+
+  @Test
+  void testDefaultSrid() {
+    assertEquals(4326, Geography.DEFAULT_SRID);
+  }
+
+  /** Tests for other Geography methods. */
+
+  @Test
+  void testEquals() {
+    Geography geography1 = Geography.fromWKB(testGeographyWkb);
+    Geography geography2 = Geography.fromWKB(testGeographyWkb);
+    Geography geography3 = Geography.fromWKB(testGeographyWkb, 1);
+    assertNotEquals(geography1, null);
+    assertNotEquals(geography2, null);
+    assertNotEquals(geography3, null);
+    assertEquals(geography1, geography2);
+    assertNotEquals(geography1, geography3);
+    assertNotEquals(geography2, geography3);
+  }
+
+  @Test
+  void testHashCode() {
+    Geography geography1 = Geography.fromWKB(testGeographyWkb);
+    Geography geography2 = Geography.fromWKB(testGeographyWkb, testGeographySrid);
+    int wkbHash = Arrays.hashCode(testGeographyWkb);
+    assertEquals(31 * wkbHash + Integer.hashCode(Geography.DEFAULT_SRID), geography1.hashCode());
+    assertEquals(31 * wkbHash + Integer.hashCode(testGeographySrid), geography2.hashCode());
+  }
+
+}

--- a/sql/core/src/test/java/org/apache/spark/sql/types/GeometryClientSuite.java
+++ b/sql/core/src/test/java/org/apache/spark/sql/types/GeometryClientSuite.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+/**
+ * Test suite for the Geometry client-side class.
+ */
+class GeometryClientSuite {
+
+  // A sample Geometry WKB array for testing purposes, representing a POINT(1 2).
+  private final byte[] testGeometryWkb = new byte[] { 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, (byte)0xF0, 0x3F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40 };
+  private final int testGeometrySrid = 4326;
+
+  /** Tests for Geometry factory methods and getters. */
+
+  @Test
+  void testFromWkb() {
+    Geometry geometry = Geometry.fromWKB(testGeometryWkb);
+    assertNotNull(geometry);
+    assertArrayEquals(testGeometryWkb, geometry.getBytes());
+    assertEquals(Geometry.DEFAULT_SRID, geometry.getSrid());
+  }
+
+  @Test
+  void testFromWkbSrid() {
+    Geometry geometry = Geometry.fromWKB(testGeometryWkb, testGeometrySrid);
+    assertNotNull(geometry);
+    assertArrayEquals(testGeometryWkb, geometry.getBytes());
+    assertEquals(testGeometrySrid, geometry.getSrid());
+  }
+
+  /** Tests for Geometry constants. */
+
+  @Test
+  void testDefaultSrid() {
+    assertEquals(0, Geometry.DEFAULT_SRID);
+  }
+
+  /** Tests for other Geometry methods. */
+
+  @Test
+  void testEquals() {
+    Geometry geometry1 = Geometry.fromWKB(testGeometryWkb);
+    Geometry geometry2 = Geometry.fromWKB(testGeometryWkb);
+    Geometry geometry3 = Geometry.fromWKB(testGeometryWkb, 1);
+    assertNotEquals(geometry1, null);
+    assertNotEquals(geometry2, null);
+    assertNotEquals(geometry3, null);
+    assertEquals(geometry1, geometry2);
+    assertNotEquals(geometry1, geometry3);
+    assertNotEquals(geometry2, geometry3);
+  }
+
+  @Test
+  void testHashCode() {
+    Geometry geometry1 = Geometry.fromWKB(testGeometryWkb);
+    Geometry geometry2 = Geometry.fromWKB(testGeometryWkb, testGeometrySrid);
+    int wkbHash = Arrays.hashCode(testGeometryWkb);
+    assertEquals(31 * wkbHash + Integer.hashCode(Geometry.DEFAULT_SRID), geometry1.hashCode());
+    assertEquals(31 * wkbHash + Integer.hashCode(testGeometrySrid), geometry2.hashCode());
+  }
+
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Introduce client-side `Geography` and `Geometry` geospatial classes in external API.

Note that the Catalyst internal server-side geospatial execution classes have already been introduced separately, as part of: https://github.com/apache/spark/pull/52737.


### Why are the changes needed?
Introducing geospatial classes to client API, which will allow various clients (JDBC, Hive, Thrift server, Spark Connect, etc.) to consume geospatial objects.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Added new Java unit test suites for the client classes:
- `GeographyClientSuite`
- `GeometryClientSuite`


### Was this patch authored or co-authored using generative AI tooling?
No.
