### PR TITLE
[SPARK-54596][CORE][K8S] Burst-aware Memory Allocation Algorithm for Spark@K8S

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -238,7 +238,7 @@ class SparkContext(config: SparkConf) extends Logging {
   private var _files: Seq[String] = _
   private var _archives: Seq[String] = _
   private var _shutdownHookRef: AnyRef = _
-  private var _statusStore: AppStatusStore = _
+  private[spark] var _statusStore: AppStatusStore = _
   private var _heartbeater: Heartbeater = _
   private var _resources: immutable.Map[String, ResourceInformation] = _
   private var _shuffleDriverComponents: ShuffleDriverComponents = _

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -238,7 +238,7 @@ class SparkContext(config: SparkConf) extends Logging {
   private var _files: Seq[String] = _
   private var _archives: Seq[String] = _
   private var _shutdownHookRef: AnyRef = _
-  private[spark] var _statusStore: AppStatusStore = _
+  private var _statusStore: AppStatusStore = _
   private var _heartbeater: Heartbeater = _
   private var _resources: immutable.Map[String, ResourceInformation] = _
   private var _shuffleDriverComponents: ShuffleDriverComponents = _

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -448,7 +448,7 @@ package object config {
   private[spark] val EXECUTOR_BURSTY_MEMORY_OVERHEAD_ENABLED =
     ConfigBuilder("spark.executor.memoryOverheadBursty.enabled")
       .doc("Whether to enable memory overhead bursty")
-      .version("3.2.0")
+      .version("4.2.0")
       .booleanConf
       .createWithDefault(false)
 
@@ -457,7 +457,7 @@ package object config {
       .doc("the bursty control factor controlling the size of memory overhead space shared with" +
         s" other processes, newMemoryOverhead=oldMemoryOverhead-MIN((onheap + memoryoverhead) *" +
         s" (this value - 1), oldMemoryOverhead)")
-      .version("3.2.0")
+      .version("4.2.0")
       .doubleConf
       .checkValue((v: Double) => v >= 1.0,
         "the value of bursty control factor has to be no less than 1")
@@ -465,10 +465,11 @@ package object config {
 
   private[spark] val EXECUTOR_BURSTY_MEMORY_OVERHEAD = ConfigBuilder(
     "spark.executor.burstyMemoryOverhead")
-    .doc(s"The adjusted amount of non-heap memory to be allocated per executor" +
+    .doc(s"The adjusted amount of memoryOverhead to be allocated per executor" +
       s" (the adjustment happens if ${EXECUTOR_BURSTY_MEMORY_OVERHEAD_ENABLED.key} is enabled," +
-      " in MiB unless otherwise specified.")
-    .version("2.3.0")
+      " in MiB unless otherwise specified. This parameter is here only for UI demonstration," +
+      " there is not effect when user sets it directly")
+    .version("4.2.0")
     .bytesConf(ByteUnit.MiB)
     .createOptional
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -469,6 +469,7 @@ package object config {
       s" (the adjustment happens if ${EXECUTOR_BURSTY_MEMORY_OVERHEAD_ENABLED.key} is enabled," +
       " in MiB unless otherwise specified. This parameter is here only for UI demonstration," +
       " there is not effect when user sets it directly")
+    .internal()
     .version("4.2.0")
     .bytesConf(ByteUnit.MiB)
     .createOptional

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -445,6 +445,33 @@ package object config {
         "Ensure that memory overhead is a double greater than 0")
       .createWithDefault(0.1)
 
+  private[spark] val EXECUTOR_BURSTY_MEMORY_OVERHEAD_ENABLED =
+    ConfigBuilder("spark.executor.memoryOverheadBursty.enabled")
+      .doc("Whether to enable memory overhead bursty")
+      .version("3.2.0")
+      .booleanConf
+      .createWithDefault(false)
+
+  private[spark] val EXECUTOR_BURSTY_MEMORY_OVERHEAD_FACTOR =
+    ConfigBuilder("spark.executor.memoryOverheadBurstyFactor")
+      .doc("the bursty control factor controlling the size of memory overhead space shared with" +
+        s" other processes, newMemoryOverhead=oldMemoryOverhead-MIN((onheap + memoryoverhead) *" +
+        s" (this value - 1), oldMemoryOverhead)")
+      .version("3.2.0")
+      .doubleConf
+      .checkValue((v: Double) => v >= 1.0,
+        "the value of bursty control factor has to be no less than 1")
+      .createWithDefault(1.2)
+
+  private[spark] val EXECUTOR_BURSTY_MEMORY_OVERHEAD = ConfigBuilder(
+    "spark.executor.burstyMemoryOverhead")
+    .doc(s"The adjusted amount of non-heap memory to be allocated per executor" +
+      s" (the adjustment happens if ${EXECUTOR_BURSTY_MEMORY_OVERHEAD_ENABLED.key} is enabled," +
+      " in MiB unless otherwise specified.")
+    .version("2.3.0")
+    .bytesConf(ByteUnit.MiB)
+    .createOptional
+
   private[spark] val CORES_MAX = ConfigBuilder("spark.cores.max")
     .doc("When running on a standalone deploy cluster, " +
       "the maximum amount of CPU cores to request for the application from across " +

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -453,14 +453,13 @@ package object config {
       .createWithDefault(false)
 
   private[spark] val EXECUTOR_BURSTY_MEMORY_OVERHEAD_FACTOR =
-    ConfigBuilder("spark.executor.memoryOverheadBurstyFactor")
+    ConfigBuilder("spark.executor.memoryOverheadBursty.factor")
       .doc("the bursty control factor controlling the size of memory overhead space shared with" +
         s" other processes, newMemoryOverhead=oldMemoryOverhead-MIN((onheap + memoryoverhead) *" +
         s" (this value - 1), oldMemoryOverhead)")
       .version("4.2.0")
       .doubleConf
-      .checkValue((v: Double) => v >= 1.0,
-        "the value of bursty control factor has to be no less than 1")
+      .checkValue(_ >= 1.0, "the value of bursty control factor has to be no less than 1")
       .createWithDefault(1.2)
 
   private[spark] val EXECUTOR_BURSTY_MEMORY_OVERHEAD = ConfigBuilder(

--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
@@ -595,17 +595,11 @@ object ResourceProfile extends Logging {
       val sparkContext = sparkContextOption.get
       val klass = classOf[ApplicationEnvironmentInfoWrapper]
       val currentAppEnvironment = sparkContext._statusStore.store.read(klass, klass.getName()).info
-      logInfo(s"currentAppEnvironment spark properties count:" +
-        s" ${currentAppEnvironment.sparkProperties.size}")
       val newAppEnvironment = ApplicationEnvironmentInfo.create(currentAppEnvironment,
         newSparkProperties = Map(EXECUTOR_BURSTY_MEMORY_OVERHEAD.key ->
           newMemoryOverheadMiB.toString))
-      logInfo(s"newAppEnvironment spark properties count:" +
-        s" ${newAppEnvironment.sparkProperties.size}")
       sparkContext._statusStore.store.write(new ApplicationEnvironmentInfoWrapper(
         newAppEnvironment))
-      // we have to post full information here, but need ensure that the downstream pipeline can
-      // consume duplicate entries properly
       this.synchronized {
         if (!loggedBurstyMemoryOverhead) {
           SparkContext.getActive.get.eventLogger.foreach { logger =>
@@ -619,11 +613,9 @@ object ResourceProfile extends Logging {
                 "Classpath Entries" -> newAppEnvironment.classpathEntries)
             ))
             loggedBurstyMemoryOverhead = true
-            logInfo("make a event log for bursty memory overhead")
           }
         }
       }
-      logInfo(s"posted memoryoverhead update event")
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
@@ -594,11 +594,11 @@ object ResourceProfile extends Logging {
     if (sparkContextOption.isDefined) {
       val sparkContext = sparkContextOption.get
       val klass = classOf[ApplicationEnvironmentInfoWrapper]
-      val currentAppEnvironment = sparkContext._statusStore.store.read(klass, klass.getName()).info
+      val currentAppEnvironment = sparkContext.statusStore.store.read(klass, klass.getName()).info
       val newAppEnvironment = ApplicationEnvironmentInfo.create(currentAppEnvironment,
         newSparkProperties = Map(EXECUTOR_BURSTY_MEMORY_OVERHEAD.key ->
           newMemoryOverheadMiB.toString))
-      sparkContext._statusStore.store.write(new ApplicationEnvironmentInfoWrapper(
+      sparkContext.statusStore.store.write(new ApplicationEnvironmentInfoWrapper(
         newAppEnvironment))
       this.synchronized {
         if (!loggedBurstyMemoryOverhead) {

--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
@@ -573,8 +573,8 @@ object ResourceProfile extends Logging {
     } else {
       val burstyControlFactor = conf.get(EXECUTOR_BURSTY_MEMORY_OVERHEAD_FACTOR)
       val newMemoryOverheadMiB = (memoryOverheadMiB - math.min(
-        (executorMemoryMiB + memoryOverheadMiB) * (burstyControlFactor - 1.0), memoryOverheadMiB))
-        .toLong
+          ((executorMemoryMiB + memoryOverheadMiB) * (burstyControlFactor - 1.0)).toLong,
+        memoryOverheadMiB))
       val totalMemMiBLimit = executorMemoryMiB + memoryOverheadMiB + memoryOffHeapMiB +
         pysparkMemToUseMiB
       val totalMemMiBRequest = executorMemoryMiB + newMemoryOverheadMiB + memoryOffHeapMiB +

--- a/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
@@ -519,6 +519,7 @@ private[spark] object ApplicationEnvironmentInfo {
       hadoopProperties = (appEnv.hadoopProperties.toMap ++ newHadoopProperties).toSeq,
       systemProperties = (appEnv.systemProperties.toMap ++ newSystemProperties).toSeq,
       classpathEntries = (appEnv.classpathEntries.toMap ++ newClasspathProperties).toSeq,
+      metricsProperties = appEnv.metricsProperties,
       resourceProfiles = appEnv.resourceProfiles ++ newResourceProfiles
     )
   }

--- a/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
@@ -501,6 +501,29 @@ class ApplicationEnvironmentInfo private[spark] (
     val classpathEntries: collection.Seq[(String, String)],
     val resourceProfiles: collection.Seq[ResourceProfileInfo])
 
+private[spark] object ApplicationEnvironmentInfo {
+  def create(appEnv: ApplicationEnvironmentInfo,
+             newSparkProperties: Map[String, String] = Map(),
+             newHadoopProperties: Map[String, String] = Map(),
+             newSystemProperties: Map[String, String] = Map(),
+             newClasspathProperties: Map[String, String] = Map(),
+             newResourceProfiles: Seq[ResourceProfileInfo] = Seq()): ApplicationEnvironmentInfo = {
+    if (newResourceProfiles.nonEmpty) {
+      require(!newResourceProfiles.exists(newRP => appEnv.resourceProfiles.map(_.id)
+        .contains(newRP.id)), "duplicate resource profile id in newResourceProfile and existing" +
+        " resource profiles")
+    }
+    new ApplicationEnvironmentInfo(
+      runtime = appEnv.runtime,
+      sparkProperties = (appEnv.sparkProperties.toMap ++ newSparkProperties).toSeq,
+      hadoopProperties = (appEnv.hadoopProperties.toMap ++ newHadoopProperties).toSeq,
+      systemProperties = (appEnv.systemProperties.toMap ++ newSystemProperties).toSeq,
+      classpathEntries = (appEnv.classpathEntries.toMap ++ newClasspathProperties).toSeq,
+      resourceProfiles = appEnv.resourceProfiles ++ newResourceProfiles
+    )
+  }
+}
+
 class RuntimeInfo private[spark](
     val javaVersion: String,
     val javaHome: String,

--- a/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
@@ -502,12 +502,13 @@ class ApplicationEnvironmentInfo private[spark] (
     val resourceProfiles: collection.Seq[ResourceProfileInfo])
 
 private[spark] object ApplicationEnvironmentInfo {
-  def create(appEnv: ApplicationEnvironmentInfo,
-             newSparkProperties: Map[String, String] = Map(),
-             newHadoopProperties: Map[String, String] = Map(),
-             newSystemProperties: Map[String, String] = Map(),
-             newClasspathProperties: Map[String, String] = Map(),
-             newResourceProfiles: Seq[ResourceProfileInfo] = Seq()): ApplicationEnvironmentInfo = {
+  def create(
+      appEnv: ApplicationEnvironmentInfo,
+      newSparkProperties: Map[String, String] = Map(),
+      newHadoopProperties: Map[String, String] = Map(),
+      newSystemProperties: Map[String, String] = Map(),
+      newClasspathProperties: Map[String, String] = Map(),
+      newResourceProfiles: Seq[ResourceProfileInfo] = Seq()): ApplicationEnvironmentInfo = {
     if (newResourceProfiles.nonEmpty) {
       require(!newResourceProfiles.exists(newRP => appEnv.resourceProfiles.map(_.id)
         .contains(newRP.id)), "duplicate resource profile id in newResourceProfile and existing" +

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -148,7 +148,7 @@ private[spark] class BasicExecutorFeatureStep(
       hostname = hostname.toLowerCase(Locale.ROOT)
     }
 
-    val executorMemoryRequestQuantity = new Quantity(s"${execResources.totalMemMiBRequest}Mi")
+    val executorMemoryRequestQuantity = new Quantity(s"${execResources.totalMemMiB}Mi")
     val executorMemoryLimitQuantity = execResources.totalMemMiBLimit.map { mem =>
       new Quantity(s"${mem}Mi")
     }.getOrElse(executorMemoryRequestQuantity)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -529,8 +529,8 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
 
   }
 
-  test("when turning on bursty memory overhead, configure request and limit correctly with" +
-    " default memoryOverhead profile") {
+  test("SPARK-54596: when turning on bursty memory overhead, configure request and" +
+    " limit correctly with default memoryOverhead profile") {
     baseConf.remove(KUBERNETES_EXECUTOR_POD_NAME_PREFIX)
     baseConf.set("spark.app.name", "xyz.abc _i_am_a_app_name_w/_some_abbrs")
     val basePod = SparkPod.initialPod()
@@ -552,8 +552,8 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     assert(resource.getRequests.get("memory").getAmount.toLong === 64 * 1024)
   }
 
-  test("when turning on bursty memory overhead, configure request and limit correctly with" +
-    " small memoryOverhead profile") {
+  test("SPARK-54596: when turning on bursty memory overhead, configure request and limit" +
+    " correctly with small memoryOverhead profile") {
     baseConf.remove(KUBERNETES_EXECUTOR_POD_NAME_PREFIX)
     baseConf.set("spark.app.name", "xyz.abc _i_am_a_app_name_w/_some_abbrs")
     val basePod = SparkPod.initialPod()
@@ -576,8 +576,8 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     assert(resource.getRequests.get("memory").getAmount.toLong === 64 * 1024)
   }
 
-  test("when turning on bursty memory overhead, configure request and limit correctly with" +
-    " big memoryOverhead profile") {
+  test("SPARK-54596: when turning on bursty memory overhead, configure request and" +
+    " limit correctly with big memoryOverhead profile") {
     baseConf.remove(KUBERNETES_EXECUTOR_POD_NAME_PREFIX)
     baseConf.set("spark.app.name", "xyz.abc _i_am_a_app_name_w/_some_abbrs")
     val basePod = SparkPod.initialPod()
@@ -600,8 +600,8 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     assert(resource.getRequests.get("memory").getAmount.toLong === math.ceil((64 + 3.2) * 1024))
   }
 
-  test("when turning on bursty memory overhead, configure request and limit correctly with" +
-    " big memoryOverhead profile and non-default factor") {
+  test("SPARK-54596: when turning on bursty memory overhead, configure request and" +
+    " limit correctly with big memoryOverhead profile and non-default factor") {
     baseConf.remove(KUBERNETES_EXECUTOR_POD_NAME_PREFIX)
     baseConf.set("spark.app.name", "xyz.abc _i_am_a_app_name_w/_some_abbrs")
     val basePod = SparkPod.initialPod()

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -597,7 +597,7 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     assert(defaultProfile.executorResources("memory").amount === 64 * 1024)
     assert(defaultProfile.executorResources("memoryOverhead").amount === 20480)
     assert(resource.getLimits.get("memory").getAmount.toLong === 84 * 1024)
-    assert(resource.getRequests.get("memory").getAmount.toLong === math.floor((64 + 3.2) * 1024))
+    assert(resource.getRequests.get("memory").getAmount.toLong === math.ceil((64 + 3.2) * 1024))
   }
 
   test("when turning on bursty memory overhead, configure request and limit correctly with" +
@@ -621,7 +621,7 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     assert(defaultProfile.executorResources("memory").amount === 64 * 1024)
     assert(defaultProfile.executorResources("memoryOverhead").amount === 20480)
     assert(resource.getLimits.get("memory").getAmount.toLong === 84 * 1024)
-    assert(resource.getRequests.get("memory").getAmount.toLong === math.floor((64 + 11.6) * 1024))
+    assert(resource.getRequests.get("memory").getAmount.toLong === math.ceil((64 + 11.6) * 1024))
   }
 
   test("SPARK-36075: Check executor pod respects nodeSelector/executorNodeSelector") {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -534,7 +534,6 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     baseConf.remove(KUBERNETES_EXECUTOR_POD_NAME_PREFIX)
     baseConf.set("spark.app.name", "xyz.abc _i_am_a_app_name_w/_some_abbrs")
     val basePod = SparkPod.initialPod()
-    // scalastyle:off
 
     val smallMemoryOverheadConf = baseConf.clone
       .set(EXECUTOR_BURSTY_MEMORY_OVERHEAD_ENABLED, true)
@@ -558,7 +557,6 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     baseConf.remove(KUBERNETES_EXECUTOR_POD_NAME_PREFIX)
     baseConf.set("spark.app.name", "xyz.abc _i_am_a_app_name_w/_some_abbrs")
     val basePod = SparkPod.initialPod()
-    // scalastyle:off
 
     val smallMemoryOverheadConf = baseConf.clone
       .set(EXECUTOR_BURSTY_MEMORY_OVERHEAD_ENABLED, true)
@@ -583,7 +581,6 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     baseConf.remove(KUBERNETES_EXECUTOR_POD_NAME_PREFIX)
     baseConf.set("spark.app.name", "xyz.abc _i_am_a_app_name_w/_some_abbrs")
     val basePod = SparkPod.initialPod()
-    // scalastyle:off
 
     val bigMemoryOverheadConf = baseConf.clone
       .set(EXECUTOR_BURSTY_MEMORY_OVERHEAD_ENABLED, true)
@@ -608,7 +605,6 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     baseConf.remove(KUBERNETES_EXECUTOR_POD_NAME_PREFIX)
     baseConf.set("spark.app.name", "xyz.abc _i_am_a_app_name_w/_some_abbrs")
     val basePod = SparkPod.initialPod()
-    // scalastyle:off
 
     val bigMemoryOverheadConf = baseConf.clone
       .set(EXECUTOR_BURSTY_MEMORY_OVERHEAD_ENABLED, true)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
#### Intro
This PR represents Pinterest's work to boost Spark cluster efficiency. 
A novel burst-aware memory allocation algorithm, Canon, that partitions part of the cluster memory into fixed and burst segments is proposed in this PR. This approach allows the burst segments to be shared among different pods, improving overall memory utilization. 

this PR implements Canon: burst aware memory allocation algorithm for memoryOverhead in Spark. The basic idea is that, given the usage of memoryOverhead is pretty bursty, we can separate memoryOverhead into two parts, fixed part (F) and shard part (S). by using K8S request/limit concept, executor pod memory equals to heap size (H) + F and limit is H + F + S

to calculate F and S, we introduced spark.executor.memoryOverheadBurstyFactor (f) as the control factor, assuming users specified spark.executor.memoryOverhead as O

then

F = O - min{(H + O) * (f  - 1), O}

users can use spark.executor.memoryOverheadBursty.enabled to control whether enabling this functionality and use spark.executor.memoryOverheadBurstyFactor to control how aggressive we want to share part of memoryOverhead among different pods.

The effectiveness of this algorithm has been validated through production tests at Pinterest.

#### Acknowledgement
This code in this PR is mainly implemented by Nan Zhu(@CodingCat) while he was working at Pinterest. The algorithm itself is 
based on https://www.vldb.org/pvldb/vol17/p3759-shi.pdf 

#### SPIP:
https://docs.google.com/document/d/1v5PQel1ygVayBFS8rdtzIH8l1el6H1TDjULD3EyBeIc/edit?tab=t.0

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT
Production tests at Pinterest


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
