### PR TITLE
[SPARK-54331][PYTHON][TESTS] Optimize `pyspark.sql.tests.connect.test_connect_plan`

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_plan.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan.py
@@ -753,7 +753,7 @@ class SparkConnectPlanTests(PlanOnlyTestFixture):
         self.assertIsInstance(col, Column)
         self.assertEqual("Column<'UnresolvedRegex(col_name)'>", str(col))
 
-        col_plan = col.to_plan(self.session.client)
+        col_plan = col.to_plan(None)
         self.assertIsNotNone(col_plan)
         self.assertEqual(col_plan.unresolved_regex.col_name, "col_name")
 
@@ -937,7 +937,7 @@ class SparkConnectPlanTests(PlanOnlyTestFixture):
         self.assertEqual("Column<'a AS martin'>", str(col0))
 
         col0 = col("a").alias("martin", metadata={"pii": True})
-        plan = col0.to_plan(self.session.client)
+        plan = col0.to_plan(None)
         self.assertIsNotNone(plan)
         self.assertEqual(plan.alias.metadata, '{"pii": true}')
 

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -16,7 +16,6 @@
 #
 import shutil
 import tempfile
-import typing
 import os
 import functools
 import unittest
@@ -133,7 +132,6 @@ class PlanOnlyTestFixture(unittest.TestCase, PySparkErrorTestUtils):
         @classmethod
         def setUpClass(cls):
             cls.connect = MockRemoteSession()
-            cls.session = SparkSession.builder.remote().getOrCreate()
             cls.tbl_name = "test_connect_plan_only_table_1"
 
             cls.connect.set_hook("readTable", cls._read_table)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Optimize `pyspark.sql.tests.connect.test_connect_plan`, by removing the remote session creation


### Why are the changes needed?
Recently, I notice that this test become extremely slow, e.g. in https://github.com/apache/spark/actions/runs/19318125464/job/55253739424

before
```
Starting test(python3.11): pyspark.sql.tests.connect.test_connect_plan (temp output: /__w/spark/spark/python/target/763913e5-9ba0-46ed-a583-56bf5fa5f588/python3.11__pyspark.sql.tests.connect.test_connect_plan__nbrkokah.log)
Finished test(python3.11): pyspark.sql.tests.connect.test_connect_plan (1222s)
```


after
```
Starting test(python3.11): pyspark.sql.tests.connect.test_connect_plan (temp output: /__w/spark/spark/python/target/45831997-66c0-4c44-89cf-1ce85dc89ee7/python3.11__pyspark.sql.tests.connect.test_connect_plan__tyaymd_b.log)
Finished test(python3.11): pyspark.sql.tests.connect.test_connect_plan (1s)
```

The tests theirselves are pretty fast, so I think the root cause is the remote session creation which is not necessary in this test which is for validation of protobufs


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI

### Was this patch authored or co-authored using generative AI tooling?
No