### PR TITLE
[SPARK-54529][BUILD] Upgrade `commons-codec` to 1.20.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -35,7 +35,7 @@ cats-kernel_2.13/2.8.0//cats-kernel_2.13-2.8.0.jar
 chill-java/0.10.0//chill-java-0.10.0.jar
 chill_2.13/0.10.0//chill_2.13-0.10.0.jar
 commons-cli/1.10.0//commons-cli-1.10.0.jar
-commons-codec/1.19.0//commons-codec-1.19.0.jar
+commons-codec/1.20.0//commons-codec-1.20.0.jar
 commons-collections4/4.5.0//commons-collections4-4.5.0.jar
 commons-compiler/3.1.9//commons-compiler-3.1.9.jar
 commons-compress/1.28.0//commons-compress-1.28.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
     <ws.xmlschema.version>2.3.1</ws.xmlschema.version>
     <snappy.version>1.1.10.8</snappy.version>
     <netlib.ludovic.dev.version>3.0.4</netlib.ludovic.dev.version>
-    <commons-codec.version>1.19.0</commons-codec.version>
+    <commons-codec.version>1.20.0</commons-codec.version>
     <commons-compress.version>1.28.0</commons-compress.version>
     <commons-io.version>2.21.0</commons-io.version>
     <!-- To support Hive UDF jars built by Hive 2.0.0 ~ 2.3.9 and 3.0.0 ~ 3.1.3. -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to upgrade `commons-codec` to `1.20.0`.
Change log: https://commons.apache.org/proper/commons-codec/changes.html#a1.20.0

### Why are the changes needed?
To maintain the dependency latest.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
No.
