### PR TITLE
[SPARK-54214][INFRA] Increase pyspark job execution time to 150 minutes on MacOS

### DIFF
--- a/.github/workflows/python_hosted_runner_test.yml
+++ b/.github/workflows/python_hosted_runner_test.yml
@@ -59,7 +59,7 @@ jobs:
   build:
     name: "PySpark test on macos: ${{ matrix.modules }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 120
+    timeout-minutes: 150
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Increase pyspark job execution time to 150 minutes on MacOS


### Why are the changes needed?
It seems that python tests are generally slower on MacOS than Ubuntu, e.g.

commit build: https://github.com/apache/spark/actions/runs/19122756224/job/54646610479
vs
macos build: https://github.com/apache/spark/actions/runs/19085576435/job/54524926812

- pyspark-connect: 1h 21m 29s vs 1h 46m 15s
- pyspark-sql:     1h 17m 19s vs 1h 17m 33s
- pyspark-core:    38m 36s vs 46m 26s
- pyspark-mllib:   1h 11m 0s vs 1h 13m 45s
- pyspark-structed-streaming:  1h 44m 50s vs timeout

And the timeout occurs frequently on MacOS, so I think we should increase the time on MacOS.
It won't consume too much additional resource, since it is a daily job.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Will monitor the CI

### Was this patch authored or co-authored using generative AI tooling?
No
