### PR TITLE
[SPARK-54461][SQL] Add XML serialization and deserialization support for TIME type

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlGenerator.scala
@@ -28,7 +28,7 @@ import org.apache.hadoop.shaded.com.ctc.wstx.api.WstxOutputProperties
 import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.ToStringBase
-import org.apache.spark.sql.catalyst.util.{ArrayData, DateFormatter, DateTimeUtils, MapData, TimestampFormatter}
+import org.apache.spark.sql.catalyst.util.{ArrayData, DateFormatter, DateTimeUtils, MapData, TimeFormatter, TimestampFormatter}
 import org.apache.spark.sql.catalyst.util.LegacyDateFormats.FAST_DATE_FORMAT
 import org.apache.spark.sql.types._
 import org.apache.spark.types.variant.VariantUtil
@@ -63,6 +63,11 @@ class StaxXmlGenerator(
     options.locale,
     legacyFormat = FAST_DATE_FORMAT,
     isParsing = false)
+
+  private val timeFormatter = options.timeFormatInWrite match {
+    case TimeFormatter.defaultPattern => TimeFormatter.getFractionFormatter()
+    case customPattern => TimeFormatter(customPattern, isParsing = false)
+  }
 
   private val binaryFormatter = ToStringBase.getBinaryFormatter
 
@@ -191,6 +196,7 @@ class StaxXmlGenerator(
       gen.writeCharacters(timestampNTZFormatter.format(DateTimeUtils.microsToLocalDateTime(v)))
     case (DateType, v: Int) =>
       gen.writeCharacters(dateFormatter.format(v))
+    case (_: TimeType, v: Long) => gen.writeCharacters(timeFormatter.format(v))
     case (IntegerType, v: Int) => gen.writeCharacters(v.toString)
     case (ShortType, v: Short) => gen.writeCharacters(v.toString)
     case (FloatType, v: Float) => gen.writeCharacters(v.toString)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlOptions.scala
@@ -23,7 +23,7 @@ import javax.xml.stream.XMLInputFactory
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.{DataSourceOptions, FileSourceOptions}
-import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, CompressionCodecs, DateFormatter, DateTimeUtils, ParseMode, PermissiveMode}
+import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, CompressionCodecs, DateFormatter, DateTimeUtils, ParseMode, PermissiveMode, TimeFormatter}
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 
@@ -152,6 +152,9 @@ class XmlOptions(
   val timestampNTZFormatInWrite: String =
     parameters.getOrElse(TIMESTAMP_NTZ_FORMAT, s"${DateFormatter.defaultPattern}'T'HH:mm:ss[.SSS]")
 
+  val timeFormatInRead: Option[String] = parameters.get(TIME_FORMAT)
+  val timeFormatInWrite: String = parameters.getOrElse(TIME_FORMAT, TimeFormatter.defaultPattern)
+
   val timezone = parameters.get("timezone")
 
   val zoneId: ZoneId = DateTimeUtils.getZoneId(
@@ -215,6 +218,7 @@ object XmlOptions extends DataSourceOptions {
   val DATE_FORMAT = newOption("dateFormat")
   val TIMESTAMP_FORMAT = newOption("timestampFormat")
   val TIMESTAMP_NTZ_FORMAT = newOption("timestampNTZFormat")
+  val TIME_FORMAT = newOption("timeFormat")
   val TIME_ZONE = newOption("timeZone")
   val INDENT = newOption("indent")
   val PREFERS_DECIMAL = newOption("prefersDecimal")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XmlFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XmlFileFormat.scala
@@ -131,8 +131,6 @@ case class XmlFileFormat() extends TextBasedFileFormat with DataSourceRegister {
 
   override def supportDataType(dataType: DataType): Boolean = dataType match {
     case _: VariantType => true
-
-    case _: TimeType => false
     case _: AtomicType => true
 
     case st: StructType => st.forall { f => supportDataType(f.dataType) }

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/xml-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/xml-functions.sql.out
@@ -415,3 +415,173 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 DROP VIEW IF EXISTS xmlTable
 -- !query analysis
 DropTempViewCommand xmlTable
+
+
+-- !query
+select from_xml('<record><time>14:30:45</time></record>', 'time TIME(0)', map('rowTag', 'record'))
+-- !query analysis
+Project [from_xml(StructField(time,TimeType(0),true), (rowTag,record), <record><time>14:30:45</time></record>, Some(America/Los_Angeles)) AS from_xml(<record><time>14:30:45</time></record>)#x]
++- OneRowRelation
+
+
+-- !query
+select from_xml('<record><time>14:30:45.123</time></record>', 'time TIME(3)', map('rowTag', 'record'))
+-- !query analysis
+Project [from_xml(StructField(time,TimeType(3),true), (rowTag,record), <record><time>14:30:45.123</time></record>, Some(America/Los_Angeles)) AS from_xml(<record><time>14:30:45.123</time></record>)#x]
++- OneRowRelation
+
+
+-- !query
+select from_xml('<record><time>14:30:45.123456</time></record>', 'time TIME(6)', map('rowTag', 'record'))
+-- !query analysis
+Project [from_xml(StructField(time,TimeType(6),true), (rowTag,record), <record><time>14:30:45.123456</time></record>, Some(America/Los_Angeles)) AS from_xml(<record><time>14:30:45.123456</time></record>)#x]
++- OneRowRelation
+
+
+-- !query
+select from_xml('<record><time>14-30-45.123456</time></record>', 'time TIME(6)', map('rowTag', 'record', 'timeFormat', 'HH-mm-ss.SSSSSS'))
+-- !query analysis
+Project [from_xml(StructField(time,TimeType(6),true), (rowTag,record), (timeFormat,HH-mm-ss.SSSSSS), <record><time>14-30-45.123456</time></record>, Some(America/Los_Angeles)) AS from_xml(<record><time>14-30-45.123456</time></record>)#x]
++- OneRowRelation
+
+
+-- !query
+select from_xml('<record><t1>09:00:00</t1><t2>17:30:00</t2></record>', 't1 TIME, t2 TIME', map('rowTag', 'record'))
+-- !query analysis
+Project [from_xml(StructField(t1,TimeType(6),true), StructField(t2,TimeType(6),true), (rowTag,record), <record><t1>09:00:00</t1><t2>17:30:00</t2></record>, Some(America/Los_Angeles)) AS from_xml(<record><t1>09:00:00</t1><t2>17:30:00</t2></record>)#x]
++- OneRowRelation
+
+
+-- !query
+select from_xml('<record><time>25:00:00</time></record>', 'time TIME', map('rowTag', 'record'))
+-- !query analysis
+Project [from_xml(StructField(time,TimeType(6),true), (rowTag,record), <record><time>25:00:00</time></record>, Some(America/Los_Angeles)) AS from_xml(<record><time>25:00:00</time></record>)#x]
++- OneRowRelation
+
+
+-- !query
+select from_xml('<record><time>invalid</time></record>', 'time TIME', map('rowTag', 'record'))
+-- !query analysis
+Project [from_xml(StructField(time,TimeType(6),true), (rowTag,record), <record><time>invalid</time></record>, Some(America/Los_Angeles)) AS from_xml(<record><time>invalid</time></record>)#x]
++- OneRowRelation
+
+
+-- !query
+select from_xml('<record></record>', 'time TIME', map('rowTag', 'record'))
+-- !query analysis
+Project [from_xml(StructField(time,TimeType(6),true), (rowTag,record), <record></record>, Some(America/Los_Angeles)) AS from_xml(<record></record>)#x]
++- OneRowRelation
+
+
+-- !query
+select to_xml(named_struct('time', TIME'14:30:45'), map('rowTag', 'record', 'indent', ''))
+-- !query analysis
+Project [to_xml((rowTag,record), (indent,), named_struct(time, 14:30:45), Some(America/Los_Angeles)) AS to_xml(named_struct(time, TIME '14:30:45'))#x]
++- OneRowRelation
+
+
+-- !query
+select to_xml(named_struct('time', TIME'14:30:45.123456'), map('rowTag', 'record', 'indent', ''))
+-- !query analysis
+Project [to_xml((rowTag,record), (indent,), named_struct(time, 14:30:45.123456), Some(America/Los_Angeles)) AS to_xml(named_struct(time, TIME '14:30:45.123456'))#x]
++- OneRowRelation
+
+
+-- !query
+select to_xml(named_struct('time', TIME'14:30:45.123456'), map('rowTag', 'record', 'timeFormat', 'HH-mm-ss.SSSSSS', 'indent', ''))
+-- !query analysis
+Project [to_xml((rowTag,record), (timeFormat,HH-mm-ss.SSSSSS), (indent,), named_struct(time, 14:30:45.123456), Some(America/Los_Angeles)) AS to_xml(named_struct(time, TIME '14:30:45.123456'))#x]
++- OneRowRelation
+
+
+-- !query
+select from_xml(to_xml(named_struct('time', TIME'14:30:45'), map('rowTag', 'record')), 'time TIME(0)', map('rowTag', 'record'))
+-- !query analysis
+Project [from_xml(StructField(time,TimeType(0),true), (rowTag,record), to_xml((rowTag,record), named_struct(time, 14:30:45), Some(America/Los_Angeles)), Some(America/Los_Angeles)) AS from_xml(to_xml(named_struct(time, TIME '14:30:45')))#x]
++- OneRowRelation
+
+
+-- !query
+select from_xml(to_xml(named_struct('time', TIME'14:30:45.1'), map('rowTag', 'record')), 'time TIME(1)', map('rowTag', 'record'))
+-- !query analysis
+Project [from_xml(StructField(time,TimeType(1),true), (rowTag,record), to_xml((rowTag,record), named_struct(time, 14:30:45.1), Some(America/Los_Angeles)), Some(America/Los_Angeles)) AS from_xml(to_xml(named_struct(time, TIME '14:30:45.1')))#x]
++- OneRowRelation
+
+
+-- !query
+select from_xml(to_xml(named_struct('time', TIME'14:30:45.12'), map('rowTag', 'record')), 'time TIME(2)', map('rowTag', 'record'))
+-- !query analysis
+Project [from_xml(StructField(time,TimeType(2),true), (rowTag,record), to_xml((rowTag,record), named_struct(time, 14:30:45.12), Some(America/Los_Angeles)), Some(America/Los_Angeles)) AS from_xml(to_xml(named_struct(time, TIME '14:30:45.12')))#x]
++- OneRowRelation
+
+
+-- !query
+select from_xml(to_xml(named_struct('time', TIME'14:30:45.123'), map('rowTag', 'record')), 'time TIME(3)', map('rowTag', 'record'))
+-- !query analysis
+Project [from_xml(StructField(time,TimeType(3),true), (rowTag,record), to_xml((rowTag,record), named_struct(time, 14:30:45.123), Some(America/Los_Angeles)), Some(America/Los_Angeles)) AS from_xml(to_xml(named_struct(time, TIME '14:30:45.123')))#x]
++- OneRowRelation
+
+
+-- !query
+select from_xml(to_xml(named_struct('time', TIME'14:30:45.1234'), map('rowTag', 'record')), 'time TIME(4)', map('rowTag', 'record'))
+-- !query analysis
+Project [from_xml(StructField(time,TimeType(4),true), (rowTag,record), to_xml((rowTag,record), named_struct(time, 14:30:45.1234), Some(America/Los_Angeles)), Some(America/Los_Angeles)) AS from_xml(to_xml(named_struct(time, TIME '14:30:45.1234')))#x]
++- OneRowRelation
+
+
+-- !query
+select from_xml(to_xml(named_struct('time', TIME'14:30:45.12345'), map('rowTag', 'record')), 'time TIME(5)', map('rowTag', 'record'))
+-- !query analysis
+Project [from_xml(StructField(time,TimeType(5),true), (rowTag,record), to_xml((rowTag,record), named_struct(time, 14:30:45.12345), Some(America/Los_Angeles)), Some(America/Los_Angeles)) AS from_xml(to_xml(named_struct(time, TIME '14:30:45.12345')))#x]
++- OneRowRelation
+
+
+-- !query
+select from_xml(to_xml(named_struct('time', TIME'14:30:45.123456'), map('rowTag', 'record')), 'time TIME(6)', map('rowTag', 'record'))
+-- !query analysis
+Project [from_xml(StructField(time,TimeType(6),true), (rowTag,record), to_xml((rowTag,record), named_struct(time, 14:30:45.123456), Some(America/Los_Angeles)), Some(America/Los_Angeles)) AS from_xml(to_xml(named_struct(time, TIME '14:30:45.123456')))#x]
++- OneRowRelation
+
+
+-- !query
+select to_xml(from_xml('<record><time>14:30:45</time></record>', 'time TIME(0)', map('rowTag', 'record')), map('rowTag', 'record', 'indent', ''))
+-- !query analysis
+Project [to_xml((rowTag,record), (indent,), from_xml(StructField(time,TimeType(0),true), (rowTag,record), <record><time>14:30:45</time></record>, Some(America/Los_Angeles)), Some(America/Los_Angeles)) AS to_xml(from_xml(<record><time>14:30:45</time></record>))#x]
++- OneRowRelation
+
+
+-- !query
+select to_xml(from_xml('<record><time>14:30:45.123</time></record>', 'time TIME(3)', map('rowTag', 'record')), map('rowTag', 'record', 'indent', ''))
+-- !query analysis
+Project [to_xml((rowTag,record), (indent,), from_xml(StructField(time,TimeType(3),true), (rowTag,record), <record><time>14:30:45.123</time></record>, Some(America/Los_Angeles)), Some(America/Los_Angeles)) AS to_xml(from_xml(<record><time>14:30:45.123</time></record>))#x]
++- OneRowRelation
+
+
+-- !query
+select to_xml(from_xml('<record><time>14:30:45.123456</time></record>', 'time TIME(6)', map('rowTag', 'record')), map('rowTag', 'record', 'indent', ''))
+-- !query analysis
+Project [to_xml((rowTag,record), (indent,), from_xml(StructField(time,TimeType(6),true), (rowTag,record), <record><time>14:30:45.123456</time></record>, Some(America/Los_Angeles)), Some(America/Los_Angeles)) AS to_xml(from_xml(<record><time>14:30:45.123456</time></record>))#x]
++- OneRowRelation
+
+
+-- !query
+select schema_of_xml('<record><time>14:30:45</time></record>', map('rowTag', 'record'))
+-- !query analysis
+Project [schema_of_xml(<record><time>14:30:45</time></record>, (rowTag,record)) AS schema_of_xml(<record><time>14:30:45</time></record>)#x]
++- OneRowRelation
+
+
+-- !query
+select schema_of_xml('<record><time>14:30:45.123456</time></record>', map('rowTag', 'record'))
+-- !query analysis
+Project [schema_of_xml(<record><time>14:30:45.123456</time></record>, (rowTag,record)) AS schema_of_xml(<record><time>14:30:45.123456</time></record>)#x]
++- OneRowRelation
+
+
+-- !query
+select from_xml('<record><time>14:30:45</time></record>', 'time TIME', map('rowTag', 'record')) LIMIT 1
+-- !query analysis
+GlobalLimit 1
++- LocalLimit 1
+   +- Project [from_xml(StructField(time,TimeType(6),true), (rowTag,record), <record><time>14:30:45</time></record>, Some(America/Los_Angeles)) AS from_xml(<record><time>14:30:45</time></record>)#x]
+      +- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/inputs/xml-functions.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/xml-functions.sql
@@ -59,3 +59,44 @@ SELECT schema_of_xml(xmlField) FROM xmlTable;
 
 -- Clean up
 DROP VIEW IF EXISTS xmlTable;
+
+-- TIME type tests
+-- from_xml with TIME type
+select from_xml('<record><time>14:30:45</time></record>', 'time TIME(0)', map('rowTag', 'record'));
+select from_xml('<record><time>14:30:45.123</time></record>', 'time TIME(3)', map('rowTag', 'record'));
+select from_xml('<record><time>14:30:45.123456</time></record>', 'time TIME(6)', map('rowTag', 'record'));
+select from_xml('<record><time>14-30-45.123456</time></record>', 'time TIME(6)', map('rowTag', 'record', 'timeFormat', 'HH-mm-ss.SSSSSS'));
+select from_xml('<record><t1>09:00:00</t1><t2>17:30:00</t2></record>', 't1 TIME, t2 TIME', map('rowTag', 'record'));
+
+-- Invalid input
+select from_xml('<record><time>25:00:00</time></record>', 'time TIME', map('rowTag', 'record'));
+select from_xml('<record><time>invalid</time></record>', 'time TIME', map('rowTag', 'record'));
+select from_xml('<record></record>', 'time TIME', map('rowTag', 'record'));
+
+-- to_xml with TIME type
+select to_xml(named_struct('time', TIME'14:30:45'), map('rowTag', 'record', 'indent', ''));
+select to_xml(named_struct('time', TIME'14:30:45.123456'), map('rowTag', 'record', 'indent', ''));
+select to_xml(named_struct('time', TIME'14:30:45.123456'), map('rowTag', 'record', 'timeFormat', 'HH-mm-ss.SSSSSS', 'indent', ''));
+
+-- TIME type roundtrip tests
+select from_xml(to_xml(named_struct('time', TIME'14:30:45'), map('rowTag', 'record')), 'time TIME(0)', map('rowTag', 'record'));
+select from_xml(to_xml(named_struct('time', TIME'14:30:45.1'), map('rowTag', 'record')), 'time TIME(1)', map('rowTag', 'record'));
+select from_xml(to_xml(named_struct('time', TIME'14:30:45.12'), map('rowTag', 'record')), 'time TIME(2)', map('rowTag', 'record'));
+select from_xml(to_xml(named_struct('time', TIME'14:30:45.123'), map('rowTag', 'record')), 'time TIME(3)', map('rowTag', 'record'));
+select from_xml(to_xml(named_struct('time', TIME'14:30:45.1234'), map('rowTag', 'record')), 'time TIME(4)', map('rowTag', 'record'));
+select from_xml(to_xml(named_struct('time', TIME'14:30:45.12345'), map('rowTag', 'record')), 'time TIME(5)', map('rowTag', 'record'));
+select from_xml(to_xml(named_struct('time', TIME'14:30:45.123456'), map('rowTag', 'record')), 'time TIME(6)', map('rowTag', 'record'));
+
+-- Reverse roundtrip
+select to_xml(from_xml('<record><time>14:30:45</time></record>', 'time TIME(0)', map('rowTag', 'record')), map('rowTag', 'record', 'indent', ''));
+select to_xml(from_xml('<record><time>14:30:45.123</time></record>', 'time TIME(3)', map('rowTag', 'record')), map('rowTag', 'record', 'indent', ''));
+select to_xml(from_xml('<record><time>14:30:45.123456</time></record>', 'time TIME(6)', map('rowTag', 'record')), map('rowTag', 'record', 'indent', ''));
+
+-- TIME type schema inference
+-- Schema inference: TIME type is never auto-inferred (requires explicit schema).
+-- Time-like strings are inferred as TIMESTAMP by XML's existing inference logic.
+select schema_of_xml('<record><time>14:30:45</time></record>', map('rowTag', 'record'));
+select schema_of_xml('<record><time>14:30:45.123456</time></record>', map('rowTag', 'record'));
+
+-- LIMIT test
+select from_xml('<record><time>14:30:45</time></record>', 'time TIME', map('rowTag', 'record')) LIMIT 1;

--- a/sql/core/src/test/resources/sql-tests/results/xml-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/xml-functions.sql.out
@@ -461,3 +461,195 @@ DROP VIEW IF EXISTS xmlTable
 struct<>
 -- !query output
 
+
+
+-- !query
+select from_xml('<record><time>14:30:45</time></record>', 'time TIME(0)', map('rowTag', 'record'))
+-- !query schema
+struct<from_xml(<record><time>14:30:45</time></record>):struct<time:time(0)>>
+-- !query output
+{"time":14:30:45}
+
+
+-- !query
+select from_xml('<record><time>14:30:45.123</time></record>', 'time TIME(3)', map('rowTag', 'record'))
+-- !query schema
+struct<from_xml(<record><time>14:30:45.123</time></record>):struct<time:time(3)>>
+-- !query output
+{"time":14:30:45.123}
+
+
+-- !query
+select from_xml('<record><time>14:30:45.123456</time></record>', 'time TIME(6)', map('rowTag', 'record'))
+-- !query schema
+struct<from_xml(<record><time>14:30:45.123456</time></record>):struct<time:time(6)>>
+-- !query output
+{"time":14:30:45.123456}
+
+
+-- !query
+select from_xml('<record><time>14-30-45.123456</time></record>', 'time TIME(6)', map('rowTag', 'record', 'timeFormat', 'HH-mm-ss.SSSSSS'))
+-- !query schema
+struct<from_xml(<record><time>14-30-45.123456</time></record>):struct<time:time(6)>>
+-- !query output
+{"time":14:30:45.123456}
+
+
+-- !query
+select from_xml('<record><t1>09:00:00</t1><t2>17:30:00</t2></record>', 't1 TIME, t2 TIME', map('rowTag', 'record'))
+-- !query schema
+struct<from_xml(<record><t1>09:00:00</t1><t2>17:30:00</t2></record>):struct<t1:time(6),t2:time(6)>>
+-- !query output
+{"t1":09:00:00,"t2":17:30:00}
+
+
+-- !query
+select from_xml('<record><time>25:00:00</time></record>', 'time TIME', map('rowTag', 'record'))
+-- !query schema
+struct<from_xml(<record><time>25:00:00</time></record>):struct<time:time(6)>>
+-- !query output
+{"time":null}
+
+
+-- !query
+select from_xml('<record><time>invalid</time></record>', 'time TIME', map('rowTag', 'record'))
+-- !query schema
+struct<from_xml(<record><time>invalid</time></record>):struct<time:time(6)>>
+-- !query output
+{"time":null}
+
+
+-- !query
+select from_xml('<record></record>', 'time TIME', map('rowTag', 'record'))
+-- !query schema
+struct<from_xml(<record></record>):struct<time:time(6)>>
+-- !query output
+{"time":null}
+
+
+-- !query
+select to_xml(named_struct('time', TIME'14:30:45'), map('rowTag', 'record', 'indent', ''))
+-- !query schema
+struct<to_xml(named_struct(time, TIME '14:30:45')):string>
+-- !query output
+<record><time>14:30:45</time></record>
+
+
+-- !query
+select to_xml(named_struct('time', TIME'14:30:45.123456'), map('rowTag', 'record', 'indent', ''))
+-- !query schema
+struct<to_xml(named_struct(time, TIME '14:30:45.123456')):string>
+-- !query output
+<record><time>14:30:45.123456</time></record>
+
+
+-- !query
+select to_xml(named_struct('time', TIME'14:30:45.123456'), map('rowTag', 'record', 'timeFormat', 'HH-mm-ss.SSSSSS', 'indent', ''))
+-- !query schema
+struct<to_xml(named_struct(time, TIME '14:30:45.123456')):string>
+-- !query output
+<record><time>14-30-45.123456</time></record>
+
+
+-- !query
+select from_xml(to_xml(named_struct('time', TIME'14:30:45'), map('rowTag', 'record')), 'time TIME(0)', map('rowTag', 'record'))
+-- !query schema
+struct<from_xml(to_xml(named_struct(time, TIME '14:30:45'))):struct<time:time(0)>>
+-- !query output
+{"time":14:30:45}
+
+
+-- !query
+select from_xml(to_xml(named_struct('time', TIME'14:30:45.1'), map('rowTag', 'record')), 'time TIME(1)', map('rowTag', 'record'))
+-- !query schema
+struct<from_xml(to_xml(named_struct(time, TIME '14:30:45.1'))):struct<time:time(1)>>
+-- !query output
+{"time":14:30:45.1}
+
+
+-- !query
+select from_xml(to_xml(named_struct('time', TIME'14:30:45.12'), map('rowTag', 'record')), 'time TIME(2)', map('rowTag', 'record'))
+-- !query schema
+struct<from_xml(to_xml(named_struct(time, TIME '14:30:45.12'))):struct<time:time(2)>>
+-- !query output
+{"time":14:30:45.12}
+
+
+-- !query
+select from_xml(to_xml(named_struct('time', TIME'14:30:45.123'), map('rowTag', 'record')), 'time TIME(3)', map('rowTag', 'record'))
+-- !query schema
+struct<from_xml(to_xml(named_struct(time, TIME '14:30:45.123'))):struct<time:time(3)>>
+-- !query output
+{"time":14:30:45.123}
+
+
+-- !query
+select from_xml(to_xml(named_struct('time', TIME'14:30:45.1234'), map('rowTag', 'record')), 'time TIME(4)', map('rowTag', 'record'))
+-- !query schema
+struct<from_xml(to_xml(named_struct(time, TIME '14:30:45.1234'))):struct<time:time(4)>>
+-- !query output
+{"time":14:30:45.1234}
+
+
+-- !query
+select from_xml(to_xml(named_struct('time', TIME'14:30:45.12345'), map('rowTag', 'record')), 'time TIME(5)', map('rowTag', 'record'))
+-- !query schema
+struct<from_xml(to_xml(named_struct(time, TIME '14:30:45.12345'))):struct<time:time(5)>>
+-- !query output
+{"time":14:30:45.12345}
+
+
+-- !query
+select from_xml(to_xml(named_struct('time', TIME'14:30:45.123456'), map('rowTag', 'record')), 'time TIME(6)', map('rowTag', 'record'))
+-- !query schema
+struct<from_xml(to_xml(named_struct(time, TIME '14:30:45.123456'))):struct<time:time(6)>>
+-- !query output
+{"time":14:30:45.123456}
+
+
+-- !query
+select to_xml(from_xml('<record><time>14:30:45</time></record>', 'time TIME(0)', map('rowTag', 'record')), map('rowTag', 'record', 'indent', ''))
+-- !query schema
+struct<to_xml(from_xml(<record><time>14:30:45</time></record>)):string>
+-- !query output
+<record><time>14:30:45</time></record>
+
+
+-- !query
+select to_xml(from_xml('<record><time>14:30:45.123</time></record>', 'time TIME(3)', map('rowTag', 'record')), map('rowTag', 'record', 'indent', ''))
+-- !query schema
+struct<to_xml(from_xml(<record><time>14:30:45.123</time></record>)):string>
+-- !query output
+<record><time>14:30:45.123</time></record>
+
+
+-- !query
+select to_xml(from_xml('<record><time>14:30:45.123456</time></record>', 'time TIME(6)', map('rowTag', 'record')), map('rowTag', 'record', 'indent', ''))
+-- !query schema
+struct<to_xml(from_xml(<record><time>14:30:45.123456</time></record>)):string>
+-- !query output
+<record><time>14:30:45.123456</time></record>
+
+
+-- !query
+select schema_of_xml('<record><time>14:30:45</time></record>', map('rowTag', 'record'))
+-- !query schema
+struct<schema_of_xml(<record><time>14:30:45</time></record>):string>
+-- !query output
+STRUCT<time: TIMESTAMP>
+
+
+-- !query
+select schema_of_xml('<record><time>14:30:45.123456</time></record>', map('rowTag', 'record'))
+-- !query schema
+struct<schema_of_xml(<record><time>14:30:45.123456</time></record>):string>
+-- !query output
+STRUCT<time: TIMESTAMP>
+
+
+-- !query
+select from_xml('<record><time>14:30:45</time></record>', 'time TIME', map('rowTag', 'record')) LIMIT 1
+-- !query schema
+struct<from_xml(<record><time>14:30:45</time></record>):struct<time:time(6)>>
+-- !query output
+{"time":14:30:45}

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
@@ -1247,7 +1247,7 @@ class FileBasedDataSourceSuite extends QueryTest
   }
 
   test("SPARK-51590: unsupported the TIME data types in data sources") {
-    val datasources = Seq("orc", "xml", "csv", "text")
+    val datasources = Seq("orc", "csv", "text")
     Seq(true, false).foreach { useV1 =>
       val useV1List = if (useV1) {
         datasources.mkString(",")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR adds XML serialization and deserialization support for Spark's TIME type
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
TIME type currently lacks XML support, preventing users from:

- Reading/writing XML files with TIME columns
- Using from_xml() and to_xml() functions with TIME type
- Integrating TIME data with external XML-based systems

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes.

Users can now:
- Read XML with TIME: `spark.read.schema("time TIME(6)").option("rowTag", "record").xml("data.xml")`
- Write XML with TIME: `df.write.option("rowTag", "record").xml("output.xml")`  → `<record><time>14:30:45.123456</time></record>`
- Use from_xml/to_xml:
  ```sql
  SELECT from_xml('<record><time>14:30:45.123456</time></record>', 'time TIME(6)', map('rowTag', 'record'));
  SELECT to_xml(named_struct('time', TIME'14:30:45'), map('rowTag', 'record'));
  ```
- Custom format: `spark.read.option("timeFormat", "HH-mm-ss.SSSSSS").xml("data.xml")`

New option: `timeFormat` - controls TIME formatting/parsing (default: HH:mm:ss with fractional seconds)

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added new test cases in XmlExpressionsSuite, XmlFunctionsSuite, SQL tests (xml-functions.sql), and XmlSuite

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes.
Generated-by: Claude 3.5 Sonnet

AI assistance was used for:
- Code pattern analysis and design discussions
- Implementation guidance following Spark conventions
- Test case generation and organization
- Documentation and examples