### PR TITLE
[SPARK-54209][CONNECT] Support TIMESTAMP type in SparkConnectResultSet

### DIFF
--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/util/JdbcTypeUtils.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/util/JdbcTypeUtils.scala
@@ -37,6 +37,8 @@ private[jdbc] object JdbcTypeUtils {
     case StringType => Types.VARCHAR
     case _: DecimalType => Types.DECIMAL
     case DateType => Types.DATE
+    case TimestampType => Types.TIMESTAMP
+    case TimestampNTZType => Types.TIMESTAMP
     case BinaryType => Types.BINARY
     case _: TimeType => Types.TIME
     case other =>
@@ -55,6 +57,8 @@ private[jdbc] object JdbcTypeUtils {
     case StringType => classOf[String].getName
     case _: DecimalType => classOf[JBigDecimal].getName
     case DateType => classOf[Date].getName
+    case TimestampType => classOf[Timestamp].getName
+    case TimestampNTZType => classOf[Timestamp].getName
     case BinaryType => classOf[Array[Byte]].getName
     case _: TimeType => classOf[Time].getName
     case other =>
@@ -64,7 +68,8 @@ private[jdbc] object JdbcTypeUtils {
   def isSigned(field: StructField): Boolean = field.dataType match {
     case ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType |
          _: DecimalType => true
-    case NullType | BooleanType | StringType | DateType | BinaryType | _: TimeType => false
+    case NullType | BooleanType | StringType | DateType | BinaryType | _: TimeType |
+         TimestampType | TimestampNTZType => false
     case other =>
       throw new SQLFeatureNotSupportedException(s"DataType $other is not supported yet.")
   }
@@ -81,6 +86,8 @@ private[jdbc] object JdbcTypeUtils {
     case StringType => 255
     case DecimalType.Fixed(p, _) => p
     case DateType => 10
+    case TimestampType => 29
+    case TimestampNTZType => 29
     case BinaryType => Int.MaxValue
     // Returns the Spark SQL TIME type precision, even though java.sql.ResultSet.getTime()
     // can only retrieve up to millisecond precision (3) due to java.sql.Time limitations.
@@ -94,6 +101,8 @@ private[jdbc] object JdbcTypeUtils {
   def getScale(field: StructField): Int = field.dataType match {
     case FloatType => 7
     case DoubleType => 15
+    case TimestampType => 6
+    case TimestampNTZType => 6
     case NullType | BooleanType | ByteType | ShortType | IntegerType | LongType | StringType |
          DateType | BinaryType | _: TimeType => 0
     case DecimalType.Fixed(_, s) => s
@@ -111,6 +120,8 @@ private[jdbc] object JdbcTypeUtils {
     case StringType =>
       getPrecision(field)
     case DateType => 10 // length of `YYYY-MM-DD`
+    case TimestampType => 29 // length of `YYYY-MM-DD HH:MM:SS.SSSSSS`
+    case TimestampNTZType => 29 // length of `YYYY-MM-DD HH:MM:SS.SSSSSS`
     case BinaryType => Int.MaxValue
     case TimeType(precision) if precision > 0 => 8 + 1 + precision // length of `HH:MM:SS.ffffff`
     case TimeType(_) => 8 // length of `HH:MM:SS`

--- a/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectJdbcDataTypeSuite.scala
+++ b/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectJdbcDataTypeSuite.scala
@@ -268,7 +268,9 @@ class SparkConnectJdbcDataTypeSuite extends ConnectFunSuite with RemoteSparkSess
       ("cast(1 AS DECIMAL(10,5))", (rs: ResultSet) => rs.getBigDecimal(999)),
       ("CAST(X'0A0B0C' AS BINARY)", (rs: ResultSet) => rs.getBytes(999)),
       ("date '2025-11-15'", (rs: ResultSet) => rs.getBytes(999)),
-      ("time '12:34:56.123456'", (rs: ResultSet) => rs.getBytes(999))
+      ("time '12:34:56.123456'", (rs: ResultSet) => rs.getBytes(999)),
+      ("timestamp '2025-11-15 10:30:45.123456'", (rs: ResultSet) => rs.getTimestamp(999)),
+      ("timestamp_ntz '2025-11-15 10:30:45.789012'", (rs: ResultSet) => rs.getTimestamp(999)),
     ).foreach {
       case (query, getter) =>
         withExecuteQuery(s"SELECT $query") { rs =>
@@ -562,6 +564,184 @@ class SparkConnectJdbcDataTypeSuite extends ConnectFunSuite with RemoteSparkSess
           val expectedMillis = timeToMillis(12, 34, 56, 123)
           assert(time.getTime === expectedMillis)
           assert(!rs.wasNull)
+          assert(!rs.next())
+        }
+      }
+    }
+  }
+
+test("get timestamp type") {
+    withExecuteQuery("SELECT timestamp '2025-11-15 10:30:45.123456'") { rs =>
+      assert(rs.next())
+      val timestamp = rs.getTimestamp(1)
+      assert(timestamp !== null)
+      assert(timestamp === java.sql.Timestamp.valueOf("2025-11-15 10:30:45.123456"))
+      assert(!rs.wasNull)
+      assert(!rs.next())
+
+      val metaData = rs.getMetaData
+      assert(metaData.getColumnCount === 1)
+      assert(metaData.getColumnName(1) === "TIMESTAMP '2025-11-15 10:30:45.123456'")
+      assert(metaData.getColumnLabel(1) === "TIMESTAMP '2025-11-15 10:30:45.123456'")
+      assert(metaData.getColumnType(1) === Types.TIMESTAMP)
+      assert(metaData.getColumnTypeName(1) === "TIMESTAMP")
+      assert(metaData.getColumnClassName(1) === "java.sql.Timestamp")
+      assert(metaData.isSigned(1) === false)
+      assert(metaData.getPrecision(1) === 29)
+      assert(metaData.getScale(1) === 6)
+      assert(metaData.getColumnDisplaySize(1) === 29)
+    }
+  }
+
+  test("get timestamp type with null") {
+    withExecuteQuery("SELECT cast(null as timestamp)") { rs =>
+      assert(rs.next())
+      assert(rs.getTimestamp(1) === null)
+      assert(rs.wasNull)
+      assert(!rs.next())
+
+      val metaData = rs.getMetaData
+      assert(metaData.getColumnCount === 1)
+      assert(metaData.getColumnName(1) === "CAST(NULL AS TIMESTAMP)")
+      assert(metaData.getColumnLabel(1) === "CAST(NULL AS TIMESTAMP)")
+      assert(metaData.getColumnType(1) === Types.TIMESTAMP)
+      assert(metaData.getColumnTypeName(1) === "TIMESTAMP")
+      assert(metaData.getColumnClassName(1) === "java.sql.Timestamp")
+      assert(metaData.isSigned(1) === false)
+      assert(metaData.getPrecision(1) === 29)
+      assert(metaData.getScale(1) === 6)
+      assert(metaData.getColumnDisplaySize(1) === 29)
+    }
+  }
+
+  test("get timestamp type by column label and with calendar") {
+    withExecuteQuery("SELECT timestamp '2025-11-15 10:30:45.987654' as test_timestamp") { rs =>
+      assert(rs.next())
+
+      // Test by column label
+      val timestamp = rs.getTimestamp("test_timestamp")
+      assert(timestamp !== null)
+      assert(timestamp === java.sql.Timestamp.valueOf("2025-11-15 10:30:45.987654"))
+      assert(!rs.wasNull)
+
+      // Test with calendar - should return same value (Calendar is ignored)
+      // Note: Spark Connect handles timezone at server, Calendar param is for API compliance
+      val calUTC = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"))
+      val timestampUTC = rs.getTimestamp(1, calUTC)
+      assert(timestampUTC !== null)
+      assert(timestampUTC.getTime === timestamp.getTime)
+
+      val calPST = java.util.Calendar.getInstance(
+        java.util.TimeZone.getTimeZone("America/Los_Angeles"))
+      val timestampPST = rs.getTimestamp(1, calPST)
+      assert(timestampPST !== null)
+      // Same value regardless of calendar
+      assert(timestampPST.getTime === timestamp.getTime)
+      assert(timestampUTC.getTime === timestampPST.getTime)
+
+      // Test with calendar by label
+      val timestampLabel = rs.getTimestamp("test_timestamp", calUTC)
+      assert(timestampLabel !== null)
+      assert(timestampLabel.getTime === timestamp.getTime)
+
+      // Test with null calendar - returns same value
+      val timestampNullCal = rs.getTimestamp(1, null)
+      assert(timestampNullCal !== null)
+      assert(timestampNullCal.getTime === timestamp.getTime)
+
+      assert(!rs.next())
+    }
+  }
+
+  test("get timestamp type with calendar for null value") {
+    withExecuteQuery("SELECT cast(null as timestamp)") { rs =>
+      assert(rs.next())
+
+      // Calendar parameter should not affect null handling
+      val cal = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"))
+      val timestamp = rs.getTimestamp(1, cal)
+      assert(timestamp === null)
+      assert(rs.wasNull)
+      assert(!rs.next())
+    }
+  }
+
+  test("get timestamp_ntz type") {
+    withExecuteQuery("SELECT timestamp_ntz '2025-11-15 10:30:45.123456'") { rs =>
+      assert(rs.next())
+      val timestamp = rs.getTimestamp(1)
+      assert(timestamp !== null)
+      assert(timestamp === java.sql.Timestamp.valueOf("2025-11-15 10:30:45.123456"))
+      assert(!rs.wasNull)
+      assert(!rs.next())
+
+      val metaData = rs.getMetaData
+      assert(metaData.getColumnCount === 1)
+      assert(metaData.getColumnName(1) === "TIMESTAMP_NTZ '2025-11-15 10:30:45.123456'")
+      assert(metaData.getColumnLabel(1) === "TIMESTAMP_NTZ '2025-11-15 10:30:45.123456'")
+      assert(metaData.getColumnType(1) === Types.TIMESTAMP)
+      assert(metaData.getColumnTypeName(1) === "TIMESTAMP_NTZ")
+      assert(metaData.getColumnClassName(1) === "java.sql.Timestamp")
+      assert(metaData.isSigned(1) === false)
+      assert(metaData.getPrecision(1) === 29)
+      assert(metaData.getScale(1) === 6)
+      assert(metaData.getColumnDisplaySize(1) === 29)
+    }
+  }
+
+  test("get timestamp_ntz type by label, null, and with calendar") {
+    // Test with non-null value
+    withExecuteQuery("SELECT timestamp_ntz '2025-11-15 14:22:33.789456' as test_ts_ntz") { rs =>
+      assert(rs.next())
+
+      // Test by column label
+      val timestamp = rs.getTimestamp("test_ts_ntz")
+      assert(timestamp !== null)
+      assert(timestamp === java.sql.Timestamp.valueOf("2025-11-15 14:22:33.789456"))
+      assert(!rs.wasNull)
+
+      // Test with calendar - should return same value (Calendar is ignored)
+      val calUTC = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"))
+      val timestampCal = rs.getTimestamp(1, calUTC)
+      assert(timestampCal !== null)
+      assert(timestampCal.getTime === timestamp.getTime)
+
+      assert(!rs.next())
+    }
+
+    // Test with null value
+    withExecuteQuery("SELECT cast(null as timestamp_ntz)") { rs =>
+      assert(rs.next())
+      assert(rs.getTimestamp(1) === null)
+      assert(rs.wasNull)
+      assert(!rs.next())
+    }
+  }
+
+  test("get timestamp types with spark.sql.datetime.java8API.enabled") {
+    withStatement { stmt =>
+      Seq(true, false).foreach { java8APIEnabled =>
+        stmt.execute(s"set spark.sql.datetime.java8API.enabled=$java8APIEnabled")
+
+        Using.resource(stmt.executeQuery(
+          """SELECT
+            |  timestamp '2025-11-15 10:30:45.123456' as ts,
+            |  timestamp_ntz '2025-11-15 14:22:33.789012' as ts_ntz
+            |""".stripMargin)) { rs =>
+          assert(rs.next())
+
+          // Test TIMESTAMP type
+          val timestamp = rs.getTimestamp(1)
+          assert(timestamp !== null)
+          assert(timestamp === java.sql.Timestamp.valueOf("2025-11-15 10:30:45.123456"))
+          assert(!rs.wasNull)
+
+          // Test TIMESTAMP_NTZ type
+          val timestampNtz = rs.getTimestamp(2)
+          assert(timestampNtz !== null)
+          assert(timestampNtz === java.sql.Timestamp.valueOf("2025-11-15 14:22:33.789012"))
+          assert(!rs.wasNull)
+
           assert(!rs.next())
         }
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add TIMESTAMP type support to the Spark Connect JDBC client

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
TIMESTAMP is a fundamental SQL type required for JDBC compliance and interoperability. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, it's part of a new feature under Spark connect JDBC support.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added new UTs in  `SparkConnectJdbcDataTypeSuite`

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
