### PR TITLE
[SPARK-47010][K8S] Support csi driver for volume type

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -822,6 +822,7 @@ private[spark] object Config extends Logging {
   val KUBERNETES_VOLUMES_PVC_TYPE = "persistentVolumeClaim"
   val KUBERNETES_VOLUMES_EMPTYDIR_TYPE = "emptyDir"
   val KUBERNETES_VOLUMES_NFS_TYPE = "nfs"
+  val KUBERNETES_VOLUMES_CSI_TYPE = "csiVolumeClaim"
   val KUBERNETES_VOLUMES_MOUNT_PATH_KEY = "mount.path"
   val KUBERNETES_VOLUMES_MOUNT_SUBPATH_KEY = "mount.subPath"
   val KUBERNETES_VOLUMES_MOUNT_SUBPATHEXPR_KEY = "mount.subPathExpr"
@@ -835,6 +836,7 @@ private[spark] object Config extends Logging {
   val KUBERNETES_VOLUMES_OPTIONS_SERVER_KEY = "options.server"
   val KUBERNETES_VOLUMES_LABEL_KEY = "label."
   val KUBERNETES_VOLUMES_ANNOTATION_KEY = "annotation."
+  val KUBERNETES_VOLUMES_OPTIONS_CSI_DRIVER_NAME_KEY = "csiDriverName"
   val KUBERNETES_DRIVER_ENV_PREFIX = "spark.kubernetes.driverEnv."
 
   val KUBERNETES_DNS_SUBDOMAIN_NAME_MAX_LENGTH = 253

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesVolumeSpec.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesVolumeSpec.scala
@@ -39,6 +39,11 @@ private[spark] case class KubernetesNFSVolumeConf(
     server: String)
   extends KubernetesVolumeSpecificConf
 
+private[spark] case class KubernetesCSIVolumeConf(
+    driverName: String,
+    attributes: Map[String, String])
+  extends KubernetesVolumeSpecificConf
+
 private[spark] case class KubernetesVolumeSpec(
     volumeName: String,
     mountPath: String,

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesVolumeUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesVolumeUtils.scala
@@ -132,6 +132,16 @@ object KubernetesVolumeUtils {
           options(pathKey),
           options(serverKey))
 
+      case KUBERNETES_VOLUMES_CSI_TYPE =>
+        val driverNameKey =
+          s"$volumeType.$volumeName.$KUBERNETES_VOLUMES_OPTIONS_CSI_DRIVER_NAME_KEY"
+        val volumeConfPrefix = s"$volumeType.$volumeName.options."
+        val attributes = options.filter { case (k, v) => k.startsWith(volumeConfPrefix) }
+          .map { case (k, v) => (k.substring(volumeConfPrefix.length), v) }
+        KubernetesCSIVolumeConf(
+          options(driverNameKey),
+          attributes)
+
       case _ =>
         throw new IllegalArgumentException(s"Kubernetes Volume type `$volumeType` is not supported")
     }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountVolumesFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountVolumesFeatureStep.scala
@@ -125,6 +125,15 @@ private[spark] class MountVolumesFeatureStep(conf: KubernetesConf)
         case KubernetesNFSVolumeConf(path, server) =>
           new VolumeBuilder()
             .withNfs(new NFSVolumeSource(path, null, server))
+
+        case KubernetesCSIVolumeConf(driverName, attributes) =>
+          val csiVolumeSourceBuilder = new CSIVolumeSourceBuilder()
+            .withDriver(driverName)
+          attributes.foreach { case (k, v) =>
+            csiVolumeSourceBuilder.addToVolumeAttributes(k, v)
+          }
+          new VolumeBuilder()
+            .withCsi(csiVolumeSourceBuilder.build())
       }
 
       val volume = volumeBuilder.withName(spec.volumeName).build()

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesTestConf.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesTestConf.scala
@@ -143,6 +143,11 @@ object KubernetesTestConf {
           (KUBERNETES_VOLUMES_NFS_TYPE, Map(
             KUBERNETES_VOLUMES_OPTIONS_PATH_KEY -> path,
             KUBERNETES_VOLUMES_OPTIONS_SERVER_KEY -> server))
+
+        case KubernetesCSIVolumeConf(driverName, attributes) =>
+          (KUBERNETES_VOLUMES_CSI_TYPE, Map(
+            KUBERNETES_VOLUMES_OPTIONS_CSI_DRIVER_NAME_KEY -> driverName
+          ) ++ attributes)
       }
 
       conf.set(key(vtype, spec.volumeName, KUBERNETES_VOLUMES_MOUNT_PATH_KEY), spec.mountPath)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds support for mounting volumes using CSI drivers.

### Why are the changes needed?
As noted in this [issue](https://issues.apache.org/jira/browse/SPARK-47010), the Kubernetes cluster operates in a multi-tenant environment and cluster-wide changes cannot be made when deploying applications. Besides, the application requires a static shared file system, but solutions like hostPath are unavailable due to lack of control over the underlying VMs, and PersistentVolumeClaim (PVC) is unsuitable because provisioning a PersistentVolume (PV) requires cluster-wide changes. Additionally, security policies preclude the use of NFS. Therefore, a CSI solution is necessary.

Additionally, by adding [CSI driver](https://kubernetes-csi.github.io/docs/introduction.html) support, Spark running on k8s can now dynamically and on-demand leverage diverse storage services (such as high-performance SSDs, low-cost HDDs, etc.) provided by the underlying infrastructure. This enhances platform independence and simplifies operations and maintenance.

### Does this PR introduce any user-facing change?
Users can now using CSI driver by adding configs like:
```
spark-submit \
--conf spark.kubernetes.executor.volumes.csiVolumeClaim.[VolumeName].mount.path=/mnt/disk  \
--conf spark.kubernetes.executor.volumes.csiVolumeClaim.[VolumeName].csiDriverName=file.csi.azure.com \
--conf spark.kubernetes.executor.volumes.csiVolumeClaim.[VolumeName].options.shareName=EXISTING_SHARE_NAME \
--conf spark.kubernetes.executor.volumes.csiVolumeClaim.[VolumeName].options.secretName=azure-secret \
...
```

### How was this patch tested?
add ut test


### Was this patch authored or co-authored using generative AI tooling?
No