### PR TITLE
[SPARK-54330][PYTHON] Optimize Py4J calls in `spark.createDataFrame`

### DIFF
--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -415,6 +415,7 @@ class SparkConversionMixin:
         prefer_timestamp_ntz = timestampType == "TIMESTAMP_NTZ"
         prefers_large_var_types = arrowUseLargeVarTypes == "true"
         timezone = sessionLocalTimeZone
+        arrow_batch_size = int(arrowMaxRecordsPerBatch)
 
         if type(data).__name__ == "Table":
             # `data` is a PyArrow Table
@@ -448,8 +449,8 @@ class SparkConversionMixin:
                     schema,
                     timezone,
                     prefer_timestamp_ntz,
-                    int(arrowMaxRecordsPerBatch),
                     prefers_large_var_types,
+                    arrow_batch_size,
                 )
             except Exception as e:
                 if arrowPySparkFallbackEnabled == "true":
@@ -678,8 +679,8 @@ class SparkConversionMixin:
         schema: Union[StructType, List[str]],
         timezone: str,
         prefer_timestamp_ntz: bool,
-        arrow_batch_size: int,
         prefers_large_var_types: bool,
+        arrow_batch_size: int,
     ) -> "DataFrame":
         """
         Create a DataFrame from a given pandas.DataFrame by slicing it into partitions, converting


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Optimize Py4J calls in `spark.createDataFrame`


### Why are the changes needed?
there are multiple configs in `spark.createDataFrame`, and they are fetched one by one.
We should minimize the number of py4j calls in the python side.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no