### PR TITLE
[SPARK-54288][INFRA] Add a daily Python 3.14 CI for branch-4.1

### DIFF
--- a/.github/workflows/build_branch41_python_3.14.yml
+++ b/.github/workflows/build_branch41_python_3.14.yml
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Build / Python-only (branch-4.1, Python 3.14)"
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  run-build:
+    permissions:
+      packages: write
+    name: Run
+    uses: ./.github/workflows/build_and_test.yml
+    if: github.repository == 'apache/spark'
+    with:
+      java: 17
+      branch: branch-4.1
+      hadoop: hadoop3
+      envs: >-
+        {
+          "PYSPARK_IMAGE_TO_TEST": "python-314",
+          "PYTHON_TO_TEST": "python3.14"
+        }
+      jobs: >-
+        {
+          "pyspark": "true",
+          "pyspark-pandas": "true"
+        }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a daily Python 3.14 CI for branch-4.1.

### Why are the changes needed?

Since Python 3.14 was released relatively recently, this will help Apache Spark 4.1.0 release preparation.

Note that we usually do not add all Python versions to the release branch and we also can remove this after the official 4.1.0 release.

### Does this PR introduce _any_ user-facing change?

No, this is a new test infra.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.