### PR TITLE
[SPARK-54508][PYTHON] Fix `spark-pipelines` to resolve `spec` file path more robustly

### DIFF
--- a/python/pyspark/pipelines/cli.py
+++ b/python/pyspark/pipelines/cli.py
@@ -228,7 +228,8 @@ def register_definitions(
     - Import Python files matching the glob patterns in the spec.
     - Register SQL files matching the glob patterns in the spec.
     """
-    path = spec_path.parent
+    path = spec_path.parent.resolve()
+
     with change_dir(path):
         with graph_element_registration_context(registry):
             log_with_curr_timestamp(f"Loading definitions. Root directory: '{path}'.")
@@ -260,7 +261,7 @@ def register_definitions(
                         log_with_curr_timestamp(f"Registering SQL file {file}...")
                         with file.open("r") as f:
                             sql = f.read()
-                        file_path_relative_to_spec = file.relative_to(spec_path.parent)
+                        file_path_relative_to_spec = file.relative_to(path)
                         registry.register_sql(sql, file_path_relative_to_spec)
                     else:
                         raise PySparkException(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes a bug that causes executing `spark-pipelines` with a spec file in a subdirectory to fail:

```
spark-pipelines run --spec subdir/spark-pipelines.yml
```

results in

```
pyspark.errors.exceptions.connect.AnalysisException: [RUN_EMPTY_PIPELINE] Pipelines are expected to have at least one non-temporary dataset defined (tables, persisted views) but no non-temporary datasets were found in your pipeline.
```

### Why are the changes needed?

Fix a bug.


### Does this PR introduce _any_ user-facing change?

Fixes a user-facing bug

### How was this patch tested?

Ran
```
spark-pipelines run --spec subdir/spark-pipelines.yml
```

Observed it fail before the change and succeed after.

With our current Pipelines CLI unit testing setup, there isn't a straightforward way to write a test for this, but I'm investigating whether we can augment it.

### Was this patch authored or co-authored using generative AI tooling?

No.