### PR TITLE
[SPARK-54426][INFRA] Fix `release-build.sh` to detect `REPO_ID` correctly

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -498,7 +498,7 @@ EOF
   # Find latest orgapachespark-* repo for this release version
   REPO_ID=$(curl --retry 10 --retry-all-errors -s -u "$ASF_USERNAME:$ASF_PASSWORD" \
     https://repository.apache.org/service/local/staging/profile_repositories | \
-    grep -A 5 "<repositoryId>orgapachespark-" | \
+    grep -A 13 "<repositoryId>orgapachespark-" | \
     awk '/<repositoryId>/ { id = $0 } /<description>/ && $0 ~ /Apache Spark '"$RELEASE_VERSION"'/ { print id }' | \
     grep -oP '(?<=<repositoryId>)orgapachespark-[0-9]+(?=</repositoryId>)' | \
     sort -V | tail -n 1)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `release-build.sh` to detect `REPO_ID` correctly.

### Why are the changes needed?

Previously, we use `grep -A 5` to find `description` tag.

https://github.com/apache/spark/blob/f328b5ef14c9ef4e2d04ab69c0578ab461388715/dev/create-release/release-build.sh#L501-L502

However, it's insufficient as of now. According to Today's result, we need to grep 13 lines like the following.

```
$ curl --retry 10 --retry-all-errors -s -u "$ASF_USERNAME:$ASF_PASSWORD" https://repository.apache.org/service/local/staging/profile_repositories | grep -A 5 "<repositoryId>orgapachespark-"
      <repositoryId>orgapachespark-1505</repositoryId>
      <type>closed</type>
      <policy>release</policy>
      <userId>dongjoon</userId>
      <userAgent>curl/7.81.0</userAgent>
      <ipAddress>35.94.112.49</ipAddress>
```

```
$ curl --retry 10 --retry-all-errors -s -u "$ASF_USERNAME:$ASF_PASSWORD" https://repository.apache.org/service/local/staging/profile_repositories | grep -A 13 "<repositoryId>orgapachespark-"
      <repositoryId>orgapachespark-1505</repositoryId>
      <type>closed</type>
      <policy>release</policy>
      <userId>dongjoon</userId>
      <userAgent>curl/7.81.0</userAgent>
      <ipAddress>35.94.112.49</ipAddress>
      <repositoryURI>https://repository.apache.org/content/repositories/orgapachespark-1505</repositoryURI>
      <created>2025-11-16T20:23:35.413Z</created>
      <createdDate>Sun Nov 16 20:23:35 UTC 2025</createdDate>
      <createdTimestamp>1763324615413</createdTimestamp>
      <updated>2025-11-16T21:02:45.041Z</updated>
      <updatedDate>Sun Nov 16 21:02:45 UTC 2025</updatedDate>
      <updatedTimestamp>1763326965041</updatedTimestamp>
      <description>Apache Spark 4.1.0-preview4 (commit c125aea395b)</description>
```


### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Manually test.

```
$ curl --retry 10 --retry-all-errors -s -u "$ASF_USERNAME:$ASF_PASSWORD" https://repository.apache.org/service/local/staging/profile_repositories | grep -A 13 "<repositoryId>orgapachespark-" | awk '/<repositoryId>/ { id = $0 } /<description>/ && $0 ~ /Apache Spark '"$RELEASE_VERSION"'/ { print id }'
      <repositoryId>orgapachespark-1505</repositoryId>
```

After merging this, I'm going to test with `Apache Spark 4.1.0-preview4`.

### Was this patch authored or co-authored using generative AI tooling?

No.