### PR TITLE
[SPARK-54149][SQL][SS][CONNECT] Enable tail-recursion wherever possible

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -181,6 +181,7 @@ private[v2] trait V2JDBCTest
   def multiplePartitionAdditionalCheck(
       df: DataFrame,
       partitioningInfo: Option[PartitioningInfo]): Unit = {
+    @scala.annotation.tailrec
     def getJDBCRDD(rdd: RDD[_]): Option[JDBCRDD] = {
       rdd match {
         case jdbcRdd: JDBCRDD => Some(jdbcRdd)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoder.scala
@@ -216,6 +216,7 @@ case class ExpressionEncoder[T](
     StructField(s.name, s.dataType, s.nullable)
   })
 
+  @scala.annotation.tailrec
   private def transformerOfOption(enc: AgnosticEncoder[_]): Boolean =
     enc match {
       case t: TransformingEncoder[_, _] => transformerOfOption(t.transformed)

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
@@ -285,6 +285,7 @@ object LiteralValueProtoConverter {
       case None =>
         val builder = toLiteralProtoBuilderInternal(literal, options)
         if (!options.useDeprecatedDataTypeFields) {
+          @scala.annotation.tailrec
           def unwrapArraySeq(value: Any): Any = value match {
             case arraySeq: mutable.ArraySeq[_] => unwrapArraySeq(arraySeq.array)
             case arraySeq: immutable.ArraySeq[_] => unwrapArraySeq(arraySeq.unsafeArray)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/InferVariantShreddingSchema.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/InferVariantShreddingSchema.scala
@@ -64,6 +64,7 @@ class InferVariantShreddingSchema(val schema: StructType) {
    * Return the VariantVal at the given path in the schema, or None if the Variant value or any of
    * its containing structs is null.
    */
+  @scala.annotation.tailrec
   private def getValueAtPath(schema: StructType, row: InternalRow, path: Seq[Int]):
       Option[VariantVal] = {
     if (row.isNullAt(path.head)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/WatermarkPropagator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/WatermarkPropagator.scala
@@ -175,6 +175,7 @@ class PropagateWatermarkSimulator extends WatermarkPropagator with Logging {
   private def getInputWatermarks(
       node: SparkPlan,
       nodeToOutputWatermark: mutable.Map[Int, Option[Long]]): Seq[Long] = {
+    @scala.annotation.tailrec
     def watermarkForChild(child: SparkPlan): Option[Long] = {
       child match {
         case s: InMemoryTableScanExec => watermarkForChild(s.relation.cachedPlan)

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -1056,6 +1056,7 @@ class ForStatementExec(
         case ForState.Body => bodyWithVariables.exists(_.getTreeIterator.hasNext)
       })
 
+      @scala.annotation.tailrec
       override def next(): CompoundStatementExec = state match {
 
         case ForState.VariableAssignment =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -20,6 +20,8 @@ package org.apache.spark.sql.scripting
 import java.util
 import java.util.{Locale, UUID}
 
+import scala.annotation.tailrec
+
 import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Row
@@ -309,7 +311,7 @@ class CompoundBodyExec(
         !stopIteration && (localIterator.hasNext || childHasNext)
       }
 
-      @scala.annotation.tailrec
+      @tailrec
       override def next(): CompoundStatementExec = {
         curr match {
           case None => throw SparkException.internalError(
@@ -1056,7 +1058,7 @@ class ForStatementExec(
         case ForState.Body => bodyWithVariables.exists(_.getTreeIterator.hasNext)
       })
 
-      @scala.annotation.tailrec
+      @tailrec
       override def next(): CompoundStatementExec = state match {
 
         case ForState.VariableAssignment =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr adds `scala.annotation.tailrec` inspected by IDE (IntelliJ),  these are new cases after Spark 4.1.0.


### Why are the changes needed?
To improve performance.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GItHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No