### PR TITLE
[SPARK-54145][PYTHON][CONNECT] Fix column check of nested type in numeric aggregation

### DIFF
--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -158,6 +158,7 @@ class GroupedData:
 
     def _numeric_agg(self, function: str, cols: Sequence[str]) -> "DataFrame":
         from pyspark.sql.connect.dataframe import DataFrame
+        from pyspark.sql.connect.types import verify_numeric_col_name
 
         assert isinstance(function, str) and function in ["min", "max", "avg", "sum"]
 
@@ -165,12 +166,8 @@ class GroupedData:
 
         schema = self._df.schema
 
-        numerical_cols: List[str] = [
-            field.name for field in schema.fields if isinstance(field.dataType, NumericType)
-        ]
-
         if len(cols) > 0:
-            invalid_cols = [c for c in cols if c not in numerical_cols]
+            invalid_cols = [c for c in cols if not verify_numeric_col_name(c, schema)]
             if len(invalid_cols) > 0:
                 raise PySparkTypeError(
                     errorClass="NOT_NUMERIC_COLUMNS",
@@ -179,7 +176,9 @@ class GroupedData:
             agg_cols = cols
         else:
             # if no column is provided, then all numerical columns are selected
-            agg_cols = numerical_cols
+            agg_cols = [
+                field.name for field in schema.fields if isinstance(field.dataType, NumericType)
+            ]
 
         return DataFrame(
             plan.Aggregate(

--- a/python/pyspark/sql/tests/test_group.py
+++ b/python/pyspark/sql/tests/test_group.py
@@ -126,6 +126,22 @@ class GroupTestsMixin:
             with self.assertRaises(IndexError):
                 df.groupBy(10).agg(sf.sum("b"))
 
+    def test_numeric_agg_with_nest_type(self):
+        df = self.spark.createDataFrame(
+            [
+                Row(a="a", b=Row(c=1)),
+                Row(a="a", b=Row(c=2)),
+                Row(a="a", b=Row(c=3)),
+                Row(a="b", b=Row(c=4)),
+                Row(a="b", b=Row(c=5)),
+            ]
+        )
+
+        res = df.groupBy("a").max("b.c").sort("a").collect()
+        # [Row(a='a', max(b.c AS c)=3), Row(a='b', max(b.c AS c)=5)]
+
+        self.assertEqual([["a", 3], ["b", 5]], [list(r) for r in res])
+
     @unittest.skipIf(not have_pandas, pandas_requirement_message)  # type: ignore
     @unittest.skipIf(not have_pyarrow, pyarrow_requirement_message)  # type: ignore
     def test_order_by_ordinal(self):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix column check in numeric agg


### Why are the changes needed?
query:

```py
        df = spark.createDataFrame(
            [
                Row(a="a", b=Row(c=1)),
                Row(a="a", b=Row(c=2)),
                Row(a="a", b=Row(c=3)),
                Row(a="b", b=Row(c=4)),
                Row(a="b", b=Row(c=5)),
            ]
        )

        df.groupBy("a").max("b.c").show()
```

in classic:
```
+---+-------------+
|  a|max(b.c AS c)|
+---+-------------+
|  a|            3|
|  b|            5|
+---+-------------+
```

in connect:
```
---------------------------------------------------------------------------
PySparkTypeError                          Traceback (most recent call last)
Cell In[2], line 11
      1 df = spark.createDataFrame(
      2     [
      3         Row(a="a", b=Row(c=1)),
   (...)      8     ]
      9 )
---> 11 df.groupBy("a").max("b.c").show()

File ~/spark/python/pyspark/sql/connect/group.py:203, in GroupedData.max(self, *cols)
    202 def max(self: "GroupedData", *cols: str) -> "DataFrame":
--> 203     return self._numeric_agg("max", list(cols))

File ~/spark/python/pyspark/sql/connect/group.py:175, in GroupedData._numeric_agg(self, function, cols)
    173     invalid_cols = [c for c in cols if c not in numerical_cols]
    174     if len(invalid_cols) > 0:
--> 175         raise PySparkTypeError(
    176             errorClass="NOT_NUMERIC_COLUMNS",
    177             messageParameters={"invalid_columns": str(invalid_cols)},
    178         )
    179     agg_cols = cols
    180 else:
    181     # if no column is provided, then all numerical columns are selected

PySparkTypeError: [NOT_NUMERIC_COLUMNS] Numeric aggregation function can only be applied on numeric columns, got ['b.c'].

```

### Does this PR introduce _any_ user-facing change?
yes, above query works after this fix


### How was this patch tested?
added test

### Was this patch authored or co-authored using generative AI tooling?
no
