### PR TITLE
[SPARK-53731][PYTHON] Update the type hints of iterator APIs

### DIFF
--- a/examples/src/main/python/sql/arrow.py
+++ b/examples/src/main/python/sql/arrow.py
@@ -24,7 +24,7 @@ Run with:
 # NOTE that this file is imported in tutorials in PySpark documentation.
 # The codes are referred via line numbers. See also `literalinclude` directive in Sphinx.
 import pandas as pd
-from typing import Iterable
+from typing import Iterator
 
 from pyspark.sql import SparkSession
 from pyspark.sql.pandas.utils import require_minimum_pandas_version, require_minimum_pyarrow_version
@@ -256,7 +256,7 @@ def grouped_apply_in_pandas_example(spark: SparkSession) -> None:
 def map_in_pandas_example(spark: SparkSession) -> None:
     df = spark.createDataFrame([(1, 21), (2, 30)], ("id", "age"))
 
-    def filter_func(iterator: Iterable[pd.DataFrame]) -> Iterable[pd.DataFrame]:
+    def filter_func(iterator: Iterator[pd.DataFrame]) -> Iterator[pd.DataFrame]:
         for pdf in iterator:
             yield pdf[pdf.id == 1]
 

--- a/examples/src/main/python/sql/streaming/structured_network_wordcount_session_window.py
+++ b/examples/src/main/python/sql/streaming/structured_network_wordcount_session_window.py
@@ -31,7 +31,7 @@ r"""
     localhost 9999`
 """
 import sys
-from typing import Iterable, Any
+from typing import Iterator, Any
 
 import pandas as pd
 
@@ -95,8 +95,8 @@ if __name__ == "__main__":
     )
 
     def func(
-        key: Any, pdfs: Iterable[pd.DataFrame], state: GroupState
-    ) -> Iterable[pd.DataFrame]:
+        key: Any, pdfs: Iterator[pd.DataFrame], state: GroupState
+    ) -> Iterator[pd.DataFrame]:
         if state.hasTimedOut:
             count, start, end = state.get
             state.remove()

--- a/python/pyspark/ml/connect/util.py
+++ b/python/pyspark/ml/connect/util.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from typing import Any, TypeVar, Callable, List, Tuple, Union, Iterable, TYPE_CHECKING
+from typing import Any, TypeVar, Callable, List, Tuple, Union, Iterator, TYPE_CHECKING
 
 import pandas as pd
 
@@ -74,7 +74,7 @@ def aggregate_dataframe(
 
     dataframe = dataframe.select(*input_col_names)
 
-    def compute_state(iterator: Iterable["pd.DataFrame"]) -> Iterable["pd.DataFrame"]:
+    def compute_state(iterator: Iterator["pd.DataFrame"]) -> Iterator["pd.DataFrame"]:
         state = None
 
         for batch_pandas_df in iterator:

--- a/python/pyspark/sql/pandas/_typing/__init__.pyi
+++ b/python/pyspark/sql/pandas/_typing/__init__.pyi
@@ -19,11 +19,9 @@
 from typing import (
     Any,
     Callable,
-    Iterable,
     Iterator,
     NewType,
     Tuple,
-    Type,
     TypeVar,
     Union,
 )
@@ -142,8 +140,8 @@ ArrowScalarToScalarFunction = Union[
 ]
 
 ArrowScalarIterFunction = Union[
-    Callable[[Iterable[pyarrow.Array]], Iterable[pyarrow.Array]],
-    Callable[[Tuple[pyarrow.Array, ...]], Iterable[pyarrow.Array]],
+    Callable[[Iterator[pyarrow.Array]], Iterator[pyarrow.Array]],
+    Callable[[Tuple[pyarrow.Array, ...]], Iterator[pyarrow.Array]],
 ]
 
 class PandasVariadicScalarToScalarFunction(Protocol):
@@ -341,8 +339,8 @@ PandasScalarToStructFunction = Union[
 ]
 
 PandasScalarIterFunction = Union[
-    Callable[[Iterable[DataFrameOrSeriesLike_]], Iterable[SeriesLike]],
-    Callable[[Tuple[DataFrameOrSeriesLike_, ...]], Iterable[SeriesLike]],
+    Callable[[Iterator[DataFrameOrSeriesLike_]], Iterator[SeriesLike]],
+    Callable[[Tuple[DataFrameOrSeriesLike_, ...]], Iterator[SeriesLike]],
 ]
 
 PandasGroupedMapFunction = Union[
@@ -353,7 +351,7 @@ PandasGroupedMapFunction = Union[
 ]
 
 PandasGroupedMapFunctionWithState = Callable[
-    [Any, Iterable[DataFrameLike], GroupState], Iterable[DataFrameLike]
+    [Any, Iterator[DataFrameLike], GroupState], Iterator[DataFrameLike]
 ]
 
 class PandasVariadicGroupedAggFunction(Protocol):
@@ -426,26 +424,23 @@ PandasGroupedAggFunction = Union[
     PandasVariadicGroupedAggFunction,
 ]
 
-PandasMapIterFunction = Callable[[Iterable[DataFrameLike]], Iterable[DataFrameLike]]
+PandasMapIterFunction = Callable[[Iterator[DataFrameLike]], Iterator[DataFrameLike]]
 
-ArrowMapIterFunction = Callable[[Iterable[pyarrow.RecordBatch]], Iterable[pyarrow.RecordBatch]]
+ArrowMapIterFunction = Callable[[Iterator[pyarrow.RecordBatch]], Iterator[pyarrow.RecordBatch]]
 
 PandasCogroupedMapFunction = Union[
     Callable[[DataFrameLike, DataFrameLike], DataFrameLike],
     Callable[[Any, DataFrameLike, DataFrameLike], DataFrameLike],
 ]
 
-ArrowGroupedMapTableFunction = Union[
+ArrowGroupedMapFunction = Union[
     Callable[[pyarrow.Table], pyarrow.Table],
     Callable[[Tuple[pyarrow.Scalar, ...], pyarrow.Table], pyarrow.Table],
-]
-ArrowGroupedMapIterFunction = Union[
     Callable[[Iterator[pyarrow.RecordBatch]], Iterator[pyarrow.RecordBatch]],
     Callable[
         [Tuple[pyarrow.Scalar, ...], Iterator[pyarrow.RecordBatch]], Iterator[pyarrow.RecordBatch]
     ],
 ]
-ArrowGroupedMapFunction = Union[ArrowGroupedMapTableFunction, ArrowGroupedMapIterFunction]
 
 ArrowCogroupedMapFunction = Union[
     Callable[[pyarrow.Table, pyarrow.Table], pyarrow.Table],

--- a/python/pyspark/sql/tests/typing/test_udf.yml
+++ b/python/pyspark/sql/tests/typing/test_udf.yml
@@ -114,12 +114,12 @@
 - case: mapIterUdf
   main: |
     from pyspark.sql.session import SparkSession
-    from typing import Iterable
+    from typing import Iterator
     import pandas.core.frame
 
     spark = SparkSession.builder.getOrCreate()
 
-    def f(batch_iter: Iterable[pandas.core.frame.DataFrame]) -> Iterable[pandas.core.frame.DataFrame]:
+    def f(batch_iter: Iterator[pandas.core.frame.DataFrame]) -> Iterator[pandas.core.frame.DataFrame]:
         for pdf in batch_iter:
             yield pdf[pdf.id == 1]
 

--- a/python/pyspark/sql/tests/typing/test_udf.yml
+++ b/python/pyspark/sql/tests/typing/test_udf.yml
@@ -47,10 +47,10 @@
     from pyspark.sql.pandas.functions import pandas_udf, PandasUDFType
     from pyspark.sql.types import IntegerType
     import pandas.core.series
-    from typing import Iterable
+    from typing import Iterator
 
     @pandas_udf(IntegerType(), PandasUDFType.SCALAR_ITER)
-    def f(xs: Iterable[pandas.core.series.Series]) -> Iterable[pandas.core.series.Series]:
+    def f(xs: Iterator[pandas.core.series.Series]) -> Iterator[pandas.core.series.Series]:
         for x in xs:
             yield x + 1
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Update the type hints of iterator APIs


### Why are the changes needed?
they should use `Iterator` instead of `Iterable`

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
No