### PR TITLE
[SPARK-54551][CONNECT][TESTS][FOLLOWUP] Redirect Test Spark connect server output stream to files

### DIFF
--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/IntegrationTestUtils.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/IntegrationTestUtils.scala
@@ -59,23 +59,21 @@ object IntegrationTestUtils {
     s"$connectClientHomeDir/target/$scalaDir/test-classes"
   }
 
-  private[sql] def debugConfigs: Seq[String] = {
+  private[sql] def log4jConfigs: Seq[String] = {
     val log4j2 = s"$connectClientHomeDir/src/test/resources/log4j2.properties"
-    if (isDebug) {
-      Seq(
-        // Enable to see the server plan change log
-        // "--conf",
-        // "spark.sql.planChangeLog.level=WARN",
+    Seq(
+      // Enable to see the server plan change log
+      // "--conf",
+      // "spark.sql.planChangeLog.level=WARN",
 
-        // Enable to see the server grpc received
-        // "--conf",
-        // "spark.connect.grpc.interceptor.classes=" +
-        //  "org.apache.spark.sql.connect.service.LoggingInterceptor",
+      // Enable to see the server grpc received
+      // "--conf",
+      // "spark.connect.grpc.interceptor.classes=" +
+      //  "org.apache.spark.sql.connect.service.LoggingInterceptor",
 
-        // Redirect server log into console
-        "--conf",
-        s"spark.driver.extraJavaOptions=-Dlog4j.configurationFile=$log4j2")
-    } else Seq.empty
+      // Redirect server log into console
+      "--conf",
+      s"spark.driver.extraJavaOptions=-Dlog4j.configurationFile=$log4j2")
   }
 
   // Log server start stop debug info into console

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/RemoteSparkSession.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/RemoteSparkSession.scala
@@ -61,15 +61,6 @@ object SparkConnectServerUtils {
   private var consoleOut: OutputStream = _
   private val serverStopCommand = "q"
 
-  /**
-   * Log4j configuration for the Spark Connect server. This ensures unit-tests.log is created for
-   * both debug and non-debug modes.
-   */
-  private def log4jConfigs: Seq[String] = {
-    val log4j2 = s"$connectClientHomeDir/src/test/resources/log4j2.properties"
-    Seq("--conf", s"spark.driver.extraJavaOptions=-Dlog4j.configurationFile=$log4j2")
-  }
-
   private lazy val sparkConnect: java.lang.Process = {
     debug("Starting the Spark Connect Server...")
     val connectJar =

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/RemoteSparkSession.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/RemoteSparkSession.scala
@@ -62,8 +62,8 @@ object SparkConnectServerUtils {
   private val serverStopCommand = "q"
 
   /**
-   * Log4j configuration for the Spark Connect server.
-   * This ensures unit-tests.log is created for both debug and non-debug modes.
+   * Log4j configuration for the Spark Connect server. This ensures unit-tests.log is created for
+   * both debug and non-debug modes.
    */
   private def log4jConfigs: Seq[String] = {
     val log4j2 = s"$connectClientHomeDir/src/test/resources/log4j2.properties"

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/RemoteSparkSession.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/RemoteSparkSession.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.connect.test
 
-import java.io.{File, IOException, OutputStream}
+import java.io.{File, FileOutputStream, InputStream, IOException, OutputStream}
 import java.lang.ProcessBuilder.Redirect
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
@@ -36,6 +36,7 @@ import org.apache.spark.sql.connect.client.{RetryPolicy, SparkConnectClient}
 import org.apache.spark.sql.connect.common.config.ConnectCommon
 import org.apache.spark.sql.connect.test.IntegrationTestUtils._
 import org.apache.spark.util.ArrayImplicits._
+import org.apache.spark.util.SparkStreamUtils
 
 /**
  * An util class to start a local spark connect server in a different process for local E2E tests.
@@ -93,19 +94,45 @@ object SparkConnectServerUtils {
     if (isDebug) {
       builder.redirectError(Redirect.INHERIT)
       builder.redirectOutput(Redirect.INHERIT)
-    } else {
-      // If output is not consumed, the stdout/stderr pipe buffers will fill up,
-      // causing the server process to block on write() calls
-      builder.redirectError(Redirect.DISCARD)
-      builder.redirectOutput(Redirect.DISCARD)
     }
 
     val process = builder.start()
     consoleOut = process.getOutputStream
 
+    if (!isDebug) {
+      // Redirect stdout and stderr to log files.
+      // If output is not consumed, the stdout/stderr pipe buffers will fill up,
+      // causing the server process to block on write() calls.
+      val targetDir = new File(s"$connectClientHomeDir/target")
+      targetDir.mkdirs()
+      val timestamp = System.currentTimeMillis()
+      val stdoutLogFile = new File(targetDir, s"spark-connect-test-server-stdout-$timestamp.log")
+      val stderrLogFile = new File(targetDir, s"spark-connect-test-server-stderr-$timestamp.log")
+
+      redirectStream(process.getInputStream, stdoutLogFile)
+      redirectStream(process.getErrorStream, stderrLogFile)
+    }
+
     // Adding JVM shutdown hook
     sys.addShutdownHook(stop())
     process
+  }
+
+  /** Spawn a thread that will redirect a given stream to a file */
+  private def redirectStream(in: InputStream, file: File): Unit = {
+    val out = new FileOutputStream(file, true)
+    val thread = new Thread(s"redirect output to ${file.getName}") {
+      override def run(): Unit = {
+        try {
+          SparkStreamUtils.copyStream(in, out, closeStreams = true)
+        } catch {
+          case _: IOException =>
+          // Ignore exception when stream is closed
+        }
+      }
+    }
+    thread.setDaemon(true)
+    thread.start()
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently, the Spark Connect test server's stdout and stderr are discarded when SPARK_DEBUG_SC_JVM_CLIENT=false, making it difficult to debug test failures. 

This PR enables log4j logging for Test Spark Connect server in all test modes (both debug and non-debug) by always configuring log4j2.properties. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When `SPARK_DEBUG_SC_JVM_CLIENT=false` 
SparkConnectJdbcDataTypeSuite randomly hangs because the child server process blocks on write() calls when stdout/stderr pipe buffers fill up. Without consuming the output, the buffers reach capacity and cause the process to block indefinitely.

Instead of `Redirect.DISCARD` , redirect the logs into log4j files

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Tested and confirmed that  log files are created  when 

1) `SPARK_DEBUG_SC_JVM_CLIENT=false  build/sbt "connect-client-jdbc/testOnly org.apache.spark.sql.connect.client.jdbc.SparkConnectJdbcDataTypeSuite"` 

OR

2) `SPARK_DEBUG_SC_JVM_CLIENT=true  build/sbt "connect-client-jdbc/testOnly org.apache.spark.sql.connect.client.jdbc.SparkConnectJdbcDataTypeSuite"`
```
In this file
./target/unit-tests.log
```
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.