### PR TITLE
[SPARK-54527][CORE] Remove `getRecoveryPath` method from `YarnShuffleService.java`

### DIFF
--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
@@ -534,13 +534,6 @@ public class YarnShuffleService extends AuxiliaryService {
   }
 
   /**
-   * Get the path specific to this auxiliary service to use for recovery.
-   */
-  protected Path getRecoveryPath(String fileName) {
-    return _recoveryPath;
-  }
-
-  /**
    * Figure out the recovery path and handle moving the DB if YARN NM recovery gets enabled
    * and DB exists in the local dir of NM by old version of shuffle service.
    */


### PR DESCRIPTION



### What changes were proposed in this pull request?
Remove `getRecoveryPath` method from `YarnShuffleService.java`, it is no longer used.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
No need test


### Was this patch authored or co-authored using generative AI tooling?
No
