### PR TITLE
[SPARK-54277][INFRA] Make `dev/run-tests` to ban `Python 3.9` and older versions

### DIFF
--- a/dev/run-tests
+++ b/dev/run-tests
@@ -20,9 +20,9 @@
 FWDIR="$(cd "`dirname $0`"/..; pwd)"
 cd "$FWDIR"
 
-PYTHON_VERSION_CHECK=$(python3 -c 'import sys; print(sys.version_info < (3, 8, 0))')
+PYTHON_VERSION_CHECK=$(python3 -c 'import sys; print(sys.version_info < (3, 10, 0))')
 if [[ "$PYTHON_VERSION_CHECK" == "True" ]]; then
-  echo "Python versions prior to 3.8 are not supported."
+  echo "Python versions prior to 3.10 are not supported."
   exit -1
 fi
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `dev/run-tests` to ban Python 3.9 and older versions.

### Why are the changes needed?

This will prevent users from running Python 3.9 and older versions for testing.

```
$ python3 --version
Python 3.9.22

$ ./python/run-tests --python-executable python3
Python versions prior to 3.10 are not supported.
```

### Does this PR introduce _any_ user-facing change?

No behavior change because this is a test change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.