### PR TITLE
[SPARK-54533][UI] Set metric ExecutorSource.METRIC_RESULT_SIZE with correct value

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -750,7 +750,6 @@ private[spark] class Executor(
           .inc(task.metrics.outputMetrics.bytesWritten)
         executorSource.METRIC_OUTPUT_RECORDS_WRITTEN
           .inc(task.metrics.outputMetrics.recordsWritten)
-        executorSource.METRIC_RESULT_SIZE.inc(task.metrics.resultSize)
         executorSource.METRIC_DISK_BYTES_SPILLED.inc(task.metrics.diskBytesSpilled)
         executorSource.METRIC_MEMORY_BYTES_SPILLED.inc(task.metrics.memoryBytesSpilled)
         incrementShuffleMetrics(executorSource, task.metrics)
@@ -764,6 +763,7 @@ private[spark] class Executor(
         val serializedDirectResult = SerializerHelper.serializeToChunkedBuffer(ser, directResult,
           valueByteBuffer.size + accumUpdates.size * 32 + metricPeaks.length * 8)
         val resultSize = serializedDirectResult.size
+        executorSource.METRIC_RESULT_SIZE.inc(resultSize)
 
         // directSend = sending directly back to the driver
         val serializedResult: ByteBuffer = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Set the metric executorSource.METRIC_RESULT_SIZE after the result size is populated.

### Why are the changes needed?
Currently the metric executorSource.METRIC_RESULT_SIZE is set to the value of `task.metrics.resultSize` which is always 0 in that line.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manually tested on local Spark. See the Jira attachments for metrics reported before and after fix.


### Was this patch authored or co-authored using generative AI tooling?
No
