### PR TITLE
[SPARK-54356][SDP] Fix EndToEndAPISuite caused by missing storage root schema

### DIFF
--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/EndToEndAPISuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/EndToEndAPISuite.scala
@@ -162,7 +162,7 @@ class EndToEndAPISuite extends PipelineTest with APITest with SparkConnectServer
       |name: test-pipeline
       |${spec.catalog.map(catalog => s"""catalog: "$catalog"""").getOrElse("")}
       |${spec.database.map(database => s"""database: "$database"""").getOrElse("")}
-      |storage: "${projectDir.resolve("storage").toAbsolutePath}"
+      |storage: "file://${projectDir.resolve("storage").toAbsolutePath}"
       |configuration:
       |  "spark.remote": "sc://localhost:$serverPort"
       |libraries:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes the `EndToEndAPISuite`, which was broken by https://github.com/apache/spark/pull/52999.

### Why are the changes needed?

For CI to pass

### Does this PR introduce _any_ user-facing change?

No - test-only change.

### How was this patch tested?

Ran tests.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
