### PR TITLE
[SPARK-53666][INFRA][FOLLOWUP] Use absolute output path for `generate-llms-txt.py`

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -838,7 +838,7 @@ if [[ "$1" == "docs" ]]; then
   echo "Generating llms.txt..."
   python "$SELF/generate-llms-txt.py" \
     --docs-path . \
-    --output _site/llms.txt \
+    --output "$SELF/_site/llms.txt" \
     --version "$SPARK_VERSION"
 
   cd ..


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use an absolute output path (`"$SELF/_site/llms.txt"`) instead of a relative path (`_site/llms.txt`) when `dev/create-release/release-build.sh` uses `generate-llms-txt.py`.

https://github.com/apache/spark/blob/47a8d2a2ce58c9a28fbbeaf8af38717895ae01a6/dev/create-release/release-build.sh#L839-L841

### Why are the changes needed?

Currently, Apache Spark release CI has been broken. (https://github.com/apache/spark/actions/workflows/release.yml)
This is a release blocker for Apache Spark 4.1.0.

  - https://github.com/apache/spark/actions/runs/19060666797 (2025-11-03)
```
+ echo 'Generating llms.txt...'
Generating llms.txt...
+ python /opt/spark-rm/generate-llms-txt.py --docs-path . --output _site/llms.txt --version 4.2.0-SNAPSHOT
Traceback (most recent call last):
  File "/opt/spark-rm/generate-llms-txt.py", line 206, in <module>
    main()
  File "/opt/spark-rm/generate-llms-txt.py", line 202, in main
    generate_llms_txt(docs_path, output_path, args.version)
  File "/opt/spark-rm/generate-llms-txt.py", line 159, in generate_llms_txt
    with open(output_path, "w", encoding="utf-8") as f:
FileNotFoundError: [Errno 2] No such file or directory: '/_site/llms.txt'
```

  - https://github.com/apache/spark/actions/runs/19094119034 (2025-11-04)

```
+ echo 'Generating llms.txt...'
Generating llms.txt...
+ python /opt/spark-rm/generate-llms-txt.py --docs-path . --output _site/llms.txt --version 4.2.0-SNAPSHOT
Traceback (most recent call last):
  File "/opt/spark-rm/generate-llms-txt.py", line 206, in <module>
    main()
  File "/opt/spark-rm/generate-llms-txt.py", line 202, in main
    generate_llms_txt(docs_path, output_path, args.version)
  File "/opt/spark-rm/generate-llms-txt.py", line 159, in generate_llms_txt
    with open(output_path, "w", encoding="utf-8") as f:
FileNotFoundError: [Errno 2] No such file or directory: '/_site/llms.txt'
```

### Does this PR introduce _any_ user-facing change?

No behavior change because this is a release script.

### How was this patch tested?

Manual test.

```
$ mkdir /tmp/SPARK-53666
$ dev/create-release/do-release-docker.sh -t SPARK-53666 -d /tmp/SPARK-53666 -n -s docs
...
= Building spark-rm image with tag SPARK-53666...
...
```

### Was this patch authored or co-authored using generative AI tooling?

No.