### PR TITLE
[SPARK-54474][PYTHON] Discard the XML report on tests that are supposed to fail

### DIFF
--- a/python/pyspark/testing/tests/test_fail.py
+++ b/python/pyspark/testing/tests/test_fail.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+import tempfile
 import unittest
 
 
@@ -25,13 +27,16 @@ class FailTests(unittest.TestCase):
 if __name__ == "__main__":
     from pyspark.testing.tests.test_fail import *  # noqa: F401
 
-    try:
-        import xmlrunner
+    # Do not keep XML report because the test is supposed to fail.
+    # We do not want to confuse XML report consumers.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        try:
+            import xmlrunner
 
-        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
-    except ImportError:
-        testRunner = None
-    try:
-        unittest.main(testRunner=testRunner, verbosity=2)
-    except SystemExit as e:
-        assert e.code == 1, f"status code: {e.code}"
+            testRunner = xmlrunner.XMLTestRunner(output=tmpdir, verbosity=2)
+        except ImportError:
+            testRunner = None
+        try:
+            unittest.main(testRunner=testRunner, verbosity=2)
+        except SystemExit as e:
+            assert e.code == 1, f"status code: {e.code}"

--- a/python/pyspark/testing/tests/test_fail_in_set_up_class.py
+++ b/python/pyspark/testing/tests/test_fail_in_set_up_class.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+import tempfile
 import unittest
 
 
@@ -30,13 +32,16 @@ class FailInSetUpClassTests(unittest.TestCase):
 if __name__ == "__main__":
     from pyspark.testing.tests.test_fail_in_set_up_class import *  # noqa: F401
 
-    try:
-        import xmlrunner
+    # Do not keep XML report because the test is supposed to fail.
+    # We do not want to confuse XML report consumers.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        try:
+            import xmlrunner
 
-        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
-    except ImportError:
-        testRunner = None
-    try:
-        unittest.main(testRunner=testRunner, verbosity=2)
-    except SystemExit as e:
-        assert e.code == 1, f"status code: {e.code}"
+            testRunner = xmlrunner.XMLTestRunner(output=tmpdir, verbosity=2)
+        except ImportError:
+            testRunner = None
+        try:
+            unittest.main(testRunner=testRunner, verbosity=2)
+        except SystemExit as e:
+            assert e.code == 1, f"status code: {e.code}"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

We do not keep the XML reports from the tests that are supposed to fail anymore.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

It will confuse XML report consumers. These are tests that are supposed to fail - we are testing if they return the expected return code.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Manually tested that no XML report is generated and the test itself still passes.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No