### PR TITLE
[SPARK-54187][PYTHON][CONNECT] Get all configs in a batch in toPandas

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -99,7 +99,7 @@ from pyspark.sql.connect.plan import (
 from pyspark.sql.connect.observation import Observation
 from pyspark.sql.connect.utils import get_python_ver
 from pyspark.sql.pandas.types import _create_converter_to_pandas, from_arrow_schema
-from pyspark.sql.types import DataType, StructType, TimestampType, _has_type
+from pyspark.sql.types import DataType, StructType, _has_type
 from pyspark.util import PythonEvalType
 from pyspark.storagelevel import StorageLevel
 from pyspark.errors import PySparkValueError, PySparkAssertionError, PySparkNotImplementedError

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -975,7 +975,7 @@ class SparkConnectClient(object):
         )
 
         table, schema, metrics, observed_metrics, _ = self._execute_and_fetch(
-            req, observations, self_destruct=self_destruct == "true"
+            req, observations, self_destruct == "true"
         )
         assert table is not None
         ei = ExecutionInfo(metrics, observed_metrics)

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -973,10 +973,9 @@ class SparkConnectClient(object):
             "spark.sql.execution.pandas.structHandlingMode",
             "spark.sql.execution.arrow.pyspark.selfDestruct.enabled",
         )
-        self_destruct: bool = self_destruct == "true"
 
         table, schema, metrics, observed_metrics, _ = self._execute_and_fetch(
-            req, observations, self_destruct=self_destruct
+            req, observations, self_destruct=self_destruct == "true"
         )
         assert table is not None
         ei = ExecutionInfo(metrics, observed_metrics)
@@ -994,7 +993,7 @@ class SparkConnectClient(object):
             renamed_table = table.rename_columns([f"col_{i}" for i in range(table.num_columns)])
 
             pandas_options = {"coerce_temporal_nanoseconds": True}
-            if self_destruct:
+            if self_destruct == "true":
                 # Configure PyArrow to use as little memory as possible:
                 # self_destruct - free columns as they are converted
                 # split_blocks - create a separate Pandas block for each column

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -973,7 +973,7 @@ class SparkConnectClient(object):
             "spark.sql.execution.pandas.structHandlingMode",
             "spark.sql.execution.arrow.pyspark.selfDestruct.enabled",
         )
-        self_destruct = self_destruct == "true"
+        self_destruct: bool = self_destruct == "true"
 
         table, schema, metrics, observed_metrics, _ = self._execute_and_fetch(
             req, observations, self_destruct=self_destruct

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1011,10 +1011,11 @@ class SparkConnectClient(object):
 
         if len(pdf.columns) > 0:
             error_on_duplicated_field_names: bool = False
-            if any(_has_type(f.dataType, StructType) for f in schema.fields):
-                if struct_in_pandas == "legacy":
-                    error_on_duplicated_field_names = True
-                    struct_in_pandas = "dict"
+            if struct_in_pandas == "legacy" and any(
+                _has_type(f.dataType, StructType) for f in schema.fields
+            ):
+                error_on_duplicated_field_names = True
+                struct_in_pandas = "dict"
 
             pdf = pd.concat(
                 [


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Get all configs in a batch in toPandas

### Why are the changes needed?
there are 3 related configs, and are fetched one by one
should get them together to reduce RPC calls

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no