### PR TITLE
[SPARK-54242][BUILD] Skip `Checkstyle` if `NOLINT_ON_COMPILE` is true

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -393,7 +393,8 @@ object SparkBuild extends PomBuild {
   /* Enable shared settings on all projects */
   (allProjects ++ optionallyEnabledProjects ++ assemblyProjects ++ copyJarsProjects ++ Seq(spark, tools))
     .foreach(enable(sharedSettings ++ DependencyOverrides.settings ++
-      ExcludedDependencies.settings ++ Checkstyle.settings ++ ExcludeShims.settings))
+      ExcludedDependencies.settings ++ (if (noLintOnCompile) Nil else Checkstyle.settings) ++
+      ExcludeShims.settings))
 
   /* Enable tests settings for all projects except examples, assembly and tools */
   (allProjects ++ optionallyEnabledProjects).foreach(enable(TestSettings.settings))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to skip `Checkstyle` if `NOLINT_ON_COMPILE` is true.

### Why are the changes needed?

Like `Scalastyle`, `Checkstyle` is also a kind of linting. So, we had better skip it when a user set `NOLINT_ON_COMPILE` to `true`.

### Does this PR introduce _any_ user-facing change?

No Spark behavior change because this is only a build change.

### How was this patch tested?

Pass the CIs and manually.

```
$ NOLINT_ON_COMPILE=true build/sbt package | grep checkstyle
```

### Was this patch authored or co-authored using generative AI tooling?

No.