### PR TITLE
[SPARK-54469][DSTREAM][TESTS] Fix `StreamingContextSuite.stop slow receiver gracefully` test to clean up `SprakContext`

### DIFF
--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -365,6 +365,8 @@ class StreamingContextSuite
     assert(runningCount > 0)
     assert(runningCount == totalNumRecords)
     Thread.sleep(100)
+    sc.stop()
+    LocalStreamingContext.ensureNoActiveSparkContext()
   }
 
   test ("registering and de-registering of streamingSource") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `StreamingContextSuite.stop slow receiver gracefully` test case to clean up `SprakContext`.

### Why are the changes needed?

According to the log, `20000s` setting is propagated to the other test case and causes flaky failures.
- https://github.com/apache/spark/actions/runs/19608517338/job/56150848587
```
- SPARK-22955 graceful shutdown shouldn't lead to job generation error *** FAILED ***
  The code passed to failAfter did not complete within 20 minutes. (StreamingContextSuite.scala:861)
```

`20000s` setting is originated from `StreamingContextSuite.stop slow receiver gracefully`. We should close the SparkContext correctly.

https://github.com/apache/spark/blob/997525cae9b00e47626ce09f00e779b279551ace/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala#L342-L344

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.