### PR TITLE
[SPARK-54139][PYTHON] Incorrect parameter passed CANNOT_PARSE_DATATYPE error class

### DIFF
--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -2854,6 +2854,17 @@ class DataTypeVerificationTests(unittest.TestCase, PySparkErrorTestUtils):
 
         self.assertEqual(repr(struct_field), "StructField('c1', StringType(), True)")
 
+        with self.assertRaises(PySparkValueError) as pe:
+            StructField.fromJson({"name": "c1", "type": "NewType"})
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="CANNOT_PARSE_DATATYPE",
+            message_parameters={
+                "msg": "NewType",
+            },
+        )
+
 
 class TypesTests(TypesTestsMixin, ReusedSQLTestCase):
     pass


### PR DESCRIPTION
### What changes were proposed in this pull request?
Incorrect parameter **error** is used for CANNOT_PARSE_DATATYPE error class in PySpark code. It expects **msg**. Due to this the error produced during usage is incorrect:

Example:
```
StructField.fromJson({"name": "col1", "type": "NewType", "nullable": "True", "metadata": None}) 
```
Error:
```
assert set(message_parameters_from_template) == set(message_parameters), (
AssertionError: Undefined error message parameter for error class: CANNOT_PARSE_DATATYPE. Parameters: {'error': 'NewType'} 
```



### Why are the changes needed?
Bug fix


### Does this PR introduce _any_ user-facing change?
Yes, now correct error would be printed into console:
```
raise PySparkValueError(
pyspark.errors.exceptions.base.PySparkValueError: [CANNOT_PARSE_DATATYPE] Unable to parse datatype. NewType.
```


### How was this patch tested?
Added unit test and tested locally.

### Was this patch authored or co-authored using generative AI tooling?
No