### PR TITLE
[SPARK-54335][SQL] Reducing skew in the number of file splits per partition

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2430,6 +2430,28 @@ object SQLConf {
     .checkValue(v => v > 0, "The maximum number of partitions must be a positive integer.")
     .createOptional
 
+  val FILES_PARTITION_STRATEGY = buildConf("spark.sql.files.partitionStrategy")
+    .doc("The strategy to coalesce small files into larger partitions when reading files. " +
+      "Options are `size_based` (coalesce based on size of files), and `file_based` "
+        + "(coalesce based on number of files). The number of output partitions depends on " +
+      "`spark.sql.files.maxPartitionBytes` and `spark.sql.files.maxPartitionNum`. " +
+      "This configuration is effective only when using file-based sources such as " +
+      "Parquet, JSON and ORC.")
+    .version("3.5.0")
+    .stringConf
+    .checkValues(Set("size_based", "file_based"))
+    .createWithDefault("size_based")
+
+  val SMALL_FILE_THRESHOLD =
+  buildConf("spark.sql.files.smallFileThreshold")
+    .doc(
+      "Defines the total size threshold for small files in a table scan. If the cumulative size " +
+        "of small files falls below this threshold, they are distributed across multiple " +
+        "partitions to avoid concentrating them in a single partition. This configuration is " +
+    "used when `spark.sql.files.coalesceStrategy` is set to `file_based`.")
+    .doubleConf
+    .createWithDefault(0.5)
+
   val IGNORE_CORRUPT_FILES = buildConf("spark.sql.files.ignoreCorruptFiles")
     .doc("Whether to ignore corrupt files. If true, the Spark jobs will continue to run when " +
       "encountering corrupted files and the contents that have been read will still be returned. " +
@@ -6948,6 +6970,10 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def filesMinPartitionNum: Option[Int] = getConf(FILES_MIN_PARTITION_NUM)
 
   def filesMaxPartitionNum: Option[Int] = getConf(FILES_MAX_PARTITION_NUM)
+
+  def filesPartitionStrategy: String = getConf(FILES_PARTITION_STRATEGY)
+
+  def smallFileThreshold: Double = getConf(SMALL_FILE_THRESHOLD)
 
   def ignoreCorruptFiles: Boolean = getConf(IGNORE_CORRUPT_FILES)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -885,7 +885,7 @@ case class FileSourceScanExec(
           Seq.empty
         }
       }
-    }.toArray.sortBy(_.length)(implicitly[Ordering[Long]].reverse)
+    }.toArray
 
     val partitions = FilePartition
       .getFilePartitions(relation.sparkSession, splitFiles.toImmutableArraySeq, maxSplitBytes)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
@@ -97,7 +97,7 @@ object FilePartition extends SessionStateHelper with Logging {
         .map(f => (f, f.length))
         .sortBy(_._2)(Ordering.Long.reverse)
 
-    val partitions = Array.fill(outputPartitions)(mutable.ArrayBuffer.empty[PartitionedFile])
+    val partitions = Seq.fill(outputPartitions)(mutable.ArrayBuffer.empty[PartitionedFile])
 
     def addToBucket(
         heap: mutable.PriorityQueue[(Long, Int, Int)],
@@ -163,7 +163,9 @@ object FilePartition extends SessionStateHelper with Logging {
       }
     }
 
-    partitions.zipWithIndex.map { case (p, idx) => FilePartition(idx, p.toArray) }
+    partitions.zipWithIndex.map {
+      case (p, idx) => FilePartition(idx, p.toArray)
+    }
   }
 
   def getFilePartitions(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -167,7 +167,7 @@ trait FileScan extends Scan
           maxSplitBytes = maxSplitBytes,
           partitionValues = partitionValues
         )
-      }.toArray.sortBy(_.length)(implicitly[Ordering[Long]].reverse)
+      }.toArray
     }
 
     if (splitFiles.length == 1) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Currently, when Spark partitions the input files in a table scan, it first sorts the input splits, then adjacent splits are coalesced into a single partition. If the input split size distribution is uneven, some partitions will have only a few splits while others will have many.

We observed that this file partitioning strategy can slow down the reading process if some tasks are reading more files than others, especially in Gluten’s native Parquet reader. To address this performance issue, we are proposing a new partitioning strategy that takes both partition size and file count into account and distributes the small files across different partitions to avoid skew.

The strategy is designed with following steps:

1. Get the number of output partition number from Spark's original logic FilePartition.getFilePartitions. If `spark.sql.files.maxPartitionNum` is set, use the smaller one as the output partition number.
2. Assign small files starting from the smallest to the partitions with the minimum file count + total file size strategy
3. Assign the remaining files from the largest into the partition with the minimum total file size + file count strategy
The total size of small files can be configured using spark.gluten.sql.columnar.smallFileThreshold, which specifies the percentage of the total input file size represented by small files.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

As described in the previous section. End users and projects like Apache Gluten can benefit from this change. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

new configurations are added for this enhancement:

- spark.sql.files.partitionStrategy
- spark.sql.files.smallFileThreshold


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Unit test
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
