### PR TITLE
[SPARK-54305][SQL][PYTHON] Add admission control support to Python DataSource streaming API

### DIFF
--- a/examples/src/main/python/sql/streaming/structured_blockchain_admission_control.py
+++ b/examples/src/main/python/sql/streaming/structured_blockchain_admission_control.py
@@ -19,7 +19,7 @@
 Demonstrates admission control in Python streaming data sources.
 
 This example implements a simple blockchain-like streaming source that generates
-sequential blocks and shows how to use admission control to limit batch sizes.  # noqa: E501
+sequential blocks and shows how to use admission control to limit batch sizes.
 
 Usage: structured_blockchain_admission_control.py [<max-blocks-per-batch>]
   <max-blocks-per-batch> Maximum number of blocks to process per microbatch
@@ -46,7 +46,7 @@ from pyspark.sql.types import StructType
 
 
 class SimpleBlockchainReader(DataSourceStreamReader):
-    """A simple streaming source that generates sequential blockchain blocks."""  # noqa: E501
+    """A simple streaming source that generates sequential blockchain blocks."""
 
     def __init__(self, max_block: int = 1000, max_blocks_per_batch: int = 0) -> None:
         self.max_block = max_block
@@ -159,7 +159,9 @@ only {max_blocks_per_batch} blocks at a time, even when more data is available.
 """
     )
     # fmt: off
-    spark = SparkSession.builder.appName("StructuredBlockchainAdmissionControl").getOrCreate()  # noqa: E501
+    spark = (
+        SparkSession.builder.appName("StructuredBlockchainAdmissionControl").getOrCreate()
+    )
     # fmt: on
 
     # Register the custom data source

--- a/examples/src/main/python/sql/streaming/structured_blockchain_admission_control.py
+++ b/examples/src/main/python/sql/streaming/structured_blockchain_admission_control.py
@@ -1,0 +1,167 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Demonstrates admission control in Python streaming data sources.
+
+This example implements a simple blockchain-like streaming source that generates
+sequential blocks and shows how to use admission control to limit batch sizes.
+
+Usage: structured_blockchain_admission_control.py [<max-blocks-per-batch>]
+  <max-blocks-per-batch> Maximum number of blocks to process per microbatch (default: 10)
+
+Run the example:
+   `$ bin/spark-submit examples/src/main/python/sql/streaming/\\
+structured_blockchain_admission_control.py 5`
+
+The example will process blocks in controlled batches of 5, demonstrating admission control.
+"""
+import sys
+import time
+
+from pyspark.sql import SparkSession
+from pyspark.sql.datasource import DataSource, DataSourceStreamReader, InputPartition
+
+
+class SimpleBlockchainReader(DataSourceStreamReader):
+    """A simple streaming source that generates sequential blockchain blocks."""
+
+    def __init__(self, max_block=1000):
+        self.max_block = max_block
+        self.current_block = 0
+
+    def initialOffset(self):
+        """Start from block 0."""
+        return {"block": self.current_block}
+
+    def latestOffset(self, start=None, limit=None):
+        """
+        Return the latest offset, respecting admission control limits.
+
+        This demonstrates the key admission control pattern:
+        - Without limit: process all available blocks
+        - With maxRows limit: cap the end block to respect batch size
+        """
+        # Determine where we are now
+        if start is None:
+            start_block = self.current_block
+        else:
+            start_block = start["block"]
+
+        # Simulate blockchain growth - advance by 20 blocks each time
+        latest_available = min(start_block + 20, self.max_block)
+
+        # Apply admission control if configured
+        if limit and limit.get("type") == "maxRows":
+            max_blocks = limit["maxRows"]
+            # Cap at the configured limit
+            end_block = min(start_block + max_blocks, latest_available)
+            print(
+                f"  [Admission Control] Start: {start_block}, Available: {latest_available}, "
+                f"Capped: {end_block} (limit: {max_blocks})"
+            )
+            # Return tuple: (capped_offset, true_latest_offset)
+            return ({"block": end_block}, {"block": latest_available})
+        else:
+            # No limit - process all available
+            end_block = latest_available
+            print(f"  [No Limit] Start: {start_block}, End: {end_block}")
+            return {"block": end_block}
+
+    def partitions(self, start, end):
+        """Create a single partition for the block range."""
+        start_block = start["block"]
+        end_block = end["block"]
+        return [InputPartition(f"{start_block}:{end_block}".encode())]
+
+    def read(self, partition):
+        """Generate block data for the partition."""
+        # Parse the block range
+        range_str = partition.value.decode()
+        start_block, end_block = map(int, range_str.split(":"))
+
+        # Generate block data
+        for block_num in range(start_block, end_block):
+            # Simulate block data: block number, timestamp, simple hash
+            yield (
+                block_num,
+                int(time.time() * 1000),
+                f"0x{'0' * 60}{block_num:04x}",
+            )
+
+    def commit(self, end):
+        """Mark this offset as committed."""
+        pass
+
+
+class SimpleBlockchainSource(DataSource):
+    """Data source for simple blockchain streaming."""
+
+    @classmethod
+    def name(cls):
+        return "simple_blockchain"
+
+    def schema(self):
+        return "block_number INT, timestamp LONG, block_hash STRING"
+
+    def streamReader(self, schema):
+        return SimpleBlockchainReader(max_block=1000)
+
+
+if __name__ == "__main__":
+    max_blocks_per_batch = int(sys.argv[1]) if len(sys.argv) > 1 else 10
+
+    print(
+        f"""
+=================================================================
+Blockchain Streaming with Admission Control
+=================================================================
+Configuration:
+  - Max blocks per batch: {max_blocks_per_batch}
+  - Total blocks to generate: 1000
+
+Watch how admission control limits each microbatch to process
+only {max_blocks_per_batch} blocks at a time, even when more data is available.
+=================================================================
+"""
+    )
+
+    spark = (
+        SparkSession.builder.appName("StructuredBlockchainAdmissionControl").getOrCreate()
+    )
+
+    # Register the custom data source
+    spark.dataSource.register(SimpleBlockchainSource)
+
+    # Create streaming DataFrame with admission control
+    blocks = (
+        spark.readStream.format("simple_blockchain")
+        .option("maxRecordsPerBatch", str(max_blocks_per_batch))
+        .load()
+    )
+
+    # Show block statistics per microbatch
+    query = (
+        blocks.writeStream.outputMode("append")
+        .format("console")
+        .option("numRows", "20")
+        .option("truncate", "false")
+        .trigger(processingTime="3 seconds")
+        .start()
+    )
+
+    query.awaitTermination()

--- a/examples/src/main/python/sql/streaming/structured_blockchain_admission_control.py
+++ b/examples/src/main/python/sql/streaming/structured_blockchain_admission_control.py
@@ -19,26 +19,32 @@
 Demonstrates admission control in Python streaming data sources.
 
 This example implements a simple blockchain-like streaming source that generates
-sequential blocks and shows how to use admission control to limit batch sizes.
+sequential blocks and shows how to use admission control to limit batch sizes.  # noqa: E501
 
 Usage: structured_blockchain_admission_control.py [<max-blocks-per-batch>]
-  <max-blocks-per-batch> Maximum number of blocks to process per microbatch (default: 10)
+  <max-blocks-per-batch> Maximum number of blocks to process per microbatch
+                         (default: 10)
 
 Run the example:
    `$ bin/spark-submit examples/src/main/python/sql/streaming/\\
 structured_blockchain_admission_control.py 5`
 
-The example will process blocks in controlled batches of 5, demonstrating admission control.
+The example will process blocks in controlled batches of 5,
+demonstrating admission control.
 """
 import sys
 import time
 
 from pyspark.sql import SparkSession
-from pyspark.sql.datasource import DataSource, DataSourceStreamReader, InputPartition
+from pyspark.sql.datasource import (
+    DataSource,
+    DataSourceStreamReader,
+    InputPartition,
+)
 
 
 class SimpleBlockchainReader(DataSourceStreamReader):
-    """A simple streaming source that generates sequential blockchain blocks."""
+    """A simple streaming source that generates sequential blockchain blocks."""  # noqa: E501
 
     def __init__(self, max_block=1000):
         self.max_block = max_block
@@ -71,8 +77,9 @@ class SimpleBlockchainReader(DataSourceStreamReader):
             # Cap at the configured limit
             end_block = min(start_block + max_blocks, latest_available)
             print(
-                f"  [Admission Control] Start: {start_block}, Available: {latest_available}, "
-                f"Capped: {end_block} (limit: {max_blocks})"
+                f"  [Admission Control] Start: {start_block}, "
+                f"Available: {latest_available}, Capped: {end_block} "
+                f"(limit: {max_blocks})"
             )
             # Return tuple: (capped_offset, true_latest_offset)
             return ({"block": end_block}, {"block": latest_available})
@@ -139,10 +146,9 @@ only {max_blocks_per_batch} blocks at a time, even when more data is available.
 =================================================================
 """
     )
-
-    spark = (
-        SparkSession.builder.appName("StructuredBlockchainAdmissionControl").getOrCreate()
-    )
+    # fmt: off
+    spark = SparkSession.builder.appName("StructuredBlockchainAdmissionControl").getOrCreate()  # noqa: E501
+    # fmt: on
 
     # Register the custom data source
     spark.dataSource.register(SimpleBlockchainSource)

--- a/python/docs/source/tutorial/sql/python_data_source.rst
+++ b/python/docs/source/tutorial/sql/python_data_source.rst
@@ -326,6 +326,101 @@ This is the same dummy streaming reader that generate 2 rows every batch impleme
             """
             pass
 
+**Admission Control for Streaming Sources**
+
+Spark supports admission control for streaming sources to limit the amount of data processed in each
+micro-batch. This helps control resource usage and maintain consistent processing times. Python
+streaming data sources support three types of admission control options:
+
+- **maxRecordsPerBatch**: Limit the maximum number of rows per batch
+- **maxFilesPerBatch**: Limit the maximum number of files per batch
+- **maxBytesPerBatch**: Limit the maximum bytes per batch (in bytes)
+
+These options can be specified when reading from a streaming source:
+
+.. code-block:: python
+
+    # Limit to 1000 rows per batch
+    query = spark.readStream \
+        .format("fake") \
+        .option("maxRecordsPerBatch", "1000") \
+        .load() \
+        .writeStream \
+        .format("console") \
+        .start()
+
+    # Limit to 100 files per batch
+    query = spark.readStream \
+        .format("fake") \
+        .option("maxFilesPerBatch", "100") \
+        .load() \
+        .writeStream \
+        .format("console") \
+        .start()
+
+    # Limit to 10 MB per batch
+    query = spark.readStream \
+        .format("fake") \
+        .option("maxBytesPerBatch", str(10 * 1024 * 1024)) \
+        .load() \
+        .writeStream \
+        .format("console") \
+        .start()
+
+**Note**:
+
+- Only one admission control option should be specified at a time
+- All admission control values must be positive integers. If an invalid value is provided (negative,
+  zero, or non-numeric), an ``IllegalArgumentException`` will be thrown
+- These options apply to ``streamReader()`` implementations. ``simpleStreamReader()`` does not
+  support admission control.
+- This behavior is consistent with Spark's built-in streaming sources (e.g., ``maxFilesPerTrigger``,
+  ``maxBytesPerTrigger`` for file sources)
+
+**Implementing Admission Control in Custom Data Sources (Advanced)**
+
+For users implementing the full ``DataSourceStreamReader`` API (not ``SimpleDataSourceStreamReader``),
+admission control is enabled through an optional ``start`` parameter on the ``latestOffset()`` method.
+As of Spark 4.2, the ``latestOffset()`` method signature has been enhanced to accept an optional start
+offset:
+
+.. code-block:: python
+
+    from pyspark.sql.datasource import DataSourceStreamReader
+    from typing import Optional, Union, Tuple
+
+    class MyStreamReader(DataSourceStreamReader):
+        def latestOffset(
+            self,
+            start: Optional[dict] = None
+        ) -> Union[dict, Tuple[dict, dict]]:
+            # Old behavior: if start is not provided, return latest offset without admission control
+            if start is None:
+                return {"offset": self.get_latest_offset()}
+
+            # New behavior: apply admission control based on configured data source options
+            true_latest = self.get_latest_offset()
+
+            max_rows = int(self.options.get("maxRecordsPerBatch", "0"))
+            if max_rows > 0:
+                capped_offset = self.calculate_capped_offset(start, max_rows)
+                return (capped_offset, true_latest)
+
+            # If the source does not implement admission control, it can return a single dict.
+            return true_latest
+
+**Key Points:**
+
+- **Backward Compatibility**: Old implementations that don't accept parameters continue to work
+  without modification
+- **Optional Parameters**: ``start`` is optional; if not provided, implement old behavior
+- **Return Type**: Return a single ``dict`` for old behavior, or a ``Tuple[dict, dict]`` for
+  admission control
+- **Admission Control Configuration**: Read admission control settings from the data source options
+  (for example, ``maxRecordsPerBatch``)
+- **SimpleDataSourceStreamReader**: The simple API does not support admission control; use the full
+  API for admission control support
+
 Implement a Streaming Writer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -486,101 +581,6 @@ We can also use the same data source in streaming reader and writer
 .. code-block:: python
 
     query = spark.readStream.format("fake").load().writeStream.format("fake").start("/output_path")
-
-**Admission Control for Streaming Sources**
-
-Spark supports admission control for streaming sources to limit the amount of data processed in each micro-batch. This helps control resource usage and maintain consistent processing times. Python streaming data sources support three types of admission control options:
-
-- **maxRecordsPerBatch**: Limit the maximum number of rows per batch
-- **maxFilesPerBatch**: Limit the maximum number of files per batch
-- **maxBytesPerBatch**: Limit the maximum bytes per batch (in bytes)
-
-These options can be specified when reading from a streaming source:
-
-.. code-block:: python
-
-    # Limit to 1000 rows per batch
-    query = spark.readStream \
-        .format("fake") \
-        .option("maxRecordsPerBatch", "1000") \
-        .load() \
-        .writeStream \
-        .format("console") \
-        .start()
-
-    # Limit to 100 files per batch
-    query = spark.readStream \
-        .format("fake") \
-        .option("maxFilesPerBatch", "100") \
-        .load() \
-        .writeStream \
-        .format("console") \
-        .start()
-
-    # Limit to 10 MB per batch
-    query = spark.readStream \
-        .format("fake") \
-        .option("maxBytesPerBatch", str(10 * 1024 * 1024)) \
-        .load() \
-        .writeStream \
-        .format("console") \
-        .start()
-
-**Note**: 
-
-- Only one admission control option should be specified at a time
-- All admission control values must be positive integers. If an invalid value is provided (negative, zero, or non-numeric), an ``IllegalArgumentException`` will be thrown
-- These options apply to both ``streamReader()`` and ``simpleStreamReader()`` implementations
-- This behavior is consistent with Spark's built-in streaming sources (e.g., ``maxFilesPerTrigger``, ``maxBytesPerTrigger`` for file sources)
-
-**Implementing Admission Control in Custom Data Sources (Advanced)**
-
-For users implementing the full ``DataSourceStreamReader`` API (not ``SimpleDataSourceStreamReader``), admission control is enabled through optional parameters on the ``latestOffset()`` method. As of Spark 4.2, the ``latestOffset()`` method signature has been enhanced to accept optional parameters:
-
-.. code-block:: python
-
-    from pyspark.sql.datasource import DataSourceStreamReader
-    from typing import Optional, Union, Tuple
-    
-    class MyStreamReader(DataSourceStreamReader):
-        def latestOffset(
-            self, 
-            start: Optional[dict] = None, 
-            limit: Optional[dict] = None
-        ) -> Union[dict, Tuple[dict, dict]]:
-            # For backward compatibility: old implementations without parameters still work
-            if start is None and limit is None:
-                # Old behavior: return latest offset without admission control
-                return {"offset": self.get_latest_offset()}
-            
-            # New behavior: with admission control support
-            true_latest = self.get_latest_offset()
-            
-            # Apply admission control if configured
-            if limit and limit.get("type") == "maxRows":
-                max_rows = limit["maxRows"]
-                capped_offset = self.calculate_capped_offset(start, max_rows)
-                # Return tuple: (capped_offset, true_latest_offset)
-                return (capped_offset, true_latest)
-            elif limit and limit.get("type") == "maxFiles":
-                max_files = limit["maxFiles"]
-                capped_offset = self.calculate_capped_offset_by_files(start, max_files)
-                return (capped_offset, true_latest)
-            else:
-                # No limit or allAvailable
-                return (true_latest, true_latest)
-
-**Key Points:**
-
-- **Backward Compatibility**: Old implementations that don't accept parameters continue to work without modification
-- **Optional Parameters**: Both ``start`` and ``limit`` are optional; if not provided, implement old behavior
-- **Return Type**: Return a single ``dict`` for old behavior, or a ``Tuple[dict, dict]`` for new behavior with admission control
-- **Limit Structure**: The ``limit`` parameter is a dictionary with:
-  - ``{"type": "maxRows", "maxRows": N}`` for row-based limits
-  - ``{"type": "maxFiles", "maxFiles": N}`` for file-based limits  
-  - ``{"type": "maxBytes", "maxBytes": N}`` for byte-based limits
-  - ``{"type": "allAvailable"}`` for no limit
-- **SimpleDataSourceStreamReader**: Users of the simple API don't need to implement this; the framework handles admission control automatically
 
 Python Data Source Reader with direct Arrow Batch support for improved performance
 ----------------------------------------------------------------------------------

--- a/python/docs/source/tutorial/sql/python_data_source.rst
+++ b/python/docs/source/tutorial/sql/python_data_source.rst
@@ -330,11 +330,9 @@ This is the same dummy streaming reader that generate 2 rows every batch impleme
 
 Spark supports admission control for streaming sources to limit the amount of data processed in each
 micro-batch. This helps control resource usage and maintain consistent processing times. Python
-streaming data sources support three types of admission control options:
+streaming data sources support one admission control option:
 
 - **maxRecordsPerBatch**: Limit the maximum number of rows per batch
-- **maxFilesPerBatch**: Limit the maximum number of files per batch
-- **maxBytesPerBatch**: Limit the maximum bytes per batch (in bytes)
 
 These options can be specified when reading from a streaming source:
 
@@ -349,33 +347,13 @@ These options can be specified when reading from a streaming source:
         .format("console") \
         .start()
 
-    # Limit to 100 files per batch
-    query = spark.readStream \
-        .format("fake") \
-        .option("maxFilesPerBatch", "100") \
-        .load() \
-        .writeStream \
-        .format("console") \
-        .start()
-
-    # Limit to 10 MB per batch
-    query = spark.readStream \
-        .format("fake") \
-        .option("maxBytesPerBatch", str(10 * 1024 * 1024)) \
-        .load() \
-        .writeStream \
-        .format("console") \
-        .start()
-
 **Note**:
 
 - Only one admission control option should be specified at a time
 - All admission control values must be positive integers. If an invalid value is provided (negative,
   zero, or non-numeric), an ``IllegalArgumentException`` will be thrown
-- These options apply to ``streamReader()`` implementations. ``simpleStreamReader()`` does not
+- This option applies to ``streamReader()`` implementations. ``simpleStreamReader()`` does not
   support admission control.
-- This behavior is consistent with Spark's built-in streaming sources (e.g., ``maxFilesPerTrigger``,
-  ``maxBytesPerTrigger`` for file sources)
 
 **Implementing Admission Control in Custom Data Sources (Advanced)**
 

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -739,7 +739,7 @@ class DataSourceStreamReader(ABC):
         New implementation (with admission control):
 
         Admission control is configured via the options passed to the data source, e.g.
-        ``maxRecordsPerBatch``, ``maxFilesPerBatch``, and ``maxBytesPerBatch``. The stream reader
+        ``maxRecordsPerBatch``. The stream reader
         can consult those options (typically stored on the data source instance) to compute a
         capped offset.
 

--- a/python/pyspark/sql/datasource_internal.py
+++ b/python/pyspark/sql/datasource_internal.py
@@ -143,7 +143,5 @@ class _SimpleStreamReaderWrapper(DataSourceStreamReader):
         it = chain(*entries)
         return it
 
-    def read(
-        self, input_partition: SimpleInputPartition  # type: ignore[override]
-    ) -> Iterator[Tuple]:
+    def read(self, input_partition: SimpleInputPartition) -> Iterator[Tuple]:  # type: ignore[override]
         return self.simple_reader.readBetweenOffsets(input_partition.start, input_partition.end)

--- a/python/pyspark/sql/datasource_internal.py
+++ b/python/pyspark/sql/datasource_internal.py
@@ -88,10 +88,13 @@ class _SimpleStreamReaderWrapper(DataSourceStreamReader):
             self.initial_offset = self.simple_reader.initialOffset()
         return self.initial_offset
 
-    def latestOffset(self) -> dict:
-        # when query start for the first time, use initial offset as the start offset.
+    def latestOffset(self, start: Optional[dict] = None) -> dict:
+        # When query starts for the first time, use either the provided start offset (if any) or
+        # the data source initial offset. The `start` parameter is accepted for API compatibility
+        # with DataSourceStreamReader.latestOffset(start=...), but admission control is not
+        # supported for the simple reader wrapper.
         if self.current_offset is None:
-            self.current_offset = self.initialOffset()
+            self.current_offset = start if start is not None else self.initialOffset()
         (iter, end) = self.simple_reader.read(self.current_offset)
         self.cache.append(PrefetchedCacheEntry(self.current_offset, end, iter))
         self.current_offset = end

--- a/python/pyspark/sql/datasource_internal.py
+++ b/python/pyspark/sql/datasource_internal.py
@@ -93,10 +93,13 @@ class _SimpleStreamReaderWrapper(DataSourceStreamReader):
             self.initial_offset = self.simple_reader.initialOffset()
         return self.initial_offset
 
-    def latestOffset(self) -> dict:
-        # when query start for the first time, use initial offset as the start offset.
+    def latestOffset(self, start: Optional[dict] = None) -> dict:
+        # When the query starts for the first time, use either the provided start offset (if any)
+        # or the data source initial offset. The `start` parameter is ignored for admission control
+        # (unsupported for the simple reader), but allows the wrapper to be compatible with the
+        # DataSourceStreamReader.latestOffset(start=...) API.
         if self.current_offset is None:
-            self.current_offset = self.initialOffset()
+            self.current_offset = start if start is not None else self.initialOffset()
         (iter, end) = self.simple_reader.read(self.current_offset)
         self.cache.append(PrefetchedCacheEntry(self.current_offset, end, iter))
         self.current_offset = end

--- a/python/pyspark/sql/datasource_internal.py
+++ b/python/pyspark/sql/datasource_internal.py
@@ -31,9 +31,7 @@ from pyspark.sql.types import StructType
 from pyspark.errors import PySparkNotImplementedError
 
 
-def _streamReader(
-    datasource: DataSource, schema: StructType
-) -> "DataSourceStreamReader":
+def _streamReader(datasource: DataSource, schema: StructType) -> "DataSourceStreamReader":
     """
     Fallback to simpleStreamReader() method when streamReader() is not implemented.
     This should be invoked whenever a DataSourceStreamReader needs to be created instead of
@@ -101,9 +99,7 @@ class _SimpleStreamReaderWrapper(DataSourceStreamReader):
         if start is None and limit is None:
             # Old behavior - no admission control
             (full_iter, true_end) = self.simple_reader.read(self.current_offset)
-            self.cache.append(
-                PrefetchedCacheEntry(self.current_offset, true_end, full_iter)
-            )
+            self.cache.append(PrefetchedCacheEntry(self.current_offset, true_end, full_iter))
             self.current_offset = true_end
             return true_end
 
@@ -191,15 +187,11 @@ class _SimpleStreamReaderWrapper(DataSourceStreamReader):
             return None  # type: ignore[return-value]
         # Chain all the data iterator between start offset and end offset
         # need to copy here to avoid exhausting the original data iterator.
-        entries = [
-            copy.copy(entry.iterator) for entry in self.cache[start_idx : end_idx + 1]
-        ]
+        entries = [copy.copy(entry.iterator) for entry in self.cache[start_idx : end_idx + 1]]
         it = chain(*entries)
         return it
 
     def read(
         self, input_partition: SimpleInputPartition  # type: ignore[override]
     ) -> Iterator[Tuple]:
-        return self.simple_reader.readBetweenOffsets(
-            input_partition.start, input_partition.end
-        )
+        return self.simple_reader.readBetweenOffsets(input_partition.start, input_partition.end)

--- a/python/pyspark/sql/datasource_internal.py
+++ b/python/pyspark/sql/datasource_internal.py
@@ -31,9 +31,7 @@ from pyspark.sql.types import StructType
 from pyspark.errors import PySparkNotImplementedError
 
 
-def _streamReader(
-    datasource: DataSource, schema: StructType
-) -> "DataSourceStreamReader":
+def _streamReader(datasource: DataSource, schema: StructType) -> "DataSourceStreamReader":
     """
     Fallback to simpleStreamReader() method when streamReader() is not implemented.
     This should be invoked whenever a DataSourceStreamReader needs to be created instead of
@@ -141,9 +139,7 @@ class _SimpleStreamReaderWrapper(DataSourceStreamReader):
             return None  # type: ignore[return-value]
         # Chain all the data iterator between start offset and end offset
         # need to copy here to avoid exhausting the original data iterator.
-        entries = [
-            copy.copy(entry.iterator) for entry in self.cache[start_idx : end_idx + 1]
-        ]
+        entries = [copy.copy(entry.iterator) for entry in self.cache[start_idx : end_idx + 1]]
         it = chain(*entries)
         return it
 

--- a/python/pyspark/sql/datasource_internal.py
+++ b/python/pyspark/sql/datasource_internal.py
@@ -58,7 +58,7 @@ class PrefetchedCacheEntry:
 
 class _SimpleStreamReaderWrapper(DataSourceStreamReader):
     """
-    A private class that wrap :class:`SimpleDataSourceStreamReader` in prefetch and cache pattern,
+    A private class that wraps :class:`SimpleDataSourceStreamReader` in a prefetch/cache pattern,
     so that :class:`SimpleDataSourceStreamReader` can integrate with streaming engine like an
     ordinary :class:`DataSourceStreamReader`.
 
@@ -66,12 +66,17 @@ class _SimpleStreamReaderWrapper(DataSourceStreamReader):
     initialOffset() when query start for the first time or initialized to be the end offset of
     the last planned batch when query restarts.
 
+    This state is required because the simple reader API does not expose partition planning; the
+    wrapper must prefetch by calling ``read(current_offset)`` when the engine requests
+    ``latestOffset()``. Tracking ``current_offset`` ensures repeated calls do not re-read or skip
+    data, and that the wrapper can serve deterministic replay via ``readBetweenOffsets``.
+
     When streaming engine calls latestOffset(), the wrapper calls read() that starts from
-    current_offset, prefetches and cache the data, then updates the current_offset to be
+    current_offset, prefetches and caches the data, then updates the current_offset to be
     the end offset of the new data.
 
-    When streaming engine call planInputPartitions(start, end), the wrapper get the prefetched data
-    from cache and send it to JVM along with the input partitions.
+    When streaming engine calls planInputPartitions(start, end), the wrapper gets the prefetched
+    data from cache and send it to JVM along with the input partitions.
 
     When query restart, batches in write ahead offset log that has not been committed will be
     replayed by reading data between start and end offset through readBetweenOffsets(start, end).
@@ -89,10 +94,10 @@ class _SimpleStreamReaderWrapper(DataSourceStreamReader):
         return self.initial_offset
 
     def latestOffset(self, start: Optional[dict] = None) -> dict:
-        # When query starts for the first time, use either the provided start offset (if any) or
-        # the data source initial offset. The `start` parameter is accepted for API compatibility
-        # with DataSourceStreamReader.latestOffset(start=...), but admission control is not
-        # supported for the simple reader wrapper.
+        # When the query starts for the first time, use either the provided start offset (if any)
+        # or the data source initial offset. The `start` parameter is ignored for admission control
+        # (unsupported for the simple reader), but allows the wrapper to be compatible with the
+        # DataSourceStreamReader.latestOffset(start=...) API.
         if self.current_offset is None:
             self.current_offset = start if start is not None else self.initialOffset()
         (iter, end) = self.simple_reader.read(self.current_offset)
@@ -143,5 +148,5 @@ class _SimpleStreamReaderWrapper(DataSourceStreamReader):
         it = chain(*entries)
         return it
 
-    def read(self, input_partition: SimpleInputPartition) -> Iterator[Tuple]:  # type: ignore[override]
+    def read(self, input_partition: SimpleInputPartition) -> Iterator[Tuple]:
         return self.simple_reader.readBetweenOffsets(input_partition.start, input_partition.end)

--- a/python/pyspark/sql/streaming/python_streaming_source_runner.py
+++ b/python/pyspark/sql/streaming/python_streaming_source_runner.py
@@ -209,12 +209,7 @@ def main(infile: IO, outfile: IO) -> None:
                     latest_offset_func(reader, outfile)
                 elif func_id == PARTITIONS_FUNC_ID:
                     partitions_func(
-                        reader,
-                        data_source,
-                        schema,
-                        max_arrow_batch_size,
-                        infile,
-                        outfile,
+                        reader, data_source, schema, max_arrow_batch_size, infile, outfile
                     )
                 elif func_id == COMMIT_FUNC_ID:
                     commit_func(reader, infile, outfile)
@@ -248,10 +243,12 @@ def main(infile: IO, outfile: IO) -> None:
 
 if __name__ == "__main__":
     # Read information about how to connect back to the JVM from the environment.
-    conn_info = os.environ.get("PYTHON_WORKER_FACTORY_SOCK_PATH", int(os.environ.get("PYTHON_WORKER_FACTORY_PORT", -1)))
+    conn_info = os.environ.get(
+        "PYTHON_WORKER_FACTORY_SOCK_PATH", int(os.environ.get("PYTHON_WORKER_FACTORY_PORT", -1))
+    )
     auth_secret = os.environ.get("PYTHON_WORKER_FACTORY_SECRET")
     (sock_file, sock) = local_connect_and_auth(conn_info, auth_secret)
-    # Prevent socket timeout error when query trigger interval is large.
+    # Prevent the socket from timeout error when query trigger interval is large.
     sock.settimeout(None)
     write_int(os.getpid(), sock_file)
     sock_file.flush()

--- a/python/pyspark/sql/streaming/python_streaming_source_runner.py
+++ b/python/pyspark/sql/streaming/python_streaming_source_runner.py
@@ -94,24 +94,18 @@ def partitions_func(
         if it is None:
             write_int(PREFETCHED_RECORDS_NOT_FOUND, outfile)
         else:
-            send_batch_func(
-                it, outfile, schema, max_arrow_batch_size, data_source
-            )  # noqa: E501
+            send_batch_func(it, outfile, schema, max_arrow_batch_size, data_source)  # noqa: E501
     else:
         write_int(PREFETCHED_RECORDS_NOT_FOUND, outfile)
 
 
-def commit_func(
-    reader: DataSourceStreamReader, infile: IO, outfile: IO
-) -> None:  # noqa: E501
+def commit_func(reader: DataSourceStreamReader, infile: IO, outfile: IO) -> None:  # noqa: E501
     end_offset = json.loads(utf8_deserializer.loads(infile))
     reader.commit(end_offset)
     write_int(0, outfile)
 
 
-def latest_offset_with_report_func(
-    reader: DataSourceStreamReader, infile: IO, outfile: IO
-) -> None:
+def latest_offset_with_report_func(reader: DataSourceStreamReader, infile: IO, outfile: IO) -> None:
     """
     Handler for function ID 890: latestOffset with admission control
     parameters.
@@ -162,9 +156,7 @@ def latest_offset_with_report_func(
     except Exception as e:
         raise IllegalArgumentException(
             errorClass="UNSUPPORTED_OPERATION",
-            messageParameters={
-                "operation": f"latestOffset with limit failed: {str(e)}"
-            },
+            messageParameters={"operation": f"latestOffset with limit failed: {str(e)}"},
         )
 
     # Send both offsets back to JVM
@@ -180,9 +172,7 @@ def send_batch_func(
     data_source: DataSource,
 ) -> None:
     batches = list(
-        records_to_arrow_batches(
-            rows, max_arrow_batch_size, schema, data_source
-        )  # noqa: E501
+        records_to_arrow_batches(rows, max_arrow_batch_size, schema, data_source)  # noqa: E501
     )
     if len(batches) != 0:
         write_int(NON_EMPTY_PYARROW_RECORD_BATCHES, outfile)
@@ -198,9 +188,7 @@ def main(infile: IO, outfile: IO) -> None:
         check_python_version(infile)
         setup_spark_files(infile)
 
-        memory_limit_mb = int(
-            os.environ.get("PYSPARK_PLANNER_MEMORY_MB", "-1")
-        )  # noqa: E501
+        memory_limit_mb = int(os.environ.get("PYSPARK_PLANNER_MEMORY_MB", "-1"))  # noqa: E501
         setup_memory_limits(memory_limit_mb)
 
         _accumulatorRegistry.clear()
@@ -212,9 +200,7 @@ def main(infile: IO, outfile: IO) -> None:
             raise PySparkAssertionError(
                 errorClass="DATA_SOURCE_TYPE_MISMATCH",
                 messageParameters={
-                    "expected": (
-                        "a Python data source instance of type " "'DataSource'"
-                    ),
+                    "expected": ("a Python data source instance of type " "'DataSource'"),
                     "actual": f"'{type(data_source).__name__}'",
                 },
             )

--- a/python/pyspark/sql/streaming/python_streaming_source_runner.py
+++ b/python/pyspark/sql/streaming/python_streaming_source_runner.py
@@ -29,10 +29,7 @@ from pyspark.serializers import (
     SpecialLengths,
 )
 from pyspark.sql.datasource import DataSource, DataSourceStreamReader
-from pyspark.sql.datasource_internal import (
-    _SimpleStreamReaderWrapper,
-    _streamReader,
-)
+from pyspark.sql.datasource_internal import _SimpleStreamReaderWrapper, _streamReader
 from pyspark.sql.pandas.serializers import ArrowStreamSerializer
 from pyspark.sql.types import (
     _parse_datatype_json_string,
@@ -146,9 +143,7 @@ def send_batch_func(
     max_arrow_batch_size: int,
     data_source: DataSource,
 ) -> None:
-    batches = list(
-        records_to_arrow_batches(rows, max_arrow_batch_size, schema, data_source)  # noqa: E501
-    )
+    batches = list(records_to_arrow_batches(rows, max_arrow_batch_size, schema, data_source))
     if len(batches) != 0:
         write_int(NON_EMPTY_PYARROW_RECORD_BATCHES, outfile)
         write_int(SpecialLengths.START_ARROW_STREAM, outfile)
@@ -163,7 +158,7 @@ def main(infile: IO, outfile: IO) -> None:
         check_python_version(infile)
         setup_spark_files(infile)
 
-        memory_limit_mb = int(os.environ.get("PYSPARK_PLANNER_MEMORY_MB", "-1"))  # noqa: E501
+        memory_limit_mb = int(os.environ.get("PYSPARK_PLANNER_MEMORY_MB", "-1"))
         setup_memory_limits(memory_limit_mb)
 
         _accumulatorRegistry.clear()
@@ -175,7 +170,7 @@ def main(infile: IO, outfile: IO) -> None:
             raise PySparkAssertionError(
                 errorClass="DATA_SOURCE_TYPE_MISMATCH",
                 messageParameters={
-                    "expected": ("a Python data source instance of type " "'DataSource'"),
+                    "expected": "a Python data source instance of type 'DataSource'",
                     "actual": f"'{type(data_source).__name__}'",
                 },
             )
@@ -229,10 +224,7 @@ def main(infile: IO, outfile: IO) -> None:
                     raise IllegalArgumentException(
                         errorClass="UNSUPPORTED_OPERATION",
                         messageParameters={
-                            "operation": (
-                                "Function call id not recognized by "  # noqa: E501
-                                "stream reader"
-                            )
+                            "operation": "Function call id not recognized by stream reader"
                         },
                     )
                 outfile.flush()
@@ -255,16 +247,11 @@ def main(infile: IO, outfile: IO) -> None:
 
 
 if __name__ == "__main__":
-    # Read information about how to connect back to the JVM from the
-    # environment.
-    conn_info = os.environ.get(
-        "PYTHON_WORKER_FACTORY_SOCK_PATH",
-        int(os.environ.get("PYTHON_WORKER_FACTORY_PORT", -1)),
-    )
+    # Read information about how to connect back to the JVM from the environment.
+    conn_info = os.environ.get("PYTHON_WORKER_FACTORY_SOCK_PATH", int(os.environ.get("PYTHON_WORKER_FACTORY_PORT", -1)))
     auth_secret = os.environ.get("PYTHON_WORKER_FACTORY_SECRET")
     (sock_file, sock) = local_connect_and_auth(conn_info, auth_secret)
-    # Prevent socket timeout error when query trigger interval is
-    # large.
+    # Prevent socket timeout error when query trigger interval is large.
     sock.settimeout(None)
     write_int(os.getpid(), sock_file)
     sock_file.flush()

--- a/python/pyspark/sql/streaming/python_streaming_source_runner.py
+++ b/python/pyspark/sql/streaming/python_streaming_source_runner.py
@@ -94,16 +94,16 @@ def partitions_func(
         if it is None:
             write_int(PREFETCHED_RECORDS_NOT_FOUND, outfile)
         else:
-            send_batch_func(  # noqa: E501
+            send_batch_func(
                 it, outfile, schema, max_arrow_batch_size, data_source
-            )
+            )  # noqa: E501
     else:
         write_int(PREFETCHED_RECORDS_NOT_FOUND, outfile)
 
 
-def commit_func(  # noqa: E501
+def commit_func(
     reader: DataSourceStreamReader, infile: IO, outfile: IO
-) -> None:
+) -> None:  # noqa: E501
     end_offset = json.loads(utf8_deserializer.loads(infile))
     reader.commit(end_offset)
     write_int(0, outfile)
@@ -180,7 +180,9 @@ def send_batch_func(
     data_source: DataSource,
 ) -> None:
     batches = list(
-        records_to_arrow_batches(rows, max_arrow_batch_size, schema, data_source)  # noqa: E501
+        records_to_arrow_batches(
+            rows, max_arrow_batch_size, schema, data_source
+        )  # noqa: E501
     )
     if len(batches) != 0:
         write_int(NON_EMPTY_PYARROW_RECORD_BATCHES, outfile)
@@ -196,9 +198,9 @@ def main(infile: IO, outfile: IO) -> None:
         check_python_version(infile)
         setup_spark_files(infile)
 
-        memory_limit_mb = int(  # noqa: E501
+        memory_limit_mb = int(
             os.environ.get("PYSPARK_PLANNER_MEMORY_MB", "-1")
-        )
+        )  # noqa: E501
         setup_memory_limits(memory_limit_mb)
 
         _accumulatorRegistry.clear()

--- a/python/pyspark/sql/streaming/python_streaming_source_runner.py
+++ b/python/pyspark/sql/streaming/python_streaming_source_runner.py
@@ -89,12 +89,12 @@ def partitions_func(
         if it is None:
             write_int(PREFETCHED_RECORDS_NOT_FOUND, outfile)
         else:
-            send_batch_func(it, outfile, schema, max_arrow_batch_size, data_source)  # noqa: E501
+            send_batch_func(it, outfile, schema, max_arrow_batch_size, data_source)
     else:
         write_int(PREFETCHED_RECORDS_NOT_FOUND, outfile)
 
 
-def commit_func(reader: DataSourceStreamReader, infile: IO, outfile: IO) -> None:  # noqa: E501
+def commit_func(reader: DataSourceStreamReader, infile: IO, outfile: IO) -> None:
     end_offset = json.loads(utf8_deserializer.loads(infile))
     reader.commit(end_offset)
     write_int(0, outfile)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
@@ -96,6 +96,8 @@ class PythonMicroBatchStream(
   }
 
   override def latestOffset(): Offset = {
+    // Required by MicroBatchStream. Since this stream implements SupportsAdmissionControl, the
+    // engine is expected to call latestOffset(startOffset, limit), but we delegate for safety.
     latestOffset(null, getDefaultReadLimit)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
@@ -58,6 +58,22 @@ class PythonMicroBatchStream(
     new PythonStreamingSourceRunner(createDataSourceFunc, outputSchema)
   runner.init()
 
+  // Validate options early to fail fast
+  validateOptions()
+
+  private def validateOptions(): Unit = {
+    if (options.containsKey(MAX_FILES_PER_BATCH)) {
+      throw new IllegalArgumentException(
+        s"Option '$MAX_FILES_PER_BATCH' is not supported for Python data sources; " +
+          s"use '$MAX_RECORDS_PER_BATCH' instead.")
+    }
+    if (options.containsKey(MAX_BYTES_PER_BATCH)) {
+      throw new IllegalArgumentException(
+        s"Option '$MAX_BYTES_PER_BATCH' is not supported for Python data sources; " +
+          s"use '$MAX_RECORDS_PER_BATCH' instead.")
+    }
+  }
+
   override def initialOffset(): Offset = PythonStreamingSourceOffset(runner.initialOffset())
 
   override def getDefaultReadLimit: ReadLimit = {
@@ -68,24 +84,6 @@ class PythonMicroBatchStream(
         throw new IllegalArgumentException(
           s"Invalid value '${options.get(key)}' for option '$key', must be a positive integer")
       }
-    }
-
-    def parseInt(key: String): Int = {
-      Try(options.get(key).toInt).toOption.filter(_ > 0).getOrElse {
-        throw new IllegalArgumentException(
-          s"Invalid value '${options.get(key)}' for option '$key', must be a positive integer")
-      }
-    }
-
-    if (options.containsKey(MAX_FILES_PER_BATCH)) {
-      throw new IllegalArgumentException(
-        s"Option '$MAX_FILES_PER_BATCH' is not supported for Python data sources; " +
-          s"use '$MAX_RECORDS_PER_BATCH' instead.")
-    }
-    if (options.containsKey(MAX_BYTES_PER_BATCH)) {
-      throw new IllegalArgumentException(
-        s"Option '$MAX_BYTES_PER_BATCH' is not supported for Python data sources; " +
-          s"use '$MAX_RECORDS_PER_BATCH' instead.")
     }
 
     if (options.containsKey(MAX_RECORDS_PER_BATCH)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
@@ -19,7 +19,8 @@ package org.apache.spark.sql.execution.datasources.v2.python
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReaderFactory}
-import org.apache.spark.sql.connector.read.streaming.{AcceptsLatestSeenOffset, MicroBatchStream, Offset}
+import org.apache.spark.sql.connector.read.streaming.{AcceptsLatestSeenOffset, MicroBatchStream, Offset, ReadLimit}
+import org.apache.spark.sql.connector.read.streaming.SupportsAdmissionControl
 import org.apache.spark.sql.execution.datasources.v2.python.PythonMicroBatchStream.nextStreamId
 import org.apache.spark.sql.execution.python.streaming.PythonStreamingSourceRunner
 import org.apache.spark.sql.types.StructType
@@ -28,15 +29,38 @@ import org.apache.spark.storage.{PythonStreamBlockId, StorageLevel}
 
 case class PythonStreamingSourceOffset(json: String) extends Offset
 
+/**
+ * Micro-batch stream implementation for Python data sources with admission control support.
+ *
+ * This class bridges JVM Spark streaming with Python-based data sources, supporting:
+ *   - Admission control via ReadLimit (maxRecordsPerBatch, maxFilesPerBatch, maxBytesPerBatch)
+ *   - Offset tracking and management
+ *   - Latest seen offset for prefetching optimization
+ *
+ * Admission control options:
+ *   - `maxRecordsPerBatch`: Maximum number of rows per batch (Long, must be > 0)
+ *   - `maxFilesPerBatch`: Maximum number of files per batch (Int, must be > 0)
+ *   - `maxBytesPerBatch`: Maximum bytes per batch (Long, must be > 0)
+ *
+ * @param ds
+ *   the Python data source V2 instance
+ * @param shortName
+ *   short name of the data source
+ * @param outputSchema
+ *   the output schema
+ * @param options
+ *   configuration options including admission control settings
+ * @since 4.2.0
+ */
 class PythonMicroBatchStream(
     ds: PythonDataSourceV2,
     shortName: String,
     outputSchema: StructType,
-    options: CaseInsensitiveStringMap
-  )
-  extends MicroBatchStream
-  with Logging
-  with AcceptsLatestSeenOffset {
+    options: CaseInsensitiveStringMap)
+    extends MicroBatchStream
+    with SupportsAdmissionControl
+    with Logging
+    with AcceptsLatestSeenOffset {
   private def createDataSourceFunc =
     ds.source.createPythonFunction(
       ds.getOrCreateDataSourceInPython(shortName, options, Some(outputSchema)).dataSource)
@@ -49,37 +73,119 @@ class PythonMicroBatchStream(
   // from python to JVM.
   private var cachedInputPartition: Option[(String, String, PythonStreamingInputPartition)] = None
 
+  // Store the latest available offset for reporting
+  private var latestAvailableOffset: Option[PythonStreamingSourceOffset] = None
+
   private val runner: PythonStreamingSourceRunner =
     new PythonStreamingSourceRunner(createDataSourceFunc, outputSchema)
   runner.init()
 
   override def initialOffset(): Offset = PythonStreamingSourceOffset(runner.initialOffset())
 
-  override def latestOffset(): Offset = PythonStreamingSourceOffset(runner.latestOffset())
+  /**
+   * Returns the default read limit based on configured options. Supports: maxRecordsPerBatch,
+   * maxFilesPerBatch, maxBytesPerBatch. Falls back to allAvailable if no valid limit is
+   * configured.
+   *
+   * @since 4.2.0
+   */
+  override def getDefaultReadLimit: ReadLimit = {
+    import scala.util.Try
+
+    def parseLong(key: String): Long = {
+      Try(options.get(key).toLong).toOption.filter(_ > 0).getOrElse {
+        throw new IllegalArgumentException(
+          s"Invalid value '${options.get(key)}' for option '$key', must be a positive integer")
+      }
+    }
+
+    def parseInt(key: String): Int = {
+      Try(options.get(key).toInt).toOption.filter(_ > 0).getOrElse {
+        throw new IllegalArgumentException(
+          s"Invalid value '${options.get(key)}' for option '$key', must be a positive integer")
+      }
+    }
+
+    if (options.containsKey("maxRecordsPerBatch")) {
+      val records = parseLong("maxRecordsPerBatch")
+      logInfo(s"Admission control: maxRecordsPerBatch = $records")
+      ReadLimit.maxRows(records)
+    } else if (options.containsKey("maxFilesPerBatch")) {
+      val files = parseInt("maxFilesPerBatch")
+      logInfo(s"Admission control: maxFilesPerBatch = $files")
+      ReadLimit.maxFiles(files)
+    } else if (options.containsKey("maxBytesPerBatch")) {
+      val bytes = parseLong("maxBytesPerBatch")
+      logInfo(s"Admission control: maxBytesPerBatch = $bytes")
+      ReadLimit.maxBytes(bytes)
+    } else {
+      logDebug("No admission control limit configured, using allAvailable")
+      ReadLimit.allAvailable()
+    }
+  }
+
+  override def latestOffset(): Offset = {
+    throw new UnsupportedOperationException(
+      "latestOffset(Offset, ReadLimit) should be called instead of this method")
+  }
+
+  /**
+   * Returns the latest offset with admission control limit applied. Also updates the true latest
+   * offset for reporting purposes.
+   *
+   * @param startOffset
+   *   the starting offset, may be null
+   * @param limit
+   *   the read limit to apply
+   * @return
+   *   the capped offset respecting the limit
+   * @since 4.2.0
+   */
+  override def latestOffset(startOffset: Offset, limit: ReadLimit): Offset = {
+    val startJson = Option(startOffset).map(_.json()).orNull
+    val (cappedOffsetJson, trueLatestJson) = runner.latestOffsetWithReport(startJson, limit)
+    val cappedOffset = PythonStreamingSourceOffset(cappedOffsetJson)
+    latestAvailableOffset = Some(PythonStreamingSourceOffset(trueLatestJson))
+    cappedOffset
+  }
+
+  /**
+   * Reports the true latest available offset without admission control limits applied.
+   *
+   * @return
+   *   the uncapped latest offset
+   * @since 4.2.0
+   */
+  override def reportLatestOffset(): Offset = {
+    latestAvailableOffset.orNull
+  }
 
   override def planInputPartitions(start: Offset, end: Offset): Array[InputPartition] = {
     val startOffsetJson = start.asInstanceOf[PythonStreamingSourceOffset].json
     val endOffsetJson = end.asInstanceOf[PythonStreamingSourceOffset].json
 
     if (cachedInputPartition.exists(p => p._1 == startOffsetJson && p._2 == endOffsetJson)) {
-      return Array(cachedInputPartition.get._3)
-    }
-
-    val (partitions, rows) = runner.partitions(startOffsetJson, endOffsetJson)
-    if (rows.isDefined) {
-      // Only SimpleStreamReader without partitioning prefetch data.
-      assert(partitions.length == 1)
-      nextBlockId = nextBlockId + 1
-      val blockId = PythonStreamBlockId(streamId, nextBlockId)
-      SparkEnv.get.blockManager.putIterator(
-        blockId, rows.get, StorageLevel.MEMORY_AND_DISK_SER, true)
-      val partition = PythonStreamingInputPartition(0, partitions.head, Some(blockId))
-      cachedInputPartition.foreach(_._3.dropCache())
-      cachedInputPartition = Some((startOffsetJson, endOffsetJson, partition))
-      Array(partition)
+      Array(cachedInputPartition.get._3)
     } else {
-      partitions.zipWithIndex
-        .map(p => PythonStreamingInputPartition(p._2, p._1, None))
+      val (partitions, rows) = runner.partitions(startOffsetJson, endOffsetJson)
+      if (rows.isDefined) {
+        // Only SimpleStreamReader without partitioning prefetch data.
+        assert(partitions.length == 1)
+        nextBlockId = nextBlockId + 1
+        val blockId = PythonStreamBlockId(streamId, nextBlockId)
+        SparkEnv.get.blockManager.putIterator(
+          blockId,
+          rows.get,
+          StorageLevel.MEMORY_AND_DISK_SER,
+          true)
+        val partition = PythonStreamingInputPartition(0, partitions.head, Some(blockId))
+        cachedInputPartition.foreach(_._3.dropCache())
+        cachedInputPartition = Some((startOffsetJson, endOffsetJson, partition))
+        Array(partition)
+      } else {
+        partitions.zipWithIndex
+          .map(p => PythonStreamingInputPartition(p._2, p._1, None))
+      }
     }
   }
 
@@ -94,8 +200,7 @@ class PythonMicroBatchStream(
   }
 
   override def createReaderFactory(): PartitionReaderFactory = {
-    new PythonStreamingPartitionReaderFactory(
-      ds.source, readInfo.func, outputSchema, None, None)
+    new PythonStreamingPartitionReaderFactory(ds.source, readInfo.func, outputSchema, None, None)
   }
 
   override def commit(end: Offset): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
@@ -125,8 +125,9 @@ class PythonMicroBatchStream(
   }
 
   override def latestOffset(): Offset = {
-    throw new UnsupportedOperationException(
-      "latestOffset(Offset, ReadLimit) should be called instead of this method")
+    // Bridge to new signature with default read limit for backward compatibility
+    // Use initialOffset as start if we don't have a better alternative
+    latestOffset(initialOffset(), getDefaultReadLimit)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
@@ -92,14 +92,6 @@ class PythonMicroBatchStream(
       val records = parseLong(MAX_RECORDS_PER_BATCH)
       logInfo(s"Admission control: $MAX_RECORDS_PER_BATCH = $records")
       ReadLimit.maxRows(records)
-    } else if (options.containsKey(MAX_FILES_PER_BATCH)) {
-      val files = parseInt(MAX_FILES_PER_BATCH)
-      logInfo(s"Admission control: $MAX_FILES_PER_BATCH = $files")
-      ReadLimit.maxFiles(files)
-    } else if (options.containsKey(MAX_BYTES_PER_BATCH)) {
-      val bytes = parseLong(MAX_BYTES_PER_BATCH)
-      logInfo(s"Admission control: $MAX_BYTES_PER_BATCH = $bytes")
-      ReadLimit.maxBytes(bytes)
     } else {
       logDebug("No admission control limit configured, using allAvailable")
       ReadLimit.allAvailable()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
@@ -59,20 +59,7 @@ class PythonMicroBatchStream(
   runner.init()
 
   // Validate options early to fail fast
-  validateOptions()
-
-  private def validateOptions(): Unit = {
-    if (options.containsKey(MAX_FILES_PER_BATCH)) {
-      throw new IllegalArgumentException(
-        s"Option '$MAX_FILES_PER_BATCH' is not supported for Python data sources; " +
-          s"use '$MAX_RECORDS_PER_BATCH' instead.")
-    }
-    if (options.containsKey(MAX_BYTES_PER_BATCH)) {
-      throw new IllegalArgumentException(
-        s"Option '$MAX_BYTES_PER_BATCH' is not supported for Python data sources; " +
-          s"use '$MAX_RECORDS_PER_BATCH' instead.")
-    }
-  }
+  PythonMicroBatchStream.validateOptions(options)
 
   override def initialOffset(): Offset = PythonStreamingSourceOffset(runner.initialOffset())
 
@@ -176,6 +163,19 @@ object PythonMicroBatchStream {
   val MAX_RECORDS_PER_BATCH = "maxRecordsPerBatch"
   val MAX_FILES_PER_BATCH = "maxFilesPerBatch"
   val MAX_BYTES_PER_BATCH = "maxBytesPerBatch"
+
+  private[python] def validateOptions(options: CaseInsensitiveStringMap): Unit = {
+    if (options.containsKey(MAX_FILES_PER_BATCH)) {
+      throw new IllegalArgumentException(
+        s"Option '$MAX_FILES_PER_BATCH' is not supported for Python data sources; " +
+          s"use '$MAX_RECORDS_PER_BATCH' instead.")
+    }
+    if (options.containsKey(MAX_BYTES_PER_BATCH)) {
+      throw new IllegalArgumentException(
+        s"Option '$MAX_BYTES_PER_BATCH' is not supported for Python data sources; " +
+          s"use '$MAX_RECORDS_PER_BATCH' instead.")
+    }
+  }
 
   def nextStreamId: Int = synchronized {
     currentId = currentId + 1

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
@@ -126,8 +126,8 @@ class PythonMicroBatchStream(
 
   override def latestOffset(): Offset = {
     // Bridge to new signature with default read limit for backward compatibility
-    // Use initialOffset as start if we don't have a better alternative
-    latestOffset(initialOffset(), getDefaultReadLimit)
+    // Pass null as start offset to maintain backward compatibility with old behavior
+    latestOffset(null, getDefaultReadLimit)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
@@ -77,6 +77,17 @@ class PythonMicroBatchStream(
       }
     }
 
+    if (options.containsKey(MAX_FILES_PER_BATCH)) {
+      throw new IllegalArgumentException(
+        s"Option '$MAX_FILES_PER_BATCH' is not supported for Python data sources; " +
+          s"use '$MAX_RECORDS_PER_BATCH' instead.")
+    }
+    if (options.containsKey(MAX_BYTES_PER_BATCH)) {
+      throw new IllegalArgumentException(
+        s"Option '$MAX_BYTES_PER_BATCH' is not supported for Python data sources; " +
+          s"use '$MAX_RECORDS_PER_BATCH' instead.")
+    }
+
     if (options.containsKey(MAX_RECORDS_PER_BATCH)) {
       val records = parseLong(MAX_RECORDS_PER_BATCH)
       logInfo(s"Admission control: $MAX_RECORDS_PER_BATCH = $records")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
@@ -183,9 +183,9 @@ class PythonMicroBatchStream(
 
 object PythonMicroBatchStream {
   private var currentId = 0
-  private[python] val MAX_RECORDS_PER_BATCH = "maxRecordsPerBatch"
-  private[python] val MAX_FILES_PER_BATCH = "maxFilesPerBatch"
-  private[python] val MAX_BYTES_PER_BATCH = "maxBytesPerBatch"
+  val MAX_RECORDS_PER_BATCH = "maxRecordsPerBatch"
+  val MAX_FILES_PER_BATCH = "maxFilesPerBatch"
+  val MAX_BYTES_PER_BATCH = "maxBytesPerBatch"
 
   def nextStreamId: Int = synchronized {
     currentId = currentId + 1

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
@@ -109,7 +109,7 @@ class PythonMicroBatchStream(
     // We still validate configured options via getDefaultReadLimit(), but do not send ReadLimit
     // to Python.
     getDefaultReadLimit
-    val startJson = Option(startOffset).map(_.json()).getOrElse("null")
+    val startJson = if (startOffset != null) startOffset.json() else "null"
     val (cappedOffsetJson, trueLatestJson) = runner.latestOffsetWithReport(startJson)
     val cappedOffset = PythonStreamingSourceOffset(cappedOffsetJson)
     latestAvailableOffset = Some(PythonStreamingSourceOffset(trueLatestJson))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonTable.scala
@@ -35,6 +35,9 @@ class PythonTable(
     BATCH_READ, BATCH_WRITE, MICRO_BATCH_READ, STREAMING_WRITE, TRUNCATE)
 
   override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
+    // Fail fast on unsupported streaming admission-control options during analysis, so errors are
+    // raised at readStream.load() time (instead of later when the stream starts).
+    PythonMicroBatchStream.validateOptions(options)
     new PythonScanBuilder(ds, shortName, outputSchema, options)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
@@ -127,9 +127,7 @@ class PythonStreamingSourceRunner(
     if (initStatus == SpecialLengths.PYTHON_EXCEPTION_THROWN) {
       val msg = PythonWorkerUtils.readUTF(dataIn)
       throw QueryCompilationErrors.pythonDataSourceError(
-        action = "plan",
-        tpe = "initialize source",
-        msg = msg)
+        action = "plan", tpe = "initialize source", msg = msg)
     }
   }
 
@@ -205,8 +203,7 @@ class PythonStreamingSourceRunner(
     if (cappedLen == SpecialLengths.PYTHON_EXCEPTION_THROWN) {
       val msg = PythonWorkerUtils.readUTF(dataIn)
       throw QueryExecutionErrors.pythonStreamingDataSourceRuntimeError(
-        action = "latestOffset",
-        msg)
+        action = "latestOffset", msg)
     }
     val cappedOffset = PythonWorkerUtils.readUTF(cappedLen, dataIn)
 
@@ -215,8 +212,7 @@ class PythonStreamingSourceRunner(
     if (trueLen == SpecialLengths.PYTHON_EXCEPTION_THROWN) {
       val msg = PythonWorkerUtils.readUTF(dataIn)
       throw QueryExecutionErrors.pythonStreamingDataSourceRuntimeError(
-        action = "latestOffset",
-        msg)
+        action = "latestOffset", msg)
     }
     val trueLatest = PythonWorkerUtils.readUTF(trueLen, dataIn)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
@@ -201,8 +201,7 @@ class PythonStreamingSourceRunner(
     if (cappedLen == SpecialLengths.PYTHON_EXCEPTION_THROWN) {
       val msg = PythonWorkerUtils.readUTF(dataIn)
       throw QueryExecutionErrors.pythonStreamingDataSourceRuntimeError(
-        action = "latestOffset",
-        msg)
+        action = "latestOffset", msg)
     }
     val cappedOffset = PythonWorkerUtils.readUTF(cappedLen, dataIn)
 
@@ -211,8 +210,7 @@ class PythonStreamingSourceRunner(
     if (trueLen == SpecialLengths.PYTHON_EXCEPTION_THROWN) {
       val msg = PythonWorkerUtils.readUTF(dataIn)
       throw QueryExecutionErrors.pythonStreamingDataSourceRuntimeError(
-        action = "latestOffset",
-        msg)
+        action = "latestOffset", msg)
     }
     val trueLatest = PythonWorkerUtils.readUTF(trueLen, dataIn)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+
 package org.apache.spark.sql.execution.python.streaming
 
 import java.io.{BufferedInputStream, BufferedOutputStream, DataInputStream, DataOutputStream}
@@ -41,13 +42,10 @@ import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch, Column
 object PythonStreamingSourceRunner {
   // When the python process for python_streaming_source_runner receives one of the
   // integers below, it will invoke the corresponding function of StreamReader instance.
-  // Function IDs for Python-JVM communication protocol
   val INITIAL_OFFSET_FUNC_ID = 884
-  // Note: 885 was deprecated (old latestOffset without admission control parameters)
   val PARTITIONS_FUNC_ID = 886
   val COMMIT_FUNC_ID = 887
-  val LATEST_OFFSET_WITH_REPORT_FUNC_ID = 890 // New: combined latestOffset + report
-
+  val LATEST_OFFSET_WITH_REPORT_FUNC_ID = 890
   // Status code for JVM to decide how to receive prefetched record batches
   // for simple stream reader.
   val PREFETCHED_RECORDS_NOT_FOUND = 0
@@ -127,9 +125,7 @@ class PythonStreamingSourceRunner(
     if (initStatus == SpecialLengths.PYTHON_EXCEPTION_THROWN) {
       val msg = PythonWorkerUtils.readUTF(dataIn)
       throw QueryCompilationErrors.pythonDataSourceError(
-        action = "plan",
-        tpe = "initialize source",
-        msg = msg)
+        action = "plan", tpe = "initialize source", msg = msg)
     }
   }
 
@@ -266,7 +262,7 @@ class PythonStreamingSourceRunner(
       case SpecialLengths.PYTHON_EXCEPTION_THROWN =>
         val msg = PythonWorkerUtils.readUTF(dataIn)
         throw QueryExecutionErrors.pythonStreamingDataSourceRuntimeError(
-          action = "prefetchArrowBatches", msg)
+        action = "prefetchArrowBatches", msg)
       case SpecialLengths.START_ARROW_STREAM =>
       case _ =>
         throw QueryExecutionErrors.pythonStreamingDataSourceRuntimeError(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
@@ -240,7 +240,8 @@ class PythonStreamingSourceRunner(func: PythonFunction, outputSchema: StructType
    */
   def latestOffsetWithReport(startOffset: String, limit: ReadLimit): (String, String) = {
     dataOut.writeInt(LATEST_OFFSET_WITH_REPORT_FUNC_ID)
-    PythonWorkerUtils.writeUTF(startOffset, dataOut)
+    // Handle null startOffset by writing empty string
+    PythonWorkerUtils.writeUTF(Option(startOffset).getOrElse(""), dataOut)
     PythonWorkerUtils.writeUTF(serializeReadLimit(limit), dataOut)
     dataOut.flush()
 
@@ -249,7 +250,7 @@ class PythonStreamingSourceRunner(func: PythonFunction, outputSchema: StructType
     if (cappedLen == SpecialLengths.PYTHON_EXCEPTION_THROWN) {
       val msg = PythonWorkerUtils.readUTF(dataIn)
       throw QueryExecutionErrors.pythonStreamingDataSourceRuntimeError(
-        action = "latestOffsetWithReport",
+        action = "latestOffset",
         msg)
     }
     val cappedOffset = PythonWorkerUtils.readUTF(cappedLen, dataIn)
@@ -259,7 +260,7 @@ class PythonStreamingSourceRunner(func: PythonFunction, outputSchema: StructType
     if (trueLen == SpecialLengths.PYTHON_EXCEPTION_THROWN) {
       val msg = PythonWorkerUtils.readUTF(dataIn)
       throw QueryExecutionErrors.pythonStreamingDataSourceRuntimeError(
-        action = "latestOffsetWithReport",
+        action = "latestOffset",
         msg)
     }
     val trueLatest = PythonWorkerUtils.readUTF(trueLen, dataIn)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
@@ -150,7 +150,8 @@ class PythonStreamingSourceRunner(func: PythonFunction, outputSchema: StructType
   /**
    * Invokes partitions(start, end) function of the stream reader and receive the return value.
    */
-  def partitions(start: String, end: String): (Array[Array[Byte]], Option[Iterator[InternalRow]]) = {
+  def partitions(start: String, end: String): (Array[Array[Byte]], Option[Iterator[InternalRow]]) =
+  {
     dataOut.writeInt(PARTITIONS_FUNC_ID)
     PythonWorkerUtils.writeUTF(start, dataOut)
     PythonWorkerUtils.writeUTF(end, dataOut)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
@@ -56,13 +56,15 @@ object PythonStreamingSourceRunner {
 }
 
 /**
+ * This class is a proxy to invoke methods in Python DataSourceStreamReader from JVM.
  * A runner spawns a python worker process. In the main function, set up communication
  * between JVM and python process through socket and create a DataSourceStreamReader instance.
  * In an infinite loop, the python worker process poll information(function name and parameters)
  * from the socket, invoke the corresponding method of StreamReader and send return value to JVM.
  */
-class PythonStreamingSourceRunner(func: PythonFunction, outputSchema: StructType)
-    extends Logging {
+class PythonStreamingSourceRunner(
+    func: PythonFunction,
+    outputSchema: StructType) extends Logging  {
   val workerModule = "pyspark.sql.streaming.python_streaming_source_runner"
 
   private val conf = SparkEnv.get.conf

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
@@ -189,7 +189,7 @@ class PythonStreamingSourceRunner(
    *   the starting offset JSON string (use "null" to represent no start offset)
    * @return
    *   tuple of (capped offset with limit applied, true latest offset)
-   * @since 4.2.0
+   * @since 4.0.0
    */
   def latestOffsetWithReport(startOffset: String): (String, String) = {
     dataOut.writeInt(LATEST_OFFSET_WITH_REPORT_FUNC_ID)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
@@ -278,13 +278,9 @@ class PythonStreamingSourceRunner(
     val schema = ArrowUtils.fromArrowSchema(root.getSchema())
     assert(schema == outputSchema)
 
-    val vectors = root
-      .getFieldVectors()
-      .asScala
-      .map { vector =>
-        new ArrowColumnVector(vector)
-      }
-      .toArray[ColumnVector]
+    val vectors = root.getFieldVectors().asScala.map { vector =>
+      new ArrowColumnVector(vector)
+    }.toArray[ColumnVector]
     val rows = ArrayBuffer[InternalRow]()
     while (reader.loadNextBatch()) {
       val batch = new ColumnarBatch(vectors)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
@@ -127,7 +127,9 @@ class PythonStreamingSourceRunner(
     if (initStatus == SpecialLengths.PYTHON_EXCEPTION_THROWN) {
       val msg = PythonWorkerUtils.readUTF(dataIn)
       throw QueryCompilationErrors.pythonDataSourceError(
-        action = "plan", tpe = "initialize source", msg = msg)
+        action = "plan",
+        tpe = "initialize source",
+        msg = msg)
     }
   }
 
@@ -203,7 +205,8 @@ class PythonStreamingSourceRunner(
     if (cappedLen == SpecialLengths.PYTHON_EXCEPTION_THROWN) {
       val msg = PythonWorkerUtils.readUTF(dataIn)
       throw QueryExecutionErrors.pythonStreamingDataSourceRuntimeError(
-        action = "latestOffset", msg)
+        action = "latestOffset",
+        msg)
     }
     val cappedOffset = PythonWorkerUtils.readUTF(cappedLen, dataIn)
 
@@ -212,7 +215,8 @@ class PythonStreamingSourceRunner(
     if (trueLen == SpecialLengths.PYTHON_EXCEPTION_THROWN) {
       val msg = PythonWorkerUtils.readUTF(dataIn)
       throw QueryExecutionErrors.pythonStreamingDataSourceRuntimeError(
-        action = "latestOffset", msg)
+        action = "latestOffset",
+        msg)
     }
     val trueLatest = PythonWorkerUtils.readUTF(trueLen, dataIn)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
@@ -56,11 +56,10 @@ object PythonStreamingSourceRunner {
 }
 
 /**
- * This class is a proxy to invoke methods in Python DataSourceStreamReader from JVM. A runner
- * spawns a python worker process. In the main function, set up communication between JVM and
- * python process through socket and create a DataSourceStreamReader instance. In an infinite
- * loop, the python worker process poll information(function name and parameters) from the socket,
- * invoke the corresponding method of StreamReader and send return value to JVM.
+ * A runner spawns a python worker process. In the main function, set up communication
+ * between JVM and python process through socket and create a DataSourceStreamReader instance.
+ * In an infinite loop, the python worker process poll information(function name and parameters)
+ * from the socket, invoke the corresponding method of StreamReader and send return value to JVM.
  */
 class PythonStreamingSourceRunner(func: PythonFunction, outputSchema: StructType)
     extends Logging {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
@@ -930,7 +930,7 @@ class PythonStreamingDataSourceWriteSuite extends PythonDataSourceSuiteBase {
   // Verify that commit runner work correctly with large timeout interval.
   test(s"data source stream write, trigger interval=20 seconds") {
     assume(shouldTestPandasUDFs)
-    val dataSource = 
+    val dataSource =
       createUserDefinedPythonDataSource(dataSourceName, simpleDataStreamWriterScript)
     spark.dataSource.registerPython(dataSourceName, dataSource)
     val inputData = MemoryStream[Int](numPartitions = 3)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
@@ -199,7 +199,8 @@ class PythonStreamingDataSourceSimpleSuite extends PythonDataSourceSuiteBase {
           // Remove the last entry of commit log to test replaying microbatch during restart.
           val offsetLog =
             new OffsetSeqLog(spark, new File(checkpointDir, "offsets").getCanonicalPath)
-          val commitLog = new CommitLog(spark, new File(checkpointDir, "commits").getCanonicalPath)
+          val commitLog =
+            new CommitLog(spark, new File(checkpointDir, "commits").getCanonicalPath)
           commitLog.purgeAfter(offsetLog.getLatest().get._1 - 1)
         }
 
@@ -222,8 +223,7 @@ class PythonStreamingDataSourceSimpleSuite extends PythonDataSourceSuiteBase {
       assert(rowCount == 2 * (lastBatchId + 1) || rowCount == 2 * (lastBatchId + 2))
       checkAnswer(
         spark.read.format("json").load(outputDir.getAbsolutePath),
-        (0 until rowCount.toInt).map(Row(_))
-      )
+        (0 until rowCount.toInt).map(Row(_)))
     }
   }
 
@@ -254,28 +254,22 @@ class PythonStreamingDataSourceSimpleSuite extends PythonDataSourceSuiteBase {
         pythonDs,
         errorDataSourceName,
         inputSchema,
-        CaseInsensitiveStringMap.empty()
-      )
+        CaseInsensitiveStringMap.empty())
       val err = intercept[SparkException] {
         func(stream)
       }
       checkErrorMatchPVals(
         err,
         condition = "PYTHON_STREAMING_DATA_SOURCE_RUNTIME_ERROR",
-        parameters = Map(
-          "action" -> action,
-          "msg" -> "(.|\\n)*"
-        )
-      )
+        parameters = Map("action" -> action, "msg" -> "(.|\\n)*"))
       assert(err.getMessage.contains(msg))
       stream.stop()
     }
 
     testMicroBatchStreamError(
       "initialOffset",
-      "[NOT_IMPLEMENTED] initialOffset is not implemented") {
-      stream =>
-        stream.initialOffset()
+      "[NOT_IMPLEMENTED] initialOffset is not implemented") { stream =>
+      stream.initialOffset()
     }
 
     // User don't need to implement latestOffset for SimpleDataSourceStreamReader.
@@ -283,9 +277,8 @@ class PythonStreamingDataSourceSimpleSuite extends PythonDataSourceSuiteBase {
     // So the not implemented method is initialOffset.
     testMicroBatchStreamError(
       "latestOffset",
-      "[NOT_IMPLEMENTED] initialOffset is not implemented") {
-      stream =>
-        stream.latestOffset()
+      "[NOT_IMPLEMENTED] initialOffset is not implemented") { stream =>
+      stream.latestOffset()
     }
   }
 
@@ -319,26 +312,225 @@ class PythonStreamingDataSourceSimpleSuite extends PythonDataSourceSuiteBase {
         pythonDs,
         errorDataSourceName,
         inputSchema,
-        CaseInsensitiveStringMap.empty()
-      )
+        CaseInsensitiveStringMap.empty())
       val err = intercept[SparkException] {
         func(stream)
       }
       checkErrorMatchPVals(
         err,
         condition = "PYTHON_STREAMING_DATA_SOURCE_RUNTIME_ERROR",
-        parameters = Map(
-          "action" -> action,
-          "msg" -> "(.|\\n)*"
-        )
-      )
+        parameters = Map("action" -> action, "msg" -> "(.|\\n)*"))
       assert(err.getMessage.contains(msg))
       stream.stop()
     }
 
-    testMicroBatchStreamError("latestOffset", "Exception: error reading available data") { stream =>
-      stream.latestOffset()
+    testMicroBatchStreamError("latestOffset", "Exception: error reading available data") {
+      stream =>
+        stream.latestOffset()
     }
+  }
+
+  test("admission control: maxRecordsPerBatch with SimpleDataSourceStreamReader") {
+    assume(shouldTestPandasUDFs)
+    val dataSourceScript =
+      s"""
+         |from pyspark.sql.datasource import DataSource
+         |$simpleDataStreamReaderScript
+         |
+         |class $dataSourceName(DataSource):
+         |    def schema(self) -> str:
+         |        return "id INT"
+         |    def simpleStreamReader(self, schema):
+         |        return SimpleDataStreamReader()
+         |""".stripMargin
+    val dataSource = createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
+    spark.dataSource.registerPython(dataSourceName, dataSource)
+
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      val checkpointDir = new File(path, "checkpoint")
+      val df = spark.readStream
+        .format(dataSourceName)
+        .option("maxRecordsPerBatch", "1") // Admission control: limit to 1 row per batch
+        .load()
+
+      val stopSignal = new CountDownLatch(1)
+      val q = df.writeStream
+        .option("checkpointLocation", checkpointDir.getAbsolutePath)
+        .foreachBatch((df: DataFrame, batchId: Long) => {
+          // With maxRecordsPerBatch=1, each batch should have at most 1 row
+          // SimpleDataStreamReader normally returns 2 rows per batch
+          assert(df.count() <= 1, s"Batch $batchId exceeded maxRecordsPerBatch limit")
+          if (batchId >= 5) stopSignal.countDown()
+        })
+        .start()
+
+      assert(
+        stopSignal.await(waitTimeout.toSeconds, java.util.concurrent.TimeUnit.SECONDS),
+        "Query did not process expected batches in time")
+      // Verify that admission control was applied (batches should have <= 1 row)
+      assert(
+        q.recentProgress.forall(_.numInputRows <= 1),
+        "Some batches exceeded maxRecordsPerBatch=1")
+      q.stop()
+      q.awaitTermination()
+    }
+  }
+
+  test("admission control: maxFilesPerBatch option") {
+    assume(shouldTestPandasUDFs)
+    val dataSourceScript =
+      s"""
+         |from pyspark.sql.datasource import DataSource
+         |$simpleDataStreamReaderScript
+         |
+         |class $dataSourceName(DataSource):
+         |    def schema(self) -> str:
+         |        return "id INT"
+         |    def simpleStreamReader(self, schema):
+         |        return SimpleDataStreamReader()
+         |""".stripMargin
+    val dataSource = createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
+    spark.dataSource.registerPython(dataSourceName, dataSource)
+
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      val checkpointDir = new File(path, "checkpoint")
+      val df = spark.readStream
+        .format(dataSourceName)
+        .option("maxFilesPerBatch", "10") // Admission control option
+        .load()
+
+      val stopSignal = new CountDownLatch(1)
+      val q = df.writeStream
+        .option("checkpointLocation", checkpointDir.getAbsolutePath)
+        .foreachBatch((df: DataFrame, batchId: Long) => {
+          // Just verify the query runs successfully with maxFilesPerBatch option
+          if (batchId >= 3) stopSignal.countDown()
+        })
+        .start()
+
+      assert(
+        stopSignal.await(waitTimeout.toSeconds, java.util.concurrent.TimeUnit.SECONDS),
+        "Query with maxFilesPerBatch did not complete")
+      q.stop()
+      q.awaitTermination()
+    }
+  }
+
+  test("admission control: maxBytesPerBatch option") {
+    assume(shouldTestPandasUDFs)
+    val dataSourceScript =
+      s"""
+         |from pyspark.sql.datasource import DataSource
+         |$simpleDataStreamReaderScript
+         |
+         |class $dataSourceName(DataSource):
+         |    def schema(self) -> str:
+         |        return "id INT"
+         |    def simpleStreamReader(self, schema):
+         |        return SimpleDataStreamReader()
+         |""".stripMargin
+    val dataSource = createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
+    spark.dataSource.registerPython(dataSourceName, dataSource)
+
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      val checkpointDir = new File(path, "checkpoint")
+      val df = spark.readStream
+        .format(dataSourceName)
+        .option("maxBytesPerBatch", "1048576") // 1MB limit
+        .load()
+
+      val stopSignal = new CountDownLatch(1)
+      val q = df.writeStream
+        .option("checkpointLocation", checkpointDir.getAbsolutePath)
+        .foreachBatch((df: DataFrame, batchId: Long) => {
+          // Just verify the query runs successfully with maxBytesPerBatch option
+          if (batchId >= 3) stopSignal.countDown()
+        })
+        .start()
+
+      assert(
+        stopSignal.await(waitTimeout.toSeconds, java.util.concurrent.TimeUnit.SECONDS),
+        "Query with maxBytesPerBatch did not complete")
+      q.stop()
+      q.awaitTermination()
+    }
+  }
+
+  private def testInvalidAdmissionControlValue(option: String, value: String): Unit = {
+    assume(shouldTestPandasUDFs)
+    val dataSourceScript =
+      s"""
+         |from pyspark.sql.datasource import DataSource
+         |$simpleDataStreamReaderScript
+         |
+         |class $dataSourceName(DataSource):
+         |    def schema(self) -> str:
+         |        return "id INT"
+         |    def simpleStreamReader(self, schema):
+         |        return SimpleDataStreamReader()
+         |""".stripMargin
+    val dataSource = createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
+    spark.dataSource.registerPython(dataSourceName, dataSource)
+
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      val checkpointDir = new File(path, "checkpoint")
+      val df = spark.readStream
+        .format(dataSourceName)
+        .option(option, value)
+        .load()
+
+      val e = intercept[StreamingQueryException] {
+        val q = df.writeStream
+          .option("checkpointLocation", checkpointDir.getAbsolutePath)
+          .foreachBatch((df: DataFrame, batchId: Long) => {})
+          .start()
+        try {
+          q.processAllAvailable()
+        } finally {
+          q.stop()
+        }
+      }
+      assert(
+        e.getCause.isInstanceOf[IllegalArgumentException],
+        s"Expected IllegalArgumentException but got ${e.getCause.getClass}")
+      Seq(option, value, "positive integer").foreach { s =>
+        assert(
+          e.getMessage.contains(s),
+          s"Expected error message to contain '$s' but got: ${e.getMessage}")
+      }
+    }
+  }
+
+  test("admission control: invalid maxRecordsPerBatch throws exception") {
+    testInvalidAdmissionControlValue("maxRecordsPerBatch", "invalid")
+  }
+
+  test("admission control: negative maxRecordsPerBatch throws exception") {
+    testInvalidAdmissionControlValue("maxRecordsPerBatch", "-1")
+  }
+
+  test("admission control: zero maxRecordsPerBatch throws exception") {
+    testInvalidAdmissionControlValue("maxRecordsPerBatch", "0")
+  }
+
+  test("admission control: decimal maxRecordsPerBatch throws exception") {
+    testInvalidAdmissionControlValue("maxRecordsPerBatch", "10.5")
+  }
+
+  test("admission control: invalid maxFilesPerBatch throws exception") {
+    testInvalidAdmissionControlValue("maxFilesPerBatch", "invalid")
+  }
+
+  test("admission control: negative maxFilesPerBatch throws exception") {
+    testInvalidAdmissionControlValue("maxFilesPerBatch", "-1")
+  }
+
+  test("admission control: invalid maxBytesPerBatch throws exception") {
+    testInvalidAdmissionControlValue("maxBytesPerBatch", "not-a-number")
   }
 }
 
@@ -408,8 +600,7 @@ class PythonStreamingDataSourceSuite extends PythonDataSourceSuiteBase {
       pythonDs,
       dataSourceName,
       inputSchema,
-      CaseInsensitiveStringMap.empty()
-    )
+      CaseInsensitiveStringMap.empty())
 
     var startOffset = stream.initialOffset()
     assert(startOffset.json == "{\"offset\": {\"partition-1\": 0}}")
@@ -655,39 +846,35 @@ class PythonStreamingDataSourceSuite extends PythonDataSourceSuiteBase {
         pythonDs,
         errorDataSourceName,
         inputSchema,
-        CaseInsensitiveStringMap.empty()
-      )
+        CaseInsensitiveStringMap.empty())
       val err = intercept[SparkException] {
         func(stream)
       }
       checkErrorMatchPVals(
         err,
         condition = "PYTHON_STREAMING_DATA_SOURCE_RUNTIME_ERROR",
-        parameters = Map(
-          "action" -> action,
-          "msg" -> "(.|\\n)*"
-        )
-      )
+        parameters = Map("action" -> action, "msg" -> "(.|\\n)*"))
       assert(err.getMessage.contains(msg))
       stream.stop()
     }
 
     testMicroBatchStreamError(
       "initialOffset",
-      "[NOT_IMPLEMENTED] initialOffset is not implemented") {
-      stream =>
-        stream.initialOffset()
+      "[NOT_IMPLEMENTED] initialOffset is not implemented") { stream =>
+      stream.initialOffset()
     }
 
-    testMicroBatchStreamError("latestOffset", "[NOT_IMPLEMENTED] latestOffset is not implemented") {
-      stream =>
-        stream.latestOffset()
+    testMicroBatchStreamError(
+      "latestOffset",
+      "[NOT_IMPLEMENTED] latestOffset is not implemented") { stream =>
+      stream.latestOffset()
     }
 
     val offset = PythonStreamingSourceOffset("{\"offset\": \"2\"}")
-    testMicroBatchStreamError("planPartitions", "[NOT_IMPLEMENTED] partitions is not implemented") {
-      stream =>
-        stream.planInputPartitions(offset, offset)
+    testMicroBatchStreamError(
+      "planPartitions",
+      "[NOT_IMPLEMENTED] partitions is not implemented") { stream =>
+      stream.planInputPartitions(offset, offset)
     }
   }
 
@@ -716,19 +903,14 @@ class PythonStreamingDataSourceSuite extends PythonDataSourceSuiteBase {
         pythonDs,
         errorDataSourceName,
         inputSchema,
-        CaseInsensitiveStringMap.empty()
-      )
+        CaseInsensitiveStringMap.empty())
       val err = intercept[SparkException] {
         func(stream)
       }
       checkErrorMatchPVals(
         err,
         condition = "PYTHON_STREAMING_DATA_SOURCE_RUNTIME_ERROR",
-        parameters = Map(
-          "action" -> action,
-          "msg" -> "(.|\\n)*"
-        )
-      )
+        parameters = Map("action" -> action, "msg" -> "(.|\\n)*"))
       assert(err.getMessage.contains(msg))
       stream.stop()
     }
@@ -808,13 +990,15 @@ class PythonStreamingDataSourceWriteSuite extends PythonDataSourceSuiteBase {
           inputData.toDF()
         } else {
           // Complete mode only supports stateful aggregation
-          inputData.toDF()
-            .groupBy("value").count()
+          inputData
+            .toDF()
+            .groupBy("value")
+            .count()
         }
-        def resultDf: DataFrame = spark.read.format("json")
+        def resultDf: DataFrame = spark.read
+          .format("json")
           .load(outputDir.getAbsolutePath)
-        val q = streamDF
-          .writeStream
+        val q = streamDF.writeStream
           .format(dataSourceName)
           .outputMode(mode)
           .option("checkpointLocation", checkpointDir.getAbsolutePath)
@@ -823,22 +1007,16 @@ class PythonStreamingDataSourceWriteSuite extends PythonDataSourceSuiteBase {
         inputData.addData(1, 2, 3)
         eventually(timeout(waitTimeout)) {
           if (mode == "append") {
-            checkAnswer(
-              resultDf,
-              Seq(Row(1), Row(2), Row(3)))
+            checkAnswer(resultDf, Seq(Row(1), Row(2), Row(3)))
           } else {
-            checkAnswer(
-              resultDf.select("value", "count"),
-              Seq(Row(1, 1), Row(2, 1), Row(3, 1)))
+            checkAnswer(resultDf.select("value", "count"), Seq(Row(1, 1), Row(2, 1), Row(3, 1)))
           }
         }
 
         inputData.addData(1, 4)
         eventually(timeout(waitTimeout)) {
           if (mode == "append") {
-            checkAnswer(
-              resultDf,
-              Seq(Row(1), Row(2), Row(3), Row(4), Row(1)))
+            checkAnswer(resultDf, Seq(Row(1), Row(2), Row(3), Row(4), Row(1)))
           } else {
             checkAnswer(
               resultDf.select("value", "count"),
@@ -867,13 +1045,13 @@ class PythonStreamingDataSourceWriteSuite extends PythonDataSourceSuiteBase {
       checkpointDir.mkdir()
       val outputDir = new File(path, "output")
       outputDir.mkdir()
-      val q = df
-        .writeStream
+      val q = df.writeStream
         .format(dataSourceName)
         .option("checkpointLocation", checkpointDir.getAbsolutePath)
         .trigger(ProcessingTimeTrigger(20 * 1000))
         .start(outputDir.getAbsolutePath)
-      def resultDf: DataFrame = spark.read.format("json")
+      def resultDf: DataFrame = spark.read
+        .format("json")
         .load(outputDir.getAbsolutePath)
 
       inputData.addData(1 to 3)
@@ -950,14 +1128,16 @@ class PythonStreamingDataSourceWriteSuite extends PythonDataSourceSuiteBase {
       checkpointDir.mkdir()
       val outputDir = new File(path, "output")
       outputDir.mkdir()
-      val q = inputData.toDF()
+      val q = inputData
+        .toDF()
         .writeStream
         .format(dataSourceName)
         .outputMode("append")
         .option("checkpointLocation", checkpointDir.getAbsolutePath)
         .start(outputDir.getAbsolutePath)
 
-      def metadataDf: DataFrame = spark.read.format("json")
+      def metadataDf: DataFrame = spark.read
+        .format("json")
         .load(outputDir.getAbsolutePath)
 
       // Batch 0-2 should succeed and json commit files are written.
@@ -997,7 +1177,8 @@ class PythonStreamingDataSourceWriteSuite extends PythonDataSourceSuiteBase {
     // the output directory in commit() function. If aborting a microbatch, it writes
     // batchId.txt into output directory.
 
-    val dataSource = createUserDefinedPythonDataSource(dataSourceName, simpleDataStreamWriterScript)
+    val dataSource =
+      createUserDefinedPythonDataSource(dataSourceName, simpleDataStreamWriterScript)
     spark.dataSource.registerPython(dataSourceName, dataSource)
 
     withTempDir { dir =>
@@ -1015,7 +1196,8 @@ class PythonStreamingDataSourceWriteSuite extends PythonDataSourceSuiteBase {
           checkpointDir.mkdir()
           val outputDir = new File(path, "output")
           outputDir.mkdir()
-          val q = inputData.toDF()
+          val q = inputData
+            .toDF()
             .writeStream
             .format(dataSourceName)
             .outputMode(mode)
@@ -1036,9 +1218,7 @@ class PythonStreamingDataSourceWriteSuite extends PythonDataSourceSuiteBase {
         },
         condition = "STREAMING_OUTPUT_MODE.UNSUPPORTED_OPERATION",
         sqlState = "42KDE",
-        parameters = Map(
-          "outputMode" -> "complete",
-          "operation" -> "no streaming aggregations"))
+        parameters = Map("outputMode" -> "complete", "operation" -> "no streaming aggregations"))
 
       // Query should fail in planning with "invalid" mode.
       val error2 = intercept[IllegalArgumentException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
@@ -759,9 +759,7 @@ class PythonStreamingDataSourceSuite extends PythonDataSourceSuiteBase {
     }
 
     val offset = PythonStreamingSourceOffset("{\"offset\": \"2\"}")
-    testMicroBatchStreamError(
-      "planPartitions",
-      "[NOT_IMPLEMENTED] partitions is not implemented") {
+    testMicroBatchStreamError("planPartitions", "[NOT_IMPLEMENTED] partitions is not implemented") {
       stream =>
         stream.planInputPartitions(offset, offset)
     }
@@ -932,7 +930,8 @@ class PythonStreamingDataSourceWriteSuite extends PythonDataSourceSuiteBase {
   // Verify that commit runner work correctly with large timeout interval.
   test(s"data source stream write, trigger interval=20 seconds") {
     assume(shouldTestPandasUDFs)
-    val dataSource = createUserDefinedPythonDataSource(dataSourceName, simpleDataStreamWriterScript)
+    val dataSource = 
+      createUserDefinedPythonDataSource(dataSourceName, simpleDataStreamWriterScript)
     spark.dataSource.registerPython(dataSourceName, dataSource)
     val inputData = MemoryStream[Int](numPartitions = 3)
     val df = inputData.toDF()
@@ -1072,8 +1071,7 @@ class PythonStreamingDataSourceWriteSuite extends PythonDataSourceSuiteBase {
     // the output directory in commit() function. If aborting a microbatch, it writes
     // batchId.txt into output directory.
 
-    val dataSource =
-      createUserDefinedPythonDataSource(dataSourceName, simpleDataStreamWriterScript)
+    val dataSource = createUserDefinedPythonDataSource(dataSourceName, simpleDataStreamWriterScript)
     spark.dataSource.registerPython(dataSourceName, dataSource)
 
     withTempDir { dir =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
@@ -88,7 +88,8 @@ class PythonStreamingDataSourceSimpleSuite extends PythonDataSourceSuiteBase {
          |    def simpleStreamReader(self, schema):
          |        return SimpleDataStreamReader()
          |""".stripMargin
-    val dataSource = createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
+    val dataSource =
+      createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
     spark.dataSource.registerPython(dataSourceName, dataSource)
     assert(spark.sessionState.dataSourceManager.dataSourceExists(dataSourceName))
     withTempDir { dir =>
@@ -435,7 +436,8 @@ class PythonStreamingDataSourceSuite extends PythonDataSourceSuiteBase {
       pythonDs,
       dataSourceName,
       inputSchema,
-      CaseInsensitiveStringMap.empty())
+      CaseInsensitiveStringMap.empty()
+    )
 
     var startOffset = stream.initialOffset()
     assert(startOffset.json == "{\"offset\": {\"partition-1\": 0}}")
@@ -790,14 +792,19 @@ class PythonStreamingDataSourceSuite extends PythonDataSourceSuiteBase {
         pythonDs,
         errorDataSourceName,
         inputSchema,
-        CaseInsensitiveStringMap.empty())
+        CaseInsensitiveStringMap.empty()
+      )
       val err = intercept[SparkException] {
         func(stream)
       }
       checkErrorMatchPVals(
         err,
         condition = "PYTHON_STREAMING_DATA_SOURCE_RUNTIME_ERROR",
-        parameters = Map("action" -> action, "msg" -> "(.|\\n)*"))
+        parameters = Map(
+          "action" -> action,
+          "msg" -> "(.|\\n)*"
+        )
+      )
       assert(err.getMessage.contains(msg))
       stream.stop()
     }
@@ -1066,7 +1073,8 @@ class PythonStreamingDataSourceWriteSuite extends PythonDataSourceSuiteBase {
     // the output directory in commit() function. If aborting a microbatch, it writes
     // batchId.txt into output directory.
 
-    val dataSource = createUserDefinedPythonDataSource(dataSourceName, simpleDataStreamWriterScript)
+    val dataSource =
+      createUserDefinedPythonDataSource(dataSourceName, simpleDataStreamWriterScript)
     spark.dataSource.registerPython(dataSourceName, dataSource)
 
     withTempDir { dir =>
@@ -1107,7 +1115,9 @@ class PythonStreamingDataSourceWriteSuite extends PythonDataSourceSuiteBase {
         sqlState = "42KDE",
         parameters = Map(
           "outputMode" -> "complete",
-          "operation" -> "no streaming aggregations"))
+          "operation" -> "no streaming aggregations"
+        )
+      )
 
       // Query should fail in planning with "invalid" mode.
       val error2 = intercept[IllegalArgumentException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
@@ -88,8 +88,7 @@ class PythonStreamingDataSourceSimpleSuite extends PythonDataSourceSuiteBase {
          |    def simpleStreamReader(self, schema):
          |        return SimpleDataStreamReader()
          |""".stripMargin
-    val dataSource =
-      createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
+    val dataSource = createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
     spark.dataSource.registerPython(dataSourceName, dataSource)
     assert(spark.sessionState.dataSourceManager.dataSourceExists(dataSourceName))
     withTempDir { dir =>
@@ -754,19 +753,15 @@ class PythonStreamingDataSourceSuite extends PythonDataSourceSuiteBase {
         stream.initialOffset()
     }
 
-    testMicroBatchStreamError(
-      "latestOffset",
-      "[NOT_IMPLEMENTED] latestOffset is not implemented") {
-      stream =>
-        stream.latestOffset()
+    testMicroBatchStreamError("latestOffset", "[NOT_IMPLEMENTED] latestOffset is not implemented") { stream =>
+      stream.latestOffset()
     }
 
     val offset = PythonStreamingSourceOffset("{\"offset\": \"2\"}")
     testMicroBatchStreamError(
       "planPartitions",
-      "[NOT_IMPLEMENTED] partitions is not implemented") {
-      stream =>
-        stream.planInputPartitions(offset, offset)
+      "[NOT_IMPLEMENTED] partitions is not implemented") { stream =>
+      stream.planInputPartitions(offset, offset)
     }
   }
 
@@ -1116,11 +1111,7 @@ class PythonStreamingDataSourceWriteSuite extends PythonDataSourceSuiteBase {
         },
         condition = "STREAMING_OUTPUT_MODE.UNSUPPORTED_OPERATION",
         sqlState = "42KDE",
-        parameters = Map(
-          "outputMode" -> "complete",
-          "operation" -> "no streaming aggregations"
-        )
-      )
+        parameters = Map("outputMode" -> "complete", "operation" -> "no streaming aggregations"))
 
       // Query should fail in planning with "invalid" mode.
       val error2 = intercept[IllegalArgumentException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
@@ -749,21 +749,24 @@ class PythonStreamingDataSourceSuite extends PythonDataSourceSuiteBase {
 
     testMicroBatchStreamError(
       "initialOffset",
-      "[NOT_IMPLEMENTED] initialOffset is not implemented") { stream =>
-      stream.initialOffset()
+      "[NOT_IMPLEMENTED] initialOffset is not implemented") {
+      stream =>
+        stream.initialOffset()
     }
 
     testMicroBatchStreamError(
       "latestOffset",
-      "[NOT_IMPLEMENTED] latestOffset is not implemented") { stream =>
-      stream.latestOffset()
+      "[NOT_IMPLEMENTED] latestOffset is not implemented") {
+      stream =>
+        stream.latestOffset()
     }
 
     val offset = PythonStreamingSourceOffset("{\"offset\": \"2\"}")
     testMicroBatchStreamError(
       "planPartitions",
-      "[NOT_IMPLEMENTED] partitions is not implemented") { stream =>
-      stream.planInputPartitions(offset, offset)
+      "[NOT_IMPLEMENTED] partitions is not implemented") {
+      stream =>
+        stream.planInputPartitions(offset, offset)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
@@ -25,6 +25,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.IntegratedUDFTestUtils.{createUserDefinedPythonDataSource, shouldTestPandasUDFs}
 import org.apache.spark.sql.execution.datasources.v2.python.{PythonDataSourceV2, PythonMicroBatchStream, PythonStreamingSourceOffset}
+import org.apache.spark.sql.execution.datasources.v2.python.PythonMicroBatchStream._
 import org.apache.spark.sql.execution.python.PythonDataSourceSuiteBase
 import org.apache.spark.sql.execution.streaming.ProcessingTimeTrigger
 import org.apache.spark.sql.execution.streaming.checkpointing.{CommitLog, OffsetSeqLog}
@@ -32,8 +33,6 @@ import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.streaming.StreamingQueryException
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-
-import org.apache.spark.sql.execution.datasources.v2.python.PythonMicroBatchStream._
 
 class PythonStreamingDataSourceSimpleSuite extends PythonDataSourceSuiteBase {
   val waitTimeout = 15.seconds

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.IntegratedUDFTestUtils.{createUserDefinedPythonDataSource, shouldTestPandasUDFs}
 import org.apache.spark.sql.execution.datasources.v2.python.{PythonDataSourceV2, PythonMicroBatchStream, PythonStreamingSourceOffset}
-import org.apache.spark.sql.execution.datasources.v2.python.PythonMicroBatchStream._
+import org.apache.spark.sql.execution.datasources.v2.python.PythonMicroBatchStream.{MAX_BYTES_PER_BATCH, MAX_FILES_PER_BATCH, MAX_RECORDS_PER_BATCH}
 import org.apache.spark.sql.execution.python.PythonDataSourceSuiteBase
 import org.apache.spark.sql.execution.streaming.ProcessingTimeTrigger
 import org.apache.spark.sql.execution.streaming.checkpointing.{CommitLog, OffsetSeqLog}
@@ -33,7 +33,6 @@ import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.streaming.StreamingQueryException
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-
 class PythonStreamingDataSourceSimpleSuite extends PythonDataSourceSuiteBase {
   val waitTimeout = 15.seconds
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
@@ -199,8 +199,7 @@ class PythonStreamingDataSourceSimpleSuite extends PythonDataSourceSuiteBase {
           // Remove the last entry of commit log to test replaying microbatch during restart.
           val offsetLog =
             new OffsetSeqLog(spark, new File(checkpointDir, "offsets").getCanonicalPath)
-          val commitLog =
-            new CommitLog(spark, new File(checkpointDir, "commits").getCanonicalPath)
+          val commitLog = new CommitLog(spark, new File(checkpointDir, "commits").getCanonicalPath)
           commitLog.purgeAfter(offsetLog.getLatest().get._1 - 1)
         }
 
@@ -223,7 +222,8 @@ class PythonStreamingDataSourceSimpleSuite extends PythonDataSourceSuiteBase {
       assert(rowCount == 2 * (lastBatchId + 1) || rowCount == 2 * (lastBatchId + 2))
       checkAnswer(
         spark.read.format("json").load(outputDir.getAbsolutePath),
-        (0 until rowCount.toInt).map(Row(_)))
+        (0 until rowCount.toInt).map(Row(_))
+      )
     }
   }
 
@@ -254,22 +254,28 @@ class PythonStreamingDataSourceSimpleSuite extends PythonDataSourceSuiteBase {
         pythonDs,
         errorDataSourceName,
         inputSchema,
-        CaseInsensitiveStringMap.empty())
+        CaseInsensitiveStringMap.empty()
+      )
       val err = intercept[SparkException] {
         func(stream)
       }
       checkErrorMatchPVals(
         err,
         condition = "PYTHON_STREAMING_DATA_SOURCE_RUNTIME_ERROR",
-        parameters = Map("action" -> action, "msg" -> "(.|\\n)*"))
+        parameters = Map(
+          "action" -> action,
+          "msg" -> "(.|\\n)*"
+        )
+      )
       assert(err.getMessage.contains(msg))
       stream.stop()
     }
 
     testMicroBatchStreamError(
       "initialOffset",
-      "[NOT_IMPLEMENTED] initialOffset is not implemented") { stream =>
-      stream.initialOffset()
+      "[NOT_IMPLEMENTED] initialOffset is not implemented") {
+      stream =>
+        stream.initialOffset()
     }
 
     // User don't need to implement latestOffset for SimpleDataSourceStreamReader.
@@ -277,8 +283,9 @@ class PythonStreamingDataSourceSimpleSuite extends PythonDataSourceSuiteBase {
     // So the not implemented method is initialOffset.
     testMicroBatchStreamError(
       "latestOffset",
-      "[NOT_IMPLEMENTED] initialOffset is not implemented") { stream =>
-      stream.latestOffset()
+      "[NOT_IMPLEMENTED] initialOffset is not implemented") {
+      stream =>
+        stream.latestOffset()
     }
   }
 
@@ -312,21 +319,25 @@ class PythonStreamingDataSourceSimpleSuite extends PythonDataSourceSuiteBase {
         pythonDs,
         errorDataSourceName,
         inputSchema,
-        CaseInsensitiveStringMap.empty())
+        CaseInsensitiveStringMap.empty()
+      )
       val err = intercept[SparkException] {
         func(stream)
       }
       checkErrorMatchPVals(
         err,
         condition = "PYTHON_STREAMING_DATA_SOURCE_RUNTIME_ERROR",
-        parameters = Map("action" -> action, "msg" -> "(.|\\n)*"))
+        parameters = Map(
+          "action" -> action,
+          "msg" -> "(.|\\n)*"
+        )
+      )
       assert(err.getMessage.contains(msg))
       stream.stop()
     }
 
-    testMicroBatchStreamError("latestOffset", "Exception: error reading available data") {
-      stream =>
-        stream.latestOffset()
+    testMicroBatchStreamError("latestOffset", "Exception: error reading available data") { stream =>
+      stream.latestOffset()
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
@@ -753,15 +753,17 @@ class PythonStreamingDataSourceSuite extends PythonDataSourceSuiteBase {
         stream.initialOffset()
     }
 
-    testMicroBatchStreamError("latestOffset", "[NOT_IMPLEMENTED] latestOffset is not implemented") { stream =>
-      stream.latestOffset()
+    testMicroBatchStreamError("latestOffset", "[NOT_IMPLEMENTED] latestOffset is not implemented") {
+      stream =>
+        stream.latestOffset()
     }
 
     val offset = PythonStreamingSourceOffset("{\"offset\": \"2\"}")
     testMicroBatchStreamError(
       "planPartitions",
-      "[NOT_IMPLEMENTED] partitions is not implemented") { stream =>
-      stream.planInputPartitions(offset, offset)
+      "[NOT_IMPLEMENTED] partitions is not implemented") {
+      stream =>
+        stream.planInputPartitions(offset, offset)
     }
   }
 
@@ -930,8 +932,7 @@ class PythonStreamingDataSourceWriteSuite extends PythonDataSourceSuiteBase {
   // Verify that commit runner work correctly with large timeout interval.
   test(s"data source stream write, trigger interval=20 seconds") {
     assume(shouldTestPandasUDFs)
-    val dataSource =
-      createUserDefinedPythonDataSource(dataSourceName, simpleDataStreamWriterScript)
+    val dataSource = createUserDefinedPythonDataSource(dataSourceName, simpleDataStreamWriterScript)
     spark.dataSource.registerPython(dataSourceName, dataSource)
     val inputData = MemoryStream[Int](numPartitions = 3)
     val df = inputData.toDF()
@@ -1111,7 +1112,9 @@ class PythonStreamingDataSourceWriteSuite extends PythonDataSourceSuiteBase {
         },
         condition = "STREAMING_OUTPUT_MODE.UNSUPPORTED_OPERATION",
         sqlState = "42KDE",
-        parameters = Map("outputMode" -> "complete", "operation" -> "no streaming aggregations"))
+        parameters = Map(
+          "outputMode" -> "complete",
+          "operation" -> "no streaming aggregations"))
 
       // Query should fail in planning with "invalid" mode.
       val error2 = intercept[IllegalArgumentException] {


### PR DESCRIPTION
[SPARK-50604][PYTHON][SS] Support admission control for Python Streaming Data Source

### What changes were proposed in this pull request?

This PR implements admission control for Python Streaming Data Sources, specifically adding support for the `maxRecordsPerBatch` option. This allows users to limit the number of records processed per micro-batch, which is critical for rate limiting and stability in streaming applications.

The changes include:

1.  **Python API Updates**:
    *   Updated `DataSourceStreamReader.latestOffset` to accept an optional `start` offset argument: `def latestOffset(self, start: Optional[dict] = None)`.
    *   Updated `DataSourceStreamReader.latestOffset` to support returning a tuple of `(capped_offset, true_latest_offset)` alongside the existing single offset return type.
    *   Modified `_SimpleStreamReaderWrapper` to maintain compatibility with the new signature (though admission control is not supported for simple readers).

2.  **Scala/Java Engine Updates**:
    *   Updated `PythonMicroBatchStream` to implement `SupportsAdmissionControl`.
    *   Added logic to validate and parse `maxRecordsPerBatch`.
    *   Explicitly blocked `maxFilesPerBatch` and `maxBytesPerBatch` with informative error messages as they are not supported for Python sources.

3.  **Internal Protocol**:
    *   Introduced a new RPC command `LATEST_OFFSET_WITH_REPORT_FUNC_ID` (890) to fetch both the capped offset and the true latest offset in a single call from the Python worker to the JVM.

4.  **Documentation & Examples**:
    *   Updated `python/docs/source/tutorial/sql/python_data_source.rst` to explain how to implement admission control in custom data sources.
    *   Added a new example `examples/src/main/python/sql/streaming/structured_blockchain_admission_control.py` demonstrating the feature.

### Why are the changes needed?
Currently, Python Streaming Data Sources read all available data in every batch. Without admission control, a sudden backlog of data can cause OOMs or unstable processing times. Enabling `maxRecordsPerBatch` brings Python sources closer to parity with native Spark sources regarding rate limiting and resource management.

### Does this PR introduce _any_ user-facing change?
Yes.

*   **API Change**: The `latestOffset` method in `DataSourceStreamReader` now accepts an optional `start` parameter.
    *   *Backward Compatibility*: Existing implementations that do not accept arguments will continue to work (the runner handles `TypeError` and falls back to the no-arg call).
*   **New Feature**: Users can now use `.option("maxRecordsPerBatch", ...)` with Python data sources to limit batch sizes.
*   **Error Handling**: Users attempting to use `maxFilesPerBatch` or `maxBytesPerBatch` with Python sources will now receive a clear `IllegalArgumentException` instead of the option being ignored or causing undefined behavior.

### How was this patch tested?
*   **Unit Tests**: Added new tests in `PythonStreamingDataSourceSuite.scala`:
    *   `test("admission control: maxRecordsPerBatch with DataSourceStreamReader")`: Verifies that batch sizes are respected.
    *   Tests verifying that `IllegalArgumentException` is thrown for unsupported options (`maxFilesPerBatch`, `maxBytesPerBatch`).
*   **Manual Verification**: Verified using the new `structured_blockchain_admission_control.py` example script, confirming that the micro-batch execution respects the configured block limits.

### Was this patch authored or co-authored using generative AI tooling?
No.