### PR TITLE
[SPARK-54101][Geo][FOLLOWUP] Re-enable Scala/Python parity check for ST functions

### DIFF
--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -80,10 +80,6 @@ class FunctionsTestsMixin:
 
         missing_in_py = jvm_fn_set.difference(py_fn_set)
 
-        # Temporarily disable Scala/Python parity check for ST geospatial functions, while the
-        # feature is under development. Once the geospatial module is stable, remove this.
-        missing_in_py = {fn for fn in missing_in_py if not fn.startswith("st_")}
-
         # Functions that we expect to be missing in python until they are added to pyspark
         expected_missing_in_py = set()
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Re-enable Scala/Python parity check for ST geospatial functions in `test_function_parity`.

### Why are the changes needed?
The test was temporarily disabled in https://github.com/apache/spark/pull/52803, but the corresponding functions have been subsequently added on PySpark side as part of https://github.com/apache/spark/pull/52849.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing tests suffice:
- `test_functions`
