### PR TITLE
[SPARK-54297][PYTHON][SQL][TESTS] Optimize tests for iterator of dataframe API in `applyInPandas`

### DIFF
--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -938,14 +938,14 @@ class ApplyInPandasTestsMixin:
                 self.assertEqual(row[1], 123)
 
     def test_arrow_batch_slicing(self):
-        df = self.spark.range(10000000).select(
+        df = self.spark.range(100000).select(
             (sf.col("id") % 2).alias("key"), sf.col("id").alias("v")
         )
         cols = {f"col_{i}": sf.col("v") + i for i in range(20)}
         df = df.withColumns(cols)
 
         def min_max_v(pdf):
-            assert len(pdf) == 10000000 / 2, len(pdf)
+            assert len(pdf) == 100000 / 2, len(pdf)
             return pd.DataFrame(
                 {
                     "key": [pdf.key.iloc[0]],
@@ -958,7 +958,7 @@ class ApplyInPandasTestsMixin:
             df.groupby("key").agg(sf.min("v").alias("min"), sf.max("v").alias("max")).sort("key")
         ).collect()
 
-        for maxRecords, maxBytes in [(1000, 2**31 - 1), (0, 1048576), (1000, 1048576)]:
+        for maxRecords, maxBytes in [(1000, 4096), (0, 4096), (1000, 4096)]:
             with self.subTest(maxRecords=maxRecords, maxBytes=maxBytes):
                 with self.sql_conf(
                     {
@@ -1057,7 +1057,7 @@ class ApplyInPandasTestsMixin:
         self.assertEqual(result[1][1], 18.0)
 
     def test_apply_in_pandas_iterator_batch_slicing(self):
-        df = self.spark.range(10000000).select(
+        df = self.spark.range(100000).select(
             (sf.col("id") % 2).alias("key"), sf.col("id").alias("v")
         )
         cols = {f"col_{i}": sf.col("v") + i for i in range(20)}
@@ -1073,7 +1073,7 @@ class ApplyInPandasTestsMixin:
                     key_val = batch.key.iloc[0]
 
             combined = pd.concat(all_data, ignore_index=True)
-            assert len(combined) == 10000000 / 2, len(combined)
+            assert len(combined) == 100000 / 2, len(combined)
 
             yield pd.DataFrame(
                 {
@@ -1092,7 +1092,7 @@ class ApplyInPandasTestsMixin:
             .sort("key")
         ).collect()
 
-        for maxRecords, maxBytes in [(1000, 2**31 - 1), (0, 1048576), (1000, 1048576)]:
+        for maxRecords, maxBytes in [(1000, 4096), (0, 4096), (1000, 4096)]:
             with self.subTest(maxRecords=maxRecords, maxBytes=maxBytes):
                 with self.sql_conf(
                     {
@@ -1109,7 +1109,7 @@ class ApplyInPandasTestsMixin:
                     self.assertEqual(expected, result)
 
     def test_apply_in_pandas_iterator_with_keys_batch_slicing(self):
-        df = self.spark.range(10000000).select(
+        df = self.spark.range(100000).select(
             (sf.col("id") % 2).alias("key"), sf.col("id").alias("v")
         )
         cols = {f"col_{i}": sf.col("v") + i for i in range(20)}
@@ -1124,7 +1124,7 @@ class ApplyInPandasTestsMixin:
                 all_data.append(batch)
 
             combined = pd.concat(all_data, ignore_index=True)
-            assert len(combined) == 10000000 / 2, len(combined)
+            assert len(combined) == 100000 / 2, len(combined)
 
             yield pd.DataFrame(
                 {
@@ -1138,7 +1138,7 @@ class ApplyInPandasTestsMixin:
             df.groupby("key").agg(sf.min("v").alias("min"), sf.max("v").alias("max")).sort("key")
         ).collect()
 
-        for maxRecords, maxBytes in [(1000, 2**31 - 1), (0, 1048576), (1000, 1048576)]:
+        for maxRecords, maxBytes in [(1000, 4096), (0, 4096), (1000, 4096)]:
             with self.subTest(maxRecords=maxRecords, maxBytes=maxBytes):
                 with self.sql_conf(
                     {


### PR DESCRIPTION
### What changes were proposed in this pull request?
We use these tests to ensure that large datasets are processed exclusively through the new iterator API and that loading them entirely into memory would fail. However, the original tests were too slow and resource-intensive. This PR optimizes the test to achieve the same validation goal while using significantly fewer resources.

### Why are the changes needed?
To save time and resources for CI.

Before:
```
7d04fd12050e/python3.11__pyspark.sql.tests.connect.pandas.test_parity_pandas_grouped_map__6iwxrtx4.log)
Finished test(python3.11): pyspark.sql.tests.connect.pandas.test_parity_pandas_grouped_map **(291s)**
Starting test(python3.11): pyspark.sql.tests.pandas.test_pandas_grouped_map (temp output: /__w/spark/spark/python/target/379cea6f-7421-4f81-ae7b-1c22baddaa92/python3.11__pyspark.sql.tests.pandas.test_pandas_grouped_map__km0800fd.log)
Finished test(python3.11): pyspark.sql.tests.pandas.test_pandas_grouped_map **(300s)**
```

After:
```

Starting test(python3.11): pyspark.sql.tests.connect.pandas.test_parity_pandas_grouped_map (temp output: /__w/spark/spark/python/target/4cbd5d5f-18b9-48ba-8bf4-30fa18698355/python3.11__pyspark.sql.tests.connect.pandas.test_parity_pandas_grouped_map__4o3yj9ck.log)
Finished test(python3.11): pyspark.sql.tests.connect.pandas.test_parity_pandas_grouped_map (130s)

```


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
CI test.

### Was this patch authored or co-authored using generative AI tooling?
No.
