### PR TITLE
[SPARK-54116][SQL] Add off-heap mode support for LongHashedRelation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1178,13 +1178,6 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       cause = null)
   }
 
-  def cannotAcquireMemoryToBuildLongHashedRelationError(size: Long, got: Long): Throwable = {
-    new SparkException(
-      errorClass = "_LEGACY_ERROR_TEMP_2106",
-      messageParameters = Map("size" -> size.toString(), "got" -> got.toString()),
-      cause = null)
-  }
-
   def cannotAcquireMemoryToBuildUnsafeHashedRelationError(): Throwable = {
     new SparkOutOfMemoryError(
       "_LEGACY_ERROR_TEMP_2107",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -977,7 +977,7 @@ private[execution] final class LongToUnsafeRowMap(
   }
 
   private class UnsafeLongArray(val length: Int) {
-    val memoryBlock = allocatePage(length * 8)
+    val memoryBlock: MemoryBlock = allocatePage(length * 8)
 
     for (i <- 0 until length) {
       update(i, 0)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
@@ -25,9 +25,10 @@ import scala.util.Random
 
 import org.apache.spark.SparkConf
 import org.apache.spark.SparkException
-import org.apache.spark.internal.config._
+import org.apache.spark.internal.config.{MEMORY_OFFHEAP_ENABLED, MEMORY_OFFHEAP_SIZE}
 import org.apache.spark.internal.config.Kryo._
 import org.apache.spark.memory.{TaskMemoryManager, UnifiedMemoryManager}
+import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.serializer.KryoSerializer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -39,9 +40,13 @@ import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.collection.CompactBuffer
 
-class HashedRelationSuite extends SharedSparkSession {
+abstract class HashedRelationSuite extends SharedSparkSession {
+  protected def useOffHeapMemoryMode: Boolean
+
   val umm = new UnifiedMemoryManager(
-    new SparkConf().set(MEMORY_OFFHEAP_ENABLED.key, "false"),
+    new SparkConf()
+      .set(MEMORY_OFFHEAP_ENABLED, useOffHeapMemoryMode)
+      .set(MEMORY_OFFHEAP_SIZE, ByteUnit.GiB.toBytes(1L)),
     Runtime.getRuntime.maxMemory,
     Runtime.getRuntime.maxMemory / 2,
     1)
@@ -753,4 +758,12 @@ class HashedRelationSuite extends SharedSparkSession {
       map.free()
     }
   }
+}
+
+class HashedRelationOnHeapSuite extends HashedRelationSuite {
+  override protected def useOffHeapMemoryMode: Boolean = true
+}
+
+class HashedRelationOffHeapSuite extends HashedRelationSuite {
+  override protected def useOffHeapMemoryMode: Boolean = false
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
@@ -146,9 +146,6 @@ abstract class HashedRelationSuite extends SharedSparkSession {
       Seq(BoundReference(0, LongType, false), BoundReference(1, IntegerType, true)))
     val rows = (0 until 100).map(i => unsafeProj(InternalRow(Int.int2long(i), i + 1)).copy())
     val key = Seq(BoundReference(0, LongType, false))
-    while (true) {
-      LongHashedRelation(rows.iterator, key, 10, mm)
-    }
     val longRelation = LongHashedRelation(rows.iterator, key, 10, mm)
     assert(longRelation.keyIsUnique)
     (0 until 100).foreach { i =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
@@ -146,6 +146,9 @@ abstract class HashedRelationSuite extends SharedSparkSession {
       Seq(BoundReference(0, LongType, false), BoundReference(1, IntegerType, true)))
     val rows = (0 until 100).map(i => unsafeProj(InternalRow(Int.int2long(i), i + 1)).copy())
     val key = Seq(BoundReference(0, LongType, false))
+    while (true) {
+      LongHashedRelation(rows.iterator, key, 10, mm)
+    }
     val longRelation = LongHashedRelation(rows.iterator, key, 10, mm)
     assert(longRelation.keyIsUnique)
     (0 until 100).foreach { i =>
@@ -761,9 +764,9 @@ abstract class HashedRelationSuite extends SharedSparkSession {
 }
 
 class HashedRelationOnHeapSuite extends HashedRelationSuite {
-  override protected def useOffHeapMemoryMode: Boolean = true
+  override protected def useOffHeapMemoryMode: Boolean = false
 }
 
 class HashedRelationOffHeapSuite extends HashedRelationSuite {
-  override protected def useOffHeapMemoryMode: Boolean = false
+  override protected def useOffHeapMemoryMode: Boolean = true
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

The PR adds off-heap memory mode support for LongHashedRelation.

The PR only affects ShuffledHashJoin. In BroadcastHashJoin, the hashed relations are not closed explicitly but are managed by GC. So it will require a different approach to allocate from off-heap.

### Why are the changes needed?

1. To avoid on-heap OOMs when user sets `spark.memory.offHeap.enabled=true`, and configures JVM with a comparatively small heap size.
2. Off-heap mode is seen faster than on-heap mode. See [benchmark results](https://github.com/apache/spark/pull/52817#issuecomment-3513268573).

### Does this PR introduce _any_ user-facing change?

By design, When `spark.memory.offHeap.enabled=true` is set:

- Required off-heap memory size may increase
- Required on-heap memory size may decrease


### How was this patch tested?

1. Functionality is covered by `HashedRelationOnHeapSuite` / `HashedRelationOffHeapSuite`.
2. Memory leak is guarded by the change in https://github.com/apache/spark/pull/52830.

### Was this patch authored or co-authored using generative AI tooling?

No.
