### PR TITLE
[SPARK-54361][SQL] Fix Spark version to intended value of 4.2.0 for spark.sql.parser.singleCharacterPipeOperator.enabled

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3855,7 +3855,7 @@ object SQLConf {
       "for SQL pipe operators. When false, only '|>' is recognized as a pipe operator, and '|' " +
       "is only used for bitwise OR operations. This provides syntax compatibility with other " +
       "languages like Splunk SPL and Kusto that use '|' for pipe operations.")
-    .version("4.1.0")
+    .version("4.2.0")
     .booleanConf
     .createWithDefault(true)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

In https://github.com/apache/spark/pull/52983 we added the following new config, but mistakenly wrote its Spark version as 4.1.0. This PR fixes it to the intended value of 4.2.0 instead:

```
  val SINGLE_CHARACTER_PIPE_OPERATOR_ENABLED =
    buildConf("spark.sql.parser.singleCharacterPipeOperator.enabled")
    .doc("When true, the single character pipe token '|' can be used as an alternative to '|>' " +
      "for SQL pipe operators. When false, only '|>' is recognized as a pipe operator, and '|' " +
      "is only used for bitwise OR operations. This provides syntax compatibility with other " +
      "languages like Splunk SPL and Kusto that use '|' for pipe operations.")
    .version("4.1.0")
    .booleanConf
    .createWithDefault(true)

```

### Why are the changes needed?

We can correctly identify Spark versions for configs.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

N/A

### Was this patch authored or co-authored using generative AI tooling?

No