### PR TITLE
[SPARK-54355][CONNECT] Make `spark.connect.session.planCompression.defaultAlgorithm` to support `NONE`

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/ConnectPlanCompressionAlgorithm.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/ConnectPlanCompressionAlgorithm.scala
@@ -17,5 +17,5 @@
 package org.apache.spark.sql.connect.config
 
 object ConnectPlanCompressionAlgorithm extends Enumeration {
-  val ZSTD = Value
+  val ZSTD, NONE = Value
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `spark.connect.session.planCompression.defaultAlgorithm` to support `NONE` additionally.

### Why are the changes needed?

**BEFORE**

```
$ bin/spark-connect-shell -c spark.connect.session.planCompression.defaultAlgorithm=NONE
...
$ scala> spark.range(1).count()
...
Caused by: org.apache.spark.SparkIllegalArgumentException:
[INVALID_CONF_VALUE.OUT_OF_RANGE_OF_OPTIONS]
The value 'NONE' in the config "spark.connect.session.planCompression.defaultAlgorithm" is invalid.
It should be one of 'ZSTD'. SQLSTATE: 22022
```

**AFTER**

```
$ bin/spark-connect-shell -c spark.connect.session.planCompression.defaultAlgorithm=NONE
...
scala> spark.range(1).count()
val res0: Long = 1
```

### Does this PR introduce _any_ user-facing change?

No behavior change because this is a new option for a new feature.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.