### PR TITLE
[SPARK-54184][K8S] Support `spark.kubernetes.executor.deletedExecutorsCacheTimeout`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -716,13 +716,13 @@ private[spark] object Config extends Logging {
       .booleanConf
       .createWithDefault(true)
 
-  val KUBERNETES_DELETED_EXECUTORS_CACHE_TTL_SECONDS =
-    ConfigBuilder("spark.kubernetes.executor.deletedExecutorsCacheTTLSeconds")
+  val KUBERNETES_DELETED_EXECUTORS_CACHE_TIMEOUT =
+    ConfigBuilder("spark.kubernetes.executor.deletedExecutorsCacheTimeout")
       .internal()
       .doc("Time-to-live (TTL) value for the cache for deleted executors")
       .version("4.1.0")
       .timeConf(TimeUnit.SECONDS)
-      .checkValue(_ >= 0, "deletedExecutorsCacheTTLSeconds must be non-negative")
+      .checkValue(_ >= 0, "deletedExecutorsCacheTimeout must be non-negative")
       .createWithDefault(180)
 
   val KUBERNETES_EXECUTOR_TERMINATION_GRACE_PERIOD_SECONDS =

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -716,6 +716,15 @@ private[spark] object Config extends Logging {
       .booleanConf
       .createWithDefault(true)
 
+  val KUBERNETES_DELETED_EXECUTORS_CACHE_TTL_SECONDS =
+    ConfigBuilder("spark.kubernetes.executor.deletedExecutorsCacheTTLSeconds")
+      .internal()
+      .doc("Time-to-live (TTL) value for the cache for deleted executors")
+      .version("4.1.0")
+      .timeConf(TimeUnit.SECONDS)
+      .checkValue(_ >= 0, "deletedExecutorsCacheTTLSeconds must be non-negative")
+      .createWithDefault(180)
+
   val KUBERNETES_EXECUTOR_TERMINATION_GRACE_PERIOD_SECONDS =
     ConfigBuilder("spark.kubernetes.executor.terminationGracePeriodSeconds")
       .doc("Time to wait for graceful termination of executor pods.")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsLifecycleManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsLifecycleManager.scala
@@ -53,7 +53,7 @@ private[spark] class ExecutorPodsLifecycleManager(
   // bounds.
   private lazy val removedExecutorsCache =
     CacheBuilder.newBuilder()
-      .expireAfterWrite(conf.get(KUBERNETES_DELETED_EXECUTORS_CACHE_TTL_SECONDS), TimeUnit.SECONDS)
+      .expireAfterWrite(conf.get(KUBERNETES_DELETED_EXECUTORS_CACHE_TIMEOUT), TimeUnit.SECONDS)
       .build[java.lang.Long, java.lang.Long]()
 
   private var lastFullSnapshotTs: Long = 0

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsLifecycleManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsLifecycleManager.scala
@@ -53,7 +53,7 @@ private[spark] class ExecutorPodsLifecycleManager(
   // bounds.
   private lazy val removedExecutorsCache =
     CacheBuilder.newBuilder()
-      .expireAfterWrite(3, TimeUnit.MINUTES)
+      .expireAfterWrite(conf.get(KUBERNETES_DELETED_EXECUTORS_CACHE_TTL_SECONDS), TimeUnit.SECONDS)
       .build[java.lang.Long, java.lang.Long]()
 
   private var lastFullSnapshotTs: Long = 0


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `spark.kubernetes.executor.deletedExecutorsCacheTimeout`.

### Why are the changes needed?

To allow users to control the TTL for the deleted executors cache.

Previously, it has a hard-coded value. In some very slow clusters, we need to remember longer than 3 minutes.

https://github.com/apache/spark/blob/a8e35c407bc5340f83b35e5a2f0b0767c6baadb0/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsLifecycleManager.scala#L54-L57

### Does this PR introduce _any_ user-facing change?

No behavior change because the default value is the same.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.