### PR TITLE
[SPARK-54154][INFRA] Run `build_branch35*.yml` every two days

### DIFF
--- a/.github/workflows/build_branch35.yml
+++ b/.github/workflows/build_branch35.yml
@@ -21,7 +21,7 @@ name: "Build (branch-3.5, Scala 2.13, Hadoop 3, JDK 8)"
 
 on:
   schedule:
-    - cron: '0 11 * * *'
+    - cron: '0 11 */2 * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_branch35_python.yml
+++ b/.github/workflows/build_branch35_python.yml
@@ -21,7 +21,7 @@ name: "Build / Python-only (branch-3.5)"
 
 on:
   schedule:
-    - cron: '0 11 * * *'
+    - cron: '0 11 */2 * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to run `build_branch35.yml` and `build_branch35_python.yml` every two days instead of daily.

### Why are the changes needed?

Recently, we added many new `branch-4.1` related CIs which increase our GitHub Action usage.

<img width="1046" height="423" alt="Screenshot 2025-11-03 at 08 55 30" src="https://github.com/user-attachments/assets/800c0503-2a13-4c3f-98fa-ce022323afcb" />

According to the ASF INFRA POLICY, we need to maintain them under the budget by reducing the usage.
- https://infra.apache.org/github-actions-policy.html
  - https://infra-reports.apache.org/#ghactions&project=spark&hours=168

> #### Resource use
> - Due to misconfigurations in their builds, some projects have been using unsupportable numbers of [GitHub Actions](https://infra.apache.org/github-actions-secrets.html). As part of fixing this situation, Infra has established a policy for GitHub Actions use:
> - All workflows MUST have a job concurrency level less than or equal to 20. This means a workflow cannot have more than 20 jobs running at the same time across all matrices.
> - All workflows SHOULD have a job concurrency level less than or equal to 15. Just because 20 is the max, doesn't mean you should strive for 20.
> - The average number of minutes a project uses per calendar week MUST NOT exceed the equivalent of 25 full-time runners (250,000 minutes, or 4,200 hours).
> - The average number of minutes a project uses in any consecutive five-day period MUST NOT exceed the equivalent of 30 full-time runners (216,000 minutes, or 3,600 hours).

As the first step, we can adjust `branch-3.5` daily jobs according to the commit frequency. Every two days (instead of daily) will be enough from now.
- https://github.com/apache/spark/commits/branch-3.5/
  - https://github.com/apache/spark/actions/workflows/build_branch35.yml
  - https://github.com/apache/spark/actions/workflows/build_branch35_python.yml

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review because the PR builder result is irrelevant to this PR.

### Was this patch authored or co-authored using generative AI tooling?

No.