### PR TITLE
[SPARK-54460][SQL][TESTS] Mark `StateStoreInstanceMetricSuite` as `ExtendedSQLTest`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreInstanceMetricSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreInstanceMetricSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.functions.expr
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming._
+import org.apache.spark.tags.ExtendedSQLTest
 
 // RocksDBSkipMaintenanceOnCertainPartitionsProvider is a test-only provider that skips running
 // maintenance for partitions 0 and 1 (these are arbitrary choices). This is used to test
@@ -49,6 +50,7 @@ class HDFSBackedSkipMaintenanceOnCertainPartitionsProvider extends HDFSBackedSta
   }
 }
 
+@ExtendedSQLTest
 class StateStoreInstanceMetricSuite extends StreamTest with AlsoTestWithRocksDBFeatures {
   import testImplicits._
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to mark `StateStoreInstanceMetricSuite` as `ExtendedSQLTest`.

### Why are the changes needed?

To balance the SQL test pipelines by moving the heavy test from `other tests` to `extended tests` pipelines.

<img width="624" height="121" alt="Screenshot 2025-11-21 at 22 03 00" src="https://github.com/user-attachments/assets/275c746e-2886-4f07-8c17-9bbc75f87954" />

`StateStoreInstanceMetricSuite` is a good candidate because it took 9 minutes in the GitHub Action environment and local environment.
- https://github.com/apache/spark/actions/runs/19588299018/job/56101678778

```
$ build/sbt "sql/testOnly *.StateStoreInstanceMetricSuite"
...
[info] Run completed in 9 minutes, 14 seconds.
[info] Total number of tests run: 11
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 11, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 586 s (0:09:46.0), completed Nov 21, 2025, 10:11:46 PM
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.