### PR TITLE
[SPARK-54240] Translate get array item catalyst expression to connector expression

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1693,6 +1693,12 @@
     ],
     "sqlState" : "42846"
   },
+  "EXPRESSION_TRANSLATION_TO_V2_IS_NOT_SUPPORTED" : {
+    "message" : [
+      "Expression <expr> cannot be translated to v2 expression."
+    ],
+    "sqlState" : "0A000"
+  },
   "EXPRESSION_TYPE_IS_NOT_ORDERABLE" : {
     "message" : [
       "Column expression <expr> cannot be sorted because its type <exprType> is not orderable."

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/GetArrayItem.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/GetArrayItem.java
@@ -51,5 +51,5 @@ public class GetArrayItem extends ExpressionWithToString {
   public boolean failOnError() { return this.failOnError; }
 
   @Override
-  public Expression[] children() { return new Expression[]{ childArray() }; }
+  public Expression[] children() { return new Expression[]{ childArray,  ordinal }; }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/GetArrayItem.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/GetArrayItem.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.expressions;
+
+import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.internal.connector.ExpressionWithToString;
+
+/**
+ * Get array item expression.
+ *
+ * @since 4.1.0
+ */
+
+@Evolving
+public class GetArrayItem extends ExpressionWithToString {
+
+  private final Expression childArray;
+  private final Expression ordinal;
+  private final boolean failOnError;
+
+  /**
+   * Creates GetArrayItem expression.
+   * @param childArray Array that is source to get element from. Child of this expression.
+   * @param ordinal Ordinal of element. Zero-based indexing.
+   * @param failOnError Whether expression should throw exception for index out of bound or to
+   *                    return null.
+   */
+  public GetArrayItem(Expression childArray, Expression ordinal, boolean failOnError) {
+    this.childArray = childArray;
+    this.ordinal = ordinal;
+    this.failOnError = failOnError;
+  }
+
+  public Expression getChildArray() { return this.childArray; }
+  public Expression getOrdinal() { return this.ordinal; }
+  public boolean getFailOnError() { return this.failOnError; }
+
+  @Override
+  public Expression[] children() { return new Expression[]{ getChildArray() }; }
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/GetArrayItem.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/GetArrayItem.java
@@ -51,5 +51,5 @@ public class GetArrayItem extends ExpressionWithToString {
   public boolean failOnError() { return this.failOnError; }
 
   @Override
-  public Expression[] children() { return new Expression[]{ childArray,  ordinal }; }
+  public Expression[] children() { return new Expression[]{ childArray, ordinal }; }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/GetArrayItem.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/GetArrayItem.java
@@ -46,10 +46,10 @@ public class GetArrayItem extends ExpressionWithToString {
     this.failOnError = failOnError;
   }
 
-  public Expression getChildArray() { return this.childArray; }
-  public Expression getOrdinal() { return this.ordinal; }
-  public boolean getFailOnError() { return this.failOnError; }
+  public Expression childArray() { return this.childArray; }
+  public Expression ordinal() { return this.ordinal; }
+  public boolean failOnError() { return this.failOnError; }
 
   @Override
-  public Expression[] children() { return new Expression[]{ getChildArray() }; }
+  public Expression[] children() { return new Expression[]{ childArray() }; }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
@@ -29,6 +29,7 @@ import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.sql.connector.expressions.Extract;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.expressions.GeneralScalarExpression;
+import org.apache.spark.sql.connector.expressions.GetArrayItem;
 import org.apache.spark.sql.connector.expressions.Literal;
 import org.apache.spark.sql.connector.expressions.NullOrdering;
 import org.apache.spark.sql.connector.expressions.SortDirection;
@@ -349,7 +350,7 @@ public class V2ExpressionSQLBuilder {
     }
   }
 
-  protected String visitGetArrayItem(String[] inputs) {
+  protected String visitGetArrayItem(GetArrayItem getArrayItem) {
     throw new SparkUnsupportedOperationException(
       "_LEGACY_ERROR_TEMP_3177",
       Map.of("class", this.getClass().getSimpleName(), "funcName", "GET_ARRAY_ITEM")

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
@@ -127,6 +127,7 @@ public class V2ExpressionSQLBuilder {
         case "LTRIM" -> visitTrim("LEADING", expressionsToStringArray(e.children()));
         case "RTRIM" -> visitTrim("TRAILING", expressionsToStringArray(e.children()));
         case "OVERLAY" -> visitOverlay(expressionsToStringArray(e.children()));
+        case "GET_ARRAY_ITEM" -> visitGetArrayItem(expressionsToStringArray(e.children()));
         // TODO supports other expressions
         default -> visitUnexpectedExpr(expr);
       };
@@ -346,6 +347,13 @@ public class V2ExpressionSQLBuilder {
     } else {
       return "TRIM(" + direction + " " + inputs[1] + " FROM " + inputs[0] + ")";
     }
+  }
+
+  protected String visitGetArrayItem(String[] inputs) {
+    throw new SparkUnsupportedOperationException(
+      "_LEGACY_ERROR_TEMP_3177",
+      Map.of("class", this.getClass().getSimpleName(), "funcName", "GET_ARRAY_ITEM")
+    );
   }
 
   protected String visitExtract(Extract extract) {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
@@ -85,6 +85,8 @@ public class V2ExpressionSQLBuilder {
     } else if (expr instanceof SortOrder sortOrder) {
       return visitSortOrder(
         build(sortOrder.expression()), sortOrder.direction(), sortOrder.nullOrdering());
+    } else if (expr instanceof GetArrayItem getArrayItem) {
+      return visitGetArrayItem(getArrayItem);
     } else if (expr instanceof GeneralScalarExpression e) {
       String name = e.name();
       return switch (name) {
@@ -128,7 +130,6 @@ public class V2ExpressionSQLBuilder {
         case "LTRIM" -> visitTrim("LEADING", expressionsToStringArray(e.children()));
         case "RTRIM" -> visitTrim("TRAILING", expressionsToStringArray(e.children()));
         case "OVERLAY" -> visitOverlay(expressionsToStringArray(e.children()));
-        case "GET_ARRAY_ITEM" -> visitGetArrayItem(expressionsToStringArray(e.children()));
         // TODO supports other expressions
         default -> visitUnexpectedExpr(expr);
       };

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
@@ -352,8 +352,8 @@ public class V2ExpressionSQLBuilder {
 
   protected String visitGetArrayItem(GetArrayItem getArrayItem) {
     throw new SparkUnsupportedOperationException(
-      "_LEGACY_ERROR_TEMP_3177",
-      Map.of("class", this.getClass().getSimpleName(), "funcName", "GET_ARRAY_ITEM")
+      "EXPRESSION_TRANSLATION_TO_V2_IS_NOT_SUPPORTED",
+      Map.of("expr", getArrayItem.toString())
     );
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
@@ -326,6 +326,9 @@ class V2ExpressionBuilder(e: Expression, isPredicate: Boolean = false) extends L
     case _: Sha2 => generateExpressionWithName("SHA2", expr, isPredicate)
     case _: StringLPad => generateExpressionWithName("LPAD", expr, isPredicate)
     case _: StringRPad => generateExpressionWithName("RPAD", expr, isPredicate)
+    case GetArrayItem(_, _, failOnError) if failOnError =>
+      // Pushdown only if ANSI is enabled (fail on error) to be compatible with remote systems.
+      generateExpressionWithName("GET_ARRAY_ITEM", expr, isPredicate)
     // TODO supports other expressions
     case ApplyFunctionExpression(function, children) =>
       val childrenExpressions = children.flatMap(generateExpression(_))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression,
 import org.apache.spark.sql.catalyst.expressions.objects.{Invoke, StaticInvoke}
 import org.apache.spark.sql.catalyst.optimizer.ConstantFolding
 import org.apache.spark.sql.connector.catalog.functions.ScalarFunction
-import org.apache.spark.sql.connector.expressions.{Cast => V2Cast, Expression => V2Expression, Extract => V2Extract, FieldReference, GeneralScalarExpression, LiteralValue, NullOrdering, SortDirection, SortValue, UserDefinedScalarFunc}
+import org.apache.spark.sql.connector.expressions.{Cast => V2Cast, Expression => V2Expression, Extract => V2Extract, FieldReference, GeneralScalarExpression, GetArrayItem => V2GetArrayItem, LiteralValue, NullOrdering, SortDirection, SortValue, UserDefinedScalarFunc}
 import org.apache.spark.sql.connector.expressions.aggregate.{AggregateFunc, Avg, Count, CountStar, GeneralAggregateFunc, Max, Min, Sum, UserDefinedAggregateFunc}
 import org.apache.spark.sql.connector.expressions.filter.{AlwaysFalse, AlwaysTrue, And => V2And, Not => V2Not, Or => V2Or, Predicate => V2Predicate}
 import org.apache.spark.sql.internal.SQLConf
@@ -326,9 +326,13 @@ class V2ExpressionBuilder(e: Expression, isPredicate: Boolean = false) extends L
     case _: Sha2 => generateExpressionWithName("SHA2", expr, isPredicate)
     case _: StringLPad => generateExpressionWithName("LPAD", expr, isPredicate)
     case _: StringRPad => generateExpressionWithName("RPAD", expr, isPredicate)
-    case GetArrayItem(_, _, failOnError) if failOnError =>
-      // Pushdown only if ANSI is enabled (fail on error) to be compatible with remote systems.
-      generateExpressionWithName("GET_ARRAY_ITEM", expr, isPredicate)
+    case GetArrayItem(child, ordinal, failOnError) =>
+      (generateExpression(child), generateExpression(ordinal)) match {
+        case (Some(v2ArrayChild), Some(v2Ordinal)) =>
+          Some(new V2GetArrayItem(v2ArrayChild, v2Ordinal, failOnError))
+        case _ =>
+          None
+      }
     // TODO supports other expressions
     case ApplyFunctionExpression(function, children) =>
       val childrenExpressions = children.flatMap(generateExpression(_))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/ToStringSQLBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/ToStringSQLBuilder.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.internal.connector
 
+import org.apache.spark.sql.connector.expressions.GetArrayItem
 import org.apache.spark.sql.connector.util.V2ExpressionSQLBuilder
 
 /**
@@ -36,7 +37,7 @@ class ToStringSQLBuilder extends V2ExpressionSQLBuilder with Serializable {
     s"""$funcName($distinct${inputs.mkString(", ")})"""
   }
 
-  override protected def visitGetArrayItem(inputs: Array[String]): String = {
-    s"${inputs(0)}[${inputs.tail.mkString(", ")}]"
+  override protected def visitGetArrayItem(getArrayItem: GetArrayItem): String = {
+    s"${getArrayItem.getChildArray.toString}[${getArrayItem.getOrdinal.toString}]"
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/ToStringSQLBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/ToStringSQLBuilder.scala
@@ -38,6 +38,6 @@ class ToStringSQLBuilder extends V2ExpressionSQLBuilder with Serializable {
   }
 
   override protected def visitGetArrayItem(getArrayItem: GetArrayItem): String = {
-    s"${getArrayItem.getChildArray.toString}[${getArrayItem.getOrdinal.toString}]"
+    s"${getArrayItem.childArray.toString}[${getArrayItem.ordinal.toString}]"
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/ToStringSQLBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/ToStringSQLBuilder.scala
@@ -35,4 +35,8 @@ class ToStringSQLBuilder extends V2ExpressionSQLBuilder with Serializable {
     val distinct = if (isDistinct) "DISTINCT " else ""
     s"""$funcName($distinct${inputs.mkString(", ")})"""
   }
+
+  override protected def visitGetArrayItem(inputs: Array[String]): String = {
+    s"${inputs(0)}[${inputs.tail.mkString(", ")}]"
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Support conversion of catalyst GetArrayItem expression to connector expression to allow data sources to implement pushdown of this expression

### Why are the changes needed?
- To allow data sources (built-in and third-party) to implement pushdown of get array item


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
No testing needed, since we did not implement pushdowns yet


### Was this patch authored or co-authored using generative AI tooling?
No
