### PR TITLE
[SPARK-54393][BUILD][TESTS] Upgrade oracle free to 23.26.0

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleDatabaseOnDocker.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleDatabaseOnDocker.scala
@@ -23,7 +23,7 @@ class OracleDatabaseOnDocker extends DatabaseOnDocker with Logging {
   // sarutak/oracle-free is a custom fork of gvenzl/oracle-free which allows to set timeout for
   // password initialization. See SPARK-54076 for details.
   lazy override val imageName =
-    sys.env.getOrElse("ORACLE_DOCKER_IMAGE_NAME", "sarutak/oracle-free:23.9-slim")
+    sys.env.getOrElse("ORACLE_DOCKER_IMAGE_NAME", "sarutak/oracle-free:23.26.0-slim")
   val oracle_password = "Th1s1sThe0racle#Pass"
   override val env = Map(
     "ORACLE_PWD" -> oracle_password, // oracle images uses this

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleDatabaseOnDocker.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleDatabaseOnDocker.scala
@@ -28,7 +28,7 @@ class OracleDatabaseOnDocker extends DatabaseOnDocker with Logging {
   override val env = Map(
     "ORACLE_PWD" -> oracle_password, // oracle images uses this
     "ORACLE_PASSWORD" -> oracle_password, // gvenzl/oracle-free uses this
-    "PASSWORD_INIT_TIMEOUT" -> "30"
+    "PASSWORD_INIT_TIMEOUT" -> "60"
   )
   override val usesIpc = false
   override val jdbcPort: Int = 1521


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade the docker image for Oracle Database to `23.26.0`.

### Why are the changes needed?
Ensuring the JDBC source works with the newer Oracle Database.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Tested on my dev environment.
With `PASSWORD_INIT_TIMEOUT=30`, I observed the test failed 3 times out of 50 rounds due to timeout. So I increased the timeout to `60` and the test failed 0 times out of 50 rounds.

### Was this patch authored or co-authored using generative AI tooling?
No.
