### PR TITLE
[SPARK-54147][SQL] Set OMP_NUM_THREADS to spark.task.cpus by default in BaseScriptTransformationExec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/BaseScriptTransformationExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/BaseScriptTransformationExec.scala
@@ -84,6 +84,10 @@ trait BaseScriptTransformationExec extends UnaryExecNode {
     val path = System.getenv("PATH") + File.pathSeparator +
       SparkFiles.getRootDirectory()
     builder.environment().put("PATH", path)
+    // if OMP_NUM_THREADS is not explicitly set, override it with the value of "spark.task.cpus"
+    if (System.getenv("OMP_NUM_THREADS") == null) {
+      builder.environment().put("OMP_NUM_THREADS", conf.getConfString("spark.task.cpus", "1"))
+    }
 
     val proc = builder.start()
     val inputStream = proc.getInputStream


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Set OMP_NUM_THREADS to spark.task.cpus by default in BaseScriptTransformationExec

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When we use the TRANSFORM function to invoke a Python script，the Python script uses packages such as PyTorch or NumPy. Since these libraries, by default, start a number of intra-op threads equal to the number of available CPU cores on the node, this can lead to CPU overload.
```
ADD ARCHIVE s3://example-bucket/udf/emotion/emotion_predict.zip;
ADD ARCHIVE s3://example-bucket/udf/emotion/python_env.zip;

INSERT OVERWRITE TABLE demo_db.text_emotion_result PARTITION (dt = 'XXX')
SELECT
    TRANSFORM(
        id,
        title,
        content
    )
    USING './python_env.zip/python_env/bin/python emotion_predict.zip/emotion_predict/predict.py'
    AS (id, title, content, emotion_label, emotion_score)
FROM (
    SELECT /*+ REPARTITION(1000) */
        id, title, content
    FROM demo_db.text_input_data
    WHERE dt = 'XXX'
) src;
```


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Manually.
