### PR TITLE
[SPARK-54367][Connect]Propagate close() from SessionState to CatalogPlugins to prevent leak

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/CatalogPlugin.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/CatalogPlugin.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.connector.catalog;
 
+import java.io.Closeable;
+
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
@@ -42,7 +44,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  * @since 3.0.0
  */
 @Evolving
-public interface CatalogPlugin {
+public interface CatalogPlugin extends Closeable {
   /**
    * Called to initialize configuration.
    * <p>
@@ -74,4 +76,7 @@ public interface CatalogPlugin {
   default String[] defaultNamespace() {
     return new String[0];
   }
+
+  @Override
+  default void close() {}
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/v2ResolutionPlans.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/v2ResolutionPlans.scala
@@ -265,6 +265,7 @@ object ResolvedIdentifier {
 object FakeSystemCatalog extends CatalogPlugin {
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {}
   override def name(): String = "system"
+  override def close(): Unit = {}
 }
 
 /**
@@ -273,4 +274,5 @@ object FakeSystemCatalog extends CatalogPlugin {
 object FakeLocalCatalog extends CatalogPlugin {
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {}
   override def name(): String = "local"
+  override def close(): Unit = {}
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/v2ResolutionPlans.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/v2ResolutionPlans.scala
@@ -265,7 +265,6 @@ object ResolvedIdentifier {
 object FakeSystemCatalog extends CatalogPlugin {
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {}
   override def name(): String = "system"
-  override def close(): Unit = {}
 }
 
 /**
@@ -274,5 +273,4 @@ object FakeSystemCatalog extends CatalogPlugin {
 object FakeLocalCatalog extends CatalogPlugin {
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {}
   override def name(): String = "local"
-  override def close(): Unit = {}
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CatalogManagerSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CatalogManagerSuite.scala
@@ -130,9 +130,7 @@ class CatalogManagerSuite extends SparkFunSuite with SQLHelper {
 
   test("CatalogManager.close should close all closeable catalogs") {
     val catalogManager = new CatalogManager(FakeV2SessionCatalog, createSessionCatalog())
-    withSQLConf("spark.sql.catalog.dummy" -> classOf[DummyCatalog].getName,
-      "spark.sql.catalog.closeable" -> classOf[CloseableCatalog].getName) {
-      catalogManager.setCurrentCatalog("dummy")
+    withSQLConf("spark.sql.catalog.closeable" -> classOf[CloseableCatalog].getName) {
       val closeable = catalogManager.catalog("closeable").asInstanceOf[CloseableCatalog]
       assert(!closeable.isClosed)
       catalogManager.close()

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/LookupCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/LookupCatalogSuite.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 private case class DummyCatalogPlugin(override val name: String) extends CatalogPlugin {
 
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = ()
+  override def close(): Unit = {}
 }
 
 class LookupCatalogSuite extends SparkFunSuite with LookupCatalog with Inside {

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -380,6 +380,7 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
 
     mlCache.clear()
 
+    session.sessionState.close()
     session.cleanupPythonWorkerLogs()
 
     eventManager.postClosed()

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListener.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListener.scala
@@ -137,13 +137,16 @@ private[sql] class SparkConnectListenerBusListener(
   }
 
   def sendResultComplete(): Unit = {
-    responseObserver
-      .asInstanceOf[ExecuteResponseObserver[ExecutePlanResponse]]
-      .onNextComplete(
-        ExecutePlanResponse
-          .newBuilder()
-          .setResultComplete(ExecutePlanResponse.ResultComplete.newBuilder().build())
-          .build())
+    responseObserver match {
+      case obs: ExecuteResponseObserver[ExecutePlanResponse] =>
+        obs.onNextComplete(
+          ExecutePlanResponse
+            .newBuilder()
+            .setResultComplete(ExecutePlanResponse.ResultComplete.newBuilder().build())
+            .build())
+      case _ =>
+        responseObserver.onCompleted()
+    }
   }
 
   // QueryStartedEvent is sent to client along with WriteStreamOperationStartResult

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/SparkConnectTestUtils.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/SparkConnectTestUtils.scala
@@ -31,6 +31,9 @@ object SparkConnectTestUtils {
         sessionId = UUID.randomUUID().toString,
         session = session)
     SparkConnectService.sessionManager.putSessionForTesting(ret)
+    if (session != null) {
+      ret.initializeSession()
+    }
     ret
   }
 }

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionHolderSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionHolderSuite.scala
@@ -48,16 +48,15 @@ class SparkConnectSessionHolderSuite extends SharedSparkSession {
   test("SessionHolder.close should close catalogs") {
     val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
     val catalogName = "my_closeable_catalog"
-    sessionHolder.session.conf.set(
-      s"spark.sql.catalog.$catalogName",
-      classOf[CloseableCatalog].getName)
+    sessionHolder.session.conf
+      .set(s"spark.sql.catalog.$catalogName", classOf[CloseableCatalog].getName)
 
     val catalog = sessionHolder.session.sessionState.catalogManager.catalog(catalogName)
     val closeableCatalog = catalog.asInstanceOf[CloseableCatalog]
     assert(!closeableCatalog.isClosed)
     sessionHolder.close()
     assert(closeableCatalog.isClosed)
-}
+  }
 
   test("DataFrame cache: Successful put and get") {
     val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
@@ -501,7 +500,7 @@ class SparkConnectSessionHolderSuite extends SharedSparkSession {
 }
 
 class CloseableCatalog
-  extends org.apache.spark.sql.connector.catalog.CatalogPlugin
+    extends org.apache.spark.sql.connector.catalog.CatalogPlugin
     with java.io.Closeable {
   private var _name: String = _
   private var closed = false

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
@@ -55,6 +55,8 @@ class V2SessionCatalog(catalog: SessionCatalog)
   // This class is instantiated by Spark, so `initialize` method will not be called.
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {}
 
+  override def close(): Unit = {}
+
   override def capabilities(): util.Set[TableCatalogCapability] = {
     Set(
       TableCatalogCapability.SUPPORT_COLUMN_DEFAULT_VALUE

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -111,7 +111,11 @@ private[sql] class SessionState(
   def catalogManager: CatalogManager = analyzer.catalogManager
 
   override def close(): Unit = {
-    catalogManager.close()
+    try {
+      catalogManager.close()
+    } finally {
+      artifactManager.close()
+    }
   }
 
   def newHadoopConf(): Configuration = SessionState.newHadoopConf(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
To fix this, I added the following changes:
1. Apache Iceberg PR(https://github.com/apache/iceberg/pull/14590) to implement closable catalog
2. Make `CatalogPlugin` interface extends `java.io.Closeable`
3. Implement a `close()` method in `CatalogManager` that iterates through all registered catalogs and calls their `close()` method
4. Make `SessionState` implements `Closeable` and calls `catalogManager.close()` from its `close()` method.
5. Invoke `session.sessionState.close()` from `SessionHolder.close()` when a Spark Connect session is stopped

Above changes create a clean lifecycle for catalogs when a session ended, a `close()` call is propagated down the chain which allow each catalog to release its resources.


### Why are the changes needed?
Spark Connect server is leaking `SparkSession` objects each time a client connects and disconnects when dealing with Apache Iceberg Apache Iceberg PR(https://github.com/apache/iceberg/pull/14590). 

The `SessionHolder.close()` method in Spark Connect is responsible for cleaning up a session. It does perform some cleanup such as artifacts and streaming queries but it doesn't perform cleanup on the main `SessionState`. This is where the `CatalogManager` lives which holds reference to `RESTCatalog` and `S3FileIO`. Since the `SessionState` is never closed, these `Closeable` catalogs are never closed and their threads leak.


### Does this PR introduce _any_ user-facing change?
N/A


### How was this patch tested?
I have a local setup which can easily reproduce this issue. Here is setup details:

REST catalog: Apache Polaris (created the basic polaris entities via getting start example)
Spark Connect server:
1. public released Spark distribution to show this issue is there and we have leaks
2. local build with changes in this PR
Spark Connect client: install public released apache spark package via pip

Testing config:
1. To make the testing easy, I set `spark.connect.session.manager.defaultSessionTimeout` from default `60m` to `1m`

Testing:

1. Check heap dump from spark UI for instance of `org.apache.spark.sql.classic.SparkSession` and `org.apache.spark.sql.internal.SessionState`
2. Make a connection to an Iceberg REST catalog and perform `close()` on spark session implicitly:
```
import uuid
from pyspark.sql import SparkSession

USER_CLIENT_ID = "xxxxx"
USER_CLIENT_SECRET = "xxxxx"

# Use `create` with defined `session_id` to ensure we will be getting a new session
session_id = str(uuid.uuid4())
spark = (
    SparkSession.builder
    .appName("Iceberg REST Catalog Quickstart")
    .remote(f"sc://localhost/;session_id={session_id}")
    .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
    .config("spark.sql.catalog.quickstart_catalog", "org.apache.iceberg.spark.SparkCatalog")
    .config("spark.sql.catalog.quickstart_catalog.catalog-impl", "org.apache.iceberg.rest.RESTCatalog")
    .config("spark.sql.catalog.quickstart_catalog.uri", "http://localhost:8181/api/catalog")
    .config("spark.sql.catalog.quickstart_catalog.warehouse", "quickstart_catalog")
    .config("spark.sql.catalog.quickstart_catalog.header.X-Iceberg-Access-Delegation", "vended-credentials")
    .config("spark.sql.catalog.quickstart_catalog.credential", f"{USER_CLIENT_ID}:{USER_CLIENT_SECRET}")
    .config("spark.sql.catalog.quickstart_catalog.scope", "PRINCIPAL_ROLE:ALL")
    .config("spark.sql.catalog.quickstart_catalog.token-refresh-enabled", "true")
    .config("spark.sql.catalog.quickstart_catalog.client.region", "us-west-2")
    .create()
)

# Setup basic namespace and perform a read/write:
spark.sql("USE quickstart_catalog").show()
spark.sql("CREATE NAMESPACE IF NOT EXISTS quickstart_namespace").show()
spark.sql("CREATE NAMESPACE IF NOT EXISTS quickstart_namespace.schema").show()
spark.sql("USE NAMESPACE quickstart_namespace.schema").show()
spark.sql("CREATE TABLE IF NOT EXISTS quickstart_table (id BIGINT, data STRING) USING ICEBERG").show()
spark.sql("INSERT INTO quickstart_table values (1, 'a')").show()
spark.sql("SELECT * FROM quickstart_table").show()

# Stop the connection
spark.stop()
```
3. Check heap dump from spark UI for instance of `org.apache.spark.sql.classic.SparkSession` and `org.apache.spark.sql.internal.SessionState` again and noticed resources are not getting cleanup
4. To make it more obvious, spin up 300 sessions and let the cleaner context stop them (with overwrite cleaning interval to 1m):
```
for _ in range (300):
    session_id = str(uuid.uuid4())
    spark = (
        SparkSession.builder
        .appName("Iceberg REST Catalog Quickstart")
        .remote(f"sc://localhost/;session_id={session_id}")
        .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
        .config("spark.sql.catalog.quickstart_catalog", "org.apache.iceberg.spark.SparkCatalog")
        .config("spark.sql.catalog.quickstart_catalog.catalog-impl", "org.apache.iceberg.rest.RESTCatalog")
        .config("spark.sql.catalog.quickstart_catalog.uri", "http://localhost:8181/api/catalog")
        .config("spark.sql.catalog.quickstart_catalog.warehouse", "quickstart_catalog")
        .config("spark.sql.catalog.quickstart_catalog.header.X-Iceberg-Access-Delegation", "vended-credentials")
        .config("spark.sql.catalog.quickstart_catalog.credential", f"{USER_CLIENT_ID}:{USER_CLIENT_SECRET}")
        .config("spark.sql.catalog.quickstart_catalog.scope", "PRINCIPAL_ROLE:ALL")
        .config("spark.sql.catalog.quickstart_catalog.token-refresh-enabled", "true")
        .config("spark.sql.catalog.quickstart_catalog.client.region", "us-west-2")
        .create()
    )
    spark.sql("USE quickstart_catalog").show()
    spark.sql("USE NAMESPACE quickstart_namespace.schema").show()
    spark.sql("SELECT * FROM quickstart_table").show()
```
6. Wait for 2-3 mins (the cleaning should start happen after 1m but it may take an extra 20-30 seconds for the cleaning to complete) then check heap dump from spark UI for instance of `org.apache.spark.sql.classic.SparkSession` and `org.apache.spark.sql.internal.SessionState` again. We will noticed the instances of these classes (along with many others) are not getting cleanup with current code. Also, heap usage will stay high and not able to garbage collected.
7. Now to test the fixed, get a local build of iceberg spark runtime jar from the PR above and a local build of apache spark from this PR, and repeat the same tests listed above. This time, we will see resources getting cleanup properly and heap usage decreased after cleanup.



### Was this patch authored or co-authored using generative AI tooling?
No