### PR TITLE
Ensure the application name in historypage get escaped

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -18,7 +18,16 @@
 /* global $, Mustache, formatDuration, formatTimeMillis, jQuery, uiRoot */
 
 var appLimit = -1;
-
+/* escape XSS  */
+function escapeHtml(text) {
+  if (typeof text !== 'string') return text;
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
 /* eslint-disable no-unused-vars */
 function setAppLimit(val) {
   appLimit = val;
@@ -147,7 +156,7 @@ $(document).ready(function() {
         attempt["durationMillisec"] = attempt["duration"];
         attempt["duration"] = formatDuration(attempt["duration"]);
         attempt["id"] = id;
-        attempt["name"] = name;
+        attempt["name"] = escapeHtml(name);
         attempt["version"] = version;
         attempt["attemptUrl"] = uiRoot + "/history/" + id + "/" +
           (attempt.hasOwnProperty("attemptId") ? attempt["attemptId"] + "/" : "") + "jobs/";


### PR DESCRIPTION


### What changes were proposed in this pull request?
In history Server main dashboard, the application name need to be escaped.


### Why are the changes needed?
Not escaped app name could lead to XSS 
Exemple:
cat << EOF > script.py
from pyspark.sql import SparkSession
if __name__ == "__main__":
   spark = SparkSession \
       .builder \
       .appName("<img src=x onerror=alert(/jedi master/)><script>alert(/Hello there/)</script>") \
       .getOrCreate()
   print(spark.range(1000 * 1000 * 1000).count())
   spark.stop()
EOF

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Tests already exist, it was manually tested.


### Was this patch authored or co-authored using generative AI tooling?
No
