### PR TITLE
[SPARK-54564] [SQL] Make QueryPlanningTracker as HybridAnalyzer field

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -319,7 +319,7 @@ class Analyzer(
         AnalysisContext.reset()
         try {
           AnalysisHelper.markInAnalyzer {
-            HybridAnalyzer.fromLegacyAnalyzer(legacyAnalyzer = this).apply(plan, tracker)
+            HybridAnalyzer.fromLegacyAnalyzer(legacyAnalyzer = this, tracker = tracker).apply(plan)
           }
         } finally {
           AnalysisContext.reset()
@@ -327,7 +327,7 @@ class Analyzer(
       } else {
         AnalysisContext.withNewAnalysisContext {
           AnalysisHelper.markInAnalyzer {
-            HybridAnalyzer.fromLegacyAnalyzer(legacyAnalyzer = this).apply(plan, tracker)
+            HybridAnalyzer.fromLegacyAnalyzer(legacyAnalyzer = this, tracker = tracker).apply(plan)
           }
         }
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/HybridAnalyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/HybridAnalyzer.scala
@@ -61,6 +61,7 @@ class HybridAnalyzer(
     legacyAnalyzer: Analyzer,
     resolverGuard: ResolverGuard,
     resolver: Resolver,
+    tracker: QueryPlanningTracker,
     extendedResolutionChecks: Seq[LogicalPlan => Unit] = Seq.empty,
     extendedRewriteRules: Seq[Rule[LogicalPlan]] = Seq.empty,
     exposeExplicitlyUnsupportedResolverFeature: Boolean = false)
@@ -74,7 +75,7 @@ class HybridAnalyzer(
   )
   private val sampleRateGenerator = new Random()
 
-  def apply(plan: LogicalPlan, tracker: QueryPlanningTracker): LogicalPlan = {
+  def apply(plan: LogicalPlan): LogicalPlan = {
     val dualRun =
       conf.getConf(SQLConf.ANALYZER_DUAL_RUN_LEGACY_AND_SINGLE_PASS_RESOLVER) &&
       checkDualRunSampleRate() &&
@@ -296,7 +297,8 @@ object HybridAnalyzer {
    */
   def fromLegacyAnalyzer(
       legacyAnalyzer: Analyzer,
-      exposeExplicitlyUnsupportedResolverFeature: Boolean = false): HybridAnalyzer = {
+      exposeExplicitlyUnsupportedResolverFeature: Boolean = false,
+      tracker: QueryPlanningTracker): HybridAnalyzer = {
     new HybridAnalyzer(
       legacyAnalyzer = legacyAnalyzer,
       resolverGuard = new ResolverGuard(legacyAnalyzer.catalogManager),
@@ -307,6 +309,7 @@ object HybridAnalyzer {
         metadataResolverExtensions = legacyAnalyzer.singlePassMetadataResolverExtensions,
         externalRelationResolution = Some(legacyAnalyzer.getRelationResolution)
       ),
+      tracker = tracker,
       extendedResolutionChecks = legacyAnalyzer.singlePassExtendedResolutionChecks,
       extendedRewriteRules = legacyAnalyzer.singlePassPostHocResolutionRules,
       exposeExplicitlyUnsupportedResolverFeature = exposeExplicitlyUnsupportedResolverFeature


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR I propose to make `QueryPlanningTracker` as `HybridAnalyzer` field.

### Why are the changes needed?
In order to simplify the code and further single-pass analyzer development.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.