### PR TITLE
[SHUFFLE][WIP]Prototype using remote storage for shuffle 

### DIFF
--- a/core/src/main/java/org/apache/spark/storage/FileSystemManagedBuffer.java
+++ b/core/src/main/java/org/apache/spark/storage/FileSystemManagedBuffer.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.storage;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import org.apache.spark.network.buffer.ManagedBuffer;
+
+/**
+ * A {@link ManagedBuffer} backed by a file using Hadoop FileSystem.
+ * This buffer creates an input stream with a 64MB buffer size for efficient reading.
+ * Note: This implementation throws UnsupportedOperationException for methods that
+ * require loading the entire file into memory (nioByteBuffer, convertToNetty, convertToNettyForSsl)
+ * as files can be very large and loading them entirely into memory is not practical.
+ */
+public class FileSystemManagedBuffer extends ManagedBuffer {
+  private int bufferSize; // 64MB buffer size
+  private final Path filePath;
+  private final long fileSize;
+  private final Configuration hadoopConf;
+
+  public FileSystemManagedBuffer(Path filePath, Configuration hadoopConf) throws IOException {
+    this.filePath = filePath;
+    this.hadoopConf = hadoopConf;
+    // Get file size using FileSystem.newInstance to avoid cached dependencies
+    FileSystem fileSystem = FileSystem.newInstance(filePath.toUri(), hadoopConf);
+    try {
+      this.fileSize = fileSystem.getFileStatus(filePath).getLen();
+    } finally {
+      fileSystem.close();
+    }
+    bufferSize = 64;
+  }
+
+  public FileSystemManagedBuffer(Path filePath, Configuration hadoopConf, int bufferSize)
+          throws IOException {
+    this(filePath, hadoopConf);
+    this.bufferSize = bufferSize;
+  }
+
+  @Override
+  public long size() {
+    return fileSize;
+  }
+
+  @Override
+  public ByteBuffer nioByteBuffer() throws IOException {
+    throw new UnsupportedOperationException(
+      "FileSystemManagedBuffer does not support nioByteBuffer() as it would require loading " +
+      "the entire file into memory, which is not practical for large files. " +
+      "Use createInputStream() instead.");
+  }
+
+  @Override
+  public InputStream createInputStream() throws IOException {
+    // Create a new FileSystem instance to avoid cached dependencies
+    // and create a buffered input stream with 64MB buffer size for efficient reading
+    FileSystem fileSystem = FileSystem.newInstance(filePath.toUri(), hadoopConf);
+    return fileSystem.open(filePath, bufferSize * 1024 * 1024);
+  }
+
+  @Override
+  public ManagedBuffer retain() {
+    // FileSystemManagedBuffer doesn't use reference counting, so just return this
+    return this;
+  }
+
+  @Override
+  public ManagedBuffer release() {
+    // FileSystemManagedBuffer doesn't use reference counting, so just return this
+    return this;
+  }
+
+  @Override
+  public Object convertToNetty() {
+    throw new UnsupportedOperationException(
+      "FileSystemManagedBuffer does not support convertToNetty() as it would require loading " +
+      "the entire file into memory, which is not practical for large files. " +
+      "Use createInputStream() instead.");
+  }
+
+  @Override
+  public Object convertToNettyForSsl() {
+    throw new UnsupportedOperationException(
+      "FileSystemManagedBuffer does not support convertToNettyForSsl()" +
+              " as it would require loading " +
+      "the entire file into memory, which is not practical for large files. " +
+      "Use createInputStream() instead.");
+  }
+
+  @Override
+  public String toString() {
+    return "FileSegmentManagedBuffer[file=" + filePath + ",length=" + fileSize + "]";
+  }
+}

--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -90,7 +90,9 @@ class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
     val mapSideCombine: Boolean = false,
     val shuffleWriterProcessor: ShuffleWriteProcessor = new ShuffleWriteProcessor,
     val rowBasedChecksums: Array[RowBasedChecksum] = ShuffleDependency.EMPTY_ROW_BASED_CHECKSUMS,
-    val checksumMismatchFullRetryEnabled: Boolean = false)
+    val checksumMismatchFullRetryEnabled: Boolean = false,
+    val useRemoteShuffleStorage: Boolean = false
+    )
   extends Dependency[Product2[K, V]] with Logging {
 
   def this(
@@ -249,7 +251,9 @@ class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
     )
   }
 
-  _rdd.sparkContext.cleaner.foreach(_.registerShuffleForCleanup(this))
+  if (!useRemoteShuffleStorage) {
+    _rdd.sparkContext.cleaner.foreach(_.registerShuffleForCleanup(this))
+  }
   _rdd.sparkContext.shuffleDriverComponents.registerShuffle(shuffleId)
 }
 

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -650,6 +650,8 @@ class SparkContext(config: SparkConf) extends Logging {
     _env.blockManager.initialize(_applicationId)
     FallbackStorage.registerBlockManagerIfNeeded(
       _env.blockManager.master, _conf, _hadoopConfiguration)
+    RemoteShuffleStorage.registerBlockManagerifNeeded(_env.blockManager.master, _conf,
+      _hadoopConfiguration)
 
     // The metrics system for Driver need to be set spark.app.id to app ID.
     // So it should start after we get app ID from the task scheduler and set spark.app.id.
@@ -2377,6 +2379,11 @@ class SparkContext(config: SparkConf) extends Logging {
     Utils.tryLogNonFatalError {
       FallbackStorage.cleanUp(_conf, _hadoopConfiguration)
     }
+
+    Utils.tryLogNonFatalError {
+      RemoteShuffleStorage.cleanUp(_conf, _hadoopConfiguration)
+    }
+
     Utils.tryLogNonFatalError {
       _eventLogger.foreach(_.stop())
     }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -626,6 +626,13 @@ package object config {
       .checkValue(_.endsWith(java.io.File.separator), "Path should end with separator.")
       .createOptional
 
+  private[spark] val SHUFFLE_REMOTE_STORAGE_CLEANUP =
+    ConfigBuilder("spark.shuffle.remote.storage.cleanUp")
+      .doc("If true, Spark cleans up its fallback storage data during shutting down.")
+      .version("3.2.0")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val STORAGE_DECOMMISSION_SHUFFLE_MAX_DISK_SIZE =
     ConfigBuilder("spark.storage.decommission.shuffleBlocks.maxDiskSize")
       .doc("Maximum disk space to use to store shuffle blocks before rejecting remote " +
@@ -2910,4 +2917,32 @@ package object config {
       .checkValue(v => v.forall(Set("stdout", "stderr").contains),
         "The value only can be one or more of 'stdout, stderr'.")
       .createWithDefault(Seq("stdout", "stderr"))
+
+  private[spark] val SHUFFLE_REMOTE_STORAGE_PATH =
+  ConfigBuilder("spark.shuffle.remote.storage.path")
+      .doc("The location for storing shuffle blocks on remote storage.")
+      .version("4.1.0")
+      .stringConf
+      .checkValue(_.endsWith(java.io.File.separator), "Path should end with separator.")
+      .createOptional
+
+  private[spark] val REMOTE_SHUFFLE_BUFFER_SIZE =
+    ConfigBuilder("spark.shuffle.remote.buffer.size")
+      .version("4.1.0")
+      .stringConf
+      .createWithDefault("64M")
+
+  private[spark] val START_REDUCERS_IN_PARALLEL_TO_MAPPER =
+    ConfigBuilder("spark.shuffle.consolidation.enabled")
+      .doc("starts reducers in parallel to mappers")
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(false)
+
+  private[spark] val EAGERNESS_THRESHOLD_PERCENTAGE =
+    ConfigBuilder("spark.shuffle.remote.eagerness.percentage")
+      .doc("Percentage of mapper complet tasks before starting reducers ")
+      .version("4.1.0")
+      .intConf
+      .createWithDefault(20)
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1755,7 +1755,12 @@ private[spark] class DAGScheduler(
         log"${MDC(STAGE, stage)} (${MDC(RDD_ID, stage.rdd)}) (first 15 tasks are " +
         log"for partitions ${MDC(PARTITION_IDS, tasks.take(15).map(_.partitionId))})")
       val shuffleId = stage match {
-        case s: ShuffleMapStage => Some(s.shuffleDep.shuffleId)
+        case s: ShuffleMapStage =>
+          // hack to prioritize remote shuffle writes
+          if (properties != null) {
+            properties.setProperty("remote", s.shuffleDep.useRemoteShuffleStorage.toString)
+          }
+          Some(s.shuffleDep.shuffleId)
         case _: ResultStage => None
       }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/Pool.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Pool.scala
@@ -53,8 +53,11 @@ private[spark] class Pool(
         new FairSchedulingAlgorithm()
       case SchedulingMode.FIFO =>
         new FIFOSchedulingAlgorithm()
+      case SchedulingMode.WEIGHTED_FIFO =>
+        new WeightedFIFOSchedulingAlgorithm()
       case _ =>
-        val msg = s"Unsupported scheduling mode: $schedulingMode. Use FAIR or FIFO instead."
+        val msg = s"Unsupported scheduling mode: $schedulingMode. Use FAIR, FIFO," +
+          s" or WEIGHTED_FIFO instead."
         throw new IllegalArgumentException(msg)
     }
   }

--- a/core/src/main/scala/org/apache/spark/scheduler/SchedulingAlgorithm.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SchedulingAlgorithm.scala
@@ -40,6 +40,25 @@ private[spark] class FIFOSchedulingAlgorithm extends SchedulingAlgorithm {
   }
 }
 
+private[spark] class WeightedFIFOSchedulingAlgorithm extends SchedulingAlgorithm {
+  override def comparator(s1: Schedulable, s2: Schedulable): Boolean = {
+    val priority1 = s1.priority
+    val priority2 = s2.priority
+    var res = math.signum(priority1 - priority2)
+    if (res == 0) {
+      if (s1.weight == s2.weight) {
+        val stageId1 = s1.stageId
+        val stageId2 = s2.stageId
+        res = math.signum(stageId1 - stageId2)
+      } else {
+        // Higher the weight, earlier should it run(unlike priority)
+        res = math.signum(s2.weight - s1.weight)
+      }
+    }
+    res < 0
+  }
+}
+
 private[spark] class FairSchedulingAlgorithm extends SchedulingAlgorithm {
   override def comparator(s1: Schedulable, s2: Schedulable): Boolean = {
     val minShare1 = s1.minShare

--- a/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
@@ -96,6 +96,7 @@ private[spark] class ShuffleMapTask(
 
     val rdd = rddAndDep._1
     val dep = rddAndDep._2
+
     // While we use the old shuffle fetch protocol, we use partitionId as mapId in the
     // ShuffleBlockId construction.
     val mapId = if (SparkEnv.get.conf.get(config.SHUFFLE_USE_OLD_FETCH_PROTOCOL)) {
@@ -115,3 +116,4 @@ private[spark] class ShuffleMapTask(
 
   override def toString: String = "ShuffleMapTask(%d, %d)".format(stageId, partitionId)
 }
+

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -213,6 +213,8 @@ private[spark] class TaskSchedulerImpl(
       schedulingMode match {
         case SchedulingMode.FIFO =>
           new FIFOSchedulableBuilder(rootPool)
+        case SchedulingMode.WEIGHTED_FIFO =>
+          new FIFOSchedulableBuilder(rootPool)
         case SchedulingMode.FAIR =>
           new FairSchedulableBuilder(rootPool, sc)
         case _ =>

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -19,6 +19,7 @@ package org.apache.spark.scheduler
 
 import java.io.NotSerializableException
 import java.nio.ByteBuffer
+import java.util.Locale
 import java.util.concurrent.{ConcurrentHashMap, ConcurrentLinkedQueue, TimeUnit}
 
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
@@ -133,7 +134,10 @@ private[spark] class TaskSetManager(
   val taskAttempts = Array.fill[List[TaskInfo]](numTasks)(Nil)
   private[scheduler] var tasksSuccessful = 0
 
-  val weight = 1
+  val weight = {
+    val remote: String = taskSet.properties.getOrDefault("remote", "false").toString
+    if (remote.toLowerCase(Locale.ROOT).equals("true")) 1000 else 1
+  }
   val minShare = 0
   var priority = taskSet.priority
   val stageId = taskSet.stageId

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleWriteProcessor.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleWriteProcessor.scala
@@ -48,6 +48,8 @@ private[spark] class ShuffleWriteProcessor extends Serializable with Logging {
       context: TaskContext): MapStatus = {
     var writer: ShuffleWriter[Any, Any] = null
     try {
+      context.getLocalProperties.setProperty("consolidation.write",
+        dep.useRemoteShuffleStorage.toString)
       val manager = SparkEnv.get.shuffleManager
       writer = manager.getWriter[Any, Any](
         dep.shuffleHandle,
@@ -85,6 +87,7 @@ private[spark] class ShuffleWriteProcessor extends Serializable with Logging {
           }
         }
       }
+
       mapStatus.get
     } catch {
       case e: Exception =>

--- a/core/src/main/scala/org/apache/spark/shuffle/sort/remote/HybridShuffleDataIO.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/remote/HybridShuffleDataIO.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.sort.remote
+
+import org.apache.spark.SparkConf
+import org.apache.spark.shuffle.api.ShuffleDataIO
+import org.apache.spark.shuffle.api.ShuffleDriverComponents
+import org.apache.spark.shuffle.api.ShuffleExecutorComponents
+import org.apache.spark.shuffle.sort.io.LocalDiskShuffleDriverComponents
+import org.apache.spark.shuffle.sort.io.LocalDiskShuffleExecutorComponents
+
+/**
+ * Implementation of the [[ShuffleDataIO]] plugin system that writes to the local and
+ * remote storage
+ */
+class HybridShuffleDataIO(sparkConf: SparkConf) extends ShuffleDataIO {
+
+  override def executor(): ShuffleExecutorComponents = {
+    new HybridShuffleExecutorComponents(sparkConf,
+      new LocalDiskShuffleExecutorComponents(sparkConf))
+  }
+
+  override def driver(): ShuffleDriverComponents = {
+    new HybridShuffleDriverComponents(new LocalDiskShuffleDriverComponents())
+  }
+}

--- a/core/src/main/scala/org/apache/spark/shuffle/sort/remote/HybridShuffleDriverComponents.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/remote/HybridShuffleDriverComponents.scala
@@ -15,16 +15,27 @@
  * limitations under the License.
  */
 
-package org.apache.spark.scheduler
+package org.apache.spark.shuffle.sort.remote
 
-/**
- *  "FAIR" and "FIFO" determines which policy is used
- *    to order tasks amongst a Schedulable's sub-queues
- *  "WEIGHTED_FIFO" is similar to FIFO but uses weight-based comparison in addition.
- *  "NONE" is used when the a Schedulable has no sub-queues.
- */
-object SchedulingMode extends Enumeration {
+import java.util.Collections
 
-  type SchedulingMode = Value
-  val FAIR, FIFO, WEIGHTED_FIFO, NONE = Value
+import org.apache.spark.shuffle.api.ShuffleDriverComponents
+import org.apache.spark.shuffle.sort.io.LocalDiskShuffleDriverComponents
+
+class HybridShuffleDriverComponents(
+       localDiskShuffleDriverComponents: LocalDiskShuffleDriverComponents)
+  extends ShuffleDriverComponents {
+
+  override def initializeApplication(): java.util.Map[String, String] = {
+    localDiskShuffleDriverComponents.initializeApplication()
+    Collections.emptyMap()
+  }
+
+  override def cleanupApplication(): Unit = {
+    localDiskShuffleDriverComponents.cleanupApplication()
+  }
+
+  override def removeShuffle(shuffleId: Int, blocking: Boolean): Unit = {
+    localDiskShuffleDriverComponents.removeShuffle(shuffleId, blocking)
+  }
 }

--- a/core/src/main/scala/org/apache/spark/shuffle/sort/remote/HybridShuffleExecutorComponents.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/remote/HybridShuffleExecutorComponents.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.sort.remote
+
+import java.util.Optional
+
+import org.apache.spark.{SparkConf, TaskContext}
+import org.apache.spark.shuffle.api.{ShuffleExecutorComponents, ShuffleMapOutputWriter, SingleSpillShuffleMapOutputWriter}
+import org.apache.spark.shuffle.sort.io.LocalDiskShuffleExecutorComponents
+
+class HybridShuffleExecutorComponents(sparkConf: SparkConf,
+    localDiskShuffleExecutorComponents: LocalDiskShuffleExecutorComponents)
+  extends ShuffleExecutorComponents {
+
+  override def initializeExecutor(appId: String, execId: String,
+                                  extraConfigs: java.util.Map[String, String]): Unit = {
+    localDiskShuffleExecutorComponents.initializeExecutor(appId, execId, extraConfigs)
+  }
+
+  override def createMapOutputWriter(
+      shuffleId: Int,
+      mapTaskId: Long,
+      numPartitions: Int): ShuffleMapOutputWriter = {
+    val isRemote = TaskContext.get().getLocalProperties
+      .getOrDefault("consolidation.write", "false").toString.toBoolean
+    if (isRemote) {
+      new RemoteShuffleMapOutputWriter(sparkConf, shuffleId, mapTaskId, numPartitions)
+    } else {
+      localDiskShuffleExecutorComponents.createMapOutputWriter(shuffleId, mapTaskId, numPartitions)
+    }
+  }
+
+  override def createSingleFileMapOutputWriter(
+      shuffleId: Int,
+      mapId: Long): Optional[SingleSpillShuffleMapOutputWriter] = {
+    Optional.empty()
+  }
+}

--- a/core/src/main/scala/org/apache/spark/shuffle/sort/remote/RemoteShuffleMapOutputWriter.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/remote/RemoteShuffleMapOutputWriter.scala
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.sort.remote
+
+import java.io.{BufferedOutputStream, IOException, OutputStream}
+import java.nio.ByteBuffer
+import java.nio.channels.{Channels, WritableByteChannel}
+import java.util.Optional
+
+import org.apache.hadoop.fs.FSDataOutputStream
+
+import org.apache.spark.{SparkConf, SparkEnv, TaskContext}
+import org.apache.spark.internal.{config, Logging}
+import org.apache.spark.internal.config.REMOTE_SHUFFLE_BUFFER_SIZE
+import org.apache.spark.shuffle.api.{ShuffleMapOutputWriter, ShufflePartitionWriter, WritableByteChannelWrapper}
+import org.apache.spark.shuffle.api.metadata.MapOutputCommitMessage
+import org.apache.spark.storage.{RemoteShuffleStorage, ShuffleChecksumBlockId, ShuffleDataBlockId}
+
+
+/** Implements the ShuffleMapOutputWriter interface.
+ *  It stores the shuffle output in one shuffle block.
+  *
+  * This file is based on Spark "LocalDiskShuffleMapOutputWriter.java".
+  */
+
+class RemoteShuffleMapOutputWriter(
+    conf: SparkConf,
+    shuffleId: Int,
+    mapId: Long,
+    numPartitions: Int
+) extends ShuffleMapOutputWriter
+    with Logging {
+
+  /* Target block for writing */
+
+  private var stream: FSDataOutputStream = _
+  private var bufferedStream: OutputStream = _
+  private var bufferedStreamAsChannel: WritableByteChannel = _
+  private var reduceIdStreamPosition: Long = 0
+
+  def initStream(): Unit = {
+    if (stream == null) {
+      val shuffleBlock = ShuffleDataBlockId(shuffleId, mapId, TaskContext.getPartitionId())
+      stream = RemoteShuffleStorage.getStream(shuffleBlock)
+      val bufferSize: Long = conf.getSizeAsBytes(REMOTE_SHUFFLE_BUFFER_SIZE.key, "64M")
+      bufferedStream = new BufferedOutputStream(stream, bufferSize.toInt)
+    }
+  }
+
+  def initChannel(): Unit = {
+    if (bufferedStreamAsChannel == null) {
+      initStream()
+      bufferedStreamAsChannel = Channels.newChannel(bufferedStream)
+    }
+  }
+
+  private val partitionLengths = Array.fill[Long](numPartitions)(0)
+  private var totalBytesWritten: Long = 0
+
+  override def getPartitionWriter(reducePartitionId: Int): ShufflePartitionWriter = {
+    if (bufferedStream != null) {
+      bufferedStream.flush()
+    }
+    if (stream != null) {
+      stream.flush()
+      reduceIdStreamPosition = stream.getPos
+    }
+    new RemoteShufflePartitionWriter(reducePartitionId)
+  }
+
+  /**
+   * Close all writers and the shuffle block.
+   */
+  override def commitAllPartitions(checksums: Array[Long]): MapOutputCommitMessage = {
+    if (bufferedStream != null) {
+      bufferedStream.flush()
+    }
+    if (stream != null) {
+      if (stream.getPos != totalBytesWritten) {
+        throw new RuntimeException(
+          f"S3ShuffleMapOutputWriter: Unexpected output length ${stream.getPos}," +
+            f" expected: $totalBytesWritten."
+        )
+      }
+    }
+    if (bufferedStreamAsChannel != null) {
+      bufferedStreamAsChannel.close()
+    }
+    if (bufferedStream != null) {
+      // Closes the underlying stream as well!
+      bufferedStream.close()
+    }
+
+    // Write checksum.
+    if (SparkEnv.get.conf.get(config.SHUFFLE_CHECKSUM_ENABLED)) {
+      RemoteShuffleStorage.writeCheckSum(ShuffleChecksumBlockId(shuffleId = shuffleId,
+        mapId = mapId, reduceId = 0), checksums)
+    }
+    MapOutputCommitMessage.of(partitionLengths)
+  }
+
+  override def abort(error: Throwable): Unit = {
+    cleanUp()
+  }
+
+  private def cleanUp(): Unit = {
+    if (bufferedStreamAsChannel != null) {
+      bufferedStreamAsChannel.close()
+    }
+    if (bufferedStream != null) {
+      bufferedStream.close()
+    }
+    if (stream != null) {
+      stream.close()
+    }
+  }
+
+  private class RemoteShufflePartitionWriter(reduceId: Int) extends ShufflePartitionWriter
+    with Logging {
+    private var partitionStream: RemoteShuffleOutputStream = _
+    private var partitionChannel: RemoteShufflePartitionWriterChannel = _
+
+    override def openStream(): OutputStream = {
+      initStream()
+      if (partitionStream == null) {
+        partitionStream = new RemoteShuffleOutputStream(reduceId)
+      }
+      partitionStream
+    }
+
+    override def openChannelWrapper(): Optional[WritableByteChannelWrapper] = {
+      if (partitionChannel == null) {
+        initChannel()
+        partitionChannel = new RemoteShufflePartitionWriterChannel(reduceId)
+      }
+      Optional.of(partitionChannel)
+    }
+
+    override def getNumBytesWritten: Long = {
+      if (partitionChannel != null) {
+        return partitionChannel.numBytesWritten
+      }
+      if (partitionStream != null) {
+        return partitionStream.numBytesWritten
+      }
+      // The partition is empty.
+      0
+    }
+  }
+
+  private class RemoteShuffleOutputStream(reduceId: Int) extends OutputStream {
+    private var byteCount: Long = 0
+    private var isClosed = false
+
+    def numBytesWritten: Long = byteCount
+
+    override def write(b: Int): Unit = {
+      if (isClosed) {
+        throw new IOException("RemoteShuffleOutputStream is already closed.")
+      }
+      bufferedStream.write(b)
+      byteCount += 1
+    }
+
+    override def write(b: Array[Byte], off: Int, len: Int): Unit = {
+      if (isClosed) {
+        throw new IOException("RemoteShuffleOutputStream is already closed.")
+      }
+      bufferedStream.write(b, off, len)
+      byteCount += len
+    }
+
+    override def flush(): Unit = {
+      if (isClosed) {
+        throw new IOException("RemoteShuffleOutputStream is already closed.")
+      }
+      bufferedStream.flush()
+    }
+
+    override def close(): Unit = {
+      partitionLengths(reduceId) = byteCount
+      totalBytesWritten += byteCount
+      isClosed = true
+    }
+  }
+
+  private class RemoteShufflePartitionWriterChannel(reduceId: Int)
+    extends WritableByteChannelWrapper {
+    private val partChannel = new RemotePartitionWritableByteChannel(bufferedStreamAsChannel)
+
+    override def channel(): WritableByteChannel = {
+      partChannel
+    }
+
+    def numBytesWritten: Long = {
+      partChannel.numBytesWritten()
+    }
+
+    override def close(): Unit = {
+      partitionLengths(reduceId) = numBytesWritten
+      totalBytesWritten += numBytesWritten
+    }
+  }
+
+  private class RemotePartitionWritableByteChannel(channel: WritableByteChannel) extends
+    WritableByteChannel {
+
+    private var count: Long = 0
+
+    def numBytesWritten(): Long = {
+      count
+    }
+
+    override def isOpen: Boolean = {
+      channel.isOpen
+    }
+
+    override def close(): Unit = {}
+
+    override def write(x: ByteBuffer): Int = {
+      var c = 0
+      while (x.hasRemaining) {
+        c += channel.write(x)
+      }
+      count += c
+      c
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/storage/RemoteShuffleStorage.scala
+++ b/core/src/main/scala/org/apache/spark/storage/RemoteShuffleStorage.scala
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.storage
+
+import java.io.{BufferedOutputStream, DataOutputStream}
+
+import scala.concurrent.Future
+import scala.reflect.ClassTag
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, FSDataOutputStream, Path}
+
+import org.apache.spark.{SparkConf, SparkEnv, SparkException}
+import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.LogKeys._
+import org.apache.spark.internal.config.{REMOTE_SHUFFLE_BUFFER_SIZE, SHUFFLE_REMOTE_STORAGE_PATH}
+import org.apache.spark.network.shuffle.BlockFetchingListener
+import org.apache.spark.network.util.JavaUtils
+import org.apache.spark.rpc.{RpcAddress, RpcEndpointRef, RpcTimeout}
+import org.apache.spark.storage.BlockManagerMessages.RemoveShuffle
+import org.apache.spark.storage.RemoteShuffleStorage.{appId, remoteFileSystem, remoteStoragePath}
+
+private[storage] class RemoteStorageRpcEndpointRef(conf: SparkConf) extends RpcEndpointRef(conf) {
+  // scalastyle:off executioncontextglobal
+  import scala.concurrent.ExecutionContext.Implicits.global
+  // scalastyle:on executioncontextglobal
+  override def address: RpcAddress = null
+  override def name: String = "remoteStorageEndpoint"
+  override def send(message: Any): Unit = {}
+  override def ask[T: ClassTag](message: Any, timeout: RpcTimeout): Future[T] = {
+    message match {
+      case RemoveShuffle(shuffleId) =>
+        val dataFile = new Path(remoteStoragePath, s"$appId/$shuffleId")
+        SparkEnv.get.mapOutputTracker.unregisterShuffle(shuffleId)
+        val shuffleManager = SparkEnv.get.shuffleManager
+        if (shuffleManager != null) {
+          shuffleManager.unregisterShuffle(shuffleId)
+        } else {
+          logDebug(log"Ignore remove shuffle ${MDC(SHUFFLE_ID, shuffleId)}")
+        }
+        Future {
+          remoteFileSystem.delete(dataFile, true).asInstanceOf[T]
+        }
+      case _ =>
+        Future{true.asInstanceOf[T]}
+    }
+  }
+}
+
+
+private[spark] object RemoteShuffleStorage extends Logging {
+
+  val blockManagerId = "remoteShuffleBlockStore"
+  lazy val hadoopConf: Configuration = SparkHadoopUtil.get.newConfiguration(SparkEnv.get.conf)
+  lazy val appId: String = SparkEnv.get.conf.getAppId
+  lazy val remoteStoragePath = new Path(SparkEnv.get.conf.get(SHUFFLE_REMOTE_STORAGE_PATH).get)
+  lazy val remoteFileSystem: FileSystem = FileSystem.get(remoteStoragePath.toUri, hadoopConf)
+
+  /** We use one block manager id as a place holder. */
+  val BLOCK_MANAGER_ID: BlockManagerId = BlockManagerId(blockManagerId, "remote", 7337)
+
+  /** Register the remote shuffle block manager and its RPC endpoint. */
+  def registerBlockManagerifNeeded(master: BlockManagerMaster, conf: SparkConf,
+                                   hadoopConf: Configuration): Unit = {
+    if (conf.get(SHUFFLE_REMOTE_STORAGE_PATH).isDefined) {
+      master.registerBlockManager(
+        BLOCK_MANAGER_ID, Array.empty[String], 0, 0, new RemoteStorageRpcEndpointRef(conf))
+    }
+  }
+
+  /** Clean up the generated remote shuffle location for this app. */
+  def cleanUp(conf: SparkConf, hadoopConf: Configuration): Unit = {
+    if (conf.contains("spark.app.id") && conf.contains(SHUFFLE_REMOTE_STORAGE_PATH)) {
+      val shuffleRemotePath =
+        new Path(conf.get(SHUFFLE_REMOTE_STORAGE_PATH).get, conf.getAppId)
+      val remoteUri = shuffleRemotePath.toUri
+      val remoteFileSystem = FileSystem.get(remoteUri, hadoopConf)
+      if (remoteFileSystem.exists(shuffleRemotePath)) {
+        if (remoteFileSystem.delete(shuffleRemotePath, true)) {
+          logInfo(log"Succeed to clean up: ${MDC(URI, remoteUri)}")
+        } else {
+          // Clean-up can fail due to the permission issues.
+          logWarning(log"Failed to clean up: ${MDC(URI, remoteUri)}")
+        }
+      }
+    }
+  }
+
+  /**
+   * Read a ManagedBuffer.
+   */
+  def read(blockIds: Seq[BlockId], listener: BlockFetchingListener): Unit = {
+    blockIds.foreach { blockId =>
+      // Use blockId.name to ensure the block name matches what's in remainingBlocks
+      // For batch blocks, this will be the batch name (e.g., "shuffle_0_0_5_8")
+      // For regular blocks, this will be the individual block name (e.g., "shuffle_0_0_5")
+      logInfo(log"Read ${MDC(BLOCK_ID, blockId)}")
+      listener.onBlockFetchSuccess(blockId.name,
+        new FileSystemManagedBuffer(getPath(blockId), hadoopConf,
+          SparkEnv.get.conf.getSizeAsMb(REMOTE_SHUFFLE_BUFFER_SIZE.key, "64M").toInt))
+    }
+  }
+
+  def getPath(blockId: BlockId): Path = {
+    val (shuffleId, name) = blockId match {
+      case ShuffleBlockId(shuffleId, mapId, reduceId) =>
+        (shuffleId, ShuffleDataBlockId(shuffleId, mapId, reduceId).name)
+      case shuffleDataBlock@ ShuffleDataBlockId(shuffleId, _, _) =>
+        (shuffleId, shuffleDataBlock.name)
+      case ShuffleBlockBatchId(shuffleId, mapId, startReduceId, endReduceId) =>
+        // For batches, we use the startReduceId to identify the block file.
+        // The batch range [startReduceId, endReduceId) will be read from the same file.
+        (shuffleId, ShuffleDataBlockId(shuffleId, mapId, startReduceId).name)
+      case shuffleCheckSumBlock@ ShuffleChecksumBlockId(shuffleId, _, _) =>
+        (shuffleId, shuffleCheckSumBlock.name)
+      case _ => throw new SparkException(s"Unsupported block id type: ${blockId.name}")
+    }
+    val hash = JavaUtils.nonNegativeHash(name)
+    new Path(remoteStoragePath, s"$appId/$shuffleId/$hash/$name")
+  }
+
+  def getStream(blockId: BlockId): FSDataOutputStream = {
+    val path = getPath(blockId)
+    remoteFileSystem.create(path)
+  }
+
+  def writeCheckSum(blockId: BlockId, array: Array[Long]): Unit = {
+    if (array.nonEmpty) {
+      val out = new DataOutputStream(new BufferedOutputStream(getStream(blockId),
+        scala.math.min(8192, 8 * array.length)))
+      array.foreach(out.writeLong)
+      out.flush()
+      out.close()
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -364,15 +364,19 @@ final class ShuffleBlockFetcherIterator(
       }
     }
 
-    // Fetch remote shuffle blocks to disk when the request is too large. Since the shuffle data is
-    // already encrypted and compressed over the wire(w.r.t. the related configs), we can just fetch
-    // the data and write it to file directly.
-    if (req.size > maxReqSizeShuffleToMem) {
-      shuffleClient.fetchBlocks(address.host, address.port, address.executorId, blockIds.toArray,
-        blockFetchingListener, this)
+    if (req.address == RemoteShuffleStorage.BLOCK_MANAGER_ID) {
+      RemoteShuffleStorage.read(req.blocks.map(_.blockId).toSeq, blockFetchingListener)
     } else {
-      shuffleClient.fetchBlocks(address.host, address.port, address.executorId, blockIds.toArray,
-        blockFetchingListener, null)
+      // Fetch remote shuffle blocks to disk when the request is too large. Since the shuffle data
+      // is already encrypted and compressed over the wire(w.r.t. the related configs),
+      // we can just fetch the data and write it to file directly.
+      if (req.size > maxReqSizeShuffleToMem) {
+        shuffleClient.fetchBlocks(address.host, address.port, address.executorId, blockIds.toArray,
+          blockFetchingListener, this)
+      } else {
+        shuffleClient.fetchBlocks(address.host, address.port, address.executorId, blockIds.toArray,
+          blockFetchingListener, null)
+      }
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/FakeTask.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/FakeTask.scala
@@ -81,7 +81,7 @@ object FakeTask {
     val tasks = Array.tabulate[Task[_]](numTasks) { i =>
       new FakeTask(stageId, i, if (prefLocs.size != 0) prefLocs(i) else Nil)
     }
-    new TaskSet(tasks, stageId, stageAttemptId, priority = priority, null, rpId, None)
+    new TaskSet(tasks, stageId, stageAttemptId, priority = priority, new Properties(), rpId, None)
   }
 
   def createShuffleMapTaskSet(
@@ -107,7 +107,7 @@ object FakeTask {
       }, 1, prefLocs(i), JobArtifactSet.defaultJobArtifactSet, new Properties,
         SparkEnv.get.closureSerializer.newInstance().serialize(TaskMetrics.registered).array())
     }
-    new TaskSet(tasks, stageId, stageAttemptId, priority = priority, null,
+    new TaskSet(tasks, stageId, stageAttemptId, priority = priority, new Properties(),
       ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID, Some(0))
   }
 
@@ -137,6 +137,6 @@ object FakeTask {
     val tasks = Array.tabulate[Task[_]](numTasks) { i =>
       new FakeTask(stageId, i, if (prefLocs.size != 0) prefLocs(i) else Nil, isBarrier = true)
     }
-    new TaskSet(tasks, stageId, stageAttemptId, priority = priority, null, rpId, None)
+    new TaskSet(tasks, stageId, stageAttemptId, priority = priority, new Properties(), rpId, None)
   }
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/PoolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/PoolSuite.scala
@@ -44,7 +44,7 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
     val tasks = Array.tabulate[Task[_]](numTasks) { i =>
       new FakeTask(stageId, i, Nil)
     }
-    new TaskSetManager(taskScheduler, new TaskSet(tasks, stageId, 0, 0, null,
+    new TaskSetManager(taskScheduler, new TaskSet(tasks, stageId, 0, 0, new Properties(),
       ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID, None), 0)
   }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -546,7 +546,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext
     val numFreeCores = 1
     val taskSet = new TaskSet(
       Array(new NotSerializableFakeTask(1, 0), new NotSerializableFakeTask(0, 1)),
-      0, 0, 0, null, ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID, None)
+      0, 0, 0, new Properties(), ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID, None)
     val multiCoreWorkerOffers = IndexedSeq(new WorkerOffer("executor0", "host0", taskCpus),
       new WorkerOffer("executor1", "host1", numFreeCores))
     taskScheduler.submitTasks(taskSet)
@@ -561,7 +561,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext
     taskScheduler.submitTasks(FakeTask.createTaskSet(1))
     val taskSet2 = new TaskSet(
       Array(new NotSerializableFakeTask(1, 0), new NotSerializableFakeTask(0, 1)),
-      1, 0, 0, null, ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID, None)
+      1, 0, 0, new Properties(), ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID, None)
     taskScheduler.submitTasks(taskSet2)
     taskDescriptions = taskScheduler.resourceOffers(multiCoreWorkerOffers).flatten
     assert(taskDescriptions.map(_.executorId) === Seq("executor0"))
@@ -2111,7 +2111,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext
     }, 1, Seq(TaskLocation("host1", "executor1")),
       JobArtifactSet.getActiveOrDefault(sc), new Properties, null)
 
-    val taskSet = new TaskSet(Array(task1, task2), 0, 0, 0, null, 0, Some(0))
+    val taskSet = new TaskSet(Array(task1, task2), 0, 0, 0, new Properties(), 0, Some(0))
 
     taskScheduler.submitTasks(taskSet)
     val taskDescriptions = taskScheduler.resourceOffers(workerOffers).flatten

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -860,7 +860,7 @@ class TaskSetManagerSuite
     sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
 
     val taskSet = new TaskSet(Array(new LargeTask(0)), 0, 0, 0,
-      null, ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID, None)
+      new Properties(), ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID, None)
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
 
     assert(!manager.emittedTaskSizeWarning)
@@ -876,7 +876,7 @@ class TaskSetManagerSuite
 
     val taskSet = new TaskSet(
       Array(new NotSerializableFakeTask(1, 0), new NotSerializableFakeTask(0, 1)),
-      0, 0, 0, null, ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID, None)
+      0, 0, 0, new Properties(), ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID, None)
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
 
     intercept[TaskNotSerializableException] {
@@ -957,7 +957,7 @@ class TaskSetManagerSuite
       }, 1, Seq(TaskLocation("host1", "execA")),
       JobArtifactSet.getActiveOrDefault(sc), new Properties, null)
     val taskSet = new TaskSet(Array(singleTask), 0, 0, 0,
-      null, ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID, Some(0))
+      new Properties(), ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID, Some(0))
     val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
 
     // Offer host1, which should be accepted as a PROCESS_LOCAL location
@@ -2287,8 +2287,8 @@ class TaskSetManagerSuite
     TestUtils.waitUntilExecutorsUp(sc, 2, 60000)
 
     val tasks = Array.tabulate[Task[_]](2)(partition => new FakeLongTasks(stageId = 0, partition))
-    val taskSet: TaskSet = new TaskSet(tasks, stageId = 0, stageAttemptId = 0, priority = 0, null,
-      ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID, None)
+    val taskSet: TaskSet = new TaskSet(tasks, stageId = 0, stageAttemptId = 0, priority = 0,
+      new Properties(), ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID, None)
     val stageId = taskSet.stageId
     val stageAttemptId = taskSet.stageAttemptId
     sched.submitTasks(taskSet)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -189,7 +189,8 @@ case class OrderedDistribution(ordering: Seq[SortOrder]) extends Distribution {
  * Represents data where tuples are broadcasted to every node. It is quite common that the
  * entire set of tuples is transformed into different data structure.
  */
-case class BroadcastDistribution(mode: BroadcastMode) extends Distribution {
+case class
+BroadcastDistribution(mode: BroadcastMode) extends Distribution {
   override def requiredNumPartitions: Option[Int] = Some(1)
 
   override def createPartitioning(numPartitions: Int): Partitioning = {
@@ -620,6 +621,54 @@ case class BroadcastPartitioning(mode: BroadcastMode) extends Partitioning {
     case _ => false
   }
 }
+
+/**
+ * A partitioning that always satisfies any distribution.
+ * This is useful when you want to ensure that a partitioning will always satisfy a distribution
+ * regardless of the distribution's requirements.
+ */
+case class PassThroughPartitioning(childPartitioning: Partitioning)
+    extends Expression with Partitioning with Unevaluable {
+  /**
+   * Always returns true, satisfying any distribution.
+   */
+  override def satisfies0(required: Distribution): Boolean = childPartitioning.satisfies(required)
+
+  override def createShuffleSpec(distribution: ClusteredDistribution): ShuffleSpec = {
+    childPartitioning.createShuffleSpec(distribution)
+  }
+
+  /** Returns the number of partitions that the data is split across */
+  override val numPartitions: Int = childPartitioning.numPartitions
+
+  // Expression interface implementation
+  override def children: Seq[Expression] = childPartitioning match {
+    case e: Expression => e.children
+    case _ => Nil
+  }
+
+  override def nullable: Boolean = false
+  override def dataType: DataType = IntegerType
+
+  override protected def withNewChildrenInternal(
+      newChildren: IndexedSeq[Expression]): PassThroughPartitioning = {
+    childPartitioning match {
+      case e: Expression =>
+        copy(childPartitioning = e.withNewChildren(newChildren).asInstanceOf[Partitioning])
+      case _ =>
+        this
+    }
+  }
+
+  override lazy val canonicalized: Expression = {
+    val canonicalizedChild = childPartitioning match {
+      case e: Expression => e.canonicalized.asInstanceOf[Partitioning]
+      case other => other
+    }
+    copy(childPartitioning = canonicalizedChild)
+  }
+}
+
 
 /**
  * This is used in the scenario where an operator has multiple children (e.g., join) and one or more

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3822,6 +3822,26 @@ object SQLConf {
       .version("4.1.0")
       .fallbackConf(SHUFFLE_DEPENDENCY_FILE_CLEANUP_ENABLED)
 
+  val ENABLE_SHUFFLE_CONSOLIDATION =
+    buildConf("spark.sql.shuffle.consolidation.enabled")
+      .doc("When enabled, creates a consolidation shuffle stage that consolidates shuffle data " +
+        "from earlier stages and uploads it to remote storage. This " +
+        "consolidation stage uses PassThroughPartitioning to satisfy distribution requirements " +
+        "without changing the actual data partitioning. The remote storage upload can improve " +
+        "shuffle performance and enable better resource utilization in distributed environments.")
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(false)
+
+  val SHUFFLE_CONSOLIDATION_SIZE_THRESHOLD =
+    buildConf("spark.sql.shuffle.consolidation.size.threshold")
+      .doc("Minimum shuffle size in bytes required to create a consolidation shuffle stage " +
+        "in adaptive execution. Only shuffles larger than this threshold will have a " +
+        "consolidation stage added. This helps avoid overhead for small shuffles.")
+      .version("4.1.0")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("100MB")
+
   val SORT_MERGE_JOIN_EXEC_BUFFER_IN_MEMORY_THRESHOLD =
     buildConf("spark.sql.sortMergeJoinExec.buffer.in.memory.threshold")
       .internal()
@@ -7900,11 +7920,13 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def hadoopLineRecordReaderEnabled: Boolean = getConf(SQLConf.HADOOP_LINE_RECORD_READER_ENABLED)
 
-  def legacyXMLParserEnabled: Boolean =
-    getConf(SQLConf.LEGACY_XML_PARSER_ENABLED)
+  def shuffleConsolidationEnabled: Boolean = getConf(SQLConf.ENABLE_SHUFFLE_CONSOLIDATION)
 
   def coerceMergeNestedTypes: Boolean =
     getConf(SQLConf.MERGE_INTO_NESTED_TYPE_COERCION_ENABLED)
+
+  def shuffleConsolidationSizeThreshold: Long =
+    getConf(SQLConf.SHUFFLE_CONSOLIDATION_SIZE_THRESHOLD)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -344,7 +344,7 @@
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
         <configuration>
-          <argLine>-ea -Xmx4g -Xss4m -XX:ReservedCodeCacheSize=${CodeCacheSize} ${extraJavaTestArgs} -Dio.netty.tryReflectionSetAccessible=true</argLine>
+          <argLine>-ea -Xmx16g -Xss4m -XX:ReservedCodeCacheSize=${CodeCacheSize} ${extraJavaTestArgs} -Dio.netty.tryReflectionSetAccessible=true</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/AddConsolidationShuffle.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/AddConsolidationShuffle.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.catalyst.plans.physical.PassThroughPartitioning
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.adaptive.ShuffleQueryStageExec
+import org.apache.spark.sql.execution.exchange.{SHUFFLE_CONSOLIDATION, ShuffleExchangeExec}
+import org.apache.spark.sql.internal.SQLConf
+
+object AddConsolidationShuffle extends Rule[SparkPlan] {
+
+  def apply(plan: SparkPlan): SparkPlan = {
+    if (!SQLConf.get.shuffleConsolidationEnabled) {
+      return plan
+    }
+    plan transformUp {
+      case plan@ShuffleExchangeExec(part, _, origin, _) =>
+        // Non-adaptive: always add consolidation exchange
+        ShuffleExchangeExec(PassThroughPartitioning(part), plan, SHUFFLE_CONSOLIDATION)
+      case p: ShuffleQueryStageExec
+        if p.shuffle.shuffleOrigin != SHUFFLE_CONSOLIDATION  && p.isMaterialized =>
+        // Add consolidation exchange only if:
+        // 1. Stage is materialized
+        // 2. Size exceeds consolidation threshold
+        val size = p.getRuntimeStatistics.sizeInBytes
+        val consolidationThreshold = SQLConf.get.shuffleConsolidationSizeThreshold
+        if (size > consolidationThreshold) {
+          ShuffleExchangeExec(PassThroughPartitioning(p.outputPartitioning), p,
+            SHUFFLE_CONSOLIDATION)
+        } else {
+          p
+        }
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/AddConsolidationShuffle.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/AddConsolidationShuffle.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution
 import org.apache.spark.sql.catalyst.plans.physical.PassThroughPartitioning
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.adaptive.ShuffleQueryStageExec
-import org.apache.spark.sql.execution.exchange.{SHUFFLE_CONSOLIDATION, ShuffleExchangeExec}
+import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, SHUFFLE_CONSOLIDATION, ShuffleExchangeExec}
 import org.apache.spark.sql.internal.SQLConf
 
 object AddConsolidationShuffle extends Rule[SparkPlan] {
@@ -29,23 +29,59 @@ object AddConsolidationShuffle extends Rule[SparkPlan] {
     if (!SQLConf.get.shuffleConsolidationEnabled) {
       return plan
     }
-    plan transformUp {
-      case plan@ShuffleExchangeExec(part, _, origin, _) =>
-        // Non-adaptive: always add consolidation exchange
-        ShuffleExchangeExec(PassThroughPartitioning(part), plan, SHUFFLE_CONSOLIDATION)
-      case p: ShuffleQueryStageExec
-        if p.shuffle.shuffleOrigin != SHUFFLE_CONSOLIDATION  && p.isMaterialized =>
-        // Add consolidation exchange only if:
-        // 1. Stage is materialized
-        // 2. Size exceeds consolidation threshold
-        val size = p.getRuntimeStatistics.sizeInBytes
-        val consolidationThreshold = SQLConf.get.shuffleConsolidationSizeThreshold
-        if (size > consolidationThreshold) {
-          ShuffleExchangeExec(PassThroughPartitioning(p.outputPartitioning), p,
-            SHUFFLE_CONSOLIDATION)
-        } else {
-          p
+    plan transformUp  {
+      case plan@ShuffleExchangeExec(part, _, ENSURE_REQUIREMENTS, _)
+        if !SQLConf.get.adaptiveExecutionEnabled =>
+        val consolidation = ShuffleExchangeExec(PassThroughPartitioning(part),
+          plan, SHUFFLE_CONSOLIDATION)
+        consolidation
+      case parent if SQLConf.get.adaptiveExecutionEnabled &&
+          parent.children.exists(_.isInstanceOf[ShuffleQueryStageExec]) =>
+
+        parent.mapChildren {
+          case stage: ShuffleQueryStageExec
+            if stage.shuffle.shuffleOrigin != SHUFFLE_CONSOLIDATION && stage.isMaterialized =>
+            // Threshold check
+            val size = stage.getRuntimeStatistics.sizeInBytes
+            val consolidationThreshold = SQLConf.get.shuffleConsolidationSizeThreshold
+            if (size > consolidationThreshold) {
+              val consolidation = ShuffleExchangeExec(
+                PassThroughPartitioning(stage.outputPartitioning),
+                stage,
+                SHUFFLE_CONSOLIDATION)
+
+              setLogicalLinkForConsolidation(consolidation, parent, stage)
+              consolidation
+            } else {
+              stage
+            }
+          case other => other
         }
+    }
+  }
+
+  /**
+   * Sets the logical link for the consolidation shuffle. If the parent and stage point to the same
+   * logical plan (e.g., Aggregate), use the parent's link to ensure the entire subtree is found
+   * together during re-planning. Otherwise (e.g., Join), the stage's link is used.
+   *
+   * @param consolidation the consolidation shuffle exchange to set the logical link for
+   * @param parent the parent plan node
+   * @param stage the shuffle query stage being consolidated
+   */
+  private def setLogicalLinkForConsolidation(
+      consolidation: ShuffleExchangeExec,
+      parent: SparkPlan,
+      stage: ShuffleQueryStageExec): Unit = {
+    val parentLogical = parent.logicalLink.map {
+      case org.apache.spark.sql.execution.adaptive.LogicalQueryStage(lp, _) => lp
+      case lp => lp
+    }
+    val stageLogical = stage.logicalLink
+
+    // Use parent's link if they point to the same logical plan
+    if (parentLogical == stageLogical) {
+      parent.logicalLink.foreach(consolidation.setLogicalLink)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -588,6 +588,7 @@ object QueryExecution {
       PlanSubqueries(sparkSession),
       RemoveRedundantProjects,
       EnsureRequirements(),
+      AddConsolidationShuffle,
       // This rule must be run after `EnsureRequirements`.
       InsertSortForLimitAndOffset,
       // `ReplaceHashWithSortAgg` needs to be added after `EnsureRequirements` to guarantee the

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -120,6 +120,7 @@ case class AdaptiveSparkPlanExec(
       CoalesceBucketsInJoin,
       RemoveRedundantProjects,
       ensureRequirements,
+      AddConsolidationShuffle,
       // This rule must be run after `EnsureRequirements`.
       InsertSortForLimitAndOffset,
       AdjustShuffleExchangePosition,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeShuffleWithLocalRead.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeShuffleWithLocalRead.scala
@@ -108,7 +108,8 @@ object OptimizeShuffleWithLocalRead extends AQEShuffleReadRule {
   }
 
   override def apply(plan: SparkPlan): SparkPlan = {
-    if (!conf.getConf(SQLConf.LOCAL_SHUFFLE_READER_ENABLED)) {
+    if (!conf.getConf(SQLConf.LOCAL_SHUFFLE_READER_ENABLED) ||
+      conf.getConf(SQLConf.ENABLE_SHUFFLE_CONSOLIDATION)) {
       return plan
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/simpleCosting.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/simpleCosting.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.adaptive
 
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.exchange.ShuffleExchangeLike
+import org.apache.spark.sql.execution.exchange.{SHUFFLE_CONSOLIDATION, ShuffleExchangeLike}
 import org.apache.spark.sql.execution.joins.ShuffledJoin
 
 /**
@@ -42,7 +42,7 @@ case class SimpleCost(value: Long) extends Cost {
 case class SimpleCostEvaluator(forceOptimizeSkewedJoin: Boolean) extends CostEvaluator {
   override def evaluateCost(plan: SparkPlan): Cost = {
     val numShuffles = plan.collect {
-      case s: ShuffleExchangeLike => s
+      case s: ShuffleExchangeLike if (s.shuffleOrigin != SHUFFLE_CONSOLIDATION) => s
     }.size
 
     if (forceOptimizeSkewedJoin) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/reuse/ReuseExchangeAndSubquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/reuse/ReuseExchangeAndSubquery.scala
@@ -42,14 +42,14 @@ case object ReuseExchangeAndSubquery extends Rule[SparkPlan] {
 
       def reuse(plan: SparkPlan): SparkPlan = {
         plan.transformUpWithPruning(_.containsAnyPattern(EXCHANGE, PLAN_EXPRESSION)) {
-          case exchange: Exchange if conf.exchangeReuseEnabled =>
+          case exchange: Exchange if conf.exchangeReuseEnabled &&
+            !conf.shuffleConsolidationEnabled =>
             val cachedExchange = exchanges.getOrElseUpdate(exchange.canonicalized, exchange)
             if (cachedExchange.ne(exchange)) {
               ReusedExchangeExec(exchange.output, cachedExchange)
             } else {
               cachedExchange
             }
-
           case other =>
             other.transformExpressionsUpWithPruning(_.containsPattern(PLAN_EXPRESSION)) {
               case sub: ExecSubqueryExpression =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ShuffleConsolidationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ShuffleConsolidationSuite.scala
@@ -1,0 +1,268 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import org.apache.spark.SparkConf
+import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, ShuffleQueryStageExec}
+import org.apache.spark.sql.execution.exchange.{SHUFFLE_CONSOLIDATION, ShuffleExchangeExec}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Test suite for shuffle consolidation
+ */
+class ShuffleConsolidationSuite
+  extends QueryTest
+  with SharedSparkSession
+  with AdaptiveSparkPlanHelper {
+
+  private val remoteStoragePath = new Path(
+    System.getProperty("java.io.tmpdir"), "shuffle-consolidation-test")
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.shuffle.remote.storage.path",
+        remoteStoragePath.toString + java.io.File.separator)
+      .set("spark.shuffle.sort.io.plugin.class",
+        "org.apache.spark.shuffle.sort.remote.HybridShuffleDataIO")
+      .set(SQLConf.ENABLE_SHUFFLE_CONSOLIDATION.key, "true")
+      .set(SQLConf.SHUFFLE_CONSOLIDATION_SIZE_THRESHOLD.key, "0")
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      // Clean up the remote storage directory
+      val hadoopConf = SparkHadoopUtil.get.newConfiguration(spark.sparkContext.getConf)
+      val fs = FileSystem.get(remoteStoragePath.toUri, hadoopConf)
+      try {
+        if (fs.exists(remoteStoragePath)) {
+          fs.delete(remoteStoragePath, true)
+        }
+      } finally {
+        fs.close()
+      }
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  /**
+   * Helper method to find consolidation shuffle stages from a plan.
+   */
+  private def findConsolidationShuffles(plan: SparkPlan): Seq[ShuffleQueryStageExec] = {
+    collectWithSubqueries(plan) {
+      case s: ShuffleQueryStageExec
+        if s.shuffle.shuffleOrigin == SHUFFLE_CONSOLIDATION => s
+    }
+  }
+
+  /**
+   * Helper method to find consolidation shuffle exchanges from a plan (non-adaptive mode).
+   */
+  private def findConsolidationExchanges(plan: SparkPlan): Seq[ShuffleExchangeExec] = {
+    collect(plan) {
+      case e: ShuffleExchangeExec
+        if e.shuffleOrigin == SHUFFLE_CONSOLIDATION => e
+    }
+  }
+
+  test("Check if ShuffleConsolidation ShuffleExchange is introduced, when enabled") {
+    val df = spark.range(100)
+      .selectExpr("id % 10 as key", "id as value")
+      .groupBy("key")
+      .count()
+    df.collect()
+    val plan = df.queryExecution.executedPlan
+
+    // Check that consolidation shuffle stage was introduced
+    val consolidationShuffles = findConsolidationShuffles(plan)
+
+    assert(consolidationShuffles.size == 1,
+      "Shuffle consolidation stage should be introduced when enabled")
+
+    // Verify output correctness
+    checkAnswer(df, (0 until 10).map(i => Row(i, 10L)))
+  }
+
+  test("shuffle consolidation respects size threshold") {
+    withSQLConf(
+      SQLConf.SHUFFLE_CONSOLIDATION_SIZE_THRESHOLD.key -> Long.MaxValue.toString) {
+
+      // With a very high threshold, consolidation should not be applied
+      val df = spark.range(10)
+        .selectExpr("id % 5 as key", "id as value")
+        .groupBy("key")
+        .count()
+
+      df.collect()
+      val plan = df.queryExecution.executedPlan
+
+      // Check that consolidation shuffle stage was introduced
+      val consolidationShuffles = findConsolidationShuffles(plan)
+
+      assert(consolidationShuffles.isEmpty,
+        "Shuffle consolidation should not be applied when size is below threshold")
+
+      // Verify output correctness
+      checkAnswer(df, (0 until 5).map(i => Row(i, 2L)))
+    }
+  }
+
+  test("shuffle consolidation in non-adaptive mode") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+
+      val df = spark.range(100)
+        .selectExpr("id % 10 as key", "id as value")
+        .groupBy("key")
+        .count()
+
+      val plan = df.queryExecution.executedPlan
+
+      // Check that consolidation shuffle stage was introduced
+      val consolidationShuffles = findConsolidationExchanges(plan)
+
+      assert(consolidationShuffles.size == 1,
+        "Shuffle consolidation stage should be introduced when enabled")
+
+      // Verify output correctness
+      checkAnswer(df, (0 until 10).map(i => Row(i, 10L)))
+    }
+  }
+
+  /**
+   * Tests shuffle consolidation for aggregate operations.
+   *
+   * This test verifies the behavior for cases where a query stage maps to a partial
+   * logical sub-tree. In aggregates, the shuffle exchange is in the middle of the
+   * transformation (e.g., both parent HashAggregate and child ShuffleQueryStage point
+   * to the same Aggregate logical node), so the consolidation uses the parent's logical
+   * link to ensure the entire subtree is found together during re-planning.
+   *
+   * See [[org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
+   * .replaceWithQueryStagesInLogicalPlan]] for details on how query stages
+   * are mapped back to logical plans.
+   */
+  test("shuffle consolidation for aggregate operations") {
+    withSQLConf(
+      SQLConf.EXCHANGE_REUSE_ENABLED.key -> "false") {
+
+      val df = spark.range(100)
+        .selectExpr("id % 10 as key", "id as value")
+        .groupBy("key")
+        .count()
+        .orderBy("key")
+
+      df.collect()
+      val plan = df.queryExecution.executedPlan
+
+      val consolidationShuffles = findConsolidationShuffles(plan)
+
+      // Should have consolidation stages for the aggregate shuffle
+      assert(consolidationShuffles.nonEmpty,
+        "Consolidation stages should be present for aggregate shuffles")
+
+      // Verify output correctness
+      checkAnswer(df, (0 until 10).map(i => Row(i, 10L)))
+    }
+  }
+
+  /**
+   * Tests shuffle consolidation for join operations.
+   *
+   * This test verifies the behavior for cases where a query stage maps to an integral
+   * logical sub-tree. In joins, each side of the join (left and right) forms a complete
+   * relation, so the query stage and parent typically point to different logical nodes.
+   * The consolidation uses the stage's logical link to maintain the proper mapping.
+   *
+   * See [[org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
+   * .replaceWithQueryStagesInLogicalPlan]] for details on how query stages
+   * are mapped back to logical plans.
+   */
+  test("shuffle consolidation for join operations") {
+    withSQLConf(
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+
+      val df1 = spark.range(50)
+        .selectExpr("id as key", "id * 2 as value1")
+      val df2 = spark.range(50)
+        .selectExpr("id as key", "id * 3 as value2")
+
+      val joined = df1.join(df2, "key").orderBy("key")
+
+      joined.collect()
+      val plan = joined.queryExecution.executedPlan
+
+      val consolidationShuffles = findConsolidationShuffles(plan)
+
+      assert(consolidationShuffles.nonEmpty,
+        "Shuffle consolidation stages should be introduced for join operations")
+
+      // Verify output correctness
+      checkAnswer(joined,
+        (0 until 50).map(i => Row(i, i * 2, i * 3)))
+    }
+  }
+
+  test("shuffle consolidation writes data to remote storage") {
+    // Run a query that should trigger shuffle consolidation
+    val df = spark.range(1000)
+      .selectExpr("id % 100 as key", "id as value")
+      .groupBy("key")
+      .count()
+
+    df.collect()
+
+    // Get the Hadoop FileSystem
+    val hadoopConf = SparkHadoopUtil.get.newConfiguration(spark.sparkContext.getConf)
+    val fs = FileSystem.get(remoteStoragePath.toUri, hadoopConf)
+    try {
+      // Check if the remote path exists
+      assert(fs.exists(remoteStoragePath),
+        s"Remote shuffle path does not exist: $remoteStoragePath")
+
+      // Look for shuffle data files recursively
+      var foundDataFiles = false
+      var totalSize = 0L
+
+      val dataFiles = fs.listFiles(remoteStoragePath, true)
+      while (dataFiles.hasNext) {
+        val file = dataFiles.next()
+        if (file.getPath.getName.startsWith("shuffle_") &&
+            !file.getPath.getName.contains("checksum")) {
+          foundDataFiles = true
+          totalSize += file.getLen
+        }
+      }
+
+      assert(foundDataFiles,
+        "No shuffle data files found in remote storage")
+      assert(totalSize > 0,
+        s"Shuffle data files exist but contain no data (total size: $totalSize)")
+    } finally {
+      fs.close()
+    }
+
+    // Verify output correctness
+    checkAnswer(df, (0 until 100).map(i => Row(i, 10L)))
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This change([design doc)](https://docs.google.com/document/d/1tuWyXAaIBR0oVD5KZwYvz7JLyn6jB55_35xeslUEu7s/edit?usp=sharing) adds support to use remote storage for shuffle data storage. 

The primary goal is to enhance the elasticity and resilience of Spark workloads, leading to substantial cost optimization opportunities.

This is a PoC to elicit feedback from community.

### Why are the changes needed?
This change decouples storage from compute, therein helping to minimize shuffle failure and also in better scaling of the cluster.

### Does this PR introduce any user-facing change?
This change adds 3 SQL configs to enable the feature
Remote storage location for shuffle
`spark.shuffle.remote.storage.path=<remote storage path>` 

Config that determines if the feature needs to be used
`spark.sql.shuffle.consolidation.enabled=true|false`

Shuffle plugin to use when the feature is enabled(This needs to be configured currently, but we can switch to this automatically when feature is enabled TBD  )
`spark.shuffle.sort.io.plugin.class=org.apache.spark.shuffle.sort.remote.HybridShuffleDataIO` - 

### How was this patch tested?
Manual testing. Unit test to be added.
Trying to get feedback from community before writing elaborate tests.

### Was this patch authored or co-authored using generative AI tooling?
No