### PR TITLE
[SPARK-54444][SQL] Relax DSv2 table checks to restore previous behavior

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Implicits.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Implicits.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.catalog.{BucketSpec, ClusterBySpec}
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
-import org.apache.spark.sql.catalyst.util.{quoteIfNeeded, QuotingUtils}
+import org.apache.spark.sql.catalyst.util.{quoteIfNeeded, quoteNameParts, QuotingUtils}
 import org.apache.spark.sql.connector.expressions.{BucketTransform, ClusterByTransform, FieldReference, IdentityTransform, LogicalExpressions, Transform}
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.types.StructType
@@ -222,6 +222,8 @@ private[sql] object CatalogV2Implicits {
     }
 
     def quoted: String = parts.map(quoteIfNeeded).mkString(".")
+
+    def fullyQuoted: String = quoteNameParts(parts)
 
     def original: String = parts.mkString(".")
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
@@ -587,12 +587,29 @@ private[sql] object CatalogV2Util {
       .asTableCatalog
   }
 
+  def toStructType(cols: Seq[MetadataColumn]): StructType = {
+    StructType(cols.map(toStructField))
+  }
+
+  private def toStructField(col: MetadataColumn): StructField = {
+    val metadata = Option(col.metadataInJSON).map(Metadata.fromJson).getOrElse(Metadata.empty)
+    var f = StructField(col.name, col.dataType, col.isNullable, metadata)
+    if (col.comment != null) {
+      f = f.withComment(col.comment)
+    }
+    f
+  }
+
+  def v2ColumnsToStructType(columns: Array[Column]): StructType = {
+    v2ColumnsToStructType(columns.toImmutableArraySeq)
+  }
+
   /**
    * Converts DS v2 columns to StructType, which encodes column comment and default value to
    * StructField metadata. This is mainly used to define the schema of v2 scan, w.r.t. the columns
    * of the v2 table.
    */
-  def v2ColumnsToStructType(columns: Array[Column]): StructType = {
+  def v2ColumnsToStructType(columns: Seq[Column]): StructType = {
     StructType(columns.map(v2ColumnToStructField))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2TableRefreshUtil.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2TableRefreshUtil.scala
@@ -22,11 +22,14 @@ import scala.collection.mutable
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.analysis.AsOfVersion
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan}
 import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableCatalog, V2TableUtil}
 import org.apache.spark.sql.connector.catalog.CatalogV2Util
 import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.util.SchemaValidationMode
+import org.apache.spark.sql.util.SchemaValidationMode.ALLOW_NEW_FIELDS
+import org.apache.spark.sql.util.SchemaValidationMode.PROHIBIT_CHANGES
 
 private[sql] object V2TableRefreshUtil extends SQLConfHelper with Logging {
   /**
@@ -55,11 +58,14 @@ private[sql] object V2TableRefreshUtil extends SQLConfHelper with Logging {
    *
    * This method reloads table metadata from the catalog and validates:
    *  - Table identity: Ensures table ID has not changed
-   *  - Data columns: Verifies captured columns match the current schema
+   *  - Data columns: Verifies captured columns align with the current schema
    *  - Metadata columns: Checks metadata column consistency
    *
    * Tables with time travel specifications are skipped as they reference a specific point
    * in time and don't have to be refreshed.
+   *
+   * Schema validation mode depends on the underlying plan. Commands, for instance,
+   * prohibit any schema changes while queries permit adding columns.
    *
    * @param spark the currently active Spark session
    * @param plan the logical plan to refresh
@@ -70,6 +76,31 @@ private[sql] object V2TableRefreshUtil extends SQLConfHelper with Logging {
       spark: SparkSession,
       plan: LogicalPlan,
       versionedOnly: Boolean = false): LogicalPlan = {
+    refresh(spark, plan, versionedOnly, determineSchemaValidationMode(plan))
+  }
+
+  /**
+   * Refreshes table metadata for tables in the plan.
+   *
+   * This method reloads table metadata from the catalog and validates:
+   *  - Table identity: Ensures table ID has not changed
+   *  - Data columns: Verifies captured columns align with the current schema
+   *  - Metadata columns: Checks metadata column consistency
+   *
+   * Tables with time travel specifications are skipped as they reference a specific point
+   * in time and don't have to be refreshed.
+   *
+   * @param spark the currently active Spark session
+   * @param plan the logical plan to refresh
+   * @param versionedOnly indicates whether to refresh only versioned tables
+   * @param schemaValidationMode schema validation mode to use
+   * @return plan with refreshed table metadata
+   */
+  def refresh(
+      spark: SparkSession,
+      plan: LogicalPlan,
+      versionedOnly: Boolean,
+      schemaValidationMode: SchemaValidationMode): LogicalPlan = {
     val currentTables = mutable.HashMap.empty[(TableCatalog, Identifier), Table]
     plan transform {
       case r @ ExtractV2CatalogAndIdentifier(catalog, ident)
@@ -86,8 +117,8 @@ private[sql] object V2TableRefreshUtil extends SQLConfHelper with Logging {
           }
         })
         validateTableIdentity(currentTable, r)
-        validateDataColumns(currentTable, r)
-        validateMetadataColumns(currentTable, r)
+        validateDataColumns(currentTable, r, schemaValidationMode)
+        validateMetadataColumns(currentTable, r, schemaValidationMode)
         r.copy(table = currentTable)
     }
   }
@@ -100,6 +131,15 @@ private[sql] object V2TableRefreshUtil extends SQLConfHelper with Logging {
     CatalogV2Util.lookupCachedRelation(spark.sharedState.relationCache, catalog, ident, table, conf)
   }
 
+  // it is not safe to allow any schema changes in commands (e.g. CTAS, RTAS, MERGE)
+  private def determineSchemaValidationMode(plan: LogicalPlan): SchemaValidationMode = {
+    if (containsCommand(plan)) PROHIBIT_CHANGES else ALLOW_NEW_FIELDS
+  }
+
+  private def containsCommand(plan: LogicalPlan): Boolean = {
+    plan.find(_.isInstanceOf[Command]).isDefined
+  }
+
   private def validateTableIdentity(currentTable: Table, relation: DataSourceV2Relation): Unit = {
     if (relation.table.id != null && relation.table.id != currentTable.id) {
       throw QueryCompilationErrors.tableIdChangedAfterAnalysis(
@@ -109,15 +149,21 @@ private[sql] object V2TableRefreshUtil extends SQLConfHelper with Logging {
     }
   }
 
-  private def validateDataColumns(currentTable: Table, relation: DataSourceV2Relation): Unit = {
-    val errors = V2TableUtil.validateCapturedColumns(currentTable, relation)
+  private def validateDataColumns(
+      currentTable: Table,
+      relation: DataSourceV2Relation,
+      mode: SchemaValidationMode): Unit = {
+    val errors = V2TableUtil.validateCapturedColumns(currentTable, relation, mode)
     if (errors.nonEmpty) {
       throw QueryCompilationErrors.columnsChangedAfterAnalysis(relation.name, errors)
     }
   }
 
-  private def validateMetadataColumns(currentTable: Table, relation: DataSourceV2Relation): Unit = {
-    val errors = V2TableUtil.validateCapturedMetadataColumns(currentTable, relation)
+  private def validateMetadataColumns(
+      currentTable: Table,
+      relation: DataSourceV2Relation,
+      mode: SchemaValidationMode): Unit = {
+    val errors = V2TableUtil.validateCapturedMetadataColumns(currentTable, relation, mode)
     if (errors.nonEmpty) {
       throw QueryCompilationErrors.metadataColumnsChangedAfterAnalysis(relation.name, errors)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
@@ -38,6 +38,7 @@ import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.joins.BaseJoinExec
 import org.apache.spark.sql.execution.metric.{CustomMetrics, SQLMetric, SQLMetrics}
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.SchemaValidationMode.PROHIBIT_CHANGES
 import org.apache.spark.util.{LongAccumulator, Utils}
 import org.apache.spark.util.ArrayImplicits._
 
@@ -171,7 +172,11 @@ case class ReplaceTableAsSelectExec(
     //
     // RTAS must refresh and pin versions in query to read from original table versions instead of
     // newly created empty table that is meant to serve as target for append/overwrite
-    val refreshedQuery = V2TableRefreshUtil.refresh(session, query, versionedOnly = true)
+    val refreshedQuery = V2TableRefreshUtil.refresh(
+      session,
+      query,
+      versionedOnly = true,
+      schemaValidationMode = PROHIBIT_CHANGES)
     val pinnedQuery = V2TableRefreshUtil.pinVersions(refreshedQuery)
     if (catalog.tableExists(ident)) {
       invalidateCache(catalog, ident)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
@@ -1124,7 +1124,7 @@ class DataSourceV2DataFrameSuite
     }
   }
 
-  test("SPARK-54157: detect column addition after DataFrame analysis") {
+  test("SPARK-54157: allow column addition after DataFrame analysis") {
     val t = "testcat.ns1.ns2.tbl"
     withTable(t) {
       sql(s"CREATE TABLE $t (id INT, data STRING) USING foo")
@@ -1137,22 +1137,15 @@ class DataSourceV2DataFrameSuite
       sql(s"ALTER TABLE $t ADD COLUMN new_col1 INT")
       sql(s"ALTER TABLE $t ADD COLUMN new_col2 INT")
 
-      // execution should fail with column mismatch
-      checkError(
-        exception = intercept[AnalysisException] { df.collect() },
-        condition = "INCOMPATIBLE_TABLE_CHANGE_AFTER_ANALYSIS.COLUMNS_MISMATCH",
-        parameters = Map(
-          "tableName" -> "`testcat`.`ns1`.`ns2`.`tbl`",
-          "errors" ->
-            """- `new_col1` INT has been added
-              |- `new_col2` INT has been added""".stripMargin))
+      // execution should succeed as column additions are allowed
+      checkAnswer(df, Seq(Row(1, "a")))
     }
   }
 
   test("SPARK-54157: detect multiple change types after DataFrame analysis") {
     val t = "testcat.ns1.ns2.tbl"
     withTable(t) {
-      sql(s"CREATE TABLE $t (col1 INT, col2 STRING, col3 BOOLEAN, col4 STRING) USING foo")
+      sql(s"CREATE TABLE $t (col1 INT, col2 STRING, col3 BOOLEAN NOT NULL, col4 STRING) USING foo")
       sql(s"INSERT INTO $t VALUES (1, 'a', true, 'x')")
 
       // create DataFrame and trigger analysis
@@ -1160,7 +1153,7 @@ class DataSourceV2DataFrameSuite
 
       // make multiple changes in table
       sql(s"ALTER TABLE $t DROP COLUMN col4")
-      sql(s"ALTER TABLE $t ADD COLUMN col5 INT")
+      sql(s"ALTER TABLE $t ALTER COLUMN col3 DROP NOT NULL")
 
       // execution should fail with column mismatch
       checkError(
@@ -1169,8 +1162,8 @@ class DataSourceV2DataFrameSuite
         parameters = Map(
           "tableName" -> "`testcat`.`ns1`.`ns2`.`tbl`",
           "errors" ->
-            """- `col4` STRING has been removed
-              |- `col5` INT has been added""".stripMargin))
+            """- `col3` is nullable now
+              |- `col4` STRING has been removed""".stripMargin))
     }
   }
 
@@ -1200,7 +1193,7 @@ class DataSourceV2DataFrameSuite
     }
   }
 
-  test("SPARK-54157: detect nested struct field changes after DataFrame analysis") {
+  test("SPARK-54157: detect incompatible nested struct field changes after DataFrame analysis") {
     val t = "testcat.ns1.ns2.tbl"
     withTable(t) {
       sql(s"CREATE TABLE $t (id INT, person STRUCT<name: STRING, age: INT>) USING foo")
@@ -1209,8 +1202,8 @@ class DataSourceV2DataFrameSuite
       // create DataFrame and trigger analysis
       val df = spark.table(t)
 
-      // add nested field to struct column
-      sql(s"ALTER TABLE $t ADD COLUMN person.city STRING")
+      // remove nested field from struct column
+      sql(s"ALTER TABLE $t DROP COLUMN person.age")
 
       // execution should fail with column mismatch
       checkError(
@@ -1218,13 +1211,11 @@ class DataSourceV2DataFrameSuite
         condition = "INCOMPATIBLE_TABLE_CHANGE_AFTER_ANALYSIS.COLUMNS_MISMATCH",
         parameters = Map(
           "tableName" -> "`testcat`.`ns1`.`ns2`.`tbl`",
-          "errors" ->
-            ("- `person` type has changed from STRUCT<name: STRING, age: INT> " +
-              "to STRUCT<name: STRING, age: INT, city: STRING>")))
+          "errors" -> "- `person`.`age` INT has been removed"))
     }
   }
 
-  test("SPARK-54157: detect schema changes in join with same table") {
+  test("SPARK-54157: allow compatible schema changes in join with same table") {
     val t = "testcat.ns1.ns2.tbl"
     withTable(t) {
       sql(s"CREATE TABLE $t (id INT, name STRING, value INT) USING foo")
@@ -1260,16 +1251,13 @@ class DataSourceV2DataFrameSuite
         Row(3, "c", 30, null),
         Row(4, "d", 40, "x")))
 
-      // join between df1 and df3 should fail as refreshing versions is not
-      // sufficient because df1 was resolved with old schema
-      checkError(
-        exception = intercept[AnalysisException] {
-          df1.join(df3, df1("id") === df3("id")).collect()
-        },
-        condition = "INCOMPATIBLE_TABLE_CHANGE_AFTER_ANALYSIS.COLUMNS_MISMATCH",
-        parameters = Map(
-          "tableName" -> "`testcat`.`ns1`.`ns2`.`tbl`",
-          "errors" -> "- `extra` STRING has been added"))
+      // join between df1 and df3 is allowed as schema changes are compatible with df1
+      // Spark will refresh versions in joined DataFrame before execution
+      checkAnswer(df1.join(df3, df1("id") === df3("id")), Seq(
+        Row(1, "a", 10, 1, "a", 10, null),
+        Row(2, "b", 20, 2, "b", 20, null),
+        Row(3, "c", 30, 3, "c", 30, null),
+        Row(4, "d", 40, 4, "d", 40, "x")))
 
       // DataFrame execution before joins must have pinned used versions
       // subsequent version refreshes must not be visible in original DataFrames
@@ -1280,6 +1268,64 @@ class DataSourceV2DataFrameSuite
         Row(2, "b", 20, null),
         Row(3, "c", 30, null),
         Row(4, "d", 40, "x")))
+    }
+  }
+
+  test("SPARK-54157: prohibit incompatible schema changes in join with same table") {
+    val t = "testcat.ns1.ns2.tbl"
+    withTable(t) {
+      sql(s"CREATE TABLE $t (id INT, name STRING, value INT) USING foo")
+      sql(s"INSERT INTO $t VALUES (1, 'a', 10), (2, 'b', 20)")
+
+      // create first DataFrame
+      val df1 = spark.table(t)
+      checkAnswer(df1, Seq(Row(1, "a", 10), Row(2, "b", 20)))
+
+      // insert more data
+      sql(s"INSERT INTO $t VALUES (3, 'c', 30)")
+
+      // create second DataFrame with new data
+      val df2 = spark.table(t)
+      checkAnswer(df2, Seq(Row(1, "a", 10), Row(2, "b", 20), Row(3, "c", 30)))
+
+      // it should be valid to join df1 and df2
+      // Spark will refresh versions in joined DataFrame before execution
+      assert(df1.join(df2, df1("id") === df2("id")).count() == 3)
+
+      // df1 has been executed that must have pinned the version
+      checkAnswer(df1, Seq(Row(1, "a", 10), Row(2, "b", 20)))
+
+      // remove column and insert more data
+      sql(s"ALTER TABLE $t DROP COLUMN value")
+      sql(s"INSERT INTO $t VALUES (4, 'd')")
+
+      // create third DataFrame with new data and schema
+      val df3 = spark.table(t)
+      checkAnswer(df3, Seq(
+        Row(1, "a"),
+        Row(2, "b"),
+        Row(3, "c"),
+        Row(4, "d")))
+
+      // join between df1 and df3 should fail due to incompatible schema changes
+      checkError(
+        exception = intercept[AnalysisException] {
+          df1.join(df3, df1("id") === df3("id")).collect()
+        },
+        condition = "INCOMPATIBLE_TABLE_CHANGE_AFTER_ANALYSIS.COLUMNS_MISMATCH",
+        parameters = Map(
+          "tableName" -> "`testcat`.`ns1`.`ns2`.`tbl`",
+          "errors" -> "- `value` INT has been removed"))
+
+      // DataFrame execution before joins must have pinned used versions
+      // subsequent version refreshes must not be visible in original DataFrames
+      checkAnswer(df1, Seq(Row(1, "a", 10), Row(2, "b", 20)))
+      checkAnswer(df2, Seq(Row(1, "a", 10), Row(2, "b", 20), Row(3, "c", 30)))
+      checkAnswer(df3, Seq(
+        Row(1, "a"),
+        Row(2, "b"),
+        Row(3, "c"),
+        Row(4, "d")))
     }
   }
 
@@ -1447,7 +1493,7 @@ class DataSourceV2DataFrameSuite
           "viewName" -> "`v`",
           "tableName" -> "`testcat`.`ns1`.`ns2`.`tbl`",
           "colType" -> "data",
-          "errors" -> "- `data` type has changed from STRING NOT NULL to STRING"))
+          "errors" -> "- `data` is nullable now"))
     }
   }
 
@@ -1704,6 +1750,33 @@ class DataSourceV2DataFrameSuite
       // verify external changes are reflected correctly when table is queried
       assertNotCached(spark.table(t))
       checkAnswer(spark.table(t), Seq.empty)
+    }
+  }
+
+  test("SPARK-54444: any schema changes after analysis are prohibited in commands") {
+    val s = "testcat.ns1.s"
+    val t = "testcat.ns1.t"
+    withTable(s, t) {
+      sql(s"CREATE TABLE $s (id bigint, data string) USING foo")
+      sql(s"INSERT INTO $s VALUES (1, 'a'), (2, 'b')")
+
+      // create source DataFrame without executing it
+      val sourceDF = spark.table(s)
+
+      // derive another DataFrame from pre-analyzed source
+      val filteredSourceDF = sourceDF.filter("id < 10")
+
+      // add column
+      sql(s"ALTER TABLE $s ADD COLUMN dep STRING")
+
+      // insert more data into source table
+      sql(s"INSERT INTO $s VALUES (3, 'c', 'finance')")
+
+      // CTAS should fail as commands must operate on current schema
+      val e = intercept[AnalysisException] {
+        filteredSourceDF.writeTo(t).createOrReplace()
+      }
+      assert(e.message.contains("incompatible changes to table `testcat`.`ns1`.`s`"))
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR relaxes DSv2 table checks to restore well-known Spark behavior that allowed new fields to be added concurrently without failing the execution of queries (not commands).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

These changes are needed to avoid behavior changes in 4.1.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, but for UNRELEASED logic. Before this PR, we would fail execution if we detected any schema changes after analysis. After this PR, we would allow new columns to be added in queries and prohibit any schema changes otherwise.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing + new tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.
