### PR TITLE
[SPARK-54334] [SQL] Move the validation of subquery expressions under lambda and higher order functions to `SubqueryExpressionInLambdaOrHigherOrderFunctionValidator`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/SubqueryExpressionInLambdaOrHigherOrderFunctionValidator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/SubqueryExpressionInLambdaOrHigherOrderFunctionValidator.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.catalyst.analysis.ResolveLambdaVariables.conf
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.trees.TreePattern.PLAN_EXPRESSION
+import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Object used to validate whether there are subquery expressions in [[LambdaFunction]] or
+ * [[HigherOrderFunction]].
+ */
+object SubqueryExpressionInLambdaOrHigherOrderFunctionValidator {
+
+  /**
+   * SPARK-47509: There is a correctness bug when subquery expressions appear within lambdas or
+   * higher-order functions. Here we check for that case and return an error if the corresponding
+   * configuration indicates to do so.
+   */
+  def apply(expression: Expression): Unit = {
+    if (expression.containsPattern(PLAN_EXPRESSION) &&
+      !conf.getConf(SQLConf.ALLOW_SUBQUERY_EXPRESSIONS_IN_LAMBDAS_AND_HIGHER_ORDER_FUNCTIONS)) {
+      throw QueryCompilationErrors.subqueryExpressionInLambdaOrHigherOrderFunctionNotAllowedError()
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/higherOrderFunctions.scala
@@ -22,7 +22,6 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.catalyst.util.TypeUtils.{toSQLConf, toSQLId}
-import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.DataType
 
@@ -114,11 +113,11 @@ object ResolveLambdaVariables extends Rule[LogicalPlan] {
     case _ if e.resolved => e
 
     case h: HigherOrderFunction if h.argumentsResolved && h.checkArgumentDataTypes().isSuccess =>
-      checkForSubqueryExpressions(e)
+      SubqueryExpressionInLambdaOrHigherOrderFunctionValidator(e)
       h.bind(createLambda).mapChildren(resolve(_, parentLambdaMap))
 
     case l: LambdaFunction if !l.bound =>
-      checkForSubqueryExpressions(e)
+      SubqueryExpressionInLambdaOrHigherOrderFunctionValidator(e)
       // Do not resolve an unbound lambda function. If we see such a lambda function this means
       // that either the higher order function has yet to be resolved, or that we are seeing
       // dangling lambda function.
@@ -140,17 +139,5 @@ object ResolveLambdaVariables extends Rule[LogicalPlan] {
 
     case _ =>
       e.mapChildren(resolve(_, parentLambdaMap))
-  }
-
-  /**
-   * SPARK-47509: There is a correctness bug when subquery expressions appear within lambdas or
-   * higher-order functions. Here we check for that case and return an error if the corresponding
-   * configuration indicates to do so.
-   */
-  private def checkForSubqueryExpressions(expression: Expression): Unit = {
-    if (expression.containsPattern(PLAN_EXPRESSION) &&
-      !conf.getConf(SQLConf.ALLOW_SUBQUERY_EXPRESSIONS_IN_LAMBDAS_AND_HIGHER_ORDER_FUNCTIONS)) {
-      throw QueryCompilationErrors.subqueryExpressionInLambdaOrHigherOrderFunctionNotAllowedError()
-    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR I propose that we refactor the code in a way that is easy to reuse between fixed-point and single-pass analyzer.

### Why are the changes needed?
To ease the development of the single-pass resolver.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.