### PR TITLE
[SPARK-54394][CORE] Move `isJavaVersionAtMost17` and `isJavaVersionAtLeast21` from `core` to `common/utils`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkSystemUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkSystemUtils.scala
@@ -40,6 +40,16 @@ private[spark] trait SparkSystemUtils {
   val javaVersion = JavaUtils.javaVersion
 
   /**
+   * Whether the underlying Java version is at most 17.
+   */
+  val isJavaVersionAtMost17 = Runtime.version().feature() <= 17
+
+  /**
+   * Whether the underlying Java version is at least 21.
+   */
+  val isJavaVersionAtLeast21 = Runtime.version().feature() >= 21
+
+  /**
    * Whether the underlying operating system is Windows.
    */
   val isWindows = JavaUtils.isWindows
@@ -63,6 +73,7 @@ private[spark] trait SparkSystemUtils {
    * Whether the underlying operating system is UNIX.
    */
   val isUnix = JavaUtils.isUnix
+
 }
 
 object SparkSystemUtils extends SparkSystemUtils

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1856,16 +1856,6 @@ private[spark] object Utils
   }
 
   /**
-   * Whether the underlying Java version is at most 17.
-   */
-  val isJavaVersionAtMost17 = Runtime.version().feature() <= 17
-
-  /**
-   * Whether the underlying Java version is at least 21.
-   */
-  val isJavaVersionAtLeast21 = Runtime.version().feature() >= 21
-
-  /**
    * Whether the underlying JVM prefer IPv6 addresses.
    */
   val preferIPv6 = "true".equals(System.getProperty("java.net.preferIPv6Addresses"))


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to move `isJavaVersionAtMost17` and `isJavaVersionAtLeast21` from `Utils.scala` in `core` to `SparkSystemUtils.scala` in `common/utils`

### Why are the changes needed?
To allow components which don't depend on `core` (like components under `common/utils`) use these methods. These utility methods can be commonly used like `javeVersion` in `SparkSystemUtils.scala`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
No.
