### PR TITLE
[SPARK-54172][SQL][FOLLOW-UP] Simplify attribute re-resolution and validate action assignment value resolution for schema evolution

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveMergeIntoSchemaEvolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveMergeIntoSchemaEvolution.scala
@@ -48,9 +48,7 @@ object ResolveMergeIntoSchemaEvolution extends Rule[LogicalPlan] {
             val newTarget = performSchemaEvolution(r, referencedSourceSchema, changes)
             val oldTargetOutput = m.targetTable.output
             val newTargetOutput = newTarget.output
-            val attributeMapping = oldTargetOutput.map(
-              oldAttr => (oldAttr, newTargetOutput.find(_.name == oldAttr.name).getOrElse(oldAttr))
-            )
+            val attributeMapping = oldTargetOutput.zip(newTargetOutput)
             newTarget -> attributeMapping
         }
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -920,9 +920,13 @@ case class MergeIntoTable(
       }.flatten
 
       val sourcePaths = MergeIntoTable.extractAllFieldPaths(sourceTable.schema)
+      // Only allow unresolved assignment keys to be candidates for schema evolution
+      // if they are directly assigned from source fields, ie UPDATE SET new = source.new
       assignments.forall { assignment =>
         assignment.resolved ||
-          sourcePaths.exists { path => MergeIntoTable.isEqual(assignment, path) }
+          (assignment.value.resolved && sourcePaths.exists {
+            path => MergeIntoTable.isEqual(assignment, path)
+          })
         }
       }
     }


### PR DESCRIPTION


### What changes were proposed in this pull request?
Addressed remaining review comments in https://github.com/apache/spark/pull/52866

### Why are the changes needed?
Small code simplification, safety

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing unit tests

### Was this patch authored or co-authored using generative AI tooling?
No