### PR TITLE
[SPARK-54467][INFRA] Disable `actions/cache` on MacOS CIs

### DIFF
--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -56,7 +56,8 @@ jobs:
   build:
     name: "Build modules: ${{ matrix.modules }} ${{ matrix.comment }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 150
+    # TODO(SPARK-54466): https://github.com/actions/runner-images/issues/13341
+    # timeout-minutes: 150
     strategy:
       fail-fast: false
       matrix:
@@ -143,6 +144,8 @@ jobs:
           git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
       # Cache local repositories. Note that GitHub Actions cache has a 10G limit.
       - name: Cache SBT and Maven
+        # TODO(SPARK-54466): https://github.com/actions/runner-images/issues/13341
+        if: ${{ runner.os != 'macOS' }}
         uses: actions/cache@v4
         with:
           path: |
@@ -153,6 +156,8 @@ jobs:
           restore-keys: |
             build-
       - name: Cache Maven local repository
+        # TODO(SPARK-54466): https://github.com/actions/runner-images/issues/13341
+        if: ${{ runner.os != 'macOS' }}
         uses: actions/cache@v4
         with:
           path: ~/.m2/repository


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to disable `actions/cache` on MacOS CIs and remove `timeout-minutes` temporarily.

- SPARK-54466 (Re-enable `actions/cache` on MacOS) is filed to recover this back after GitHub Action outage is resolved.

### Why are the changes needed?

Currently, GitHub Action has an outage on `actions/cache` step due to `hashFiles` fails .

- https://github.com/orgs/community/discussions/180160
- https://github.com/actions/runner-images/issues/13341

Apache Spark MacOS CIs are affected like the following currently.

- https://github.com/apache/spark/actions/workflows/build_maven_java21_macos26.yml
- https://github.com/apache/spark/actions/workflows/build_python_3.11_macos.yml
- https://github.com/apache/spark/actions/workflows/build_python_3.11_macos26.yml


    > Error: The template is not valid. apache/spark/.github/workflows/python_hosted_runner_test.yml@01fa49b9755f324d9d30cf1e61b07188a59342c7 (Line: 126, Col: 16): hashFiles('**/pom.xml, project/build.properties, build/mvn, build/sbt, build/sbt-launch-lib.bash, build/spark-build-info') failed. Fail to hash files under directory '/Users/runner/work/spark/spark'

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.