### PR TITLE
[SPARK-54323][PYTHON] Change the way to access logs to TVF instead of system view

### DIFF
--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -52,7 +52,10 @@ object MimaExcludes {
     ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.sql.Dataset.repartitionById"),
 
     // [SPARK-54001][CONNECT] Replace block copying with ref-counting in ArtifactManager cloning
-    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.artifact.ArtifactManager.cachedBlockIdList")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.artifact.ArtifactManager.cachedBlockIdList"),
+
+    // [SPARK-54323][PYTHON] Change the way to access logs to TVF instead of system view
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.sql.TableValuedFunction.python_worker_logs")
   )
 
   // Default exclude rules

--- a/python/docs/source/user_guide/bugbusting.ipynb
+++ b/python/docs/source/user_guide/bugbusting.ipynb
@@ -945,7 +945,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "logs = spark.table(\"system.session.python_worker_logs\")"
+    "logs = spark.tvf.python_worker_logs()"
    ]
   },
   {
@@ -1021,7 +1021,7 @@
     "df.select(my_udf(\"text\")).show()\n",
     "\n",
     "# Query the logs\n",
-    "logs = spark.table(\"system.session.python_worker_logs\")\n",
+    "logs = spark.tvf.python_worker_logs()\n",
     "logs.select(\"level\", \"msg\", \"logger\", \"context\").show(truncate=False)"
    ]
   },
@@ -1076,7 +1076,7 @@
     "spark.conf.set(\"spark.sql.pyspark.worker.logging.enabled\", \"true\")\n",
     "spark.range(1).select(contextual_udf(lit(\"test\"))).show()\n",
     "\n",
-    "logs = spark.table(\"system.session.python_worker_logs\")\n",
+    "logs = spark.tvf.python_worker_logs()\n",
     "logs.filter(\"logger = 'contextual'\").select(\"msg\", \"context\").show(truncate=False)"
    ]
   },
@@ -1135,7 +1135,7 @@
     "spark.conf.set(\"spark.sql.pyspark.worker.logging.enabled\", \"true\")\n",
     "spark.createDataFrame([(0,), (5,)], [\"value\"]).select(failing_udf(\"value\")).show()\n",
     "\n",
-    "logs = spark.table(\"system.session.python_worker_logs\")\n",
+    "logs = spark.tvf.python_worker_logs()\n",
     "logs.filter(\"logger = 'error_handler'\").select(\"msg\", \"exception\").show(truncate=False)"
    ]
   },
@@ -1193,7 +1193,7 @@
     "df = spark.createDataFrame([(\"hello world\",)], [\"text\"])\n",
     "df.lateralJoin(WordSplitter(col(\"text\").outer())).show()\n",
     "\n",
-    "logs = spark.table(\"system.session.python_worker_logs\")\n",
+    "logs = spark.tvf.python_worker_logs()\n",
     "logs.filter(\"logger = 'udtf_logger'\").select(\"msg\", \"context\").show(truncate=False)"
    ]
   },
@@ -1231,7 +1231,7 @@
     }
    ],
    "source": [
-    "logs = spark.table(\"system.session.python_worker_logs\")\n",
+    "logs = spark.tvf.python_worker_logs()\n",
     "\n",
     "# Count logs by level\n",
     "logs.groupBy(\"level\").count().show()\n",

--- a/python/pyspark/sql/connect/tvf.py
+++ b/python/pyspark/sql/connect/tvf.py
@@ -109,6 +109,11 @@ class TableValuedFunction:
 
     variant_explode_outer.__doc__ = PySparkTableValuedFunction.variant_explode_outer.__doc__
 
+    def python_worker_logs(self) -> "DataFrame":
+        return self._fn("python_worker_logs")
+
+    python_worker_logs.__doc__ = PySparkTableValuedFunction.python_worker_logs.__doc__
+
     def _fn(self, name: str, *args: "Column") -> "DataFrame":
         from pyspark.sql.connect.dataframe import DataFrame
         from pyspark.sql.connect.plan import UnresolvedTableValuedFunction

--- a/python/pyspark/sql/tests/arrow/test_arrow_cogrouped_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_cogrouped_map.py
@@ -396,20 +396,20 @@ class CogroupedMapInArrowTestsMixin:
                 + [Row(id=2, v1=20, v2=200)],
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select("level", "msg", "context", "logger"),
-            [
-                Row(
-                    level="WARNING",
-                    msg=f"arrow cogrouped map: {dict(v1=v1, v2=v2)}",
-                    context={"func_name": func_with_logging.__name__},
-                    logger="test_arrow_cogrouped_map",
-                )
-                for v1, v2 in [([10, 30], [100, 300]), ([20], [200])]
-            ],
-        )
+            assertDataFrameEqual(
+                logs.select("level", "msg", "context", "logger"),
+                [
+                    Row(
+                        level="WARNING",
+                        msg=f"arrow cogrouped map: {dict(v1=v1, v2=v2)}",
+                        context={"func_name": func_with_logging.__name__},
+                        logger="test_arrow_cogrouped_map",
+                    )
+                    for v1, v2 in [([10, 30], [100, 300]), ([20], [200])]
+                ],
+            )
 
 
 class CogroupedMapInArrowTests(CogroupedMapInArrowTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/arrow/test_arrow_grouped_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_grouped_map.py
@@ -416,20 +416,20 @@ class ApplyInArrowTestsMixin:
                 df,
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select("level", "msg", "context", "logger"),
-            [
-                Row(
-                    level="WARNING",
-                    msg=f"arrow grouped map: {dict(id=lst, value=[v*10 for v in lst])}",
-                    context={"func_name": func_with_logging.__name__},
-                    logger="test_arrow_grouped_map",
-                )
-                for lst in [[0, 2, 4, 6, 8], [1, 3, 5, 7]]
-            ],
-        )
+            assertDataFrameEqual(
+                logs.select("level", "msg", "context", "logger"),
+                [
+                    Row(
+                        level="WARNING",
+                        msg=f"arrow grouped map: {dict(id=lst, value=[v*10 for v in lst])}",
+                        context={"func_name": func_with_logging.__name__},
+                        logger="test_arrow_grouped_map",
+                    )
+                    for lst in [[0, 2, 4, 6, 8], [1, 3, 5, 7]]
+                ],
+            )
 
     @unittest.skipIf(is_remote_only(), "Requires JVM access")
     def test_apply_in_arrow_iter_with_logging(self):
@@ -456,20 +456,20 @@ class ApplyInArrowTestsMixin:
                 df,
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select("level", "msg", "context", "logger"),
-            [
-                Row(
-                    level="WARNING",
-                    msg=f"arrow grouped map: {dict(id=lst, value=[v*10 for v in lst])}",
-                    context={"func_name": func_with_logging.__name__},
-                    logger="test_arrow_grouped_map",
-                )
-                for lst in [[0, 2, 4], [6, 8], [1, 3, 5], [7]]
-            ],
-        )
+            assertDataFrameEqual(
+                logs.select("level", "msg", "context", "logger"),
+                [
+                    Row(
+                        level="WARNING",
+                        msg=f"arrow grouped map: {dict(id=lst, value=[v*10 for v in lst])}",
+                        context={"func_name": func_with_logging.__name__},
+                        logger="test_arrow_grouped_map",
+                    )
+                    for lst in [[0, 2, 4], [6, 8], [1, 3, 5], [7]]
+                ],
+            )
 
 
 class ApplyInArrowTests(ApplyInArrowTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/arrow/test_arrow_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_map.py
@@ -247,12 +247,12 @@ class MapInArrowTestsMixin(object):
                 [Row(id=i) for i in range(9)],
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select("level", "msg", "context", "logger"),
-            self._expected_logs_for_test_map_in_arrow_with_logging(func_with_logging.__name__),
-        )
+            assertDataFrameEqual(
+                logs.select("level", "msg", "context", "logger"),
+                self._expected_logs_for_test_map_in_arrow_with_logging(func_with_logging.__name__),
+            )
 
     def _expected_logs_for_test_map_in_arrow_with_logging(self, func_name):
         return [

--- a/python/pyspark/sql/tests/arrow/test_arrow_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf_grouped_agg.py
@@ -1044,20 +1044,20 @@ class GroupedAggArrowUDFTestsMixin:
                 [Row(id=1, result=3.0), Row(id=2, result=18.0)],
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select("level", "msg", "context", "logger"),
-            [
-                Row(
-                    level="WARNING",
-                    msg=f"grouped agg arrow udf: {n}",
-                    context={"func_name": my_grouped_agg_arrow_udf.__name__},
-                    logger="test_grouped_agg_arrow",
-                )
-                for n in [2, 3]
-            ],
-        )
+            assertDataFrameEqual(
+                logs.select("level", "msg", "context", "logger"),
+                [
+                    Row(
+                        level="WARNING",
+                        msg=f"grouped agg arrow udf: {n}",
+                        context={"func_name": my_grouped_agg_arrow_udf.__name__},
+                        logger="test_grouped_agg_arrow",
+                    )
+                    for n in [2, 3]
+                ],
+            )
 
 
 class GroupedAggArrowUDFTests(GroupedAggArrowUDFTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/arrow/test_arrow_udf_scalar.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf_scalar.py
@@ -1201,20 +1201,20 @@ class ScalarArrowUDFTestsMixin:
                 [Row(result=f"scalar_arrow_{i}") for i in range(3)],
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select("level", "msg", "context", "logger"),
-            [
-                Row(
-                    level="WARNING",
-                    msg=f"scalar arrow udf: {lst}",
-                    context={"func_name": my_scalar_arrow_udf.__name__},
-                    logger="test_scalar_arrow",
-                )
-                for lst in [[0], [1, 2]]
-            ],
-        )
+            assertDataFrameEqual(
+                logs.select("level", "msg", "context", "logger"),
+                [
+                    Row(
+                        level="WARNING",
+                        msg=f"scalar arrow udf: {lst}",
+                        context={"func_name": my_scalar_arrow_udf.__name__},
+                        logger="test_scalar_arrow",
+                    )
+                    for lst in [[0], [1, 2]]
+                ],
+            )
 
     @unittest.skipIf(is_remote_only(), "Requires JVM access")
     def test_scalar_iter_arrow_udf_with_logging(self):
@@ -1241,20 +1241,20 @@ class ScalarArrowUDFTestsMixin:
                 [Row(result=f"scalar_iter_arrow_{i}") for i in range(9)],
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select("level", "msg", "context", "logger"),
-            [
-                Row(
-                    level="WARNING",
-                    msg=f"scalar iter arrow udf: {lst}",
-                    context={"func_name": my_scalar_iter_arrow_udf.__name__},
-                    logger="test_scalar_iter_arrow",
-                )
-                for lst in [[0, 1, 2], [3], [4, 5, 6], [7, 8]]
-            ],
-        )
+            assertDataFrameEqual(
+                logs.select("level", "msg", "context", "logger"),
+                [
+                    Row(
+                        level="WARNING",
+                        msg=f"scalar iter arrow udf: {lst}",
+                        context={"func_name": my_scalar_iter_arrow_udf.__name__},
+                        logger="test_scalar_iter_arrow",
+                    )
+                    for lst in [[0, 1, 2], [3], [4, 5, 6], [7, 8]]
+                ],
+            )
 
 
 class ScalarArrowUDFTests(ScalarArrowUDFTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/arrow/test_arrow_udf_window.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf_window.py
@@ -834,20 +834,20 @@ class WindowArrowUDFTestsMixin:
                 ],
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select("level", "msg", "context", "logger"),
-            [
-                Row(
-                    level="WARNING",
-                    msg=f"window arrow udf: {lst}",
-                    context={"func_name": my_window_arrow_udf.__name__},
-                    logger="test_window_arrow",
-                )
-                for lst in [[1.0], [1.0, 2.0], [3.0], [3.0, 5.0], [3.0, 5.0, 10.0]]
-            ],
-        )
+            assertDataFrameEqual(
+                logs.select("level", "msg", "context", "logger"),
+                [
+                    Row(
+                        level="WARNING",
+                        msg=f"window arrow udf: {lst}",
+                        context={"func_name": my_window_arrow_udf.__name__},
+                        logger="test_window_arrow",
+                    )
+                    for lst in [[1.0], [1.0, 2.0], [3.0], [3.0, 5.0], [3.0, 5.0, 10.0]]
+                ],
+            )
 
 
 class WindowArrowUDFTests(WindowArrowUDFTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/arrow/test_arrow_udtf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udtf.py
@@ -1721,20 +1721,20 @@ class ArrowUDTFTestsMixin:
                 [Row(id=i, doubled=i * 2) for i in range(9)],
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select("level", "msg", "context", "logger"),
-            [
-                Row(
-                    level="WARNING",
-                    msg=f"arrow udtf: {dict(id=lst)}",
-                    context={"class_name": "TestArrowUDTFWithLogging", "func_name": "eval"},
-                    logger="test_arrow_udtf",
-                )
-                for lst in [[0, 1, 2], [3], [4, 5, 6], [7, 8]]
-            ],
-        )
+            assertDataFrameEqual(
+                logs.select("level", "msg", "context", "logger"),
+                [
+                    Row(
+                        level="WARNING",
+                        msg=f"arrow udtf: {dict(id=lst)}",
+                        context={"class_name": "TestArrowUDTFWithLogging", "func_name": "eval"},
+                        logger="test_arrow_udtf",
+                    )
+                    for lst in [[0, 1, 2], [3], [4, 5, 6], [7, 8]]
+                ],
+            )
 
 
 class ArrowUDTFTests(ArrowUDTFTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
@@ -742,20 +742,20 @@ class CogroupedApplyInPandasTestsMixin:
                 + [Row(id=2, v1=20, v2=200)],
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select("level", "msg", "context", "logger"),
-            [
-                Row(
-                    level="WARNING",
-                    msg=f"pandas cogrouped map: {dict(v1=v1, v2=v2)}",
-                    context={"func_name": func_with_logging.__name__},
-                    logger="test_pandas_cogrouped_map",
-                )
-                for v1, v2 in [([10, 30], [100, 300]), ([20], [200])]
-            ],
-        )
+            assertDataFrameEqual(
+                logs.select("level", "msg", "context", "logger"),
+                [
+                    Row(
+                        level="WARNING",
+                        msg=f"pandas cogrouped map: {dict(v1=v1, v2=v2)}",
+                        context={"func_name": func_with_logging.__name__},
+                        logger="test_pandas_cogrouped_map",
+                    )
+                    for v1, v2 in [([10, 30], [100, 300]), ([20], [200])]
+                ],
+            )
 
 
 class CogroupedApplyInPandasTests(CogroupedApplyInPandasTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -1000,20 +1000,20 @@ class ApplyInPandasTestsMixin:
                 df,
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select("level", "msg", "context", "logger"),
-            [
-                Row(
-                    level="WARNING",
-                    msg=f"pandas grouped map: {dict(id=lst, value=[v*10 for v in lst])}",
-                    context={"func_name": func_with_logging.__name__},
-                    logger="test_pandas_grouped_map",
-                )
-                for lst in [[0, 2, 4, 6, 8], [1, 3, 5, 7]]
-            ],
-        )
+            assertDataFrameEqual(
+                logs.select("level", "msg", "context", "logger"),
+                [
+                    Row(
+                        level="WARNING",
+                        msg=f"pandas grouped map: {dict(id=lst, value=[v*10 for v in lst])}",
+                        context={"func_name": func_with_logging.__name__},
+                        logger="test_pandas_grouped_map",
+                    )
+                    for lst in [[0, 2, 4, 6, 8], [1, 3, 5, 7]]
+                ],
+            )
 
     def test_apply_in_pandas_iterator_basic(self):
         df = self.spark.createDataFrame(

--- a/python/pyspark/sql/tests/pandas/test_pandas_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_map.py
@@ -510,20 +510,20 @@ class MapInPandasTestsMixin:
                 [Row(id=i) for i in range(9)],
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select("level", "msg", "context", "logger"),
-            [
-                Row(
-                    level="WARNING",
-                    msg=f"pandas map: {lst}",
-                    context={"func_name": func_with_logging.__name__},
-                    logger="test_pandas_map",
-                )
-                for lst in [[0, 1, 2], [3], [4, 5, 6], [7, 8]]
-            ],
-        )
+            assertDataFrameEqual(
+                logs.select("level", "msg", "context", "logger"),
+                [
+                    Row(
+                        level="WARNING",
+                        msg=f"pandas map: {lst}",
+                        context={"func_name": func_with_logging.__name__},
+                        logger="test_pandas_map",
+                    )
+                    for lst in [[0, 1, 2], [3], [4, 5, 6], [7, 8]]
+                ],
+            )
 
 
 class MapInPandasTests(ReusedSQLTestCase, MapInPandasTestsMixin):

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_grouped_agg.py
@@ -846,20 +846,20 @@ class GroupedAggPandasUDFTestsMixin:
                 [Row(id=1, result=3.0), Row(id=2, result=18.0)],
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select("level", "msg", "context", "logger"),
-            [
-                Row(
-                    level="WARNING",
-                    msg=f"grouped agg pandas udf: {n}",
-                    context={"func_name": my_grouped_agg_pandas_udf.__name__},
-                    logger="test_grouped_agg_pandas",
-                )
-                for n in [2, 3]
-            ],
-        )
+            assertDataFrameEqual(
+                logs.select("level", "msg", "context", "logger"),
+                [
+                    Row(
+                        level="WARNING",
+                        msg=f"grouped agg pandas udf: {n}",
+                        context={"func_name": my_grouped_agg_pandas_udf.__name__},
+                        logger="test_grouped_agg_pandas",
+                    )
+                    for n in [2, 3]
+                ],
+            )
 
     def test_grouped_agg_pandas_udf_with_compression_codec(self):
         # Test grouped agg Pandas UDF with different compression codec settings

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -1935,20 +1935,20 @@ class ScalarPandasUDFTestsMixin:
                 [Row(result=f"scalar_pandas_{i}") for i in range(3)],
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select("level", "msg", "context", "logger"),
-            [
-                Row(
-                    level="WARNING",
-                    msg=f"scalar pandas udf: {lst}",
-                    context={"func_name": my_scalar_pandas_udf.__name__},
-                    logger="test_scalar_pandas",
-                )
-                for lst in [[0], [1, 2]]
-            ],
-        )
+            assertDataFrameEqual(
+                logs.select("level", "msg", "context", "logger"),
+                [
+                    Row(
+                        level="WARNING",
+                        msg=f"scalar pandas udf: {lst}",
+                        context={"func_name": my_scalar_pandas_udf.__name__},
+                        logger="test_scalar_pandas",
+                    )
+                    for lst in [[0], [1, 2]]
+                ],
+            )
 
     @unittest.skipIf(is_remote_only(), "Requires JVM access")
     def test_scalar_iter_pandas_udf_with_logging(self):
@@ -1973,20 +1973,20 @@ class ScalarPandasUDFTestsMixin:
                 [Row(result=f"scalar_iter_pandas_{i}") for i in range(9)],
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select("level", "msg", "context", "logger"),
-            [
-                Row(
-                    level="WARNING",
-                    msg=f"scalar iter pandas udf: {lst}",
-                    context={"func_name": my_scalar_iter_pandas_udf.__name__},
-                    logger="test_scalar_iter_pandas",
-                )
-                for lst in [[0, 1, 2], [3], [4, 5, 6], [7, 8]]
-            ],
-        )
+            assertDataFrameEqual(
+                logs.select("level", "msg", "context", "logger"),
+                [
+                    Row(
+                        level="WARNING",
+                        msg=f"scalar iter pandas udf: {lst}",
+                        context={"func_name": my_scalar_iter_pandas_udf.__name__},
+                        logger="test_scalar_iter_pandas",
+                    )
+                    for lst in [[0, 1, 2], [3], [4, 5, 6], [7, 8]]
+                ],
+            )
 
     def test_scalar_pandas_udf_with_compression_codec(self):
         # Test scalar Pandas UDF with different compression codec settings

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_window.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_window.py
@@ -664,20 +664,20 @@ class WindowPandasUDFTestsMixin:
                 ],
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select("level", "msg", "context", "logger"),
-            [
-                Row(
-                    level="WARNING",
-                    msg=f"window pandas udf: {lst}",
-                    context={"func_name": my_window_pandas_udf.__name__},
-                    logger="test_window_pandas",
-                )
-                for lst in [[1.0], [1.0, 2.0], [3.0], [3.0, 5.0], [3.0, 5.0, 10.0]]
-            ],
-        )
+            assertDataFrameEqual(
+                logs.select("level", "msg", "context", "logger"),
+                [
+                    Row(
+                        level="WARNING",
+                        msg=f"window pandas udf: {lst}",
+                        context={"func_name": my_window_pandas_udf.__name__},
+                        logger="test_window_pandas",
+                    )
+                    for lst in [[1.0], [1.0, 2.0], [3.0], [3.0, 5.0], [3.0, 5.0, 10.0]]
+                ],
+            )
 
 
 class WindowPandasUDFTests(WindowPandasUDFTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -965,49 +965,49 @@ class BasePythonDataSourceTestsMixin:
                 ],
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select("level", "msg", "context", "logger"),
-            [
-                Row(
-                    level="WARNING",
-                    msg=msg,
-                    context=context,
-                    logger="test_data_source_reader",
-                )
-                for msg, context in [
-                    (
-                        "TestJsonDataSource.__init__: ['path']",
-                        {"class_name": "TestJsonDataSource", "func_name": "__init__"},
-                    ),
-                    (
-                        "TestJsonDataSource.name",
-                        {"class_name": "TestJsonDataSource", "func_name": "name"},
-                    ),
-                    (
-                        "TestJsonDataSource.schema",
-                        {"class_name": "TestJsonDataSource", "func_name": "schema"},
-                    ),
-                    (
-                        "TestJsonDataSource.reader: ['name', 'age']",
-                        {"class_name": "TestJsonDataSource", "func_name": "reader"},
-                    ),
-                    (
-                        "TestJsonReader.__init__: ['path']",
-                        {"class_name": "TestJsonDataSource", "func_name": "reader"},
-                    ),
-                    (
-                        "TestJsonReader.partitions",
-                        {"class_name": "TestJsonReader", "func_name": "partitions"},
-                    ),
-                    (
-                        "TestJsonReader.read: None",
-                        {"class_name": "TestJsonReader", "func_name": "read"},
-                    ),
-                ]
-            ],
-        )
+            assertDataFrameEqual(
+                logs.select("level", "msg", "context", "logger"),
+                [
+                    Row(
+                        level="WARNING",
+                        msg=msg,
+                        context=context,
+                        logger="test_data_source_reader",
+                    )
+                    for msg, context in [
+                        (
+                            "TestJsonDataSource.__init__: ['path']",
+                            {"class_name": "TestJsonDataSource", "func_name": "__init__"},
+                        ),
+                        (
+                            "TestJsonDataSource.name",
+                            {"class_name": "TestJsonDataSource", "func_name": "name"},
+                        ),
+                        (
+                            "TestJsonDataSource.schema",
+                            {"class_name": "TestJsonDataSource", "func_name": "schema"},
+                        ),
+                        (
+                            "TestJsonDataSource.reader: ['name', 'age']",
+                            {"class_name": "TestJsonDataSource", "func_name": "reader"},
+                        ),
+                        (
+                            "TestJsonReader.__init__: ['path']",
+                            {"class_name": "TestJsonDataSource", "func_name": "reader"},
+                        ),
+                        (
+                            "TestJsonReader.partitions",
+                            {"class_name": "TestJsonReader", "func_name": "partitions"},
+                        ),
+                        (
+                            "TestJsonReader.read: None",
+                            {"class_name": "TestJsonReader", "func_name": "read"},
+                        ),
+                    ]
+                ],
+            )
 
     @unittest.skipIf(is_remote_only(), "Requires JVM access")
     def test_data_source_reader_pushdown_with_logging(self):
@@ -1072,53 +1072,53 @@ class BasePythonDataSourceTestsMixin:
                 ],
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select("level", "msg", "context", "logger"),
-            [
-                Row(
-                    level="WARNING",
-                    msg=msg,
-                    context=context,
-                    logger="test_data_source_reader_pushdown",
-                )
-                for msg, context in [
-                    (
-                        "TestJsonDataSource.__init__: ['path']",
-                        {"class_name": "TestJsonDataSource", "func_name": "__init__"},
-                    ),
-                    (
-                        "TestJsonDataSource.name",
-                        {"class_name": "TestJsonDataSource", "func_name": "name"},
-                    ),
-                    (
-                        "TestJsonDataSource.schema",
-                        {"class_name": "TestJsonDataSource", "func_name": "schema"},
-                    ),
-                    (
-                        "TestJsonDataSource.reader: ['name', 'age']",
-                        {"class_name": "TestJsonDataSource", "func_name": "reader"},
-                    ),
-                    (
-                        "TestJsonReader.pushFilters: [IsNotNull(attribute=('age',))]",
-                        {"class_name": "TestJsonReader", "func_name": "pushFilters"},
-                    ),
-                    (
-                        "TestJsonReader.__init__: ['path']",
-                        {"class_name": "TestJsonDataSource", "func_name": "reader"},
-                    ),
-                    (
-                        "TestJsonReader.partitions",
-                        {"class_name": "TestJsonReader", "func_name": "partitions"},
-                    ),
-                    (
-                        "TestJsonReader.read: None",
-                        {"class_name": "TestJsonReader", "func_name": "read"},
-                    ),
-                ]
-            ],
-        )
+            assertDataFrameEqual(
+                logs.select("level", "msg", "context", "logger"),
+                [
+                    Row(
+                        level="WARNING",
+                        msg=msg,
+                        context=context,
+                        logger="test_data_source_reader_pushdown",
+                    )
+                    for msg, context in [
+                        (
+                            "TestJsonDataSource.__init__: ['path']",
+                            {"class_name": "TestJsonDataSource", "func_name": "__init__"},
+                        ),
+                        (
+                            "TestJsonDataSource.name",
+                            {"class_name": "TestJsonDataSource", "func_name": "name"},
+                        ),
+                        (
+                            "TestJsonDataSource.schema",
+                            {"class_name": "TestJsonDataSource", "func_name": "schema"},
+                        ),
+                        (
+                            "TestJsonDataSource.reader: ['name', 'age']",
+                            {"class_name": "TestJsonDataSource", "func_name": "reader"},
+                        ),
+                        (
+                            "TestJsonReader.pushFilters: [IsNotNull(attribute=('age',))]",
+                            {"class_name": "TestJsonReader", "func_name": "pushFilters"},
+                        ),
+                        (
+                            "TestJsonReader.__init__: ['path']",
+                            {"class_name": "TestJsonDataSource", "func_name": "reader"},
+                        ),
+                        (
+                            "TestJsonReader.partitions",
+                            {"class_name": "TestJsonReader", "func_name": "partitions"},
+                        ),
+                        (
+                            "TestJsonReader.read: None",
+                            {"class_name": "TestJsonReader", "func_name": "read"},
+                        ),
+                    ]
+                ],
+            )
 
     @unittest.skipIf(is_remote_only(), "Requires JVM access")
     def test_data_source_writer_with_logging(self):
@@ -1197,69 +1197,69 @@ class BasePythonDataSourceTestsMixin:
                 with self.assertRaises(Exception, msg="abort test"):
                     df.write.format("my-json").mode("append").option("abort", "true").save(d)
 
-        logs = self.spark.table("system.session.python_worker_logs")
+                logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select("level", "msg", "context", "logger"),
-            [
-                Row(
-                    level="WARNING",
-                    msg=msg,
-                    context=context,
-                    logger="test_datasource_writer",
+                assertDataFrameEqual(
+                    logs.select("level", "msg", "context", "logger"),
+                    [
+                        Row(
+                            level="WARNING",
+                            msg=msg,
+                            context=context,
+                            logger="test_datasource_writer",
+                        )
+                        for msg, context in [
+                            (
+                                "TestJsonDataSource.name",
+                                {"class_name": "TestJsonDataSource", "func_name": "name"},
+                            ),
+                            (
+                                "TestJsonDataSource.writer: (['name', 'age'], {True})",
+                                {"class_name": "TestJsonDataSource", "func_name": "writer"},
+                            ),
+                            (
+                                "TestJsonWriter.__init__: ['path']",
+                                {"class_name": "TestJsonDataSource", "func_name": "writer"},
+                            ),
+                            (
+                                "TestJsonWriter.write: 1, [{'name': 'Diana', 'age': 28}]",
+                                {"class_name": "TestJsonWriter", "func_name": "write"},
+                            ),
+                            (
+                                "TestJsonWriter.write: 1, [{'name': 'Charlie', 'age': 35}]",
+                                {"class_name": "TestJsonWriter", "func_name": "write"},
+                            ),
+                            (
+                                "TestJsonWriter.commit: 2",
+                                {"class_name": "TestJsonWriter", "func_name": "commit"},
+                            ),
+                            (
+                                "TestJsonDataSource.name",
+                                {"class_name": "TestJsonDataSource", "func_name": "name"},
+                            ),
+                            (
+                                "TestJsonDataSource.writer: (['name', 'age'], {False})",
+                                {"class_name": "TestJsonDataSource", "func_name": "writer"},
+                            ),
+                            (
+                                "TestJsonWriter.__init__: ['abort', 'path']",
+                                {"class_name": "TestJsonDataSource", "func_name": "writer"},
+                            ),
+                            (
+                                "TestJsonWriter.write: abort test",
+                                {"class_name": "TestJsonWriter", "func_name": "write"},
+                            ),
+                            (
+                                "TestJsonWriter.write: abort test",
+                                {"class_name": "TestJsonWriter", "func_name": "write"},
+                            ),
+                            (
+                                "TestJsonWriter.abort",
+                                {"class_name": "TestJsonWriter", "func_name": "abort"},
+                            ),
+                        ]
+                    ],
                 )
-                for msg, context in [
-                    (
-                        "TestJsonDataSource.name",
-                        {"class_name": "TestJsonDataSource", "func_name": "name"},
-                    ),
-                    (
-                        "TestJsonDataSource.writer: (['name', 'age'], {True})",
-                        {"class_name": "TestJsonDataSource", "func_name": "writer"},
-                    ),
-                    (
-                        "TestJsonWriter.__init__: ['path']",
-                        {"class_name": "TestJsonDataSource", "func_name": "writer"},
-                    ),
-                    (
-                        "TestJsonWriter.write: 1, [{'name': 'Diana', 'age': 28}]",
-                        {"class_name": "TestJsonWriter", "func_name": "write"},
-                    ),
-                    (
-                        "TestJsonWriter.write: 1, [{'name': 'Charlie', 'age': 35}]",
-                        {"class_name": "TestJsonWriter", "func_name": "write"},
-                    ),
-                    (
-                        "TestJsonWriter.commit: 2",
-                        {"class_name": "TestJsonWriter", "func_name": "commit"},
-                    ),
-                    (
-                        "TestJsonDataSource.name",
-                        {"class_name": "TestJsonDataSource", "func_name": "name"},
-                    ),
-                    (
-                        "TestJsonDataSource.writer: (['name', 'age'], {False})",
-                        {"class_name": "TestJsonDataSource", "func_name": "writer"},
-                    ),
-                    (
-                        "TestJsonWriter.__init__: ['abort', 'path']",
-                        {"class_name": "TestJsonDataSource", "func_name": "writer"},
-                    ),
-                    (
-                        "TestJsonWriter.write: abort test",
-                        {"class_name": "TestJsonWriter", "func_name": "write"},
-                    ),
-                    (
-                        "TestJsonWriter.write: abort test",
-                        {"class_name": "TestJsonWriter", "func_name": "write"},
-                    ),
-                    (
-                        "TestJsonWriter.abort",
-                        {"class_name": "TestJsonWriter", "func_name": "abort"},
-                    ),
-                ]
-            ],
-        )
 
 
 class PythonDataSourceTests(BasePythonDataSourceTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -3079,20 +3079,20 @@ class BaseUDTFTestsMixin:
                 [Row(x=x, a=x * 2, b=x + 10) for x in [5, 10]],
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select("level", "msg", "context", "logger"),
-            [
-                Row(
-                    level="WARNING",
-                    msg=f"udtf with logging: {x}",
-                    context={"class_name": "TestUDTFWithLogging", "func_name": "eval"},
-                    logger="test_udtf",
-                )
-                for x in [5, 10]
-            ],
-        )
+            assertDataFrameEqual(
+                logs.select("level", "msg", "context", "logger"),
+                [
+                    Row(
+                        level="WARNING",
+                        msg=f"udtf with logging: {x}",
+                        context={"class_name": "TestUDTFWithLogging", "func_name": "eval"},
+                        logger="test_udtf",
+                    )
+                    for x in [5, 10]
+                ],
+            )
 
     @unittest.skipIf(is_remote_only(), "Requires JVM access")
     def test_udtf_analyze_with_logging(self):
@@ -3115,26 +3115,26 @@ class BaseUDTFTestsMixin:
                 [Row(x=x, a=x * 2, b=x + 10) for x in [5, 10]],
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select(
-                "level",
-                "msg",
-                col("context.class_name").alias("context_class_name"),
-                col("context.func_name").alias("context_func_name"),
-                "logger",
-            ).distinct(),
-            [
-                Row(
-                    level="WARNING",
-                    msg='udtf analyze: "long"',
-                    context_class_name="TestUDTFWithLogging",
-                    context_func_name="analyze",
-                    logger="test_udtf",
-                )
-            ],
-        )
+            assertDataFrameEqual(
+                logs.select(
+                    "level",
+                    "msg",
+                    col("context.class_name").alias("context_class_name"),
+                    col("context.func_name").alias("context_func_name"),
+                    "logger",
+                ).distinct(),
+                [
+                    Row(
+                        level="WARNING",
+                        msg='udtf analyze: "long"',
+                        context_class_name="TestUDTFWithLogging",
+                        context_func_name="analyze",
+                        logger="test_udtf",
+                    )
+                ],
+            )
 
     @unittest.skipIf(is_remote_only(), "Requires JVM access")
     def test_udtf_analyze_with_pyspark_logger(self):
@@ -3157,28 +3157,28 @@ class BaseUDTFTestsMixin:
                 [Row(x=x, a=x * 2, b=x + 10) for x in [5, 10]],
             )
 
-        logs = self.spark.table("system.session.python_worker_logs")
+            logs = self.spark.tvf.python_worker_logs()
 
-        assertDataFrameEqual(
-            logs.select(
-                "level",
-                "msg",
-                col("context.class_name").alias("context_class_name"),
-                col("context.func_name").alias("context_func_name"),
-                col("context.dt").alias("context_dt"),
-                "logger",
-            ).distinct(),
-            [
-                Row(
-                    level="WARNING",
-                    msg='udtf analyze: "long"',
-                    context_class_name="TestUDTFWithLogging",
-                    context_func_name="analyze",
-                    context_dt='"long"',
-                    logger="PySparkLogger",
-                )
-            ],
-        )
+            assertDataFrameEqual(
+                logs.select(
+                    "level",
+                    "msg",
+                    col("context.class_name").alias("context_class_name"),
+                    col("context.func_name").alias("context_func_name"),
+                    col("context.dt").alias("context_dt"),
+                    "logger",
+                ).distinct(),
+                [
+                    Row(
+                        level="WARNING",
+                        msg='udtf analyze: "long"',
+                        context_class_name="TestUDTFWithLogging",
+                        context_func_name="analyze",
+                        context_dt='"long"',
+                        logger="PySparkLogger",
+                    )
+                ],
+            )
 
 
 class UDTFTests(BaseUDTFTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tvf.py
+++ b/python/pyspark/sql/tvf.py
@@ -677,6 +677,45 @@ class TableValuedFunction:
         """
         return self._fn("variant_explode_outer", input)
 
+    def python_worker_logs(self) -> DataFrame:
+        """
+        Returns a DataFrame of logs collected from Python workers.
+
+        .. versionadded:: 4.1.0
+
+        Returns
+        -------
+        :class:`DataFrame`
+
+        Examples
+        --------
+        >>> import pyspark.sql.functions as sf
+        >>> import logging
+        >>>
+        >>> @sf.udf("string")
+        ... def my_udf(x):
+        ...     logger = logging.getLogger("my_custom_logger")
+        ...     logger.warning("This is a warning")
+        ...     return str(x)
+        ...
+        >>> spark.conf.set("spark.sql.pyspark.worker.logging.enabled", "true")
+        >>> spark.range(1).select(my_udf("id")).show()
+        +----------+
+        |my_udf(id)|
+        +----------+
+        |         0|
+        +----------+
+        >>> spark.tvf.python_worker_logs().select(
+        ...     "level", "msg", "context", "logger"
+        ... ).show(truncate=False)  # doctest: +SKIP
+        +-------+-----------------+---------------------+----------------+
+        |level  |msg              |context              |logger          |
+        +-------+-----------------+---------------------+----------------+
+        |WARNING|This is a warning|{func_name -> my_udf}|my_custom_logger|
+        +-------+-----------------+---------------------+----------------+
+        """
+        return self._fn("python_worker_logs")
+
     def _fn(self, functionName: str, *args: Column) -> DataFrame:
         from pyspark.sql.classic.column import _to_java_column
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/TableValuedFunction.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/TableValuedFunction.scala
@@ -181,4 +181,12 @@ abstract class TableValuedFunction {
    * @since 4.0.0
    */
   def variant_explode_outer(input: Column): Dataset[Row]
+
+  /**
+   * Returns a `DataFrame` of logs collected from Python workers.
+   *
+   * @group table_funcs
+   * @since 4.1.0
+   */
+  def python_worker_logs(): Dataset[Row]
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.expressions.st._
 import org.apache.spark.sql.catalyst.expressions.variant._
 import org.apache.spark.sql.catalyst.expressions.xml._
-import org.apache.spark.sql.catalyst.plans.logical.{FunctionBuilderBase, Generate, LogicalPlan, OneRowRelation, Range}
+import org.apache.spark.sql.catalyst.plans.logical.{FunctionBuilderBase, Generate, LogicalPlan, OneRowRelation, PythonWorkerLogs, Range}
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.internal.SQLConf
@@ -1233,7 +1233,8 @@ object TableFunctionRegistry {
     generator[Collations]("collations"),
     generator[SQLKeywords]("sql_keywords"),
     generatorBuilder("variant_explode", VariantExplodeGeneratorBuilder),
-    generatorBuilder("variant_explode_outer", VariantExplodeOuterGeneratorBuilder)
+    generatorBuilder("variant_explode_outer", VariantExplodeOuterGeneratorBuilder),
+    PythonWorkerLogs.functionBuilder
   )
 
   val builtin: SimpleTableFunctionRegistry = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.catalog.{
   TemporaryViewRelation,
   UnresolvedCatalogRelation
 }
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, PythonWorkerLogs, SubqueryAlias}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, SubqueryAlias}
 import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
 import org.apache.spark.sql.connector.catalog.{
   CatalogManager,
@@ -112,8 +112,6 @@ class RelationResolution(override val catalogManager: CatalogManager)
       u.isStreaming,
       finalTimeTravelSpec.isDefined
     ).orElse {
-      resolveSystemSessionView(u.multipartIdentifier)
-    }.orElse {
       expandIdentifier(u.multipartIdentifier) match {
         case CatalogAndIdentifier(catalog, ident) =>
           val key = toCacheKey(catalog, ident, finalTimeTravelSpec)
@@ -236,22 +234,6 @@ class RelationResolution(override val catalogManager: CatalogManager)
         case (a, b) => resolver(a, b)
       }
     }
-  }
-
-  private def isSystemSessionIdentifier(identifier: Seq[String]): Boolean = {
-    identifier.length > 2 &&
-      identifier(0).equalsIgnoreCase(CatalogManager.SYSTEM_CATALOG_NAME) &&
-      identifier(1).equalsIgnoreCase(CatalogManager.SESSION_NAMESPACE)
-  }
-
-  private def resolveSystemSessionView(
-      identifier: Seq[String]): Option[LogicalPlan] = {
-    if (isSystemSessionIdentifier(identifier)) {
-      Option(identifier.drop(2)).collect {
-        case Seq(viewName) if viewName.equalsIgnoreCase(PythonWorkerLogs.ViewName) =>
-          PythonWorkerLogs.viewDefinition()
-      }
-    } else None
   }
 
   private def toCacheKey(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -4419,4 +4419,15 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       origin = origin
     )
   }
+
+  def pythonWorkerLoggingNotEnabledError(): Throwable = {
+    new AnalysisException(
+      errorClass = "FEATURE_NOT_ENABLED",
+      messageParameters = Map(
+        "featureName" -> "Python Worker Logging",
+        "configKey" -> "spark.sql.pyspark.worker.logging.enabled",
+        "configValue" -> "true"
+      )
+    )
+  }
 }

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/TableValuedFunction.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/TableValuedFunction.scala
@@ -102,4 +102,8 @@ class TableValuedFunction(sparkSession: SparkSession) extends sql.TableValuedFun
   /** @inheritdoc */
   override def variant_explode_outer(input: Column): Dataset[Row] =
     fn("variant_explode_outer", Seq(input))
+
+  /** @inheritdoc */
+  override def python_worker_logs(): Dataset[Row] =
+    fn("python_worker_logs", Seq.empty)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/TableValuedFunction.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/TableValuedFunction.scala
@@ -97,4 +97,8 @@ class TableValuedFunction(sparkSession: SparkSession)
   /** @inheritdoc */
   override def variant_explode_outer(input: Column): Dataset[Row] =
     fn("variant_explode_outer", Seq(input))
+
+  /** @inheritdoc */
+  override def python_worker_logs(): Dataset[Row] =
+    fn("python_worker_logs", Seq.empty)
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Changes the way to access logs to TVF instead of system view.

```sql
SELECT * FROM python_worker_logs()
```

```py
spark.tvf.python_worker_logs()
```

Also blocks the TVF when the python worker logging is disabled.

```py
>>> spark.conf.get('spark.sql.pyspark.worker.logging.enabled')
'false'
>>> spark.tvf.python_worker_logs().show()
Traceback (most recent call last):
...
pyspark.errors.exceptions.captured.AnalysisException: [FEATURE_NOT_ENABLED] The feature Python Worker Logging is not enabled. Consider setting the config spark.sql.pyspark.worker.logging.enabled to true to enable this capability. SQLSTATE: 56038

>>> spark.conf.set('spark.sql.pyspark.worker.logging.enabled', True)
>>> spark.tvf.python_worker_logs().show()
+---+-----+---+-------+---------+------+
| ts|level|msg|context|exception|logger|
+---+-----+---+-------+---------+------+
+---+-----+---+-------+---------+------+
```

### Why are the changes needed?

There may be namespace conflicts with the other system tables/views, etc..

For example, the variables in SQL has the same namespace `system.session.varname`, which may potentially cause an issue.

### Does this PR introduce _any_ user-facing change?

Yes, the way to access python worker logs will be changed.

### How was this patch tested?

Modified the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.