### PR TITLE
[SPARK-54164][INFRA] Add `branch-4.1` to daily `Publish Snapshot` GitHub Action job

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -28,7 +28,7 @@ on:
         description: 'list of branches to publish (JSON)'
         required: true
         # keep in sync with default value of strategy matrix 'branch'
-        default: '["master", "branch-4.0", "branch-3.5"]'
+        default: '["master", "branch-4.1", "branch-4.0", "branch-3.5"]'
 
 jobs:
   publish-snapshot:
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         # keep in sync with default value of workflow_dispatch input 'branch'
-        branch: ${{ fromJSON( inputs.branch || '["master", "branch-4.0", "branch-3.5"]' ) }}
+        branch: ${{ fromJSON( inputs.branch || '["master", "branch-4.1", "branch-4.0", "branch-3.5"]' ) }}
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v4


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `branch-4.1` to daily `Publish Snapshot` GitHub Action job.

### Why are the changes needed?

To publish Apache Spark 4.1.0-SNAPSHOT from `branch-4.1`.
- https://repository.apache.org/content/groups/snapshots/org/apache/spark/spark-core_2.13/4.1.0-SNAPSHOT/

### Does this PR introduce _any_ user-facing change?

No, this is an infra-only change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.