### PR TITLE
[SPARK-54403][SQL][Metric View] Add YAML serde infrastructure for metric views

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1079,11 +1079,6 @@
         <type>pom</type>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
-        <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>${fasterxml.jackson.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.ws.xmlschema</groupId>
         <artifactId>xmlschema-core</artifactId>
         <version>${ws.xmlschema.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1079,6 +1079,11 @@
         <type>pom</type>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-yaml</artifactId>
+        <version>${fasterxml.jackson.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.ws.xmlschema</groupId>
         <artifactId>xmlschema-core</artifactId>
         <version>${ws.xmlschema.version}</version>

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -131,6 +131,10 @@
       <type>jar</type>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.ws.xmlschema</groupId>
       <artifactId>xmlschema-core</artifactId>
     </dependency>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/JsonUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/JsonUtils.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.metricview.serde
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 
-object JsonUtils {
+private[sql] object JsonUtils {
   // Singleton ObjectMapper that can be used across the project
   private lazy val mapper: ObjectMapper = {
     val m = new ObjectMapper()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/JsonUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/JsonUtils.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.metricview.serde
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+
+object JsonUtils {
+  // Singleton ObjectMapper that can be used across the project
+  private lazy val mapper: ObjectMapper = {
+    val m = new ObjectMapper()
+    m.registerModule(DefaultScalaModule)
+    m
+  }
+
+  def toJson[T: Manifest](obj: T): String = {
+    mapper.writeValueAsString(obj)
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewCanonical.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewCanonical.scala
@@ -122,7 +122,10 @@ object Source {
         Try(CatalystSqlParser.parseQuery(sourceText)) match {
           case Success(_) => SQLSource(sourceText)
           case Failure(queryEx) =>
-            throw queryEx
+            throw MetricViewValidationException(
+              s"Invalid source: $sourceText",
+              Some(queryEx)
+            )
         }
     }
   }
@@ -178,7 +181,7 @@ case class ColumnMetadata(
 // Only parse the "version" field and ignore all others
 @JsonIgnoreProperties(ignoreUnknown = true)
 case class YAMLVersion(version: String) extends Validatable {
-  def validYAMLVersions: Set[String] = Set("0.1")
+  private def validYAMLVersions: Set[String] = Set("0.1")
   def validate(): Try[Unit] = {
     if (!validYAMLVersions.contains(version)) {
       Failure(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewCanonical.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewCanonical.scala
@@ -81,7 +81,7 @@ sealed trait Source extends Validatable {
   def validate(): Try[Unit]
 }
 
-// Asset source, representing a UC table, view, or Metric View, etc.
+// Asset source, representing a catalog table, view, or Metric View, etc.
 case class AssetSource(name: String) extends Source {
   val sourceType: SourceType = SourceType.ASSET
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewCanonical.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewCanonical.scala
@@ -36,7 +36,9 @@ private[sql] sealed abstract class MetricViewSerdeException(
     cause: Option[Throwable] = None)
   extends Exception(message, cause.orNull)
 
-case class MetricViewValidationException(message: String, cause: Option[Throwable] = None)
+private[sql] case class MetricViewValidationException(
+    message: String,
+    cause: Option[Throwable] = None)
   extends MetricViewSerdeException(message, cause)
 
 private[sql] case class MetricViewFromProtoException(
@@ -44,7 +46,9 @@ private[sql] case class MetricViewFromProtoException(
     cause: Option[Throwable] = None)
   extends MetricViewSerdeException(message, cause)
 
-case class MetricViewYAMLParsingException(message: String, cause: Option[Throwable] = None)
+private[sql] case class MetricViewYAMLParsingException(
+    message: String,
+    cause: Option[Throwable] = None)
   extends MetricViewSerdeException(message, cause)
 
 // Expression types in a Metric View
@@ -86,7 +90,7 @@ private[sql] sealed trait Source extends Validatable {
 }
 
 // Asset source, representing a catalog table, view, or Metric View, etc.
-case class AssetSource(name: String) extends Source {
+private[sql] case class AssetSource(name: String) extends Source {
   val sourceType: SourceType = SourceType.ASSET
 
   def validate(): Unit = {
@@ -99,7 +103,7 @@ case class AssetSource(name: String) extends Source {
 }
 
 // SQL source, representing a SQL query
-case class SQLSource(sql: String) extends Source {
+private[sql] case class SQLSource(sql: String) extends Source {
   val sourceType: SourceType = SourceType.SQL
 
   def validate(): Unit = {
@@ -199,10 +203,8 @@ private[sql] object YAMLVersion {
   }
 }
 
-case class MetricView(
+private[sql] case class MetricView(
     version: String,
     from: Source,
     where: Option[String] = None,
-    select: Seq[Column]) {
-
-}
+    select: Seq[Column])

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewCanonical.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewCanonical.scala
@@ -163,19 +163,6 @@ private[sql] case class ColumnMetadata(
 private[sql] case class YAMLVersion(version: String) {
 }
 
-private[sql] object YAMLVersion {
-  private def validYAMLVersions: Set[String] = Set("0.1")
-
-  def apply(version: String): YAMLVersion = {
-    if (!validYAMLVersions.contains(version)) {
-      throw MetricViewValidationException(
-        s"Invalid YAML version: $version"
-      )
-    }
-    new YAMLVersion(version)
-  }
-}
-
 private[sql] case class MetricView(
     version: String,
     from: Source,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewCanonical.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewCanonical.scala
@@ -161,7 +161,6 @@ private[sql] case class ColumnMetadata(
 // Only parse the "version" field and ignore all others
 @JsonIgnoreProperties(ignoreUnknown = true)
 private[sql] case class YAMLVersion(version: String) {
-  private def validYAMLVersions: Set[String] = Set("0.1")
 }
 
 private[sql] object YAMLVersion {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewFactory.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewFactory.scala
@@ -23,10 +23,10 @@ object MetricViewFactory {
   def fromYAML(yamlContent: String): MetricView = {
     try {
       val yamlVersion =
-        YamlMapperProvider.mapperWithAllFields.readValue(yamlContent, classOf[YAMLVersion])
+        YamlMapperProviderV01.mapperWithAllFields.readValue(yamlContent, classOf[YAMLVersion])
       yamlVersion.version match {
         case "0.1" =>
-          MetricViewYAMLDeserializer.parseYaml(yamlContent).toCanonical
+          MetricViewYAMLDeserializerV01.parseYaml(yamlContent).toCanonical
         case _ =>
           throw MetricViewValidationException(
             s"Invalid YAML version: ${yamlVersion.version}"
@@ -48,7 +48,7 @@ object MetricViewFactory {
       val versionSpecific = MetricViewBase.fromCanonical(metricView)
       versionSpecific.version match {
         case "0.1" =>
-          MetricViewYAMLSerializer.toYaml(
+          MetricViewYAMLSerializerV01.toYaml(
             versionSpecific.asInstanceOf[MetricViewV01]
           )
         case _ =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewFactory.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewFactory.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.metricview.serde
 
 import scala.util.control.NonFatal
 
-object MetricViewFactory {
+private[sql] object MetricViewFactory {
   def fromYAML(yamlContent: String): MetricView = {
     try {
       val yamlVersion =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewFactory.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewFactory.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.metricview.serde
+
+import scala.util.control.NonFatal
+
+object MetricViewFactory {
+  def fromYAML(yamlContent: String): MetricView = {
+    try {
+      val yamlVersion =
+        YamlMapperProvider.mapperWithAllFields.readValue(yamlContent, classOf[YAMLVersion])
+      yamlVersion.version match {
+        case "0.1" =>
+          MetricViewYAMLDeserializer.parseYaml(yamlContent).toCanonical
+        case _ =>
+          throw MetricViewValidationException(
+            s"Invalid YAML version: ${yamlVersion.version}"
+          )
+      }
+    } catch {
+      case e: MetricViewSerdeException =>
+        throw e
+      case NonFatal(e) =>
+        throw MetricViewYAMLParsingException(
+          s"Failed to parse YAML: ${e.getMessage}",
+          Some(e)
+        )
+    }
+  }
+
+  def toYAML(metricView: MetricView): String = {
+    try {
+      val versionSpecific = MetricViewBase.fromCanonical(metricView)
+      versionSpecific.version match {
+        case "0.1" =>
+          MetricViewYAMLSerializer.toYaml(
+            versionSpecific.asInstanceOf[MetricViewV01]
+          )
+        case _ =>
+          throw MetricViewValidationException(
+            s"Invalid YAML version: ${metricView.version}"
+          )
+      }
+    } catch {
+      case e: MetricViewSerdeException =>
+        throw e
+      case NonFatal(e) =>
+        throw MetricViewYAMLParsingException(
+          s"Failed to serialize to YAML: ${e.getMessage}",
+          Some(e)
+        )
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewSerDeBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewSerDeBase.scala
@@ -59,9 +59,9 @@ trait YamlMapperProviderBase {
 
     val mapper = new ObjectMapper(yamlFactory)
       // Exclude null values from serialized output
-      .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+      .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
       // Exclude empty collections/strings from serialized output
-      .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+      .setDefaultPropertyInclusion(JsonInclude.Include.NON_EMPTY)
 
     mapper.registerModule(DefaultScalaModule)
     mapper

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewSerDeBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewSerDeBase.scala
@@ -25,13 +25,13 @@ import com.fasterxml.jackson.dataformat.yaml.{YAMLFactory, YAMLGenerator}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.yaml.snakeyaml.DumperOptions
 
-object Constants {
+private[sql] object Constants {
   final val MAXIMUM_PROPERTY_SIZE: Int = 1 * 1024
   final val COLUMN_TYPE_PROPERTY_KEY = "metric_view.type"
   final val COLUMN_EXPR_PROPERTY_KEY = "metric_view.expr"
 }
 
-trait YamlMapperProviderBase {
+private[sql] trait YamlMapperProviderBase {
   def mapperWithAllFields: ObjectMapper = {
     val options = new DumperOptions()
     // Set flow style to BLOCK for better readability (each key-value pair on separate lines)
@@ -73,7 +73,7 @@ trait YamlMapperProviderBase {
  * This trait provides the core parsing functionality while allowing version-specific
  * implementations to specify the target type and YAML configuration.
  */
-trait BaseMetricViewYAMLDeserializer[T] {
+private[sql] trait BaseMetricViewYAMLDeserializer[T] {
   /**
    * The YAML utilities to use for deserialization.
    * Subclasses can override this to provide version-specific YAML behavior.
@@ -104,7 +104,7 @@ trait BaseMetricViewYAMLDeserializer[T] {
   protected def getTargetClass: Class[T]
 }
 
-trait BaseMetricViewYAMLSerializer[T] {
+private[sql] trait BaseMetricViewYAMLSerializer[T] {
   protected def yamlMapperProvider: YamlMapperProviderBase
 
   def toYaml(obj: T): String = {
@@ -120,10 +120,10 @@ trait BaseMetricViewYAMLSerializer[T] {
   }
 }
 
-trait ColumnBase {
+private[sql] trait ColumnBase {
   def name: String
   def expr: String
-  def toCanonical(ordinal: Int, isDimension: Boolean): Column[_ <: Expression] = {
+  def toCanonical(ordinal: Int, isDimension: Boolean): Column = {
     if (isDimension) {
       Column(
         name = name,
@@ -140,7 +140,7 @@ trait ColumnBase {
   }
 }
 
-trait MetricViewBase {
+private[sql] trait MetricViewBase {
   def version: String
   def source: String
   def filter: Option[String]
@@ -167,7 +167,7 @@ trait MetricViewBase {
   }
 }
 
-object MetricViewBase {
+private[sql] object MetricViewBase {
   /**
    * Factory method to create the appropriate version-specific MetricView from canonical form.
    * @param canonical The canonical MetricView to convert from

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewSerDeBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewSerDeBase.scala
@@ -147,6 +147,11 @@ private[sql] trait MetricViewBase {
   def dimensions: Seq[ColumnBase]
   def measures: Seq[ColumnBase]
 
+  // Different YAML versions could have differnt syntax to describe a MetricView, but
+  // all of them should be able to be converted to the same canonical form.
+  // For example, in later versions, we may change the syntax of source to support
+  // multiple sources (e.g. joins, compared to the current single source). But the
+  // canonical form should be able to represent both syntaxes.
   def toCanonical: MetricView = {
     // Convert dimensions with proper ordinals (0 to dimensions.length-1)
     val dimensionsCanonical = dimensions.zipWithIndex.map {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewSerDeBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewSerDeBase.scala
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.metricview.serde
+
+import scala.util.control.NonFatal
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.{YAMLFactory, YAMLGenerator}
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.yaml.snakeyaml.DumperOptions
+
+object Constants {
+  final val MAXIMUM_PROPERTY_SIZE: Int = 1 * 1024
+  final val COLUMN_TYPE_PROPERTY_KEY = "metric_view.type"
+  final val COLUMN_EXPR_PROPERTY_KEY = "metric_view.expr"
+}
+
+trait YamlMapperProviderBase {
+  def mapperWithAllFields: ObjectMapper = {
+    val options = new DumperOptions()
+    // Set flow style to BLOCK for better readability (each key-value pair on separate lines)
+    options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK)
+    // Set indentation to 2 spaces
+    options.setIndent(2)
+    // Set indicator indentation to 2 spaces for list/dict indicators
+    options.setIndicatorIndent(2)
+    // Enable indentation with indicators for better readability
+    options.setIndentWithIndicator(true)
+    // Disable pretty flow so that it doesn't add unnecessary newlines after dashes
+    options.setPrettyFlow(false)
+
+    val yamlFactory = YAMLFactory.builder()
+      // Minimize quotes around strings when possible
+      .configure(YAMLGenerator.Feature.MINIMIZE_QUOTES, true)
+      // Don't force numbers to be quoted as strings (preserve numeric types)
+      .configure(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS, false)
+      // Don't write YAML document start marker (---)
+      .configure(YAMLGenerator.Feature.WRITE_DOC_START_MARKER, false)
+      // Disable native type IDs and use explicit type instead
+      .configure(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID, false)
+      .dumperOptions(options)
+      .build()
+
+    val mapper = new ObjectMapper(yamlFactory)
+      // Exclude null values from serialized output
+      .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+      // Exclude empty collections/strings from serialized output
+      .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+
+    mapper.registerModule(DefaultScalaModule)
+    mapper
+  }
+}
+
+/**
+ * Common YAML parsing logic shared by version-specific YAML parsers.
+ * This trait provides the core parsing functionality while allowing version-specific
+ * implementations to specify the target type and YAML configuration.
+ */
+trait BaseMetricViewYAMLDeserializer[T] {
+  /**
+   * The YAML utilities to use for deserialization.
+   * Subclasses can override this to provide version-specific YAML behavior.
+   */
+  protected def yamlMapperProvider: YamlMapperProviderBase
+
+  /**
+   * Parse YAML content into the specified type.
+   * @param yamlContent The YAML content to parse
+   * @return The parsed MetricView of type T
+   */
+  def parseYaml(yamlContent: String): T = {
+    try {
+      yamlMapperProvider.mapperWithAllFields.readValue(yamlContent, getTargetClass)
+    } catch {
+      case NonFatal(e) =>
+        throw MetricViewYAMLParsingException(
+          s"Failed to parse YAML: ${e.getMessage}",
+          Some(e)
+        )
+    }
+  }
+  /**
+   * Get the target class for deserialization.
+   * This must be implemented by version-specific implementations.
+   * @return The Class object for the target type
+   */
+  protected def getTargetClass: Class[T]
+}
+
+trait BaseMetricViewYAMLSerializer[T] {
+  protected def yamlMapperProvider: YamlMapperProviderBase
+
+  def toYaml(obj: T): String = {
+    try {
+      yamlMapperProvider.mapperWithAllFields.writeValueAsString(obj)
+    } catch {
+      case NonFatal(e) =>
+        throw MetricViewYAMLParsingException(
+          s"Failed to serialize to YAML: ${e.getMessage}",
+          Some(e)
+        )
+    }
+  }
+}
+
+trait ColumnBase {
+  def name: String
+  def expr: String
+  def toCanonical(ordinal: Int, isDimension: Boolean): Column[_ <: Expression] = {
+    if (isDimension) {
+      Column(
+        name = name,
+        expression = DimensionExpression(expr),
+        ordinal = ordinal
+      )
+    } else {
+      Column(
+        name = name,
+        expression = MeasureExpression(expr),
+        ordinal = ordinal
+      )
+    }
+  }
+}
+
+trait MetricViewBase {
+  def version: String
+  def source: String
+  def filter: Option[String]
+  def dimensions: Seq[ColumnBase]
+  def measures: Seq[ColumnBase]
+
+  def toCanonical: MetricView = {
+    // Convert dimensions with proper ordinals (0 to dimensions.length-1)
+    val dimensionsCanonical = dimensions.zipWithIndex.map {
+      case (column, index) => column.toCanonical(index, isDimension = true)
+    }
+    // Convert measures with proper ordinals
+    // (dimensions.length to dimensions.length + measures.length - 1)
+    val measuresCanonical = measures.zipWithIndex.map {
+      case (column, index) =>
+        column.toCanonical(dimensions.length + index, isDimension = false)
+    }
+    MetricView(
+      version = version,
+      from = Source(source),
+      where = filter,
+      select = dimensionsCanonical ++ measuresCanonical
+    )
+  }
+}
+
+object MetricViewBase {
+  /**
+   * Factory method to create the appropriate version-specific MetricView from canonical form.
+   * @param canonical The canonical MetricView to convert from
+   * @return The appropriate version-specific MetricView
+   */
+  def fromCanonical(canonical: MetricView): MetricViewBase = {
+    canonical.version match {
+      case "0.1" =>
+        MetricViewV01.fromCanonical(canonical)
+      case _ =>
+        throw new IllegalArgumentException(s"Unsupported version: ${canonical.version}")
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewSerDeV01.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewSerDeV01.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.metricview.serde
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+case class ColumnV01(
+    @JsonProperty(required = true) name: String,
+    @JsonProperty(required = true) expr: String
+) extends ColumnBase
+
+object ColumnV01 {
+  def fromCanonical(canonical: Column[_ <: Expression], ordinal: Int): ColumnV01 = {
+    val name = canonical.name
+    val expr = canonical.expression match {
+      case DimensionExpression(exprStr) => exprStr
+      case MeasureExpression(exprStr) => exprStr
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Unsupported expression type: ${canonical.expression.getClass.getName}")
+    }
+    ColumnV01(name = name, expr = expr)
+  }
+}
+
+case class MetricViewV01(
+    @JsonProperty(required = true) version: String,
+    @JsonProperty(required = true) source: String,
+    filter: Option[String] = None,
+    dimensions: Seq[ColumnV01] = Seq.empty,
+    measures: Seq[ColumnV01] = Seq.empty) extends MetricViewBase
+
+object MetricViewV01 {
+  def fromCanonical(canonical: MetricView): MetricViewV01 = {
+    val source = canonical.from.toString
+    val filter = canonical.where
+    // Separate dimensions and measures based on expression type
+    val dimensions = canonical.select.zipWithIndex.collect {
+      case (column, index) if column.expression.isInstanceOf[DimensionExpression] =>
+        ColumnV01.fromCanonical(column, index)
+    }
+    val measures = canonical.select.zipWithIndex.collect {
+      case (column, index) if column.expression.isInstanceOf[MeasureExpression] =>
+        ColumnV01.fromCanonical(column, index)
+    }
+    MetricViewV01(
+      version = canonical.version,
+      source = source,
+      filter = filter,
+      dimensions = dimensions,
+      measures = measures
+    )
+  }
+}
+
+object YamlMapperProvider extends YamlMapperProviderBase
+
+object MetricViewYAMLDeserializer extends BaseMetricViewYAMLDeserializer[MetricViewV01] {
+  override protected def yamlMapperProvider: YamlMapperProviderBase = YamlMapperProvider
+
+  protected def getTargetClass: Class[MetricViewV01] = classOf[MetricViewV01]
+}
+
+object MetricViewYAMLSerializer extends BaseMetricViewYAMLSerializer[MetricViewV01] {
+  override protected def yamlMapperProvider: YamlMapperProviderBase = YamlMapperProvider
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewSerDeV01.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewSerDeV01.scala
@@ -19,13 +19,13 @@ package org.apache.spark.sql.metricview.serde
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-case class ColumnV01(
+private[sql] case class ColumnV01(
     @JsonProperty(required = true) name: String,
     @JsonProperty(required = true) expr: String
 ) extends ColumnBase
 
-object ColumnV01 {
-  def fromCanonical(canonical: Column[_ <: Expression]): ColumnV01 = {
+private[sql] object ColumnV01 {
+  def fromCanonical(canonical: Column): ColumnV01 = {
     val name = canonical.name
     val expr = canonical.expression match {
       case DimensionExpression(exprStr) => exprStr
@@ -38,14 +38,14 @@ object ColumnV01 {
   }
 }
 
-case class MetricViewV01(
+private[sql] case class MetricViewV01(
     @JsonProperty(required = true) version: String,
     @JsonProperty(required = true) source: String,
     filter: Option[String] = None,
     dimensions: Seq[ColumnV01] = Seq.empty,
     measures: Seq[ColumnV01] = Seq.empty) extends MetricViewBase
 
-object MetricViewV01 {
+private[sql] object MetricViewV01 {
   def fromCanonical(canonical: MetricView): MetricViewV01 = {
     val source = canonical.from.toString
     val filter = canonical.where
@@ -68,14 +68,16 @@ object MetricViewV01 {
   }
 }
 
-object YamlMapperProvider extends YamlMapperProviderBase
+private[sql] object YamlMapperProviderV01 extends YamlMapperProviderBase
 
-object MetricViewYAMLDeserializer extends BaseMetricViewYAMLDeserializer[MetricViewV01] {
-  override protected def yamlMapperProvider: YamlMapperProviderBase = YamlMapperProvider
+private[sql] object MetricViewYAMLDeserializerV01
+  extends BaseMetricViewYAMLDeserializer[MetricViewV01] {
+  override protected def yamlMapperProvider: YamlMapperProviderBase = YamlMapperProviderV01
 
   protected def getTargetClass: Class[MetricViewV01] = classOf[MetricViewV01]
 }
 
-object MetricViewYAMLSerializer extends BaseMetricViewYAMLSerializer[MetricViewV01] {
-  override protected def yamlMapperProvider: YamlMapperProviderBase = YamlMapperProvider
+private[sql] object MetricViewYAMLSerializerV01
+  extends BaseMetricViewYAMLSerializer[MetricViewV01] {
+  override protected def yamlMapperProvider: YamlMapperProviderBase = YamlMapperProviderV01
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewSerDeV01.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewSerDeV01.scala
@@ -25,7 +25,7 @@ case class ColumnV01(
 ) extends ColumnBase
 
 object ColumnV01 {
-  def fromCanonical(canonical: Column[_ <: Expression], ordinal: Int): ColumnV01 = {
+  def fromCanonical(canonical: Column[_ <: Expression]): ColumnV01 = {
     val name = canonical.name
     val expr = canonical.expression match {
       case DimensionExpression(exprStr) => exprStr
@@ -50,13 +50,13 @@ object MetricViewV01 {
     val source = canonical.from.toString
     val filter = canonical.where
     // Separate dimensions and measures based on expression type
-    val dimensions = canonical.select.zipWithIndex.collect {
-      case (column, index) if column.expression.isInstanceOf[DimensionExpression] =>
-        ColumnV01.fromCanonical(column, index)
+    val dimensions = canonical.select.collect {
+      case column if column.expression.isInstanceOf[DimensionExpression] =>
+        ColumnV01.fromCanonical(column)
     }
-    val measures = canonical.select.zipWithIndex.collect {
-      case (column, index) if column.expression.isInstanceOf[MeasureExpression] =>
-        ColumnV01.fromCanonical(column, index)
+    val measures = canonical.select.collect {
+      case column if column.expression.isInstanceOf[MeasureExpression] =>
+        ColumnV01.fromCanonical(column)
     }
     MetricViewV01(
       version = canonical.version,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/metricview/serde/MetricViewFactorySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/metricview/serde/MetricViewFactorySuite.scala
@@ -1,0 +1,373 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.metricview.serde
+
+import org.apache.spark.SparkFunSuite
+
+/**
+ * Test suite for [[MetricViewFactory]] YAML serialization and deserialization.
+ */
+class MetricViewFactorySuite extends SparkFunSuite {
+
+  test("fromYAML - parse basic metric view with asset source") {
+    val yaml =
+      """version: "0.1"
+        |source: my_table
+        |dimensions:
+        |  - name: customer_id
+        |    expr: customer_id
+        |measures:
+        |  - name: total_revenue
+        |    expr: SUM(revenue)
+        |""".stripMargin
+
+    val metricView = MetricViewFactory.fromYAML(yaml)
+
+    assert(metricView.version === "0.1")
+    assert(metricView.from.isInstanceOf[AssetSource])
+    assert(metricView.from.asInstanceOf[AssetSource].name === "my_table")
+    assert(metricView.where.isEmpty)
+    assert(metricView.select.length === 2)
+
+    val customerIdCol = metricView.select(0)
+    assert(customerIdCol.name === "customer_id")
+    assert(customerIdCol.expression.isInstanceOf[DimensionExpression])
+    assert(customerIdCol.expression.expr === "customer_id")
+
+    val revenueCol = metricView.select(1)
+    assert(revenueCol.name === "total_revenue")
+    assert(revenueCol.expression.isInstanceOf[MeasureExpression])
+    assert(revenueCol.expression.expr === "SUM(revenue)")
+  }
+
+  test("fromYAML - parse metric view with SQL source") {
+    val yaml =
+      """version: "0.1"
+        |source: SELECT * FROM my_table WHERE year = 2024
+        |dimensions:
+        |  - name: product_id
+        |    expr: product_id
+        |measures:
+        |  - name: quantity_sold
+        |    expr: SUM(quantity)
+        |""".stripMargin
+
+    val metricView = MetricViewFactory.fromYAML(yaml)
+
+    assert(metricView.from.isInstanceOf[SQLSource])
+    assert(metricView.from.asInstanceOf[SQLSource].sql ===
+      "SELECT * FROM my_table WHERE year = 2024")
+    assert(metricView.select.length === 2)
+  }
+
+  test("fromYAML - parse metric view with filter clause") {
+    val yaml =
+      """version: "0.1"
+        |source: sales_data
+        |filter: year >= 2020 AND status = 'completed'
+        |dimensions:
+        |  - name: region
+        |    expr: region
+        |measures:
+        |  - name: sales
+        |    expr: SUM(amount)
+        |""".stripMargin
+
+    val metricView = MetricViewFactory.fromYAML(yaml)
+
+    assert(metricView.where.isDefined)
+    assert(metricView.where.get === "year >= 2020 AND status = 'completed'")
+  }
+
+  test("fromYAML - parse metric view with multiple dimensions and measures") {
+    val yaml =
+      """version: "0.1"
+        |source: transactions
+        |dimensions:
+        |  - name: customer_id
+        |    expr: customer_id
+        |  - name: product_id
+        |    expr: product_id
+        |  - name: region
+        |    expr: region
+        |measures:
+        |  - name: total_revenue
+        |    expr: SUM(revenue)
+        |  - name: avg_revenue
+        |    expr: AVG(revenue)
+        |  - name: transaction_count
+        |    expr: COUNT(*)
+        |""".stripMargin
+
+    val metricView = MetricViewFactory.fromYAML(yaml)
+
+    assert(metricView.select.length === 6)
+
+    // Check dimensions
+    assert(metricView.select(0).expression.isInstanceOf[DimensionExpression])
+    assert(metricView.select(1).expression.isInstanceOf[DimensionExpression])
+    assert(metricView.select(2).expression.isInstanceOf[DimensionExpression])
+
+    // Check measures
+    assert(metricView.select(3).expression.isInstanceOf[MeasureExpression])
+    assert(metricView.select(4).expression.isInstanceOf[MeasureExpression])
+    assert(metricView.select(5).expression.isInstanceOf[MeasureExpression])
+  }
+
+  test("fromYAML - invalid YAML version") {
+    val yaml =
+      """version: "99.9"
+        |source: my_table
+        |dimensions:
+        |  - name: id
+        |    expr: id
+        |""".stripMargin
+
+    val exception = intercept[MetricViewValidationException] {
+      MetricViewFactory.fromYAML(yaml)
+    }
+    assert(exception.getMessage.contains("Invalid YAML version: 99.9"))
+  }
+
+  test("fromYAML - malformed YAML") {
+    val yaml = """this is not valid yaml: [unclosed bracket"""
+
+    val exception = intercept[MetricViewYAMLParsingException] {
+      MetricViewFactory.fromYAML(yaml)
+    }
+    assert(exception.getMessage.contains("Failed to parse YAML"))
+  }
+
+  test("toYAML - serialize basic metric view") {
+    val metricView = MetricView(
+      version = "0.1",
+      from = AssetSource("my_table"),
+      where = None,
+      select = Seq(
+        Column("customer_id", DimensionExpression("customer_id"), 0),
+        Column("total_revenue", MeasureExpression("SUM(revenue)"), 1)
+      )
+    )
+
+    val yaml = MetricViewFactory.toYAML(metricView)
+
+    assert(yaml.contains("version: 0.1") || yaml.contains("version: \"0.1\""))
+    assert(yaml.contains("source: my_table"))
+    assert(yaml.contains("customer_id"))
+    assert(yaml.contains("total_revenue"))
+
+    // Verify it can be parsed back
+    val reparsed = MetricViewFactory.fromYAML(yaml)
+    assert(reparsed.version === "0.1")
+    assert(reparsed.from.asInstanceOf[AssetSource].name === "my_table")
+  }
+
+  test("toYAML - serialize metric view with SQL source") {
+    val metricView = MetricView(
+      version = "0.1",
+      from = SQLSource("SELECT * FROM table WHERE id > 100"),
+      where = None,
+      select = Seq(
+        Column("id", DimensionExpression("id"), 0)
+      )
+    )
+
+    val yaml = MetricViewFactory.toYAML(metricView)
+
+    assert(yaml.contains("source: SELECT * FROM table WHERE id > 100"))
+  }
+
+  test("toYAML - serialize metric view with filter clause") {
+    val metricView = MetricView(
+      version = "0.1",
+      from = AssetSource("sales"),
+      where = Some("year >= 2020"),
+      select = Seq(
+        Column("region", DimensionExpression("region"), 0),
+        Column("sales", MeasureExpression("SUM(amount)"), 1)
+      )
+    )
+
+    val yaml = MetricViewFactory.toYAML(metricView)
+
+    assert(yaml.contains("year >= 2020"))
+
+    // Verify it can be parsed back
+    val reparsed = MetricViewFactory.fromYAML(yaml)
+    assert(reparsed.where.isDefined)
+    assert(reparsed.where.get === "year >= 2020")
+  }
+
+  test("roundtrip - fromYAML and toYAML preserve data") {
+    val originalYaml =
+      """version: "0.1"
+        |source: sales_table
+        |filter: status = 'active'
+        |dimensions:
+        |  - name: customer_id
+        |    expr: customer_id
+        |  - name: product_name
+        |    expr: product_name
+        |measures:
+        |  - name: total_revenue
+        |    expr: SUM(revenue)
+        |  - name: order_count
+        |    expr: COUNT(order_id)
+        |""".stripMargin
+
+    // Parse the YAML
+    val metricView = MetricViewFactory.fromYAML(originalYaml)
+
+    // Serialize it back
+    val serializedYaml = MetricViewFactory.toYAML(metricView)
+
+    // Parse again to verify
+    val reparsedMetricView = MetricViewFactory.fromYAML(serializedYaml)
+
+    // Verify all fields match
+    assert(reparsedMetricView.version === metricView.version)
+    assert(reparsedMetricView.from === metricView.from)
+    assert(reparsedMetricView.where === metricView.where)
+    assert(reparsedMetricView.select.length === metricView.select.length)
+
+    reparsedMetricView.select.zip(metricView.select).foreach { case (col1, col2) =>
+      assert(col1.name === col2.name)
+      assert(col1.expression.expr === col2.expression.expr)
+      assert(col1.expression.getClass === col2.expression.getClass)
+    }
+  }
+
+  test("roundtrip - SQL source preservation") {
+    val originalYaml =
+      """version: "0.1"
+        |source: SELECT * FROM my_table WHERE year = 2024
+        |dimensions:
+        |  - name: id
+        |    expr: id
+        |measures:
+        |  - name: total
+        |    expr: SUM(value)
+        |""".stripMargin
+
+    val metricView = MetricViewFactory.fromYAML(originalYaml)
+    val serializedYaml = MetricViewFactory.toYAML(metricView)
+    val reparsedMetricView = MetricViewFactory.fromYAML(serializedYaml)
+
+    assert(reparsedMetricView.from.isInstanceOf[SQLSource])
+    assert(reparsedMetricView.from.asInstanceOf[SQLSource].sql ===
+      "SELECT * FROM my_table WHERE year = 2024")
+  }
+
+  test("column ordinals are preserved") {
+    val yaml =
+      """version: "0.1"
+        |source: my_table
+        |dimensions:
+        |  - name: col1
+        |    expr: col1
+        |  - name: col2
+        |    expr: col2
+        |measures:
+        |  - name: col3
+        |    expr: SUM(value)
+        |""".stripMargin
+
+    val metricView = MetricViewFactory.fromYAML(yaml)
+
+    assert(metricView.select(0).ordinal === 0)
+    assert(metricView.select(1).ordinal === 1)
+    assert(metricView.select(2).ordinal === 2)
+  }
+
+  test("column metadata extraction") {
+    val yaml =
+      """version: "0.1"
+        |source: my_table
+        |dimensions:
+        |  - name: customer_id
+        |    expr: customer_id
+        |measures:
+        |  - name: revenue
+        |    expr: SUM(amount)
+        |""".stripMargin
+
+    val metricView = MetricViewFactory.fromYAML(yaml)
+
+    val dimensionMetadata = metricView.select(0).getColumnMetadata
+    assert(dimensionMetadata.columnType === "dimension")
+    assert(dimensionMetadata.expr === "customer_id")
+
+    val measureMetadata = metricView.select(1).getColumnMetadata
+    assert(measureMetadata.columnType === "measure")
+    assert(measureMetadata.expr === "SUM(amount)")
+  }
+
+  test("empty source validation") {
+    val yaml =
+      """version: "0.1"
+        |source: ""
+        |dimensions:
+        |  - name: id
+        |    expr: id
+        |""".stripMargin
+
+    intercept[Exception] {
+      MetricViewFactory.fromYAML(yaml)
+    }
+  }
+
+  test("complex SQL expressions in measures") {
+    val yaml =
+      """version: "0.1"
+        |source: transactions
+        |dimensions:
+        |  - name: date
+        |    expr: DATE(timestamp)
+        |measures:
+        |  - name: weighted_avg
+        |    expr: SUM(amount * weight) / SUM(weight)
+        |  - name: distinct_customers
+        |    expr: COUNT(DISTINCT customer_id)
+        |""".stripMargin
+
+    val metricView = MetricViewFactory.fromYAML(yaml)
+
+    assert(metricView.select.length === 3)
+    assert(metricView.select(0).expression.expr === "DATE(timestamp)")
+    assert(metricView.select(1).expression.expr === "SUM(amount * weight) / SUM(weight)")
+    assert(metricView.select(2).expression.expr === "COUNT(DISTINCT customer_id)")
+  }
+
+  test("special characters in column names and expressions") {
+    val yaml =
+      """version: "0.1"
+        |source: my_table
+        |dimensions:
+        |  - name: "customer.id"
+        |    expr: "`customer.id`"
+        |measures:
+        |  - name: "revenue_$"
+        |    expr: "SUM(`revenue_$`)"
+        |""".stripMargin
+
+    val metricView = MetricViewFactory.fromYAML(yaml)
+
+    assert(metricView.select(0).name === "customer.id")
+    assert(metricView.select(1).name === "revenue_$")
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR adds the complete serialization/deserialization infrastructure for parsing metric view YAML definitions:
- Add Jackson YAML dependencies to pom.xml
- Implement canonical model for metric views:
  - Column, Expression (Dimension/Measure), MetricView, Source
  - YAMLVersion validation and exception types
- Implement version-specific serde (v0.1):
  - YAML deserializer/serializer
  - Base classes for extensibility
- Add JSON utilities for metadata serialization

### Why are the changes needed?
[SPIP: Metrics & semantic modeling in Spark](https://docs.google.com/document/d/1xVTLijvDTJ90lZ_ujwzf9HvBJgWg0mY6cYM44Fcghl0/edit?tab=t.0#heading=h.4iogryr5qznc)


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
```
build/sbt "catalyst/testOnly org.apache.spark.sql.metricview.serde.MetricViewFactorySuite"
```


### Was this patch authored or co-authored using generative AI tooling?
Generated-by: [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>
