### PR TITLE
[SPARK-54371][INFRA] Fix `spark-rm` Dockefile to install `pkgdown` version at the end

### DIFF
--- a/dev/create-release/spark-rm/Dockerfile
+++ b/dev/create-release/spark-rm/Dockerfile
@@ -86,8 +86,8 @@ RUN Rscript -e "install.packages(c('devtools', 'knitr', 'markdown',  \
     'ggplot2', 'mvtnorm', 'statmod', 'xml2'), repos='https://cloud.r-project.org/')" && \
     Rscript -e "devtools::install_version('roxygen2', version='7.2.0', repos='https://cloud.r-project.org')" && \
     Rscript -e "devtools::install_version('lintr', version='2.0.1', repos='https://cloud.r-project.org')" && \
-    Rscript -e "devtools::install_version('pkgdown', version='2.0.1', repos='https://cloud.r-project.org')" && \
-    Rscript -e "devtools::install_version('preferably', version='0.4', repos='https://cloud.r-project.org')"
+    Rscript -e "devtools::install_version('preferably', version='0.4', repos='https://cloud.r-project.org')" && \
+    Rscript -e "devtools::install_version('pkgdown', version='2.0.1', repos='https://cloud.r-project.org')"
 
 # See more in SPARK-39735
 ENV R_LIBS_SITE="/usr/local/lib/R/site-library:${R_LIBS_SITE}:/usr/lib/R/library"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `spark-rm` Dockefile to install `pkgdown` version at the end.

### Why are the changes needed?

Although `pkgdown` is supposed to be `2.0.1`, it's changed at the next package installation like the following. We should install `pkgdown` at the end to make it sure.
https://github.com/apache/spark/blob/0311f44e33e5cf8ba60ccc330de3df4f688f5847/dev/create-release/spark-rm/Dockerfile#L89

- https://github.com/apache/spark/actions/workflows/release.yml
  - https://github.com/apache/spark/actions/runs/19386198324/job/55473421715

```
#11 1007.3 Downloading package from url: https://cloud.r-project.org/src/contrib/Archive/preferably/preferably_0.4.tar.gz
#11 1008.9 pkgdown (2.0.1 -> 2.2.0) [CRAN]
#11 1008.9 Installing 1 packages: pkgdown
#11 1008.9 Installing package into '/usr/local/lib/R/site-library'
#11 1008.9 (as 'lib' is unspecified)
#11 1009.4 trying URL 'https://cloud.r-project.org/src/contrib/pkgdown_2.2.0.tar.gz'
#11 1009.7 Content type 'application/x-gzip' length 1280630 bytes (1.2 MB)
#11 1009.7 ==================================================
#11 1009.7 downloaded 1.2 MB
#11 1009.7 
#11 1010.2 * installing *source* package 'pkgdown' ...
#11 1010.2 ** package 'pkgdown' successfully unpacked and MD5 sums checked
#11 1010.2 ** using staged installation
#11 1010.3 ** R
#11 1010.3 ** inst
#11 1010.3 ** byte-compile and prepare package for lazy loading
#11 1013.1 ** help
#11 1013.2 *** installing help indices
#11 1013.2 *** copying figures
#11 1013.2 ** building package indices
#11 1013.5 ** installing vignettes
#11 1013.5 ** testing if installed package can be loaded from temporary location
#11 1013.8 ** testing if installed package can be loaded from final location
#11 1014.1 ** testing if installed package keeps a record of temporary installation path
#11 1014.1 * DONE (pkgdown)
```


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

```
$ dev/create-release/do-release-docker.sh -d /tmp/spark-4.1.0 -n -s docs

$ docker run -it --rm --entrypoint /bin/bash spark-rm
spark-rm@923a388425fa:/opt/spark-rm/output$ Rscript -e 'installed.packages()' | grep pkgdown | head -n1
pkgdown      "pkgdown"      "/usr/local/lib/R/site-library" "2.0.1"
```

### Was this patch authored or co-authored using generative AI tooling?

No.