### PR TITLE
[SPARK-54384][PYTHON] Modernize the _batched method for BatchedSerializer

### DIFF
--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -55,7 +55,7 @@ which contains two batches of two objects:
 
 import sys
 import os
-from itertools import chain, product
+from itertools import batched, chain, product
 import marshal
 import struct
 import types
@@ -203,22 +203,8 @@ class BatchedSerializer(Serializer):
     def _batched(self, iterator):
         if self.batchSize == self.UNLIMITED_BATCH_SIZE:
             yield list(iterator)
-        elif hasattr(iterator, "__len__") and hasattr(iterator, "__getslice__"):
-            n = len(iterator)
-            for i in range(0, n, self.batchSize):
-                yield iterator[i : i + self.batchSize]
         else:
-            items = []
-            count = 0
-            for item in iterator:
-                items.append(item)
-                count += 1
-                if count == self.batchSize:
-                    yield items
-                    items = []
-                    count = 0
-            if items:
-                yield items
+            yield from map(list(batched(iterator, self.batchSize)))
 
     def dump_stream(self, iterator, stream):
         self.serializer.dump_stream(self._batched(iterator), stream)

--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -55,7 +55,7 @@ which contains two batches of two objects:
 
 import sys
 import os
-from itertools import batched, chain, product
+from itertools import chain, product
 import marshal
 import struct
 import types
@@ -204,7 +204,9 @@ class BatchedSerializer(Serializer):
         if self.batchSize == self.UNLIMITED_BATCH_SIZE:
             yield list(iterator)
         else:
-            yield from map(list(batched(iterator, self.batchSize)))
+            it = iter(iterator)
+            while batch := list(itertools.islice(it, self.batchSize)):
+                yield batch
 
     def dump_stream(self, iterator, stream):
         self.serializer.dump_stream(self._batched(iterator), stream)


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Use the modern itertools to do `_batch` function in `BatchedSerializer` to make code cleaner and faster.

The code is about 170% faster than the original implementation.

<details>
<summary>
Result with the following code

```
Batching batch_original took 0.3086 seconds
Batching batch_after took 0.1159 seconds
```


</summary>

```python
import itertools
import time

def batch_original(iterator, batch_size):
    items = []
    count = 0
    for item in iterator:
        items.append(item)
        count += 1
        if count == batch_size:
            yield items
            items = []
            count = 0
    if items:
        yield items

def batch_list(iterator, batch_size):
    n = len(iterator)
    for i in range(0, n, batch_size):
        yield iterator[i : i + batch_size]

def batch_after(iterator, batch_size):
    it = iter(iterator)
    while batch := list(itertools.islice(it, batch_size)):
        yield batch


def do_test(iterator, batch):
    result = []
    start = time.perf_counter_ns()
    for b in batch(iterator, 10000):
        result.append(b)
    end = time.perf_counter_ns()
    print(f"Batching {batch.__name__} took {(end - start)/1e9:.4f} seconds")
    return result

if __name__ == "__main__":
    data = range(10000005)

    result_original = do_test(data, batch_original)
    result_after = do_test(data, batch_after)

    assert result_original == result_after

    data = list(range(10000005))
    result_list = do_test(data, batch_list)
    result_after = do_test(data, batch_after)
    assert result_list == result_after
```

</details>

Notice that `__getslice__` is **removed** since Python 3.0, so the optimization for known size iterators like lists is not working at all. There's no simple way to know if an iterator supports slice operation now. The most straightforward way is to try it out like `iterator[:1]` - I don't know how frequent we are dealing with lists, if the iterator is often lists, then we can do it. The raw `[:]` operation is 22% faster than this implementation.

I like the simplicity without the `try ... except ...` block.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Most importantly, the code is less verbose. Also it's much faster.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

The script above checks if the result is the same as before. Also we will have CI.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No