### PR TITLE
[SPARK-53944][K8S][CORE][FOLLOWUP] Fix SparkEnv to use `DRIVER_BIND_ADDRESS` in case of `useDriverPodIP=true`

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -374,6 +374,8 @@ object SparkEnv extends Logging {
         val useDriverPodIP =
           conf.get("spark.kubernetes.executor.useDriverPodIP", "false").equalsIgnoreCase("true")
         if (useDriverPodIP) {
+          logInfo(log"Use DRIVER_BIND_ADDRESS instead of DRIVER_HOST_ADDRESS because " +
+            log"spark.kubernetes.executor.useDriverPodIP is true")
           conf.set(config.DRIVER_HOST_ADDRESS.key, conf.get(config.DRIVER_BIND_ADDRESS.key))
         }
         RpcUtils.makeDriverRef(name, conf, rpcEnv)

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
@@ -53,6 +53,14 @@ private[spark] trait BasicTestsSuite { k8sSuite: KubernetesSuite =>
     runSparkPiAndVerifyCompletion()
   }
 
+  test("SPARK-53944: Run SparkPi without driver service", k8sTestTag) {
+    sparkAppConf.set(
+      "spark.kubernetes.driver.pod.excludedFeatureSteps",
+      "org.apache.spark.deploy.k8s.features.DriverServiceFeatureStep")
+    sparkAppConf.set("spark.kubernetes.executor.useDriverPodIP", "true")
+    runSparkPiAndVerifyCompletion()
+  }
+
   test("Run SparkPi with no resources & statefulset allocation", k8sTestTag) {
     sparkAppConf.set("spark.kubernetes.allocation.pods.allocator", "statefulset")
     runSparkPiAndVerifyCompletion()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of the following to fix `SparkEnv` to use `DRIVER_BIND_ADDRESS` in case of `useDriverPodIP=true`.
- #52650 

Specifically, two places are updated.
- `SparkEnv.createDriverEnv`
- `RpcUtils.makeDriverRef`

### Why are the changes needed?

- To prevent `Spark Driver` from advertising hostname consistently.
- This PR also adds a K8s integration test by removing K8s Driver Service completely.

### Does this PR introduce _any_ user-facing change?

No, this feature is not released yet.

### How was this patch tested?

Pass the CIs with newly added K8s integration test.

We can see that `Driver` also uses IP address like executors. Previously, `Driver` was registered with `hostname` instead of IP.

<img width="255" height="280" alt="Screenshot 2025-11-06 at 13 31 20" src="https://github.com/user-attachments/assets/7b41a61c-c19f-4337-bb4d-508888a386d2" />

### Was this patch authored or co-authored using generative AI tooling?

No.