### PR TITLE
[SPARK-54155][BUILD][TESTS] Upgrade `mssql-jdbc` to `13.2.1.jre11`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -344,7 +344,7 @@
     <mysql.connector.version>9.2.0</mysql.connector.version>
     <postgresql.version>42.7.7</postgresql.version>
     <db2.jcc.version>11.5.9.0</db2.jcc.version>
-    <mssql.jdbc.version>12.8.1.jre11</mssql.jdbc.version>
+    <mssql.jdbc.version>13.2.1.jre11</mssql.jdbc.version>
     <ojdbc17.version>23.6.0.24.10</ojdbc17.version>
     <databricks.jdbc.version>2.7.1</databricks.jdbc.version>
     <snowflake.jdbc.version>3.26.1</snowflake.jdbc.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `mssql-jdbc` test dependency to `13.2.1.jre11`.

### Why are the changes needed?

To use the latest features (like JDK 23 official support) and bug fixed versions during testing.
- https://github.com/microsoft/mssql-jdbc/releases/tag/v13.2.1
  - https://github.com/microsoft/mssql-jdbc/pull/2801
- https://github.com/microsoft/mssql-jdbc/releases/tag/v13.2.0
  - https://github.com/microsoft/mssql-jdbc/pull/2724
- https://github.com/microsoft/mssql-jdbc/releases/tag/v12.10.2
- https://github.com/microsoft/mssql-jdbc/releases/tag/v12.10.1
- https://github.com/microsoft/mssql-jdbc/releases/tag/v12.10.0
- https://github.com/microsoft/mssql-jdbc/releases/tag/v12.9.0
  - https://github.com/microsoft/mssql-jdbc/pull/2515 
- https://github.com/microsoft/mssql-jdbc/releases/tag/v12.8.2

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.