### PR TITLE
[SPARK-54245][INFRA] Install `mlflow` at Python 3.14 Docker image

### DIFF
--- a/dev/spark-test-image/python-314/Dockerfile
+++ b/dev/spark-test-image/python-314/Dockerfile
@@ -68,7 +68,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 
-ARG BASIC_PIP_PKGS="numpy pyarrow>=22.0.0 six==1.16.0 pandas==2.3.3 scipy plotly<6.0.0 coverage matplotlib openpyxl memory-profiler>=0.61.0 scikit-learn>=1.3.2"
+ARG BASIC_PIP_PKGS="numpy pyarrow>=22.0.0 six==1.16.0 pandas==2.3.3 scipy plotly<6.0.0 mlflow>=2.8.1 coverage matplotlib openpyxl memory-profiler>=0.61.0 scikit-learn>=1.3.2"
 # Python deps for Spark Connect
 ARG CONNECT_PIP_PKGS="grpcio==1.76.0 grpcio-status==1.76.0 protobuf==6.33.0 googleapis-common-protos==1.71.0 graphviz==0.20.3"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to install `mlflow` at Python 3.14 Docker image.

### Why are the changes needed?

MLFlow 3.6.0 is released with Python 3.14 support via PyArrow 22.0.0.
- https://pypi.org/project/mlflow/3.6.0/

Like the other images, we will add the same condition `mlflow>=2.8.1`, but it will install `MLFlow>=3.6.0` effectively.

https://github.com/apache/spark/blob/a871ba4464e07cb0229b1289b125bb07da7b6265/dev/spark-test-image/python-313/Dockerfile#L71

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.