### PR TITLE
[SPARK-54485][SPARK-54494][PYTHON][TESTS][4.0] Re-enable tests in test_parity_udf_profiler and test_parity_memory_profiler

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_memory_profiler.py
+++ b/python/pyspark/sql/tests/connect/test_parity_memory_profiler.py
@@ -19,13 +19,24 @@ import os
 import unittest
 
 from pyspark.tests.test_memory_profiler import MemoryProfiler2TestsMixin, _do_computation
-from pyspark.testing.connectutils import ReusedConnectTestCase
+from pyspark.testing.connectutils import (
+    ReusedConnectTestCase,
+    skip_if_server_version_is_greater_than_or_equal_to,
+)
 
 
 class MemoryProfilerParityTests(MemoryProfiler2TestsMixin, ReusedConnectTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.spark._profiler_collector._value = None
+
+    @skip_if_server_version_is_greater_than_or_equal_to("4.1.0")
+    def test_memory_profiler_pandas_udf_iterator_not_supported(self):
+        super().test_memory_profiler_pandas_udf_iterator_not_supported()
+
+    @skip_if_server_version_is_greater_than_or_equal_to("4.1.0")
+    def test_memory_profiler_map_in_pandas_not_supported(self):
+        super().test_memory_profiler_map_in_pandas_not_supported()
 
 
 class MemoryProfilerWithoutPlanCacheParityTests(MemoryProfilerParityTests):

--- a/python/pyspark/sql/tests/connect/test_parity_udf_profiler.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udf_profiler.py
@@ -22,7 +22,10 @@ from pyspark.sql.tests.test_udf_profiler import (
     UDFProfiler2TestsMixin,
     _do_computation,
 )
-from pyspark.testing.connectutils import ReusedConnectTestCase
+from pyspark.testing.connectutils import (
+    ReusedConnectTestCase,
+    skip_if_server_version_is_greater_than_or_equal_to,
+)
 from pyspark.testing.utils import have_flameprof
 
 
@@ -30,6 +33,14 @@ class UDFProfilerParityTests(UDFProfiler2TestsMixin, ReusedConnectTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.spark._profiler_collector._value = None
+
+    @skip_if_server_version_is_greater_than_or_equal_to("4.1.0")
+    def test_perf_profiler_pandas_udf_iterator_not_supported(self):
+        super().test_perf_profiler_pandas_udf_iterator_not_supported()
+
+    @skip_if_server_version_is_greater_than_or_equal_to("4.1.0")
+    def test_perf_profiler_map_in_pandas_not_supported(self):
+        super().test_perf_profiler_map_in_pandas_not_supported()
 
 
 class UDFProfilerWithoutPlanCacheParityTests(UDFProfilerParityTests):

--- a/python/pyspark/sql/tests/test_udf_profiler.py
+++ b/python/pyspark/sql/tests/test_udf_profiler.py
@@ -307,9 +307,6 @@ class UDFProfiler2TestsMixin:
                 self.assertIn("svg", self.spark.profile.render(id))
 
     @unittest.skipIf(
-        os.environ.get("SPARK_SKIP_CONNECT_COMPAT_TESTS") == "1", "SPARK-54494: To be reenabled"
-    )
-    @unittest.skipIf(
         not have_pandas or not have_pyarrow,
         cast(str, pandas_requirement_message or pyarrow_requirement_message),
     )
@@ -345,9 +342,6 @@ class UDFProfiler2TestsMixin:
             if have_flameprof:
                 self.assertIn("svg", self.spark.profile.render(id))
 
-    @unittest.skipIf(
-        os.environ.get("SPARK_SKIP_CONNECT_COMPAT_TESTS") == "1", "SPARK-54494: To be reenabled"
-    )
     @unittest.skipIf(
         not have_pandas or not have_pyarrow,
         cast(str, pandas_requirement_message or pyarrow_requirement_message),

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -36,6 +36,7 @@ from pyspark.testing import (
     should_test_connect,
 )
 from pyspark import Row, SparkConf
+from pyspark.loose_version import LooseVersion
 from pyspark.util import is_remote_only
 from pyspark.testing.utils import PySparkErrorTestUtils
 from pyspark.testing.sqlutils import (
@@ -197,3 +198,28 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
             return QuietTest(self._legacy_sc)
         else:
             return contextlib.nullcontext()
+
+
+def skip_if_server_version_is(
+    cond: typing.Callable[[LooseVersion], bool], reason: typing.Optional[str] = None
+) -> typing.Callable[[...], ...]:
+    def decorator(f: typing.Callable) -> typing.Callable:
+        @functools.wraps(f)
+        def wrapper(self, *args, **kwargs):
+            version = self.spark.version
+            if cond(LooseVersion(version)):
+                raise unittest.SkipTest(
+                    f"Skipping test {f.__name__} because server version is {version}"
+                    + (f" ({reason})" if reason else "")
+                )
+            return f(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def skip_if_server_version_is_greater_than_or_equal_to(
+    version: str, reason: typing.Optional[str] = None
+) -> typing.Callable[[...], ...]:
+    return skip_if_server_version_is(lambda v: v >= LooseVersion(version), reason)

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -16,12 +16,12 @@
 #
 import shutil
 import tempfile
-import typing
 import os
 import functools
 import unittest
 import uuid
 import contextlib
+from typing import Callable, Optional
 
 from pyspark.testing import (
     grpc_requirement_message,
@@ -201,9 +201,9 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
 
 
 def skip_if_server_version_is(
-    cond: typing.Callable[[LooseVersion], bool], reason: typing.Optional[str] = None
-) -> typing.Callable[[...], ...]:
-    def decorator(f: typing.Callable) -> typing.Callable:
+    cond: Callable[[LooseVersion], bool], reason: Optional[str] = None
+) -> Callable[[...], ...]:
+    def decorator(f: Callable) -> Callable:
         @functools.wraps(f)
         def wrapper(self, *args, **kwargs):
             version = self.spark.version
@@ -220,6 +220,6 @@ def skip_if_server_version_is(
 
 
 def skip_if_server_version_is_greater_than_or_equal_to(
-    version: str, reason: typing.Optional[str] = None
-) -> typing.Callable[[...], ...]:
+    version: str, reason: Optional[str] = None
+) -> Callable[[...], ...]:
     return skip_if_server_version_is(lambda v: v >= LooseVersion(version), reason)

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -202,7 +202,7 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
 
 def skip_if_server_version_is(
     cond: Callable[[LooseVersion], bool], reason: Optional[str] = None
-) -> Callable[[...], ...]:
+) -> Callable:
     def decorator(f: Callable) -> Callable:
         @functools.wraps(f)
         def wrapper(self, *args, **kwargs):
@@ -221,5 +221,5 @@ def skip_if_server_version_is(
 
 def skip_if_server_version_is_greater_than_or_equal_to(
     version: str, reason: Optional[str] = None
-) -> Callable[[...], ...]:
+) -> Callable:
     return skip_if_server_version_is(lambda v: v >= LooseVersion(version), reason)

--- a/python/pyspark/tests/test_memory_profiler.py
+++ b/python/pyspark/tests/test_memory_profiler.py
@@ -346,9 +346,6 @@ class MemoryProfiler2TestsMixin:
             )
 
     @unittest.skipIf(
-        os.environ.get("SPARK_SKIP_CONNECT_COMPAT_TESTS") == "1", "SPARK-54494: To be reenabled"
-    )
-    @unittest.skipIf(
         not have_pandas or not have_pyarrow,
         cast(str, pandas_requirement_message or pyarrow_requirement_message),
     )
@@ -381,9 +378,6 @@ class MemoryProfiler2TestsMixin:
                 io.getvalue(), f"Filename.*{os.path.basename(inspect.getfile(_do_computation))}"
             )
 
-    @unittest.skipIf(
-        os.environ.get("SPARK_SKIP_CONNECT_COMPAT_TESTS") == "1", "SPARK-54494: To be reenabled"
-    )
     @unittest.skipIf(
         not have_pandas or not have_pyarrow,
         cast(str, pandas_requirement_message or pyarrow_requirement_message),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Re-enables tests in `test_parity_udf_profiler` and `test_parity_memory_profiler`.

Added utility decorators for Spark Connect parity tests.

- `skip_if_server_version_is`
- `skip_if_server_version_is_greater_than_or_equal_to`

### Why are the changes needed?

Some tests are disabled due to Spark Connect cross version tests.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Modified the related tests to use the utility.

### Was this patch authored or co-authored using generative AI tooling?

No.
