### PR TITLE
[SPARK-54314][PYTHON][CONNECT] Improve Server-Side debuggability in Spark Connect by capturing client application's file name and line numbers

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -1160,6 +1160,7 @@ pyspark_connect = Module(
         "pyspark.sql.tests.connect.client.test_artifact",
         "pyspark.sql.tests.connect.client.test_artifact_localcluster",
         "pyspark.sql.tests.connect.client.test_client",
+        "pyspark.sql.tests.connect.client.test_client_call_stack_trace",
         "pyspark.sql.tests.connect.client.test_reattach",
         "pyspark.sql.tests.connect.test_resources",
         "pyspark.sql.tests.connect.shell.test_progress",

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -644,6 +644,7 @@ def _retrieve_stack_frames() -> List[CallSite]:
     for i, frame in enumerate(frames):
         filename, lineno, func, _ = frame
         if _is_pyspark_source(filename):
+            # Do not include PySpark internal frames as they are not user application code
             break
         if i + 1 < len(frames):
             _, _, func, _ = frames[i + 1]

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -68,7 +68,6 @@ from google.rpc import error_details_pb2
 from pyspark.util import is_remote_only
 from pyspark.accumulators import SpecialAccumulatorIds
 from pyspark.version import __version__
-from pyspark import traceback_utils
 from pyspark.traceback_utils import CallSite
 from pyspark.resource.information import ResourceInformation
 from pyspark.sql.metrics import MetricValue, PlanMetrics, ExecutionInfo, ObservedMetrics
@@ -658,7 +657,8 @@ def _build_call_stack_trace() -> any_pb2.Any:
     Build a call stack trace for the current Spark Connect action
     Returns
     -------
-    FetchErrorDetailsResponse.Error: An Error object containing list of stack frames of the user code packed as Any protobuf.
+    FetchErrorDetailsResponse.Error: An Error object containing list of stack frames
+    of the user code packed as Any protobuf.
     """
     if os.getenv("SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK", "false").lower() in ("true", "1"):
         stack_frames = _retrieve_stack_frames()

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -823,7 +823,7 @@ class SparkConnectClient(object):
         Return list of currently used policies
         """
         return list(self._retry_policies)
-    
+
     @classmethod
     def _retrieve_stack_frames(cls) -> List[CallSite]:
         """

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -633,50 +633,6 @@ def _is_pyspark_source(filename: str) -> bool:
     return filename.startswith(PYSPARK_ROOT)
 
 
-def _retrieve_stack_frames() -> List[CallSite]:
-    """
-    Return a list of CallSites representing the relevant stack frames in the callstack.
-    """
-    frames = traceback.extract_stack()
-
-    filtered_stack_frames = []
-    for i, frame in enumerate(frames):
-        filename, lineno, func, _ = frame
-        if _is_pyspark_source(filename):
-            # Do not include PySpark internal frames as they are not user application code
-            break
-        if i + 1 < len(frames):
-            _, _, func, _ = frames[i + 1]
-        filtered_stack_frames.append(CallSite(function=func, file=filename, linenum=lineno))
-
-    return filtered_stack_frames
-
-
-def _build_call_stack_trace() -> Optional[any_pb2.Any]:
-    """
-    Build a call stack trace for the current Spark Connect action
-    Returns
-    -------
-    FetchErrorDetailsResponse.Error: An Error object containing list of stack frames
-    of the user code packed as Any protobuf.59
-    """
-    if os.getenv("SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK", "false").lower() in ("true", "1"):
-        stack_frames = _retrieve_stack_frames()
-        call_stack = FetchErrorDetailsResponse.Error()
-        for call_site in stack_frames:
-            stack_trace_element = pb2.FetchErrorDetailsResponse.StackTraceElement()
-            stack_trace_element.declaring_class = ""  # unknown information
-            stack_trace_element.method_name = call_site.function
-            stack_trace_element.file_name = call_site.file
-            stack_trace_element.line_number = call_site.linenum
-            call_stack.stack_trace.append(stack_trace_element)
-        if len(call_stack.stack_trace) > 0:
-            call_stack_details = any_pb2.Any()
-            call_stack_details.Pack(call_stack)
-            return call_stack_details
-    return None
-
-
 class SparkConnectClient(object):
     """
     Conceptually the remote spark session that communicates with the server
@@ -867,6 +823,50 @@ class SparkConnectClient(object):
         Return list of currently used policies
         """
         return list(self._retry_policies)
+    
+    @classmethod
+    def _retrieve_stack_frames(cls) -> List[CallSite]:
+        """
+        Return a list of CallSites representing the relevant stack frames in the callstack.
+        """
+        frames = traceback.extract_stack()
+
+        filtered_stack_frames = []
+        for i, frame in enumerate(frames):
+            filename, lineno, func, _ = frame
+            if _is_pyspark_source(filename):
+                # Do not include PySpark internal frames as they are not user application code
+                break
+            if i + 1 < len(frames):
+                _, _, func, _ = frames[i + 1]
+            filtered_stack_frames.append(CallSite(function=func, file=filename, linenum=lineno))
+
+        return filtered_stack_frames
+
+    @classmethod
+    def _build_call_stack_trace(cls) -> Optional[any_pb2.Any]:
+        """
+        Build a call stack trace for the current Spark Connect action
+        Returns
+        -------
+        FetchErrorDetailsResponse.Error: An Error object containing list of stack frames
+        of the user code packed as Any protobuf
+        """
+        if os.getenv("SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK", "false").lower() in ("true", "1"):
+            stack_frames = cls._retrieve_stack_frames()
+            call_stack = FetchErrorDetailsResponse.Error()
+            for call_site in stack_frames:
+                stack_trace_element = pb2.FetchErrorDetailsResponse.StackTraceElement()
+                stack_trace_element.declaring_class = ""  # unknown information
+                stack_trace_element.method_name = call_site.function
+                stack_trace_element.file_name = call_site.file
+                stack_trace_element.line_number = call_site.linenum
+                call_stack.stack_trace.append(stack_trace_element)
+            if len(call_stack.stack_trace) > 0:
+                call_stack_details = any_pb2.Any()
+                call_stack_details.Pack(call_stack)
+                return call_stack_details
+        return None
 
     def register_udf(
         self,
@@ -1348,8 +1348,7 @@ class SparkConnectClient(object):
             req.operation_id = operation_id
         self._update_request_with_user_context_extensions(req)
 
-        call_stack_trace = _build_call_stack_trace()
-        if call_stack_trace:
+        if call_stack_trace := self.__class__._build_call_stack_trace():
             req.user_context.extensions.append(call_stack_trace)
         return req
 
@@ -1362,8 +1361,7 @@ class SparkConnectClient(object):
         if self._user_id:
             req.user_context.user_id = self._user_id
         self._update_request_with_user_context_extensions(req)
-        call_stack_trace = _build_call_stack_trace()
-        if call_stack_trace:
+        if call_stack_trace := self.__class__._build_call_stack_trace():
             req.user_context.extensions.append(call_stack_trace)
         return req
 
@@ -1780,8 +1778,7 @@ class SparkConnectClient(object):
         if self._user_id:
             req.user_context.user_id = self._user_id
         self._update_request_with_user_context_extensions(req)
-        call_stack_trace = _build_call_stack_trace()
-        if call_stack_trace:
+        if call_stack_trace := self.__class__._build_call_stack_trace():
             req.user_context.extensions.append(call_stack_trace)
         return req
 

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -627,6 +627,7 @@ class ConfigResult:
             warnings=list(pb.warnings),
         )
 
+
 def _is_pyspark_source(filename: str) -> bool:
     """Check if the given filename is from the pyspark package."""
     return filename.startswith(PYSPARK_ROOT)
@@ -643,11 +644,12 @@ def _retrieve_stack_frames() -> List[CallSite]:
         filename, lineno, func, _ = frame
         if _is_pyspark_source(filename):
             break
-        if i+1 < len(frames):
-            _, _, func, _ = frames[i+1]
+        if i + 1 < len(frames):
+            _, _, func, _ = frames[i + 1]
         filtered_stack_frames.append(CallSite(function=func, file=filename, linenum=lineno))
 
     return filtered_stack_frames
+
 
 def _build_call_stack_trace() -> List[any_pb2.Any]:
     """

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -652,13 +652,13 @@ def _retrieve_stack_frames() -> List[CallSite]:
     return filtered_stack_frames
 
 
-def _build_call_stack_trace() -> any_pb2.Any:
+def _build_call_stack_trace() -> Optional[any_pb2.Any]:
     """
     Build a call stack trace for the current Spark Connect action
     Returns
     -------
     FetchErrorDetailsResponse.Error: An Error object containing list of stack frames
-    of the user code packed as Any protobuf.
+    of the user code packed as Any protobuf.59
     """
     if os.getenv("SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK", "false").lower() in ("true", "1"):
         stack_frames = _retrieve_stack_frames()

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1297,7 +1297,6 @@ class SparkConnectClient(object):
         """
         return self._builder.token
 
-
     def _update_request_with_user_context_extensions(
         self,
         req: Union[
@@ -1315,7 +1314,6 @@ class SparkConnectClient(object):
             return
         for _, extension in self.thread_local.user_context_extensions:
             req.user_context.extensions.append(extension)
-
 
     def _execute_plan_request_with_metadata(
         self, operation_id: Optional[str] = None

--- a/python/pyspark/sql/tests/connect/client/test_client_call_stack_trace.py
+++ b/python/pyspark/sql/tests/connect/client/test_client_call_stack_trace.py
@@ -41,7 +41,9 @@ if should_test_connect:
     # in `SparkConnectClient` constructor. To bypass the issue, patch the method in the test.
     SparkConnectClient._cleanup_ml_cache = lambda _: None
 
-
+# SPARK-54314: Improve Server-Side debuggability in Spark Connect by capturing client application's 
+# file name and line numbers in PySpark
+# https://issues.apache.org/jira/browse/SPARK-54314
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)
 class CallStackTraceTestCase(unittest.TestCase):

--- a/python/pyspark/sql/tests/connect/client/test_client_call_stack_trace.py
+++ b/python/pyspark/sql/tests/connect/client/test_client_call_stack_trace.py
@@ -1,0 +1,433 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+import pyspark
+from pyspark.sql import functions
+from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
+
+if should_test_connect:
+    import pyspark.sql.connect.proto as pb2
+    from pyspark.sql.connect.client import SparkConnectClient, core
+    from pyspark.sql.connect.client.core import (
+        _is_pyspark_source,
+        _retrieve_stack_frames,
+        _build_call_stack_trace,
+    )
+    from pyspark.traceback_utils import CallSite
+    from google.protobuf import any_pb2
+
+
+    # The _cleanup_ml_cache invocation will hang in this test (no valid spark cluster)
+    # and it blocks the test process exiting because it is registered as the atexit handler
+    # in `SparkConnectClient` constructor. To bypass the issue, patch the method in the test.
+    SparkConnectClient._cleanup_ml_cache = lambda _: None
+
+
+
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
+class CallStackTraceTestCase(unittest.TestCase):
+    """Test cases for call stack trace functionality in Spark Connect client."""
+
+    def setUp(self):
+        # Since this test itself is under pyspark module path, stack frames for test functions inside 
+        # this file - for example, user_function() - will normally be filtered out. So here we 
+        # set the PYSPARK_ROOT to more specific pyspaark.sql.connect that doesn't include this 
+        # test file to ensure that the stack frames for user functions inside this test file are 
+        # not filtered out.
+        self.original_pyspark_root = core.PYSPARK_ROOT
+        core.PYSPARK_ROOT = os.path.dirname(pyspark.sql.connect.__file__)
+    
+    def tearDown(self):
+        # Restore the original PYSPARK_ROOT
+        core.PYSPARK_ROOT = self.original_pyspark_root
+
+    def test_is_pyspark_source_with_pyspark_file(self):
+        """Test that _is_pyspark_source correctly identifies PySpark files."""
+        # Get a known pyspark file path
+        from pyspark import sql
+
+        pyspark_file = sql.connect.client.__file__
+        self.assertTrue(_is_pyspark_source(pyspark_file))
+
+    def test_is_pyspark_source_with_non_pyspark_file(self):
+        """Test that _is_pyspark_source correctly identifies non-PySpark files."""
+        # Use the current test file which is in pyspark but we'll simulate a non-pyspark path
+        non_pyspark_file = "/tmp/user_script.py"
+        self.assertFalse(_is_pyspark_source(non_pyspark_file))
+
+        # Test with stdlib file
+        stdlib_file = os.__file__
+        self.assertFalse(_is_pyspark_source(stdlib_file))
+
+    def test_is_pyspark_source_with_relative_path(self):
+        """Test _is_pyspark_source with various path formats."""
+        from pyspark import sql
+
+        # Test with absolute path to pyspark file
+        pyspark_sql_file = sql.connect.client.__file__
+        self.assertTrue(_is_pyspark_source(pyspark_sql_file))
+
+        # Test with non-pyspark absolute path
+        self.assertFalse(_is_pyspark_source("/home/user/my_script.py"))
+
+    def test_retrieve_stack_frames_filters_pyspark_frames(self):
+        """Test that _retrieve_stack_frames filters out PySpark internal frames."""
+        def user_function():
+            return _retrieve_stack_frames()
+
+        stack_frames = user_function()
+        
+        # Verify we have at least some frames
+        self.assertGreater(len(stack_frames), 0, "Expected at least some stack frames")
+        
+        # Verify that none of the returned frames are from PySpark internal code
+        for frame in stack_frames:
+            # Check that this frame is not from pyspark internal code
+            self.assertFalse(
+                _is_pyspark_source(frame.file),
+                f"Expected frame from {frame.file} (function: {frame.function}) to be filtered out as PySpark internal frame"
+            )
+        
+        # Verify that user function names are present (confirming user frames are included)
+        function_names = [frame.function for frame in stack_frames]
+        expected_functions = ["user_function", "test_retrieve_stack_frames_filters_pyspark_frames"]
+        self.assertTrue("user_function" in function_names, f"Expected user function names not found in: {function_names}")
+        self.assertTrue("test_retrieve_stack_frames_filters_pyspark_frames" in function_names, f"Expected user function names not found in: {function_names}")
+
+    def test_retrieve_stack_frames_includes_user_frames(self):
+        """Test that _retrieve_stack_frames includes user code frames."""
+        def user_function():
+            """Simulate a user function."""
+            return _retrieve_stack_frames()
+
+        def another_user_function():
+            """Another level of user code."""
+            return user_function()
+        
+        stack_frames = another_user_function()
+
+        # We should have at least some frames from the test
+        self.assertGreater(len(stack_frames), 0)
+
+        # Check that we have frames with function names we expect
+        function_names = [frame.function for frame in stack_frames]
+        # At least one of our test functions should be in the stack
+        self.assertTrue("user_function" in function_names, f"Expected user function names not found in: {function_names}")
+        self.assertTrue("another_user_function" in function_names, f"Expected user function names not found in: {function_names}")
+        self.assertTrue("test_retrieve_stack_frames_includes_user_frames" in function_names, f"Expected user function names not found in: {function_names}")
+
+    def test_retrieve_stack_frames_captures_correct_info(self):
+        """Test that _retrieve_stack_frames captures correct frame information."""
+        def user_function():
+            return _retrieve_stack_frames()
+
+        stack_frames = user_function()
+
+        # Verify each frame has the expected attributes
+        functions = set()
+        files = set()
+        for frame in stack_frames:
+            functions.add(frame.function)
+            files.add(frame.file)
+            self.assertIsNotNone(frame.function)
+            self.assertIsNotNone(frame.file)
+            self.assertIsNotNone(frame.linenum)
+            self.assertIsInstance(frame.function, str)
+            self.assertIsInstance(frame.file, str)
+            self.assertIsInstance(frame.linenum, int)
+            self.assertGreater(frame.linenum, 0)
+        
+        self.assertTrue("user_function" in functions, f"Expected user function names not found in: {functions}")
+        self.assertTrue("test_retrieve_stack_frames_captures_correct_info" in functions, f"Expected user function names not found in: {functions}")
+        self.assertTrue(__file__ in files, f"Expected user function names not found in: {files}")
+
+    def test_build_call_stack_trace_without_env_var(self):
+        """Test that _build_call_stack_trace returns empty list when env var is not set."""
+        # Make sure the env var is not set
+        with patch.dict(os.environ, {}, clear=False):
+            if "SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK" in os.environ:
+                del os.environ["SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK"]
+
+            call_stack = _build_call_stack_trace()
+
+            self.assertIsInstance(call_stack, list)
+            self.assertEqual(len(call_stack), 0, "Expected empty list when env var is not set")
+
+    def test_build_call_stack_trace_with_env_var_set(self):
+        """Test that _build_call_stack_trace builds trace when env var is set."""
+        # Set the env var to enable call stack tracing
+        with patch.dict(os.environ, {"SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK": "1"}):
+            call_stack = _build_call_stack_trace()
+
+            self.assertIsInstance(call_stack, list)
+            # Should have at least one frame (this test function)
+            self.assertGreater(
+                len(call_stack), 0, "Expected non-empty list when env var is set"
+            )
+
+            # Verify each element is an Any protobuf message
+            functions = set()
+            files = set()
+            for stack_frame in call_stack:
+                self.assertIsInstance(stack_frame, any_pb2.Any)
+
+                # Unpack and verify it's a StackTraceElement
+                stack_trace_element = pb2.FetchErrorDetailsResponse.StackTraceElement()
+                stack_frame.Unpack(stack_trace_element)
+                functions.add(stack_trace_element.method_name)
+                files.add(stack_trace_element.file_name)
+
+                # Verify the fields are populated
+                self.assertIsInstance(stack_trace_element.method_name, str)
+                self.assertIsInstance(stack_trace_element.file_name, str)
+                self.assertIsInstance(stack_trace_element.line_number, int)
+                self.assertEqual(
+                    stack_trace_element.declaring_class, "", "declaring_class should be empty"
+                )
+            
+            self.assertTrue("test_build_call_stack_trace_with_env_var_set" in functions, f"Expected user function names not found in: {functions}")
+            self.assertTrue(__file__ in files, f"Expected user function names not found in: {files}")
+
+    def test_build_call_stack_trace_with_env_var_empty_string(self):
+        """Test that _build_call_stack_trace returns empty list when env var is empty string."""
+        with patch.dict(os.environ, {"SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK": ""}):
+            call_stack = _build_call_stack_trace()
+
+            self.assertIsInstance(call_stack, list)
+            self.assertEqual(
+                len(call_stack), 0, "Expected empty list when env var is empty string"
+            )
+
+    def test_build_call_stack_trace_with_various_env_var_values(self):
+        """Test _build_call_stack_trace behavior with various env var values."""
+        test_cases = [
+            ("0", 0, "zero string should be treated as falsy"),
+            ("false", 0, "non-empty string 'false' should be falsy"),
+            ("TRUE", 1, "string 'TRUE' should be truthy"),
+            ("true", 1, "string 'true' should be truthy"),
+            ("1", 1, "string '1' should be truthy"),
+            ("any_value", 0, "any non-empty string should be falsy"),
+        ]
+
+        for env_value, expected_behavior, message in test_cases:
+            with self.subTest(env_value=env_value):
+                with patch.dict(
+                    os.environ, {"SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK": env_value}
+                ):
+                    call_stack = _build_call_stack_trace()
+                    if expected_behavior == 0:
+                        self.assertEqual(len(call_stack), 0, message)
+                    else:
+                        self.assertGreater(len(call_stack), 0, message)
+
+
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
+class CallStackTraceIntegrationTestCase(unittest.TestCase):
+    """Integration tests for call stack trace in client request methods."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.client = SparkConnectClient("sc://localhost:15002", use_reattachable_execute=False)
+        # Since this test itself is under pyspark module path, stack frames for test functions inside 
+        # this file - for example, user_function() - will normally be filtered out. So here we 
+        # set the PYSPARK_ROOT to more specific pyspaark.sql.connect that doesn't include this 
+        # test file to ensure that the stack frames for user functions inside this test file are 
+        # not filtered out.
+        self.original_pyspark_root = core.PYSPARK_ROOT
+        core.PYSPARK_ROOT = os.path.dirname(pyspark.sql.connect.__file__)
+    
+    def tearDown(self):
+        # Restore the original PYSPARK_ROOT
+        core.PYSPARK_ROOT = self.original_pyspark_root
+
+    def test_execute_plan_request_includes_call_stack_without_env_var(self):
+        """Test that _execute_plan_request_with_metadata doesn't include call stack without env var."""
+        with patch.dict(os.environ, {}, clear=False):
+            if "SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK" in os.environ:
+                del os.environ["SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK"]
+
+            req = self.client._execute_plan_request_with_metadata()
+
+            # Should have no extensions when env var is not set
+            self.assertEqual(
+                len(req.user_context.extensions),
+                0,
+                "Expected no extensions without env var",
+            )
+
+    def test_execute_plan_request_includes_call_stack_with_env_var(self):
+        """Test that _execute_plan_request_with_metadata includes call stack with env var."""
+        with patch.dict(os.environ, {"SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK": "1"}):
+            req = self.client._execute_plan_request_with_metadata()
+
+            # Should have extensions when env var is set
+            self.assertGreater(
+                len(req.user_context.extensions),
+                0,
+                "Expected extensions with env var set",
+            )
+
+            # Verify each extension can be unpacked as StackTraceElement
+            files = set()
+            functions = set()
+            for extension in req.user_context.extensions:
+                stack_trace_element = pb2.FetchErrorDetailsResponse.StackTraceElement()
+                extension.Unpack(stack_trace_element)
+                functions.add(stack_trace_element.method_name)
+                files.add(stack_trace_element.file_name)
+                self.assertIsInstance(stack_trace_element.method_name, str)
+                self.assertIsInstance(stack_trace_element.file_name, str)
+            
+            self.assertTrue("test_execute_plan_request_includes_call_stack_with_env_var" in functions, f"Expected user function names not found in: {functions}")
+            self.assertTrue(__file__ in files, f"Expected user function names not found in: {files}")
+
+    def test_analyze_plan_request_includes_call_stack_without_env_var(self):
+        """Test that _analyze_plan_request_with_metadata doesn't include call stack without env var."""
+        with patch.dict(os.environ, {}, clear=False):
+            if "SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK" in os.environ:
+                del os.environ["SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK"]
+
+            req = self.client._analyze_plan_request_with_metadata()
+
+            # Should have no extensions when env var is not set
+            self.assertEqual(
+                len(req.user_context.extensions),
+                0,
+                "Expected no extensions without env var",
+            )
+
+    def test_analyze_plan_request_includes_call_stack_with_env_var(self):
+        """Test that _analyze_plan_request_with_metadata includes call stack with env var."""
+        with patch.dict(os.environ, {"SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK": "1"}):
+            req = self.client._analyze_plan_request_with_metadata()
+
+            # Should have extensions when env var is set
+            self.assertGreater(
+                len(req.user_context.extensions),
+                0,
+                "Expected extensions with env var set",
+            )
+
+            # Verify each extension can be unpacked as StackTraceElement
+            files = set()
+            functions = set()
+            for extension in req.user_context.extensions:
+                stack_trace_element = pb2.FetchErrorDetailsResponse.StackTraceElement()
+                extension.Unpack(stack_trace_element)
+                functions.add(stack_trace_element.method_name)
+                files.add(stack_trace_element.file_name)
+                self.assertIsInstance(stack_trace_element.method_name, str)
+                self.assertIsInstance(stack_trace_element.file_name, str)
+
+            self.assertTrue("test_analyze_plan_request_includes_call_stack_with_env_var" in functions, f"Expected user function names not found in: {functions}")
+            self.assertTrue(__file__ in files, f"Expected user function names not found in: {files}")
+
+    def test_config_request_includes_call_stack_without_env_var(self):
+        """Test that _config_request_with_metadata doesn't include call stack without env var."""
+        with patch.dict(os.environ, {}, clear=False):
+            if "SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK" in os.environ:
+                del os.environ["SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK"]
+
+            req = self.client._config_request_with_metadata()
+
+            # Should have no extensions when env var is not set
+            self.assertEqual(
+                len(req.user_context.extensions),
+                0,
+                "Expected no extensions without env var",
+            )
+
+    def test_config_request_includes_call_stack_with_env_var(self):
+        """Test that _config_request_with_metadata includes call stack with env var."""
+        with patch.dict(os.environ, {"SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK": "1"}):
+            req = self.client._config_request_with_metadata()
+
+            # Should have extensions when env var is set
+            self.assertGreater(
+                len(req.user_context.extensions),
+                0,
+                "Expected extensions with env var set",
+            )
+
+            # Verify each extension can be unpacked as StackTraceElement
+            files = set()
+            functions = set()
+            for extension in req.user_context.extensions:
+                stack_trace_element = pb2.FetchErrorDetailsResponse.StackTraceElement()
+                extension.Unpack(stack_trace_element)
+                functions.add(stack_trace_element.method_name)
+                files.add(stack_trace_element.file_name)
+                self.assertIsInstance(stack_trace_element.method_name, str)
+                self.assertIsInstance(stack_trace_element.file_name, str)
+
+            self.assertTrue("test_config_request_includes_call_stack_with_env_var" in functions, f"Expected user function names not found in: {functions}")
+            self.assertTrue(__file__ in files, f"Expected user function names not found in: {files}")
+
+    def test_call_stack_trace_captures_correct_calling_context(self):
+        """Test that call stack trace captures the correct calling context."""
+
+        def level3():
+            """Third level function."""
+            with patch.dict(os.environ, {"SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK": "1"}):
+                req = self.client._execute_plan_request_with_metadata()
+                return req
+
+        def level2():
+            """Second level function."""
+            return level3()
+
+        def level1():
+            """First level function."""
+            return level2()
+
+        req = level1()
+
+        # Verify we captured frames from our nested functions
+        self.assertGreater(len(req.user_context.extensions), 0)
+
+        # Unpack and check that we have function names from our call chain
+        functions = set()
+        files = set()
+        for extension in req.user_context.extensions:
+            stack_trace_element = pb2.FetchErrorDetailsResponse.StackTraceElement()
+            extension.Unpack(stack_trace_element)
+            functions.add(stack_trace_element.method_name)
+            files.add(stack_trace_element.file_name)
+            self.assertGreater(stack_trace_element.line_number, 0, f"Expected line number to be greater than 0, got: {stack_trace_element.line_number}")
+
+        self.assertTrue("level1" in functions, f"Expected user function names not found in: {functions}")
+        self.assertTrue("level2" in functions, f"Expected user function names not found in: {functions}")
+        self.assertTrue("level3" in functions, f"Expected user function names not found in: {functions}")
+        self.assertTrue(__file__ in files, f"Expected user function names not found in: {files}")
+
+
+if __name__ == "__main__":
+    from pyspark.sql.tests.connect.client.test_client_call_stack_trace import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)
+

--- a/python/pyspark/sql/tests/connect/client/test_client_call_stack_trace.py
+++ b/python/pyspark/sql/tests/connect/client/test_client_call_stack_trace.py
@@ -201,12 +201,16 @@ class CallStackTraceTestCase(unittest.TestCase):
         # Set the env var to enable call stack tracing
         with patch.dict(os.environ, {"SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK": "1"}):
             stack_trace_details = _build_call_stack_trace()
-            self.assertIsNotNone(stack_trace_details, "Expected non-None call stack when env var is set")
+            self.assertIsNotNone(
+                stack_trace_details, "Expected non-None call stack when env var is set"
+            )
             error = pb2.FetchErrorDetailsResponse.Error()
             if not stack_trace_details.Unpack(error):
                 self.assertTrue(False, "Expected to unpack stack trace details into Error object")
             # Should have at least one frame (this test function)
-            self.assertGreater(len(error.stack_trace), 0, "Expected > 0 call stack frames when env var is set")
+            self.assertGreater(
+                len(error.stack_trace), 0, "Expected > 0 call stack frames when env var is set"
+            )
 
             # Verify each element is an Any protobuf message
             functions = set()

--- a/python/pyspark/sql/tests/connect/client/test_client_call_stack_trace.py
+++ b/python/pyspark/sql/tests/connect/client/test_client_call_stack_trace.py
@@ -46,7 +46,7 @@ class CallStackTraceTestCase(unittest.TestCase):
     """Test cases for call stack trace functionality in Spark Connect client."""
 
     def setUp(self):
-        # Since this test itself is under pyspark module path, stack frames for test functions 
+        # Since this test itself is under pyspark module path, stack frames for test functions
         # inside this file - for example, user_function() - will normally be filtered out. So here
         # we set the PYSPARK_ROOT to more specific pyspaark.sql.connect that doesn't include this
         # test file to ensure that the stack frames for user functions inside this test file are
@@ -102,8 +102,9 @@ class CallStackTraceTestCase(unittest.TestCase):
         for frame in stack_frames:
             # Check that this frame is not from pyspark internal code
             self.assertFalse(
-                _is_pyspark_source(frame.file),(
-                    f"Expected frame from {frame.file} (function: {frame.function})"   
+                _is_pyspark_source(frame.file),
+                (
+                    f"Expected frame from {frame.file} (function: {frame.function})"
                     f"to be filtered out as PySpark internal frame"
                 ),
             )
@@ -265,8 +266,8 @@ class CallStackTraceIntegrationTestCase(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         self.client = SparkConnectClient("sc://localhost:15002", use_reattachable_execute=False)
-        # Since this test itself is under pyspark module path, stack frames for test functions 
-        # inside this file - for example, user_function() - will normally be filtered out. So here 
+        # Since this test itself is under pyspark module path, stack frames for test functions
+        # inside this file - for example, user_function() - will normally be filtered out. So here
         # we set the PYSPARK_ROOT to more specific pyspaark.sql.connect that doesn't include this
         # test file to ensure that the stack frames for user functions inside this test file are
         # not filtered out.
@@ -278,7 +279,7 @@ class CallStackTraceIntegrationTestCase(unittest.TestCase):
         core.PYSPARK_ROOT = self.original_pyspark_root
 
     def test_execute_plan_request_includes_call_stack_without_env_var(self):
-        """ _execute_plan_request_with_metadata doesn't include call stack without env var."""
+        """_execute_plan_request_with_metadata doesn't include call stack without env var."""
         with patch.dict(os.environ, {}, clear=False):
             if "SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK" in os.environ:
                 del os.environ["SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK"]
@@ -456,8 +457,10 @@ class CallStackTraceIntegrationTestCase(unittest.TestCase):
                     self.assertGreater(
                         stack_trace_element.line_number,
                         0,
-                        (f"Expected line number to be greater than 0,"
-                         f"got: {stack_trace_element.line_number}"),
+                        (
+                            f"Expected line number to be greater than 0,"
+                            f"got: {stack_trace_element.line_number}"
+                        ),
                     )
 
         self.assertTrue(

--- a/python/pyspark/sql/tests/connect/client/test_client_call_stack_trace.py
+++ b/python/pyspark/sql/tests/connect/client/test_client_call_stack_trace.py
@@ -16,13 +16,10 @@
 #
 
 import os
-import sys
 import unittest
 from unittest.mock import patch
 
 import pyspark
-from pyspark.sql import functions
-from pyspark.sql.connect.proto.base_pb2 import FetchErrorDetailsResponse
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 
 if should_test_connect:
@@ -33,8 +30,6 @@ if should_test_connect:
         _retrieve_stack_frames,
         _build_call_stack_trace,
     )
-    from pyspark.traceback_utils import CallSite
-    from google.protobuf import any_pb2
 
     # The _cleanup_ml_cache invocation will hang in this test (no valid spark cluster)
     # and it blocks the test process exiting because it is registered as the atexit handler
@@ -51,9 +46,9 @@ class CallStackTraceTestCase(unittest.TestCase):
     """Test cases for call stack trace functionality in Spark Connect client."""
 
     def setUp(self):
-        # Since this test itself is under pyspark module path, stack frames for test functions inside
-        # this file - for example, user_function() - will normally be filtered out. So here we
-        # set the PYSPARK_ROOT to more specific pyspaark.sql.connect that doesn't include this
+        # Since this test itself is under pyspark module path, stack frames for test functions 
+        # inside this file - for example, user_function() - will normally be filtered out. So here
+        # we set the PYSPARK_ROOT to more specific pyspaark.sql.connect that doesn't include this
         # test file to ensure that the stack frames for user functions inside this test file are
         # not filtered out.
         self.original_pyspark_root = core.PYSPARK_ROOT
@@ -107,13 +102,14 @@ class CallStackTraceTestCase(unittest.TestCase):
         for frame in stack_frames:
             # Check that this frame is not from pyspark internal code
             self.assertFalse(
-                _is_pyspark_source(frame.file),
-                f"Expected frame from {frame.file} (function: {frame.function}) to be filtered out as PySpark internal frame",
+                _is_pyspark_source(frame.file),(
+                    f"Expected frame from {frame.file} (function: {frame.function})"   
+                    f"to be filtered out as PySpark internal frame"
+                ),
             )
 
         # Verify that user function names are present (confirming user frames are included)
         function_names = [frame.function for frame in stack_frames]
-        expected_functions = ["user_function", "test_retrieve_stack_frames_filters_pyspark_frames"]
         self.assertTrue(
             "user_function" in function_names,
             f"Expected user function names not found in: {function_names}",
@@ -269,9 +265,9 @@ class CallStackTraceIntegrationTestCase(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         self.client = SparkConnectClient("sc://localhost:15002", use_reattachable_execute=False)
-        # Since this test itself is under pyspark module path, stack frames for test functions inside
-        # this file - for example, user_function() - will normally be filtered out. So here we
-        # set the PYSPARK_ROOT to more specific pyspaark.sql.connect that doesn't include this
+        # Since this test itself is under pyspark module path, stack frames for test functions 
+        # inside this file - for example, user_function() - will normally be filtered out. So here 
+        # we set the PYSPARK_ROOT to more specific pyspaark.sql.connect that doesn't include this
         # test file to ensure that the stack frames for user functions inside this test file are
         # not filtered out.
         self.original_pyspark_root = core.PYSPARK_ROOT
@@ -282,7 +278,7 @@ class CallStackTraceIntegrationTestCase(unittest.TestCase):
         core.PYSPARK_ROOT = self.original_pyspark_root
 
     def test_execute_plan_request_includes_call_stack_without_env_var(self):
-        """Test that _execute_plan_request_with_metadata doesn't include call stack without env var."""
+        """ _execute_plan_request_with_metadata doesn't include call stack without env var."""
         with patch.dict(os.environ, {}, clear=False):
             if "SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK" in os.environ:
                 del os.environ["SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK"]
@@ -330,7 +326,7 @@ class CallStackTraceIntegrationTestCase(unittest.TestCase):
             )
 
     def test_analyze_plan_request_includes_call_stack_without_env_var(self):
-        """Test that _analyze_plan_request_with_metadata doesn't include call stack without env var."""
+        """_analyze_plan_request_with_metadata doesn't include call stack without env var."""
         with patch.dict(os.environ, {}, clear=False):
             if "SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK" in os.environ:
                 del os.environ["SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK"]
@@ -460,7 +456,8 @@ class CallStackTraceIntegrationTestCase(unittest.TestCase):
                     self.assertGreater(
                         stack_trace_element.line_number,
                         0,
-                        f"Expected line number to be greater than 0, got: {stack_trace_element.line_number}",
+                        (f"Expected line number to be greater than 0,"
+                         f"got: {stack_trace_element.line_number}"),
                     )
 
         self.assertTrue(

--- a/python/pyspark/sql/tests/connect/client/test_client_call_stack_trace.py
+++ b/python/pyspark/sql/tests/connect/client/test_client_call_stack_trace.py
@@ -25,11 +25,7 @@ from pyspark.testing.connectutils import should_test_connect, connect_requiremen
 if should_test_connect:
     import pyspark.sql.connect.proto as pb2
     from pyspark.sql.connect.client import SparkConnectClient, core
-    from pyspark.sql.connect.client.core import (
-        _is_pyspark_source,
-        _retrieve_stack_frames,
-        _build_call_stack_trace,
-    )
+    from pyspark.sql.connect.client.core import _is_pyspark_source
 
     # The _cleanup_ml_cache invocation will hang in this test (no valid spark cluster)
     # and it blocks the test process exiting because it is registered as the atexit handler
@@ -76,56 +72,12 @@ class CallStackTraceTestCase(unittest.TestCase):
         stdlib_file = os.__file__
         self.assertFalse(_is_pyspark_source(stdlib_file))
 
-    def test_is_pyspark_source_with_relative_path(self):
-        """Test _is_pyspark_source with various path formats."""
-        from pyspark import sql
-
-        # Test with absolute path to pyspark file
-        pyspark_sql_file = sql.connect.client.__file__
-        self.assertTrue(_is_pyspark_source(pyspark_sql_file))
-
-        # Test with non-pyspark absolute path
-        self.assertFalse(_is_pyspark_source("/home/user/my_script.py"))
-
-    def test_retrieve_stack_frames_filters_pyspark_frames(self):
-        """Test that _retrieve_stack_frames filters out PySpark internal frames."""
-
-        def user_function():
-            return _retrieve_stack_frames()
-
-        stack_frames = user_function()
-
-        # Verify we have at least some frames
-        self.assertGreater(len(stack_frames), 0, "Expected at least some stack frames")
-
-        # Verify that none of the returned frames are from PySpark internal code
-        for frame in stack_frames:
-            # Check that this frame is not from pyspark internal code
-            self.assertFalse(
-                _is_pyspark_source(frame.file),
-                (
-                    f"Expected frame from {frame.file} (function: {frame.function})"
-                    f"to be filtered out as PySpark internal frame"
-                ),
-            )
-
-        # Verify that user function names are present (confirming user frames are included)
-        function_names = [frame.function for frame in stack_frames]
-        self.assertTrue(
-            "user_function" in function_names,
-            f"Expected user function names not found in: {function_names}",
-        )
-        self.assertTrue(
-            "test_retrieve_stack_frames_filters_pyspark_frames" in function_names,
-            f"Expected user function names not found in: {function_names}",
-        )
-
     def test_retrieve_stack_frames_includes_user_frames(self):
         """Test that _retrieve_stack_frames includes user code frames."""
 
         def user_function():
             """Simulate a user function."""
-            return _retrieve_stack_frames()
+            return SparkConnectClient._retrieve_stack_frames()
 
         def another_user_function():
             """Another level of user code."""
@@ -152,52 +104,25 @@ class CallStackTraceTestCase(unittest.TestCase):
             f"Expected user function names not found in: {function_names}",
         )
 
-    def test_retrieve_stack_frames_captures_correct_info(self):
-        """Test that _retrieve_stack_frames captures correct frame information."""
-
-        def user_function():
-            return _retrieve_stack_frames()
-
-        stack_frames = user_function()
-
-        # Verify each frame has the expected attributes
-        functions = set()
-        files = set()
-        for frame in stack_frames:
-            functions.add(frame.function)
-            files.add(frame.file)
-            self.assertIsNotNone(frame.function)
-            self.assertIsNotNone(frame.file)
-            self.assertIsNotNone(frame.linenum)
-            self.assertIsInstance(frame.function, str)
-            self.assertIsInstance(frame.file, str)
-            self.assertIsInstance(frame.linenum, int)
-            self.assertGreater(frame.linenum, 0)
-
-        self.assertTrue(
-            "user_function" in functions, f"Expected user function names not found in: {functions}"
-        )
-        self.assertTrue(
-            "test_retrieve_stack_frames_captures_correct_info" in functions,
-            f"Expected user function names not found in: {functions}",
-        )
-        self.assertTrue(__file__ in files, f"Expected user function names not found in: {files}")
-
     def test_build_call_stack_trace_without_env_var(self):
         """Test that _build_call_stack_trace returns empty list when env var is not set."""
         # Make sure the env var is not set
         with patch.dict(os.environ, {}, clear=False):
             if "SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK" in os.environ:
                 del os.environ["SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK"]
-
-            call_stack = _build_call_stack_trace()
+            call_stack = SparkConnectClient._build_call_stack_trace()
             self.assertIsNone(call_stack, "Expected None when env var is not set")
+
+        """Test that _build_call_stack_trace returns empty list when env var is empty string."""
+        with patch.dict(os.environ, {"SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK": ""}):
+            call_stack = SparkConnectClient._build_call_stack_trace()
+            self.assertIsNone(call_stack, "Expected empty list when env var is empty string")
 
     def test_build_call_stack_trace_with_env_var_set(self):
         """Test that _build_call_stack_trace builds trace when env var is set."""
         # Set the env var to enable call stack tracing
         with patch.dict(os.environ, {"SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK": "1"}):
-            stack_trace_details = _build_call_stack_trace()
+            stack_trace_details = SparkConnectClient._build_call_stack_trace()
             self.assertIsNotNone(
                 stack_trace_details, "Expected non-None call stack when env var is set"
             )
@@ -208,56 +133,6 @@ class CallStackTraceTestCase(unittest.TestCase):
             self.assertGreater(
                 len(error.stack_trace), 0, "Expected > 0 call stack frames when env var is set"
             )
-
-            # Verify each element is an Any protobuf message
-            functions = set()
-            files = set()
-            for stack_trace_element in error.stack_trace:
-                functions.add(stack_trace_element.method_name)
-                files.add(stack_trace_element.file_name)
-
-                # Verify the fields are populated
-                self.assertIsInstance(stack_trace_element.method_name, str)
-                self.assertIsInstance(stack_trace_element.file_name, str)
-                self.assertIsInstance(stack_trace_element.line_number, int)
-                self.assertEqual(
-                    stack_trace_element.declaring_class, "", "declaring_class should be empty"
-                )
-
-            self.assertTrue(
-                "test_build_call_stack_trace_with_env_var_set" in functions,
-                f"Expected user function names not found in: {functions}",
-            )
-            self.assertTrue(
-                __file__ in files, f"Expected user function names not found in: {files}"
-            )
-
-    def test_build_call_stack_trace_with_env_var_empty_string(self):
-        """Test that _build_call_stack_trace returns empty list when env var is empty string."""
-        with patch.dict(os.environ, {"SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK": ""}):
-            call_stack = _build_call_stack_trace()
-            self.assertIsNone(call_stack, "Expected empty list when env var is empty string")
-
-    def test_build_call_stack_trace_with_various_env_var_values(self):
-        """Test _build_call_stack_trace behavior with various env var values."""
-        test_cases = [
-            ("0", 0, "zero string should be treated as falsy"),
-            ("false", 0, "non-empty string 'false' should be falsy"),
-            ("TRUE", 1, "string 'TRUE' should be truthy"),
-            ("true", 1, "string 'true' should be truthy"),
-            ("1", 1, "string '1' should be truthy"),
-            ("any_value", 0, "any non-empty string should be falsy"),
-        ]
-
-        for env_value, expected_behavior, message in test_cases:
-            with self.subTest(env_value=env_value):
-                with patch.dict(os.environ, {"SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK": env_value}):
-                    call_stack = _build_call_stack_trace()
-                    if expected_behavior == 0:
-                        self.assertIsNone(call_stack, message)
-                    else:
-                        self.assertIsNotNone(call_stack, message)
-
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)
 class CallStackTraceIntegrationTestCase(unittest.TestCase):
@@ -278,22 +153,8 @@ class CallStackTraceIntegrationTestCase(unittest.TestCase):
         # Restore the original PYSPARK_ROOT
         core.PYSPARK_ROOT = self.original_pyspark_root
 
-    def test_execute_plan_request_includes_call_stack_without_env_var(self):
-        """_execute_plan_request_with_metadata doesn't include call stack without env var."""
-        with patch.dict(os.environ, {}, clear=False):
-            if "SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK" in os.environ:
-                del os.environ["SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK"]
 
-            req = self.client._execute_plan_request_with_metadata()
-
-            # Should have no extensions when env var is not set
-            self.assertEqual(
-                len(req.user_context.extensions),
-                0,
-                "Expected no extensions without env var",
-            )
-
-    def test_execute_plan_request_includes_call_stack_with_env_var(self):
+    def test_execute_plan_request_includes_call_stack(self):
         """Test that _execute_plan_request_with_metadata includes call stack with env var."""
         with patch.dict(os.environ, {"SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK": "1"}):
             req = self.client._execute_plan_request_with_metadata()
@@ -326,22 +187,7 @@ class CallStackTraceIntegrationTestCase(unittest.TestCase):
                 __file__ in files, f"Expected user function names not found in: {files}"
             )
 
-    def test_analyze_plan_request_includes_call_stack_without_env_var(self):
-        """_analyze_plan_request_with_metadata doesn't include call stack without env var."""
-        with patch.dict(os.environ, {}, clear=False):
-            if "SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK" in os.environ:
-                del os.environ["SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK"]
-
-            req = self.client._analyze_plan_request_with_metadata()
-
-            # Should have no extensions when env var is not set
-            self.assertEqual(
-                len(req.user_context.extensions),
-                0,
-                "Expected no extensions without env var",
-            )
-
-    def test_analyze_plan_request_includes_call_stack_with_env_var(self):
+    def test_analyze_plan_request_includes_call_stack(self):
         """Test that _analyze_plan_request_with_metadata includes call stack with env var."""
         with patch.dict(os.environ, {"SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK": "1"}):
             req = self.client._analyze_plan_request_with_metadata()
@@ -374,20 +220,6 @@ class CallStackTraceIntegrationTestCase(unittest.TestCase):
                 __file__ in files, f"Expected user function names not found in: {files}"
             )
 
-    def test_config_request_includes_call_stack_without_env_var(self):
-        """Test that _config_request_with_metadata doesn't include call stack without env var."""
-        with patch.dict(os.environ, {}, clear=False):
-            if "SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK" in os.environ:
-                del os.environ["SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK"]
-
-            req = self.client._config_request_with_metadata()
-
-            # Should have no extensions when env var is not set
-            self.assertEqual(
-                len(req.user_context.extensions),
-                0,
-                "Expected no extensions without env var",
-            )
 
     def test_config_request_includes_call_stack_with_env_var(self):
         """Test that _config_request_with_metadata includes call stack with env var."""

--- a/python/pyspark/sql/tests/connect/client/test_client_call_stack_trace.py
+++ b/python/pyspark/sql/tests/connect/client/test_client_call_stack_trace.py
@@ -180,7 +180,7 @@ class CallStackTraceIntegrationTestCase(unittest.TestCase):
                         self.assertIsInstance(stack_trace_element.file_name, str)
 
             self.assertTrue(
-                "test_execute_plan_request_includes_call_stack_with_env_var" in functions,
+                "test_execute_plan_request_includes_call_stack" in functions,
                 f"Expected user function names not found in: {functions}",
             )
             self.assertTrue(
@@ -213,7 +213,7 @@ class CallStackTraceIntegrationTestCase(unittest.TestCase):
                         self.assertIsInstance(stack_trace_element.file_name, str)
 
             self.assertTrue(
-                "test_analyze_plan_request_includes_call_stack_with_env_var" in functions,
+                "test_analyze_plan_request_includes_call_stack" in functions,
                 f"Expected user function names not found in: {functions}",
             )
             self.assertTrue(

--- a/python/pyspark/sql/tests/connect/client/test_client_call_stack_trace.py
+++ b/python/pyspark/sql/tests/connect/client/test_client_call_stack_trace.py
@@ -134,6 +134,7 @@ class CallStackTraceTestCase(unittest.TestCase):
                 len(error.stack_trace), 0, "Expected > 0 call stack frames when env var is set"
             )
 
+
 @unittest.skipIf(not should_test_connect, connect_requirement_message)
 class CallStackTraceIntegrationTestCase(unittest.TestCase):
     """Integration tests for call stack trace in client request methods."""
@@ -152,7 +153,6 @@ class CallStackTraceIntegrationTestCase(unittest.TestCase):
     def tearDown(self):
         # Restore the original PYSPARK_ROOT
         core.PYSPARK_ROOT = self.original_pyspark_root
-
 
     def test_execute_plan_request_includes_call_stack(self):
         """Test that _execute_plan_request_with_metadata includes call stack with env var."""
@@ -219,7 +219,6 @@ class CallStackTraceIntegrationTestCase(unittest.TestCase):
             self.assertTrue(
                 __file__ in files, f"Expected user function names not found in: {files}"
             )
-
 
     def test_config_request_includes_call_stack_with_env_var(self):
         """Test that _config_request_with_metadata includes call stack with env var."""


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Optionally transmitting client-side code location details (function name, file name and line number) along with actions. 

### Why are the changes needed?
Right now there is no information sent to Spark Connect server that will aid in pointing the location of the call  (i.e. Spark data frame action) in the client application code. By making this change, client application call stack details are sent to the server as a list of (function name, file name, line number) tuples where they can be logged in the server logs, included in corresponding open telemetry spans as attributes etc. This will help users looking from server side UI or Console to quickly pinpoint call locations of erring or slow calls in their own (client application) code without server needing to have access to the actual code.

### Does this PR introduce _any_ user-facing change?
It includes a new ENV variable `SPARK_CONNECT_DEBUG_CLIENT_CALL_STACK` which user can set to true / 1 to opt into transmitting client application code locations to server. If opted into, the client app call stack trace details are included in the `user_context.extensions` field of the Spark Connect protobufs

### How was this patch tested?
By adding new unit test `test_client_call_stack_trace.py`

### Was this patch authored or co-authored using generative AI tooling?
Yes.
Some of the unit tests were Generated-by:  Cursor
