### PR TITLE
[SPARK-54520][INFRA] Ignore Missing Packages in CI free_disk_space Step

### DIFF
--- a/dev/free_disk_space
+++ b/dev/free_disk_space
@@ -44,6 +44,7 @@ sudo rm -rf /opt/hostedtoolcache/go
 sudo rm -rf /opt/hostedtoolcache/node
 du -sh /opt/*
 
+sudo apt-get update --fix-missing
 sudo apt-get remove --purge -y '^aspnet.*'
 sudo apt-get remove --purge -y '^dotnet-.*'
 sudo apt-get remove --purge -y '^llvm-.*'


### PR DESCRIPTION
### What changes were proposed in this pull request?
Allow the CI `free_disk_space` step to ignore missing packages during `apt-get remove`.

### Why are the changes needed?
Intermittent network or upstream issues can cause apt-get to fail when certain packages cannot be located. This failure blocks the `apt-get remove` operations in `free_disk_space`. Since these packages are optional for cleanup and their absence is harmless, we can safely ignore missing-package errors and let the step continue.

Example CI failure: [https://github.com/Yicong-Huang/spark/actions/runs/19686762867/job/56398651193](https://github.com/Yicong-Huang/spark/actions/runs/19686762867/job/56398651193)

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
No