### PR TITLE
[SPARK-54263][INFRA] Fix `run-in-container` script to use Python 3.11 instead of 3.9

### DIFF
--- a/dev/spark-test-image-util/docs/run-in-container
+++ b/dev/spark-test-image-util/docs/run-in-container
@@ -28,8 +28,8 @@ cd /__w/spark/spark/docs
 bundle install
 
 # 3.Build docs, includes: `error docs`, `scala doc`, `python doc`, `sql doc`, excludes: `r doc`.
-# We need this link to make sure `python3` points to `python3.9` which contains the prerequisite packages.
-ln -s "$(which python3.9)" "/usr/local/bin/python3"
+# We need this link to make sure `python3` points to `python3.11` which contains the prerequisite packages.
+ln -s "$(which python3.11)" "/usr/local/bin/python3"
 
 # Build docs first with SKIP_API to ensure they are buildable without requiring any
 # language docs to be built beforehand.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `run-in-container` script to use Python 3.11 instead of 3.9.

### Why are the changes needed?

Since Apache Spark 4.0.0, we have an optional way to build docs in Docker image.
- #48860

https://github.com/apache/spark/blob/fa33ea000a0bda9e5a3fa1af98e8e85b8cc5e4d4/docs/README.md?plain=1#L129-L136

When we started to use Python 3.11 instead of 3.9 for Apache Spark 4.1.0, we missed to update this `run-in-container`.
- #51150
- #51198

### Does this PR introduce _any_ user-facing change?

No behavior change because this is an optional way to generate Spark docs.

### How was this patch tested?

Manually test.

### Was this patch authored or co-authored using generative AI tooling?

No.