### PR TITLE
[SPARK-54326][INFRA] Recover MacOS CIs by installing `zstandard==0.25.0`

### DIFF
--- a/.github/workflows/python_hosted_runner_test.yml
+++ b/.github/workflows/python_hosted_runner_test.yml
@@ -148,7 +148,7 @@ jobs:
           python${{matrix.python}} -m pip install --ignore-installed 'blinker>=1.6.2'
           python${{matrix.python}} -m pip install --ignore-installed 'six==1.16.0'
           python${{matrix.python}} -m pip install numpy 'pyarrow>=22.0.0' 'six==1.16.0' 'pandas==2.3.3' scipy 'plotly<6.0.0' 'mlflow>=2.8.1' coverage matplotlib openpyxl 'memory-profiler>=0.61.0' 'scikit-learn>=1.3.2' unittest-xml-reporting && \
-          python${{matrix.python}} -m pip install 'grpcio==1.76.0' 'grpcio-status==1.76.0' 'protobuf==6.33.0' 'googleapis-common-protos==1.71.0' 'graphviz==0.20.3' && \
+          python${{matrix.python}} -m pip install 'grpcio==1.76.0' 'grpcio-status==1.76.0' 'protobuf==6.33.0' 'googleapis-common-protos==1.71.0' 'zstandard==0.25.0' 'graphviz==0.20.3' && \
           python${{matrix.python}} -m pip cache purge
       - name: List Python packages
         run: python${{matrix.python}} -m pip list


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to recover MacOS CIs by installing `zstandard==0.25.0`.

### Why are the changes needed?

After SPARK-54194, `zstandard` Python package is required for `Connect`.
- https://github.com/apache/spark/pull/52894

Currently, MacOS CIs are broken.
- https://github.com/apache/spark/actions/workflows/build_python_3.11_macos26.yml
- https://github.com/apache/spark/actions/workflows/build_python_3.11_macos.yml

```
Traceback (most recent call last):
  File "/Users/runner/work/spark/spark/python/pyspark/sql/connect/utils.py", line 105, in require_minimum_zstandard_version
    import zstandard  # noqa
    ^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'zstandard'
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs and manual review because MacOS CIs are triggered daily CIs only.

### Was this patch authored or co-authored using generative AI tooling?

No.