### PR TITLE
[SPARK-54301][SQL][TESTS] Enhance Spark SQL test suites for easier integration with other projects

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.connector.expressions.Expressions._
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
-import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+import org.apache.spark.sql.execution.exchange.{ShuffleExchangeExec, ShuffleExchangeLike}
 import org.apache.spark.sql.execution.joins.SortMergeJoinExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf._
@@ -299,13 +299,13 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase {
         Row("bbb", 20, 250.0), Row("bbb", 20, 350.0), Row("ccc", 30, 400.50)))
   }
 
-  private def collectAllShuffles(plan: SparkPlan): Seq[ShuffleExchangeExec] = {
+  protected def collectAllShuffles(plan: SparkPlan): Seq[ShuffleExchangeLike] = {
     collect(plan) {
       case s: ShuffleExchangeExec => s
     }
   }
 
-  private def collectShuffles(plan: SparkPlan): Seq[ShuffleExchangeExec] = {
+  protected def collectShuffles(plan: SparkPlan): Seq[ShuffleExchangeLike] = {
     // here we skip collecting shuffle operators that are not associated with SMJ
     collect(plan) {
       case s: SortMergeJoinExec => s

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala
@@ -61,16 +61,18 @@ abstract class DisableUnnecessaryBucketedScanSuite
   private lazy val df2 =
     (0 until 50).map(i => (i % 7, i % 11, i.toString)).toDF("i", "j", "k").as("df2")
 
+  protected def checkNumBucketedScan(query: String, expectedNumBucketedScan: Int): Unit = {
+    val df = sql(query)
+    df.collect()
+    val plan = df.queryExecution.executedPlan
+    val bucketedScan = collect(plan) { case s: FileSourceScanExec if s.bucketedScan => s }
+    assert(bucketedScan.length == expectedNumBucketedScan)
+  }
+  
   private def checkDisableBucketedScan(
       query: String,
       expectedNumScanWithAutoScanEnabled: Int,
       expectedNumScanWithAutoScanDisabled: Int): Unit = {
-
-    def checkNumBucketedScan(query: String, expectedNumBucketedScan: Int): Unit = {
-      val plan = sql(query).queryExecution.executedPlan
-      val bucketedScan = collect(plan) { case s: FileSourceScanExec if s.bucketedScan => s }
-      assert(bucketedScan.length == expectedNumBucketedScan)
-    }
 
     withSQLConf(SQLConf.AUTO_BUCKETED_SCAN_ENABLED.key -> "true") {
       checkNumBucketedScan(query, expectedNumScanWithAutoScanEnabled)

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala
@@ -68,7 +68,7 @@ abstract class DisableUnnecessaryBucketedScanSuite
     val bucketedScan = collect(plan) { case s: FileSourceScanExec if s.bucketedScan => s }
     assert(bucketedScan.length == expectedNumBucketedScan)
   }
-  
+
   private def checkDisableBucketedScan(
       query: String,
       expectedNumScanWithAutoScanEnabled: Int,


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR refactors Spark SQL test suites(`KeyGroupedPartitioningSuite` and `DisableUnnecessaryBucketedScanSuite`) to facilitate seamless integration with other projects. e.g.: Apache Gluten.

### Why are the changes needed?
Simplifying future maintenance and cross-project support.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
No production code changes.