### PR TITLE
[SPARK-54450][INFRA] Allow run-tests to accept unittest style string for test names

### DIFF
--- a/python/docs/source/development/testing.rst
+++ b/python/docs/source/development/testing.rst
@@ -36,6 +36,13 @@ After that, the PySpark test cases can be run via using ``python/run-tests``. Fo
 
     python/run-tests --python-executable=python3
 
+You can run individual tests by using ``--testnames`` option. For example,
+
+.. code-block:: bash
+
+    python/run-tests --testnames pyspark.sql.tests.test_dataframe
+    python/run-tests --testnames pyspark.sql.tests.test_dataframe.DataFrameTests.test_range
+
 Note that you may set ``OBJC_DISABLE_INITIALIZE_FORK_SAFETY`` environment variable to ``YES`` if you are running tests on Mac OS.
 
 Please see the guidance on how to |building_spark|_,

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -20,6 +20,7 @@
 import logging
 from argparse import ArgumentParser
 import os
+import importlib
 import platform
 import re
 import shutil
@@ -224,6 +225,42 @@ def get_default_python_executables():
     return python_execs
 
 
+def split_and_validate_testnames(testnames):
+    testnames_to_test = []
+
+    def module_exists(module):
+        try:
+            return importlib.util.find_spec(module) is not None
+        except ModuleNotFoundError:
+            return False
+
+    for testname in testnames.split(','):
+        if " " in testname:
+            # "{module} {class.testcase_name}"
+            module, testcase = testname.split(" ")
+            if not module_exists(module):
+                print(f"Error: Can't find module '{module}'.")
+                sys.exit(-1)
+            testnames_to_test.append(f"{module} {testcase}")
+        else:
+            if module_exists(testname):
+                # "{module}"
+                testnames_to_test.append(testname)
+            else:
+                # "{module.class.testcase_name}"
+                index = len(testname)
+                while (index := testname.rfind(".", 0, index)) != -1:
+                    module, testcase = testname[:index], testname[index+1:]
+                    if module_exists(module):
+                        testnames_to_test.append(f"{module} {testcase}")
+                        break
+                else:
+                    print(f"Error: Invalid testname '{testname}'.")
+                    sys.exit(-1)
+
+    return testnames_to_test
+
+
 def parse_opts():
     parser = ArgumentParser(
         prog="run-tests"
@@ -312,7 +349,7 @@ def main():
                 sys.exit(-1)
         LOGGER.info("Will test the following Python modules: %s", [x.name for x in modules_to_test])
     else:
-        testnames_to_test = opts.testnames.split(',')
+        testnames_to_test = split_and_validate_testnames(opts.testnames)
         LOGGER.info("Will test the following Python tests: %s", testnames_to_test)
 
     task_queue = Queue.PriorityQueue()

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -293,6 +293,7 @@ def parse_opts():
             "For example, 'pyspark.sql.foo' to run the module as unittests or doctests, "
             "'pyspark.sql.tests FooTests' to run the specific class of unittests, "
             "'pyspark.sql.tests FooTests.test_foo' to run the specific unittest in the class. "
+            "'pyspark.sql.tests.FooTests.test_foo' will work too. "
             "'--modules' option is ignored if they are given.")
     )
     group.add_argument(

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -250,7 +250,7 @@ def split_and_validate_testnames(testnames):
                 # "{module.class.testcase_name}"
                 index = len(testname)
                 while (index := testname.rfind(".", 0, index)) != -1:
-                    module, testcase = testname[:index], testname[index+1:]
+                    module, testcase = testname[:index], testname[index + 1:]
                     if module_exists(module):
                         testnames_to_test.append(f"{module} {testcase}")
                         break


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Allow `run-tests` to take unittest style string like `test_module.TestClass.test_case`, in addition to `test_module TestClass.test_case`.

Also some extra check is added for the existence of the test module - we are not sending it to `bin/pyspark` if we can't find the module.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

It's extra work to split the string when copy/paste directly from unittest output (CI failures for example).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Manually confirmed the `.` connection works and the original way is not impacted (except that we have some new checks for the module). 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.