### PR TITLE
[SQL][MINOR] Defensive code for number of Partitions in rCTEs

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/UnionLoopExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/UnionLoopExec.scala
@@ -181,7 +181,8 @@ case class UnionLoopExec(
 
     var limitReached: Boolean = false
 
-    val numPartitions = prevDF.queryExecution.toRdd.partitions.length
+    // Defensive: ensure at least one partition.
+    val numPartitions = Math.max(1, prevDF.queryExecution.toRdd.partitions.length)
 
     // Main loop for obtaining the result of the recursive query.
     while (prevCount > 0 && !limitReached) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Set the number of partitions in recursive CTEs to be at least 1.

### Why are the changes needed?

Defensive programming to avoid zero-partition RDDs, which could cause potential issues in downstream operations like coalesce.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.
