### PR TITLE
[SPARK-54395][SHUFFLE] RemoteBlockPushResolver class repeatedly initializes ObjectMapper

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -881,7 +881,6 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
       String mergeDirInfo =
         shuffleManagerMeta.substring(shuffleManagerMeta.indexOf(SHUFFLE_META_DELIMITER) + 1);
       try {
-        ObjectMapper mapper = new ObjectMapper();
         TypeReference<Map<String, String>> typeRef
           = new TypeReference<Map<String, String>>(){};
         Map<String, String> metaMap = mapper.readValue(mergeDirInfo, typeRef);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -119,7 +119,7 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
 
   private static final ObjectMapper mapper = new ObjectMapper();
 
-  private static final TypeReference<Map<String, String>> typeRef =
+  private static final TypeReference<Map<String, String>> SHUFFLE_MANAGER_META_TYPE_REF =
     new TypeReference<Map<String, String>>(){};
 
   /**
@@ -884,7 +884,7 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
       String mergeDirInfo =
         shuffleManagerMeta.substring(shuffleManagerMeta.indexOf(SHUFFLE_META_DELIMITER) + 1);
       try {
-        Map<String, String> metaMap = mapper.readValue(mergeDirInfo, typeRef);
+        Map<String, String> metaMap = mapper.readValue(mergeDirInfo, SHUFFLE_MANAGER_META_TYPE_REF);
         String mergeDir = metaMap.get(MERGE_DIR_KEY);
         int attemptId = Integer.valueOf(
           metaMap.getOrDefault(ATTEMPT_ID_KEY, String.valueOf(UNDEFINED_ATTEMPT_ID)));

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -119,6 +119,9 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
 
   private static final ObjectMapper mapper = new ObjectMapper();
 
+  private static final TypeReference<Map<String, String>> typeRef =
+    new TypeReference<Map<String, String>>(){};
+
   /**
    * This a common prefix to the key for each app shuffle partition we add to leveldb, so they
    * are easy to find, since leveldb lets you search based on prefix.
@@ -881,8 +884,6 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
       String mergeDirInfo =
         shuffleManagerMeta.substring(shuffleManagerMeta.indexOf(SHUFFLE_META_DELIMITER) + 1);
       try {
-        TypeReference<Map<String, String>> typeRef
-          = new TypeReference<Map<String, String>>(){};
         Map<String, String> metaMap = mapper.readValue(mergeDirInfo, typeRef);
         String mergeDir = metaMap.get(MERGE_DIR_KEY);
         int attemptId = Integer.valueOf(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

RemoteBlockPushResolver class repeatedly initializes ObjectMapper

`ObjectMapper mapper = new ObjectMapper();`


### Why are the changes needed?

repeatedly initializes ObjectMapper

### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

verified


### Was this patch authored or co-authored using generative AI tooling?

No