### PR TITLE
[SPARK-54358][SDP][FOLLOWUP] Add `tableIdentifierToPathString` helper method for SDP checkpoint path construction

### DIFF
--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/SystemMetadata.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/SystemMetadata.scala
@@ -22,6 +22,7 @@ import scala.util.Try
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.internal.{Logging, LogKeys}
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.classic.SparkSession
 
 sealed trait SystemMetadata {}
@@ -44,7 +45,9 @@ case class FlowSystemMetadata(
     Option(if (graph.table.contains(flow.destinationIdentifier) ||
       graph.sink.contains(flow.destinationIdentifier)) {
       val checkpointRoot = new Path(context.storageRoot, "_checkpoints")
-      val flowTableId = flow.destinationIdentifier.nameParts.mkString(Path.SEPARATOR)
+      // Different tables in the pipeline can have flows with the same name, so we include
+      // the table's fully qualified identifier in the path to avoid collisions.
+      val flowTableId = tableIdentifierToPathString(flow.destinationIdentifier)
       val flowName = flow.identifier.table
       val checkpointDir = new Path(
         new Path(checkpointRoot, flowTableId),
@@ -60,6 +63,13 @@ case class FlowSystemMetadata(
         s"Flow ${flow.identifier} does not have a valid destination for checkpoints."
       )
     })
+  }
+
+  /**
+   * Converts a TableIdentifier to a path string by joining its name parts with the path separator.
+   */
+  private def tableIdentifierToPathString(tableIdentifier: TableIdentifier): String = {
+    tableIdentifier.nameParts.mkString(Path.SEPARATOR)
   }
 
   /** Returns the location for the most recent checkpoint of a given flow. */


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Followups from https://github.com/apache/spark/pull/53070 to improve code clarity.

### Why are the changes needed?

Make sure the code for constructing SDP checkpoint directory paths is clear.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
