### PR TITLE
[SPARK-54194][PYTHON][FOLLOWUP] Fix `connectutils.py` to import `pb2` conditionally

### DIFF
--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -23,7 +23,6 @@ import unittest
 import uuid
 import contextlib
 
-import pyspark.sql.connect.proto as pb2
 from pyspark import Row, SparkConf
 from pyspark.util import is_remote_only
 from pyspark.testing.utils import PySparkErrorTestUtils
@@ -53,6 +52,7 @@ if should_test_connect:
     from pyspark.sql.connect.dataframe import DataFrame
     from pyspark.sql.connect.plan import Read, Range, SQL, LogicalPlan
     from pyspark.sql.connect.session import SparkSession
+    import pyspark.sql.connect.proto as pb2
 
 
 class MockRemoteSession:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a follow-up of the following to fix `connectutils.py` to import `pb2` conditionally.
- #52894

### Why are the changes needed?

Currently, Python CIs are broken like the following.
- https://github.com/apache/spark/actions/workflows/build_python_3.11_classic_only.yml
    - https://github.com/apache/spark/actions/runs/19316448951/job/55248810741
- https://github.com/apache/spark/actions/workflows/build_python_3.12.yml
    - https://github.com/apache/spark/actions/runs/19275741458/job/55212353468

```
  File "/__w/spark/spark/python/pyspark/testing/connectutils.py", line 26, in <module>
    import pyspark.sql.connect.proto as pb2
  File "/__w/spark/spark/python/pyspark/sql/connect/proto/__init__.py", line 18, in <module>
    from pyspark.sql.connect.proto.base_pb2_grpc import *
  File "/__w/spark/spark/python/pyspark/sql/connect/proto/base_pb2_grpc.py", line 19, in <module>
    import grpc
ModuleNotFoundError: No module named 'grpc'
```

### Does this PR introduce _any_ user-facing change?

No behavior change. We has been importing `pyspark.sql.connect` conditionally before #52894 .

### How was this patch tested?

Pass the CIs and manual test.

### Was this patch authored or co-authored using generative AI tooling?

No.