### PR TITLE
[SPARK-54230][CORE][SQL][TESTS] Clean up the usage of deprecated selenium API

### DIFF
--- a/core/src/test/scala/org/apache/spark/ui/RealBrowserUISeleniumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/RealBrowserUISeleniumSuite.scala
@@ -64,17 +64,17 @@ abstract class RealBrowserUISeleniumSuite(val driverProp: String)
 
         val jobDesc =
           webDriver.findElement(By.cssSelector("div[class='application-timeline-content']"))
-        jobDesc.getAttribute("data-title") should include  ("collect at &lt;console&gt;:25")
+        jobDesc.getDomAttribute("data-title") should include  ("collect at &lt;console&gt;:25")
 
         goToUi(sc, "/jobs/job/?id=0")
         webDriver.get(sc.ui.get.webUrl.stripSuffix("/") + "/jobs/job/?id=0")
         val stageDesc = webDriver.findElement(By.cssSelector("div[class='job-timeline-content']"))
-        stageDesc.getAttribute("data-title") should include ("collect at &lt;console&gt;:25")
+        stageDesc.getDomAttribute("data-title") should include ("collect at &lt;console&gt;:25")
 
         // Open DAG Viz.
         webDriver.findElement(By.id("job-dag-viz")).click()
         val nodeDesc = webDriver.findElement(By.cssSelector("g[id='node_0']"))
-        nodeDesc.getAttribute("innerHTML") should include ("collect at &lt;console&gt;:25")
+        nodeDesc.getDomProperty("innerHTML") should include ("collect at &lt;console&gt;:25")
       }
     }
   }
@@ -94,9 +94,9 @@ abstract class RealBrowserUISeleniumSuite(val driverProp: String)
         val stages = webDriver.findElements(By.cssSelector("svg[class='job'] > a"))
         stages.size() should be (3)
 
-        stages.get(0).getAttribute("href") should include ("/stages/stage/?id=0&attempt=0")
-        stages.get(1).getAttribute("href") should include ("/stages/stage/?id=1&attempt=0")
-        stages.get(2).getAttribute("href") should include ("/stages/stage/?id=2&attempt=0")
+        stages.get(0).getDomProperty("href") should include ("/stages/stage/?id=0&attempt=0")
+        stages.get(1).getDomProperty("href") should include ("/stages/stage/?id=1&attempt=0")
+        stages.get(2).getDomProperty("href") should include ("/stages/stage/?id=2&attempt=0")
       }
     }
   }
@@ -114,8 +114,8 @@ abstract class RealBrowserUISeleniumSuite(val driverProp: String)
         val stage1 = webDriver.findElement(By.cssSelector("g[id='graph_stage_1']"))
           .findElement(By.xpath(".."))
         val barrieredOps = webDriver.findElements(By.className("barrier-rdd")).iterator()
-        val id1 = barrieredOps.next().getAttribute("innerHTML")
-        val id2 = barrieredOps.next().getAttribute("innerHTML")
+        val id1 = barrieredOps.next().getDomProperty("innerHTML")
+        val id2 = barrieredOps.next().getDomProperty("innerHTML")
         assert(!barrieredOps.hasNext())
 
         val prefix = "g[class='cluster barrier']#cluster_"

--- a/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
@@ -417,7 +417,7 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser with Matchers {
         // Instead, it's safer to check that each row contains a link to a stage details page.
         findAll(cssSelector("tbody tr")).foreach { row =>
           val link = row.underlying.findElement(By.xpath("./td/div/a"))
-          link.getAttribute("href") should include ("stage")
+          link.getDomProperty("href") should include ("stage")
         }
       }
     }
@@ -473,7 +473,7 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser with Matchers {
         // Instead, it's safer to check that each row contains a link to a stage details page.
         findAll(cssSelector("tbody tr")).foreach { row =>
           val link = row.underlying.findElement(By.xpath(".//a"))
-          link.getAttribute("href") should include ("stage")
+          link.getDomProperty("href") should include ("stage")
         }
       }
     }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/UISeleniumSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/UISeleniumSuite.scala
@@ -156,7 +156,7 @@ class UISeleniumSuite
       }
 
       val sessionLink =
-        find(cssSelector("table#sessionstat td a")).head.underlying.getAttribute("href")
+        find(cssSelector("table#sessionstat td a")).head.underlying.getDomProperty("href")
       eventually(timeout(10.seconds), interval(50.milliseconds)) {
         go to sessionLink
         val statements = findAll(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr replaces the deprecated `org.openqa.selenium.WebElement#getAttribute` with `org.openqa.selenium.WebElement#getDomProperty/getDomAttribute`. 

The relevant changes are based on references from: https://github.com/SeleniumHQ/selenium/blob/d17c8aa95092dc25ae64f12e7abdc844cf3503f0/java/src/org/openqa/selenium/WebElement.java#L94C3-L172C46

Specifically,

- For static values in HTML tags, use `getDomAttribute()` as a replacement.
- For dynamic properties of DOM objects, use `getDomProperty()` as a replacement.


### Why are the changes needed?
To clean up deprecated APIs.

### Does this PR introduce _any_ user-facing change?
No,only for test

### How was this patch tested?
- Pass Github Actions
- Manual check `ChromeUISeleniumSuite`:

```
build/sbt -Dguava.version=33.4.8-jre \
    -Dspark.test.webdriver.chrome.driver=/Users/yangjie01/Tools/chromedriver-mac-arm64/chromedriver \
    -Dtest.default.exclude.tags="" -Phive -Phive-thriftserver \
    "core/testOnly org.apache.spark.ui.ChromeUISeleniumSuite"
```

```
[info] ChromeUISeleniumSuite:
[info] - SPARK-31534: text for tooltip should be escaped (3 seconds, 777 milliseconds)
[info] - SPARK-31882: Link URL for Stage DAGs should not depend on paged table. (2 seconds, 480 milliseconds)
[info] - SPARK-31886: Color barrier execution mode RDD correctly (2 seconds, 203 milliseconds)
[info] - Search text for paged tables should not be saved (3 seconds, 37 milliseconds)
[info] Run completed in 14 seconds, 795 milliseconds.
[info] Total number of tests run: 4
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 4, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```


### Was this patch authored or co-authored using generative AI tooling?
No