### PR TITLE
[SPARK-54473][SQL] Add Avro read and write support for TIME type

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -203,6 +203,14 @@ private[sql] class AvroDeserializer(
           s"Avro logical type $other cannot be converted to SQL type ${TimestampNTZType.sql}.")
       }
 
+      case (LONG, _: TimeType) => avroType.getLogicalType match {
+        case _: LogicalTypes.TimeMicros => (updater, ordinal, value) =>
+          val micros = value.asInstanceOf[Long]
+          updater.setLong(ordinal, micros)
+        case other => throw new IncompatibleSchemaException(errorPrefix +
+          s"Avro logical type $other cannot be converted to SQL type ${TimeType().sql}.")
+      }
+
       // Before we upgrade Avro to 1.8 for logical type support, spark-avro converts Long to Date.
       // For backward compatibility, we still keep this conversion.
       case (LONG, DateType) => (updater, ordinal, value) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroSerializer.scala
@@ -191,6 +191,12 @@ private[sql] class AvroSerializer(
           s"SQL type ${TimestampNTZType.sql} cannot be converted to Avro logical type $other")
       }
 
+      case (_: TimeType, LONG) => avroType.getLogicalType match {
+        case _: LogicalTypes.TimeMicros => (getter, ordinal) => getter.getLong(ordinal)
+        case other => throw new IncompatibleSchemaException(errorPrefix +
+          s"SQL type ${TimeType().sql} cannot be converted to Avro logical type $other")
+      }
+
       case (ArrayType(et, containsNull), ARRAY) =>
         val elementConverter = newConverter(
           et, resolveNullableType(avroType.getElementType, containsNull),

--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
@@ -83,7 +83,6 @@ private[sql] object AvroUtils extends Logging {
   def supportsDataType(dataType: DataType): Boolean = dataType match {
     case _: VariantType => false
 
-    case _: TimeType => false
     case _: AtomicType => true
 
     case st: StructType => st.forall { f => supportsDataType(f.dataType) }

--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
@@ -131,6 +131,16 @@ object SchemaConverters extends Logging {
         case _: TimestampMillis | _: TimestampMicros => SchemaType(TimestampType, nullable = false)
         case _: LocalTimestampMillis | _: LocalTimestampMicros =>
           SchemaType(TimestampNTZType, nullable = false)
+        case _: LogicalTypes.TimeMicros =>
+          // Falls back to default precision for backward compatibility with
+          // Avro files written by external tools.
+          val catalystTypeAttrValue = avroSchema.getProp(CATALYST_TYPE_PROP_NAME)
+          val timeType = if (catalystTypeAttrValue == null) {
+            TimeType(TimeType.MICROS_PRECISION)
+          } else {
+            CatalystSqlParser.parseDataType(catalystTypeAttrValue).asInstanceOf[TimeType]
+          }
+          SchemaType(timeType, nullable = false)
         case _ =>
           val catalystTypeAttrValue = avroSchema.getProp(CATALYST_TYPE_PROP_NAME)
           val catalystType = if (catalystTypeAttrValue == null) {
@@ -324,6 +334,10 @@ object SchemaConverters extends Logging {
         LogicalTypes.timestampMicros().addToSchema(builder.longType())
       case TimestampNTZType =>
         LogicalTypes.localTimestampMicros().addToSchema(builder.longType())
+      case t: TimeType =>
+        val timeSchema = LogicalTypes.timeMicros().addToSchema(builder.longType())
+        timeSchema.addProp(CATALYST_TYPE_PROP_NAME, t.typeName)
+        timeSchema
 
       case FloatType => builder.floatType()
       case DoubleType => builder.doubleType()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds Avro serialization and deserialization support for Spark's TIME type.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
TIME type currently lacks Avro support, preventing users from:

- Reading/writing Avro files with TIME columns
- Using TIME with data exchange pipelines (Kafka, streaming)
- Integrating TIME data with Avro-based systems
- Preserving TIME precision in schema evolution

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Users can now:

1. Read Avro with TIME columns
```scala
spark.read.format("avro").load("data.avro")
// Returns DataFrame with TIME columns preserved
```

2. Write DataFrames with TIME to Avro
```scala
val df = spark.sql("SELECT TIME'14:30:45.123456' as shift_start")
df.write.format("avro").save("output.avro")
```

3. Use to_avro/from_avro functions with TIME
```scala
import org.apache.spark.sql.avro.functions.{to_avro, from_avro}

// Serialize TIME to Avro binary
val avroDF = df.select(to_avro($"shift_start").as("avro"))

// Deserialize Avro binary back to TIME (with precision metadata)
val schema = """
  {
    "type": "long",
    "logicalType": "time-micros",
    "spark.sql.catalyst.type": "time(3)"
  }
"""
val timeDF = avroDF.select(from_avro($"avro", schema).as("shift_start"))
```

4. Use TIME in Avro-based streaming
```scala
// Kafka with Avro serialization
df.selectExpr("to_avro(struct(shift_start)) as value")
  .write
  .format("kafka")
  .save()
```
### How was this patch tested?
Added tests in `AvroSuite` and `AvroFunctionsSuite.scala`

Also manually tested using 

`spark-shell --packages org.apache.spark:spark-avro_2.13:4.0.0`
```scala
val df = spark.sql("SELECT TIME'14:30:45.123456' as shift_start")
import org.apache.spark.sql.avro.functions.{to_avro, from_avro}
val avroDF = df.select(to_avro($"shift_start").as("avro"))

// Deserialize Avro binary back to TIME (with precision metadata)
val schema = """
  {
    "type": "long",
    "logicalType": "time-micros",
    "spark.sql.catalyst.type": "time(3)"
  }
"""
val timeDF = avroDF.select(from_avro($"avro", schema).as("shift_start"))
timeDF.show
```

```
+---------------+
|    shift_start|
+---------------+
|14:30:45.123456|
+---------------+
```

```scala
timeDF.printSchema
```

```
root
 |-- shift_start: time(3) (nullable = true)
```
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes.
Generated-by: Claude 3.5 Sonnet

AI assistance was used for:

- Code pattern analysis and design discussions
- Implementation guidance following Spark conventions
- Test case generation and organization
- Documentation and examples