### PR TITLE
[SPARK-54333][BUILD] Upgrade `commons-io` to 2.21.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -41,7 +41,7 @@ commons-compiler/3.1.9//commons-compiler-3.1.9.jar
 commons-compress/1.28.0//commons-compress-1.28.0.jar
 commons-crypto/1.1.0//commons-crypto-1.1.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar
-commons-io/2.20.0//commons-io-2.20.0.jar
+commons-io/2.21.0//commons-io-2.21.0.jar
 commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/3.19.0//commons-lang3-3.19.0.jar
 commons-math3/3.6.1//commons-math3-3.6.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
     <netlib.ludovic.dev.version>3.0.4</netlib.ludovic.dev.version>
     <commons-codec.version>1.19.0</commons-codec.version>
     <commons-compress.version>1.28.0</commons-compress.version>
-    <commons-io.version>2.20.0</commons-io.version>
+    <commons-io.version>2.21.0</commons-io.version>
     <!-- To support Hive UDF jars built by Hive 2.0.0 ~ 2.3.9 and 3.0.0 ~ 3.1.3. -->
     <commons-lang2.version>2.6</commons-lang2.version>
     <!-- org.apache.commons/commons-lang3/-->


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade Apache `commons-io` from 2.20.0 to 2.21.0.

### Why are the changes needed?
The new version has passed the testing for Java 24 and comes with some bug fixes. The release notes are as follows:

- https://commons.apache.org/proper/commons-io/changes.html#a2.21.0

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No