### PR TITLE
[SPARK-54269][PYTHON] Upgrade `cloudpickle` to 3.1.2 for Python 3.14

### DIFF
--- a/python/pyspark/cloudpickle/__init__.py
+++ b/python/pyspark/cloudpickle/__init__.py
@@ -3,7 +3,7 @@ from pyspark.cloudpickle.cloudpickle import *  # noqa
 
 __doc__ = cloudpickle.__doc__
 
-__version__ = "3.1.1"
+__version__ = "3.1.2"
 
 __all__ = [  # noqa
     "__version__",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `cloudpickle` to 3.1.2.

### Why are the changes needed?

To support Python 3.14 properly.
- https://github.com/cloudpipe/cloudpickle/releases/tag/v3.1.2
- https://github.com/cloudpipe/cloudpickle/blob/master/CHANGES.md#312

    > Fix pickling of abstract base classes containing type annotations for Python 3.14. (https://github.com/cloudpipe/cloudpickle/pull/578)

### Does this PR introduce _any_ user-facing change?

No, Python 3.14 support is not announced yet.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.