### PR TITLE
[SPARK-54300][PYTHON] Optimize Py4J calls in `df.toPandas`

### DIFF
--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -71,9 +71,25 @@ class PandasConversionMixin:
 
         import pandas as pd
 
-        jconf = self.sparkSession._jconf
+        (
+            sessionLocalTimeZone,
+            arrowPySparkEnabled,
+            arrowUseLargeVarTypes,
+            arrowPySparkFallbackEnabled,
+            arrowPySparkSelfDestructEnabled,
+            pandasStructHandlingMode,
+        ) = self.sparkSession._jconf.getConfs(
+            [
+                "spark.sql.session.timeZone",
+                "spark.sql.execution.arrow.pyspark.enabled",
+                "spark.sql.execution.arrow.useLargeVarTypes",
+                "spark.sql.execution.arrow.pyspark.fallback.enabled",
+                "spark.sql.execution.arrow.pyspark.selfDestruct.enabled",
+                "spark.sql.execution.pandas.structHandlingMode",
+            ]
+        )
 
-        if jconf.arrowPySparkEnabled():
+        if arrowPySparkEnabled == "true":
             use_arrow = True
             try:
                 from pyspark.sql.pandas.types import to_arrow_schema
@@ -81,10 +97,10 @@ class PandasConversionMixin:
 
                 require_minimum_pyarrow_version()
                 arrow_schema = to_arrow_schema(
-                    self.schema, prefers_large_types=jconf.arrowUseLargeVarTypes()
+                    self.schema, prefers_large_types=arrowUseLargeVarTypes == "true"
                 )
             except Exception as e:
-                if jconf.arrowPySparkFallbackEnabled():
+                if arrowPySparkFallbackEnabled == "true":
                     msg = (
                         "toPandas attempted Arrow optimization because "
                         "'spark.sql.execution.arrow.pyspark.enabled' is set to true; however, "
@@ -112,7 +128,7 @@ class PandasConversionMixin:
                 try:
                     import pyarrow as pa
 
-                    self_destruct = jconf.arrowPySparkSelfDestructEnabled()
+                    self_destruct = arrowPySparkSelfDestructEnabled == "true"
                     batches = self._collect_as_arrow(split_batches=self_destruct)
 
                     # Rename columns to avoid duplicated column names.
@@ -148,8 +164,8 @@ class PandasConversionMixin:
                         )
 
                     if len(self.columns) > 0:
-                        timezone = jconf.sessionLocalTimeZone()
-                        struct_in_pandas = jconf.pandasStructHandlingMode()
+                        timezone = sessionLocalTimeZone
+                        struct_in_pandas = pandasStructHandlingMode
 
                         error_on_duplicated_field_names = False
                         if struct_in_pandas == "legacy":
@@ -200,8 +216,8 @@ class PandasConversionMixin:
             pdf = pd.DataFrame(columns=self.columns)
 
         if len(pdf.columns) > 0:
-            timezone = jconf.sessionLocalTimeZone()
-            struct_in_pandas = jconf.pandasStructHandlingMode()
+            timezone = sessionLocalTimeZone
+            struct_in_pandas = pandasStructHandlingMode
 
             return pd.concat(
                 [

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -7873,6 +7873,12 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
     }
   }
 
+  /** Return the value of Spark SQL configuration property for the given keys. */
+  @throws[NoSuchElementException]("if key is not set")
+  private[spark] def getConfs(keys: util.List[String]): Array[String] = {
+    Array.tabulate(keys.size())(i => this.getConfString(keys.get(i)))
+  }
+
   /**
    * Return all the configuration properties that have been set (i.e. not the default).
    * This creates a new copy of the config properties in the form of a Map.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Optimize Py4J config calls in df.toPandas


### Why are the changes needed?
In spark connect, we get all configs in a batch; in spark classic, we can do the similar optimization that all configs are fetched in a batch, so that the py4j calls can be minimized.


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no