### PR TITLE
[SPARK-54452] Fix empty response from SparkConnect server for `spark.sql(...)` inside FlowFunction

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -2992,6 +2992,13 @@ class SparkConnectPlanner(
     // the SQL command and defer the actual analysis and execution to the flow function.
     if (insidePipelineFlowFunction) {
       result.setRelation(relation)
+      responseObserver.onNext(
+        ExecutePlanResponse
+          .newBuilder()
+          .setSessionId(sessionHolder.sessionId)
+          .setServerSideSessionId(sessionHolder.serverSessionId)
+          .setSqlCommandResult(result)
+          .build)
       return
     }
 

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -2992,6 +2992,7 @@ class SparkConnectPlanner(
     // the SQL command and defer the actual analysis and execution to the flow function.
     if (insidePipelineFlowFunction) {
       result.setRelation(relation)
+      executeHolder.eventsManager.postFinished()
       responseObserver.onNext(
         ExecutePlanResponse
           .newBuilder()

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerSuite.scala
@@ -889,10 +889,13 @@ class SparkDeclarativePipelinesServerSuite
         .newBuilder()
         .setUserContext(userContext)
         .setPlan(relation)
+        .setSessionId(UUID.randomUUID().toString)
         .build()
       val sparkSqlResponse = stub.executePlan(sparkSqlRequest).next()
       assert(sparkSqlResponse.hasSqlCommandResult)
-      assert(sparkSqlResponse.getSqlCommandResult.getRelation == relation)
+      assert(
+        sparkSqlResponse.getSqlCommandResult.getRelation ==
+          relation.getCommand.getSqlCommand.getInput)
     }
   }
 }

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerSuite.scala
@@ -851,7 +851,8 @@ class SparkDeclarativePipelinesServerSuite
     }
   }
 
-  test("spark.sql() inside a pipeline flow function should return a sql_command_result") {
+  test(
+    "SPARK-54452: spark.sql() inside a pipeline flow function should return a sql_command_result") {
     withRawBlockingStub { implicit stub =>
       val graphId = createDataflowGraph
       val pipelineAnalysisContext = proto.PipelineAnalysisContext
@@ -882,6 +883,51 @@ class SparkDeclarativePipelinesServerSuite
                         proto.Read.NamedTable.newBuilder().setUnparsedIdentifier("table"))
                       .build())
                     .build()))
+            .build())
+        .build()
+
+      val sparkSqlRequest = proto.ExecutePlanRequest
+        .newBuilder()
+        .setUserContext(userContext)
+        .setPlan(relation)
+        .setSessionId(UUID.randomUUID().toString)
+        .build()
+      val sparkSqlResponse = stub.executePlan(sparkSqlRequest).next()
+      assert(sparkSqlResponse.hasSqlCommandResult)
+      assert(
+        sparkSqlResponse.getSqlCommandResult.getRelation ==
+          relation.getCommand.getSqlCommand.getInput)
+    }
+  }
+
+  test(
+    "SPARK-54452: spark.sql() outside a pipeline flow function should return a " +
+      "sql_command_result") {
+    withRawBlockingStub { implicit stub =>
+      val graphId = createDataflowGraph
+      val pipelineAnalysisContext = proto.PipelineAnalysisContext
+        .newBuilder()
+        .setDataflowGraphId(graphId)
+        .build()
+      val userContext = proto.UserContext
+        .newBuilder()
+        .addExtensions(com.google.protobuf.Any.pack(pipelineAnalysisContext))
+        .setUserId("test_user")
+        .build()
+
+      val relation = proto.Plan
+        .newBuilder()
+        .setCommand(
+          proto.Command
+            .newBuilder()
+            .setSqlCommand(
+              proto.SqlCommand
+                .newBuilder()
+                .setInput(proto.Relation
+                  .newBuilder()
+                  .setSql(proto.SQL.newBuilder().setQuery("SELECT * FROM RANGE(5)"))
+                  .build())
+                .build())
             .build())
         .build()
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In PR #53024, we added SDP support for `spark.sql(...)` inside a FlowFunction. For these calls, instead of eagerly executing the SQL, the Spark Connect server should return the raw logical plan to the client and defer execution to the flow function.

However, in that PR we constructed the response object but forgot to actually return it to the Spark Connect client, so the client received an empty response.

This went unnoticed in tests because, when the client sees an empty `spark.sql(...)` response, [it falls back to creating an empty DataFrame holding the raw logical plan](https://github.com/apache/spark/blob/master/python/pyspark/sql/connect/session.py#L829-L835), which happens to match the desired behavior. This PR fixes the bug by returning the proper response instead of relying on that implicit fallback.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
This PR fixes a bug introduced in #53024 where the server did not return the constructed spark.sql(...) response to the client.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No