### PR TITLE
[SPARK-54329][INFRA] Use shorter prefix before build name

### DIFF
--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -54,7 +54,7 @@ on:
 jobs:
   # Build: build Spark and run the tests for specified modules using maven
   build:
-    name: "Build modules using Maven: ${{ matrix.modules }} ${{ matrix.comment }}"
+    name: "Build modules: ${{ matrix.modules }} ${{ matrix.comment }}"
     runs-on: ${{ inputs.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/python_hosted_runner_test.yml
+++ b/.github/workflows/python_hosted_runner_test.yml
@@ -57,7 +57,7 @@ on:
         default: '{}'
 jobs:
   build:
-    name: "PySpark test on macos: ${{ matrix.modules }}"
+    name: "Build modules: ${{ matrix.modules }}"
     runs-on: ${{ inputs.os }}
     timeout-minutes: 150
     strategy:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Use shorter prefix before build name

### Why are the changes needed?
<img width="835" height="771" alt="image" src="https://github.com/user-attachments/assets/d6318f62-315c-4e6b-bdf6-d72f1f6e5eb2" />

the prefix is long that not convenient to select the tests

### Does this PR introduce _any_ user-facing change?
No, infra-only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no