### PR TITLE
[SPARK-54140][INFRA] Add `libwebp-dev` to fix `dev/spark-test-image/lint/Dockerfile` building

### DIFF
--- a/dev/spark-test-image/lint/Dockerfile
+++ b/dev/spark-test-image/lint/Dockerfile
@@ -46,6 +46,7 @@ RUN apt-get update && apt-get install -y \
     libpng-dev \
     libssl-dev \
     libtiff5-dev \
+    libwebp-dev \
     libxml2-dev \
     nodejs \
     npm \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `libwebp-dev` to fix `dev/spark-test-image/lint/Dockerfile` building in both `master` and `branch-4.1`.

### Why are the changes needed?

Currently, `dev/spark-test-image/lint/Dockerfile` fails to build.
- For master branch, it wasn't revealed yet because we use the cached image.
- For `branch-4.1`, it is currently breaking the CIs.
  - https://github.com/apache/spark/tree/branch-4.1
    - https://github.com/apache/spark/actions/runs/19015025991/job/54307102990

```
#9 454.6 -------------------------- [ERROR MESSAGE] ---------------------------
#9 454.6 <stdin>:1:10: fatal error: ft2build.h: No such file or directory
#9 454.6 compilation terminated.
#9 454.6 --------------------------------------------------------------------
#9 454.6 ERROR: configuration failed for package 'ragg'
#9 454.6 * removing '/usr/local/lib/R/site-library/ragg'
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs. Especially, `Base image build` job.
- https://github.com/dongjoon-hyun/spark/actions/runs/19018354185/job/54309542386

### Was this patch authored or co-authored using generative AI tooling?

No.