### PR TITLE
[MINOR][INFRA] Fix the install version comment to Python 3.10 in python-minimum Dockerfile

### DIFF
--- a/dev/spark-test-image/python-minimum/Dockerfile
+++ b/dev/spark-test-image/python-minimum/Dockerfile
@@ -66,7 +66,7 @@ ARG BASIC_PIP_PKGS="numpy==1.22.4 pyarrow==15.0.0 pandas==2.2.0 six==1.16.0 scip
 # Python deps for Spark Connect
 ARG CONNECT_PIP_PKGS="grpcio==1.76.0 grpcio-status==1.76.0 googleapis-common-protos==1.71.0 graphviz==0.20 protobuf"
 
-# Install Python 3.9 packages
+# Install Python 3.10 packages
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
 RUN python3.10 -m pip install --force $BASIC_PIP_PKGS $CONNECT_PIP_PKGS && \
     python3.10 -m pip cache purge


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix a comment with `Python 3.10` instead of `Python 3.9` according to the code inside `python-minimum/Dockerfile`.

### Why are the changes needed?

This seems to be a left-over which we missed.

### Does this PR introduce _any_ user-facing change?

No. This is a comment change in the infra Dockerfile.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.