### PR TITLE
[SPARK-54153][PYTHON] Support profiling iterator based Python UDFs

### DIFF
--- a/python/pyspark/sql/tests/test_udf_profiler.py
+++ b/python/pyspark/sql/tests/test_udf_profiler.py
@@ -339,9 +339,7 @@ class UDFProfiler2TestsMixin:
                 yield s + 2
 
         with self.sql_conf({"spark.sql.pyspark.udf.profiler": "perf"}):
-            df = self.spark.range(10, numPartitions=2).select(
-                add1("id"), add2("id"), add1("id")
-            )
+            df = self.spark.range(10, numPartitions=2).select(add1("id"), add2("id"), add1("id"))
             df.collect()
 
         self.assertEqual(2, len(self.profile_results), str(self.profile_results.keys()))
@@ -364,9 +362,7 @@ class UDFProfiler2TestsMixin:
                 yield pa.compute.add(s, 2)
 
         with self.sql_conf({"spark.sql.pyspark.udf.profiler": "perf"}):
-            df = self.spark.range(10, numPartitions=2).select(
-                add1("id"), add2("id"), add1("id")
-            )
+            df = self.spark.range(10, numPartitions=2).select(add1("id"), add2("id"), add1("id"))
             df.collect()
 
         self.assertEqual(2, len(self.profile_results), str(self.profile_results.keys()))
@@ -401,7 +397,9 @@ class UDFProfiler2TestsMixin:
 
         def map_func(iterator: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
             for batch in iterator:
-                yield pa.RecordBatch.from_arrays([batch.column("id"), pa.compute.add(batch.column("age"), 1)], ["id", "age"])
+                yield pa.RecordBatch.from_arrays(
+                    [batch.column("id"), pa.compute.add(batch.column("age"), 1)], ["id", "age"]
+                )
 
         with self.sql_conf({"spark.sql.pyspark.udf.profiler": "perf"}):
             df.mapInArrow(map_func, df.schema).show()

--- a/python/pyspark/sql/tests/test_udf_profiler.py
+++ b/python/pyspark/sql/tests/test_udf_profiler.py
@@ -330,20 +330,15 @@ class UDFProfiler2TestsMixin:
         import pandas as pd
 
         @pandas_udf("long")
-        def add1(iter: Iterator[pd.Series]) -> Iterator[pd.Series]:
+        def add(iter: Iterator[pd.Series]) -> Iterator[pd.Series]:
             for s in iter:
                 yield s + 1
 
-        @pandas_udf("long")
-        def add2(iter: Iterator[pd.Series]) -> Iterator[pd.Series]:
-            for s in iter:
-                yield s + 2
-
         with self.sql_conf({"spark.sql.pyspark.udf.profiler": "perf"}):
-            df = self.spark.range(10, numPartitions=2).select(add1("id"), add2("id"), add1("id"))
+            df = self.spark.range(10, numPartitions=2).select(add("id"))
             df.collect()
 
-        self.assertEqual(2, len(self.profile_results), str(self.profile_results.keys()))
+        self.assertEqual(1, len(self.profile_results), str(self.profile_results.keys()))
 
         for id in self.profile_results:
             self.assert_udf_profile_present(udf_id=id, expected_line_count_prefix=4)
@@ -353,20 +348,15 @@ class UDFProfiler2TestsMixin:
         import pyarrow as pa
 
         @arrow_udf("long")
-        def add1(iter: Iterator[pa.Array]) -> Iterator[pa.Array]:
+        def add(iter: Iterator[pa.Array]) -> Iterator[pa.Array]:
             for s in iter:
                 yield pa.compute.add(s, 1)
 
-        @arrow_udf("long")
-        def add2(iter: Iterator[pa.Array]) -> Iterator[pa.Array]:
-            for s in iter:
-                yield pa.compute.add(s, 2)
-
         with self.sql_conf({"spark.sql.pyspark.udf.profiler": "perf"}):
-            df = self.spark.range(10, numPartitions=2).select(add1("id"), add2("id"), add1("id"))
+            df = self.spark.range(10, numPartitions=2).select(add("id"))
             df.collect()
 
-        self.assertEqual(2, len(self.profile_results), str(self.profile_results.keys()))
+        self.assertEqual(1, len(self.profile_results), str(self.profile_results.keys()))
 
         for id in self.profile_results:
             self.assert_udf_profile_present(udf_id=id, expected_line_count_prefix=4)

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -1249,9 +1249,11 @@ def wrap_memory_profiler(f, eval_type, result_id):
 
         def profiling_func(*args, **kwargs):
             profiler = UDFLineProfilerV2()
+            profiler.add_function(f)
 
-            wrapped = profiler(f)
-            ret = wrapped(*args, **kwargs)
+            with profiler:
+                ret = f(*args, **kwargs)
+
             codemap_dict = {
                 filename: list(line_iterator)
                 for filename, line_iterator in profiler.code_map.items()

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -1219,6 +1219,9 @@ def wrap_memory_profiler(f, eval_type, result_id):
     from pyspark.sql.profiler import ProfileResultsParam
     from pyspark.profiler import UDFLineProfilerV2
 
+    if not has_memory_profiler:
+        return f
+
     accumulator = _deserialize_accumulator(
         SpecialAccumulatorIds.SQL_UDF_PROFIER, None, ProfileResultsParam
     )
@@ -1308,10 +1311,8 @@ def read_single_udf(pickleSer, infile, eval_type, runner_conf, udf_index, profil
 
     elif profiler == "memory":
         result_id = read_long(infile)
-        if not has_memory_profiler:
-            profiling_func = chained_func
-        else:
-            profiling_func = wrap_memory_profiler(chained_func, eval_type, result_id)
+
+        profiling_func = wrap_memory_profiler(chained_func, eval_type, result_id)
     else:
         profiling_func = chained_func
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -1326,7 +1326,7 @@ def read_single_udf(pickleSer, infile, eval_type, runner_conf, udf_index, profil
         if not has_memory_profiler:
             profiling_func = chained_func
         elif _is_iter_based(eval_type):
-            profiling_func = chained_func
+            profiling_func = wrap_iter_memory_profiler(chained_func, result_id)
         else:
             profiling_func = wrap_memory_profiler(chained_func, result_id)
     else:

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/UserDefinedPythonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/UserDefinedPythonDataSource.scala
@@ -173,7 +173,7 @@ case class UserDefinedPythonDataSource(dataSourceCls: PythonFunction) {
       metrics,
       jobArtifactUUID,
       sessionUUID,
-      None)
+      conf.pythonUDFProfiler)
   }
 
   def createPythonMetrics(): Array[CustomMetric] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/UserDefinedPythonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/UserDefinedPythonDataSource.scala
@@ -172,7 +172,8 @@ case class UserDefinedPythonDataSource(dataSourceCls: PythonFunction) {
       pythonRunnerConf,
       metrics,
       jobArtifactUUID,
-      sessionUUID)
+      sessionUUID,
+      None)
   }
 
   def createPythonMetrics(): Array[CustomMetric] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
@@ -41,7 +41,8 @@ class MapInBatchEvaluatorFactory(
     pythonRunnerConf: Map[String, String],
     val pythonMetrics: Map[String, SQLMetric],
     jobArtifactUUID: Option[String],
-    sessionUUID: Option[String])
+    sessionUUID: Option[String],
+    profiler: Option[String])
   extends PartitionEvaluatorFactory[InternalRow, InternalRow] {
 
   override def createEvaluator(): PartitionEvaluator[InternalRow, InternalRow] =
@@ -74,7 +75,7 @@ class MapInBatchEvaluatorFactory(
         pythonMetrics,
         jobArtifactUUID,
         sessionUUID,
-        None) with BatchedPythonArrowInput
+        profiler) with BatchedPythonArrowInput
       val columnarBatchIter = pyRunner.compute(batchIter, context.partitionId(), context)
 
       val unsafeProj = UnsafeProjection.create(output, output)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchExec.scala
@@ -70,7 +70,8 @@ trait MapInBatchExec extends UnaryExecNode with PythonSQLMetrics {
       pythonRunnerConf,
       pythonMetrics,
       jobArtifactUUID,
-      sessionUUID)
+      sessionUUID,
+      conf.pythonUDFProfiler)
 
     val rdd = if (isBarrier) {
       val rddBarrier = child.execute().barrier()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Updates the v2 Spark-session based Python UDF profiler to support profiling iterator based UDFs.

```python
from collections.abc import Iterator
from pstats import SortKey
import pyarrow as pa

df = spark.range(100000)

def map_func(iter: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
    for batch in iter:
        yield pa.RecordBatch.from_arrays([pa.compute.add(batch.column("id"), 10)], ["id"])

spark.conf.set('spark.sql.pyspark.udf.profiler', 'perf')
df.mapInArrow(map_func, df.schema).collect()

spark.conf.set('spark.sql.pyspark.udf.profiler', 'memory')
df.mapInArrow(map_func, df.schema).collect()

for stats in spark.profile.profiler_collector._perf_profile_results.values():
    stats.sort_stats(SortKey.CUMULATIVE).print_stats(20)

spark.profile.show(type="memory")
```

```
1395288 function calls (1359888 primitive calls) in 2.850 seconds

   Ordered by: cumulative time
   List reduced from 1546 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      416    0.008    0.000    5.901    0.014 __init__.py:1(<module>)
   424/24    0.000    0.000    2.850    0.119 {built-in method builtins.next}
       24    0.001    0.000    2.850    0.119 test.py:11(map_func)
       16    0.002    0.000    2.646    0.165 compute.py:244(wrapper)
  2752/24    0.016    0.000    2.642    0.110 <frozen importlib._bootstrap>:1349(_find_and_load)
  2752/24    0.013    0.000    2.641    0.110 <frozen importlib._bootstrap>:1304(_find_and_load_unlocked)
       64    0.002    0.000    2.618    0.041 api.py:1(<module>)
  2704/24    0.009    0.000    2.612    0.109 <frozen importlib._bootstrap>:911(_load_unlocked)
  2264/24    0.005    0.000    2.611    0.109 <frozen importlib._bootstrap_external>:993(exec_module)
  6336/48    0.004    0.000    2.591    0.054 <frozen importlib._bootstrap>:480(_call_with_frames_removed)
  2400/24    0.023    0.000    2.591    0.108 {built-in method builtins.exec}
       24    0.002    0.000    1.927    0.080 generic.py:1(<module>)
  520/320    0.002    0.000    1.429    0.004 {built-in method builtins.__import__}
4312/2896    0.006    0.000    1.190    0.000 <frozen importlib._bootstrap>:1390(_handle_fromlist)
        8    0.001    0.000    1.014    0.127 frame.py:1(<module>)
4392/4312    0.069    0.000    0.953    0.000 {built-in method builtins.__build_class__}
     2264    0.030    0.000    0.562    0.000 <frozen importlib._bootstrap_external>:1066(get_code)
       16    0.001    0.000    0.551    0.034 indexing.py:1(<module>)
       24    0.001    0.000    0.451    0.019 datetimes.py:1(<module>)
       16    0.001    0.000    0.401    0.025 datetimelike.py:1(<module>)


============================================================
Profile of UDF<id=3>
============================================================
Filename: /data/projects/spark/python/test.py

Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
    11   1212.1 MiB   1212.1 MiB           8   def map_func(iter: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
    12   1212.1 MiB     -0.2 MiB          24       for batch in iter:
    13   1212.1 MiB     -0.2 MiB          32           yield pa.RecordBatch.from_arrays([pa.compute.add(batch.column("id"), 10)], ["id"])
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To add valuable profiling support to all types of UDFs.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, iterator based Python UDFs can now be profiled with the SQL config based profiler.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Updated UTs that were specifically testing that this wasn't supported to show they are now supported.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
