### PR TITLE
[SPARK-54226][SQL] Extend Arrow compression to Pandas UDF

### DIFF
--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -1458,7 +1458,12 @@ class ApplyInPandasTestsMixin:
         for codec in ["none", "zstd", "lz4"]:
             with self.subTest(compressionCodec=codec):
                 with self.sql_conf({"spark.sql.execution.arrow.compressionCodec": codec}):
-                    result = df.groupby("id").applyInPandas(sum_func, schema="v double").orderBy("v").collect()
+                    result = (
+                        df.groupby("id")
+                        .applyInPandas(sum_func, schema="v double")
+                        .orderBy("v")
+                        .collect()
+                    )
                     self.assertEqual(result, expected)
 
 

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_grouped_agg.py
@@ -887,21 +887,13 @@ class GroupedAggPandasUDFTestsMixin:
             return v.sum()
 
         df = self.data
-        expected = (
-            df.groupby("id")
-            .agg(mean_udf(df.v), sum_udf(df.v))
-            .sort("id")
-            .toPandas()
-        )
+        expected = df.groupby("id").agg(mean_udf(df.v), sum_udf(df.v)).sort("id").toPandas()
 
         for codec in ["none", "zstd", "lz4"]:
             with self.subTest(compressionCodec=codec):
                 with self.sql_conf({"spark.sql.execution.arrow.compressionCodec": codec}):
                     result = (
-                        df.groupby("id")
-                        .agg(mean_udf(df.v), sum_udf(df.v))
-                        .sort("id")
-                        .toPandas()
+                        df.groupby("id").agg(mean_udf(df.v), sum_udf(df.v)).sort("id").toPandas()
                     )
                     assert_frame_equal(expected, result)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4063,6 +4063,19 @@ object SQLConf {
       .checkValues(Set("none", "zstd", "lz4"))
       .createWithDefault("none")
 
+  val ARROW_EXECUTION_ZSTD_COMPRESSION_LEVEL =
+    buildConf("spark.sql.execution.arrow.zstd.compressionLevel")
+      .doc("Compression level for Zstandard (zstd) codec when compressing Arrow IPC data. " +
+        "This config is only used when spark.sql.execution.arrow.compressionCodec is set to " +
+        "'zstd'. Valid values are integers from 1 (fastest, lowest compression) to 22 " +
+        "(slowest, highest compression). The default value 3 provides a good balance between " +
+        "compression speed and compression ratio.")
+      .version("4.1.0")
+      .intConf
+      .checkValue(level => level >= 1 && level <= 22,
+        "Zstd compression level must be between 1 and 22")
+      .createWithDefault(3)
+
   val ARROW_TRANSFORM_WITH_STATE_IN_PYSPARK_MAX_STATE_RECORDS_PER_BATCH =
     buildConf("spark.sql.execution.arrow.transformWithStateInPySpark.maxStateRecordsPerBatch")
       .doc("When using TransformWithState in PySpark (both Python Row and Pandas), limit " +
@@ -7423,6 +7436,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def arrowMaxBytesPerBatch: Long = getConf(ARROW_EXECUTION_MAX_BYTES_PER_BATCH)
 
   def arrowCompressionCodec: String = getConf(ARROW_EXECUTION_COMPRESSION_CODEC)
+
+  def arrowZstdCompressionLevel: Int = getConf(ARROW_EXECUTION_ZSTD_COMPRESSION_LEVEL)
 
   def arrowTransformWithStateInPySparkMaxStateRecordsPerBatch: Int =
     getConf(ARROW_TRANSFORM_WITH_STATE_IN_PYSPARK_MAX_STATE_RECORDS_PER_BATCH)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowConverters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowConverters.scala
@@ -103,8 +103,9 @@ private[sql] object ArrowConverters extends Logging {
     private val codec = compressionCodecName match {
       case "none" => NoCompressionCodec.INSTANCE
       case "zstd" =>
+        val compressionLevel = SQLConf.get.arrowZstdCompressionLevel
         val factory = CompressionCodec.Factory.INSTANCE
-        val codecType = new ZstdCompressionCodec().getCodecType()
+        val codecType = new ZstdCompressionCodec(compressionLevel).getCodecType()
         factory.createCodec(codecType)
       case "lz4" =>
         val factory = CompressionCodec.Factory.INSTANCE

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowConverters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowConverters.scala
@@ -31,6 +31,7 @@ import org.apache.arrow.vector.compression.{CompressionCodec, NoCompressionCodec
 import org.apache.arrow.vector.ipc.{ArrowStreamReader, ArrowStreamWriter, ReadChannel, WriteChannel}
 import org.apache.arrow.vector.ipc.message.{ArrowRecordBatch, IpcOption, MessageSerializer}
 
+import org.apache.spark.SparkException
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.network.util.JavaUtils
@@ -110,7 +111,7 @@ private[sql] object ArrowConverters extends Logging {
         val codecType = new Lz4CompressionCodec().getCodecType()
         factory.createCodec(codecType)
       case other =>
-        throw new IllegalArgumentException(
+        throw SparkException.internalError(
           s"Unsupported Arrow compression codec: $other. Supported values: none, zstd, lz4")
     }
     protected val unloader = new VectorUnloader(root, true, codec, true)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/CoGroupedArrowPythonRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/CoGroupedArrowPythonRunner.scala
@@ -87,8 +87,9 @@ class CoGroupedArrowPythonRunner(
     val codec = compressionCodecName match {
       case "none" => NoCompressionCodec.INSTANCE
       case "zstd" =>
+        val compressionLevel = SQLConf.get.arrowZstdCompressionLevel
         val factory = CompressionCodec.Factory.INSTANCE
-        val codecType = new ZstdCompressionCodec().getCodecType()
+        val codecType = new ZstdCompressionCodec(compressionLevel).getCodecType()
         factory.createCodec(codecType)
       case "lz4" =>
         val factory = CompressionCodec.Factory.INSTANCE

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/CoGroupedArrowPythonRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/CoGroupedArrowPythonRunner.scala
@@ -24,7 +24,7 @@ import org.apache.arrow.compression.{Lz4CompressionCodec, ZstdCompressionCodec}
 import org.apache.arrow.vector.{VectorSchemaRoot, VectorUnloader}
 import org.apache.arrow.vector.compression.{CompressionCodec, NoCompressionCodec}
 
-import org.apache.spark.{SparkEnv, TaskContext}
+import org.apache.spark.{SparkEnv, SparkException, TaskContext}
 import org.apache.spark.api.python.{BasePythonRunner, ChainedPythonFunctions, PythonRDD, PythonWorker}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.arrow.ArrowWriterWrapper
@@ -95,7 +95,7 @@ class CoGroupedArrowPythonRunner(
         val codecType = new Lz4CompressionCodec().getCodecType()
         factory.createCodec(codecType)
       case other =>
-        throw new IllegalArgumentException(
+        throw SparkException.internalError(
           s"Unsupported Arrow compression codec: $other. Supported values: none, zstd, lz4")
     }
     new VectorUnloader(root, true, codec, true)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonArrowInput.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonArrowInput.scala
@@ -81,8 +81,9 @@ private[python] trait PythonArrowInput[IN] { self: BasePythonRunner[IN, _] =>
   private val codec = compressionCodecName match {
     case "none" => NoCompressionCodec.INSTANCE
     case "zstd" =>
+      val compressionLevel = SQLConf.get.arrowZstdCompressionLevel
       val factory = CompressionCodec.Factory.INSTANCE
-      val codecType = new ZstdCompressionCodec().getCodecType()
+      val codecType = new ZstdCompressionCodec(compressionLevel).getCodecType()
       factory.createCodec(codecType)
     case "lz4" =>
       val factory = CompressionCodec.Factory.INSTANCE
@@ -278,8 +279,9 @@ private[python] trait GroupedPythonArrowInput { self: RowInputArrowPythonRunner 
     val codec = SQLConf.get.arrowCompressionCodec match {
       case "none" => NoCompressionCodec.INSTANCE
       case "zstd" =>
+        val compressionLevel = SQLConf.get.arrowZstdCompressionLevel
         val factory = CompressionCodec.Factory.INSTANCE
-        val codecType = new ZstdCompressionCodec().getCodecType()
+        val codecType = new ZstdCompressionCodec(compressionLevel).getCodecType()
         factory.createCodec(codecType)
       case "lz4" =>
         val factory = CompressionCodec.Factory.INSTANCE

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonArrowInput.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonArrowInput.scala
@@ -26,7 +26,7 @@ import org.apache.arrow.vector.ipc.ArrowStreamWriter
 import org.apache.arrow.vector.ipc.WriteChannel
 import org.apache.arrow.vector.ipc.message.MessageSerializer
 
-import org.apache.spark.{SparkEnv, TaskContext}
+import org.apache.spark.{SparkEnv, SparkException, TaskContext}
 import org.apache.spark.api.python.{BasePythonRunner, PythonRDD, PythonWorker}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.arrow
@@ -89,7 +89,7 @@ private[python] trait PythonArrowInput[IN] { self: BasePythonRunner[IN, _] =>
       val codecType = new Lz4CompressionCodec().getCodecType()
       factory.createCodec(codecType)
     case other =>
-      throw new IllegalArgumentException(
+      throw SparkException.internalError(
         s"Unsupported Arrow compression codec: $other. Supported values: none, zstd, lz4")
   }
   protected val unloader = new VectorUnloader(root, true, codec, true)
@@ -286,7 +286,7 @@ private[python] trait GroupedPythonArrowInput { self: RowInputArrowPythonRunner 
         val codecType = new Lz4CompressionCodec().getCodecType()
         factory.createCodec(codecType)
       case other =>
-        throw new IllegalArgumentException(
+        throw SparkException.internalError(
           s"Unsupported Arrow compression codec: $other. Supported values: none, zstd, lz4")
     }
     new VectorUnloader(root, true, codec, true)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This is an extension to https://github.com/apache/spark/pull/52747. In https://github.com/apache/spark/pull/52747, we add the support of Arrow compression to `toArrow` and `toPandas` to reduce memory usage. We would like to extend the memory optimization feature to Pandas UDF case.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To optimize memory usage for Pandas UDF case.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Unit test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Generated-by: Claude Code v2.0.14