### PR TITLE
[SPARK-54204][INFRA] Run `build_branch40*.yml` every two days

### DIFF
--- a/.github/workflows/build_branch40.yml
+++ b/.github/workflows/build_branch40.yml
@@ -21,7 +21,7 @@ name: "Build (branch-4.0, Scala 2.13, Hadoop 3, JDK 17)"
 
 on:
   schedule:
-    - cron: '0 12 * * *'
+    - cron: '0 12 */2 * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_branch40_java21.yml
+++ b/.github/workflows/build_branch40_java21.yml
@@ -21,7 +21,7 @@ name: "Build (branch-4.0, Scala 2.13, Hadoop 3, JDK 21)"
 
 on:
   schedule:
-    - cron: '0 5 * * *'
+    - cron: '0 5 */2 * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_branch40_maven.yml
+++ b/.github/workflows/build_branch40_maven.yml
@@ -21,7 +21,7 @@ name: "Build / Maven (branch-4.0, Scala 2.13, Hadoop 3, JDK 17)"
 
 on:
   schedule:
-    - cron: '0 14 * * *'
+    - cron: '0 14 */2 * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_branch40_maven_java21.yml
+++ b/.github/workflows/build_branch40_maven_java21.yml
@@ -21,7 +21,7 @@ name: "Build / Maven (branch-4.0, Scala 2.13, Hadoop 3, JDK 21)"
 
 on:
   schedule:
-    - cron: '0 14 * * *'
+    - cron: '0 14 */2 * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_branch40_non_ansi.yml
+++ b/.github/workflows/build_branch40_non_ansi.yml
@@ -21,7 +21,7 @@ name: "Build / Non-ANSI (branch-4.0, Hadoop 3, JDK 17, Scala 2.13)"
 
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 2 */2 * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_branch40_python.yml
+++ b/.github/workflows/build_branch40_python.yml
@@ -21,7 +21,7 @@ name: "Build / Python-only (branch-4.0)"
 
 on:
   schedule:
-    - cron: '0 12 * * *'
+    - cron: '0 12 */2 * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_branch40_python_pypy3.10.yml
+++ b/.github/workflows/build_branch40_python_pypy3.10.yml
@@ -21,7 +21,7 @@ name: "Build / Python-only (branch-4.0, PyPy 3.10)"
 
 on:
   schedule:
-    - cron: '0 16 * * *'
+    - cron: '0 16 */2 * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to run the following GitHub Action jobs every two days instead of daily.
- build_branch40.yml
- build_branch40_java21.yml
- build_branch40_maven.yml
- build_branch40_maven_java21.yml
- build_branch40_non_ansi.yml
- build_branch40_python.yml
- build_branch40_python_pypy3.10.yml

### Why are the changes needed?

Recently, we added many new `branch-4.1` related CIs which increase our GitHub Action usage.

<img width="879" height="73" alt="Screenshot 2025-11-05 at 19 03 38" src="https://github.com/user-attachments/assets/5b0246d3-598c-4b3d-970c-7b29c00bc9e1" />

According to the ASF INFRA POLICY, we need to maintain them under the budget by reducing the usage.
- https://infra.apache.org/github-actions-policy.html
  - https://infra-reports.apache.org/#ghactions&project=spark&hours=168

> #### Resource use
> - Due to misconfigurations in their builds, some projects have been using unsupportable numbers of [GitHub Actions](https://infra.apache.org/github-actions-secrets.html). As part of fixing this situation, Infra has established a policy for GitHub Actions use:
> - All workflows MUST have a job concurrency level less than or equal to 20. This means a workflow cannot have more than 20 jobs running at the same time across all matrices.
> - All workflows SHOULD have a job concurrency level less than or equal to 15. Just because 20 is the max, doesn't mean you should strive for 20.
> - The average number of minutes a project uses per calendar week MUST NOT exceed the equivalent of 25 full-time runners (250,000 minutes, or 4,200 hours).
> - The average number of minutes a project uses in any consecutive five-day period MUST NOT exceed the equivalent of 30 full-time runners (216,000 minutes, or 3,600 hours).

Previously, we adjusted `branch-3.5` GitHub Action jobs.
- https://github.com/apache/spark/pull/52854

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review because the PR builder result is irrelevant to this PR.

### Was this patch authored or co-authored using generative AI tooling?

No.