### PR TITLE
[SPARK-54506][CORE] Add $init$ method to LogKey for backward compatibility

### DIFF
--- a/common/utils-java/src/main/java/org/apache/spark/internal/LogKey.java
+++ b/common/utils-java/src/main/java/org/apache/spark/internal/LogKey.java
@@ -49,4 +49,14 @@ package org.apache.spark.internal;
  */
 public interface LogKey {
   String name();
+
+  /**
+   * This method is added for backward compatibility with libraries compiled against older Spark
+   * versions where LogKey was a Scala trait. Scala traits generate a $init$ method that gets
+   * called during initialization. Since LogKey is now a Java interface, we provide this empty
+   * static method to prevent NoSuchMethodError at runtime.
+   */
+  static void $init$(LogKey logKey) {
+    // Empty method for binary compatibility
+  }
 }

--- a/common/utils-java/src/main/java/org/apache/spark/internal/LogKey.java
+++ b/common/utils-java/src/main/java/org/apache/spark/internal/LogKey.java
@@ -51,8 +51,8 @@ public interface LogKey {
   String name();
 
   /**
-   * This method is added for backward compatibility with libraries compiled against older Spark
-   * versions where LogKey was a Scala trait. Scala traits generate a $init$ method that gets
+   * This method is added for backward compatibility with libraries compiled against Spark
+   * 4.0 where LogKey was a Scala trait. Scala traits generate a $init$ method that gets
    * called during initialization. Since LogKey is now a Java interface, we provide this empty
    * static method to prevent NoSuchMethodError at runtime.
    */

--- a/common/utils-java/src/test/java/org/apache/spark/util/LogKeySuite.java
+++ b/common/utils-java/src/test/java/org/apache/spark/util/LogKeySuite.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.spark.internal.LogKey;
+import org.apache.spark.internal.LogKeys;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Test suite for {@link LogKey} interface.
+ */
+public class LogKeySuite {
+
+  /**
+   * Test that the $init$ method exists and can be called without throwing an exception.
+   * This method is added for backward compatibility with libraries compiled against Spark 4.0
+   * where LogKey was a Scala trait. Scala traits generate a $init$ method that gets called
+   * during initialization.
+   */
+  @Test
+  public void testBackwardCompatibilityInitMethod() {
+    // Test with a standard LogKey
+    LogKey logKey = LogKeys.EXECUTOR_ID;
+    assertDoesNotThrow(() -> LogKey.$init$(logKey));
+
+    // Test with null (should not throw)
+    assertDoesNotThrow(() -> LogKey.$init$(null));
+
+    // Test with a custom LogKey implementation
+    LogKey customLogKey = CustomLogKeys.CUSTOM_LOG_KEY;
+    assertDoesNotThrow(() -> LogKey.$init$(customLogKey));
+  }
+}
+


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Follow-up of https://issues.apache.org/jira/browse/SPARK-53064.

Add a static `$init$` method to the `LogKey` interface for backward compatibility with libraries compiled against Spark 4.0 where `LogKey` was a Scala trait.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In Spark 4.0, `LogKey` was a Scala trait which generates a `$init$` method during compilation. Libraries like Delta Lake compiled against Spark 4.0 expect this method to exist. Since `LogKey` has been changed to a Java interface, calling the `$init$` method throws `NoSuchMethodError`:
```
java.lang.NoSuchMethodError: 'void org.apache.spark.internal.LogKey.$init$(org.apache.spark.internal.LogKey)'
```
This change adds an empty `$init$` static method to maintain binary compatibility.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added a new test `LogKeySuite` to verify the `$init$` method exists and can be called without throwing an exception.



