### PR TITLE
[SPARK-54127][BUILD] Fix sbt inconsistent shading package

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -808,7 +808,7 @@ object SparkConnect {
     },
 
     (assembly / assemblyShadeRules) := Seq(
-      ShadeRule.rename("io.grpc.**" -> "org.sparkproject.connect.grpc.@0").inAll,
+      ShadeRule.rename("io.grpc.**" -> "org.sparkproject.connect.grpc.@1").inAll,
       ShadeRule.rename("com.google.common.**" -> "org.sparkproject.connect.guava.@1").inAll,
       ShadeRule.rename("com.google.thirdparty.**" -> "org.sparkproject.connect.guava.@1").inAll,
       ShadeRule.rename("com.google.protobuf.**" -> "org.sparkproject.connect.protobuf.@1").inAll,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix sbt inconsistent shading package for `spark-connect` module

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Take 4.1.0-preview3 as the example, which is built by Maven.
```
$ jar tf jars/spark-connect_2.13-4.1.0-preview3.jar | grep 'connect/grpc' | head
org/sparkproject/connect/grpc/
org/sparkproject/connect/grpc/inprocess/
org/sparkproject/connect/grpc/inprocess/InProcessTransport$InProcessStream$InProcessServerStream.class
org/sparkproject/connect/grpc/inprocess/InProcessTransport$2.class
org/sparkproject/connect/grpc/inprocess/InProcessTransport$InProcessStream$InProcessClientStream.class
org/sparkproject/connect/grpc/inprocess/InProcessTransport$SingleMessageProducer.class
org/sparkproject/connect/grpc/inprocess/InProcessTransport$6.class
org/sparkproject/connect/grpc/inprocess/InProcessTransport$1.class
org/sparkproject/connect/grpc/inprocess/InProcessSocketAddress.class
org/sparkproject/connect/grpc/inprocess/InProcessTransport$InProcessStream.class
```

the produced jar built by SBT has a different relocated package for grpc classes
```
$ jar tf jars/spark-connect_2.13-4.1.0-SNAPSHOT.jar | grep 'connect/grpc' | head
org/sparkproject/connect/grpc/
org/sparkproject/connect/grpc/io/
org/sparkproject/connect/grpc/io/grpc/
org/sparkproject/connect/grpc/io/grpc/Attributes$1.class
org/sparkproject/connect/grpc/io/grpc/Attributes$Builder.class
org/sparkproject/connect/grpc/io/grpc/Attributes$Key.class
org/sparkproject/connect/grpc/io/grpc/Attributes.class
org/sparkproject/connect/grpc/io/grpc/BinaryLog.class
org/sparkproject/connect/grpc/io/grpc/BindableService.class
org/sparkproject/connect/grpc/io/grpc/CallCredentials$MetadataApplier.class
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, so far I don't see such inconsistent causes real issue.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Verified the output of `dev/make-distribution.sh --sbt-enabled`

```
jar tf jars/spark-connect_2.13-4.1.0-SNAPSHOT.jar | grep 'connect/grpc' | head
org/sparkproject/connect/grpc/
org/sparkproject/connect/grpc/Attributes$1.class
org/sparkproject/connect/grpc/Attributes$Builder.class
org/sparkproject/connect/grpc/Attributes$Key.class
org/sparkproject/connect/grpc/Attributes.class
org/sparkproject/connect/grpc/BinaryLog.class
org/sparkproject/connect/grpc/BindableService.class
org/sparkproject/connect/grpc/CallCredentials$MetadataApplier.class
org/sparkproject/connect/grpc/CallCredentials$RequestInfo.class
org/sparkproject/connect/grpc/CallCredentials.class
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.