### PR TITLE
[SPARK-54352] [SQL] Introduce `SQLConf.canonicalize` to centralize normalization of strings

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -7211,6 +7211,20 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   }
 
   /**
+   * Returns the lower case representation of a string if `caseSensitiveAnalysis` is enabled.
+   * Otherwise, returns the original string.
+   */
+  def canonicalize(s: String): String = {
+    if (!caseSensitiveAnalysis) {
+      // scalastyle:off caselocale
+      s.toLowerCase
+      // scalastyle:on caselocale
+    } else {
+      s
+    }
+  }
+
+  /**
    * Returns the error handler for handling hint errors.
    */
   def hintErrorHandler: HintErrorHandler = HintErrorLogger


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR I propose that we introduce `SQLConf.canonicalize` to centralize normalization of strings. This will help us avoid the code duplication and ease the development of the single-pass analyzer.

### Why are the changes needed?
To ease the development of the single-pass analyzer (avoid code duplication).

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.