### PR TITLE
[SPARK-54451][SQL] Add JSON serialization and deserialization support for TIME type

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
@@ -32,7 +32,7 @@ import org.json4s.jackson.JsonMethods.{compact, pretty, render}
 import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.annotation.{Stable, Unstable}
 import org.apache.spark.sql.catalyst.expressions.GenericRow
-import org.apache.spark.sql.catalyst.util.{DateFormatter, SparkDateTimeUtils, TimestampFormatter, UDTUtils}
+import org.apache.spark.sql.catalyst.util.{DateFormatter, SparkDateTimeUtils, TimeFormatter, TimestampFormatter, UDTUtils}
 import org.apache.spark.sql.errors.DataTypeErrors
 import org.apache.spark.sql.errors.DataTypeErrors.{toSQLType, toSQLValue}
 import org.apache.spark.sql.internal.SqlApiConf
@@ -619,6 +619,7 @@ trait Row extends Serializable {
     lazy val zoneId = SparkDateTimeUtils.getZoneId(SqlApiConf.get.sessionLocalTimeZone)
     lazy val dateFormatter = DateFormatter()
     lazy val timestampFormatter = TimestampFormatter(zoneId)
+    lazy val timeFormatter = TimeFormatter.getFractionFormatter()
 
     // Convert an iterator of values to a json array
     def iteratorToJsonArray(iterator: Iterator[_], elementType: DataType): JArray = {
@@ -632,6 +633,7 @@ trait Row extends Serializable {
       case (b: Byte, _) => JLong(b)
       case (s: Short, _) => JLong(s)
       case (i: Int, _) => JLong(i)
+      case (nanos: Long, _: TimeType) => JString(timeFormatter.format(nanos))
       case (l: Long, _) => JLong(l)
       case (f: Float, _) => JDouble(f)
       case (d: Double, _) => JDouble(d)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -129,6 +129,10 @@ class JSONOptions(
   val timestampNTZFormatInWrite: String =
     parameters.getOrElse(TIMESTAMP_NTZ_FORMAT, s"${DateFormatter.defaultPattern}'T'HH:mm:ss[.SSS]")
 
+  val timeFormatInRead: Option[String] = parameters.get(TIME_FORMAT)
+  val timeFormatInWrite: String =
+    parameters.getOrElse(TIME_FORMAT, TimeFormatter.defaultPattern)
+
   // SPARK-39731: Enables the backward compatible parsing behavior.
   // Generally, this config should be set to false to avoid producing potentially incorrect results
   // which is the current default (see JacksonParser).
@@ -279,6 +283,7 @@ object JSONOptions extends DataSourceOptions {
   val DATE_FORMAT = newOption("dateFormat")
   val TIMESTAMP_FORMAT = newOption("timestampFormat")
   val TIMESTAMP_NTZ_FORMAT = newOption("timestampNTZFormat")
+  val TIME_FORMAT = newOption("timeFormat")
   val ENABLE_DATETIME_PARSING_FALLBACK = newOption("enableDateTimeParsingFallback")
   val MULTI_LINE = newOption("multiLine")
   val LINE_SEP = newOption("lineSep")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -130,8 +130,7 @@ class JSONOptions(
     parameters.getOrElse(TIMESTAMP_NTZ_FORMAT, s"${DateFormatter.defaultPattern}'T'HH:mm:ss[.SSS]")
 
   val timeFormatInRead: Option[String] = parameters.get(TIME_FORMAT)
-  val timeFormatInWrite: String =
-    parameters.getOrElse(TIME_FORMAT, TimeFormatter.defaultPattern)
+  val timeFormatInWrite: String = parameters.getOrElse(TIME_FORMAT, TimeFormatter.defaultPattern)
 
   // SPARK-39731: Enables the backward compatible parsing behavior.
   // Generally, this config should be set to false to avoid producing potentially incorrect results

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonGenerator.scala
@@ -106,6 +106,10 @@ class JacksonGenerator(
     options.locale,
     legacyFormat = FAST_DATE_FORMAT,
     isParsing = false)
+  private val timeFormatter = options.timeFormatInWrite match {
+    case TimeFormatter.defaultPattern => TimeFormatter.getFractionFormatter()
+    case customPattern => TimeFormatter(customPattern, isParsing = false)
+  }
 
   private def makeWriter(dataType: DataType): ValueWriter = dataType match {
     case NullType =>
@@ -181,6 +185,11 @@ class JacksonGenerator(
           start,
           end)
         gen.writeString(dtString)
+
+    case _: TimeType =>
+      (row: SpecializedGetters, ordinal: Int) =>
+        val timeString = timeFormatter.format(row.getLong(ordinal))
+        gen.writeString(timeString)
 
     case BinaryType =>
       (row: SpecializedGetters, ordinal: Int) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -80,9 +80,7 @@ class JacksonParser(
     options.locale,
     legacyFormat = FAST_DATE_FORMAT,
     isParsing = true)
-  private lazy val timeFormatter = TimeFormatter(
-    options.timeFormatInRead,
-    isParsing = true)
+  private lazy val timeFormatter = TimeFormatter(options.timeFormatInRead, isParsing = true)
 
   // Flags to signal if we need to fall back to the backward compatible behavior of parsing
   // dates and timestamps.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -80,6 +80,9 @@ class JacksonParser(
     options.locale,
     legacyFormat = FAST_DATE_FORMAT,
     isParsing = true)
+  private lazy val timeFormatter = TimeFormatter(
+    options.timeFormatInRead,
+    isParsing = true)
 
   // Flags to signal if we need to fall back to the backward compatible behavior of parsing
   // dates and timestamps.
@@ -433,6 +436,12 @@ class JacksonParser(
         case VALUE_STRING =>
           val expr = Cast(Literal(parser.getText), dt)
           java.lang.Long.valueOf(expr.eval(EmptyRow).asInstanceOf[Long])
+      }
+
+    case _: TimeType => (parser: JsonParser) =>
+      parseJsonToken[java.lang.Long](parser, dataType) {
+        case VALUE_STRING if parser.getTextLength >= 1 =>
+          timeFormatter.parse(parser.getText)
       }
 
     case st: StructType =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -115,7 +115,6 @@ case class JsonFileFormat() extends TextBasedFileFormat with DataSourceRegister 
   override def supportDataType(dataType: DataType): Boolean = dataType match {
     case _: VariantType => true
 
-    case _: TimeType => false
     case _: AtomicType => true
 
     case st: StructType => st.forall { f => supportDataType(f.dataType) }

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/json-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/json-functions.sql.out
@@ -722,3 +722,236 @@ Project [json_object_keys([1, 2, 3]) AS json_object_keys([1, 2, 3])#x]
 DROP VIEW IF EXISTS jsonTable
 -- !query analysis
 DropTempViewCommand jsonTable
+
+
+-- !query
+select from_json('{"time": "14:30:45"}', 'time TIME(0)')
+-- !query analysis
+Project [from_json(StructField(time,TimeType(0),true), {"time": "14:30:45"}, Some(America/Los_Angeles), false) AS from_json({"time": "14:30:45"})#x]
++- OneRowRelation
+
+
+-- !query
+select from_json('{"time": "14:30:45.123"}', 'time TIME(3)')
+-- !query analysis
+Project [from_json(StructField(time,TimeType(3),true), {"time": "14:30:45.123"}, Some(America/Los_Angeles), false) AS from_json({"time": "14:30:45.123"})#x]
++- OneRowRelation
+
+
+-- !query
+select from_json('{"time": "14:30:45.123456"}', 'time TIME(6)')
+-- !query analysis
+Project [from_json(StructField(time,TimeType(6),true), {"time": "14:30:45.123456"}, Some(America/Los_Angeles), false) AS from_json({"time": "14:30:45.123456"})#x]
++- OneRowRelation
+
+
+-- !query
+select from_json('{"time": "14-30-45.123456"}', 'time TIME(6)', map('timeFormat', 'HH-mm-ss.SSSSSS'))
+-- !query analysis
+Project [from_json(StructField(time,TimeType(6),true), (timeFormat,HH-mm-ss.SSSSSS), {"time": "14-30-45.123456"}, Some(America/Los_Angeles), false) AS from_json({"time": "14-30-45.123456"})#x]
++- OneRowRelation
+
+
+-- !query
+select from_json('{"t1": "09:00:00", "t2": "17:30:00"}', 't1 TIME, t2 TIME')
+-- !query analysis
+Project [from_json(StructField(t1,TimeType(6),true), StructField(t2,TimeType(6),true), {"t1": "09:00:00", "t2": "17:30:00"}, Some(America/Los_Angeles), false) AS from_json({"t1": "09:00:00", "t2": "17:30:00"})#x]
++- OneRowRelation
+
+
+-- !query
+select from_json('{"time": "25:00:00"}', 'time TIME')
+-- !query analysis
+Project [from_json(StructField(time,TimeType(6),true), {"time": "25:00:00"}, Some(America/Los_Angeles), false) AS from_json({"time": "25:00:00"})#x]
++- OneRowRelation
+
+
+-- !query
+select from_json('{"time": "invalid"}', 'time TIME')
+-- !query analysis
+Project [from_json(StructField(time,TimeType(6),true), {"time": "invalid"}, Some(America/Los_Angeles), false) AS from_json({"time": "invalid"})#x]
++- OneRowRelation
+
+
+-- !query
+select from_json('{"time": null}', 'time TIME')
+-- !query analysis
+Project [from_json(StructField(time,TimeType(6),true), {"time": null}, Some(America/Los_Angeles), false) AS from_json({"time": null})#x]
++- OneRowRelation
+
+
+-- !query
+select to_json(named_struct('time', TIME'14:30:45'))
+-- !query analysis
+Project [to_json(named_struct(time, 14:30:45), Some(America/Los_Angeles)) AS to_json(named_struct(time, TIME '14:30:45'))#x]
++- OneRowRelation
+
+
+-- !query
+select to_json(named_struct('time', TIME'14:30:45.123456'))
+-- !query analysis
+Project [to_json(named_struct(time, 14:30:45.123456), Some(America/Los_Angeles)) AS to_json(named_struct(time, TIME '14:30:45.123456'))#x]
++- OneRowRelation
+
+
+-- !query
+select to_json(named_struct('time', TIME'14:30:45.123456'), map('timeFormat', 'HH-mm-ss.SSSSSS'))
+-- !query analysis
+Project [to_json((timeFormat,HH-mm-ss.SSSSSS), named_struct(time, 14:30:45.123456), Some(America/Los_Angeles)) AS to_json(named_struct(time, TIME '14:30:45.123456'))#x]
++- OneRowRelation
+
+
+-- !query
+select to_json(array(TIME'09:00:00', TIME'17:45:30'))
+-- !query analysis
+Project [to_json(array(09:00:00, 17:45:30), Some(America/Los_Angeles)) AS to_json(array(TIME '09:00:00', TIME '17:45:30'))#x]
++- OneRowRelation
+
+
+-- !query
+select from_json(to_json(named_struct('time', TIME'14:30:45')), 'time TIME(0)')
+-- !query analysis
+Project [from_json(StructField(time,TimeType(0),true), to_json(named_struct(time, 14:30:45), Some(America/Los_Angeles)), Some(America/Los_Angeles), false) AS from_json(to_json(named_struct(time, TIME '14:30:45')))#x]
++- OneRowRelation
+
+
+-- !query
+select from_json(to_json(named_struct('time', TIME'14:30:45.1')), 'time TIME(1)')
+-- !query analysis
+Project [from_json(StructField(time,TimeType(1),true), to_json(named_struct(time, 14:30:45.1), Some(America/Los_Angeles)), Some(America/Los_Angeles), false) AS from_json(to_json(named_struct(time, TIME '14:30:45.1')))#x]
++- OneRowRelation
+
+
+-- !query
+select from_json(to_json(named_struct('time', TIME'14:30:45.12')), 'time TIME(2)')
+-- !query analysis
+Project [from_json(StructField(time,TimeType(2),true), to_json(named_struct(time, 14:30:45.12), Some(America/Los_Angeles)), Some(America/Los_Angeles), false) AS from_json(to_json(named_struct(time, TIME '14:30:45.12')))#x]
++- OneRowRelation
+
+
+-- !query
+select from_json(to_json(named_struct('time', TIME'14:30:45.123')), 'time TIME(3)')
+-- !query analysis
+Project [from_json(StructField(time,TimeType(3),true), to_json(named_struct(time, 14:30:45.123), Some(America/Los_Angeles)), Some(America/Los_Angeles), false) AS from_json(to_json(named_struct(time, TIME '14:30:45.123')))#x]
++- OneRowRelation
+
+
+-- !query
+select from_json(to_json(named_struct('time', TIME'14:30:45.1234')), 'time TIME(4)')
+-- !query analysis
+Project [from_json(StructField(time,TimeType(4),true), to_json(named_struct(time, 14:30:45.1234), Some(America/Los_Angeles)), Some(America/Los_Angeles), false) AS from_json(to_json(named_struct(time, TIME '14:30:45.1234')))#x]
++- OneRowRelation
+
+
+-- !query
+select from_json(to_json(named_struct('time', TIME'14:30:45.12345')), 'time TIME(5)')
+-- !query analysis
+Project [from_json(StructField(time,TimeType(5),true), to_json(named_struct(time, 14:30:45.12345), Some(America/Los_Angeles)), Some(America/Los_Angeles), false) AS from_json(to_json(named_struct(time, TIME '14:30:45.12345')))#x]
++- OneRowRelation
+
+
+-- !query
+select from_json(to_json(named_struct('time', TIME'14:30:45.123456')), 'time TIME(6)')
+-- !query analysis
+Project [from_json(StructField(time,TimeType(6),true), to_json(named_struct(time, 14:30:45.123456), Some(America/Los_Angeles)), Some(America/Los_Angeles), false) AS from_json(to_json(named_struct(time, TIME '14:30:45.123456')))#x]
++- OneRowRelation
+
+
+-- !query
+select from_json(to_json(named_struct('time', TIME'00:00:00')), 'time TIME(0)')
+-- !query analysis
+Project [from_json(StructField(time,TimeType(0),true), to_json(named_struct(time, 00:00:00), Some(America/Los_Angeles)), Some(America/Los_Angeles), false) AS from_json(to_json(named_struct(time, TIME '00:00:00')))#x]
++- OneRowRelation
+
+
+-- !query
+select from_json(to_json(named_struct('time', TIME'23:59:59.999999')), 'time TIME(6)')
+-- !query analysis
+Project [from_json(StructField(time,TimeType(6),true), to_json(named_struct(time, 23:59:59.999999), Some(America/Los_Angeles)), Some(America/Los_Angeles), false) AS from_json(to_json(named_struct(time, TIME '23:59:59.999999')))#x]
++- OneRowRelation
+
+
+-- !query
+select to_json(from_json('{"time":"14:30:45"}', 'time TIME(0)'))
+-- !query analysis
+Project [to_json(from_json(StructField(time,TimeType(0),true), {"time":"14:30:45"}, Some(America/Los_Angeles), false), Some(America/Los_Angeles)) AS to_json(from_json({"time":"14:30:45"}))#x]
++- OneRowRelation
+
+
+-- !query
+select to_json(from_json('{"time":"14:30:45.1"}', 'time TIME(1)'))
+-- !query analysis
+Project [to_json(from_json(StructField(time,TimeType(1),true), {"time":"14:30:45.1"}, Some(America/Los_Angeles), false), Some(America/Los_Angeles)) AS to_json(from_json({"time":"14:30:45.1"}))#x]
++- OneRowRelation
+
+
+-- !query
+select to_json(from_json('{"time":"14:30:45.12"}', 'time TIME(2)'))
+-- !query analysis
+Project [to_json(from_json(StructField(time,TimeType(2),true), {"time":"14:30:45.12"}, Some(America/Los_Angeles), false), Some(America/Los_Angeles)) AS to_json(from_json({"time":"14:30:45.12"}))#x]
++- OneRowRelation
+
+
+-- !query
+select to_json(from_json('{"time":"14:30:45.123"}', 'time TIME(3)'))
+-- !query analysis
+Project [to_json(from_json(StructField(time,TimeType(3),true), {"time":"14:30:45.123"}, Some(America/Los_Angeles), false), Some(America/Los_Angeles)) AS to_json(from_json({"time":"14:30:45.123"}))#x]
++- OneRowRelation
+
+
+-- !query
+select to_json(from_json('{"time":"14:30:45.1234"}', 'time TIME(4)'))
+-- !query analysis
+Project [to_json(from_json(StructField(time,TimeType(4),true), {"time":"14:30:45.1234"}, Some(America/Los_Angeles), false), Some(America/Los_Angeles)) AS to_json(from_json({"time":"14:30:45.1234"}))#x]
++- OneRowRelation
+
+
+-- !query
+select to_json(from_json('{"time":"14:30:45.12345"}', 'time TIME(5)'))
+-- !query analysis
+Project [to_json(from_json(StructField(time,TimeType(5),true), {"time":"14:30:45.12345"}, Some(America/Los_Angeles), false), Some(America/Los_Angeles)) AS to_json(from_json({"time":"14:30:45.12345"}))#x]
++- OneRowRelation
+
+
+-- !query
+select to_json(from_json('{"time":"14:30:45.123456"}', 'time TIME(6)'))
+-- !query analysis
+Project [to_json(from_json(StructField(time,TimeType(6),true), {"time":"14:30:45.123456"}, Some(America/Los_Angeles), false), Some(America/Los_Angeles)) AS to_json(from_json({"time":"14:30:45.123456"}))#x]
++- OneRowRelation
+
+
+-- !query
+select to_json(from_json('{"time":"00:00:00"}', 'time TIME(0)'))
+-- !query analysis
+Project [to_json(from_json(StructField(time,TimeType(0),true), {"time":"00:00:00"}, Some(America/Los_Angeles), false), Some(America/Los_Angeles)) AS to_json(from_json({"time":"00:00:00"}))#x]
++- OneRowRelation
+
+
+-- !query
+select to_json(from_json('{"time":"23:59:59.999999"}', 'time TIME(6)'))
+-- !query analysis
+Project [to_json(from_json(StructField(time,TimeType(6),true), {"time":"23:59:59.999999"}, Some(America/Los_Angeles), false), Some(America/Los_Angeles)) AS to_json(from_json({"time":"23:59:59.999999"}))#x]
++- OneRowRelation
+
+
+-- !query
+select schema_of_json('{"time": "14:30:45"}')
+-- !query analysis
+Project [schema_of_json({"time": "14:30:45"}) AS schema_of_json({"time": "14:30:45"})#x]
++- OneRowRelation
+
+
+-- !query
+select schema_of_json('{"time": "14:30:45.123456"}')
+-- !query analysis
+Project [schema_of_json({"time": "14:30:45.123456"}) AS schema_of_json({"time": "14:30:45.123456"})#x]
++- OneRowRelation
+
+
+-- !query
+select from_json('{"time": "14:30:45"}', 'time TIME') LIMIT 1
+-- !query analysis
+GlobalLimit 1
++- LocalLimit 1
+   +- Project [from_json(StructField(time,TimeType(6),true), {"time": "14:30:45"}, Some(America/Los_Angeles), false) AS from_json({"time": "14:30:45"})#x]
+      +- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/inputs/json-functions.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/json-functions.sql
@@ -109,3 +109,45 @@ select json_object_keys('[1, 2, 3]');
 
 -- Clean up
 DROP VIEW IF EXISTS jsonTable;
+
+-- TIME type tests
+-- from_json with TIME type
+select from_json('{"time": "14:30:45"}', 'time TIME(0)');
+select from_json('{"time": "14:30:45.123"}', 'time TIME(3)');
+select from_json('{"time": "14:30:45.123456"}', 'time TIME(6)');
+select from_json('{"time": "14-30-45.123456"}', 'time TIME(6)', map('timeFormat', 'HH-mm-ss.SSSSSS'));
+select from_json('{"t1": "09:00:00", "t2": "17:30:00"}', 't1 TIME, t2 TIME');
+select from_json('{"time": "25:00:00"}', 'time TIME');
+select from_json('{"time": "invalid"}', 'time TIME');
+select from_json('{"time": null}', 'time TIME');
+
+-- to_json with TIME type
+select to_json(named_struct('time', TIME'14:30:45'));
+select to_json(named_struct('time', TIME'14:30:45.123456'));
+select to_json(named_struct('time', TIME'14:30:45.123456'), map('timeFormat', 'HH-mm-ss.SSSSSS'));
+select to_json(array(TIME'09:00:00', TIME'17:45:30'));
+
+-- TIME type roundtrip tests
+select from_json(to_json(named_struct('time', TIME'14:30:45')), 'time TIME(0)');
+select from_json(to_json(named_struct('time', TIME'14:30:45.1')), 'time TIME(1)');
+select from_json(to_json(named_struct('time', TIME'14:30:45.12')), 'time TIME(2)');
+select from_json(to_json(named_struct('time', TIME'14:30:45.123')), 'time TIME(3)');
+select from_json(to_json(named_struct('time', TIME'14:30:45.1234')), 'time TIME(4)');
+select from_json(to_json(named_struct('time', TIME'14:30:45.12345')), 'time TIME(5)');
+select from_json(to_json(named_struct('time', TIME'14:30:45.123456')), 'time TIME(6)');
+select from_json(to_json(named_struct('time', TIME'00:00:00')), 'time TIME(0)');
+select from_json(to_json(named_struct('time', TIME'23:59:59.999999')), 'time TIME(6)');
+select to_json(from_json('{"time":"14:30:45"}', 'time TIME(0)'));
+select to_json(from_json('{"time":"14:30:45.1"}', 'time TIME(1)'));
+select to_json(from_json('{"time":"14:30:45.12"}', 'time TIME(2)'));
+select to_json(from_json('{"time":"14:30:45.123"}', 'time TIME(3)'));
+select to_json(from_json('{"time":"14:30:45.1234"}', 'time TIME(4)'));
+select to_json(from_json('{"time":"14:30:45.12345"}', 'time TIME(5)'));
+select to_json(from_json('{"time":"14:30:45.123456"}', 'time TIME(6)'));
+select to_json(from_json('{"time":"00:00:00"}', 'time TIME(0)'));
+select to_json(from_json('{"time":"23:59:59.999999"}', 'time TIME(6)'));
+
+-- TIME type schema inference and other tests
+select schema_of_json('{"time": "14:30:45"}');
+select schema_of_json('{"time": "14:30:45.123456"}');
+select from_json('{"time": "14:30:45"}', 'time TIME') LIMIT 1;

--- a/sql/core/src/test/resources/sql-tests/results/json-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/json-functions.sql.out
@@ -805,3 +805,267 @@ DROP VIEW IF EXISTS jsonTable
 struct<>
 -- !query output
 
+
+
+-- !query
+select from_json('{"time": "14:30:45"}', 'time TIME(0)')
+-- !query schema
+struct<from_json({"time": "14:30:45"}):struct<time:time(0)>>
+-- !query output
+{"time":14:30:45}
+
+
+-- !query
+select from_json('{"time": "14:30:45.123"}', 'time TIME(3)')
+-- !query schema
+struct<from_json({"time": "14:30:45.123"}):struct<time:time(3)>>
+-- !query output
+{"time":14:30:45.123}
+
+
+-- !query
+select from_json('{"time": "14:30:45.123456"}', 'time TIME(6)')
+-- !query schema
+struct<from_json({"time": "14:30:45.123456"}):struct<time:time(6)>>
+-- !query output
+{"time":14:30:45.123456}
+
+
+-- !query
+select from_json('{"time": "14-30-45.123456"}', 'time TIME(6)', map('timeFormat', 'HH-mm-ss.SSSSSS'))
+-- !query schema
+struct<from_json({"time": "14-30-45.123456"}):struct<time:time(6)>>
+-- !query output
+{"time":14:30:45.123456}
+
+
+-- !query
+select from_json('{"t1": "09:00:00", "t2": "17:30:00"}', 't1 TIME, t2 TIME')
+-- !query schema
+struct<from_json({"t1": "09:00:00", "t2": "17:30:00"}):struct<t1:time(6),t2:time(6)>>
+-- !query output
+{"t1":09:00:00,"t2":17:30:00}
+
+
+-- !query
+select from_json('{"time": "25:00:00"}', 'time TIME')
+-- !query schema
+struct<from_json({"time": "25:00:00"}):struct<time:time(6)>>
+-- !query output
+{"time":null}
+
+
+-- !query
+select from_json('{"time": "invalid"}', 'time TIME')
+-- !query schema
+struct<from_json({"time": "invalid"}):struct<time:time(6)>>
+-- !query output
+{"time":null}
+
+
+-- !query
+select from_json('{"time": null}', 'time TIME')
+-- !query schema
+struct<from_json({"time": null}):struct<time:time(6)>>
+-- !query output
+{"time":null}
+
+
+-- !query
+select to_json(named_struct('time', TIME'14:30:45'))
+-- !query schema
+struct<to_json(named_struct(time, TIME '14:30:45')):string>
+-- !query output
+{"time":"14:30:45"}
+
+
+-- !query
+select to_json(named_struct('time', TIME'14:30:45.123456'))
+-- !query schema
+struct<to_json(named_struct(time, TIME '14:30:45.123456')):string>
+-- !query output
+{"time":"14:30:45.123456"}
+
+
+-- !query
+select to_json(named_struct('time', TIME'14:30:45.123456'), map('timeFormat', 'HH-mm-ss.SSSSSS'))
+-- !query schema
+struct<to_json(named_struct(time, TIME '14:30:45.123456')):string>
+-- !query output
+{"time":"14-30-45.123456"}
+
+
+-- !query
+select to_json(array(TIME'09:00:00', TIME'17:45:30'))
+-- !query schema
+struct<to_json(array(TIME '09:00:00', TIME '17:45:30')):string>
+-- !query output
+["09:00:00","17:45:30"]
+
+
+-- !query
+select from_json(to_json(named_struct('time', TIME'14:30:45')), 'time TIME(0)')
+-- !query schema
+struct<from_json(to_json(named_struct(time, TIME '14:30:45'))):struct<time:time(0)>>
+-- !query output
+{"time":14:30:45}
+
+
+-- !query
+select from_json(to_json(named_struct('time', TIME'14:30:45.1')), 'time TIME(1)')
+-- !query schema
+struct<from_json(to_json(named_struct(time, TIME '14:30:45.1'))):struct<time:time(1)>>
+-- !query output
+{"time":14:30:45.1}
+
+
+-- !query
+select from_json(to_json(named_struct('time', TIME'14:30:45.12')), 'time TIME(2)')
+-- !query schema
+struct<from_json(to_json(named_struct(time, TIME '14:30:45.12'))):struct<time:time(2)>>
+-- !query output
+{"time":14:30:45.12}
+
+
+-- !query
+select from_json(to_json(named_struct('time', TIME'14:30:45.123')), 'time TIME(3)')
+-- !query schema
+struct<from_json(to_json(named_struct(time, TIME '14:30:45.123'))):struct<time:time(3)>>
+-- !query output
+{"time":14:30:45.123}
+
+
+-- !query
+select from_json(to_json(named_struct('time', TIME'14:30:45.1234')), 'time TIME(4)')
+-- !query schema
+struct<from_json(to_json(named_struct(time, TIME '14:30:45.1234'))):struct<time:time(4)>>
+-- !query output
+{"time":14:30:45.1234}
+
+
+-- !query
+select from_json(to_json(named_struct('time', TIME'14:30:45.12345')), 'time TIME(5)')
+-- !query schema
+struct<from_json(to_json(named_struct(time, TIME '14:30:45.12345'))):struct<time:time(5)>>
+-- !query output
+{"time":14:30:45.12345}
+
+
+-- !query
+select from_json(to_json(named_struct('time', TIME'14:30:45.123456')), 'time TIME(6)')
+-- !query schema
+struct<from_json(to_json(named_struct(time, TIME '14:30:45.123456'))):struct<time:time(6)>>
+-- !query output
+{"time":14:30:45.123456}
+
+
+-- !query
+select from_json(to_json(named_struct('time', TIME'00:00:00')), 'time TIME(0)')
+-- !query schema
+struct<from_json(to_json(named_struct(time, TIME '00:00:00'))):struct<time:time(0)>>
+-- !query output
+{"time":00:00:00}
+
+
+-- !query
+select from_json(to_json(named_struct('time', TIME'23:59:59.999999')), 'time TIME(6)')
+-- !query schema
+struct<from_json(to_json(named_struct(time, TIME '23:59:59.999999'))):struct<time:time(6)>>
+-- !query output
+{"time":23:59:59.999999}
+
+
+-- !query
+select to_json(from_json('{"time":"14:30:45"}', 'time TIME(0)'))
+-- !query schema
+struct<to_json(from_json({"time":"14:30:45"})):string>
+-- !query output
+{"time":"14:30:45"}
+
+
+-- !query
+select to_json(from_json('{"time":"14:30:45.1"}', 'time TIME(1)'))
+-- !query schema
+struct<to_json(from_json({"time":"14:30:45.1"})):string>
+-- !query output
+{"time":"14:30:45.1"}
+
+
+-- !query
+select to_json(from_json('{"time":"14:30:45.12"}', 'time TIME(2)'))
+-- !query schema
+struct<to_json(from_json({"time":"14:30:45.12"})):string>
+-- !query output
+{"time":"14:30:45.12"}
+
+
+-- !query
+select to_json(from_json('{"time":"14:30:45.123"}', 'time TIME(3)'))
+-- !query schema
+struct<to_json(from_json({"time":"14:30:45.123"})):string>
+-- !query output
+{"time":"14:30:45.123"}
+
+
+-- !query
+select to_json(from_json('{"time":"14:30:45.1234"}', 'time TIME(4)'))
+-- !query schema
+struct<to_json(from_json({"time":"14:30:45.1234"})):string>
+-- !query output
+{"time":"14:30:45.1234"}
+
+
+-- !query
+select to_json(from_json('{"time":"14:30:45.12345"}', 'time TIME(5)'))
+-- !query schema
+struct<to_json(from_json({"time":"14:30:45.12345"})):string>
+-- !query output
+{"time":"14:30:45.12345"}
+
+
+-- !query
+select to_json(from_json('{"time":"14:30:45.123456"}', 'time TIME(6)'))
+-- !query schema
+struct<to_json(from_json({"time":"14:30:45.123456"})):string>
+-- !query output
+{"time":"14:30:45.123456"}
+
+
+-- !query
+select to_json(from_json('{"time":"00:00:00"}', 'time TIME(0)'))
+-- !query schema
+struct<to_json(from_json({"time":"00:00:00"})):string>
+-- !query output
+{"time":"00:00:00"}
+
+
+-- !query
+select to_json(from_json('{"time":"23:59:59.999999"}', 'time TIME(6)'))
+-- !query schema
+struct<to_json(from_json({"time":"23:59:59.999999"})):string>
+-- !query output
+{"time":"23:59:59.999999"}
+
+
+-- !query
+select schema_of_json('{"time": "14:30:45"}')
+-- !query schema
+struct<schema_of_json({"time": "14:30:45"}):string>
+-- !query output
+STRUCT<time: STRING>
+
+
+-- !query
+select schema_of_json('{"time": "14:30:45.123456"}')
+-- !query schema
+struct<schema_of_json({"time": "14:30:45.123456"}):string>
+-- !query output
+STRUCT<time: STRING>
+
+
+-- !query
+select from_json('{"time": "14:30:45"}', 'time TIME') LIMIT 1
+-- !query schema
+struct<from_json({"time": "14:30:45"}):struct<time:time(6)>>
+-- !query output
+{"time":14:30:45}

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
@@ -1247,7 +1247,7 @@ class FileBasedDataSourceSuite extends QueryTest
   }
 
   test("SPARK-51590: unsupported the TIME data types in data sources") {
-    val datasources = Seq("orc", "xml", "csv", "json", "text")
+    val datasources = Seq("orc", "xml", "csv", "text")
     Seq(true, false).foreach { useV1 =>
       val useV1List = if (useV1) {
         datasources.mkString(",")

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -1479,4 +1479,86 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
       checkAnswer(df4, Row("1", "2", "3"))
     }
   }
+
+  test("from_json/to_json with TIME type - all precisions") {
+    import java.time.LocalTime
+    // Test data: (precision, LocalTime, expected JSON string)
+    val testData = Seq(
+      (0, LocalTime.of(14, 30, 45), "14:30:45"),
+      (1, LocalTime.of(14, 30, 45, 100000000), "14:30:45.1"),
+      (2, LocalTime.of(14, 30, 45, 120000000), "14:30:45.12"),
+      (3, LocalTime.of(14, 30, 45, 123000000), "14:30:45.123"),
+      (4, LocalTime.of(14, 30, 45, 123400000), "14:30:45.1234"),
+      (5, LocalTime.of(14, 30, 45, 123450000), "14:30:45.12345"),
+      (6, LocalTime.of(14, 30, 45, 123456000), "14:30:45.123456")
+    )
+
+    testData.foreach { case (precision, time, timeStr) =>
+      val schema = new StructType().add("time", TimeType(precision))
+
+      // Test from_json
+      val parseResult = Seq(s"""{"time": "$timeStr"}""").toDS()
+        .select(from_json($"value", schema)).collect().head.getAs[Row](0).getAs[LocalTime](0)
+      assert(parseResult == time, s"from_json failed for precision $precision")
+
+      // Test to_json
+      val jsonResult = Seq(time).toDF("time")
+        .select(to_json(struct($"time"))).collect().head.getString(0)
+      assert(jsonResult == s"""{"time":"$timeStr"}""", s"to_json failed for precision $precision")
+
+      // Test roundtrip
+      val roundtrip = Seq(time).toDF("time")
+        .select(to_json(struct($"time")).as("json"))
+        .select(from_json($"json", schema).as("struct"))
+        .select($"struct.time").collect().head.getAs[LocalTime](0)
+      assert(roundtrip == time, s"Roundtrip failed for precision $precision")
+    }
+
+    // Test custom format
+    val schema = new StructType().add("time", TimeType(6))
+    val customTime = LocalTime.of(14, 30, 45, 123456000)
+    val customFormat = Map("timeFormat" -> "HH-mm-ss.SSSSSS")
+
+    checkAnswer(
+      Seq("""{"time": "14-30-45.123456"}""").toDS()
+        .select(from_json($"value", schema, customFormat).as("data"))
+        .select($"data.time"),
+      Row(customTime) :: Nil)
+
+    checkAnswer(
+      Seq(customTime).toDF("time").select(to_json(struct($"time"), customFormat)),
+      Row("""{"time":"14-30-45.123456"}""") :: Nil)
+  }
+
+  test("TIME type with arrays and nulls") {
+    import java.time.LocalTime
+
+    // Test array support
+    val times = Seq(LocalTime.of(9, 0, 0), LocalTime.of(17, 45, 30))
+    val schema = new StructType().add("times", ArrayType(TimeType()))
+    val jsonStr = """{"times":["09:00:00","17:45:30"]}"""
+
+    // to_json
+    checkAnswer(
+      Seq(times).toDF("times").select(to_json(struct($"times"))),
+      Row(jsonStr) :: Nil)
+
+    // from_json
+    val parsed = Seq(jsonStr).toDS()
+      .select(from_json($"value", schema).as("data"))
+      .select($"data.times").collect().head.getSeq[LocalTime](0)
+    assert(parsed == times)
+
+    // Test null handling
+    checkAnswer(
+      Seq("""{"time": null}""").toDS()
+        .select(from_json($"value", new StructType().add("time", TimeType())).as("data"))
+        .select($"data.time"),
+      Row(null) :: Nil)
+
+    // Verify schema inference treats TIME strings as STRING (like TIMESTAMP)
+    val inferredSchema = spark.sql("SELECT schema_of_json('{\"time\": \"14:30:45\"}')")
+      .collect().head.getString(0)
+    assert(inferredSchema.contains("STRING"))
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds JSON serialization and deserialization support for Spark's TIME type

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
TIME type currently lacks JSON support, preventing users from:

- Reading/writing JSON files with TIME columns
- Using from_json() and to_json() functions with TIME type
- Integrating TIME data with  external systems

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. 
Users can now:
1) Read JSON with TIME: `spark.read.schema("time TIME").json("data.json")`
2) Write JSON with TIME: `df.write.json("output.json")  // {"time":"14:30:45.123456"}`
3) Use from_json/to_json: 
```
SELECT from_json('{"time": "14:30:45.123456"}', 'time TIME(6)');
SELECT to_json(named_struct('time', TIME'14:30:45'));
```
4) Custom format: `spark.read.option("timeFormat", "HH-mm-ss.SSSSSS").json("data.json")`
New option: `timeFormat` - controls TIME formatting/parsing (default: HH:mm:ss with fractional seconds)

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added new testscase in JsonExpressionsSuite , JsonFunctionsSuite, SQL tests , and JsonSuite

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes. 
Generated-by:  Claude 3.5 Sonnet

 AI assistance was used for:
- Code pattern analysis and design discussions
- Implementation guidance following Spark conventions  
- Test case generation and organization
- Documentation and examples
