### PR TITLE
[SPARK-54470][CORE][TESTS] Fix `BlockManagerDecommissionIntegrationSuite` to wait shuffle migrations

### DIFF
--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerDecommissionIntegrationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerDecommissionIntegrationSuite.scala
@@ -418,8 +418,11 @@ class BlockManagerDecommissionIntegrationSuite extends SparkFunSuite with LocalS
       .map(_.asInstanceOf[ShuffleIndexBlockId].shuffleId)
       .get
 
+    eventually(timeout(1.minute), interval(10.milliseconds)) {
+      val newShuffleFiles = shuffleFiles.diff(existingShuffleFiles)
+      assert(newShuffleFiles.size >= shuffleBlockUpdates.size)
+    }
     val newShuffleFiles = shuffleFiles.diff(existingShuffleFiles)
-    assert(newShuffleFiles.size >= shuffleBlockUpdates.size)
 
     // Remove the shuffle data
     sc.shuffleDriverComponents.removeShuffle(shuffleId, true)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `BlockManagerDecommissionIntegrationSuite` to wait shuffle migrations to mitigate the flakiness in the slow environment.

### Why are the changes needed?

`BlockManagerDecommissionIntegrationSuite` shows a flakiness like the following in a slow environment.
- https://github.com/apache/spark/actions/runs/19608517338/job/56150848584
```
- SPARK-46957: Migrated shuffle files should be able to cleanup from executor *** FAILED ***
  0 was not greater than or equal to 12 (BlockManagerDecommissionIntegrationSuite.scala:422)
```

It's because line 412 only ensures the start of migration. We need to wait more to proceed the next step, line 422.

https://github.com/apache/spark/blob/997525cae9b00e47626ce09f00e779b279551ace/core/src/test/scala/org/apache/spark/storage/BlockManagerDecommissionIntegrationSuite.scala#L409-L422

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.