### PR TITLE
[SPARK-54287][PYTHON] Add Python 3.14 support in `pyspark-client` and `pyspark-connect`

### DIFF
--- a/python/packaging/client/setup.py
+++ b/python/packaging/client/setup.py
@@ -221,6 +221,7 @@ try:
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",
             "Programming Language :: Python :: 3.13",
+            "Programming Language :: Python :: 3.14",
             "Programming Language :: Python :: Implementation :: CPython",
             "Programming Language :: Python :: Implementation :: PyPy",
             "Typing :: Typed",

--- a/python/packaging/connect/setup.py
+++ b/python/packaging/connect/setup.py
@@ -131,6 +131,7 @@ try:
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",
             "Programming Language :: Python :: 3.13",
+            "Programming Language :: Python :: 3.14",
             "Programming Language :: Python :: Implementation :: CPython",
             "Programming Language :: Python :: Implementation :: PyPy",
             "Typing :: Typed",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Python 3.14` support in `pyspark-client` and `pyspark-connect` for Apache Spark 4.1.0.

### Why are the changes needed?

Apache Spark 4.0+ has three Python packages.
- `pyspark` contains the whole package to run PySpark, Spark Classic by default
- `pyspark-connect` depends on `pyspark`, Spark Connect by default
- `pyspark-client` only contains Python files to work as a Spark Connect client

Like `pyspark` package, we need to add it consistently.
- #52556

### Does this PR introduce _any_ user-facing change?

No behavior change because Python 3.14 support is newly added at Apache Spark 4.1.0.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.