### PR TITLE
[SPARK-54114][CONNECT] Support getColumns for SparkConnectDatabaseMetaData

### DIFF
--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/util/JdbcTypeUtils.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/util/JdbcTypeUtils.scala
@@ -134,4 +134,19 @@ private[jdbc] object JdbcTypeUtils {
     case other =>
       throw new SQLFeatureNotSupportedException(s"DataType $other is not supported yet.")
   }
+
+  def getDecimalDigits(field: StructField): Integer = field.dataType match {
+    case BooleanType | _: IntegralType => 0
+    case FloatType => 7
+    case DoubleType => 15
+    case d: DecimalType => d.scale
+    case TimeType(scale) => scale
+    case TimestampType | TimestampNTZType => 6
+    case _ => null
+  }
+
+  def getNumPrecRadix(field: StructField): Integer = field.dataType match {
+    case _: NumericType => 10
+    case _ => null
+  }
 }

--- a/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaDataSuite.scala
+++ b/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaDataSuite.scala
@@ -547,7 +547,8 @@ class SparkConnectDatabaseMetaDataSuite extends ConnectFunSuite with RemoteSpark
       }
     }
   }
-  test("SparkConnectDatabaseMetaData getTables") {
+
+  test("SparkConnectDatabaseMetaData getColumns") {
 
      case class GetColumnResult(
        TABLE_CAT: String,
@@ -605,7 +606,7 @@ class SparkConnectDatabaseMetaDataSuite extends ConnectFunSuite with RemoteSpark
             NULLABLE = rs.getInt("NULLABLE"),
             REMARKS = rs.getString("REMARKS"),
             COLUMN_DEF = rs.getString("COLUMN_DEF"),
-            SQL_DATA_TYPE = rs.getShort("SQL_DATA_TYPE"),
+            SQL_DATA_TYPE = rs.getInt("SQL_DATA_TYPE"),
             SQL_DATETIME_SUB = rs.getInt("SQL_DATETIME_SUB"),
             CHAR_OCTET_LENGTH = rs.getInt("CHAR_OCTET_LENGTH"),
             ORDINAL_POSITION = rs.getInt("ORDINAL_POSITION"),
@@ -624,10 +625,165 @@ class SparkConnectDatabaseMetaDataSuite extends ConnectFunSuite with RemoteSpark
     withConnection { conn =>
       implicit val spark: SparkSession = conn.asInstanceOf[SparkConnectConnection].spark
 
-      // this catalog does not support view
-      registerCatalog("testcat", TEST_IN_MEMORY_CATALOG)
+      spark.sql("CREATE DATABASE IF NOT EXISTS testcat.t_db1")
+      spark.sql("CREATE TABLE IF NOT EXISTS testcat.t_db1.t_t1 (id INT)")
 
-      // TODO
+      spark.sql("CREATE DATABASE IF NOT EXISTS spark_catalog.db1")
+      spark.sql(
+        """CREATE TABLE IF NOT EXISTS spark_catalog.db1.t1 (
+          |  id INT NOT NULL,
+          |  i_ INT,
+          |  location STRING COMMENT 'city name' DEFAULT 'unknown')
+          |""".stripMargin)
+      spark.sql(
+        """CREATE TABLE IF NOT EXISTS spark_catalog.db1.t2 (
+          |  col_null VOID,
+          |  col_boolean BOOLEAN,
+          |  col_byte BYTE,
+          |  col_short SHORT,
+          |  col_int INT,
+          |  col_long LONG,
+          |  col_float FLOAT,
+          |  col_double DOUBLE,
+          |  col_string STRING,
+          |  col_decimal DECIMAL(10, 5),
+          |  col_date DATE,
+          |  col_timestamp TIMESTAMP,
+          |  col_timestamp_ntz TIMESTAMP_NTZ,
+          |  col_binary BINARY,
+          |  col_time TIME)""".stripMargin)
+
+      spark.sql(
+        """CREATE VIEW IF NOT EXISTS spark_catalog.db1.t1_v AS
+          |SELECT id FROM spark_catalog.db1.t1
+          |""".stripMargin)
+
+      spark.sql("CREATE DATABASE IF NOT EXISTS spark_catalog.db_")
+      spark.sql("CREATE TABLE IF NOT EXISTS spark_catalog.db_.t_ (id INT, i_ INT)")
+
+      spark.sql("CREATE DATABASE IF NOT EXISTS spark_catalog.db_2")
+      spark.sql("CREATE TABLE IF NOT EXISTS spark_catalog.db_2.t_2 (id INT)")
+
+      val metadata = conn.getMetaData
+
+      // no need to care about "testcat" because it is memory based and session isolated,
+      // also is inaccessible from another SparkSession
+      withDatabase("spark_catalog.db1", "spark_catalog.db_2", "spark_catalog.db_") {
+        // list columns of all tables in all catalogs and schemas
+        val getColumnsInAllTables = List(null, "%").flatMap { database =>
+          List(null, "%").flatMap { table =>
+            List(null, "%").map { column =>
+              () => metadata.getColumns(null, database, table, column)
+            }
+          }
+        }
+
+        getColumnsInAllTables.foreach { getColumns =>
+          verifyGetColumns(getColumns) { getColumnResults =>
+            // results are ordered by TABLE_CAT, TABLE_SCHEM, TABLE_NAME, ORDINAL_POSITION
+            assert {
+              getColumnResults.map { r =>
+                (r.TABLE_CAT, r.TABLE_SCHEM, r.TABLE_NAME, r.ORDINAL_POSITION, r.COLUMN_NAME)
+              } === Seq(
+                ("spark_catalog", "db1", "t1", 1, "id"),
+                ("spark_catalog", "db1", "t1", 2, "i_"),
+                ("spark_catalog", "db1", "t1", 3, "location"),
+                ("spark_catalog", "db1", "t1_v", 1, "id"),
+                ("spark_catalog", "db1", "t2", 1, "col_null"),
+                ("spark_catalog", "db1", "t2", 2, "col_boolean"),
+                ("spark_catalog", "db1", "t2", 3, "col_byte"),
+                ("spark_catalog", "db1", "t2", 4, "col_short"),
+                ("spark_catalog", "db1", "t2", 5, "col_int"),
+                ("spark_catalog", "db1", "t2", 6, "col_long"),
+                ("spark_catalog", "db1", "t2", 7, "col_float"),
+                ("spark_catalog", "db1", "t2", 8, "col_double"),
+                ("spark_catalog", "db1", "t2", 9, "col_string"),
+                ("spark_catalog", "db1", "t2", 10, "col_decimal"),
+                ("spark_catalog", "db1", "t2", 11, "col_date"),
+                ("spark_catalog", "db1", "t2", 12, "col_timestamp"),
+                ("spark_catalog", "db1", "t2", 13, "col_timestamp_ntz"),
+                ("spark_catalog", "db1", "t2", 14, "col_binary"),
+                ("spark_catalog", "db1", "t2", 15, "col_time"),
+                ("spark_catalog", "db_", "t_", 1, "id"),
+                ("spark_catalog", "db_", "t_", 2, "i_"),
+                ("spark_catalog", "db_2", "t_2", 1, "id"),
+                ("testcat", "t_db1", "t_t1", 1, "id"))
+            }
+
+            // TODO verify the remaining attributes
+            // DATA_TYPE = rs.getInt("DATA_TYPE"),
+            // TYPE_NAME = rs.getString("TYPE_NAME"),
+            // COLUMN_SIZE = rs.getInt("COLUMN_SIZE"),
+            // DECIMAL_DIGITS = rs.getInt("DECIMAL_DIGITS"),
+            // NUM_PREC_RADIX = rs.getInt("NUM_PREC_RADIX"),
+            // NULLABLE = rs.getInt("NULLABLE"),
+            // REMARKS = rs.getString("REMARKS"),
+            // COLUMN_DEF = rs.getString("COLUMN_DEF"),
+            // CHAR_OCTET_LENGTH = rs.getInt("CHAR_OCTET_LENGTH"),
+            // IS_NULLABLE = rs.getString("IS_NULLABLE"),
+            // IS_AUTOINCREMENT = rs.getString("IS_AUTOINCREMENT"),
+            // IS_GENERATEDCOLUMN = rs.getString("IS_GENERATEDCOLUMN")
+
+            getColumnResults.foreach(verifyEmptyFields)
+          }
+        }
+
+        // list columns of all tables in the current catalog and schema
+        conn.setCatalog("spark_catalog")
+        conn.setSchema("db1")
+        assert(conn.getCatalog === "spark_catalog")
+        assert(conn.getSchema === "db1")
+
+        verifyGetColumns(() => metadata.getColumns("", "", "%", "id")) { getColumnResults =>
+            // results are ordered by TABLE_CAT, TABLE_SCHEM, TABLE_NAME, ORDINAL_POSITION
+            assert {
+              getColumnResults.map { r =>
+                (r.TABLE_CAT, r.TABLE_SCHEM, r.TABLE_NAME, r.ORDINAL_POSITION, r.COLUMN_NAME)
+              } === Seq(
+                ("spark_catalog", "db1", "t1", 1, "id"),
+                ("spark_catalog", "db1", "t1_v", 1, "id"))
+            }
+
+          getColumnResults.foreach(verifyEmptyFields)
+        }
+
+        // list columns of tables with schema pattern, table mame pattern, and column name pattern
+        verifyGetColumns {
+          () => metadata.getColumns(null, "%db_", "%t_", "%d%")
+        } { getColumnResults =>
+          // results are ordered by TABLE_CAT, TABLE_SCHEM, TABLE_NAME, ORDINAL_POSITION
+          assert {
+            getColumnResults.map { r =>
+              (r.TABLE_CAT, r.TABLE_SCHEM, r.TABLE_NAME, r.ORDINAL_POSITION, r.COLUMN_NAME)
+            } === Seq(
+              ("spark_catalog", "db1", "t1", 1, "id"),
+              ("spark_catalog", "db1", "t2", 8, "col_double"),
+              ("spark_catalog", "db1", "t2", 10, "col_decimal"),
+              ("spark_catalog", "db1", "t2", 11, "col_date"),
+              ("spark_catalog", "db_", "t_", 1, "id"),
+              ("testcat", "t_db1", "t_t1", 1, "id"))
+          }
+
+          getColumnResults.foreach(verifyEmptyFields)
+        }
+
+        // escape _ in schema pattern and table mame pattern
+        verifyGetColumns {
+          () => metadata.getColumns(null, "db\\_", "t\\_", "i\\_")
+        } { getColumnResults =>
+          // results are ordered by TABLE_CAT, TABLE_SCHEM, TABLE_NAME, ORDINAL_POSITION
+          assert {
+            getColumnResults.map { r =>
+              (r.TABLE_CAT, r.TABLE_SCHEM, r.TABLE_NAME, r.ORDINAL_POSITION, r.COLUMN_NAME)
+            } === Seq(("spark_catalog", "db_", "t_", 2, "i_"))
+          }
+
+          getColumnResults.foreach(verifyEmptyFields)
+        }
+
+        // skip testing escape ', % in schema pattern, because Spark SQL does not
+        // allow using those chars in schema table name.
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


This PR implements the [`java.sql.DatabaseMetaData#getColumns`](
https://docs.oracle.com/en/java/javase/17/docs/api/java.sql/java/sql/DatabaseMetaData.html#getColumns(java.lang.String,java.lang.String,java.lang.String,java.lang.String)) for `SparkConnectDatabaseMetaData`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Improve JDBC API coverage for Connect JDBC driver.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, the Connect JDBC driver is a new feature under development.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New UTs.

Also tested with BeeLine, and DBeaver

```
0: jdbc:sc://localhost:15002> use tpch_sf1;
No rows affected (0.042 seconds)
0: jdbc:sc://localhost:15002> !columns customer
+----------------+--------------+-------------+-------------------------+------------+------------+--------------+----------------+-----------------+-----------------+-----------+----------+-------------+----------------+-------------------+--------------------+-------------------+--------------+----------------+---------------+--------------+-------------------+-------------------+---------------------+
|   TABLE_CAT    | TABLE_SCHEM  | TABLE_NAME  |       COLUMN_NAME       | DATA_TYPE  | TYPE_NAME  | COLUMN_SIZE  | BUFFER_LENGTH  | DECIMAL_DIGITS  | NUM_PREC_RADIX  | NULLABLE  | REMARKS  | COLUMN_DEF  | SQL_DATA_TYPE  | SQL_DATETIME_SUB  | CHAR_OCTET_LENGTH  | ORDINAL_POSITION  | IS_NULLABLE  | SCOPE_CATALOG  | SCOPE_SCHEMA  | SCOPE_TABLE  | SOURCE_DATA_TYPE  | IS_AUTOINCREMENT  | IS_GENERATEDCOLUMN  |
+----------------+--------------+-------------+-------------------------+------------+------------+--------------+----------------+-----------------+-----------------+-----------+----------+-------------+----------------+-------------------+--------------------+-------------------+--------------+----------------+---------------+--------------+-------------------+-------------------+---------------------+
| spark_catalog  | tpcds_sf1    | customer    | c_customer_sk           | -5         | BIGINT     | 20           | 0              | NULL            | 10              | 1         |          | NULL        | 0              | 0                 | 0                  | 1                 | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpcds_sf1    | customer    | c_customer_id           | 12         | STRING     | 255          | 0              | NULL            | NULL            | 1         |          | NULL        | 0              | 0                 | 0                  | 2                 | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpcds_sf1    | customer    | c_current_cdemo_sk      | -5         | BIGINT     | 20           | 0              | NULL            | 10              | 1         |          | NULL        | 0              | 0                 | 0                  | 3                 | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpcds_sf1    | customer    | c_current_hdemo_sk      | -5         | BIGINT     | 20           | 0              | NULL            | 10              | 1         |          | NULL        | 0              | 0                 | 0                  | 4                 | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpcds_sf1    | customer    | c_current_addr_sk       | -5         | BIGINT     | 20           | 0              | NULL            | 10              | 1         |          | NULL        | 0              | 0                 | 0                  | 5                 | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpcds_sf1    | customer    | c_first_shipto_date_sk  | -5         | BIGINT     | 20           | 0              | NULL            | 10              | 1         |          | NULL        | 0              | 0                 | 0                  | 6                 | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpcds_sf1    | customer    | c_first_sales_date_sk   | -5         | BIGINT     | 20           | 0              | NULL            | 10              | 1         |          | NULL        | 0              | 0                 | 0                  | 7                 | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpcds_sf1    | customer    | c_salutation            | 12         | STRING     | 255          | 0              | NULL            | NULL            | 1         |          | NULL        | 0              | 0                 | 0                  | 8                 | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpcds_sf1    | customer    | c_first_name            | 12         | STRING     | 255          | 0              | NULL            | NULL            | 1         |          | NULL        | 0              | 0                 | 0                  | 9                 | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpcds_sf1    | customer    | c_last_name             | 12         | STRING     | 255          | 0              | NULL            | NULL            | 1         |          | NULL        | 0              | 0                 | 0                  | 10                | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpcds_sf1    | customer    | c_preferred_cust_flag   | 12         | STRING     | 255          | 0              | NULL            | NULL            | 1         |          | NULL        | 0              | 0                 | 0                  | 11                | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpcds_sf1    | customer    | c_birth_day             | 4          | INT        | 11           | 0              | 0               | 10              | 1         |          | NULL        | 0              | 0                 | 0                  | 12                | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpcds_sf1    | customer    | c_birth_month           | 4          | INT        | 11           | 0              | 0               | 10              | 1         |          | NULL        | 0              | 0                 | 0                  | 13                | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpcds_sf1    | customer    | c_birth_year            | 4          | INT        | 11           | 0              | 0               | 10              | 1         |          | NULL        | 0              | 0                 | 0                  | 14                | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpcds_sf1    | customer    | c_birth_country         | 12         | STRING     | 255          | 0              | NULL            | NULL            | 1         |          | NULL        | 0              | 0                 | 0                  | 15                | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpcds_sf1    | customer    | c_login                 | 12         | STRING     | 255          | 0              | NULL            | NULL            | 1         |          | NULL        | 0              | 0                 | 0                  | 16                | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpcds_sf1    | customer    | c_email_address         | 12         | STRING     | 255          | 0              | NULL            | NULL            | 1         |          | NULL        | 0              | 0                 | 0                  | 17                | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpcds_sf1    | customer    | c_last_review_date_sk   | -5         | BIGINT     | 20           | 0              | NULL            | 10              | 1         |          | NULL        | 0              | 0                 | 0                  | 18                | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpch_sf1     | customer    | c_custkey               | -5         | BIGINT     | 20           | 0              | NULL            | 10              | 1         |          | NULL        | 0              | 0                 | 0                  | 1                 | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpch_sf1     | customer    | c_name                  | 12         | STRING     | 255          | 0              | NULL            | NULL            | 1         |          | NULL        | 0              | 0                 | 0                  | 2                 | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpch_sf1     | customer    | c_address               | 12         | STRING     | 255          | 0              | NULL            | NULL            | 1         |          | NULL        | 0              | 0                 | 0                  | 3                 | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpch_sf1     | customer    | c_nationkey             | -5         | BIGINT     | 20           | 0              | NULL            | 10              | 1         |          | NULL        | 0              | 0                 | 0                  | 4                 | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpch_sf1     | customer    | c_phone                 | 12         | STRING     | 255          | 0              | NULL            | NULL            | 1         |          | NULL        | 0              | 0                 | 0                  | 5                 | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpch_sf1     | customer    | c_acctbal               | 8          | DOUBLE     | 24           | 0              | 15              | 10              | 1         |          | NULL        | 0              | 0                 | 0                  | 6                 | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpch_sf1     | customer    | c_mktsegment            | 12         | STRING     | 255          | 0              | NULL            | NULL            | 1         |          | NULL        | 0              | 0                 | 0                  | 7                 | YES          |                |               |              | 0                 |                   |                     |
| spark_catalog  | tpch_sf1     | customer    | c_comment               | 12         | STRING     | 255          | 0              | NULL            | NULL            | 1         |          | NULL        | 0              | 0                 | 0                  | 8                 | YES          |                |               |              | 0                 |                   |                     |
+----------------+--------------+-------------+-------------------------+------------+------------+--------------+----------------+-----------------+-----------------+-----------+----------+-------------+----------------+-------------------+--------------------+-------------------+--------------+----------------+---------------+--------------+-------------------+-------------------+---------------------+
```

<img width="1624" height="1056" alt="image" src="https://github.com/user-attachments/assets/0a5b2f24-1b03-4e7a-a858-e4f66cb206dc" />


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.