### PR TITLE
[SPARK-54370][INFRA] Limit the Maven GitHub Action job timeout to 150 minutes

### DIFF
--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -56,6 +56,7 @@ jobs:
   build:
     name: "Build modules: ${{ matrix.modules }} ${{ matrix.comment }}"
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 150
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to limit the Maven GitHub Action job timeout to 150 minutes.

### Why are the changes needed?

Currently, Maven CI runs 6 hours which is the default timeout. In general, this job should pass in 150 minutes.

<img width="641" height="444" alt="Screenshot 2025-11-15 at 18 44 28" src="https://github.com/user-attachments/assets/16e3bfce-1eab-4671-8ec1-cec209c4f0e3" />

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.