### PR TITLE
[SPARK-54207][CONNECT] Supports Date type data in SparkConnectResultSet

### DIFF
--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/util/JdbcTypeUtils.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/util/JdbcTypeUtils.scala
@@ -36,6 +36,7 @@ private[jdbc] object JdbcTypeUtils {
     case DoubleType => Types.DOUBLE
     case StringType => Types.VARCHAR
     case _: DecimalType => Types.DECIMAL
+    case DateType => Types.DATE
     case other =>
       throw new SQLFeatureNotSupportedException(s"DataType $other is not supported yet.")
   }
@@ -51,6 +52,7 @@ private[jdbc] object JdbcTypeUtils {
     case DoubleType => classOf[JDouble].getName
     case StringType => classOf[String].getName
     case _: DecimalType => classOf[JBigDecimal].getName
+    case DateType => classOf[Date].getName
     case other =>
       throw new SQLFeatureNotSupportedException(s"DataType $other is not supported yet.")
   }
@@ -58,7 +60,7 @@ private[jdbc] object JdbcTypeUtils {
   def isSigned(field: StructField): Boolean = field.dataType match {
     case ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType |
          _: DecimalType => true
-    case NullType | BooleanType | StringType => false
+    case NullType | BooleanType | StringType | DateType => false
     case other =>
       throw new SQLFeatureNotSupportedException(s"DataType $other is not supported yet.")
   }
@@ -74,6 +76,7 @@ private[jdbc] object JdbcTypeUtils {
     case DoubleType => 15
     case StringType => 255
     case DecimalType.Fixed(p, _) => p
+    case DateType => 10
     case other =>
       throw new SQLFeatureNotSupportedException(s"DataType $other is not supported yet.")
   }
@@ -81,7 +84,8 @@ private[jdbc] object JdbcTypeUtils {
   def getScale(field: StructField): Int = field.dataType match {
     case FloatType => 7
     case DoubleType => 15
-    case NullType | BooleanType | ByteType | ShortType | IntegerType | LongType | StringType => 0
+    case NullType | BooleanType | ByteType | ShortType | IntegerType | LongType | StringType |
+         DateType => 0
     case DecimalType.Fixed(_, s) => s
     case other =>
       throw new SQLFeatureNotSupportedException(s"DataType $other is not supported yet.")
@@ -96,6 +100,7 @@ private[jdbc] object JdbcTypeUtils {
     case DoubleType => 24
     case StringType =>
       getPrecision(field)
+    case DateType => 10 // length of `YYYY-MM-DD`
     // precision + negative sign + leading zero + decimal point, like DECIMAL(5,5) = -0.12345
     case DecimalType.Fixed(p, s) if p == s => p + 3
     // precision + negative sign, like DECIMAL(5,0) = -12345

--- a/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectJdbcDataTypeSuite.scala
+++ b/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectJdbcDataTypeSuite.scala
@@ -301,4 +301,113 @@ class SparkConnectJdbcDataTypeSuite extends ConnectFunSuite with RemoteSparkSess
         assert(exception.getMessage() === "JDBC Statement is closed.")
     }
   }
+
+  test("get date type") {
+    withExecuteQuery("SELECT date '2023-11-15'") { rs =>
+      assert(rs.next())
+      assert(rs.getDate(1) === java.sql.Date.valueOf("2023-11-15"))
+      assert(!rs.wasNull)
+      assert(!rs.next())
+
+      val metaData = rs.getMetaData
+      assert(metaData.getColumnCount === 1)
+      assert(metaData.getColumnName(1) === "DATE '2023-11-15'")
+      assert(metaData.getColumnLabel(1) === "DATE '2023-11-15'")
+      assert(metaData.getColumnType(1) === Types.DATE)
+      assert(metaData.getColumnTypeName(1) === "DATE")
+      assert(metaData.getColumnClassName(1) === "java.sql.Date")
+      assert(metaData.isSigned(1) === false)
+      assert(metaData.getPrecision(1) === 10)
+      assert(metaData.getScale(1) === 0)
+      assert(metaData.getColumnDisplaySize(1) === 10)
+    }
+  }
+
+  test("get date type with null") {
+    withExecuteQuery("SELECT cast(null as date)") { rs =>
+      assert(rs.next())
+      assert(rs.getDate(1) === null)
+      assert(rs.wasNull)
+      assert(!rs.next())
+
+      val metaData = rs.getMetaData
+      assert(metaData.getColumnCount === 1)
+      assert(metaData.getColumnName(1) === "CAST(NULL AS DATE)")
+      assert(metaData.getColumnLabel(1) === "CAST(NULL AS DATE)")
+      assert(metaData.getColumnType(1) === Types.DATE)
+      assert(metaData.getColumnTypeName(1) === "DATE")
+      assert(metaData.getColumnClassName(1) === "java.sql.Date")
+      assert(metaData.isSigned(1) === false)
+      assert(metaData.getPrecision(1) === 10)
+      assert(metaData.getScale(1) === 0)
+      assert(metaData.getColumnDisplaySize(1) === 10)
+    }
+  }
+
+  test("get date type by column label") {
+    withExecuteQuery("SELECT date '2025-11-15' as test_date") { rs =>
+      assert(rs.next())
+      assert(rs.getDate("test_date") === java.sql.Date.valueOf("2025-11-15"))
+      assert(!rs.wasNull)
+      assert(!rs.next())
+    }
+  }
+
+  test("get date type with calendar by column index") {
+    withExecuteQuery("SELECT date '2025-11-15'") { rs =>
+      assert(rs.next())
+
+      val calUTC = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"))
+      val dateUTC = rs.getDate(1, calUTC)
+      assert(dateUTC !== null)
+      assert(!rs.wasNull)
+
+      val calPST = java.util.Calendar.getInstance(
+        java.util.TimeZone.getTimeZone("America/Los_Angeles"))
+      val datePST = rs.getDate(1, calPST)
+      assert(datePST !== null)
+      assert(!rs.wasNull)
+      assert(!rs.next())
+    }
+  }
+
+  test("get date type with calendar by column label") {
+    withExecuteQuery("SELECT date '2025-11-15' as test_date") { rs =>
+      assert(rs.next())
+
+      val cal = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"))
+      val date = rs.getDate("test_date", cal)
+      assert(date !== null)
+      assert(!rs.wasNull)
+      assert(!rs.next())
+
+      val metaData = rs.getMetaData
+      assert(metaData.getColumnCount === 1)
+      assert(metaData.getColumnName(1) === "test_date")
+      assert(metaData.getColumnLabel(1) === "test_date")
+    }
+  }
+
+  test("get date type with calendar for null value") {
+    withExecuteQuery("SELECT cast(null as date)") { rs =>
+      assert(rs.next())
+
+      val cal = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"))
+      val date = rs.getDate(1, cal)
+      assert(date === null)
+      assert(rs.wasNull)
+      assert(!rs.next())
+    }
+  }
+
+  test("get date type with null calendar") {
+    withExecuteQuery("SELECT date '2025-11-15'") { rs =>
+      assert(rs.next())
+
+      val date = rs.getDate(1, null)
+      assert(date === java.sql.Date.valueOf("2025-11-15"))
+      assert(!rs.wasNull)
+      assert(!rs.next())
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add DATE type support to the Spark Connect JDBC client

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
DATE is a fundamental SQL type required for JDBC compliance and interoperability. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, it's part of a new feature under Spark connect JDBC support.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added new UTs in  `SparkConnectJdbcDataTypeSuite`

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
