### PR TITLE
[SPARK-54272][SQL] Add aggTime for SortAggregateExec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
@@ -60,7 +60,6 @@ case class SortAggregateExec(
     val numOutputRows = longMetric("numOutputRows")
     val aggTime = longMetric("aggTime")
     child.execute().mapPartitionsWithIndexInternal { (partIndex, iter) =>
-      val beforeAgg = System.nanoTime()
       // Because the constructor of an aggregation iterator will read at least the first row,
       // we need to get the value of iter.hasNext first.
       val hasInput = iter.hasNext

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
@@ -66,7 +66,7 @@ case class SortAggregateExec(
       // Because the constructor of an aggregation iterator will read at least the first row,
       // we need to get the value of iter.hasNext first.
       val hasInput = iter.hasNext
-      val res = if (!hasInput && groupingExpressions.nonEmpty) {
+      if (!hasInput && groupingExpressions.nonEmpty) {
         // This is a grouped aggregate and the input iterator is empty,
         // so return an empty iterator.
         Iterator[UnsafeRow]()
@@ -82,7 +82,8 @@ case class SortAggregateExec(
           resultExpressions,
           (expressions, inputSchema) =>
             MutableProjection.create(expressions, inputSchema),
-          numOutputRows)
+          numOutputRows,
+          aggTime)
         if (!hasInput && groupingExpressions.isEmpty) {
           // There is no input and there is no grouping expressions.
           // We need to output a single row as the output.
@@ -92,8 +93,6 @@ case class SortAggregateExec(
           outputIter
         }
       }
-      aggTime += NANOSECONDS.toMillis(System.nanoTime() - beforeAgg)
-      res
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.execution.aggregate
 
-import java.util.concurrent.TimeUnit.NANOSECONDS
-
 import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -318,7 +318,6 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
       //       -> Exchange(nodeId = 2)
       //          -> SortAggregate(...)
       val df = testData2.groupBy($"a").count()
-      df.explain(true)
 
       // Test aggTime metric for grouped aggregate
       testSparkPlanMetricsWithPredicates(df, 1, Map(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecutionSuite
-import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, SortAggregateExec}
+import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.execution.command.DataWritingCommandExec
 import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, InsertIntoHadoopFsRelationCommand, SQLHadoopMapReduceCommitProtocol, V1WriteCommand}
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ShuffleExchangeExec}
@@ -310,32 +310,18 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
 
   test("SortAggregate metrics") {
     // Force use SortAggregateExec instead of HashAggregateExec
-    withSQLConf("spark.sql.test.forceApplySortAggregate" -> "true") {
+    withSQLConf("spark.sql.test.forceApplySortAggregate" -> "true",
+      SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false") {
       // Assume the execution plan is
-      // ... -> SortAggregate(nodeId = 2) -> Exchange(nodeId = 1)
       // -> SortAggregate(nodeId = 0)
+      //     -> Sort(nodeId = 1)
+      //       -> Exchange(nodeId = 2)
+      //          -> SortAggregate(...)
       val df = testData2.groupBy($"a").count()
-      val expected2 = Seq(
-        Map("number of output rows" -> 4L),
-        Map("number of output rows" -> 3L))
-
-      val shuffleExpected2 = Map(
-        "records read" -> 4L,
-        "local blocks read" -> 4L,
-        "remote blocks read" -> 0L,
-        "shuffle records written" -> 4L)
-      testSparkPlanMetrics(df, 1, Map(
-        2L -> (("SortAggregate", expected2(0))),
-        1L -> (("Exchange", shuffleExpected2)),
-        0L -> (("SortAggregate", expected2(1))))
-      )
+      df.explain(true)
 
       // Test aggTime metric for grouped aggregate
       testSparkPlanMetricsWithPredicates(df, 1, Map(
-        2L -> (("SortAggregate", Map(
-          "time in aggregation build" -> {
-            _.toString.matches(timingMetricPattern)
-          }))),
         0L -> (("SortAggregate", Map(
           "time in aggregation build" -> {
             _.toString.matches(timingMetricPattern)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -310,8 +310,7 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
 
   test("SortAggregate metrics") {
     // Force use SortAggregateExec instead of HashAggregateExec
-    withSQLConf("spark.sql.test.forceApplySortAggregate" -> "true",
-      SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false") {
+    withSQLConf("spark.sql.test.forceApplySortAggregate" -> "true") {
       // Assume the execution plan is
       // -> SortAggregate(nodeId = 0)
       //     -> Sort(nodeId = 1)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `aggTime` metrics for `SortAggregateExec`


### Why are the changes needed?
Add more metrics


### Does this PR introduce _any_ user-facing change?
Yes the SQL metrics "time in aggregation build" itself on Spark UI.


### How was this patch tested?
UT


### Was this patch authored or co-authored using generative AI tooling?
No
