### PR TITLE
[SPARK-54467][INFRA][FOLLOWUP] Disable `actions/cache` on `python_hosted_runner_test.yml` too

### DIFF
--- a/.github/workflows/python_hosted_runner_test.yml
+++ b/.github/workflows/python_hosted_runner_test.yml
@@ -59,7 +59,8 @@ jobs:
   build:
     name: "Build modules: ${{ matrix.modules }}"
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 150
+    # TODO(SPARK-54466): https://github.com/actions/runner-images/issues/13341
+    # timeout-minutes: 150
     strategy:
       fail-fast: false
       matrix:
@@ -117,6 +118,8 @@ jobs:
           git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
       # Cache local repositories. Note that GitHub Actions cache has a 10G limit.
       - name: Cache SBT and Maven
+        # TODO(SPARK-54466): https://github.com/actions/runner-images/issues/13341
+        if: ${{ runner.os != 'macOS' }}
         uses: actions/cache@v4
         with:
           path: |
@@ -127,6 +130,8 @@ jobs:
           restore-keys: |
             build-
       - name: Cache Coursier local repository
+        # TODO(SPARK-54466): https://github.com/actions/runner-images/issues/13341
+        if: ${{ runner.os != 'macOS' }}
         uses: actions/cache@v4
         with:
           path: ~/.cache/coursier


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a follow-up of the following to disable `actions/cache` on `python_hosted_runner_test.yml` and remove `timeout-minutes` temporarily, too.

- #53180 

### Why are the changes needed?

Currently, GitHub Action has an outage on `actions/cache` step due to `hashFiles` fails .

- https://github.com/orgs/community/discussions/180160
- https://github.com/actions/runner-images/issues/13341

Apache Spark MacOS CIs are affected like the following currently.

- https://github.com/apache/spark/actions/workflows/build_python_3.11_macos.yml
- https://github.com/apache/spark/actions/workflows/build_python_3.11_macos26.yml

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.