### PR TITLE
[SPARK-54488][BUILD] Fix Connect JVM client leaks `protobuf-java-util` in shading rules

### DIFF
--- a/sql/connect/client/jvm/pom.xml
+++ b/sql/connect/client/jvm/pom.xml
@@ -75,6 +75,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <scope>compile</scope>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix Connect JVM client leaks `protobuf-java-util` in shading rules by setting `protobuf-java-util` to `compile` scope (was `provided`)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
A bug fix, `spark-connect-client-jvm` jar should correctly shade all protobuf classes, same as the `spark-connect` server jar does.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, users who pull `spark-connect-client-jvm` as dependencies, will not see transitive `protobuf-java-util` dependency.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

```
build/mvn clean install -DskipTests -pl sql/connect/client/jvm -am
```

```patch
  [INFO] --- shade:3.6.0:shade (default) @ spark-connect-client-jvm_2.13 ---
  [INFO] Including org.apache.spark:spark-connect-common_2.13:jar:4.2.0-SNAPSHOT in the shaded jar.
  [INFO] Including io.grpc:grpc-netty:jar:1.76.0 in the shaded jar.
  [INFO] Including io.grpc:grpc-api:jar:1.76.0 in the shaded jar.
  [INFO] Including org.codehaus.mojo:animal-sniffer-annotations:jar:1.24 in the shaded jar.
  [INFO] Including io.grpc:grpc-core:jar:1.76.0 in the shaded jar.
  [INFO] Including com.google.android:annotations:jar:4.1.1.4 in the shaded jar.
  [INFO] Including io.grpc:grpc-context:jar:1.76.0 in the shaded jar.
  [INFO] Including io.perfmark:perfmark-api:jar:0.27.0 in the shaded jar.
  [INFO] Including io.grpc:grpc-util:jar:1.76.0 in the shaded jar.
  [INFO] Including io.grpc:grpc-protobuf:jar:1.76.0 in the shaded jar.
  [INFO] Including com.google.api.grpc:proto-google-common-protos:jar:2.59.2 in the shaded jar.
  [INFO] Including io.grpc:grpc-protobuf-lite:jar:1.76.0 in the shaded jar.
  [INFO] Including io.grpc:grpc-services:jar:1.76.0 in the shaded jar.
  [INFO] Including io.grpc:grpc-stub:jar:1.76.0 in the shaded jar.
  [INFO] Including io.grpc:grpc-inprocess:jar:1.76.0 in the shaded jar.
  [INFO] Including io.netty:netty-codec-http2:jar:4.2.7.Final in the shaded jar.
  [INFO] Including io.netty:netty-common:jar:4.2.7.Final in the shaded jar.
  [INFO] Including io.netty:netty-buffer:jar:4.2.7.Final in the shaded jar.
  [INFO] Including io.netty:netty-transport:jar:4.2.7.Final in the shaded jar.
  [INFO] Including io.netty:netty-resolver:jar:4.2.7.Final in the shaded jar.
  [INFO] Including io.netty:netty-codec-base:jar:4.2.7.Final in the shaded jar.
  [INFO] Including io.netty:netty-handler:jar:4.2.7.Final in the shaded jar.
  [INFO] Including io.netty:netty-codec-http:jar:4.2.7.Final in the shaded jar.
  [INFO] Including io.netty:netty-codec-compression:jar:4.2.7.Final in the shaded jar.
  [INFO] Including io.netty:netty-handler-proxy:jar:4.2.7.Final in the shaded jar.
  [INFO] Including io.netty:netty-codec-socks:jar:4.2.7.Final in the shaded jar.
  [INFO] Including io.netty:netty-transport-native-unix-common:jar:4.2.7.Final in the shaded jar.
  [INFO] Including org.apache.spark:spark-sql-api_2.13:jar:4.2.0-SNAPSHOT in the shaded jar.
  [INFO] Including org.apache.arrow:arrow-vector:jar:18.3.0 in the shaded jar.
  [INFO] Including org.apache.arrow:arrow-format:jar:18.3.0 in the shaded jar.
  [INFO] Including org.apache.arrow:arrow-memory-core:jar:18.3.0 in the shaded jar.
  [INFO] Including com.google.flatbuffers:flatbuffers-java:jar:25.2.10 in the shaded jar.
  [INFO] Including org.apache.arrow:arrow-memory-netty:jar:18.3.0 in the shaded jar.
  [INFO] Including org.apache.arrow:arrow-memory-netty-buffer-patch:jar:18.3.0 in the shaded jar.
  [INFO] Including com.google.protobuf:protobuf-java:jar:4.33.0 in the shaded jar.
+ [INFO] Including com.google.protobuf:protobuf-java-util:jar:4.33.0 in the shaded jar.
  [INFO] Including com.google.code.gson:gson:jar:2.11.0 in the shaded jar.
  [INFO] Including com.google.guava:guava:jar:33.4.8-jre in the shaded jar.
  [INFO] Including com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava in the shaded jar.
  [INFO] Including com.google.guava:failureaccess:jar:1.0.3 in the shaded jar.
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.