### PR TITLE
[SPARK-54315][PYTHON][TESTS] Optimize test `ApplyInArrowTests.test_arrow_batch_slicing`

### DIFF
--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -938,14 +938,14 @@ class ApplyInPandasTestsMixin:
                 self.assertEqual(row[1], 123)
 
     def test_arrow_batch_slicing(self):
-        df = self.spark.range(100000).select(
-            (sf.col("id") % 2).alias("key"), sf.col("id").alias("v")
-        )
+        n = 100000
+
+        df = self.spark.range(n).select((sf.col("id") % 2).alias("key"), sf.col("id").alias("v"))
         cols = {f"col_{i}": sf.col("v") + i for i in range(20)}
         df = df.withColumns(cols)
 
         def min_max_v(pdf):
-            assert len(pdf) == 100000 / 2, len(pdf)
+            assert len(pdf) == n / 2, len(pdf)
             return pd.DataFrame(
                 {
                     "key": [pdf.key.iloc[0]],
@@ -958,7 +958,7 @@ class ApplyInPandasTestsMixin:
             df.groupby("key").agg(sf.min("v").alias("min"), sf.max("v").alias("max")).sort("key")
         ).collect()
 
-        for maxRecords, maxBytes in [(1000, 4096), (0, 4096), (1000, 4096)]:
+        for maxRecords, maxBytes in [(1000, 2**31 - 1), (0, 4096), (1000, 4096)]:
             with self.subTest(maxRecords=maxRecords, maxBytes=maxBytes):
                 with self.sql_conf(
                     {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Optimize test `ApplyInArrowTests.test_arrow_batch_slicing`


### Why are the changes needed?
before
```
Starting test(python3.11): pyspark.sql.tests.connect.arrow.test_parity_arrow_grouped_map (temp output: /__w/spark/spark/python/target/84531e82-addd-4a47-bb65-9006099020a0/python3.11__pyspark.sql.tests.connect.arrow.test_parity_arrow_grouped_map__l8scrw6b.log)
Finished test(python3.11): pyspark.sql.tests.connect.arrow.test_parity_arrow_grouped_map (100s)
```

after
```
Starting test(python3.11): pyspark.sql.tests.connect.arrow.test_parity_arrow_grouped_map (temp output: /__w/spark/spark/python/target/f8e27057-d295-433e-99a2-a429a48278d5/python3.11__pyspark.sql.tests.connect.arrow.test_parity_arrow_grouped_map__ss4itrd9.log)
Finished test(python3.11): pyspark.sql.tests.connect.arrow.test_parity_arrow_grouped_map (39s)
```


### Does this PR introduce _any_ user-facing change?
No, test-only


### How was this patch tested?
CI

### Was this patch authored or co-authored using generative AI tooling?
No