### PR TITLE
[SPARK-54545][INFRA] Allow test case pattern for run-tests

### DIFF
--- a/python/docs/source/development/testing.rst
+++ b/python/docs/source/development/testing.rst
@@ -40,8 +40,19 @@ You can run individual tests by using ``--testnames`` option. For example,
 
 .. code-block:: bash
 
+    # Run all tests in a module
     python/run-tests --testnames pyspark.sql.tests.test_dataframe
+    # Run a specific test case
     python/run-tests --testnames pyspark.sql.tests.test_dataframe.DataFrameTests.test_range
+    # Equivalent to the above
+    python/run-tests --testnames "pyspark.sql.tests.test_dataframe DataFrameTests.test_range"
+    # You don't need to specify everything, run-tests will do a pattern match
+    # It uses "-k" for unittest
+    python/run-tests --testnames "pyspark.sql.tests.test_dataframe test_range"
+    # This works too
+    python/run-tests --testnames pyspark.sql.tests.test_dataframe.test_range
+    # This will match all tests with "range" in their names
+    python/run-tests --testnames pyspark.sql.tests.test_dataframe.range
 
 Note that you may set ``OBJC_DISABLE_INITIALIZE_FORK_SAFETY`` environment variable to ``YES`` if you are running tests on Mac OS.
 

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -144,8 +144,11 @@ def run_individual_python_test(target_dir, test_name, pyspark_python, keep_test_
         "Starting test(%s): %s (temp output: %s)", pyspark_python, test_name, per_test_output.name)
     start_time = time.time()
     try:
+        args = test_name.split()
+        if len(args) == 2:
+            args.insert(1, "-k")
         retcode = subprocess.Popen(
-            [os.path.join(SPARK_HOME, "bin/pyspark")] + test_name.split(),
+            [os.path.join(SPARK_HOME, "bin/pyspark")] + args,
             stderr=per_test_output, stdout=per_test_output, env=env).wait()
         if not keep_test_output:
             # There exists a race condition in Python and it causes flakiness in MacOS


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Allow test name patterns in `run-tests`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Looking for the actual TestClass for a specific test is not trivial - because we are using Mixin pattern. The class where the test method is defined in is not the actual unittest class we run. This makes specifying a test case very difficult.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Manually comfirmed that pattern works.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No