### PR TITLE
[MINOR][DOCS] Replace pyspark[connect] with pyspark-client in the Connect overview

### DIFF
--- a/docs/spark-connect-overview.md
+++ b/docs/spark-connect-overview.md
@@ -284,11 +284,11 @@ The connection may also be programmatically created using _SparkSession#builder_
 
 <div data-lang="python"  markdown="1">
 
-First, install PySpark with `pip install pyspark[connect]=={{site.SPARK_VERSION_SHORT}}` or if building a packaged PySpark application/library,
+First, install PySpark with `pip install pyspark-client=={{site.SPARK_VERSION_SHORT}}` or if building a packaged PySpark application/library,
 add it your setup.py file as:
 {% highlight python %}
 install_requires=[
-'pyspark[connect]=={{site.SPARK_VERSION_SHORT}}'
+'pyspark-client=={{site.SPARK_VERSION_SHORT}}'
 ]
 {% endhighlight %}
 


### PR DESCRIPTION

### What changes were proposed in this pull request?
Spark Connect Overview doc should reference the non-JVM pyspark-client pip package instead of `pyspark[connect]`   which includes a complete SPARK_HOME with JVM jars

### Why are the changes needed?
Spark Connect Overview is a top search result  and should encourage using a package with the minimum footprint.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Previewed the doc on Github

### Was this patch authored or co-authored using generative AI tooling?
No
