### PR TITLE
[SPARK-54499][SQL][4.1] Re-enable `spark.sql.scripting.enabled` by default for Spark 4.1.0

### DIFF
--- a/docs/sql-ref-scripting.md
+++ b/docs/sql-ref-scripting.md
@@ -32,10 +32,6 @@ This is followed by the compound statement body, which consists of:
 - The [EXECUTE IMMEDIATE](sql-ref-syntax-aux-exec-imm.html) statement.
 - Nested compound statements, which provide nested scopes for variables, conditions, and condition handlers.
 
-## Enablement
-
-To enable SQL Scripting, set the `spark.sql.scripting.enabled` flag to `true`.
-
 ## Passing data between the invoker and the compound statement
 
 There are two ways to pass data to and from a SQL script:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4336,7 +4336,7 @@ object SQLConf {
         "flow and error handling.")
       .version("4.0.0")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val SQL_SCRIPTING_CONTINUE_HANDLER_ENABLED =
     buildConf("spark.sql.scripting.continueHandlerEnabled")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR aims to re-enable SQL Scripting in Spark 4.1, ahead of its RC.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
There was a previous misunderstanding/miscommunication, that I did not notice in time. The feature was disabled because it was thought that it is not ready, due to unclosed JIRA items.

However, it was just a case of not 100% up-to-date items. I have cleaned up and classified remaining work items (children of [SPARK-48338](https://issues.apache.org/jira/browse/SPARK-48338)) into 4 categories:
- M0 - basic support
- M1 - features and changes required to enable SQL Scripting by default
- M2 - follow-up improvements and additional functionalities that are non-fundamental and should not block M1
- M3 - potential improvements for the future, need investigation

M0 and M1 are done, meaning the feature is stable, useful and also ready to be used.

M2 will improve some of the aspects of using it by introducing a newer and more user-friendly statements, like SIGNAL/RESIGNAL and GET DIAGNOSTICS, as well as do some very minor optimizations. However, without those, feature is still ready to be used as is.

The only missing aspect is documentation, for which we have a PR (https://github.com/apache/spark/pull/50592) but it was closed. I'll work on re-submitting that one.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
I am not sure 100% how this classifies - the feature was already present in 4.0, but was not enabled by default.
Anyways, the feature is completely orthogonal to all other standalone statement execution paths, so it is just adding to functionality of Spark.
There is no difference in behavior for any standalone SQL statement compared to when SQL Scripting is turned off.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
SQL Scripting has a thorough support in tests.
CI ensures the feature does not affect any other.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.