### PR TITLE
[SPARK-54206][CONNECT][FOLLOWUP] Use VARBINARY type and reasonable max length for BinaryType

### DIFF
--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/util/JdbcTypeUtils.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/util/JdbcTypeUtils.scala
@@ -25,11 +25,6 @@ import org.apache.spark.sql.types._
 
 private[jdbc] object JdbcTypeUtils {
 
-  /**
-   * Maximum length for variable-length binary types (VARBINARY).
-   */
-  private val VARBINARY_MAX_LENGTH = 1024 * 1024 * 1024
-
   def getColumnType(field: StructField): Int = field.dataType match {
     case NullType => Types.NULL
     case BooleanType => Types.BOOLEAN
@@ -88,12 +83,12 @@ private[jdbc] object JdbcTypeUtils {
     case LongType => 19
     case FloatType => 7
     case DoubleType => 15
-    case StringType => 255
+    case StringType => Int.MaxValue
     case DecimalType.Fixed(p, _) => p
     case DateType => 10
     case TimestampType => 29
     case TimestampNTZType => 29
-    case BinaryType => VARBINARY_MAX_LENGTH
+    case BinaryType => Int.MaxValue
     // Returns the Spark SQL TIME type precision, even though java.sql.ResultSet.getTime()
     // can only retrieve up to millisecond precision (3) due to java.sql.Time limitations.
     // Users can call getObject(index, classOf[LocalTime]) to access full microsecond
@@ -127,7 +122,7 @@ private[jdbc] object JdbcTypeUtils {
     case DateType => 10 // length of `YYYY-MM-DD`
     case TimestampType => 29 // length of `YYYY-MM-DD HH:MM:SS.SSSSSS`
     case TimestampNTZType => 29 // length of `YYYY-MM-DD HH:MM:SS.SSSSSS`
-    case BinaryType => VARBINARY_MAX_LENGTH
+    case BinaryType => Int.MaxValue
     case TimeType(precision) if precision > 0 => 8 + 1 + precision // length of `HH:MM:SS.ffffff`
     case TimeType(_) => 8 // length of `HH:MM:SS`
     // precision + negative sign + leading zero + decimal point, like DECIMAL(5,5) = -0.12345

--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/util/JdbcTypeUtils.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/util/JdbcTypeUtils.scala
@@ -25,6 +25,11 @@ import org.apache.spark.sql.types._
 
 private[jdbc] object JdbcTypeUtils {
 
+  /**
+   * Maximum length for variable-length binary types (VARBINARY).
+   */
+  private val VARBINARY_MAX_LENGTH = 1024 * 1024 * 1024
+
   def getColumnType(field: StructField): Int = field.dataType match {
     case NullType => Types.NULL
     case BooleanType => Types.BOOLEAN
@@ -39,7 +44,7 @@ private[jdbc] object JdbcTypeUtils {
     case DateType => Types.DATE
     case TimestampType => Types.TIMESTAMP
     case TimestampNTZType => Types.TIMESTAMP
-    case BinaryType => Types.BINARY
+    case BinaryType => Types.VARBINARY
     case _: TimeType => Types.TIME
     case other =>
       throw new SQLFeatureNotSupportedException(s"DataType $other is not supported yet.")
@@ -88,7 +93,7 @@ private[jdbc] object JdbcTypeUtils {
     case DateType => 10
     case TimestampType => 29
     case TimestampNTZType => 29
-    case BinaryType => Int.MaxValue
+    case BinaryType => VARBINARY_MAX_LENGTH
     // Returns the Spark SQL TIME type precision, even though java.sql.ResultSet.getTime()
     // can only retrieve up to millisecond precision (3) due to java.sql.Time limitations.
     // Users can call getObject(index, classOf[LocalTime]) to access full microsecond
@@ -122,7 +127,7 @@ private[jdbc] object JdbcTypeUtils {
     case DateType => 10 // length of `YYYY-MM-DD`
     case TimestampType => 29 // length of `YYYY-MM-DD HH:MM:SS.SSSSSS`
     case TimestampNTZType => 29 // length of `YYYY-MM-DD HH:MM:SS.SSSSSS`
-    case BinaryType => Int.MaxValue
+    case BinaryType => VARBINARY_MAX_LENGTH
     case TimeType(precision) if precision > 0 => 8 + 1 + precision // length of `HH:MM:SS.ffffff`
     case TimeType(_) => 8 // length of `HH:MM:SS`
     // precision + negative sign + leading zero + decimal point, like DECIMAL(5,5) = -0.12345

--- a/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectJdbcDataTypeSuite.scala
+++ b/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectJdbcDataTypeSuite.scala
@@ -216,9 +216,9 @@ class SparkConnectJdbcDataTypeSuite extends ConnectFunSuite with RemoteSparkSess
       assert(metaData.getColumnTypeName(1) === "STRING")
       assert(metaData.getColumnClassName(1) === "java.lang.String")
       assert(metaData.isSigned(1) === false)
-      assert(metaData.getPrecision(1) === 255)
+      assert(metaData.getPrecision(1) === Int.MaxValue)
       assert(metaData.getScale(1) === 0)
-      assert(metaData.getColumnDisplaySize(1) === 255)
+      assert(metaData.getColumnDisplaySize(1) === Int.MaxValue)
     }
   }
 

--- a/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectJdbcDataTypeSuite.scala
+++ b/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectJdbcDataTypeSuite.scala
@@ -389,7 +389,7 @@ class SparkConnectJdbcDataTypeSuite extends ConnectFunSuite with RemoteSparkSess
 
       val metaData = rs.getMetaData
       assert(metaData.getColumnCount === 1)
-      assert(metaData.getColumnType(1) === Types.BINARY)
+      assert(metaData.getColumnType(1) === Types.VARBINARY)
       assert(metaData.getColumnTypeName(1) === "BINARY")
       assert(metaData.getColumnClassName(1) === "[B")
       assert(metaData.isSigned(1) === false)
@@ -405,7 +405,7 @@ class SparkConnectJdbcDataTypeSuite extends ConnectFunSuite with RemoteSparkSess
 
       val metaData = rs.getMetaData
       assert(metaData.getColumnCount === 1)
-      assert(metaData.getColumnType(1) === Types.BINARY)
+      assert(metaData.getColumnType(1) === Types.VARBINARY)
       assert(metaData.getColumnTypeName(1) === "BINARY")
       assert(metaData.getColumnClassName(1) === "[B")
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR improves the JDBC type mapping for BinaryType in the Spark Connect JDBC client

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

- **Semantic correctness**: Types.VARBINARY (variable-length) better matches Spark's BinaryType semantics.

- **Industry alignment**: 
SQL Server dialect already uses VARBINARY(MAX) for BinaryType . 
Trino JDBC driver uses VARBINARY with a maximum of 1 GB.
MariaDB JDBC driver uses VARBINARY/LONGVARBINARY for blob types


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, but minimal impact.
Both BINARY and VARBINARY map to byte array types
The precision change is within reasonable bounds

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests: All tests in `SparkConnectJdbcDataTypeSuite` pass.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No