### PR TITLE
[SPARK-54296][PYTHON][TESTS] Optimize the arrow batch slicing tests for cogrouped

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_cogrouped_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_cogrouped_map.py
@@ -313,21 +313,19 @@ class CogroupedMapInArrowTestsMixin:
         self.assertEqual(df2.join(df2).count(), 1)
 
     def test_arrow_batch_slicing(self):
-        df1 = self.spark.range(10000000).select(
-            (sf.col("id") % 2).alias("key"), sf.col("id").alias("v")
-        )
+        m, n = 100000, 10000
+
+        df1 = self.spark.range(m).select((sf.col("id") % 2).alias("key"), sf.col("id").alias("v"))
         cols = {f"col_{i}": sf.col("v") + i for i in range(10)}
         df1 = df1.withColumns(cols)
 
-        df2 = self.spark.range(100000).select(
-            (sf.col("id") % 4).alias("key"), sf.col("id").alias("v")
-        )
+        df2 = self.spark.range(n).select((sf.col("id") % 4).alias("key"), sf.col("id").alias("v"))
         cols = {f"col_{i}": sf.col("v") + i for i in range(20)}
         df2 = df2.withColumns(cols)
 
         def summarize(key, left, right):
-            assert len(left) == 10000000 / 2 or len(left) == 0, len(left)
-            assert len(right) == 100000 / 4, len(right)
+            assert len(left) == m / 2 or len(left) == 0, len(left)
+            assert len(right) == n / 4, len(right)
             return pa.Table.from_pydict(
                 {
                     "key": [key[0].as_py()],
@@ -341,13 +339,13 @@ class CogroupedMapInArrowTestsMixin:
         schema = "key long, left_rows long, left_columns long, right_rows long, right_columns long"
 
         expected = [
-            Row(key=0, left_rows=5000000, left_columns=12, right_rows=25000, right_columns=22),
-            Row(key=1, left_rows=5000000, left_columns=12, right_rows=25000, right_columns=22),
-            Row(key=2, left_rows=0, left_columns=12, right_rows=25000, right_columns=22),
-            Row(key=3, left_rows=0, left_columns=12, right_rows=25000, right_columns=22),
+            Row(key=0, left_rows=m / 2, left_columns=12, right_rows=n / 4, right_columns=22),
+            Row(key=1, left_rows=m / 2, left_columns=12, right_rows=n / 4, right_columns=22),
+            Row(key=2, left_rows=0, left_columns=12, right_rows=n / 4, right_columns=22),
+            Row(key=3, left_rows=0, left_columns=12, right_rows=n / 4, right_columns=22),
         ]
 
-        for maxRecords, maxBytes in [(1000, 2**31 - 1), (0, 1048576), (1000, 1048576)]:
+        for maxRecords, maxBytes in [(1000, 2**31 - 1), (0, 4096), (1000, 4096)]:
             with self.subTest(maxRecords=maxRecords, maxBytes=maxBytes):
                 with self.sql_conf(
                     {

--- a/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
@@ -660,21 +660,19 @@ class CogroupedApplyInPandasTestsMixin:
             self.__test_merge(left, right, by, fn, output_schema)
 
     def test_arrow_batch_slicing(self):
-        df1 = self.spark.range(10000000).select(
-            (sf.col("id") % 2).alias("key"), sf.col("id").alias("v")
-        )
+        m, n = 100000, 10000
+
+        df1 = self.spark.range(m).select((sf.col("id") % 2).alias("key"), sf.col("id").alias("v"))
         cols = {f"col_{i}": sf.col("v") + i for i in range(10)}
         df1 = df1.withColumns(cols)
 
-        df2 = self.spark.range(100000).select(
-            (sf.col("id") % 4).alias("key"), sf.col("id").alias("v")
-        )
+        df2 = self.spark.range(n).select((sf.col("id") % 4).alias("key"), sf.col("id").alias("v"))
         cols = {f"col_{i}": sf.col("v") + i for i in range(20)}
         df2 = df2.withColumns(cols)
 
         def summarize(key, left, right):
-            assert len(left) == 10000000 / 2 or len(left) == 0, len(left)
-            assert len(right) == 100000 / 4, len(right)
+            assert len(left) == m / 2 or len(left) == 0, len(left)
+            assert len(right) == n / 4, len(right)
             return pd.DataFrame(
                 {
                     "key": [key[0]],
@@ -688,13 +686,13 @@ class CogroupedApplyInPandasTestsMixin:
         schema = "key long, left_rows long, left_columns long, right_rows long, right_columns long"
 
         expected = [
-            Row(key=0, left_rows=5000000, left_columns=12, right_rows=25000, right_columns=22),
-            Row(key=1, left_rows=5000000, left_columns=12, right_rows=25000, right_columns=22),
-            Row(key=2, left_rows=0, left_columns=12, right_rows=25000, right_columns=22),
-            Row(key=3, left_rows=0, left_columns=12, right_rows=25000, right_columns=22),
+            Row(key=0, left_rows=m / 2, left_columns=12, right_rows=n / 4, right_columns=22),
+            Row(key=1, left_rows=m / 2, left_columns=12, right_rows=n / 4, right_columns=22),
+            Row(key=2, left_rows=0, left_columns=12, right_rows=n / 4, right_columns=22),
+            Row(key=3, left_rows=0, left_columns=12, right_rows=n / 4, right_columns=22),
         ]
 
-        for maxRecords, maxBytes in [(1000, 2**31 - 1), (0, 1048576), (1000, 1048576)]:
+        for maxRecords, maxBytes in [(1000, 2**31 - 1), (0, 4096), (1000, 4096)]:
             with self.subTest(maxRecords=maxRecords, maxBytes=maxBytes):
                 with self.sql_conf(
                     {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
to optimize newly added tests


### Why are the changes needed?
before:
```
Starting test(python3.11): pyspark.sql.tests.connect.arrow.test_parity_arrow_cogrouped_map (temp output: /__w/spark/spark/python/target/6f28044e-b489-483a-ad37-c4f631875f4e/python3.11__pyspark.sql.tests.connect.arrow.test_parity_arrow_cogrouped_map__1r4fgqd_.log)
Finished test(python3.11): pyspark.sql.tests.connect.arrow.test_parity_arrow_cogrouped_map (58s)

Starting test(python3.11): pyspark.sql.tests.connect.pandas.test_parity_pandas_cogrouped_map (temp output: /__w/spark/spark/python/target/93d6495c-37be-4360-bc64-b7f8ccc2020e/python3.11__pyspark.sql.tests.connect.pandas.test_parity_pandas_cogrouped_map__phtfyjt1.log)
Finished test(python3.11): pyspark.sql.tests.connect.pandas.test_parity_pandas_cogrouped_map (73s)
```

after:
```
Starting test(python3.11): pyspark.sql.tests.connect.arrow.test_parity_arrow_cogrouped_map (temp output: /__w/spark/spark/python/target/2240e5cc-4080-477f-866d-cd7183a5de64/python3.11__pyspark.sql.tests.connect.arrow.test_parity_arrow_cogrouped_map__msogniqf.log)
Finished test(python3.11): pyspark.sql.tests.connect.arrow.test_parity_arrow_cogrouped_map (28s)


Starting test(python3.11): pyspark.sql.tests.connect.pandas.test_parity_pandas_cogrouped_map (temp output: /__w/spark/spark/python/target/e5d113a7-2779-4d64-88a7-6236fbc6d641/python3.11__pyspark.sql.tests.connect.pandas.test_parity_pandas_cogrouped_map__cv8fi_l0.log)
Finished test(python3.11): pyspark.sql.tests.connect.pandas.test_parity_pandas_cogrouped_map (47s)
```

### Does this PR introduce _any_ user-facing change?
No, test-only


### How was this patch tested?
CI

### Was this patch authored or co-authored using generative AI tooling?
No