### PR TITLE
[SPARK-54278][PYTHON][TESTS] Simplify `pyspark/util.py` doctests by removing Python 3.9+ condition

### DIFF
--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -918,7 +918,7 @@ def default_api_mode() -> str:
 
 
 if __name__ == "__main__":
-    if "pypy" not in platform.python_implementation().lower() and sys.version_info[:2] >= (3, 9):
+    if "pypy" not in platform.python_implementation().lower():
         import doctest
         import pyspark.util
         from pyspark.core.context import SparkContext


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to simplify `pyspark/util.py` doctests by removing Python 3.9+ condition.

### Why are the changes needed?

Since Apache Spark 4.1.0 dropped `Python 3.9` support, we can assume that this doctests are Python 3.10+ always.
- #51416
- #51259
- #52974

### Does this PR introduce _any_ user-facing change?

No, this is a test change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.