### PR TITLE
[SPARK-54213][PYTHON][CONNECT] Remove Python 3.9 from Spark Connect

### DIFF
--- a/python/packaging/connect/setup.py
+++ b/python/packaging/connect/setup.py
@@ -124,10 +124,9 @@ try:
             "numpy>=%s" % _minimum_numpy_version,
             "pyyaml>=%s" % _minimum_pyyaml_version,
         ],
-        python_requires=">=3.9",
+        python_requires=">=3.10",
         classifiers=[
             "Development Status :: 5 - Production/Stable",
-            "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `Python 3.9` from `Spark Connect`.

### Why are the changes needed?

`Python 3.9` reached the end-of-life on 2025-10-31.
- https://devguide.python.org/versions/#unsupported-versions

Apache Spark 4.1.0 dropped `Python 3.9` support and we don't have a test coverage. We had better make it clear even that is `Spark Connect` module.
- https://github.com/apache/spark/pull/51259
- https://github.com/apache/spark/pull/51416
- https://github.com/apache/spark/pull/51631
- https://github.com/apache/spark/pull/51371

### Does this PR introduce _any_ user-facing change?

No behavior change for Python 3.10+ users.

### How was this patch tested?

Pass the CIs and manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.