### PR TITLE
[SPARK-54400][SQL] Replace `HtmlUtils.parseQueryString` in	`ThriftHttpServlet.java` with `HttpServletRequest.getQueryString`

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/thrift/ThriftHttpServlet.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/thrift/ThriftHttpServlet.java
@@ -157,7 +157,7 @@ public class ThriftHttpServlet extends TServlet {
       SessionManager.setUserName(clientUserName);
 
       // find proxy user if any from query param
-      String doAsQueryParam = getDoAsQueryParam(request.getQueryString());
+      String doAsQueryParam = getDoAsQueryParam(request);
       if (doAsQueryParam != null) {
         SessionManager.setProxyUserName(doAsQueryParam);
       }
@@ -546,14 +546,15 @@ public class ThriftHttpServlet extends TServlet {
     return authType.equalsIgnoreCase(HiveAuthFactory.AuthTypes.KERBEROS.toString());
   }
 
-  private static String getDoAsQueryParam(String queryString) {
+  private static String getDoAsQueryParam(HttpServletRequest request) {
+    String queryString = request.getQueryString();
     if (LOG.isDebugEnabled()) {
       LOG.debug("URL query string:" + queryString);
     }
     if (queryString == null) {
       return null;
     }
-    Map<String, String[]> params = jakarta.servlet.http.HttpUtils.parseQueryString( queryString );
+    Map<String, String[]> params = request.getParameterMap();
     Set<String> keySet = params.keySet();
     for (String key: keySet) {
       if (key.equalsIgnoreCase("doAs")) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to replace `HtmlUtils.parseQueryString` in	`ThriftHttpServlet.java` with `HttpServletRequest.getQueryString`

### Why are the changes needed?
`HttpUtils` was deprecated in Servlet 5.0 and removed in 6.0.
https://jakarta.ee/specifications/servlet/5.0/apidocs/jakarta/servlet/http/httputils

This change is necessary for upgrading Jetty to 12 in #53116

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
No.
