### PR TITLE
[SPARK-54188][K8S] Improve `ExecutorPodsWatchSnapshotSource` to watch only active executors

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsWatchSnapshotSource.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsWatchSnapshotSource.scala
@@ -64,6 +64,7 @@ class ExecutorPodsWatchSnapshotSource(
         .inNamespace(namespace)
         .withLabel(SPARK_APP_ID_LABEL, applicationId)
         .withLabel(SPARK_ROLE_LABEL, SPARK_POD_EXECUTOR_ROLE)
+        .withoutLabel(SPARK_EXECUTOR_INACTIVE_LABEL, "true")
         .watch(new ExecutorPodsWatcher())
     }
   }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsWatchSnapshotSourceSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsWatchSnapshotSourceSuite.scala
@@ -51,6 +51,9 @@ class ExecutorPodsWatchSnapshotSourceSuite extends SparkFunSuite with BeforeAndA
   private var executorRoleLabeledPods: LABELED_PODS = _
 
   @Mock
+  private var executorRoleLabeledActivePods: LABELED_PODS = _
+
+  @Mock
   private var watchConnection: Watch = _
 
   private var watch: ArgumentCaptor[Watcher[Pod]] = _
@@ -66,7 +69,9 @@ class ExecutorPodsWatchSnapshotSourceSuite extends SparkFunSuite with BeforeAndA
       .thenReturn(appIdLabeledPods)
     when(appIdLabeledPods.withLabel(SPARK_ROLE_LABEL, SPARK_POD_EXECUTOR_ROLE))
       .thenReturn(executorRoleLabeledPods)
-    when(executorRoleLabeledPods.watch(watch.capture())).thenReturn(watchConnection)
+    when(executorRoleLabeledPods.withoutLabel(SPARK_EXECUTOR_INACTIVE_LABEL, "true"))
+      .thenReturn(executorRoleLabeledActivePods)
+    when(executorRoleLabeledActivePods.watch(watch.capture())).thenReturn(watchConnection)
   }
 
   test("Watch events should be pushed to the snapshots store as snapshot updates.") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `ExecutorPodsWatchSnapshotSource` to watch only active executors like `ExecutorPodsPollingSnapshotSource`.

### Why are the changes needed?

`ExecutorPodsPollingSnapshotSource` has been monitoring with `.withoutLabel(SPARK_EXECUTOR_INACTIVE_LABEL, "true")` condition. We had better make `ExecutorPodsWatchSnapshotSource` behave consistently.

https://github.com/apache/spark/blob/a8e35c407bc5340f83b35e5a2f0b0767c6baadb0/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsPollingSnapshotSource.scala#L77-L81

### Does this PR introduce _any_ user-facing change?

No. This will reduce Apache Spark's operation overhead because we ignore inactive pods.

### How was this patch tested?

Pass the CIs with the revised unit test.

### Was this patch authored or co-authored using generative AI tooling?

No.