### PR TITLE
[SPARK-54414][SQL] EnsureRequirements reorderJoinPredicates should use copy avoid missing tag

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -372,18 +372,16 @@ case class EnsureRequirements(
    */
   private def reorderJoinPredicates(plan: SparkPlan): SparkPlan = {
     plan match {
-      case ShuffledHashJoinExec(
-        leftKeys, rightKeys, joinType, buildSide, condition, left, right, isSkew) =>
+      case shj @ ShuffledHashJoinExec(
+        leftKeys, rightKeys, _, _, _, left, right, _) =>
         val (reorderedLeftKeys, reorderedRightKeys) =
           reorderJoinKeys(leftKeys, rightKeys, left.outputPartitioning, right.outputPartitioning)
-        ShuffledHashJoinExec(reorderedLeftKeys, reorderedRightKeys, joinType, buildSide, condition,
-          left, right, isSkew)
+        shj.copy(leftKeys = reorderedLeftKeys, rightKeys = reorderedRightKeys)
 
-      case SortMergeJoinExec(leftKeys, rightKeys, joinType, condition, left, right, isSkew) =>
+      case smj @ SortMergeJoinExec(leftKeys, rightKeys, _, _, left, right, _) =>
         val (reorderedLeftKeys, reorderedRightKeys) =
           reorderJoinKeys(leftKeys, rightKeys, left.outputPartitioning, right.outputPartitioning)
-        SortMergeJoinExec(reorderedLeftKeys, reorderedRightKeys, joinType, condition,
-          left, right, isSkew)
+        smj.copy(leftKeys = reorderedLeftKeys, rightKeys = reorderedRightKeys)
 
       case other => other
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
EnsureRequirements reorderJoinPredicates will create a new node, should use copy
```
private def reorderJoinPredicates(plan: SparkPlan): SparkPlan = {
  plan match {
    case ShuffledHashJoinExec(
      leftKeys, rightKeys, joinType, buildSide, condition, left, right, isSkew) =>
      val (reorderedLeftKeys, reorderedRightKeys) =
        reorderJoinKeys(leftKeys, rightKeys, left.outputPartitioning, right.outputPartitioning)
      ShuffledHashJoinExec(reorderedLeftKeys, reorderedRightKeys, joinType, buildSide, condition,
        left, right, isSkew)

    case SortMergeJoinExec(leftKeys, rightKeys, joinType, condition, left, right, isSkew) =>
      val (reorderedLeftKeys, reorderedRightKeys) =
        reorderJoinKeys(leftKeys, rightKeys, left.outputPartitioning, right.outputPartitioning)
      SortMergeJoinExec(reorderedLeftKeys, reorderedRightKeys, joinType, condition,
        left, right, isSkew)

    case other => other
  }
}
```


### Why are the changes needed?
Avoid tag missing after this process


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?



### Was this patch authored or co-authored using generative AI tooling?
No
