### PR TITLE
[SPARK-54455][CORE][TESTS] Disable a flaky `unmanaged memory tracking with off-heap memory enabled` test in MacOS CI

### DIFF
--- a/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/memory/UnifiedMemoryManagerSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.Tests._
 import org.apache.spark.storage.TestBlockId
 import org.apache.spark.storage.memory.MemoryStore
+import org.apache.spark.util.Utils
 
 class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTester {
   private val dummyBlock = TestBlockId("--")
@@ -554,6 +555,7 @@ class UnifiedMemoryManagerSuite extends MemoryManagerSuite with PrivateMethodTes
   }
 
   test("unmanaged memory tracking with off-heap memory enabled") {
+    assume(!Utils.isMacOnAppleSilicon)
     val maxOnHeapMemory = 1000L
     val maxOffHeapMemory = 1500L
     val taskAttemptId = 0L


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to disable a flaky `unmanaged memory tracking with off-heap memory enabled` test in MacOS CI

### Why are the changes needed?

This test suite passed locally, but has been flaky in MacOS GitHub Action environment.

- https://github.com/apache/spark/actions/runs/19442963476/job/55985972662
```
- unmanaged memory tracking with off-heap memory enabled *** FAILED ***
  1400 was not less than or equal to 1200 Off-heap memory should be reduced by unmanaged usage (UnifiedMemoryManagerSuite.scala:592)
```

- https://github.com/apache/spark/actions/runs/19582140886/job/56082446144
```
- unmanaged memory tracking with off-heap memory enabled *** FAILED ***
  mm.acquireStorageMemory(UnifiedMemoryManagerSuite.this.dummyBlock, 1100L, OFF_HEAP) was true (UnifiedMemoryManagerSuite.scala:600)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.