### PR TITLE
[SPARK-54383][SQL] Add precomputed schema variant for InternalRowComparableWrapper util

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -428,13 +428,13 @@ case class KeyGroupedPartitioning(
   }
 
   lazy val uniquePartitionValues: Seq[InternalRow] = {
-    val dataTypes = expressions.map(_.dataType)
     val internalRowComparableFactory =
-      InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(dataTypes)
+      InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(
+        expressions.map(_.dataType))
     partitionValues
-      .map(internalRowComparableFactory)
-      .distinct
-      .map(_.row)
+        .map(internalRowComparableFactory)
+        .distinct
+        .map(_.row)
   }
 
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression =
@@ -451,9 +451,9 @@ object KeyGroupedPartitioning {
     val projectedPartitionValues = partitionValues.map(project(expressions, projectionPositions, _))
     val projectedOriginalPartitionValues =
       originalPartitionValues.map(project(expressions, projectionPositions, _))
-    val dataTypes = projectedExpressions.map(_.dataType)
     val internalRowComparableFactory =
-      InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(dataTypes)
+      InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(
+        projectedExpressions.map(_.dataType))
 
     val finalPartitionValues = projectedPartitionValues
       .map(internalRowComparableFactory)
@@ -873,9 +873,9 @@ case class KeyGroupedShuffleSpec(
     //        transform functions.
     //  4. the partition values from both sides are following the same order.
     case otherSpec @ KeyGroupedShuffleSpec(otherPartitioning, otherDistribution, _) =>
-      lazy val dataTypes = partitioning.expressions.map(_.dataType)
       lazy val internalRowComparableFactory =
-        InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(dataTypes)
+        InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(
+          partitioning.expressions.map(_.dataType))
       distribution.clustering.length == otherDistribution.clustering.length &&
         numPartitions == other.numPartitions && areKeysCompatible(otherSpec) &&
           partitioning.partitionValues.zip(otherPartitioning.partitionValues).forall {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/InternalRowComparableWrapper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/InternalRowComparableWrapper.scala
@@ -39,6 +39,12 @@ class InternalRowComparableWrapper private (
     val structType: StructType,
     val ordering: BaseOrdering) {
 
+  /**
+   * Previous constructor for binary compatibility. Prefer using
+   * `getInternalRowComparableWrapperFactory` for the creation of InternalRowComparableWrapper's in
+   * hot paths to avoid excessive cache lookups.
+   */
+  @deprecated
   def this(row: InternalRow, dataTypes: Seq[DataType]) = this(
     row,
     dataTypes,
@@ -120,6 +126,7 @@ object InternalRowComparableWrapper {
     result.toSeq
   }
 
+  /** Creates a shared factory method for a given row schema to avoid excessive cache lookups. */
   def getInternalRowComparableWrapperFactory(
       dataTypes: Seq[DataType]): InternalRow => InternalRowComparableWrapper = {
     val structType = structTypeCache.get(dataTypes)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/InternalRowComparableWrapper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/InternalRowComparableWrapper.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.util
 import scala.collection.mutable
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Expression, Murmur3HashFunction, RowOrdering}
+import org.apache.spark.sql.catalyst.expressions.{BaseOrdering, Expression, Murmur3HashFunction, RowOrdering}
 import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition}
 import org.apache.spark.sql.types.{DataType, StructField, StructType}
 import org.apache.spark.util.NonFateSharingCache
@@ -102,6 +102,68 @@ object InternalRowComparableWrapper {
     val rightPartitionSet = new mutable.HashSet[InternalRowComparableWrapper]
     rightPartitioning
       .map(new InternalRowComparableWrapper(_, partitionDataTypes))
+      .foreach(partition => rightPartitionSet.add(partition))
+
+    val result = if (intersect) {
+      leftPartitionSet.intersect(rightPartitionSet)
+    } else {
+      leftPartitionSet.union(rightPartitionSet)
+    }
+    result.toSeq
+  }
+}
+
+/**
+ * Effectively the same as [[InternalRowComparableWrapper]], but using a precomputed `ordering`
+ * and `structType` to avoid the cache lookup for each row.
+ */
+class BoundInternalRowComparableWrapper(
+  val row: InternalRow,
+  val dataTypes: Seq[DataType],
+  val ordering: BaseOrdering,
+  val structType: StructType) {
+
+  override def hashCode(): Int = Murmur3HashFunction.hash(
+    row,
+    structType,
+    42L,
+    isCollationAware = true,
+    // legacyCollationAwareHashing only matters when isCollationAware is false.
+    legacyCollationAwareHashing = false).toInt
+
+  override def equals(other: Any): Boolean = {
+    if (!other.isInstanceOf[BoundInternalRowComparableWrapper]) {
+      return false
+    }
+    val otherWrapper = other.asInstanceOf[BoundInternalRowComparableWrapper]
+    if (!otherWrapper.dataTypes.equals(this.dataTypes)) {
+      return false
+    }
+    ordering.compare(row, otherWrapper.row) == 0
+  }
+}
+
+object BoundInternalRowComparableWrapper {
+  /** Compute the schema and row ordering for a given list of data types. */
+  def getStructTypeAndOrdering(dataTypes: Seq[DataType]): (StructType, BaseOrdering) =
+    StructType(dataTypes.map(t => StructField("f", t))) ->
+      RowOrdering.createNaturalAscendingOrdering(dataTypes)
+
+  def mergePartitions(
+      leftPartitioning: Seq[InternalRow],
+      rightPartitioning: Seq[InternalRow],
+      partitionExpression: Seq[Expression],
+      intersect: Boolean = false): Seq[BoundInternalRowComparableWrapper] = {
+    val partitionDataTypes = partitionExpression.map(_.dataType)
+    val (structType, ordering) = getStructTypeAndOrdering(partitionDataTypes)
+
+    val leftPartitionSet = new mutable.HashSet[BoundInternalRowComparableWrapper]
+    leftPartitioning
+      .map(new BoundInternalRowComparableWrapper(_, partitionDataTypes, ordering, structType))
+      .foreach(partition => leftPartitionSet.add(partition))
+    val rightPartitionSet = new mutable.HashSet[BoundInternalRowComparableWrapper]
+    rightPartitioning
+      .map(new BoundInternalRowComparableWrapper(_, partitionDataTypes, ordering, structType))
       .foreach(partition => rightPartitionSet.add(partition))
 
     val result = if (intersect) {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/InternalRowComparableWrapperBenchmark.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/InternalRowComparableWrapperBenchmark.scala
@@ -48,8 +48,11 @@ object InternalRowComparableWrapperBenchmark extends BenchmarkBase {
     val benchmark = new Benchmark("internal row comparable wrapper", partitionNum, output = output)
 
     benchmark.addCase("toSet") { _ =>
+      val internalRowComparableWrapperFactory =
+        InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(
+          Seq(IntegerType, IntegerType))
       val distinct = partitions
-        .map(new InternalRowComparableWrapper(_, Seq(IntegerType, IntegerType)))
+        .map(internalRowComparableWrapperFactory)
         .toSet
       assert(distinct.size == bucketNum)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/KeyGroupedPartitionedScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/KeyGroupedPartitionedScan.scala
@@ -50,9 +50,9 @@ trait KeyGroupedPartitionedScan[T] {
       case None =>
         spjParams.joinKeyPositions match {
           case Some(projectionPositions) =>
-            val dataTypes = expressions.map(_.dataType)
             val internalRowComparableWrapperFactory =
-              InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(dataTypes)
+              InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(
+                expressions.map(_.dataType))
             basePartitioning.partitionValues.map { r =>
             val projectedRow = KeyGroupedPartitioning.project(expressions,
               projectionPositions, r)
@@ -87,9 +87,9 @@ trait KeyGroupedPartitionedScan[T] {
     val (groupedPartitions, partExpressions) = spjParams.joinKeyPositions match {
       case Some(projectPositions) =>
         val projectedExpressions = projectPositions.map(i => expressions(i))
-        val projectedTypes = projectedExpressions.map(_.dataType)
         val internalRowComparableWrapperFactory =
-          InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(projectedTypes)
+          InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(
+            projectedExpressions.map(_.dataType))
         val parts = filteredPartitions.flatten.groupBy(part => {
           val row = partitionValueAccessor(part)
           val projectedRow = KeyGroupedPartitioning.project(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/KeyGroupedPartitionedScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/KeyGroupedPartitionedScan.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.RowOrdering
 import org.apache.spark.sql.catalyst.plans.physical.{KeyGroupedPartitioning, KeyGroupedShuffleSpec}
-import org.apache.spark.sql.catalyst.util.BoundInternalRowComparableWrapper
+import org.apache.spark.sql.catalyst.util.InternalRowComparableWrapper
 import org.apache.spark.sql.execution.joins.StoragePartitionJoinParams
 
 /** Base trait for a data source scan capable of producing a key-grouped output. */
@@ -49,13 +49,14 @@ trait KeyGroupedPartitionedScan[T] {
          }
       case None =>
         spjParams.joinKeyPositions match {
-          case Some(projectionPositions) => basePartitioning.partitionValues.map { r =>
+          case Some(projectionPositions) =>
             val dataTypes = expressions.map(_.dataType)
-            val (structType, ordering) =
-              BoundInternalRowComparableWrapper.getStructTypeAndOrdering(dataTypes)
+            val internalRowComparableWrapperFactory =
+              InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(dataTypes)
+            basePartitioning.partitionValues.map { r =>
             val projectedRow = KeyGroupedPartitioning.project(expressions,
               projectionPositions, r)
-            new BoundInternalRowComparableWrapper(projectedRow, dataTypes, ordering, structType)
+            internalRowComparableWrapperFactory(projectedRow)
           }.distinct.map(_.row)
           case _ => basePartitioning.partitionValues
         }
@@ -87,13 +88,13 @@ trait KeyGroupedPartitionedScan[T] {
       case Some(projectPositions) =>
         val projectedExpressions = projectPositions.map(i => expressions(i))
         val projectedTypes = projectedExpressions.map(_.dataType)
-        val (structType, ordering) =
-          BoundInternalRowComparableWrapper.getStructTypeAndOrdering(projectedTypes)
+        val internalRowComparableWrapperFactory =
+          InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(projectedTypes)
         val parts = filteredPartitions.flatten.groupBy(part => {
           val row = partitionValueAccessor(part)
           val projectedRow = KeyGroupedPartitioning.project(
             expressions, projectPositions, row)
-          new BoundInternalRowComparableWrapper(projectedRow, projectedTypes, ordering, structType)
+          internalRowComparableWrapperFactory(projectedRow)
         }).map { case (wrapper, splits) => (wrapper.row, splits) }.toSeq
         (parts, projectedExpressions)
       case _ =>
@@ -106,13 +107,13 @@ trait KeyGroupedPartitionedScan[T] {
 
     // Also re-group the partitions if we are reducing compatible partition expressions
     val partitionDataTypes = partExpressions.map(_.dataType)
-    val (structType, ordering) =
-      BoundInternalRowComparableWrapper.getStructTypeAndOrdering(partitionDataTypes)
+    val internalRowComparableWrapperFactory =
+      InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(partitionDataTypes)
     val finalGroupedPartitions = spjParams.reducers match {
       case Some(reducers) =>
         val result = groupedPartitions.groupBy { case (row, _) =>
           KeyGroupedShuffleSpec.reducePartitionValue(
-            row, reducers, partitionDataTypes, ordering, structType)
+            row, reducers, partitionDataTypes, internalRowComparableWrapperFactory)
         }.map { case (wrapper, splits) => (wrapper.row, splits.flatMap(_._2)) }.toSeq
         val rowOrdering = RowOrdering.createNaturalAscendingOrdering(
           partExpressions.map(_.dataType))
@@ -128,21 +129,15 @@ trait KeyGroupedPartitionedScan[T] {
       // should contain.
       val commonPartValuesMap = spjParams.commonPartitionValues
           .get
-          .map(t => (new BoundInternalRowComparableWrapper(
-            t._1, partitionDataTypes, ordering, structType), t._2))
+          .map(t => (internalRowComparableWrapperFactory(t._1), t._2))
           .toMap
       val filteredGroupedPartitions = finalGroupedPartitions.filter {
         case (partValues, _) =>
-         commonPartValuesMap.keySet.contains(
-          new BoundInternalRowComparableWrapper(
-            partValues, partitionDataTypes, ordering, structType))
+         commonPartValuesMap.keySet.contains(internalRowComparableWrapperFactory(partValues))
       }
       val nestGroupedPartitions = filteredGroupedPartitions.map { case (partValue, splits) =>
         // `commonPartValuesMap` should contain the part value since it's the super set.
-        val numSplits = commonPartValuesMap
-            .get(
-              new BoundInternalRowComparableWrapper(
-                partValue, partitionDataTypes, ordering, structType))
+        val numSplits = commonPartValuesMap.get(internalRowComparableWrapperFactory(partValue))
         assert(numSplits.isDefined, s"Partition value $partValue does not exist in " +
             "common partition values from Spark plan")
 
@@ -157,11 +152,7 @@ trait KeyGroupedPartitionedScan[T] {
           // sides of a join will have the same number of partitions & splits.
           splits.map(Seq(_)).padTo(numSplits.get, Seq.empty)
         }
-        (
-          new BoundInternalRowComparableWrapper(
-            partValue, partitionDataTypes, ordering, structType),
-          newSplits
-        )
+        (internalRowComparableWrapperFactory(partValue), newSplits)
       }
 
       // Now fill missing partition keys with empty partitions
@@ -170,16 +161,14 @@ trait KeyGroupedPartitionedScan[T] {
         case (partValue, numSplits) =>
           // Use empty partition for those partition values that are not present.
           partitionMapping.getOrElse(
-            new BoundInternalRowComparableWrapper(
-              partValue, partitionDataTypes, ordering, structType),
+            internalRowComparableWrapperFactory(partValue),
             Seq.fill(numSplits)(Seq.empty))
       }
     } else {
       // either `commonPartitionValues` is not defined, or it is defined but
       // `applyPartialClustering` is false.
       val partitionMapping = finalGroupedPartitions.map { case (partValue, splits) =>
-        new BoundInternalRowComparableWrapper(
-          partValue, partitionDataTypes, ordering, structType) -> splits
+        internalRowComparableWrapperFactory(partValue) -> splits
       }.toMap
 
       // In case `commonPartitionValues` is not defined (e.g., SPJ is not used), there
@@ -188,9 +177,7 @@ trait KeyGroupedPartitionedScan[T] {
       // partition values here so that grouped partitions won't get duplicated.
       p.uniquePartitionValues.map { partValue =>
         // Use empty partition for those partition values that are not present
-        partitionMapping.getOrElse(
-          new BoundInternalRowComparableWrapper(
-            partValue, partitionDataTypes, ordering, structType), Seq.empty)
+        partitionMapping.getOrElse(internalRowComparableWrapperFactory(partValue), Seq.empty)
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.exchange
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.spark.internal.LogKeys
+import org.apache.spark.internal.{LogKeys}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans._
@@ -579,10 +579,9 @@ case class EnsureRequirements(
               // In partially clustered distribution, we should use un-grouped partition values
               val spec = if (replicateLeftSide) rightSpec else leftSpec
               val partValues = spec.partitioning.originalPartitionValues
-              val partitionDataTypes = partitionExprs.map(_.dataType)
               val internalRowComparableWrapperFactory =
                 InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(
-                  partitionDataTypes)
+                  partitionExprs.map(_.dataType))
 
               val numExpectedPartitions = partValues
                 .map(internalRowComparableWrapperFactory)
@@ -747,9 +746,9 @@ case class EnsureRequirements(
       rightPartitioning: Seq[InternalRow],
       partitionExpression: Seq[Expression],
       joinType: JoinType): Seq[InternalRow] = {
-    val partitionDataTypes = partitionExpression.map(_.dataType)
     val internalRowComparableWrapperFactory =
-      InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(partitionDataTypes)
+      InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(
+        partitionExpression.map(_.dataType))
 
     val merged = if (SQLConf.get.getConf(SQLConf.V2_BUCKETING_PARTITION_FILTER_ENABLED)) {
       joinType match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -753,7 +753,7 @@ case class EnsureRequirements(
     val merged = if (SQLConf.get.getConf(SQLConf.V2_BUCKETING_PARTITION_FILTER_ENABLED)) {
       joinType match {
         case Inner => InternalRowComparableWrapper.mergePartitions(
-          leftPartitioning, rightPartitioning, partitionExpression)
+          leftPartitioning, rightPartitioning, partitionExpression, intersect = true)
         case LeftOuter => leftPartitioning.map(internalRowComparableWrapperFactory)
         case RightOuter => rightPartitioning.map(internalRowComparableWrapperFactory)
         case _ => InternalRowComparableWrapper.mergePartitions(leftPartitioning,


### PR DESCRIPTION
### What changes were proposed in this pull request?
The InternalRowComparableWrapper util is often used in a very hot-path for physical planning (most often, to compare partition values for key-grouped partitioned scans). While the current implementation does schema lookup that each instance uses to create a new instance of this object, this cache lookup itself can become a bottleneck for planning when there are large numbers of partitions. This PR adds a new InternalRowComparableWrapper factory for this util that has a precomputed schema and ordering that can be shared across multiple objects, removing this schema or cache lookup from the hot-path for physical planning.

### Why are the changes needed?
Removes a physical planning bottleneck.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
This change should not change any behavior (existing tests should suffice).

This PR also includes changes to the `InternalRowComparableWrapperBenchmark` to use these new utils. Results before change:
```
[info] internal row comparable wrapper:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] toSet                                                74             76           2          2.7         367.5       1.0X
[info] mergePartitions                                     136            143          11          1.5         680.0       0.5X
[success] Total time: 11 s, completed Nov 17, 2025, 2:29:22 PM
```

Results after change:
```
[info] internal row comparable wrapper:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] toSet                                                13             13           1         15.9          62.9       1.0X
[info] mergePartitions                                      17             17           1         11.8          84.7       0.7X

```

### Was this patch authored or co-authored using generative AI tooling?
No.
