### PR TITLE
[SPARK-54247][PYTHON][FOLLOWUP] Ensure socket is not leaked and add regression tests

### DIFF
--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -668,7 +668,7 @@ class PythonEvalType:
     SQL_ARROW_UDTF: "SQLArrowUDTFType" = 302
 
 
-def _create_local_socket(sock_info: "JavaArray") -> "io.BufferedRWPair":
+def _create_local_socket(sock_info: "JavaArray") -> Tuple["io.BufferedRWPair", "socket.socket"]:
     """
     Create a local socket that can be used to load deserialized data from the JVM
 
@@ -689,7 +689,7 @@ def _create_local_socket(sock_info: "JavaArray") -> "io.BufferedRWPair":
     # The RDD materialization time is unpredictable, if we set a timeout for socket reading
     # operation, it will very possibly fail. See SPARK-18281.
     sock.settimeout(None)
-    return sockfile
+    return sockfile, sock
 
 
 @contextmanager
@@ -710,10 +710,11 @@ def _load_from_socket(sock_info: "JavaArray", serializer: "Serializer") -> Itera
     usually a generator that yields deserialized data
     """
     try:
-        sockfile = _create_local_socket(sock_info)
+        sockfile, sock = _create_local_socket(sock_info)
         yield serializer.load_stream(sockfile)
     finally:
         sockfile.close()
+        sock.close()
 
 
 def _local_iterator_from_socket(sock_info: "JavaArray", serializer: "Serializer") -> Iterator[Any]:
@@ -725,7 +726,7 @@ def _local_iterator_from_socket(sock_info: "JavaArray", serializer: "Serializer"
             auth_secret: str
             jsocket_auth_server: "JavaObject"
             port, auth_secret, self.jsocket_auth_server = _sock_info
-            self._sockfile = _create_local_socket((port, auth_secret))
+            self._sockfile, self._sock = _create_local_socket((port, auth_secret))
             self._serializer = _serializer
             self._read_iter: Iterator[Any] = iter([])  # Initialize as empty iterator
             self._read_status = 1
@@ -761,6 +762,8 @@ def _local_iterator_from_socket(sock_info: "JavaArray", serializer: "Serializer"
                 except Exception:
                     # Ignore any errors, socket is automatically closed when garbage-collected
                     pass
+            self._sockfile.close()
+            self._sock.close()
 
     return iter(PyLocalIterable(sock_info, serializer))
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

* #53200 did not fix the socket leak issue properly. This PR fixed it by closing the socket as well
* In order to prevent such mistakes, regression tests are added
* `_local_iterator_from_socket` is leaking socket too, fixed in this PR as well.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To avoid leaking socket (technically it's still closed at GC, it was explained in #53200).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

A new regression test is added and I confirmed the test fails before fix and passes after.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
