### PR TITLE
[SPARK-54544][PYTHON] Enable flake8 F811 check

### DIFF
--- a/dev/tox.ini
+++ b/dev/tox.ini
@@ -18,9 +18,6 @@
 ignore =
     E203, # Skip as black formatter adds a whitespace around ':'.
     E402, # Module top level import is disabled for optional import check, etc.
-    # 1. Type hints with def are treated as redefinition (e.g., functions.log).
-    # 2. Some are used for testing.
-    F811,
     # There are too many instances to fix. Ignored for now.
     W503,
     W504,

--- a/python/pyspark/logger/tests/test_logger.py
+++ b/python/pyspark/logger/tests/test_logger.py
@@ -215,7 +215,6 @@ class LoggerTests(LoggerTestsMixin, ReusedSQLTestCase):
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.logger.tests.test_logger import *  # noqa: F401
 
     try:

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -50,7 +50,6 @@ if TYPE_CHECKING:
     from py4j.java_gateway import JavaGateway, JavaObject
     from pyspark.ml._typing import PipelineStage
     from pyspark.ml.base import Params
-    from pyspark.ml.wrapper import JavaWrapper
     from pyspark.core.context import SparkContext
     from pyspark.sql import DataFrame
     from pyspark.sql.connect.dataframe import DataFrame as ConnectDataFrame

--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -34,7 +34,6 @@ from pyspark.mllib.regression import (
 )
 from pyspark.mllib.util import Saveable, Loader, inherit_doc
 from pyspark.mllib.linalg import Vector
-from pyspark.mllib.regression import LabeledPoint
 
 if TYPE_CHECKING:
     from pyspark.mllib._typing import VectorLike

--- a/python/pyspark/mllib/feature.py
+++ b/python/pyspark/mllib/feature.py
@@ -36,7 +36,6 @@ from py4j.java_collections import JavaMap
 
 if TYPE_CHECKING:
     from pyspark.mllib._typing import VectorLike
-    from py4j.java_collections import JavaMap
 
 __all__ = [
     "Normalizer",

--- a/python/pyspark/mllib/regression.py
+++ b/python/pyspark/mllib/regression.py
@@ -32,7 +32,7 @@ from typing import (
 
 import numpy as np
 
-from pyspark import RDD, since
+from pyspark import since
 from pyspark.streaming.dstream import DStream
 from pyspark.mllib.common import callMLlibFunc, _py2java, _java2py, inherit_doc
 from pyspark.mllib.linalg import _convert_to_vector

--- a/python/pyspark/mllib/tree.py
+++ b/python/pyspark/mllib/tree.py
@@ -18,7 +18,7 @@
 import sys
 import random
 
-from pyspark import RDD, since
+from pyspark import since
 from pyspark.mllib.common import callMLlibFunc, inherit_doc, JavaModelWrapper
 from pyspark.mllib.linalg import _convert_to_vector
 from pyspark.mllib.regression import LabeledPoint

--- a/python/pyspark/mllib/util.py
+++ b/python/pyspark/mllib/util.py
@@ -20,7 +20,7 @@ from functools import reduce
 
 import numpy as np
 
-from pyspark import SparkContext, since
+from pyspark import since
 from pyspark.mllib.common import callMLlibFunc, inherit_doc
 from pyspark.mllib.linalg import Vectors, SparseVector, _convert_to_vector
 from pyspark.sql import DataFrame
@@ -28,7 +28,6 @@ from typing import Generic, Iterable, List, Optional, Tuple, Type, TypeVar, cast
 from pyspark.core.context import SparkContext
 from pyspark.mllib.linalg import Vector
 from pyspark.core.rdd import RDD
-from pyspark.sql.dataframe import DataFrame
 
 T = TypeVar("T")
 L = TypeVar("L", bound="Loader")

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_corrwith.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_corrwith.py
@@ -124,7 +124,6 @@ class DiffFramesCorrWithTests(
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.pandas.tests.diff_frames_ops.test_corrwith import *  # noqa: F401
 
     try:

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_dot_frame.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_dot_frame.py
@@ -91,7 +91,6 @@ class DiffFramesDotFrameTests(DiffFramesDotFrameMixin, PandasOnSparkTestCase, SQ
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.pandas.tests.diff_frames_ops.test_dot_frame import *  # noqa: F401
 
     try:

--- a/python/pyspark/pandas/tests/indexes/test_category.py
+++ b/python/pyspark/pandas/tests/indexes/test_category.py
@@ -402,7 +402,6 @@ class CategoricalIndexTests(CategoricalIndexTestsMixin, PandasOnSparkTestCase, T
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.pandas.tests.indexes.test_category import *  # noqa: F401
 
     try:

--- a/python/pyspark/pandas/tests/indexes/test_timedelta.py
+++ b/python/pyspark/pandas/tests/indexes/test_timedelta.py
@@ -115,7 +115,6 @@ class TimedeltaIndexTests(
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.pandas.tests.indexes.test_timedelta import *  # noqa: F401
 
     try:

--- a/python/pyspark/pandas/tests/series/test_string_ops_adv.py
+++ b/python/pyspark/pandas/tests/series/test_string_ops_adv.py
@@ -226,7 +226,6 @@ class SeriesStringOpsAdvTests(
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.pandas.tests.series.test_string_ops_adv import *  # noqa: F401
 
     try:

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -683,7 +683,6 @@ class NamespaceTests(NamespaceTestsMixin, PandasOnSparkTestCase, SQLTestUtils):
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.pandas.tests.test_namespace import *  # noqa: F401
 
     try:

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -198,7 +198,6 @@ class NumPyCompatTests(
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.pandas.tests.test_numpy_compat import *  # noqa: F401
 
     try:

--- a/python/pyspark/pandas/tests/test_utils.py
+++ b/python/pyspark/pandas/tests/test_utils.py
@@ -181,7 +181,7 @@ class UtilsTestsMixin:
             },
         )
 
-    def test_series_error_assert_pandas_equal(self):
+    def test_series_error_assert_pandas_almost_equal_2(self):
         series1 = pd.Series([1, 2, 3])
         series2 = pd.Series([4, 5, 6])
 

--- a/python/pyspark/pipelines/tests/test_block_connect_access.py
+++ b/python/pyspark/pipelines/tests/test_block_connect_access.py
@@ -17,7 +17,6 @@
 import unittest
 
 from pyspark.errors import PySparkException
-from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.connectutils import (
     ReusedConnectTestCase,
     should_test_connect,

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -19,7 +19,6 @@
 from pyspark.errors.exceptions.base import (
     SessionNotSameException,
     PySparkIndexError,
-    PySparkAttributeError,
 )
 from pyspark.resource import ResourceProfile
 from pyspark.sql.connect.logging import logger

--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -55,7 +55,6 @@ if TYPE_CHECKING:
         PandasGroupedMapFunctionWithState,
     )
     from pyspark.sql.connect.dataframe import DataFrame
-    from pyspark.sql.types import StructType
 
 
 class GroupedData:

--- a/python/pyspark/sql/connect/udf.py
+++ b/python/pyspark/sql/connect/udf.py
@@ -50,7 +50,6 @@ if TYPE_CHECKING:
         UserDefinedFunctionLike,
     )
     from pyspark.sql.connect.session import SparkSession
-    from pyspark.sql.types import StringType
 
 
 def _create_py_udf(

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -3062,56 +3062,6 @@ def floor(col: "ColumnOrName", scale: Optional[Union[Column, int]] = None) -> Co
 
 
 @_try_remote_functions
-def log(col: "ColumnOrName") -> Column:
-    """
-    Computes the natural logarithm of the given value.
-
-    .. versionadded:: 1.4.0
-
-    .. versionchanged:: 3.4.0
-        Supports Spark Connect.
-
-    Parameters
-    ----------
-    col : :class:`~pyspark.sql.Column` or column name
-        column to calculate natural logarithm for.
-
-    Returns
-    -------
-    :class:`~pyspark.sql.Column`
-        natural logarithm of the given value.
-
-    Examples
-    --------
-    Example 1: Compute the natural logarithm of E
-
-    >>> from pyspark.sql import functions as sf
-    >>> spark.range(1).select(sf.log(sf.e())).show()
-    +-------+
-    |ln(E())|
-    +-------+
-    |    1.0|
-    +-------+
-
-    Example 2: Compute the natural logarithm of invalid values
-
-    >>> from pyspark.sql import functions as sf
-    >>> spark.sql(
-    ...     "SELECT * FROM VALUES (-1), (0), (FLOAT('NAN')), (NULL) AS TAB(value)"
-    ... ).select("*", sf.log("value")).show()
-    +-----+---------+
-    |value|ln(value)|
-    +-----+---------+
-    | -1.0|     NULL|
-    |  0.0|     NULL|
-    |  NaN|      NaN|
-    | NULL|     NULL|
-    +-----+---------+
-    """
-    return _invoke_function_over_columns("log", col)
-
-
-@_try_remote_functions
 def log10(col: "ColumnOrName") -> Column:
     """
     Computes the logarithm of the given value in Base 10.
@@ -8342,7 +8292,7 @@ def when(condition: Column, value: Any) -> Column:
     return _invoke_function("when", condition._jc, v)
 
 
-@overload  # type: ignore[no-redef]
+@overload
 def log(arg1: "ColumnOrName") -> Column:
     ...
 

--- a/python/pyspark/sql/tests/arrow/test_arrow.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow.py
@@ -61,7 +61,6 @@ from pyspark.testing.sqlutils import (
 from pyspark.errors import ArithmeticException, PySparkTypeError, UnsupportedOperationException
 from pyspark.loose_version import LooseVersion
 from pyspark.util import is_remote_only
-from pyspark.loose_version import LooseVersion
 
 if have_pandas:
     import pandas as pd
@@ -1008,11 +1007,6 @@ class ArrowTestsMixin:
                         self.assertTrue(
                             expected[r][e] == result[r][e], f"{expected[r][e]} == {result[r][e]}"
                         )
-
-    def test_createDataFrame_pandas_with_struct_type(self):
-        for arrow_enabled in [True, False]:
-            with self.subTest(arrow_enabled=arrow_enabled):
-                self.check_createDataFrame_pandas_with_struct_type(arrow_enabled)
 
     def test_createDataFrame_arrow_with_struct_type_nulls(self):
         t = pa.table(

--- a/python/pyspark/sql/tests/arrow/test_arrow_udf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf.py
@@ -164,13 +164,13 @@ class ArrowUDFTestsMixin:
             with self.assertRaises(ParseException):
 
                 @arrow_udf("blah")
-                def foo(x):
+                def _(x):
                     return x
 
             with self.assertRaises(PySparkTypeError) as pe:
 
                 @arrow_udf(returnType="double", functionType=PandasUDFType.SCALAR)
-                def foo(df):
+                def _(df):
                     return df
 
             self.check_error(
@@ -185,7 +185,7 @@ class ArrowUDFTestsMixin:
             with self.assertRaises(PySparkTypeError) as pe:
 
                 @arrow_udf(functionType=ArrowUDFType.SCALAR)
-                def foo(x):
+                def _(x):
                     return x
 
             self.check_error(
@@ -197,7 +197,7 @@ class ArrowUDFTestsMixin:
             with self.assertRaises(PySparkTypeError) as pe:
 
                 @arrow_udf("double", 100)
-                def foo(x):
+                def _(x):
                     return x
 
             self.check_error(
@@ -209,7 +209,7 @@ class ArrowUDFTestsMixin:
             with self.assertRaises(PySparkTypeError) as pe:
 
                 @arrow_udf(returnType=PandasUDFType.GROUPED_MAP)
-                def foo(df):
+                def _(df):
                     return df
 
             self.check_error(
@@ -224,13 +224,13 @@ class ArrowUDFTestsMixin:
             with self.assertRaisesRegex(ValueError, "0-arg arrow_udfs.*not.*supported"):
 
                 @arrow_udf(LongType(), ArrowUDFType.SCALAR)
-                def zero_with_type():
+                def _():
                     return 1
 
             with self.assertRaisesRegex(ValueError, "0-arg arrow_udfs.*not.*supported"):
 
                 @arrow_udf(LongType(), ArrowUDFType.SCALAR_ITER)
-                def zero_with_type():
+                def _():
                     yield 1
                     yield 2
 

--- a/python/pyspark/sql/tests/arrow/test_arrow_udf_scalar.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf_scalar.py
@@ -27,7 +27,7 @@ from typing import Iterator, Tuple
 from pyspark.util import PythonEvalType
 
 from pyspark.sql.functions import arrow_udf, ArrowUDFType
-from pyspark.sql import Row, functions as F
+from pyspark.sql import functions as F
 from pyspark.sql.types import (
     IntegerType,
     ByteType,

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_listener.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_listener.py
@@ -313,7 +313,6 @@ class StreamingListenerParityTests(StreamingListenerTestsMixin, ReusedConnectTes
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.sql.tests.connect.streaming.test_parity_listener import *  # noqa: F401
 
     try:

--- a/python/pyspark/sql/tests/connect/test_parity_dataframe_query_context.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe_query_context.py
@@ -26,7 +26,6 @@ class DataFrameQueryContextParityTests(DataFrameQueryContextTestsMixin, ReusedCo
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.sql.tests.connect.test_parity_dataframe_query_context import *  # noqa: F401
 
     try:

--- a/python/pyspark/sql/tests/connect/test_parity_geographytype.py
+++ b/python/pyspark/sql/tests/connect/test_parity_geographytype.py
@@ -26,7 +26,6 @@ class GeographyTypeParityTest(GeographyTypeTestMixin, ReusedConnectTestCase):
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.sql.tests.connect.test_parity_geographytype import *  # noqa: F401
 
     try:

--- a/python/pyspark/sql/tests/connect/test_parity_geometrytype.py
+++ b/python/pyspark/sql/tests/connect/test_parity_geometrytype.py
@@ -26,7 +26,6 @@ class GeometryTypeParityTest(GeometryTypeTestMixin, ReusedConnectTestCase):
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.sql.tests.connect.test_parity_geometrytype import *  # noqa: F401
 
     try:

--- a/python/pyspark/sql/tests/connect/test_parity_observation.py
+++ b/python/pyspark/sql/tests/connect/test_parity_observation.py
@@ -29,7 +29,6 @@ class DataFrameObservationParityTests(
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.sql.tests.connect.test_parity_observation import *  # noqa: F401
 
     try:

--- a/python/pyspark/sql/tests/connect/test_parity_readwriter.py
+++ b/python/pyspark/sql/tests/connect/test_parity_readwriter.py
@@ -37,7 +37,6 @@ class ReadwriterV2ParityTests(ReadwriterV2TestsMixin, ReusedConnectTestCase):
 
 
 if __name__ == "__main__":
-    import unittest
     from pyspark.sql.tests.connect.test_parity_readwriter import *  # noqa: F401
 
     try:

--- a/python/pyspark/sql/tests/connect/test_parity_udf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udf.py
@@ -56,10 +56,6 @@ class UDFParityTests(BaseUDFTestsMixin, ReusedConnectTestCase):
     def test_nondeterministic_udf3(self):
         super().test_nondeterministic_udf3()
 
-    @unittest.skip("Spark Connect doesn't support RDD but the test depends on it.")
-    def test_worker_original_stdin_closed(self):
-        super().test_worker_original_stdin_closed()
-
     @unittest.skip("Spark Connect does not support SQLContext but the test depends on it.")
     def test_udf_on_sql_context(self):
         super().test_udf_on_sql_context()

--- a/python/pyspark/sql/tests/pandas/streaming/test_transform_with_state_state_variable.py
+++ b/python/pyspark/sql/tests/pandas/streaming/test_transform_with_state_state_variable.py
@@ -26,7 +26,6 @@ from pyspark.testing.sqlutils import (
     ReusedSQLTestCase,
 )
 
-from pyspark.testing.sqlutils import ReusedSQLTestCase
 from pyspark.sql.tests.pandas.streaming.test_pandas_transform_with_state_state_variable import (
     TransformWithStateStateVariableTestsMixin,
 )

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf.py
@@ -170,13 +170,13 @@ class PandasUDFTestsMixin:
             with self.assertRaises(ParseException):
 
                 @pandas_udf("blah")
-                def foo(x):
+                def _(x):
                     return x
 
             with self.assertRaises(PySparkTypeError) as pe:
 
                 @pandas_udf(returnType="double", functionType=PandasUDFType.GROUPED_MAP)
-                def foo(df):
+                def _(df):
                     return df
 
             self.check_error(
@@ -193,14 +193,14 @@ class PandasUDFTestsMixin:
             with self.assertRaisesRegex(ValueError, "Invalid function"):
 
                 @pandas_udf(returnType="k int, v double", functionType=PandasUDFType.GROUPED_MAP)
-                def foo(k, v, w):
+                def _(k, v, w):
                     return k
 
     def check_udf_wrong_arg(self):
         with self.assertRaises(PySparkTypeError) as pe:
 
             @pandas_udf(functionType=PandasUDFType.SCALAR)
-            def foo(x):
+            def _(x):
                 return x
 
         self.check_error(
@@ -212,7 +212,7 @@ class PandasUDFTestsMixin:
         with self.assertRaises(PySparkTypeError) as pe:
 
             @pandas_udf("double", 100)
-            def foo(x):
+            def _(x):
                 return x
 
         self.check_error(
@@ -227,20 +227,20 @@ class PandasUDFTestsMixin:
         with self.assertRaisesRegex(ValueError, "0-arg pandas_udfs.*not.*supported"):
 
             @pandas_udf(LongType(), PandasUDFType.SCALAR)
-            def zero_with_type():
+            def _():
                 return 1
 
         with self.assertRaisesRegex(ValueError, "0-arg pandas_udfs.*not.*supported"):
 
             @pandas_udf(LongType(), PandasUDFType.SCALAR_ITER)
-            def zero_with_type():
+            def _():
                 yield 1
                 yield 2
 
         with self.assertRaises(PySparkTypeError) as pe:
 
             @pandas_udf(returnType=PandasUDFType.GROUPED_MAP)
-            def foo(df):
+            def _(df):
                 return df
 
         self.check_error(

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -53,7 +53,6 @@ from pyspark.sql.types import (
     StringType,
     ArrayType,
     StructField,
-    Row,
     TimestampType,
     MapType,
     DateType,

--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -20,7 +20,6 @@ import tempfile
 import unittest
 import logging
 import json
-import os
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
@@ -852,9 +851,9 @@ class BasePythonDataSourceTestsMixin:
                             return "x string"
 
                         def reader(self, schema):
-                            return TestReader()
+                            return TestReader2()
 
-                    class TestReader(DataSourceReader):
+                    class TestReader2(DataSourceReader):
                         def read(self, partition):
                             ctypes.string_at(0)
                             yield "x",
@@ -894,9 +893,9 @@ class BasePythonDataSourceTestsMixin:
                             return "test"
 
                         def writer(self, schema, overwrite):
-                            return TestWriter()
+                            return TestWriter2()
 
-                    class TestWriter(DataSourceWriter):
+                    class TestWriter2(DataSourceWriter):
                         def write(self, iterator):
                             return WriterCommitMessage()
 

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -40,7 +40,6 @@ from pyspark.sql.functions import (
     array,
     col,
     create_map,
-    array,
     lit,
     named_struct,
     udf,

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -923,7 +923,7 @@ class UtilsTestsMixin:
         assertDataFrameEqual(df1, df2, checkRowOrder=True)
 
     @unittest.skipIf(not have_pandas or not have_pyarrow, "no pandas or pyarrow dependency")
-    def test_assert_equal_exact_pandas_on_spark_df(self):
+    def test_assert_equal_exact_pandas_on_spark_df_no_order(self):
         import pyspark.pandas as ps
 
         df1 = ps.DataFrame(data=[10, 20, 30], columns=["Numbers"])
@@ -1590,7 +1590,7 @@ class UtilsTestsMixin:
             messageParameters={"error_msg": error_msg},
         )
 
-    def test_list_row_unequal_schema(self):
+    def test_list_row_unequal_schema_2(self):
         from pyspark.sql import Row
 
         df1 = self.spark.createDataFrame(

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -1544,53 +1544,6 @@ class UtilsTestsMixin:
         )
 
     def test_list_row_unequal_schema(self):
-        df1 = self.spark.createDataFrame(
-            data=[
-                (1, 3000),
-                (2, 1000),
-                (3, 10),
-            ],
-            schema=["id", "amount"],
-        )
-
-        list_of_rows = [Row(id=1, amount=300), Row(id=2, amount=100), Row(id=3, amount=10)]
-
-        rows_str1 = ""
-        rows_str2 = ""
-
-        # count different rows
-        for r1, r2 in list(zip_longest(df1, list_of_rows)):
-            rows_str1 += str(r1) + "\n"
-            rows_str2 += str(r2) + "\n"
-
-        generated_diff = _context_diff(
-            actual=rows_str1.splitlines(), expected=rows_str2.splitlines(), n=3
-        )
-
-        error_msg = "Results do not match: "
-        percent_diff = (2 / 3) * 100
-        error_msg += "( %.5f %% )" % percent_diff
-        error_msg += "\n" + "\n".join(generated_diff)
-
-        with self.assertRaises(PySparkAssertionError) as pe:
-            assertDataFrameEqual(df1, list_of_rows)
-
-        self.check_error(
-            exception=pe.exception,
-            errorClass="DIFFERENT_ROWS",
-            messageParameters={"error_msg": error_msg},
-        )
-
-        with self.assertRaises(PySparkAssertionError) as pe:
-            assertDataFrameEqual(df1, list_of_rows, checkRowOrder=True)
-
-        self.check_error(
-            exception=pe.exception,
-            errorClass="DIFFERENT_ROWS",
-            messageParameters={"error_msg": error_msg},
-        )
-
-    def test_list_row_unequal_schema_2(self):
         from pyspark.sql import Row
 
         df1 = self.spark.createDataFrame(

--- a/python/pyspark/sql/tests/udf_type_tests/test_udf_return_types.py
+++ b/python/pyspark/sql/tests/udf_type_tests/test_udf_return_types.py
@@ -21,7 +21,6 @@ import os
 import platform
 import unittest
 from decimal import Decimal
-import numpy as np
 import pandas as pd
 
 from pyspark.sql import Row

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -19,7 +19,6 @@
 Worker that receives input from Piped RDD.
 """
 import datetime
-import itertools
 import os
 import sys
 import dataclasses
@@ -54,7 +53,6 @@ from pyspark.sql.functions import SkipRestOfInputTableException
 from pyspark.sql.pandas.serializers import (
     ArrowStreamPandasUDFSerializer,
     ArrowStreamPandasUDTFSerializer,
-    GroupPandasUDFSerializer,
     GroupArrowUDFSerializer,
     CogroupArrowUDFSerializer,
     CogroupPandasUDFSerializer,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Enabled flake8 [F811](https://www.flake8rules.com/rules/F811.html) check on our repo and fixed reported issues. 


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

I know upgrading lint system is a pain, but we should not just put it aside forever. Our pinned `flake8` version is not even usable on Python3.12+.

During this "lint fix", I actually discovered a few real bugs - most of them are silently disabled unittests because there is a test method that has the same name (probably due to copy/paste). I think this result supported the idea that we should take lint more seriously.

About `functions.log`, we got it wrong. It's not because `@overload` does not work properly - it's because we have two `log` function in that gigantic file. The former one is [dead](https://app.codecov.io/gh/apache/spark/blob/master/python%2Fpyspark%2Fsql%2Ffunctions%2Fbuiltin.py#L3111). I just removed that one.

Again, I really think we should upgrade our lint system. I'm trying to do it slowly - piece by piece, so that people's daily workflow is not impacted too much.

I hope we can eventually move to a place where all linters are updated and people can be more confident about their changes.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

`flake8` test on major directories. CI should give more a comprehensive result.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No