### PR TITLE
[SPARK-54557] [SQL] Make CSV/JSON/XmlOptions and CSV/JSON/XmlInferSchema comparable

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchema.scala
@@ -68,6 +68,14 @@ class CSVInferSchema(val options: CSVOptions) extends Serializable {
 
   private val isDefaultNTZ = SQLConf.get.timestampType == TimestampNTZType
 
+  override def equals(obj: Any): Boolean = obj match {
+    case other: CSVInferSchema =>
+      options == other.options
+    case _ => false
+  }
+
+  override def hashCode(): Int = options.hashCode()
+
   /**
    * Similar to the JSON schema inference
    *     1. Infer type of each row

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -34,8 +34,8 @@ import org.apache.spark.sql.types.StructType
 class CSVOptions(
     @transient val parameters: CaseInsensitiveMap[String],
     val columnPruning: Boolean,
-    defaultTimeZoneId: String,
-    defaultColumnNameOfCorruptRecord: String)
+    private val defaultTimeZoneId: String,
+    private val defaultColumnNameOfCorruptRecord: String)
   extends FileSourceOptions(parameters) with Logging {
 
   import CSVOptions._
@@ -61,6 +61,24 @@ class CSVOptions(
         columnPruning,
         defaultTimeZoneId,
         defaultColumnNameOfCorruptRecord)
+  }
+
+  override def equals(obj: Any): Boolean = obj match {
+    case other: CSVOptions =>
+      (parameters == null && other.parameters == null ||
+      parameters != null && parameters == other.parameters) &&
+      columnPruning == other.columnPruning &&
+      defaultTimeZoneId == other.defaultTimeZoneId &&
+      defaultColumnNameOfCorruptRecord == other.defaultColumnNameOfCorruptRecord
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    var result = Option(parameters).map(_.hashCode()).getOrElse(0)
+    result = 31 * result + (if (columnPruning) 1 else 0)
+    result = 31 * result + defaultTimeZoneId.hashCode()
+    result = 31 * result + defaultColumnNameOfCorruptRecord.hashCode()
+    result
   }
 
   private def getChar(paramName: String, default: Char): Char = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -36,8 +36,8 @@ import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
  */
 class JSONOptions(
     @transient val parameters: CaseInsensitiveMap[String],
-    defaultTimeZoneId: String,
-    defaultColumnNameOfCorruptRecord: String)
+    private val defaultTimeZoneId: String,
+    private val defaultColumnNameOfCorruptRecord: String)
   extends FileSourceOptions(parameters) with Logging  {
 
   import JSONOptions._
@@ -155,6 +155,22 @@ class JSONOptions(
 
   protected def checkedEncoding(enc: String): String =
     CharsetProvider.forName(enc, caller = "JSONOptions").name()
+
+  override def equals(obj: Any): Boolean = obj match {
+    case other: JSONOptions =>
+      (parameters == null && other.parameters == null ||
+      parameters != null && parameters == other.parameters) &&
+      defaultTimeZoneId == other.defaultTimeZoneId &&
+      defaultColumnNameOfCorruptRecord == other.defaultColumnNameOfCorruptRecord
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    var result = Option(parameters).map(_.hashCode()).getOrElse(0)
+    result = 31 * result + defaultTimeZoneId.hashCode()
+    result = 31 * result + defaultColumnNameOfCorruptRecord.hashCode()
+    result
+  }
 
   /**
    * Standard encoding (charset) name. For example UTF-8, UTF-16LE and UTF-32BE.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JsonInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JsonInferSchema.scala
@@ -39,7 +39,7 @@ import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Utils
 
-class JsonInferSchema(options: JSONOptions) extends Serializable with Logging {
+class JsonInferSchema(private val options: JSONOptions) extends Serializable with Logging {
 
   private val decimalParser = ExprUtils.getDecimalParser(options.locale)
 
@@ -60,6 +60,13 @@ class JsonInferSchema(options: JSONOptions) extends Serializable with Logging {
   private val ignoreMissingFiles = options.ignoreMissingFiles
   private val isDefaultNTZ = SQLConf.get.timestampType == TimestampNTZType
   private val legacyMode = SQLConf.get.legacyTimeParserPolicy == LegacyBehaviorPolicy.LEGACY
+
+  override def equals(obj: Any): Boolean = obj match {
+    case other: JsonInferSchema => options == other.options
+    case _ => false
+  }
+
+  override def hashCode(): Int = options.hashCode()
 
   private def handleJsonErrorsByParseMode(parseMode: ParseMode,
       columnNameOfCorruptRecord: String, e: Throwable): Option[StructType] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlInferSchema.scala
@@ -45,7 +45,7 @@ import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.SparkErrorUtils
 
-class XmlInferSchema(options: XmlOptions, caseSensitive: Boolean)
+class XmlInferSchema(private val options: XmlOptions, private val caseSensitive: Boolean)
     extends Serializable
     with Logging {
 
@@ -72,6 +72,19 @@ class XmlInferSchema(options: XmlOptions, caseSensitive: Boolean)
     options.locale,
     legacyFormat = FAST_DATE_FORMAT,
     isParsing = true)
+
+  override def equals(obj: Any): Boolean = obj match {
+    case other: XmlInferSchema =>
+      options == other.options &&
+      caseSensitive == other.caseSensitive
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    var result = options.hashCode()
+    result = 31 * result + (if (caseSensitive) 1 else 0)
+    result
+  }
 
   private def handleXmlErrorsByParseMode(
       parser: XMLEventReader,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlOptions.scala
@@ -32,9 +32,9 @@ import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
  */
 class XmlOptions(
     val parameters: CaseInsensitiveMap[String],
-    defaultTimeZoneId: String,
-    defaultColumnNameOfCorruptRecord: String,
-    rowTagRequired: Boolean)
+    private val defaultTimeZoneId: String,
+    private val defaultColumnNameOfCorruptRecord: String,
+    private val rowTagRequired: Boolean)
   extends FileSourceOptions(parameters) with Logging {
 
   import XmlOptions._
@@ -49,6 +49,25 @@ class XmlOptions(
       defaultTimeZoneId,
       defaultColumnNameOfCorruptRecord,
       rowTagRequired)
+  }
+
+
+  override def equals(obj: Any): Boolean = obj match {
+    case other: XmlOptions =>
+      (parameters == null && other.parameters == null ||
+      parameters != null && parameters == other.parameters) &&
+      defaultTimeZoneId == other.defaultTimeZoneId &&
+      defaultColumnNameOfCorruptRecord == other.defaultColumnNameOfCorruptRecord &&
+      rowTagRequired == other.rowTagRequired
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    var result = Option(parameters).map(_.hashCode()).getOrElse(0)
+    result = 31 * result + defaultTimeZoneId.hashCode()
+    result = 31 * result + defaultColumnNameOfCorruptRecord.hashCode()
+    result = 31 * result + (if (rowTagRequired) 1 else 0)
+    result
   }
 
   private def getBool(paramName: String, default: Boolean = false): Boolean = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR I propose to make `XmlOptions` and `XmlInferSchema` comparable.

### Why are the changes needed?
In order to be able to compare them while working on the single-pass implementation (dual-runs).

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.