### PR TITLE
[SPARK-54285][PYTHON] Cache timezone info to avoid expensive timestamp conversion

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -199,6 +199,7 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
      conf.get(PYTHON_DAEMON_KILL_WORKER_ON_FLUSH_FAILURE)
   protected val hideTraceback: Boolean = false
   protected val simplifiedTraceback: Boolean = false
+  protected val sessionLocalTimeZone = conf.getOption("spark.sql.session.timeZone")
 
   // All the Python functions should have the same exec, version and envvars.
   protected val envVars: java.util.Map[String, String] = funcs.head.funcs.head.envVars
@@ -281,6 +282,9 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
     }
     if (simplifiedTraceback) {
       envVars.put("SPARK_SIMPLIFIED_TRACEBACK", "1")
+    }
+    if (sessionLocalTimeZone.isDefined) {
+      envVars.put("TZ", sessionLocalTimeZone.get)
     }
     // SPARK-30299 this could be wrong with standalone mode when executor
     // cores might not be correct because it defaults to all cores on the box.

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -284,7 +284,7 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
       envVars.put("SPARK_SIMPLIFIED_TRACEBACK", "1")
     }
     if (sessionLocalTimeZone.isDefined) {
-      envVars.put("TZ", sessionLocalTimeZone.get)
+      envVars.put("SPARK_SESSION_LOCAL_TIMEZONE", sessionLocalTimeZone.get)
     }
     // SPARK-30299 this could be wrong with standalone mode when executor
     // cores might not be correct because it defaults to all cores on the box.

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -199,7 +199,6 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
      conf.get(PYTHON_DAEMON_KILL_WORKER_ON_FLUSH_FAILURE)
   protected val hideTraceback: Boolean = false
   protected val simplifiedTraceback: Boolean = false
-  protected val sessionLocalTimeZone = conf.getOption("spark.sql.session.timeZone")
 
   // All the Python functions should have the same exec, version and envvars.
   protected val envVars: java.util.Map[String, String] = funcs.head.funcs.head.envVars
@@ -282,9 +281,6 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
     }
     if (simplifiedTraceback) {
       envVars.put("SPARK_SIMPLIFIED_TRACEBACK", "1")
-    }
-    if (sessionLocalTimeZone.isDefined) {
-      envVars.put("SPARK_SESSION_LOCAL_TIMEZONE", sessionLocalTimeZone.get)
     }
     // SPARK-30299 this could be wrong with standalone mode when executor
     // cores might not be correct because it defaults to all cores on the box.

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -460,6 +460,9 @@ class TimestampType(DatetimeType, metaclass=DataTypeSingleton):
     def fromInternal(self, ts: int) -> datetime.datetime:
         if ts is not None:
             # using int to avoid precision loss in float
+            # If TimestampType.tz_info is not None, we need to use it to convert the timestamp.
+            # Otherwise, we need to use the default timezone.
+            # We need to replace the tzinfo to None to keep backward compatibility
             return datetime.datetime.fromtimestamp(ts // 1000000, self.tz_info).replace(
                 microsecond=ts % 1000000, tzinfo=None
             )

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -461,7 +461,7 @@ class TimestampType(DatetimeType, metaclass=DataTypeSingleton):
         if ts is not None:
             # using int to avoid precision loss in float
             return datetime.datetime.fromtimestamp(ts // 1000000, self.tz_info).replace(
-                microsecond=ts % 1000000
+                microsecond=ts % 1000000, tzinfo=None
             )
 
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -445,7 +445,7 @@ class TimestampType(DatetimeType, metaclass=DataTypeSingleton):
     # otherwise the forked process will be extremely slow to convert the timestamp.
     # This is probably a glibc issue - the forked process will have a bad cache/lock
     # status for the timezone info.
-    tz_info = datetime.datetime.now().astimezone().tzinfo
+    tz_info = None
 
     def needConversion(self) -> bool:
         return True
@@ -460,9 +460,14 @@ class TimestampType(DatetimeType, metaclass=DataTypeSingleton):
     def fromInternal(self, ts: int) -> datetime.datetime:
         if ts is not None:
             # using int to avoid precision loss in float
-            return datetime.datetime.fromtimestamp(ts // 1000000, self.tz_info).replace(
-                microsecond=ts % 1000000, tzinfo=None
-            )
+            if self.tz_info is None:
+                return datetime.datetime.fromtimestamp(ts // 1000000).replace(
+                    microsecond=ts % 1000000
+                )
+            else:
+                return datetime.datetime.fromtimestamp(ts // 1000000, self.tz_info).replace(
+                    microsecond=ts % 1000000, tzinfo=None
+                )
 
 
 class TimestampNTZType(DatetimeType, metaclass=DataTypeSingleton):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -460,14 +460,9 @@ class TimestampType(DatetimeType, metaclass=DataTypeSingleton):
     def fromInternal(self, ts: int) -> datetime.datetime:
         if ts is not None:
             # using int to avoid precision loss in float
-            if self.tz_info is None:
-                return datetime.datetime.fromtimestamp(ts // 1000000).replace(
-                    microsecond=ts % 1000000
-                )
-            else:
-                return datetime.datetime.fromtimestamp(ts // 1000000, self.tz_info).replace(
-                    microsecond=ts % 1000000, tzinfo=None
-                )
+            return datetime.datetime.fromtimestamp(ts // 1000000, self.tz_info).replace(
+                microsecond=ts % 1000000, tzinfo=None
+            )
 
 
 class TimestampNTZType(DatetimeType, metaclass=DataTypeSingleton):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -440,6 +440,7 @@ class TimeType(AnyTimeType):
 
 class TimestampType(DatetimeType, metaclass=DataTypeSingleton):
     """Timestamp (datetime.datetime) data type."""
+
     # We need to cache the timezone info for datetime.datetime.fromtimestamp
     # otherwise the forked process will be extremely slow to convert the timestamp.
     # This is probably a glibc issue - the forked process will have a bad cache/lock

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -28,7 +28,6 @@ import inspect
 import itertools
 import json
 from typing import Any, Callable, Iterable, Iterator, Optional, Tuple
-import zoneinfo
 
 from pyspark.accumulators import (
     SpecialAccumulatorIds,

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -28,6 +28,7 @@ import inspect
 import itertools
 import json
 from typing import Any, Callable, Iterable, Iterator, Optional, Tuple
+import zoneinfo
 
 from pyspark.accumulators import (
     SpecialAccumulatorIds,
@@ -3304,8 +3305,12 @@ def main(infile, outfile):
             sys.exit(-1)
         start_faulthandler_periodic_traceback()
 
-        tz = os.environ.get("TZ", datetime.datetime.now().astimezone().tzinfo)
-        time.tzset(tz)
+        tzname = os.environ.get("TZ", None)
+        if tzname is not None:
+            tz = zoneinfo.ZoneInfo(tzname)
+            time.tzset()
+        else:
+            tz = datetime.datetime.now().astimezone().tzinfo
         TimestampType.tz_info = tz
 
         check_python_version(infile)

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -18,6 +18,7 @@
 """
 Worker that receives input from Piped RDD.
 """
+import datetime
 import itertools
 import os
 import sys
@@ -71,7 +72,7 @@ from pyspark.sql.pandas.serializers import (
     ArrowStreamUDTFSerializer,
     ArrowStreamArrowUDTFSerializer,
 )
-from pyspark.sql.pandas.types import to_arrow_type
+from pyspark.sql.pandas.types import to_arrow_type, TimestampType
 from pyspark.sql.types import (
     ArrayType,
     BinaryType,
@@ -3302,6 +3303,11 @@ def main(infile, outfile):
         if split_index == -1:  # for unit tests
             sys.exit(-1)
         start_faulthandler_periodic_traceback()
+
+        tz = os.environ.get("TZ", datetime.datetime.now().astimezone().tzinfo)
+        time.tzset(tz)
+        TimestampType.tz_info = tz
+
         check_python_version(infile)
 
         # read inputs only for a barrier task

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -3305,10 +3305,9 @@ def main(infile, outfile):
             sys.exit(-1)
         start_faulthandler_periodic_traceback()
 
-        tzname = os.environ.get("TZ", None)
+        tzname = os.environ.get("SPARK_SESSION_LOCAL_TIMEZONE", None)
         if tzname is not None:
             tz = zoneinfo.ZoneInfo(tzname)
-            time.tzset()
         else:
             tz = datetime.datetime.now().astimezone().tzinfo
         TimestampType.tz_info = tz

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -3305,11 +3305,8 @@ def main(infile, outfile):
             sys.exit(-1)
         start_faulthandler_periodic_traceback()
 
-        tzname = os.environ.get("SPARK_SESSION_LOCAL_TIMEZONE", None)
-        if tzname is not None:
-            tz = zoneinfo.ZoneInfo(tzname)
-        else:
-            tz = datetime.datetime.now().astimezone().tzinfo
+        # Use the local timezone to convert the timestamp
+        tz = datetime.datetime.now().astimezone().tzinfo
         TimestampType.tz_info = tz
 
         check_python_version(infile)


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

We cache the tzinfo on local machine for timestamp conversion to avoid extra latency for calling `datetime.datetime.fromtimestamp()`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

In Python, a forked process on Unix (that uses glibc I believe) will have a bad lock/cache state for timezone, which result in a extremely slow `datetime.datetime.from_timestamp()` (2000x slower on my machine). 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

It was tested locally by hand to confirm the timestamp result is the same and the performance is normal.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No