### PR TITLE
[SPARK-54030][SQL][FOLLOWUP] Refactor test to use withBasicCatalog for consistency

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -2030,66 +2030,67 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
 
   test("corrupted view metadata: mismatch between viewQueryColumnNames and schema") {
     withSQLConf("spark.sql.viewSchemaBinding.enabled" -> "true") {
-      val catalog = new SessionCatalog(newBasicCatalog())
-      val db = "test_db"
-      catalog.createDatabase(newDb(db), ignoreIfExists = false)
+      withBasicCatalog { catalog =>
+        val db = "test_db"
+        catalog.createDatabase(newDb(db), ignoreIfExists = false)
 
-      // First create a base table for the view to reference
-      val baseTable = CatalogTable(
-        identifier = TableIdentifier("base_table", Some(db)),
-        tableType = CatalogTableType.MANAGED,
-        storage = CatalogStorageFormat.empty,
-        schema = new StructType()
-          .add("id", IntegerType)
-          .add("name", StringType)
-          .add("value", DoubleType)
-      )
-      catalog.createTable(baseTable, ignoreIfExists = false)
+        // First create a base table for the view to reference
+        val baseTable = CatalogTable(
+          identifier = TableIdentifier("base_table", Some(db)),
+          tableType = CatalogTableType.MANAGED,
+          storage = CatalogStorageFormat.empty,
+          schema = new StructType()
+            .add("id", IntegerType)
+            .add("name", StringType)
+            .add("value", DoubleType)
+        )
+        catalog.createTable(baseTable, ignoreIfExists = false)
 
-      // Create a view with corrupted metadata where viewQueryColumnNames length
-      // doesn't match schema length
-      // We need to set the properties to define viewQueryColumnNames
-      val properties = Map(
-        "view.query.out.numCols" -> "2",
-        "view.query.out.col.0" -> "id",
-        "view.query.out.col.1" -> "name",
-        "view.schema.mode" -> "binding"  // Ensure it's not SchemaEvolution
-      )
-      val corruptedView = CatalogTable(
-        identifier = TableIdentifier("corrupted_view", Some(db)),
-        tableType = CatalogTableType.VIEW,
-        storage = CatalogStorageFormat.empty,
-        schema = new StructType()
-          .add("id", IntegerType)
-          .add("name", StringType)
-          .add("value", DoubleType),
-        viewText = Some("SELECT * FROM test_db.base_table"),
-        provider = Some("spark"),  // Ensure it's not Hive-created
-        properties = properties  // Only 2 query column names but schema has 3 columns
-      )
+        // Create a view with corrupted metadata where viewQueryColumnNames length
+        // doesn't match schema length
+        // We need to set the properties to define viewQueryColumnNames
+        val properties = Map(
+          "view.query.out.numCols" -> "2",
+          "view.query.out.col.0" -> "id",
+          "view.query.out.col.1" -> "name",
+          "view.schema.mode" -> "binding"  // Ensure it's not SchemaEvolution
+        )
+        val corruptedView = CatalogTable(
+          identifier = TableIdentifier("corrupted_view", Some(db)),
+          tableType = CatalogTableType.VIEW,
+          storage = CatalogStorageFormat.empty,
+          schema = new StructType()
+            .add("id", IntegerType)
+            .add("name", StringType)
+            .add("value", DoubleType),
+          viewText = Some("SELECT * FROM test_db.base_table"),
+          provider = Some("spark"),  // Ensure it's not Hive-created
+          properties = properties  // Only 2 query column names but schema has 3 columns
+        )
 
-      catalog.createTable(corruptedView, ignoreIfExists = false)
+        catalog.createTable(corruptedView, ignoreIfExists = false)
 
-      // Verify the view was created with corrupted metadata
-      val retrievedView = catalog.getTableMetadata(TableIdentifier("corrupted_view", Some(db)))
-      assert(retrievedView.viewQueryColumnNames.length == 2)
-      assert(retrievedView.schema.length == 3)
+        // Verify the view was created with corrupted metadata
+        val retrievedView = catalog.getTableMetadata(TableIdentifier("corrupted_view", Some(db)))
+        assert(retrievedView.viewQueryColumnNames.length == 2)
+        assert(retrievedView.schema.length == 3)
 
-      // Attempting to look up the view should throw an assertion error with detailed message
-      val exception = intercept[AssertionError] {
-        catalog.lookupRelation(TableIdentifier("corrupted_view", Some(db)))
+        // Attempting to look up the view should throw an assertion error with detailed message
+        val exception = intercept[AssertionError] {
+          catalog.lookupRelation(TableIdentifier("corrupted_view", Some(db)))
+        }
+
+        // The expected message pattern allows for optional catalog prefix
+        val expectedPattern =
+          "assertion failed: Corrupted view metadata detected for view " +
+          "(\\`\\w+\\`\\.)?\\`test_db\\`\\.\\`corrupted_view\\`\\. " +
+          "The number of view query column names 2 " +
+          "does not match the number of columns in the view schema 3\\. " +
+          "View query column names: \\[id, name\\], " +
+          "View schema columns: \\[id, name, value\\]\\. " +
+          "This indicates corrupted view metadata that needs to be repaired\\."
+        assert(exception.getMessage.matches(expectedPattern))
       }
-
-      // The expected message pattern allows for optional catalog prefix
-      val expectedPattern =
-        "assertion failed: Corrupted view metadata detected for view " +
-        "(\\`\\w+\\`\\.)?\\`test_db\\`\\.\\`corrupted_view\\`\\. " +
-        "The number of view query column names 2 " +
-        "does not match the number of columns in the view schema 3\\. " +
-        "View query column names: \\[id, name\\], " +
-        "View schema columns: \\[id, name, value\\]\\. " +
-        "This indicates corrupted view metadata that needs to be repaired\\."
-      assert(exception.getMessage.matches(expectedPattern))
     }
   }
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR refactors the test "corrupted view metadata: mismatch between viewQueryColumnNames and schema" in `SessionCatalogSuite.scala` to use the `withBasicCatalog` helper method instead of manually creating a `SessionCatalog` instance with `newBasicCatalog()`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

**Consistency**: All other tests in `SessionCatalogSuite` use the `withBasicCatalog` helper pattern


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No. This is a test-only refactoring with no functional changes.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

- Verified no linter errors in the modified file
- The test logic remains identical, only the catalog initialization pattern changed
- Existing test validates the same corrupted view metadata error message


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Sonnet 4.5