### PR TITLE
[SPARK-54193][SHUFFLE] Deprecated spark.shuffle.server.finalizeShuffleMergeThreadsPercent

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -502,6 +502,7 @@ public class TransportConf {
    * handling finalizeShuffleMerge requests are percentage of io.serverThreads (if defined) else it
    * is a percentage of 2 * #cores.
    */
+  @Deprecated(since = "4.2.0", forRemoval = true)
   public int finalizeShuffleMergeHandlerThreads() {
     if (!this.getModuleName().equalsIgnoreCase("shuffle")) {
       return 0;
@@ -519,6 +520,7 @@ public class TransportConf {
    * Whether to use a separate EventLoopGroup to process FinalizeShuffleMerge messages, it is
    * decided by the config `spark.shuffle.server.finalizeShuffleMergeThreadsPercent` is set or not.
    */
+  @Deprecated(since = "4.2.0", forRemoval = true)
   public boolean separateFinalizeShuffleMerge() {
     return conf.getInt("spark.shuffle.server.finalizeShuffleMergeThreadsPercent", 0) > 0;
   }

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -720,6 +720,9 @@ private[spark] object SparkConf extends Logging {
         "Please use spark.shuffle.localDisk.file.output.buffer"),
       DeprecatedConfig("spark.shuffle.server.chunkFetchHandlerThreadsPercent", "4.2.0",
         "Using separate chunkFetchHandlers could be problematic according to the underlying" +
+          " netty layer"),
+      DeprecatedConfig("spark.shuffle.server.finalizeShuffleMergeThreadsPercent", "4.2.0",
+        "Using separate finalizeWorkers could be problematic according to the underlying" +
           " netty layer")
     )
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Deprecated spark.shuffle.server.finalizeShuffleMergeThreadsPercent first, and then we can remove finalizeWorker usages in the future.

### Why are the changes needed?
In the Netty project, those related APIs are
- removed from the main branch https://github.com/netty/netty/pull/8778
- and deprecated in 4.2 branch https://github.com/netty/netty/pull/14538

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

I verified this by a SparkPi local test
```scala
bin/run-example -c spark.shuffle.server.finalizeShuffleMergeThreadsPercent=10 SparkPi
WARNING: Using incubator modules: jdk.incubator.vector
Using Spark's default log4j profile: org/apache/spark/log4j2-defaults.properties
25/11/05 15:22:14 WARN SparkConf: The configuration key 'spark.shuffle.server.finalizeShuffleMergeThreadsPercent' has been deprecated as of Spark 4.2.0 and may be removed in the future. Using separate finalizeWorkers could be problematic due to the underlying netty layer
```

### Was this patch authored or co-authored using generative AI tooling?
no
