### PR TITLE
[SPARK-53337][UI] XSS: Ensure the application name in historypage get escaped

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -1,34 +1,15 @@
-#
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-#
-
-name: "Build"
-
-on:
-  push:
-    branches:
-    - '**'
+name: Open new issue
+on: workflow_dispatch
 
 jobs:
-  call-build-and-test:
+  open-issue:
+    runs-on: ubuntu-latest
     permissions:
-      packages: write
-    name: Run
-    uses: ./.github/workflows/build_and_test.yml
-    secrets:
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}
+      contents: read
+      issues: write
+    steps:
+      - run: |
+          gh issue --repo ${{ github.repository }} \
+            create --title "Issue title" --body "Issue body"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -1,15 +1,34 @@
-name: Open new issue
-on: workflow_dispatch
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Build"
+
+on:
+  push:
+    branches:
+    - '**'
 
 jobs:
-  open-issue:
-    runs-on: ubuntu-latest
+  call-build-and-test:
     permissions:
-      contents: read
-      issues: write
-    steps:
-      - run: |
-          gh issue --repo ${{ github.repository }} \
-            create --title "Issue title" --body "Issue body"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      packages: write
+    name: Run
+    uses: ./.github/workflows/build_and_test.yml
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -27,6 +27,16 @@ var appLimit = -1;
 function setAppLimit(val) {
   appLimit = val;
 }
+/* escape XSS  */
+function escapeHtml(text) {
+  if (typeof text !== 'string') return text;
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
 /* eslint-enable no-unused-vars*/
 
 function makeIdNumeric(id) {
@@ -151,7 +161,7 @@ $(document).ready(function() {
         attempt["durationMillisec"] = attempt["duration"];
         attempt["duration"] = formatDuration(attempt["duration"]);
         attempt["id"] = id;
-        attempt["name"] = name;
+        attempt["name"] = escapeHtml(name);
         attempt["version"] = version;
         attempt["attemptUrl"] = uiRoot + "/history/" + id + "/" +
           (attempt.hasOwnProperty("attemptId") ? attempt["attemptId"] + "/" : "") + "jobs/";


### PR DESCRIPTION

### What changes were proposed in this pull request?
In history Server main dashboard, the application name need to be escaped.


### Why are the changes needed?
Not escaped app name could lead to XSS 
Exemple:
cat << EOF > script.py
from pyspark.sql import SparkSession
if __name__ == "__main__":
   spark = SparkSession \
       .builder \
       .appName("<img src=x onerror=alert(/jedi master/)><script>alert(/Hello there/)</script>") \
       .getOrCreate()
   print(spark.range(1000 * 1000 * 1000).count())
   spark.stop()
EOF

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Tests already exist, it was manually tested.


### Was this patch authored or co-authored using generative AI tooling?
No
