### PR TITLE
[SPARK-55179][PYTHON][CONNECT] Skip eager column name validation in `df.col_name`

### DIFF
--- a/python/docs/source/migration_guide/pyspark_upgrade.rst
+++ b/python/docs/source/migration_guide/pyspark_upgrade.rst
@@ -22,6 +22,7 @@ Upgrading PySpark
 Upgrading from PySpark 4.1 to 4.2
 ---------------------------------
 * In Spark 4.2, the minimum supported version for PyArrow has been raised from 15.0.0 to 18.0.0 in PySpark.
+* In Spark 4.2, ``DataFrame.__getattr__`` on Spark Connect Python Client no longer eagerly validate the column name. To restore the legacy behavior, set ``PYSPARK_VALIDATE_COLUMN_NAME_LEGACY`` environment variable to ``1``.
 * In Spark 4.2, columnar data exchange between PySpark and the JVM uses Apache Arrow by default. The configuration ``spark.sql.execution.arrow.pyspark.enabled`` now defaults to true. To restore the legacy (non-Arrow) row-based data exchange, set ``spark.sql.execution.arrow.pyspark.enabled`` to ``false``.
 * In Spark 4.2, regular Python UDFs are Arrow-optimized by default. The configuration ``spark.sql.execution.pythonUDF.arrow.enabled`` now defaults to true. To restore the legacy behavior for Python UDF execution, set ``spark.sql.execution.pythonUDF.arrow.enabled`` to ``false``.
 * In Spark 4.2, regular Python UDTFs are Arrow-optimized by default. The configuration ``spark.sql.execution.pythonUDTF.arrow.enabled`` now defaults to true. To restore the legacy behavior for Python UDTF execution, set ``spark.sql.execution.pythonUDTF.arrow.enabled`` to ``false``.
@@ -32,7 +33,7 @@ Upgrading from PySpark 4.0 to 4.1
 * In Spark 4.1, Python 3.9 support was dropped in PySpark.
 * In Spark 4.1, the minimum supported version for PyArrow has been raised from 11.0.0 to 15.0.0 in PySpark.
 * In Spark 4.1, the minimum supported version for Pandas has been raised from 2.0.0 to 2.2.0 in PySpark.
-* In Spark 4.1, ``DataFrame['name']`` and ``DataFrame.name`` on Spark Connect Python Client no longer eagerly validate the column name. To restore the legacy behavior, set ``PYSPARK_VALIDATE_COLUMN_NAME_LEGACY`` environment variable to ``1``.
+* In Spark 4.1, ``DataFrame.__getitem__`` on Spark Connect Python Client no longer eagerly validate the column name. To restore the legacy behavior, set ``PYSPARK_VALIDATE_COLUMN_NAME_LEGACY`` environment variable to ``1``.
 * In Spark 4.1, Arrow-optimized Python UDF supports UDT input / output instead of falling back to the regular UDF. To restore the legacy behavior, set ``spark.sql.execution.pythonUDF.arrow.legacy.fallbackOnUDT`` to ``true``.
 * In Spark 4.1, unnecessary conversion to pandas instances is removed when ``spark.sql.execution.pythonUDF.arrow.enabled`` is enabled. As a result, the type coercion changes when the produced output has a schema different from the specified schema. To restore the previous behavior, enable ``spark.sql.legacy.execution.pythonUDF.pandas.conversion.enabled``.
 * In Spark 4.1, unnecessary conversion to pandas instances is removed when ``spark.sql.execution.pythonUDTF.arrow.enabled`` is enabled. As a result, the type coercion changes when the produced output has a schema different from the specified schema. To restore the previous behavior, enable ``spark.sql.legacy.execution.pythonUDTF.pandas.conversion.enabled``.

--- a/python/docs/source/migration_guide/pyspark_upgrade.rst
+++ b/python/docs/source/migration_guide/pyspark_upgrade.rst
@@ -32,7 +32,7 @@ Upgrading from PySpark 4.0 to 4.1
 * In Spark 4.1, Python 3.9 support was dropped in PySpark.
 * In Spark 4.1, the minimum supported version for PyArrow has been raised from 11.0.0 to 15.0.0 in PySpark.
 * In Spark 4.1, the minimum supported version for Pandas has been raised from 2.0.0 to 2.2.0 in PySpark.
-* In Spark 4.1, ``DataFrame['name']`` on Spark Connect Python Client no longer eagerly validate the column name. To restore the legacy behavior, set ``PYSPARK_VALIDATE_COLUMN_NAME_LEGACY`` environment variable to ``1``.
+* In Spark 4.1, ``DataFrame['name']`` and ``DataFrame.name`` on Spark Connect Python Client no longer eagerly validate the column name. To restore the legacy behavior, set ``PYSPARK_VALIDATE_COLUMN_NAME_LEGACY`` environment variable to ``1``.
 * In Spark 4.1, Arrow-optimized Python UDF supports UDT input / output instead of falling back to the regular UDF. To restore the legacy behavior, set ``spark.sql.execution.pythonUDF.arrow.legacy.fallbackOnUDT`` to ``true``.
 * In Spark 4.1, unnecessary conversion to pandas instances is removed when ``spark.sql.execution.pythonUDF.arrow.enabled`` is enabled. As a result, the type coercion changes when the produced output has a schema different from the specified schema. To restore the previous behavior, enable ``spark.sql.legacy.execution.pythonUDF.pandas.conversion.enabled``.
 * In Spark 4.1, unnecessary conversion to pandas instances is removed when ``spark.sql.execution.pythonUDTF.arrow.enabled`` is enabled. As a result, the type coercion changes when the produced output has a schema different from the specified schema. To restore the previous behavior, enable ``spark.sql.legacy.execution.pythonUDTF.pandas.conversion.enabled``.

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1739,7 +1739,7 @@ class DataFrame(ParentDataFrame):
         # Only eagerly validate the column name when:
         # 1, PYSPARK_VALIDATE_COLUMN_NAME_LEGACY is set 1; or
         # 2, name starting with '__', because this is likely a python internal method and
-        # an AttributeError might be expected to make getattr(df, name) work.
+        # an AttributeError might be expected to make hasattr(df, name) work.
         # For example:
         # pickle/cloudpickle need to check whether method '__setstate__' is defined or not,
         # and it internally invokes __getattr__("__setstate__").

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1739,10 +1739,12 @@ class DataFrame(ParentDataFrame):
         # Only eagerly validate the column name when:
         # 1, PYSPARK_VALIDATE_COLUMN_NAME_LEGACY is set 1; or
         # 2, name starting with '__', because this is likely a python internal method and
-        # an AttributeError is expected, for example,
-        # pickle will internally invoke __getattr__("__setstate__"), returning a column
-        # self._col("__setstate__") in this case will break the serialization of connect
-        # dataframe and features built atop it (e.g. FEB).
+        # an AttributeError might be expected to make getattr(df, name) work.
+        # For example:
+        # pickle/cloudpickle need to check whether method '__setstate__' is defined or not,
+        # and it internally invokes __getattr__("__setstate__").
+        # Returning a dataframe column self._col("__setstate__") in this case will break
+        # the serialization of connect dataframe and features built atop it (e.g. FEB).
         if os.environ.get("PYSPARK_VALIDATE_COLUMN_NAME_LEGACY") == "1" or name.startswith("__"):
             if name not in self.columns:
                 raise PySparkAttributeError(

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1742,7 +1742,7 @@ class DataFrame(ParentDataFrame):
         # an AttributeError might be expected to make hasattr(df, name) work.
         # For example:
         # pickle/cloudpickle need to check whether method '__setstate__' is defined or not,
-        # and it internally invokes __getattr__("__setstate__").
+        # and it internally invokes hasattr(df, "__setstate__") -> __getattr__("__setstate__").
         # Returning a dataframe column self._col("__setstate__") in this case will break
         # the serialization of connect dataframe and features built atop it (e.g. FEB).
         if os.environ.get("PYSPARK_VALIDATE_COLUMN_NAME_LEGACY") == "1" or name.startswith("__"):

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1736,9 +1736,8 @@ class DataFrame(ParentDataFrame):
                 errorClass="JVM_ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": name}
             )
 
-        if (
-            os.environ.get("PYSPARK_VALIDATE_COLUMN_NAME_LEGACY") == "1"
-            and name not in self.columns
+        if os.environ.get("PYSPARK_VALIDATE_COLUMN_NAME_LEGACY", "1") == "1" and not any(
+            field.name == name for field in self._schema
         ):
             raise PySparkAttributeError(
                 errorClass="ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": name}

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1742,11 +1742,13 @@ class DataFrame(ParentDataFrame):
                 errorClass="JVM_ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": name}
             )
 
-        if os.environ.get("PYSPARK_VALIDATE_COLUMN_NAME_LEGACY") == "1":
-            if not any(field.name == name for field in self._schema):
-                raise PySparkAttributeError(
-                    errorClass="ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": name}
-                )
+        if (
+            os.environ.get("PYSPARK_VALIDATE_COLUMN_NAME_LEGACY") == "1"
+            and name not in self.columns
+        ):
+            raise PySparkAttributeError(
+                errorClass="ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": name}
+            )
         return self._col(name)
 
     @overload

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1737,8 +1737,8 @@ class DataFrame(ParentDataFrame):
             )
 
         # Only eagerly validate the column name when:
-        # 1, PYSPARK_VALIDATE_COLUMN_NAME_LEGACY is set; or
-        # 2, name starts with __, because this is likely a python internal method and
+        # 1, PYSPARK_VALIDATE_COLUMN_NAME_LEGACY is set 1; or
+        # 2, name starting with '__', because this is likely a python internal method and
         # an AttributeError is expected, for example,
         # pickle will internally invoke __getattr__("__setstate__"), returning a column
         # self._col("__setstate__") in this case will break the serialization of connect

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -169,10 +169,10 @@ class DataFrame(ParentDataFrame):
             },
         )
 
-    def __getstate__(self):
+    def __getstate__(self) -> Any:
         return self.__dict__.copy()
 
-    def __setstate__(self, state):
+    def __setstate__(self, state) -> None:
         self.__dict__.update(state)
 
     def __repr__(self) -> str:

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -169,6 +169,12 @@ class DataFrame(ParentDataFrame):
             },
         )
 
+    def __getstate__(self):
+        return self.__dict__.copy()
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
     def __repr__(self) -> str:
         if not self._support_repr_html:
             (
@@ -1736,13 +1742,11 @@ class DataFrame(ParentDataFrame):
                 errorClass="JVM_ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": name}
             )
 
-        if os.environ.get("PYSPARK_VALIDATE_COLUMN_NAME_LEGACY") == "1" and not any(
-            field.name == name for field in self._schema
-        ):
-            raise PySparkAttributeError(
-                errorClass="ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": name}
-            )
-
+        if os.environ.get("PYSPARK_VALIDATE_COLUMN_NAME_LEGACY") == "1":
+            if not any(field.name == name for field in self._schema):
+                raise PySparkAttributeError(
+                    errorClass="ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": name}
+                )
         return self._col(name)
 
     @overload

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -169,10 +169,12 @@ class DataFrame(ParentDataFrame):
             },
         )
 
-    def __getstate__(self) -> Any:
-        return self.__dict__.copy()
-
     def __setstate__(self, state: Any) -> None:
+        # state {'_support_repr_html': False, '_cached_schema': None}
+        # the state is defined by the 3rd item of __reduce__
+        # see https://docs.python.org/3/library/pickle.html#object.__reduce__
+        # This method is to avoid __getattr__ being invoked on unpickling,
+        # which always return True and fail the deserialization.
         self.__dict__.update(state)
 
     def __repr__(self) -> str:

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1736,7 +1736,7 @@ class DataFrame(ParentDataFrame):
                 errorClass="JVM_ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": name}
             )
 
-        if os.environ.get("PYSPARK_VALIDATE_COLUMN_NAME_LEGACY", "1") == "1" and not any(
+        if os.environ.get("PYSPARK_VALIDATE_COLUMN_NAME_LEGACY") == "1" and not any(
             field.name == name for field in self._schema
         ):
             raise PySparkAttributeError(

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1736,7 +1736,10 @@ class DataFrame(ParentDataFrame):
                 errorClass="JVM_ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": name}
             )
 
-        if name not in self.columns:
+        if (
+            os.environ.get("PYSPARK_VALIDATE_COLUMN_NAME_LEGACY") == "1"
+            and name not in self.columns
+        ):
             raise PySparkAttributeError(
                 errorClass="ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": name}
             )

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -172,7 +172,7 @@ class DataFrame(ParentDataFrame):
     def __getstate__(self) -> Any:
         return self.__dict__.copy()
 
-    def __setstate__(self, state) -> None:
+    def __setstate__(self, state: Any) -> None:
         self.__dict__.update(state)
 
     def __repr__(self) -> str:

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1738,11 +1738,11 @@ class DataFrame(ParentDataFrame):
 
         # Only eagerly validate the column name when:
         # 1, PYSPARK_VALIDATE_COLUMN_NAME_LEGACY is set 1; or
-        # 2, name starting with '__', because this is likely a python internal method and
-        # an AttributeError might be expected to make hasattr(df, name) work.
+        # 2, the name starts with '__', because it is likely a python internal method and
+        # an AttributeError might be expected to check whether the attribute exists.
         # For example:
         # pickle/cloudpickle need to check whether method '__setstate__' is defined or not,
-        # and it internally invokes hasattr(df, "__setstate__") -> __getattr__("__setstate__").
+        # and it internally invokes __getattr__("__setstate__").
         # Returning a dataframe column self._col("__setstate__") in this case will break
         # the serialization of connect dataframe and features built atop it (e.g. FEB).
         if os.environ.get("PYSPARK_VALIDATE_COLUMN_NAME_LEGACY") == "1" or name.startswith("__"):

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -143,6 +143,16 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         cdf2 = loads(data)
         self.assertEqual(cdf.collect(), cdf2.collect())
 
+    def test_serialization_II(self):
+        from pyspark.serializers import CPickleSerializer
+
+        pickle_ser = CPickleSerializer()
+
+        cdf = self.connect.range(10)
+        data = pickle_ser.dumps(cdf)
+        cdf2 = pickle_ser.loads(data)
+        self.assertEqual(cdf.collect(), cdf2.collect())
+
     def test_window_spec_serialization(self):
         from pyspark.sql.connect.window import Window
         from pyspark.serializers import CPickleSerializer
@@ -164,7 +174,14 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         self.assertEqual(type(sdf._simple_extension), type(cdf._simple_extension))
 
         self.assertTrue(hasattr(cdf, "_simple_extension"))
-        self.assertFalse(hasattr(cdf, "_simple_extension_does_not_exsit"))
+
+        with self.temp_env({"PYSPARK_VALIDATE_COLUMN_NAME_LEGACY": "0"}):
+            self.assertTrue(hasattr(cdf, "_simple_extension_does_not_exsit"))
+            self.assertIsInstance(getattr(cdf, "_simple_extension_does_not_exsit"), Column)
+            self.assertIsInstance(cdf._simple_extension_does_not_exsit, Column)
+
+        with self.temp_env({"PYSPARK_VALIDATE_COLUMN_NAME_LEGACY": "1"}):
+            self.assertFalse(hasattr(cdf, "_simple_extension_does_not_exsit"))
 
     def test_df_get_item(self):
         # SPARK-41779: test __getitem__

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -175,13 +175,18 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
 
         self.assertTrue(hasattr(cdf, "_simple_extension"))
 
-        with self.temp_env({"PYSPARK_VALIDATE_COLUMN_NAME_LEGACY": "0"}):
+        with self.temp_env({"PYSPARK_VALIDATE_COLUMN_NAME_LEGACY": None}):
             self.assertTrue(hasattr(cdf, "_simple_extension_does_not_exsit"))
             self.assertIsInstance(getattr(cdf, "_simple_extension_does_not_exsit"), Column)
             self.assertIsInstance(cdf._simple_extension_does_not_exsit, Column)
 
+            # For name starting with '__', still validate it eagerly
+            self.assertFalse(hasattr(cdf, "__simple_extension_does_not_exsit"))
+
         with self.temp_env({"PYSPARK_VALIDATE_COLUMN_NAME_LEGACY": "1"}):
             self.assertFalse(hasattr(cdf, "_simple_extension_does_not_exsit"))
+
+            self.assertFalse(hasattr(cdf, "__simple_extension_does_not_exsit"))
 
     def test_df_get_item(self):
         # SPARK-41779: test __getitem__


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Follow up of https://github.com/apache/spark/pull/51400, also skip eager column name validation in `df.col_name`


### Why are the changes needed?
to be consistent with `df["col_name"]`

### Does this PR introduce _any_ user-facing change?
yes, `df.bad_column` failure will be delayed to analysis or execution

before:
```
In [1]: df = spark.range(10)

In [2]: df.abc
---------------------------------------------------------------------------
...

PySparkAttributeError: [ATTRIBUTE_NOT_SUPPORTED] Attribute `abc` is not supported.

In [3]: df._abc
---------------------------------------------------------------------------
...

PySparkAttributeError: [ATTRIBUTE_NOT_SUPPORTED] Attribute `_abc` is not supported.

In [4]: df.__abc
---------------------------------------------------------------------------
...

PySparkAttributeError: [ATTRIBUTE_NOT_SUPPORTED] Attribute `__abc` is not supported.
```

after:
```
In [1]: df = spark.range(10)

In [2]: df.abc
Out[2]: Column<'abc'>

In [3]: df._abc
Out[3]: Column<'_abc'>

In [4]: df.__abc
---------------------------------------------------------------------------
...

PySparkAttributeError: [ATTRIBUTE_NOT_SUPPORTED] Attribute `__abc` is not supported.
```

### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no