### PR TITLE
[SPARK-54517][PYTHON][TESTS][FOLLOWUP] Fix typehints using ellipsis

### DIFF
--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -309,7 +309,7 @@ class ReusedMixedTestCase(ReusedConnectTestCase, SQLTestUtils):
 
 def skip_if_server_version_is(
     cond: Callable[[LooseVersion], bool], reason: Optional[str] = None
-) -> Callable[[...], ...]:
+) -> Callable:
     def decorator(f: Callable) -> Callable:
         @functools.wraps(f)
         def wrapper(self, *args, **kwargs):
@@ -328,5 +328,5 @@ def skip_if_server_version_is(
 
 def skip_if_server_version_is_greater_than_or_equal_to(
     version: str, reason: Optional[str] = None
-) -> Callable[[...], ...]:
+) -> Callable:
     return skip_if_server_version_is(lambda v: v >= LooseVersion(version), reason)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #53223.

Fixes a typehint using ellipsis that are not available as type arguments in Python 3.10.

### Why are the changes needed?

#53223 caused a test failure in Python 3.10 tests:

```
  File "/__w/spark/spark/python/pyspark/testing/connectutils.py", line 312, in <module>
    ) -> Callable[[...], ...]:
         ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/pypy/pypy3.10/lib/pypy3.10/typing.py", line 1206, in __getitem__
    return self.__getitem_inner__(params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/pypy/pypy3.10/lib/pypy3.10/typing.py", line 312, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/pypy/pypy3.10/lib/pypy3.10/typing.py", line 1212, in __getitem_inner__
    result = _type_check(result, msg)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/pypy/pypy3.10/lib/pypy3.10/typing.py", line 176, in _type_check
    raise TypeError(f"{msg} Got {arg!r:.100}.")
TypeError: Callable[args, result]: result must be a type. Got Ellipsis.
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
