### PR TITLE
[SPARK-54253][Geo][CONNECT][FOLLOWUP] Enforce geospatial support config in Spark Connect

### DIFF
--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/GeographyConnectDataFrameSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/GeographyConnectDataFrameSuite.scala
@@ -114,16 +114,14 @@ class GeographyConnectDataFrameSuite extends QueryTest with RemoteSparkSession {
         exception = intercept[AnalysisException] {
           spark.createDataFrame(javaList, schema).collect()
         },
-        condition = "UNSUPPORTED_FEATURE.GEOSPATIAL_DISABLED"
-      )
+        condition = "UNSUPPORTED_FEATURE.GEOSPATIAL_DISABLED")
       // Implicit encoder path.
       import testImplicits._
       checkError(
         exception = intercept[AnalysisException] {
           Seq(geography).toDF("g").collect()
         },
-        condition = "UNSUPPORTED_FEATURE.GEOSPATIAL_DISABLED"
-      )
+        condition = "UNSUPPORTED_FEATURE.GEOSPATIAL_DISABLED")
     }
   }
 }

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/GeographyConnectDataFrameSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/GeographyConnectDataFrameSuite.scala
@@ -103,4 +103,27 @@ class GeographyConnectDataFrameSuite extends QueryTest with RemoteSparkSession {
     val expectedGeog = Geography.fromWKB(point, 4326)
     checkAnswer(df, Seq(Row(expectedGeog)))
   }
+
+  test("geospatial feature disabled") {
+    withSQLConf("spark.sql.geospatial.enabled" -> "false") {
+      val geography = Geography.fromWKB(point1, 4326)
+      val schema = StructType(Seq(StructField("col1", GeographyType(4326))))
+      // Java List[Row] + schema.
+      val javaList = java.util.Arrays.asList(Row(geography))
+      checkError(
+        exception = intercept[AnalysisException] {
+          spark.createDataFrame(javaList, schema).collect()
+        },
+        condition = "UNSUPPORTED_FEATURE.GEOSPATIAL_DISABLED"
+      )
+      // Implicit encoder path.
+      import testImplicits._
+      checkError(
+        exception = intercept[AnalysisException] {
+          Seq(geography).toDF("g").collect()
+        },
+        condition = "UNSUPPORTED_FEATURE.GEOSPATIAL_DISABLED"
+      )
+    }
+  }
 }

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/GeometryConnectDataFrameSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/GeometryConnectDataFrameSuite.scala
@@ -112,8 +112,8 @@ class GeometryConnectDataFrameSuite extends QueryTest with RemoteSparkSession {
 
   test("geospatial feature disabled") {
     withSQLConf("spark.sql.geospatial.enabled" -> "false") {
-      val geometry = Geometry.fromWKB(point1, 4326)
-      val schema = StructType(Seq(StructField("col1", GeometryType(4326))))
+      val geometry = Geometry.fromWKB(point1, 0)
+      val schema = StructType(Seq(StructField("col1", GeometryType(0))))
       // Java List[Row] + schema.
       val javaList = java.util.Arrays.asList(Row(geometry))
       checkError(

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/GeometryConnectDataFrameSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/GeometryConnectDataFrameSuite.scala
@@ -109,4 +109,25 @@ class GeometryConnectDataFrameSuite extends QueryTest with RemoteSparkSession {
     val expectedGeom = Geometry.fromWKB(point, 0)
     checkAnswer(df, Seq(Row(expectedGeom)))
   }
+
+  test("geospatial feature disabled") {
+    withSQLConf("spark.sql.geospatial.enabled" -> "false") {
+      val geometry = Geometry.fromWKB(point1, 4326)
+      val schema = StructType(Seq(StructField("col1", GeometryType(4326))))
+      // Java List[Row] + schema.
+      val javaList = java.util.Arrays.asList(Row(geometry))
+      checkError(
+        exception = intercept[AnalysisException] {
+          spark.createDataFrame(javaList, schema).collect()
+        },
+        condition = "UNSUPPORTED_FEATURE.GEOSPATIAL_DISABLED")
+      // Implicit encoder path.
+      import testImplicits._
+      checkError(
+        exception = intercept[AnalysisException] {
+          Seq(geometry).toDF("g").collect()
+        },
+        condition = "UNSUPPORTED_FEATURE.GEOSPATIAL_DISABLED")
+    }
+  }
 }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/SparkConnectPlanExecution.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/SparkConnectPlanExecution.scala
@@ -128,8 +128,7 @@ private[execution] class SparkConnectPlanExecution(executeHolder: ExecuteHolder)
     val spark = dataframe.sparkSession
     val schema = dataframe.schema
     val geospatialEnabled = spark.sessionState.conf.geospatialEnabled
-    if (!geospatialEnabled && schema.fields.exists(field =>
-        STExpressionUtils.isGeoSpatialType(field.dataType))) {
+    if (!geospatialEnabled && schema.existsRecursively(STExpressionUtils.isGeoSpatialType)) {
       throw new org.apache.spark.sql.AnalysisException(
         errorClass = "UNSUPPORTED_FEATURE.GEOSPATIAL_DISABLED",
         messageParameters = scala.collection.immutable.Map.empty)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
A new SQL config (`spark.sql.geospatial.enabled`) was introduced as part of https://github.com/apache/spark/pull/53009.

However, the original PR didn't fully gate geospatial functionality, so this PR also forbids geo dataframes in Spark Connect.

### Why are the changes needed?
Guard the geospatial feature until it's fully finished.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Added appropriate unit tests to confirm that the config is effective:

- `GeographyConnectDataFrameSuite`
- `GeometryConnectDataFrameSuite`


### Was this patch authored or co-authored using generative AI tooling?
No.
