### PR TITLE
[SPARK-53525][CONNECT][FOLLOWUP] Allow io.grpc classes in Spark Connect testing

### DIFF
--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/RemoteSparkSession.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/RemoteSparkSession.scala
@@ -180,7 +180,8 @@ object SparkConnectServerUtils {
         val fileName = e.substring(e.lastIndexOf(File.separatorChar) + 1)
         fileName.endsWith(".jar") &&
         (fileName.startsWith("scalatest") || fileName.startsWith("scalactic") ||
-          (fileName.startsWith("spark-catalyst") && fileName.endsWith("-tests")))
+          (fileName.startsWith("spark-catalyst") && fileName.endsWith("-tests")) ||
+          fileName.startsWith("grpc-"))
       }
       .map(e => Paths.get(e).toUri)
     spark.client.artifactManager.addArtifacts(jars.toImmutableArraySeq)


### PR DESCRIPTION
### What changes were proposed in this pull request?

In this PR https://github.com/apache/spark/pull/52496, tests were implemented using `io.grpc.ClientInterceptor` to verify gRPC messages. However, it failed the Maven tests ([comment](https://github.com/apache/spark/pull/52496#issuecomment-3493042929)) because the related gRPC classes are missing in the testing SparkConnectService in Maven tests.

In this PR, gRPC classes for testing purposes are added as artifacts like other existing classes from `scalatest` and `spark-catalyst` to also allow io.grpc classes in tests.

### Why are the changes needed?

To fix the broken daily Maven tests ([comment](https://github.com/apache/spark/pull/52496#issuecomment-3493042929)).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Maven tests with following commands passed.

```
$ build/mvn -Phive clean install -DskipTests
$ build/mvn -Phive -pl sql/connect/client/jvm test -Dtest=none -DwildcardSuites=org.apache.spark.sql.connect.ClientE2ETestSuite
```

### Was this patch authored or co-authored using generative AI tooling?

No.
