### PR TITLE
[SPARK-54033][Geo][SQL][FOLLOWUP] Fix Java test suite names for geospatial execution classes

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/GeographyExecutionSuite.java
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/GeographyExecutionSuite.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Test suite for the Geography server-side execution class.
  */
-class GeographyExecutionTest {
+class GeographyExecutionSuite {
 
   // A sample Geography byte array for testing purposes, representing a POINT(1 2) with SRID 4326.
   private final byte[] testGeographyVal = new byte[] {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/GeometryExecutionSuite.java
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/GeometryExecutionSuite.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Test suite for the Geometry server-side execution class.
  */
-class GeometryExecutionTest {
+class GeometryExecutionSuite {
 
   // A sample Geometry byte array for testing purposes, representing a POINT(1 2) with SRID 4326.
   private final byte[] testGeometryVal = new byte[] {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Following up on the original PR (https://github.com/apache/spark/pull/52737), this PR fixes Java test suite names.


### Why are the changes needed?
Java test classes should be named same as the corresponding test suite files.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing tests suffice.


### Was this patch authored or co-authored using generative AI tooling?
No.
