### PR TITLE
[SPARK-54389] [SS] Fix RocksDB State Store Invalid Stamp error when task is marked as failed during initialization

### DIFF
--- a/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
@@ -269,6 +269,10 @@ class BarrierTaskContext private[spark] (
     taskContext.markTaskCompleted(error)
   }
 
+  override private[spark] def getTaskFailure: Option[Throwable] = {
+    taskContext.getTaskFailure
+  }
+
   override private[spark] def fetchFailed: Option[FetchFailedException] = {
     taskContext.fetchFailed
   }

--- a/core/src/main/scala/org/apache/spark/TaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContext.scala
@@ -309,7 +309,11 @@ abstract class TaskContext extends Serializable {
   /** Marks the task as completed and triggers the completion listeners. */
   private[spark] def markTaskCompleted(error: Option[Throwable]): Unit
 
-  /** If the task fails, the exception that caused it, otherwise None */
+  /**
+   * ::DeveloperApi::
+   * If the task fails, the exception that caused it, otherwise None
+   */
+  @DeveloperApi
   private[spark] def getTaskFailure: Option[Throwable]
 
   /** Optionally returns the stored fetch failure in the task. */

--- a/core/src/main/scala/org/apache/spark/TaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContext.scala
@@ -309,12 +309,8 @@ abstract class TaskContext extends Serializable {
   /** Marks the task as completed and triggers the completion listeners. */
   private[spark] def markTaskCompleted(error: Option[Throwable]): Unit
 
-  /**
-   * ::DeveloperApi::
-   * If the task fails, the exception that caused it, otherwise None
-   */
-  @DeveloperApi
-  private[spark] def getTaskFailure: Option[Throwable]
+  /** If the task fails, the exception that caused it, otherwise None. */
+  private[spark] def getTaskFailure: Option[Throwable] = None
 
   /** Optionally returns the stored fetch failure in the task. */
   private[spark] def fetchFailed: Option[FetchFailedException]

--- a/core/src/main/scala/org/apache/spark/TaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContext.scala
@@ -309,6 +309,9 @@ abstract class TaskContext extends Serializable {
   /** Marks the task as completed and triggers the completion listeners. */
   private[spark] def markTaskCompleted(error: Option[Throwable]): Unit
 
+  /** If the task fails, the exception that caused it, otherwise None */
+  private[spark] def getTaskFailure: Option[Throwable]
+
   /** Optionally returns the stored fetch failure in the task. */
   private[spark] def fetchFailed: Option[FetchFailedException]
 

--- a/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
@@ -146,6 +146,10 @@ private[spark] class TaskContextImpl(
     invokeTaskCompletionListeners(error)
   }
 
+  private[spark] override def getTaskFailure: Option[Throwable] = {
+    failureCauseOpt
+  }
+
   private def invokeTaskCompletionListeners(error: Option[Throwable]): Unit = {
     // It is safe to access the reference to `onCompleteCallbacks` without holding the TaskContext
     // lock. `invokeListeners()` acquires the lock before accessing the contents.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateMachine.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateMachine.scala
@@ -172,13 +172,16 @@ class RocksDBStateMachine(
     }
   }
 
-  // Return the task ID from the active TaskContext if exists for logging purposes
+  /**
+   * Return the task ID from the active TaskContext if exists for logging purposes.
+   * Returns "undefined" if no TaskContext is active.
+   */
   private def taskID: String = {
     val taskContext = TaskContext.get()
     if (taskContext != null) {
       taskContext.taskAttemptId().toString
     } else {
-      "N/A"
+      "undefined"
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -184,6 +184,13 @@ private[sql] class RocksDBStateStoreProvider
       ctxt.addTaskFailureListener((_, _) => {
         if (!hasCommitted) abort()
       })
+      // Failure/completion listeners were invoked during adding if the task has
+      // failed already. Prevent further access (resulting in invalid stamp error)
+      // by throwing an error here.
+      ctxt.getTaskFailure match {
+        case Some(failure) => throw failure
+        case None =>
+      }
     }
 
     override def createColFamilyIfAbsent(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -30,7 +30,7 @@ import org.scalatest.PrivateMethodTester
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.SpanSugar._
 
-import org.apache.spark.{SparkConf, SparkException, SparkRuntimeException, SparkUnsupportedOperationException, TaskContext}
+import org.apache.spark.{SparkConf, SparkException, SparkRuntimeException, SparkThrowable, SparkUnsupportedOperationException, TaskContext}
 import org.apache.spark.io.CompressionCodec
 import org.apache.spark.sql.LocalSparkSession.withSparkSession
 import org.apache.spark.sql.SparkSession
@@ -2560,6 +2560,81 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
       val stamp = stateMachineObj.asInstanceOf[RocksDBStateMachine].currentValidStamp.get()
       assert(stamp == -1,
         s"state machine stamp should be -1 (unlocked) but was $stamp")
+    }
+  }
+
+  test("State store loading fails when TaskContext has failed") {
+    // Timeline of this test (* means thread is active):
+    // STATE | MAIN THREAD            | STATE STORE THREAD          |
+    // ------| ---------------------- | --------------------------- |
+    // 1.    | wait for s2            | *set task context           |
+    //       |                        | *signal s2                  |
+    // ------| ---------------------- | --------------------------- |
+    // 2.    | *mark task failed      | wait for s3                 |
+    //       | *signal s3             |                             |
+    // ------| ---------------------- | --------------------------- |
+    // 3.    | wait thread return     | *call getStore().iterator() |
+    //       |                        | *exception thrown           |
+    // ------| ---------------------- | --------------------------- |
+    // 4.    | *verify exception, END |                             |
+
+    // Create a custom ExecutionContext with 2 threads
+    implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(
+      ThreadUtils.newDaemonFixedThreadPool(2, "pool-thread-executor"))
+    val stateLock = new Object()
+    var state = 1
+    val timeout = 10.seconds
+
+    tryWithProviderResource(newStoreProvider()) { provider =>
+      val taskContext = TaskContext.empty()
+
+      val stateStoreFuture = Future { // STATE STORE THREAD
+        stateLock.synchronized {
+          // -------------------- STATE 1 --------------------
+          // Set the task context for this thread
+          TaskContext.setTaskContext(taskContext)
+
+          // Signal that we have entered state 2
+          state = 2
+          stateLock.notifyAll()
+
+          // -------------------- STATE 3 --------------------
+          // Wait until we have entered state 3 (main thread marked task as failed)
+          while (state != 3) {
+            stateLock.wait()
+          }
+
+          // Try to call getStore().iterator() which should trigger the error handling
+          provider.getStore(0).iterator()
+        }
+      }
+
+      stateLock.synchronized {
+        // -------------------- STATE 2 --------------------
+        // Wait until we have entered state 2 (state store thread set task context)
+        while (state != 2) {
+          stateLock.wait()
+        }
+
+        // Mark the task as failed
+        val ex = new IllegalStateException("failure")
+        taskContext.markTaskFailed(ex)
+
+        // Signal that we have entered state 3
+        state = 3
+        stateLock.notifyAll()
+      }
+
+      // Wait for the future to complete and verify the exception
+      val thrown = intercept[SparkException] {
+        ThreadUtils.awaitResult(stateStoreFuture, timeout)
+      }.getCause.asInstanceOf[SparkThrowable]
+
+      checkError(
+        thrown,
+        condition = "CANNOT_LOAD_STATE_STORE.UNCATEGORIZED",
+        parameters = Map.empty
+      )
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Check if the task is failed after setting the RocksDB State Store listeners and fail the initialization if so. Also add some more info to RocksDB state machine log lines.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Invalid stamp error will be thrown in the following situation:

1. Stateful task begins, begins initializing state store and grabs a stamp
2. Another task sets markTaskFailed for the stateful task
3. StateStore is initialized, setting the taskCompletion and taskFailure listeners. Since the task was marked as failed, these listeners are invoked immediately, releasing the stamp. However, since no failure is thrown, the StateStore initialization completes.
4. Stateful task continues to call the iterator method on the returned StateStore. Since the stamp is invalid, StateStoreErrors.invalidStamp is thrown.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
RocksDB invalid stamp error will no longer be thrown in this case

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated by: Claude 4.5