### PR TITLE
[SPARK-54261][SQL][4.1] Disable `spark.sql.scripting.enabled` by default in Apache Spark 4.1.0

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4295,7 +4295,7 @@ object SQLConf {
         "flow and error handling.")
       .version("4.0.0")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED =
     buildConf("spark.sql.scripting.continueHandlerEnabled")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -30,10 +30,12 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
 
   protected override def beforeAll(): Unit = {
     super.beforeAll()
+    conf.setConf(SQLConf.SQL_SCRIPTING_ENABLED, true)
     conf.setConf(SQLConf.SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED, true)
   }
 
   protected override def afterAll(): Unit = {
+    conf.unsetConf(SQLConf.SQL_SCRIPTING_ENABLED.key)
     conf.unsetConf(SQLConf.SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED.key)
     super.afterAll()
   }

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
@@ -1797,57 +1797,65 @@ class ClientE2ETestSuite
 
   // SQL Scripting tests
   test("SQL Script result") {
-    val df = spark.sql("""BEGIN
-        |  IF 1=1 THEN
-        |    SELECT 1;
-        |  ELSE
-        |    SELECT 3;
-        |  END IF;
-        |END
-        |""".stripMargin)
-    checkAnswer(df, Seq(Row(1)))
+    withSQLConf("spark.sql.scripting.enabled" -> "true") {
+      val df = spark.sql("""BEGIN
+          |  IF 1=1 THEN
+          |    SELECT 1;
+          |  ELSE
+          |    SELECT 3;
+          |  END IF;
+          |END
+          |""".stripMargin)
+      checkAnswer(df, Seq(Row(1)))
+    }
   }
 
   test("SQL Script schema") {
-    withTable("script_tbl") {
-      val df = spark.sql("""BEGIN
-          |  CREATE TABLE script_tbl (a INT, b STRING);
-          |  INSERT INTO script_tbl VALUES (1, 'Hello'), (2, 'World');
-          |  SELECT * FROM script_tbl;
-          |END
-          |""".stripMargin)
-      assert(
-        df.schema == StructType(
-          StructField("a", IntegerType, nullable = true)
-            :: StructField("b", StringType, nullable = true)
-            :: Nil))
+    withSQLConf("spark.sql.scripting.enabled" -> "true") {
+      withTable("script_tbl") {
+        val df = spark.sql("""BEGIN
+            |  CREATE TABLE script_tbl (a INT, b STRING);
+            |  INSERT INTO script_tbl VALUES (1, 'Hello'), (2, 'World');
+            |  SELECT * FROM script_tbl;
+            |END
+            |""".stripMargin)
+        assert(
+          df.schema == StructType(
+            StructField("a", IntegerType, nullable = true)
+              :: StructField("b", StringType, nullable = true)
+              :: Nil))
+      }
     }
   }
 
   test("SQL Script empty result") {
-    withTable("script_tbl") {
-      val df = spark.sql("""BEGIN
-          |  CREATE TABLE script_tbl (a INT, b STRING);
-          |  SELECT * FROM script_tbl;
-          |END
-          |""".stripMargin)
-      assert(
-        df.schema == StructType(
-          StructField("a", IntegerType, nullable = true)
-            :: StructField("b", StringType, nullable = true)
-            :: Nil))
-      checkAnswer(df, Seq.empty)
+    withSQLConf("spark.sql.scripting.enabled" -> "true") {
+      withTable("script_tbl") {
+        val df = spark.sql("""BEGIN
+            |  CREATE TABLE script_tbl (a INT, b STRING);
+            |  SELECT * FROM script_tbl;
+            |END
+            |""".stripMargin)
+        assert(
+          df.schema == StructType(
+            StructField("a", IntegerType, nullable = true)
+              :: StructField("b", StringType, nullable = true)
+              :: Nil))
+        checkAnswer(df, Seq.empty)
+      }
     }
   }
 
   test("SQL Script no result") {
-    withTable("script_tbl") {
-      val df = spark.sql("""BEGIN
-          |  CREATE TABLE script_tbl (a INT, b STRING);
-          |END
-          |""".stripMargin)
-      assert(df.schema == StructType(Nil))
-      checkAnswer(df, Seq.empty)
+    withSQLConf("spark.sql.scripting.enabled" -> "true") {
+      withTable("script_tbl") {
+        val df = spark.sql("""BEGIN
+            |  CREATE TABLE script_tbl (a INT, b STRING);
+            |END
+            |""".stripMargin)
+        assert(df.schema == StructType(Nil))
+        checkAnswer(df, Seq.empty)
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -158,6 +158,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession with SQLHelper
     // regex magic.
     .set("spark.test.noSerdeInExplain", "true")
     .set(SQLConf.SCHEMA_LEVEL_COLLATIONS_ENABLED, true)
+    .set(SQLConf.SQL_SCRIPTING_ENABLED, true)
 
   // SPARK-32106 Since we add SQL test 'transform.sql' will use `cat` command,
   // here we need to ignore it.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 class ExecuteImmediateEndToEndSuite extends QueryTest with SharedSparkSession {
@@ -38,12 +39,14 @@ class ExecuteImmediateEndToEndSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SQL Scripting not supported inside EXECUTE IMMEDIATE") {
-    val executeImmediateText = "EXECUTE IMMEDIATE 'BEGIN SELECT 1; END'"
-    checkError(
-      exception = intercept[AnalysisException ] {
-        spark.sql(executeImmediateText)
-      },
-      condition = "SQL_SCRIPT_IN_EXECUTE_IMMEDIATE",
-      parameters = Map("sqlString" -> "BEGIN SELECT 1; END"))
+    withSQLConf(SQLConf.SQL_SCRIPTING_ENABLED.key -> "true") {
+      val executeImmediateText = "EXECUTE IMMEDIATE 'BEGIN SELECT 1; END'"
+      checkError(
+        exception = intercept[AnalysisException ] {
+          spark.sql(executeImmediateText)
+        },
+        condition = "SQL_SCRIPT_IN_EXECUTE_IMMEDIATE",
+        parameters = Map("sqlString" -> "BEGIN SELECT 1; END"))
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingE2eSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingE2eSuite.scala
@@ -69,6 +69,7 @@ class SqlScriptingE2eSuite extends QueryTest with SharedSparkSession {
   override protected def sparkConf: SparkConf = {
     super.sparkConf
       .set(SQLConf.ANSI_ENABLED.key, "true")
+      .set(SQLConf.SQL_SCRIPTING_ENABLED.key, "true")
   }
 
   // Tests

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -50,6 +50,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
   override protected def sparkConf: SparkConf = {
     super.sparkConf
       .set(SQLConf.ANSI_ENABLED.key, "true")
+      .set(SQLConf.SQL_SCRIPTING_ENABLED.key, "true")
   }
 
   // Helpers

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -40,10 +40,12 @@ class SqlScriptingInterpreterSuite
 
   protected override def beforeAll(): Unit = {
     super.beforeAll()
+    conf.setConf(SQLConf.SQL_SCRIPTING_ENABLED, true)
     conf.setConf(SQLConf.SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED, true)
   }
 
   protected override def afterAll(): Unit = {
+    conf.unsetConf(SQLConf.SQL_SCRIPTING_ENABLED.key)
     conf.unsetConf(SQLConf.SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED.key)
     super.afterAll()
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to revert the following logically to disable `spark.sql.scripting.enabled` by default in Apache Spark 4.1.0 while keeping it in Apache Spark 4.2.0 in `master` branch.

-  #52272

### Why are the changes needed?

Given that too many open subtasks of SPARK-48338 exist, the feature is still experimental like Apache Spark 4.0.0.

### Does this PR introduce _any_ user-facing change?

No because Apache Spark 4.1.0 will disable this feature by default like Apache Spark 4.0.0.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.