### PR TITLE
[SPARK-54192][BUILD] Upgrade roaringbitmap from 1.3.0 to 1.5.3

### DIFF
--- a/common/network-common/pom.xml
+++ b/common/network-common/pom.xml
@@ -132,10 +132,9 @@
       <artifactId>tink</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.roaringbitmap</groupId>
-      <artifactId>RoaringBitmap</artifactId>
+      <groupId>com.github.RoaringBitmap.RoaringBitmap</groupId>
+      <artifactId>roaringbitmap</artifactId>
     </dependency>
-
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/common/network-shuffle/pom.xml
+++ b/common/network-shuffle/pom.xml
@@ -68,10 +68,9 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.roaringbitmap</groupId>
-      <artifactId>RoaringBitmap</artifactId>
+      <groupId>com.github.RoaringBitmap.RoaringBitmap</groupId>
+      <artifactId>roaringbitmap</artifactId>
     </dependency>
-
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -240,8 +240,8 @@
       <artifactId>zstd-jni</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.roaringbitmap</groupId>
-      <artifactId>RoaringBitmap</artifactId>
+      <groupId>com.github.RoaringBitmap.RoaringBitmap</groupId>
+      <artifactId>roaringbitmap</artifactId>
     </dependency>
     <dependency>
       <groupId>org.scala-lang.modules</groupId>

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -1,7 +1,6 @@
 HikariCP/2.5.1//HikariCP-2.5.1.jar
 JLargeArrays/1.5//JLargeArrays-1.5.jar
 JTransforms/3.1//JTransforms-3.1.jar
-RoaringBitmap/1.3.0//RoaringBitmap-1.3.0.jar
 ST4/4.0.4//ST4-4.0.4.jar
 aircompressor/2.0.2//aircompressor-2.0.2.jar
 algebra_2.13/2.8.0//algebra_2.13-2.8.0.jar
@@ -263,6 +262,7 @@ parquet-jackson/1.16.0//parquet-jackson-1.16.0.jar
 pickle/1.5//pickle-1.5.jar
 py4j/0.10.9.9//py4j-0.10.9.9.jar
 remotetea-oncrpc/1.1.2//remotetea-oncrpc-1.1.2.jar
+roaringbitmap/1.5.3//roaringbitmap-1.5.3.jar
 rocksdbjni/9.8.4//rocksdbjni-9.8.4.jar
 scala-compiler/2.13.17//scala-compiler-2.13.17.jar
 scala-library/2.13.17//scala-library-2.13.17.jar

--- a/pom.xml
+++ b/pom.xml
@@ -382,6 +382,17 @@
         <enabled>false</enabled>
       </snapshots>
     </repository>
+    <repository>
+      <id>jitpack.io</id>
+      <name>JitPack</name>
+      <url>https://jitpack.io</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>
@@ -897,11 +908,10 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>org.roaringbitmap</groupId>
-        <artifactId>RoaringBitmap</artifactId>
-        <version>1.3.0</version>
+        <groupId>com.github.RoaringBitmap.RoaringBitmap</groupId>
+        <artifactId>roaringbitmap</artifactId>
+        <version>1.5.3</version>
       </dependency>
-
       <!-- Netty Begin -->
       <dependency>
         <groupId>io.netty</groupId>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -304,6 +304,7 @@ object SparkBuild extends PomBuild {
       // Google Mirror of Maven Central, placed first so that it's used instead of flaky Maven Central.
       // See https://storage-download.googleapis.com/maven-central/index.html for more info.
       "gcs-maven-central-mirror" at "https://maven-central.storage-download.googleapis.com/maven2/",
+      "jitpack" at "https://jitpack.io",
       DefaultMavenRepository,
       Resolver.mavenLocal,
       Resolver.file("ivyLocal", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns)


### PR DESCRIPTION


### What changes were proposed in this pull request?

Upgrade roaringbitmap from 1.3.0 to 1.5.3

Artifact updates at https://mvnrepository.com/artifact/org.roaringbitmap/RoaringBitmap have been stopped since 1.3.0. We need to add an additional repository, jitpack.io.

### Why are the changes needed?
Dependency updates


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Passing GA


### Was this patch authored or co-authored using generative AI tooling?
no
