### PR TITLE
[SPARK-54459][SQL][TESTS] Increase `StateStoreSuite.maintenance` test timeout to 2 minutes

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -952,7 +952,7 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
       }
     }
 
-    val timeoutDuration = 1.minute
+    val timeoutDuration = 2.minutes
 
     quietly {
       withSpark(SparkContext.getOrCreate(conf)) { sc =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to increase `StateStoreSuite.maintenance` test timeout to 2 minutes for two test suites.

- `StateStoreSuite`
- `StateStoreSuiteWithRowChecksum`

### Why are the changes needed?

To reduce the flakiness.

https://github.com/apache/spark/actions/runs/19514807897/job/56065943462
```
- maintenance *** FAILED ***
  The code passed to eventually never returned normally. Attempted 833 times over 1.0000272319333332 minutes. Last failure message: StateStore.isLoaded(storeProviderId2) was true. (StateStoreSuite.scala:1032)
```

https://github.com/apache/spark/actions/runs/19588308656/job/56101679879
```
- maintenance *** FAILED ***
  The code passed to eventually never returned normally. Attempted 851 times over 1.0017263236166667 minutes. Last failure message: StateStore.isLoaded(storeProviderId2) was true. (StateStoreSuite.scala:1032)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.