### PR TITLE
[SPARK-54238][CORE][TESTS] Clean up unused `private val regenerateCommand` from `SparkThrowableSuite`

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -37,17 +37,13 @@ import org.apache.spark.util.Utils
 
 /**
  * Test suite for Spark Throwables.
+ * To re-generate the error class file, run:
+ * {{{
+ *   SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \
+ *     "core/testOnly *SparkThrowableSuite -- -t \"Error conditions are correctly formatted\""
+ * }}}
  */
 class SparkThrowableSuite extends SparkFunSuite {
-
-  /* Used to regenerate the error class file. Run:
-   {{{
-      SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \
-        "core/testOnly *SparkThrowableSuite -- -t \"Error conditions are correctly formatted\""
-   }}}
-   */
-  private val regenerateCommand = "SPARK_GENERATE_GOLDEN_FILES=1 build/sbt " +
-    "\"core/testOnly *SparkThrowableSuite -- -t \\\"Error conditions are correctly formatted\\\"\""
 
   private val errorJsonFilePath = getWorkspaceFilePath(
     "common", "utils", "src", "main", "resources", "error", "error-conditions.json")


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR moves the comment about regenerating the error class file to the class comment of SparkThrowableSuite and cleans up the unused private val regenerateCommand from SparkThrowableSuite.

### Why are the changes needed?
Code cleanup


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions


### Was this patch authored or co-authored using generative AI tooling?
No