### PR TITLE
[SPARK-53944][K8S][CORE][FOLLOWUP] Override DRIVER_HOST_ADDRESS in SparkContext instead of SparkEnv when useDriverPodIP is true

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -454,7 +454,14 @@ class SparkContext(config: SparkConf) extends Logging {
 
     // Set Spark driver host and port system properties. This explicitly sets the configuration
     // instead of relying on the default value of the config constant.
-    _conf.set(DRIVER_HOST_ADDRESS, _conf.get(DRIVER_HOST_ADDRESS))
+    if (master.startsWith("k8s") &&
+      _conf.getBoolean("spark.kubernetes.executor.useDriverPodIP", defaultValue = false)) {
+      logInfo("Use DRIVER_BIND_ADDRESS instead of DRIVER_HOST_ADDRESS as driver address " +
+        "because running in K8s mode and spark.kubernetes.executor.useDriverPodIP is true")
+      _conf.set(DRIVER_HOST_ADDRESS, _conf.get(DRIVER_BIND_ADDRESS))
+    } else {
+      _conf.set(DRIVER_HOST_ADDRESS, _conf.get(DRIVER_HOST_ADDRESS))
+    }
     _conf.setIfMissing(DRIVER_PORT, 0)
 
     _conf.set(EXECUTOR_ID, SparkContext.DRIVER_IDENTIFIER)

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -455,9 +455,9 @@ class SparkContext(config: SparkConf) extends Logging {
     // Set Spark driver host and port system properties. This explicitly sets the configuration
     // instead of relying on the default value of the config constant.
     if (master.startsWith("k8s") &&
-      _conf.getBoolean("spark.kubernetes.executor.useDriverPodIP", defaultValue = false)) {
+        _conf.getBoolean("spark.kubernetes.executor.useDriverPodIP", false)) {
       logInfo("Use DRIVER_BIND_ADDRESS instead of DRIVER_HOST_ADDRESS as driver address " +
-        "because running in K8s mode and spark.kubernetes.executor.useDriverPodIP is true")
+        "because spark.kubernetes.executor.useDriverPodIP is true in K8s mode.")
       _conf.set(DRIVER_HOST_ADDRESS, _conf.get(DRIVER_BIND_ADDRESS))
     } else {
       _conf.set(DRIVER_HOST_ADDRESS, _conf.get(DRIVER_HOST_ADDRESS))

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -263,9 +263,7 @@ object SparkEnv extends Logging {
       s"${DRIVER_HOST_ADDRESS.key} is not set on the driver!")
     assert(conf.contains(DRIVER_PORT), s"${DRIVER_PORT.key} is not set on the driver!")
     val bindAddress = conf.get(DRIVER_BIND_ADDRESS)
-    val useDriverPodIP =
-      conf.get("spark.kubernetes.executor.useDriverPodIP", "false").equalsIgnoreCase("true")
-    val advertiseAddress = if (useDriverPodIP) bindAddress else conf.get(DRIVER_HOST_ADDRESS)
+    val advertiseAddress = conf.get(DRIVER_HOST_ADDRESS)
     val port = conf.get(DRIVER_PORT)
     val ioEncryptionKey = if (conf.get(IO_ENCRYPTION_ENABLED)) {
       Some(CryptoStreamUtils.createKey(conf))
@@ -371,13 +369,6 @@ object SparkEnv extends Logging {
         logInfo(log"Registering ${MDC(LogKeys.ENDPOINT_NAME, name)}")
         rpcEnv.setupEndpoint(name, endpointCreator)
       } else {
-        val useDriverPodIP =
-          conf.get("spark.kubernetes.executor.useDriverPodIP", "false").equalsIgnoreCase("true")
-        if (useDriverPodIP) {
-          logInfo(log"Use DRIVER_BIND_ADDRESS instead of DRIVER_HOST_ADDRESS because " +
-            log"spark.kubernetes.executor.useDriverPodIP is true")
-          conf.set(config.DRIVER_HOST_ADDRESS.key, conf.get(config.DRIVER_BIND_ADDRESS.key))
-        }
         RpcUtils.makeDriverRef(name, conf, rpcEnv)
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is an alternative to #52923.

In addition, this ensures `spark.kubernetes.executor.useDriverPodIP` only takes effect when `spark.master` startsWith `k8s`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is a simpler way than https://github.com/apache/spark/pull/52923, see more details at the discussion https://github.com/apache/spark/pull/52923#discussion_r2501500911

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass the K8s IT case provided by #52923
```
[info] KubernetesSuite:
[info] - SPARK-53944: Run SparkPi without driver service (11 seconds, 914 milliseconds)
[info] YuniKornSuite:
[info] Run completed in 21 seconds, 737 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 2, aborted 0
[info] Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 44 s, completed Nov 9, 2025, 1:19:07 AM
```

Also manually tested in the internal cluster.

checklist:

- `spark.kubernetes.executor.useDriverPodIP` only takes effect on K8s mode
- when `s.k.e.useDriverPodIP` is true, check UI `Executors` and `Environment` tabs, driver address displays correctly in IP, not svc endpoint
  <img width="574" height="189" alt="image" src="https://github.com/user-attachments/assets/9e538448-b66f-482b-b97a-ae1ee00601b3" />
  <img width="969" height="125" alt="image" src="https://github.com/user-attachments/assets/27f77899-1e04-40de-9f23-a66e5e6e3ce3" />
- run some queries, shuffle works as expected. (we use Apache Celeborn as Remote Shuffle Service)
- all built-in functionalities that we used work with the driver svc disabled.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.