### PR TITLE
[SPARK-54141][INFRA] Add `libwebp-dev` to fix `dev/infra/Dockerfile` building

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update && apt-get install -y \
     libpython3-dev \
     libssl-dev \
     libtiff5-dev \
+    libwebp-dev \
     libxml2-dev \
     nodejs \
     npm \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `libwebp-dev` to fix `dev/infra/Dockerfile` building.

### Why are the changes needed?

To fix `build_infra_images_cache` GitHub Action job
- https://github.com/apache/spark/actions/workflows/build_infra_images_cache.yml

<img width="545" height="88" alt="Screenshot 2025-11-02 at 14 56 19" src="https://github.com/user-attachments/assets/f70d6093-6574-40f3-a097-ba5c9086f3c1" />

The root cause is identical with other Dockerfile failure.
```
#13 578.4 -------------------------- [ERROR MESSAGE] ---------------------------
#13 578.4 <stdin>:1:10: fatal error: ft2build.h: No such file or directory
#13 578.4 compilation terminated.
#13 578.4 --------------------------------------------------------------------
#13 578.4 ERROR: configuration failed for package 'ragg'
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs. Especially, `Cache base image` test.

### Was this patch authored or co-authored using generative AI tooling?

No.