### PR TITLE
[SPARK-54065][PYTHON][TESTS][FOLLOWUP] Remove unused import module from `test_python_datasource.py`

### DIFF
--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -16,7 +16,6 @@
 #
 import os
 import platform
-import sys
 import tempfile
 import unittest
 import logging


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to recover CI by removing `import sys` from `test_python_datasource.py`
After #52967, CI consistently fails because `sys` is no longer used.

### Why are the changes needed?
To recover CI.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
