### PR TITLE
[SPARK-54353][SQL] Make CollectMetricsExec.collectedMetrics thread-safe

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.execution
 import java.io.{BufferedWriter, OutputStreamWriter}
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
-import javax.annotation.concurrent.GuardedBy
 
 import scala.util.control.NonFatal
 
@@ -298,13 +297,8 @@ class QueryExecution(
    */
   def toRdd: RDD[InternalRow] = lazyToRdd.get
 
-  private val observedMetricsLock = new Object
-
   /** Get the metrics observed during the execution of the query plan. */
-  @GuardedBy("observedMetricsLock")
-  def observedMetrics: Map[String, Row] = observedMetricsLock.synchronized {
-    CollectMetricsExec.collect(executedPlan)
-  }
+  def observedMetrics: Map[String, Row] = CollectMetricsExec.collect(executedPlan)
 
   protected def preparations: Seq[Rule[SparkPlan]] = {
     QueryExecution.preparations(sparkSession,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR makes `CollectMetricsExec.collectedMetrics` thread-safe by introducing synchronization and caching at the accumulator level.

**Key changes:**
1. Added a `collectedMetricsRow` field to cache the converted metrics row
2. Modified `collectedMetrics` method to use `accumulator.synchronized` block with lazy initialization and caching
3. Updated `resetMetrics()` to clear the cache and reset the accumulator within a synchronized block
4. Removed the `observedMetricsLock` from `QueryExecution.observedMetrics` since thread-safety is now handled at the `CollectMetricsExec` level

The synchronization ensures that:
- Multiple threads can safely call `collectedMetrics` concurrently
- The row conversion (`toRowConverter`) is performed only once and cached
- The cache is properly invalidated when metrics are reset

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The `CollectMetricsExec.collectedMetrics` method can be called concurrently from multiple threads when accessing `QueryExecution.observedMetrics` in connect mode. Without proper synchronization, this can lead to:

1. Race conditions during the row conversion process
2. Potential inconsistent or corrupted metrics results
3. Possible thread-safety violations in the underlying conversion logic

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. This is an internal bug fix that improves thread-safety. Users should not observe any behavioral changes except for the elimination of potential race conditions and incorrect results when accessing metrics concurrently.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
`build/sbt "sql/testOnly *DatasetSuite -- -z SPARK-54353"`

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Cursor 1.7.54