### PR TITLE
[SPARK-54294][CONNECT] Normalize Connect server printed IP address

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectServer.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectServer.scala
@@ -21,6 +21,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{HOST, PORT}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.util.Utils
 
 /**
  * The Spark Connect server
@@ -38,9 +39,9 @@ object SparkConnectServer extends Logging {
       try {
         SparkConnectService.start(session.sparkContext)
         val isa = SparkConnectService.bindingAddress
+        val host = Utils.normalizeIpIfNeeded(isa.getAddress.getHostAddress)
         logInfo(
-          log"Spark Connect server started at: " +
-            log"${MDC(HOST, isa.getAddress.getHostAddress)}:${MDC(PORT, isa.getPort)}")
+          log"Spark Connect server started at: ${MDC(HOST, host)}:${MDC(PORT, isa.getPort)}")
       } catch {
         case e: Exception =>
           logError("Error starting Spark Connect server", e)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
As title, normalize Connect server printed IP address, mostly for IPv6 address cases.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Start Connect server without configuring the binding host, it binds any host and reports the IPv6 anyhost on my MacBook.

```
$ SPARK_NO_DAEMONIZE=1 sbin/start-connect-server.sh
...
25/11/11 02:03:49 INFO SparkConnectServer: Spark Connect server started at: 0:0:0:0:0:0:0:0:15002
```

while this is illegal for `java.net.URI`, which is used by Spark Connect JVM client to parse the connection url.

```
$ bin/spark-shell --remote sc://0:0:0:0:0:0:0:0:15002
WARNING: Using incubator modules: jdk.incubator.vector
Using Spark's default log4j profile: org/apache/spark/log4j2-defaults.properties
25/11/11 10:56:51 WARN Utils: Your hostname, H27212-MAC-01.local, resolves to a loopback address: 127.0.0.1; using 10.242.159.140 instead (on interface en0)
25/11/11 10:56:51 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address

Spark Connect REPL
Host for connection URI must be defined.

Options:
   --remote REMOTE              URI of the Spark Connect Server to connect to.
   --host HOST                  Host where the Spark Connect Server is running.
   --port PORT                  Port where the Spark Connect Server is running.
   --use_ssl                    Connect to the server using SSL.
   --token TOKEN                Token to use for authentication.
   --user_id USER_ID            Id of the user connecting.
   --user_name USER_NAME        Name of the user connecting.
   --user_agent USER_AGENT      The User-Agent Client information (only intended for logging purposes by the server).
   --session_id SESSION_ID      Session Id of the user connecting.
   --grpc_max_message_size SIZE Maximum message size allowed for gRPC messages in bytes.
   --option KEY=VALUE           Key-value pair that is used to further configure the session.


25/11/11 10:56:51 INFO ShutdownHookManager: Shutdown hook called
25/11/11 10:56:51 INFO ShutdownHookManager: Deleting directory /private/var/folders/kz/qv5g7w5s1rgb_9d4mpym2v1h0000gn/T/spark-e7766d62-d66d-4a04-8c18-eeee332eedf4
```


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Only affects logs.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

before

```
...
25/11/11 02:03:49 INFO SparkConnectServer: Spark Connect server started at: 0:0:0:0:0:0:0:0:15002
```
`bin/spark-shell --remote sc://0:0:0:0:0:0:0:0:15002` does not work.

after
```
...
25/11/11 02:31:15 INFO SparkConnectServer: Spark Connect server started at: [::]:15002
```

`bin/spark-shell --remote sc://[::]:15002` works

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.