### PR TITLE
[SPARK-54532][PYTHON] Add support for sqlstate for PySparkException

### DIFF
--- a/python/pyspark/errors/exceptions/base.py
+++ b/python/pyspark/errors/exceptions/base.py
@@ -121,7 +121,7 @@ class PySparkException(Exception):
         :meth:`PySparkException.getMessageParameters`
         :meth:`PySparkException.getQueryContext`
         """
-        return None
+        return self._error_reader.get_sqlstate(self._errorClass)
 
     def getMessage(self) -> str:
         """

--- a/python/pyspark/errors/exceptions/base.py
+++ b/python/pyspark/errors/exceptions/base.py
@@ -121,6 +121,8 @@ class PySparkException(Exception):
         :meth:`PySparkException.getMessageParameters`
         :meth:`PySparkException.getQueryContext`
         """
+        if self._errorClass is None:
+            return None
         return self._error_reader.get_sqlstate(self._errorClass)
 
     def getMessage(self) -> str:

--- a/python/pyspark/errors/exceptions/base.py
+++ b/python/pyspark/errors/exceptions/base.py
@@ -121,8 +121,6 @@ class PySparkException(Exception):
         :meth:`PySparkException.getMessageParameters`
         :meth:`PySparkException.getQueryContext`
         """
-        if self._errorClass is None:
-            return None
         return self._error_reader.get_sqlstate(self._errorClass)
 
     def getMessage(self) -> str:

--- a/python/pyspark/errors/exceptions/base.py
+++ b/python/pyspark/errors/exceptions/base.py
@@ -110,7 +110,7 @@ class PySparkException(Exception):
         """
         Returns an SQLSTATE as a string.
 
-        Errors generated in Python have no SQLSTATE, so it always returns None.
+        If the errorClass has no corresponding SQLSTATE, it returns None.
 
         .. versionadded:: 3.4.0
 

--- a/python/pyspark/errors/tests/test_errors.py
+++ b/python/pyspark/errors/tests/test_errors.py
@@ -19,7 +19,7 @@
 import json
 import unittest
 
-from pyspark.errors import PySparkValueError
+from pyspark.errors import PySparkRuntimeError, PySparkValueError
 from pyspark.errors.error_classes import ERROR_CLASSES_JSON
 from pyspark.errors.utils import ErrorClassesReader
 
@@ -107,6 +107,16 @@ class ErrorsTest(unittest.TestCase):
         )
         subclass_map = error_reader.error_info_map["TEST_ERROR_WITH_SUB_CLASS"]["sub_class"]
         self.assertEqual(breaking_change_info2, subclass_map["SUBCLASS"]["breaking_change_info"])
+
+    def test_sqlstate(self):
+        error = PySparkRuntimeError(errorClass="APPLICATION_NAME_NOT_SET", messageParameters={})
+        self.assertIsNone(error.getSqlState())
+
+        error = PySparkRuntimeError(
+            errorClass="SESSION_MUTATION_IN_DECLARATIVE_PIPELINE.SET_RUNTIME_CONF",
+            messageParameters={"method": "set"},
+        )
+        self.assertIsNone(error.getSqlState())
 
 
 if __name__ == "__main__":

--- a/python/pyspark/errors/utils.py
+++ b/python/pyspark/errors/utils.py
@@ -95,6 +95,18 @@ class ErrorClassesReader:
     def __init__(self) -> None:
         self.error_info_map = ERROR_CLASSES_MAP
 
+    def get_sqlstate(self, errorClass: str) -> str:
+        """
+        Returns the SQL state for the given error class.
+        """
+        error_classes = errorClass.split(".")
+        if len(error_classes) == 1:
+            return self.error_info_map[errorClass].get("sqlState", None)
+        else:
+            return self.error_info_map[error_classes[0]]["sub_class"][error_classes[1]].get(
+                "sqlState", None
+            )
+
     def get_error_message(self, errorClass: str, messageParameters: Dict[str, str]) -> str:
         """
         Returns the completed error message by applying message parameters to the message template.

--- a/python/pyspark/errors/utils.py
+++ b/python/pyspark/errors/utils.py
@@ -95,17 +95,23 @@ class ErrorClassesReader:
     def __init__(self) -> None:
         self.error_info_map = ERROR_CLASSES_MAP
 
-    def get_sqlstate(self, errorClass: str) -> Optional[str]:
+    def get_sqlstate(self, errorClass: Optional[str]) -> Optional[str]:
         """
         Returns the SQL state for the given error class.
         """
+        if errorClass is None:
+            return None
+
         error_classes = errorClass.split(".")
-        if len(error_classes) == 1:
-            return self.error_info_map[errorClass].get("sqlState", None)
-        else:
-            return self.error_info_map[error_classes[0]]["sub_class"][error_classes[1]].get(
-                "sqlState", None
-            )
+        try:
+            if len(error_classes) == 1:
+                return self.error_info_map[errorClass]["sqlState"]
+            else:
+                return self.error_info_map[error_classes[0]]["sub_class"][error_classes[1]][
+                    "sqlState"
+                ]
+        except KeyError:
+            return None
 
     def get_error_message(self, errorClass: str, messageParameters: Dict[str, str]) -> str:
         """

--- a/python/pyspark/errors/utils.py
+++ b/python/pyspark/errors/utils.py
@@ -95,7 +95,7 @@ class ErrorClassesReader:
     def __init__(self) -> None:
         self.error_info_map = ERROR_CLASSES_MAP
 
-    def get_sqlstate(self, errorClass: str) -> str:
+    def get_sqlstate(self, errorClass: str) -> Optional[str]:
         """
         Returns the SQL state for the given error class.
         """


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Allow `PySparkException` to get `sqlstate` from the json file.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

It's useful for python client to throw exceptions with sqlstate.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

For this specific PR no. It's an infra to have more sqlstate in the future.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

A feature test is added. However, we don't have any sqlstate assigned to python exceptions now - so we can't test the positive case. The future PRs will add more sqlstate and we can test then.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No