### PR TITLE
[SPARK-54448][SQL][DOCS] Fix docs and error message because CREATE TEMP VIEW does not support IF NOT EXISTS

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -6019,7 +6019,7 @@
   "TEMP_TABLE_OR_VIEW_ALREADY_EXISTS" : {
     "message" : [
       "Cannot create the temporary view <relationName> because it already exists.",
-      "Choose a different name, drop or replace the existing view,  or add the IF NOT EXISTS clause to tolerate pre-existing views."
+      "Choose a different name, drop or replace the existing view."
     ],
     "sqlState" : "42P07"
   },

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -40,7 +40,7 @@ import org.apache.spark.util.Utils
  * To re-generate the error class file, run:
  * {{{
  *   SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \
- *     "core/testOnly *SparkThrowableSuite -- -t \"Error conditions are correctly formatted\""
+ *     'core/testOnly *SparkThrowableSuite -- -t "Error conditions are correctly formatted"'
  * }}}
  */
 class SparkThrowableSuite extends SparkFunSuite {

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -40,7 +40,7 @@ import org.apache.spark.util.Utils
  * To re-generate the error class file, run:
  * {{{
  *   SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \
- *     'core/testOnly *SparkThrowableSuite -- -t "Error conditions are correctly formatted"'
+ *     "core/testOnly *SparkThrowableSuite -- -t \"Error conditions are correctly formatted\""
  * }}}
  */
 class SparkThrowableSuite extends SparkFunSuite {

--- a/docs/sql-ref-syntax-ddl-create-view.md
+++ b/docs/sql-ref-syntax-ddl-create-view.md
@@ -47,6 +47,7 @@ CREATE [ OR REPLACE ] [ [ GLOBAL ] TEMPORARY ] VIEW [ IF NOT EXISTS ] view_ident
 * **IF NOT EXISTS**
 
     Creates a view if it does not exist.
+    This clause is not supported for `TEMPORARY` views yet.
 
 * **view_identifier**
 
@@ -86,8 +87,8 @@ CREATE OR REPLACE VIEW experienced_employee
     AS SELECT id, name FROM all_employee
         WHERE working_years > 5;
 
--- Create a global temporary view `subscribed_movies` if it does not exist.
-CREATE GLOBAL TEMPORARY VIEW IF NOT EXISTS subscribed_movies 
+-- Create a global temporary view `subscribed_movies`.
+CREATE GLOBAL TEMPORARY VIEW subscribed_movies 
     AS SELECT mo.member_id, mb.full_name, mo.movie_title
         FROM movies AS mo INNER JOIN members AS mb 
         ON mo.member_id = mb.id;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Currently, Spark SQL supports `CREATE [ OR REPLACE ] [ [ GLOBAL ] TEMPORARY ] VIEW [ IF NOT EXISTS ] view_identifier ...` syntax, but the implementation forbids using `CREATE [ GLOBAL ] TEMPORARY VIEW` with `IF NOT EXISTS`, this is likely an incompleted feature.

And this was also provided as an example in the docs, but actually does not work.

https://spark.apache.org/docs/4.0.1/sql-ref-syntax-ddl-create-view.html

<img width="890" height="366" alt="image" src="https://github.com/user-attachments/assets/d3a30055-866b-4307-904e-10e908b953a2" />

In addition, the error condition `TEMP_TABLE_OR_VIEW_ALREADY_EXISTS`'s message suggests "add the IF NOT EXISTS clause", which does not work either.

```
spark-sql (default)> CREATE GLOBAL TEMPORARY VIEW v AS SELECT 1;
spark-sql (default)> CREATE GLOBAL TEMPORARY VIEW v AS SELECT 1;
[TEMP_TABLE_OR_VIEW_ALREADY_EXISTS] Cannot create the temporary view `v` because it already exists.
Choose a different name, drop or replace the existing view,  or add the IF NOT EXISTS clause to tolerate pre-existing views. SQLSTATE: 42P07
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix wrong docs and error condition message.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
It only updates the docs and error condition message, with no functionality changes.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

<img width="928" height="1652" alt="image" src="https://github.com/user-attachments/assets/ec6d4a35-285a-4431-b456-60d2c4c8b1ac" />


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.