### PR TITLE
[SPARK-54115][TESTS][FOLLOW-UP] Refine `org.apache.spark.util.UtilsSuite`

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2079,7 +2079,7 @@ private[spark] object Utils
 
   val CONNECT_EXECUTE_THREAD_PREFIX = "SparkConnectExecuteThread"
 
-  private val threadInfoOrdering = Ordering.fromLessThan {
+  private[spark] val threadInfoOrdering = Ordering.fromLessThan {
     (threadTrace1: ThreadInfo, threadTrace2: ThreadInfo) => {
       def priority(ti: ThreadInfo): Int = ti.getThreadName match {
         case name if name.startsWith(TASK_THREAD_NAME_PREFIX) => 100

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -38,8 +38,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.hadoop.fs.audit.CommonAuditContext.currentAuditContext
 import org.apache.hadoop.ipc.{CallerContext => HadoopCallerContext}
 import org.apache.logging.log4j.Level
-import org.mockito.Mockito.doReturn
-import org.scalatest.PrivateMethodTester
+import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.spark.{SparkConf, SparkException, SparkFunSuite, TaskContext}
@@ -51,7 +50,7 @@ import org.apache.spark.scheduler.SparkListener
 import org.apache.spark.util.collection.Utils.createArray
 import org.apache.spark.util.io.ChunkedByteBufferInputStream
 
-class UtilsSuite extends SparkFunSuite with ResetSystemProperties with PrivateMethodTester {
+class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
 
   test("timeConversion") {
     // Test -1
@@ -1132,37 +1131,35 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with PrivateMe
 
   test("ThreadInfoOrdering") {
     val task1T = mock[ThreadInfo]
-    doReturn(11L).when(task1T).getThreadId
-    doReturn("Executor task launch worker for task 1.0 in stage 1.0 (TID 11)")
-      .when(task1T).getThreadName
-    doReturn("Executor task launch worker for task 1.0 in stage 1.0 (TID 11)")
-      .when(task1T).toString
+    when(task1T.getThreadId).thenReturn(11L)
+    when(task1T.getThreadName)
+      .thenReturn("Executor task launch worker for task 1.0 in stage 1.0 (TID 11)")
+    when(task1T.toString)
+      .thenReturn("Executor task launch worker for task 1.0 in stage 1.0 (TID 11)")
 
     val task2T = mock[ThreadInfo]
-    doReturn(12L).when(task2T).getThreadId
-    doReturn("Executor task launch worker for task 2.0 in stage 1.0 (TID 22)")
-      .when(task2T).getThreadName
-    doReturn("Executor task launch worker for task 2.0 in stage 1.0 (TID 22)")
-      .when(task2T).toString
+    when(task2T.getThreadId).thenReturn(12L)
+    when(task2T.getThreadName)
+      .thenReturn("Executor task launch worker for task 2.0 in stage 1.0 (TID 22)")
+    when(task2T.toString)
+      .thenReturn("Executor task launch worker for task 2.0 in stage 1.0 (TID 22)")
 
     val connectExecuteOp1T = mock[ThreadInfo]
-    doReturn(21L).when(connectExecuteOp1T).getThreadId
-    doReturn("SparkConnectExecuteThread_opId=16148fb4-4189-43c3-b8d4-8b3b6ddd41c7")
-      .when(connectExecuteOp1T).getThreadName
-    doReturn("SparkConnectExecuteThread_opId=16148fb4-4189-43c3-b8d4-8b3b6ddd41c7")
-      .when(connectExecuteOp1T).toString
+    when(connectExecuteOp1T.getThreadId).thenReturn(21L)
+    when(connectExecuteOp1T.getThreadName)
+      .thenReturn("SparkConnectExecuteThread_opId=16148fb4-4189-43c3-b8d4-8b3b6ddd41c7")
+    when(connectExecuteOp1T.toString)
+      .thenReturn("SparkConnectExecuteThread_opId=16148fb4-4189-43c3-b8d4-8b3b6ddd41c7")
 
     val connectExecuteOp2T = mock[ThreadInfo]
-    doReturn(22L).when(connectExecuteOp2T).getThreadId
-    doReturn("SparkConnectExecuteThread_opId=4e4d1cac-ffde-46c1-b7c2-808b726cb47e")
-      .when(connectExecuteOp2T).getThreadName
-    doReturn("SparkConnectExecuteThread_opId=4e4d1cac-ffde-46c1-b7c2-808b726cb47e")
-      .when(connectExecuteOp2T).toString
+    when(connectExecuteOp2T.getThreadId).thenReturn(22L)
+    when(connectExecuteOp2T.getThreadName)
+      .thenReturn("SparkConnectExecuteThread_opId=4e4d1cac-ffde-46c1-b7c2-808b726cb47e")
+    when(connectExecuteOp2T.toString)
+      .thenReturn("SparkConnectExecuteThread_opId=4e4d1cac-ffde-46c1-b7c2-808b726cb47e")
 
-    val threadInfoOrderingMethod =
-      PrivateMethod[Ordering[ThreadInfo]](Symbol("threadInfoOrdering"))
     val sorted = Seq(connectExecuteOp1T, connectExecuteOp2T, task1T, task2T)
-      .sorted(Utils.invokePrivate(threadInfoOrderingMethod()))
+      .sorted(Utils.threadInfoOrdering)
     assert(sorted === Seq(task1T, task2T, connectExecuteOp1T, connectExecuteOp2T))
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
> Use doReturn() in those rare occasions when you cannot use when(Object)

`when` is preferred in the official doc https://javadoc.io/static/org.mockito/mockito-core/5.12.0/org/mockito/Mockito.html#when(T)


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
