### PR TITLE
[SPARK-54541][SQL] Rename _LEGACY_ERROR_TEMP_1007 and add sqlState

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -6029,9 +6029,9 @@
     ],
     "sqlState" : "428EK"
   },
-  "TEMP_VIEW_WRITE_NOT_ALLOWED" : {
+  "VIEW_WRITE_NOT_ALLOWED" : {
     "message" : [
-      "Cannot write into temp view <quoted> as it's not a data source v2 relation."
+      "Cannot write into view <quoted> as it's not a data source v2 relation."
     ],
     "sqlState" : "42809"
   },
@@ -7637,11 +7637,6 @@
   "_LEGACY_ERROR_TEMP_1008" : {
     "message" : [
       "<quoted> is not a temp view of streaming logical plan, please use batch API such as `DataFrameReader.table` to read it."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1011" : {
-    "message" : [
-      "Writing into a view is not allowed. View: <identifier>."
     ]
   },
   "_LEGACY_ERROR_TEMP_1012" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -7406,7 +7406,7 @@
   },
   "VIEW_WRITE_NOT_ALLOWED" : {
     "message" : [
-      "Cannot write into view <quoted> as it's not a data source v2 relation."
+      "Cannot write into view <name>, please write into a table instead."
     ],
     "sqlState" : "42809"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -6029,6 +6029,12 @@
     ],
     "sqlState" : "428EK"
   },
+  "TEMP_VIEW_WRITE_NOT_ALLOWED" : {
+    "message" : [
+      "Cannot write into temp view <quoted> as it's not a data source v2 relation."
+    ],
+    "sqlState" : "42809"
+  },
   "THETA_INVALID_INPUT_SKETCH_BUFFER" : {
     "message" : [
       "Invalid call to <function>; only valid Theta sketch buffers are supported as inputs (such as those produced by the `theta_sketch_agg` function)."
@@ -7626,11 +7632,6 @@
   "_LEGACY_ERROR_TEMP_1006" : {
     "message" : [
       "Aggregate expression required for pivot, but '<sql>' did not appear in any aggregate function."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1007" : {
-    "message" : [
-      "Cannot write into temp view <quoted> as it's not a data source v2 relation."
     ]
   },
   "_LEGACY_ERROR_TEMP_1008" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -6029,12 +6029,6 @@
     ],
     "sqlState" : "428EK"
   },
-  "VIEW_WRITE_NOT_ALLOWED" : {
-    "message" : [
-      "Cannot write into view <quoted> as it's not a data source v2 relation."
-    ],
-    "sqlState" : "42809"
-  },
   "THETA_INVALID_INPUT_SKETCH_BUFFER" : {
     "message" : [
       "Invalid call to <function>; only valid Theta sketch buffers are supported as inputs (such as those produced by the `theta_sketch_agg` function)."
@@ -7409,6 +7403,12 @@
       "To tolerate the error on drop use DROP VIEW IF EXISTS."
     ],
     "sqlState" : "42P01"
+  },
+  "VIEW_WRITE_NOT_ALLOWED" : {
+    "message" : [
+      "Cannot write into view <quoted> as it's not a data source v2 relation."
+    ],
+    "sqlState" : "42809"
   },
   "WINDOW_FUNCTION_AND_FRAME_MISMATCH" : {
     "message" : [

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -547,7 +547,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def writeIntoTempViewNotAllowedError(quoted: String): Throwable = {
     new AnalysisException(
-      errorClass = "TEMP_VIEW_WRITE_NOT_ALLOWED",
+      errorClass = "VIEW_WRITE_NOT_ALLOWED",
       messageParameters = Map("quoted" -> quoted))
   }
 
@@ -578,8 +578,8 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def writeIntoViewNotAllowedError(identifier: TableIdentifier, t: TreeNode[_]): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1011",
-      messageParameters = Map("identifier" -> identifier.toString),
+      errorClass = "VIEW_WRITE_NOT_ALLOWED",
+      messageParameters = Map("quoted" -> toSQLId(identifier.nameParts)),
       origin = t.origin)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -548,7 +548,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
   def writeIntoTempViewNotAllowedError(quoted: String): Throwable = {
     new AnalysisException(
       errorClass = "VIEW_WRITE_NOT_ALLOWED",
-      messageParameters = Map("quoted" -> quoted))
+      messageParameters = Map("name" -> quoted))
   }
 
   def readNonStreamingTempViewError(quoted: String): Throwable = {
@@ -579,7 +579,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
   def writeIntoViewNotAllowedError(identifier: TableIdentifier, t: TreeNode[_]): Throwable = {
     new AnalysisException(
       errorClass = "VIEW_WRITE_NOT_ALLOWED",
-      messageParameters = Map("quoted" -> toSQLId(identifier.nameParts)),
+      messageParameters = Map("name" -> toSQLId(identifier.nameParts)),
       origin = t.origin)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -547,7 +547,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def writeIntoTempViewNotAllowedError(quoted: String): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1007",
+      errorClass = "TEMP_VIEW_WRITE_NOT_ALLOWED",
       messageParameters = Map("quoted" -> quoted))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
@@ -169,17 +169,20 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
       exception = intercept[AnalysisException] {
         spark.table("source").writeTo("temp_view").append()
       },
-      condition = "TEMP_VIEW_WRITE_NOT_ALLOWED",
+      condition = "VIEW_WRITE_NOT_ALLOWED",
       parameters = Map("quoted" -> "temp_view")
     )
   }
 
   test("Append: fail if it writes to a view") {
     spark.sql("CREATE VIEW v AS SELECT 1")
-    val exc = intercept[AnalysisException] {
-      spark.table("source").writeTo("v").append()
-    }
-    assert(exc.getMessage.contains("Writing into a view is not allowed"))
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.table("source").writeTo("v").append()
+      },
+      condition = "VIEW_WRITE_NOT_ALLOWED",
+      parameters = Map("quoted" -> "`spark_catalog`.`default`.`v`")
+    )
   }
 
   test("Append: fail if it writes to a v1 table") {
@@ -276,17 +279,20 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
       exception = intercept[AnalysisException] {
         spark.table("source").writeTo("temp_view").overwrite(lit(true))
       },
-      condition = "TEMP_VIEW_WRITE_NOT_ALLOWED",
+      condition = "VIEW_WRITE_NOT_ALLOWED",
       parameters = Map("quoted" -> "temp_view")
     )
   }
 
   test("Overwrite: fail if it writes to a view") {
     spark.sql("CREATE VIEW v AS SELECT 1")
-    val exc = intercept[AnalysisException] {
-      spark.table("source").writeTo("v").overwrite(lit(true))
-    }
-    assert(exc.getMessage.contains("Writing into a view is not allowed"))
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.table("source").writeTo("v").overwrite(lit(true))
+      },
+      condition = "VIEW_WRITE_NOT_ALLOWED",
+      parameters = Map("quoted" -> "`spark_catalog`.`default`.`v`")
+    )
   }
 
   test("Overwrite: fail if it writes to a v1 table") {
@@ -383,17 +389,20 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
       exception = intercept[AnalysisException] {
         spark.table("source").writeTo("temp_view").overwritePartitions()
       },
-      condition = "TEMP_VIEW_WRITE_NOT_ALLOWED",
+      condition = "VIEW_WRITE_NOT_ALLOWED",
       parameters = Map("quoted" -> "temp_view")
     )
   }
 
   test("OverwritePartitions: fail if it writes to a view") {
     spark.sql("CREATE VIEW v AS SELECT 1")
-    val exc = intercept[AnalysisException] {
-      spark.table("source").writeTo("v").overwritePartitions()
-    }
-    assert(exc.getMessage.contains("Writing into a view is not allowed"))
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.table("source").writeTo("v").overwritePartitions()
+      },
+      condition = "VIEW_WRITE_NOT_ALLOWED",
+      parameters = Map("quoted" -> "`spark_catalog`.`default`.`v`")
+    )
   }
 
   test("OverwritePartitions: fail if it writes to a v1 table") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
@@ -165,11 +165,13 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
 
   test("Append: fail if it writes to a temp view that is not v2 relation") {
     spark.range(10).createOrReplaceTempView("temp_view")
-    val exc = intercept[AnalysisException] {
-      spark.table("source").writeTo("temp_view").append()
-    }
-    assert(exc.getMessage.contains("Cannot write into temp view temp_view as it's not a " +
-      "data source v2 relation"))
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.table("source").writeTo("temp_view").append()
+      },
+      condition = "TEMP_VIEW_WRITE_NOT_ALLOWED",
+      parameters = Map("quoted" -> "temp_view")
+    )
   }
 
   test("Append: fail if it writes to a view") {
@@ -270,11 +272,13 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
 
   test("Overwrite: fail if it writes to a temp view that is not v2 relation") {
     spark.range(10).createOrReplaceTempView("temp_view")
-    val exc = intercept[AnalysisException] {
-      spark.table("source").writeTo("temp_view").overwrite(lit(true))
-    }
-    assert(exc.getMessage.contains("Cannot write into temp view temp_view as it's not a " +
-      "data source v2 relation"))
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.table("source").writeTo("temp_view").overwrite(lit(true))
+      },
+      condition = "TEMP_VIEW_WRITE_NOT_ALLOWED",
+      parameters = Map("quoted" -> "temp_view")
+    )
   }
 
   test("Overwrite: fail if it writes to a view") {
@@ -375,11 +379,13 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
 
   test("OverwritePartitions: fail if it writes to a temp view that is not v2 relation") {
     spark.range(10).createOrReplaceTempView("temp_view")
-    val exc = intercept[AnalysisException] {
-      spark.table("source").writeTo("temp_view").overwritePartitions()
-    }
-    assert(exc.getMessage.contains("Cannot write into temp view temp_view as it's not a " +
-      "data source v2 relation"))
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.table("source").writeTo("temp_view").overwritePartitions()
+      },
+      condition = "TEMP_VIEW_WRITE_NOT_ALLOWED",
+      parameters = Map("quoted" -> "temp_view")
+    )
   }
 
   test("OverwritePartitions: fail if it writes to a view") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
@@ -170,7 +170,7 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
         spark.table("source").writeTo("temp_view").append()
       },
       condition = "VIEW_WRITE_NOT_ALLOWED",
-      parameters = Map("quoted" -> "temp_view")
+      parameters = Map("name" -> "temp_view")
     )
   }
 
@@ -181,7 +181,7 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
         spark.table("source").writeTo("v").append()
       },
       condition = "VIEW_WRITE_NOT_ALLOWED",
-      parameters = Map("quoted" -> "`spark_catalog`.`default`.`v`")
+      parameters = Map("name" -> "`spark_catalog`.`default`.`v`")
     )
   }
 
@@ -280,7 +280,7 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
         spark.table("source").writeTo("temp_view").overwrite(lit(true))
       },
       condition = "VIEW_WRITE_NOT_ALLOWED",
-      parameters = Map("quoted" -> "temp_view")
+      parameters = Map("name" -> "temp_view")
     )
   }
 
@@ -291,7 +291,7 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
         spark.table("source").writeTo("v").overwrite(lit(true))
       },
       condition = "VIEW_WRITE_NOT_ALLOWED",
-      parameters = Map("quoted" -> "`spark_catalog`.`default`.`v`")
+      parameters = Map("name" -> "`spark_catalog`.`default`.`v`")
     )
   }
 
@@ -390,7 +390,7 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
         spark.table("source").writeTo("temp_view").overwritePartitions()
       },
       condition = "VIEW_WRITE_NOT_ALLOWED",
-      parameters = Map("quoted" -> "temp_view")
+      parameters = Map("name" -> "temp_view")
     )
   }
 
@@ -401,7 +401,7 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
         spark.table("source").writeTo("v").overwritePartitions()
       },
       condition = "VIEW_WRITE_NOT_ALLOWED",
-      parameters = Map("quoted" -> "`spark_catalog`.`default`.`v`")
+      parameters = Map("name" -> "`spark_catalog`.`default`.`v`")
     )
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

I renamed _LEGACY_ERROR_TEMP_1007 to VIEW_WRITE_NOT_ALLOWED and added sqlState 42809.

The changes include:
- New error class VIEW_WRITE_NOT_ALLOWED in error-conditions.json with sqlState 42809
- Updated QueryCompilationErrors.scala to reference the new error class
- Refactored 6 test cases in DataFrameWriterV2Suite to use checkError() instead of string matching

### Why are the changes needed?

Users frequently encounter this error when attempting to write to temporary views using the DataFrameWriter V2 API. The legacy error name is non-descriptive and lacks an sqlState, which makes it difficult to handle programatically and reduces compatibility with JDBC/ODBC clients.

### Does this PR introduce any user-facing change?

No. The error message text stays the same. User will only see the same error message, but the underlying error class is now properly named and includes a sqlState for better tooling support.

### How was this patch tested?

I tested this change in multiple ways:
- Manually triggered the error in spark-shell to verify the new error class is used
- Updated 6 existing tests in DataFrameWriterV2Suite to use checkError() for structured validation of error class and parameters
- Ran the full test suite: all tests pass successfully


#### Manual Testing in Spark-Shell

**Before (legacy error):**


```
scala> val sourceData = Seq((1, "a"), (2, "b"), (3, "c")).toDF("id", "name")
scala> sourceData.createOrReplaceTempView("source")
scala> spark.range(10).createOrReplaceTempView("temp_view")
scala> spark.table("source").writeTo("temp_view").append()

org.apache.spark.sql.AnalysisException: Cannot write into temp view temp_view as it's not a data source v2 relation.
at org.apache.spark.sql.errors.QueryCompilationErrors$.writeIntoTempViewNotAllowedError(QueryCompilationErrors.scala:551)
at org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveRelations$$anonfun$apply$12.$anonfun$applyOrElse$73(Analyzer.scala:1237)

```


**After (new error with class and sqlState):**
```
scala> val sourceData = Seq((1, "a"), (2, "b"), (3, "c")).toDF("id", "name")
scala> sourceData.createOrReplaceTempView("source")
scala> spark.range(10).createOrReplaceTempView("temp_view")
scala> spark.table("source").writeTo("temp_view").append()

org.apache.spark.sql.AnalysisException: [VIEW_WRITE_NOT_ALLOWED] Cannot write into view temp_view, please write into a table instead. SQLSTATE: 42809
  at org.apache.spark.sql.errors.QueryCompilationErrors$.writeIntoTempViewNotAllowedError(QueryCompilationErrors.scala:551)
  at org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveRelations$$anonfun$apply$12.$anonfun$applyOrElse$73(Analyzer.scala:1237)
```
  

*Note: The error now displays the error class `[VIEW_WRITE_NOT_ALLOWED]` and includes sqlState `42809` (accessible via `getSqlState()`).*

Ran the full DataFrameWriterV2Suite test suite: all tests pass successfully

```
[info] Test run finished: 0 failed, 0 ignored, 6 total, 0.602s
[info] ScalaTest
[info] Run completed in 8 seconds, 683 milliseconds.
[info] Total number of tests run: 48
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 48, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 54, Failed 0, Errors 0, Passed 54
[success] Total time: 38 s, completed 13-Dec-2025, 10:51:11 pm
```


### Was this patch authored or co-authored using generative AI tooling? 
No



<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->
