### PR TITLE
[SPARK-54368][INFRA] Remove `generate-llms-txt.py` from `release-build.sh`

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -834,14 +834,6 @@ if [[ "$1" == "docs" ]]; then
   bundle install
   PRODUCTION=1 RELEASE_VERSION="$SPARK_VERSION" bundle exec jekyll build
 
-  # Generate llms.txt for LLM consumption
-  # Note this doc is currently versionless and need to be placed at the documentation root.
-  echo "Generating llms.txt..."
-  python "$SELF/generate-llms-txt.py" \
-    --docs-path . \
-    --output "$SELF/llms.txt" \
-    --version "latest"
-
   cd ..
   cd ..
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to de-couple the version-less document from the release process by removing `generate-llms-txt.py` from `release-build.sh`

### Why are the changes needed?

We have monthly snapshot releases and many maintenance releases which is improper to update the `versionless` documents which in the parent directory.

https://github.com/apache/spark/blob/e09c9994910704a54aca76953a80b0824812e620/dev/create-release/release-build.sh#L837-L843

Like we did already, this should be done manually without tightly-coupled with our maintenance release cadence.
- https://github.com/apache/spark-website/pull/647
- https://github.com/apache/spark-website/pull/646
- https://github.com/apache/spark-website/pull/645

### Does this PR introduce _any_ user-facing change?

No, this is not released yet officially.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.