### PR TITLE
[SPARK-54313][CORE] Add --extra-properties-file option for configuration layering

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -49,6 +49,7 @@ abstract class AbstractCommandBuilder {
   String master;
   String remote;
   protected String propertiesFile;
+  protected List<String> extraPropertiesFiles = new ArrayList<>();
   protected boolean loadSparkDefaults;
   final List<String> appArgs;
   final List<String> jars;
@@ -379,6 +380,16 @@ abstract class AbstractCommandBuilder {
       File propsFile = new File(propertiesFile);
       checkArgument(propsFile.isFile(), "Invalid properties file '%s'.", propertiesFile);
       props = loadPropertiesFile(propsFile);
+    }
+
+    // Load extra properties files, later files override earlier ones
+    for (String extraFile : extraPropertiesFiles) {
+      File extraPropsFile = new File(extraFile);
+      checkArgument(extraPropsFile.isFile(), "Invalid properties file '%s'.", extraFile);
+      Properties extraProps = loadPropertiesFile(extraPropsFile);
+      for (Map.Entry<Object, Object> entry : extraProps.entrySet()) {
+        props.put(entry.getKey(), entry.getValue());
+      }
     }
 
     Properties defaultsProps = new Properties();

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -251,6 +251,13 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
       args.add(propertiesFile);
     }
 
+    if (extraPropertiesFiles != null) {
+      for (String file : extraPropertiesFiles) {
+        args.add(parser.EXTRA_PROPERTIES_FILE);
+        args.add(file);
+      }
+    }
+
     if (loadSparkDefaults) {
       args.add(parser.LOAD_SPARK_DEFAULTS);
     }
@@ -554,6 +561,7 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
         }
         case DEPLOY_MODE -> deployMode = value;
         case PROPERTIES_FILE -> propertiesFile = value;
+        case EXTRA_PROPERTIES_FILE -> extraPropertiesFiles.add(value);
         case LOAD_SPARK_DEFAULTS -> loadSparkDefaults = true;
         case DRIVER_MEMORY -> conf.put(SparkLauncher.DRIVER_MEMORY, value);
         case DRIVER_JAVA_OPTIONS -> conf.put(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS, value);

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
@@ -55,6 +55,7 @@ class SparkSubmitOptionParser {
   protected final String PACKAGES = "--packages";
   protected final String PACKAGES_EXCLUDE = "--exclude-packages";
   protected final String PROPERTIES_FILE = "--properties-file";
+  protected final String EXTRA_PROPERTIES_FILE = "--extra-properties-file";
   protected final String LOAD_SPARK_DEFAULTS = "--load-spark-defaults";
   protected final String PROXY_USER = "--proxy-user";
   protected final String PY_FILES = "--py-files";
@@ -114,6 +115,7 @@ class SparkSubmitOptionParser {
     { PACKAGES_EXCLUDE },
     { PRINCIPAL },
     { PROPERTIES_FILE },
+    { EXTRA_PROPERTIES_FILE },
     { PROXY_USER },
     { PY_FILES },
     { QUEUE },


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds support for multiple properties files via the `--extra-properties-file` option in spark-submit, enabling configuration layering and composition.

**Changes:**
- Added `extraPropertiesFiles: Seq[String]` field to `SparkSubmitArguments`
- Added `EXTRA_PROPERTIES_FILE` constant to `SparkSubmitOptionParser`
- Modified `AbstractCommandBuilder` to load and merge extra properties files
- Updated `SparkSubmitCommandBuilder` to parse and rebuild args with extra files
- Added 4 unit tests in `SparkSubmitSuite`

### Why are the changes needed?

Large-scale Spark deployments often need to compose configurations from multiple sources:

- Base/shared defaults - Common settings reused across applications
- Environment-specific configs - Different settings for dev/staging/prod
- Cluster-specific settings - YARN queues, resource limits per cluster
- Application-specific overrides - Per-app tuning parameters

### Does this PR introduce any user-facing changes?

Yes. Adds new `--extra-properties-file` option to spark-submit.

**Usage:**
```bash
spark-submit \
  --properties-file base.conf \
  --extra-properties-file cluster.conf \
  --extra-properties-file app.conf \
  --class com.example.App app.jar
```

**Property Precedence** (highest to lowest):
1. `--conf` flags (command-line overrides)
2. `--extra-properties-file` files (later files override earlier ones)
3. `--properties-file` (base file)
4. `conf/spark-defaults.conf` (with `--load-spark-defaults`)

**Key Features:**
- Repeatable flag - can be specified multiple times
- Later files override earlier files (left-to-right precedence)
- No breaking changes - new flag, existing behavior unchanged
- Shell-friendly - no comma escaping or string manipulation needed

### How was this patch tested?

Added 4 unit tests in `SparkSubmitSuite`.

### Was this patch authored or co-authored using generative AI tooling?

Unit tests and descriptions were generated by Claude Code.