### PR TITLE
[SPARK-54445][SQL][TESTS] Fix configuration related to `ThresholdFilter` in `log4j2.properties` within `hive-thriftserver` module

### DIFF
--- a/sql/hive-thriftserver/src/test/resources/log4j2.properties
+++ b/sql/hive-thriftserver/src/test/resources/log4j2.properties
@@ -27,8 +27,8 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %maxLen{%m}{512}%n%ex{8}%n
 
-appender.console.filter.1.type = ThresholdFilter
-appender.console.filter.1.level = warn
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = warn
 
 #File Appender
 appender.file.type = File
@@ -37,8 +37,8 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex
 
-appender.file.filter.1.type = ThresholdFilter
-appender.file.filter.1.level = debug
+appender.file.filter.threshold.type = ThresholdFilter
+appender.file.filter.threshold.level = debug
 
 # Some packages are noisy for no good reason.
 logger.parquet_recordreader.name = org.apache.parquet.hadoop.ParquetRecordReader

--- a/sql/hive-thriftserver/src/test/resources/log4j2.properties
+++ b/sql/hive-thriftserver/src/test/resources/log4j2.properties
@@ -27,10 +27,8 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %maxLen{%m}{512}%n%ex{8}%n
 
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = warn
+appender.console.filter.1.type = ThresholdFilter
+appender.console.filter.1.level = warn
 
 #File Appender
 appender.file.type = File
@@ -39,10 +37,8 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex
 
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = ThresholdFilter
-appender.file.filter.1.a.level = debug
+appender.file.filter.1.type = ThresholdFilter
+appender.file.filter.1.level = debug
 
 # Some packages are noisy for no good reason.
 logger.parquet_recordreader.name = org.apache.parquet.hadoop.ParquetRecordReader


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr has corrected the configurations related to `ThresholdFilter` in `log4j2.properties` within `hive-thriftserver` module to prevent the following ERROR messages in the test logs:

- https://github.com/apache/spark/actions/runs/19555422394/job/55996708612

```
2025-11-20T05:56:22.1186895Z 2025-11-20T05:56:22.115648760Z pool-1-thread-1 ERROR Filters contains invalid attributes "onMatch", "onMismatch"
2025-11-20T05:56:22.1317678Z 2025-11-20T05:56:22.130070007Z pool-1-thread-1 ERROR Filters contains invalid attributes "onMatch", "onMismatch"
```

### Why are the changes needed?
Fix log4j configurations related to `ThresholdFilter`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass Github Actions
- Manually verify that the test logs no longer contain similar printouts as described above.


### Was this patch authored or co-authored using generative AI tooling?
No