### PR TITLE
[SPARK-54330][PYTHON][FOLLOW-UP] Further avoid unnecessary py4j calls

### DIFF
--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -513,6 +513,7 @@ class SparkConversionMixin:
         prefers_large_var_types = arrowUseLargeVarTypes == "true"
         timezone = sessionLocalTimeZone
         arrow_batch_size = int(arrowMaxRecordsPerBatch)
+        selfcheck = arrowSafeTypeConversion == "true"
 
         if type(data).__name__ == "Table":
             # `data` is a PyArrow Table

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -496,6 +496,7 @@ class SparkConversionMixin:
             arrowUseLargeVarTypes,
             arrowPySparkFallbackEnabled,
             arrowMaxRecordsPerBatch,
+            arrowSafeTypeConversion,
         ) = self._jconf.getConfs(
             [
                 "spark.sql.timestampType",
@@ -504,6 +505,7 @@ class SparkConversionMixin:
                 "spark.sql.execution.arrow.useLargeVarTypes",
                 "spark.sql.execution.arrow.pyspark.fallback.enabled",
                 "spark.sql.execution.arrow.maxRecordsPerBatch",
+                "spark.sql.execution.pandas.convertToArrowArraySafely",
             ]
         )
 
@@ -526,7 +528,14 @@ class SparkConversionMixin:
             if schema is None:
                 schema = data.schema.names
 
-            return self._create_from_arrow_table(data, schema, timezone, prefer_timestamp_ntz)
+            return self._create_from_arrow_table(
+                data,
+                schema,
+                timezone,
+                prefer_timestamp_ntz,
+                prefers_large_var_types,
+                arrow_batch_size,
+            )
 
         # `data` is a PandasDataFrameLike object
         from pyspark.sql.pandas.utils import require_minimum_pandas_version
@@ -546,6 +555,7 @@ class SparkConversionMixin:
                     prefer_timestamp_ntz,
                     prefers_large_var_types,
                     arrow_batch_size,
+                    selfcheck,
                 )
             except Exception as e:
                 if arrowPySparkFallbackEnabled == "true":
@@ -776,6 +786,7 @@ class SparkConversionMixin:
         prefer_timestamp_ntz: bool,
         prefers_large_var_types: bool,
         arrow_batch_size: int,
+        safecheck: bool,
     ) -> "DataFrame":
         """
         Create a DataFrame from a given pandas.DataFrame by slicing it into partitions, converting
@@ -881,7 +892,6 @@ class SparkConversionMixin:
 
         jsparkSession = self._jsparkSession
 
-        safecheck = self._jconf.arrowSafeTypeConversion()
         ser = ArrowStreamPandasSerializer(timezone, safecheck, False)
 
         @no_type_check
@@ -906,6 +916,8 @@ class SparkConversionMixin:
         schema: Union[StructType, List[str]],
         timezone: str,
         prefer_timestamp_ntz: bool,
+        prefers_large_var_types: bool,
+        arrow_batch_size: int,
     ) -> "DataFrame":
         """
         Create a DataFrame from a given pyarrow.Table by slicing it into partitions then
@@ -943,7 +955,6 @@ class SparkConversionMixin:
         if not isinstance(schema, StructType):
             schema = from_arrow_schema(table.schema, prefer_timestamp_ntz=prefer_timestamp_ntz)
 
-        prefers_large_var_types = self._jconf.arrowUseLargeVarTypes()
         table = _check_arrow_table_timestamps_localize(table, schema, True, timezone).cast(
             to_arrow_schema(
                 schema,
@@ -953,7 +964,7 @@ class SparkConversionMixin:
         )
 
         # Chunk the Arrow Table into RecordBatches
-        chunk_size = self._jconf.arrowMaxRecordsPerBatch()
+        chunk_size = arrow_batch_size
         arrow_data = table.to_batches(max_chunksize=chunk_size)
 
         jsparkSession = self._jsparkSession


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
follow-up of https://github.com/apache/spark/pull/53031, further avoid unnecessary py4j calls


### Why are the changes needed?
there are still some py4j calls in the internal functions


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
