### PR TITLE
[WIP][SPARK-47031] Union determinism fix

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -287,6 +287,7 @@ case class UnresolvedAttribute(nameParts: Seq[String]) extends Attribute with Un
 
   override def newInstance(): UnresolvedAttribute = this
   override def withNullability(newNullability: Boolean): UnresolvedAttribute = this
+  override def withDeterminism(newDeterminism: Boolean): UnresolvedAttribute = this
   override def withQualifier(newQualifier: Seq[String]): UnresolvedAttribute = this
   override def withName(newName: String): UnresolvedAttribute = UnresolvedAttribute.quoted(newName)
   override def withMetadata(newMetadata: Metadata): Attribute = this

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -341,7 +341,7 @@ case class AttributeReference(
     if (nullable == newNullability) {
       this
     } else {
-      AttributeReference(name, dataType, newNullability, metadata, determinism)(exprId, qualifier)
+      this.copy(nullable = newNullability)(exprId, qualifier)
     }
   }
 
@@ -352,7 +352,7 @@ case class AttributeReference(
     if (determinism == newDeterminism) {
       this
     } else {
-      AttributeReference(name, dataType, nullable, metadata, newDeterminism)(exprId, qualifier)
+      this.copy(determinism = newDeterminism)(exprId, qualifier)
     }
   }
 
@@ -360,7 +360,7 @@ case class AttributeReference(
     if (name == newName) {
       this
     } else {
-      AttributeReference(newName, dataType, nullable, metadata, determinism)(exprId, qualifier)
+      this.copy(name = newName)(exprId, qualifier)
     }
   }
 
@@ -371,7 +371,7 @@ case class AttributeReference(
     if (newQualifier == qualifier) {
       this
     } else {
-      AttributeReference(name, dataType, nullable, metadata, determinism)(exprId, newQualifier)
+      this.copy()(exprId, newQualifier)
     }
   }
 
@@ -379,16 +379,16 @@ case class AttributeReference(
     if (exprId == newExprId) {
       this
     } else {
-      AttributeReference(name, dataType, nullable, metadata, determinism)(newExprId, qualifier)
+      this.copy()(newExprId, qualifier)
     }
   }
 
   override def withMetadata(newMetadata: Metadata): AttributeReference = {
-    AttributeReference(name, dataType, nullable, newMetadata, determinism)(exprId, qualifier)
+    this.copy(metadata = newMetadata)(exprId, qualifier)
   }
 
   override def withDataType(newType: DataType): AttributeReference = {
-    AttributeReference(name, newType, nullable, metadata, determinism)(exprId, qualifier)
+    this.copy(dataType = newType)(exprId, qualifier)
   }
 
   override protected final def otherCopyArgs: Seq[AnyRef] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -478,11 +478,12 @@ object Union {
     childOutputs.transpose.map { attrs =>
       val firstAttr = attrs.head
       val nullable = attrs.exists(_.nullable)
+      val deterministic = attrs.forall(_.deterministic)
       val newDt = attrs.map(_.dataType).reduce(StructType.unionLikeMerge)
       if (firstAttr.dataType == newDt) {
-        firstAttr.withNullability(nullable)
+        firstAttr.withNullability(nullable).withDeterminism(deterministic)
       } else {
-        AttributeReference(firstAttr.name, newDt, nullable, firstAttr.metadata)(
+         AttributeReference(firstAttr.name, newDt, nullable, firstAttr.metadata, deterministic)(
           firstAttr.exprId, firstAttr.qualifier)
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

We plumb through non-determinism information, as with nullability, from projection to union.
WIP: I need to double check the other set operations.

### Why are the changes needed?

We need to be careful pushing through non-deterministic components & other changes.

### Does this PR introduce _any_ user-facing change?

Yes, the attribute reference now has a determinism field. For backwards compat, unpack does not unpack that field, and it has a default value.

### How was this patch tested?

Added a test in the filter pushdown logic.

### Was this patch authored or co-authored using generative AI tooling?

No