### PR TITLE
[SPARK-54270][CONNECT] SparkConnectResultSet get* methods should call checkOpen and check index boundary

### DIFF
--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
@@ -76,7 +76,7 @@ class SparkConnectResultSet(
     }
   }
 
-  private[jdbc] def getColumnValue[T](columnIndex: Int, defaultVal: T)(getter: Int => T): T = {
+  private def getColumnValue[T](columnIndex: Int, defaultVal: T)(getter: Int => T): T = {
     checkOpen()
     // the passed index value is 1-indexed, but the underlying array is 0-indexed
     val index = columnIndex - 1

--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
@@ -232,7 +232,8 @@ class SparkConnectResultSet(
 
   override def getBigDecimal(columnIndex: Int): java.math.BigDecimal = {
     getColumnValue(columnIndex - 1, null: java.math.BigDecimal) { idx =>
-      currentRow.getDecimal(idx) }
+      currentRow.getDecimal(idx)
+    }
   }
 
   override def getBigDecimal(columnLabel: String): java.math.BigDecimal =

--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
@@ -84,7 +84,7 @@ class SparkConnectResultSet(
     }
 
     Option(currentRow.get(columnIndex)) match {
-      case Some(rawField) =>
+      case Some(_) =>
         _wasNull = false
         Some(get(columnIndex))
       case None =>

--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
@@ -119,7 +119,7 @@ class SparkConnectResultSet(
   }
 
   override def getInt(columnIndex: Int): Int = {
-    getColumnValue(columnIndex, 0.toInt) { idx => currentRow.getInt(idx) }
+    getColumnValue(columnIndex, 0) { idx => currentRow.getInt(idx) }
   }
 
   override def getLong(columnIndex: Int): Long = {

--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
@@ -76,7 +76,7 @@ class SparkConnectResultSet(
     }
   }
 
-  private[jdbc] def getField[T](columnIndex: Int)(get: Int => T): Option[T] = {
+  private[jdbc] def getColumnValue[T](columnIndex: Int)(get: Int => T): Option[T] = {
     checkOpen()
     if (columnIndex < 0 || columnIndex >= currentRow.length) {
       throw new SQLException(s"The column index is out of range: $columnIndex, " +
@@ -101,35 +101,35 @@ class SparkConnectResultSet(
   }
 
   override def getString(columnIndex: Int): String = {
-    getField(columnIndex - 1) { idx => String.valueOf(currentRow.get(idx)) }.orNull
+    getColumnValue(columnIndex - 1) { idx => String.valueOf(currentRow.get(idx)) }.orNull
   }
 
   override def getBoolean(columnIndex: Int): Boolean = {
-    getField(columnIndex - 1) { idx => currentRow.getBoolean(idx) }.getOrElse(false)
+    getColumnValue(columnIndex - 1) { idx => currentRow.getBoolean(idx) }.getOrElse(false)
   }
 
   override def getByte(columnIndex: Int): Byte = {
-    getField(columnIndex - 1) { idx => currentRow.getByte(idx) }.getOrElse(0)
+    getColumnValue(columnIndex - 1) { idx => currentRow.getByte(idx) }.getOrElse(0)
   }
 
   override def getShort(columnIndex: Int): Short = {
-    getField(columnIndex - 1) { idx => currentRow.getShort(idx) }.getOrElse(0)
+    getColumnValue(columnIndex - 1) { idx => currentRow.getShort(idx) }.getOrElse(0)
   }
 
   override def getInt(columnIndex: Int): Int = {
-    getField(columnIndex - 1) { idx => currentRow.getInt(idx) }.getOrElse(0)
+    getColumnValue(columnIndex - 1) { idx => currentRow.getInt(idx) }.getOrElse(0)
   }
 
   override def getLong(columnIndex: Int): Long = {
-    getField(columnIndex - 1) { idx => currentRow.getLong(idx) }.getOrElse(0)
+    getColumnValue(columnIndex - 1) { idx => currentRow.getLong(idx) }.getOrElse(0)
   }
 
   override def getFloat(columnIndex: Int): Float = {
-    getField(columnIndex - 1) { idx => currentRow.getFloat(idx) }.getOrElse(0)
+    getColumnValue(columnIndex - 1) { idx => currentRow.getFloat(idx) }.getOrElse(0)
   }
 
   override def getDouble(columnIndex: Int): Double = {
-    getField(columnIndex - 1) { idx => currentRow.getDouble(idx) }.getOrElse(0)
+    getColumnValue(columnIndex - 1) { idx => currentRow.getDouble(idx) }.getOrElse(0)
   }
 
   override def getBigDecimal(columnIndex: Int, scale: Int): java.math.BigDecimal =
@@ -216,7 +216,7 @@ class SparkConnectResultSet(
   }
 
   override def getObject(columnIndex: Int): AnyRef = {
-    getField(columnIndex - 1) { idx => currentRow.get(idx).asInstanceOf[AnyRef] }.orNull
+    getColumnValue(columnIndex - 1) { idx => currentRow.get(idx).asInstanceOf[AnyRef] }.orNull
   }
 
   override def getObject(columnLabel: String): AnyRef =
@@ -229,7 +229,7 @@ class SparkConnectResultSet(
     throw new SQLFeatureNotSupportedException
 
   override def getBigDecimal(columnIndex: Int): java.math.BigDecimal = {
-    getField(columnIndex - 1) { idx => currentRow.getDecimal(idx) }.orNull
+    getColumnValue(columnIndex - 1) { idx => currentRow.getDecimal(idx) }.orNull
   }
 
   override def getBigDecimal(columnLabel: String): java.math.BigDecimal =

--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
@@ -76,10 +76,12 @@ class SparkConnectResultSet(
     }
   }
 
-  private[jdbc] def getColumnValue[T](columnIndex: Int, defaultVal: T)(getter: Int => T): T = {
+  private[jdbc] def getColumnValue[T](index: Int, defaultVal: T)(getter: Int => T): T = {
     checkOpen()
+    // the passed index value is 1-indexed, but the underlying array is 0-indexed
+    val columnIndex = index - 1
     if (columnIndex < 0 || columnIndex >= currentRow.length) {
-      throw new SQLException(s"The column index is out of range: $columnIndex, " +
+      throw new SQLException(s"The column index is out of range: $index, " +
         s"number of columns: ${currentRow.length}.")
     }
 
@@ -101,35 +103,35 @@ class SparkConnectResultSet(
   }
 
   override def getString(columnIndex: Int): String = {
-    getColumnValue(columnIndex - 1, null: String) { idx => String.valueOf(currentRow.get(idx)) }
+    getColumnValue(columnIndex, null: String) { idx => String.valueOf(currentRow.get(idx)) }
   }
 
   override def getBoolean(columnIndex: Int): Boolean = {
-    getColumnValue(columnIndex - 1, false) { idx => currentRow.getBoolean(idx) }
+    getColumnValue(columnIndex, false) { idx => currentRow.getBoolean(idx) }
   }
 
   override def getByte(columnIndex: Int): Byte = {
-    getColumnValue(columnIndex - 1, 0.toByte) { idx => currentRow.getByte(idx) }
+    getColumnValue(columnIndex, 0.toByte) { idx => currentRow.getByte(idx) }
   }
 
   override def getShort(columnIndex: Int): Short = {
-    getColumnValue(columnIndex - 1, 0.toShort) { idx => currentRow.getShort(idx) }
+    getColumnValue(columnIndex, 0.toShort) { idx => currentRow.getShort(idx) }
   }
 
   override def getInt(columnIndex: Int): Int = {
-    getColumnValue(columnIndex - 1, 0.toInt) { idx => currentRow.getInt(idx) }
+    getColumnValue(columnIndex, 0.toInt) { idx => currentRow.getInt(idx) }
   }
 
   override def getLong(columnIndex: Int): Long = {
-    getColumnValue(columnIndex - 1, 0.toLong) { idx => currentRow.getLong(idx) }
+    getColumnValue(columnIndex, 0.toLong) { idx => currentRow.getLong(idx) }
   }
 
   override def getFloat(columnIndex: Int): Float = {
-    getColumnValue(columnIndex - 1, 0.toFloat) { idx => currentRow.getFloat(idx) }
+    getColumnValue(columnIndex, 0.toFloat) { idx => currentRow.getFloat(idx) }
   }
 
   override def getDouble(columnIndex: Int): Double = {
-    getColumnValue(columnIndex - 1, 0.toDouble) { idx => currentRow.getDouble(idx) }
+    getColumnValue(columnIndex, 0.toDouble) { idx => currentRow.getDouble(idx) }
   }
 
   override def getBigDecimal(columnIndex: Int, scale: Int): java.math.BigDecimal =
@@ -216,7 +218,7 @@ class SparkConnectResultSet(
   }
 
   override def getObject(columnIndex: Int): AnyRef = {
-    getColumnValue(columnIndex - 1, null: AnyRef) { idx =>
+    getColumnValue(columnIndex, null: AnyRef) { idx =>
       currentRow.get(idx).asInstanceOf[AnyRef]
     }
   }
@@ -231,7 +233,7 @@ class SparkConnectResultSet(
     throw new SQLFeatureNotSupportedException
 
   override def getBigDecimal(columnIndex: Int): java.math.BigDecimal = {
-    getColumnValue(columnIndex - 1, null: java.math.BigDecimal) { idx =>
+    getColumnValue(columnIndex, null: java.math.BigDecimal) { idx =>
       currentRow.getDecimal(idx)
     }
   }

--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
@@ -76,21 +76,21 @@ class SparkConnectResultSet(
     }
   }
 
-  private[jdbc] def getColumnValue[T](index: Int, defaultVal: T)(getter: Int => T): T = {
+  private[jdbc] def getColumnValue[T](columnIndex: Int, defaultVal: T)(getter: Int => T): T = {
     checkOpen()
     // the passed index value is 1-indexed, but the underlying array is 0-indexed
-    val columnIndex = index - 1
-    if (columnIndex < 0 || columnIndex >= currentRow.length) {
-      throw new SQLException(s"The column index is out of range: $index, " +
+    val index = columnIndex - 1
+    if (index < 0 || index >= currentRow.length) {
+      throw new SQLException(s"The column index is out of range: $columnIndex, " +
         s"number of columns: ${currentRow.length}.")
     }
 
-    if (currentRow.isNullAt(columnIndex)) {
+    if (currentRow.isNullAt(index)) {
       _wasNull = true
       defaultVal
     } else {
       _wasNull = false
-      getter(columnIndex)
+      getter(index)
     }
   }
 

--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
@@ -217,7 +217,8 @@ class SparkConnectResultSet(
 
   override def getObject(columnIndex: Int): AnyRef = {
     getColumnValue(columnIndex - 1, null: AnyRef) { idx =>
-      currentRow.get(idx).asInstanceOf[AnyRef] }
+      currentRow.get(idx).asInstanceOf[AnyRef]
+    }
   }
 
   override def getObject(columnLabel: String): AnyRef =

--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectResultSet.scala
@@ -83,13 +83,12 @@ class SparkConnectResultSet(
         s"number of columns: ${currentRow.length}.")
     }
 
-    Option(currentRow.get(columnIndex)) match {
-      case Some(_) =>
-        _wasNull = false
-        Some(get(columnIndex))
-      case None =>
-        _wasNull = true
-        None
+    if (currentRow.isNullAt(columnIndex)) {
+      _wasNull = true
+      None
+    } else {
+      _wasNull = false
+      Some(get(columnIndex))
     }
   }
 

--- a/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectJdbcDataTypeSuite.scala
+++ b/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectJdbcDataTypeSuite.scala
@@ -268,7 +268,7 @@ class SparkConnectJdbcDataTypeSuite extends ConnectFunSuite with RemoteSparkSess
             getter(rs)
           }
           assert(exception.getMessage() ===
-            "The column index is out of range: 998, number of columns: 1.")
+            "The column index is out of range: 999, number of columns: 1.")
         }
     }
   }

--- a/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectJdbcDataTypeSuite.scala
+++ b/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectJdbcDataTypeSuite.scala
@@ -286,7 +286,7 @@ class SparkConnectJdbcDataTypeSuite extends ConnectFunSuite with RemoteSparkSess
       ("cast(1 as DECIMAL(10,5))", (rs: ResultSet) => rs.getBigDecimal(1),
         new java.math.BigDecimal("1.00000"))
     ).foreach {
-      case (query, getter, value) =>
+      case (query, getter, expectedValue) =>
         var resultSet: Option[ResultSet] = None
         withExecuteQuery(s"SELECT $query") { rs =>
           assert(rs.next())


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR aims to do a minor correction on the current get* functions from `SparkConnectResultSet` class. As previously discussed in the PR https://github.com/apache/spark/pull/52947, 

>1. For every getter function, if the statement is closed, the ResultSet should be unusable. I have verified this with MySQL driver and Postgresql driver.
>
>2. Right now when index goes out of bound, it throws  `java.lang.ArrayIndexOutOfBoundsException`, but based on the specification on `java.sql.ResultSet` which is implemented by `SparkConnectResultSet` class, it should throw `java.sql.SQLException`
>
>```
>     * @throws SQLException if the columnIndex is not valid;
>```

This PR proposes a unified wrapper function called `getColumnValue(columnIndex: Int)` that aims to wrap the `checkOpen` as well as the index boundary check.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently the get* functions don't follow the expected behaviors of `java.sql.ResultSet`. It's technically not a big problem, but since the `SparkConnectResultSet` aims to implement the `java.sql.ResultSet` class, it should strictly follow the specification documented on the interface definition.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

This PR is a small fix related to a new feature introduced recently.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

I added 2 tests each covering a bullet point I named above. These 2 functions calls all the get* functions inside `SparkConnectResultSet` class to make sure the correct exception(java.sql.SQLException) is thrown.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
