### PR TITLE
[SPARK-54568][PYTHON] Avoid unnecessary pandas conversion in create dataframe from ndarray

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -52,7 +52,6 @@ from pyspark.sql.streaming import DataStreamReader
 from pyspark.sql.types import (
     AtomicType,
     DataType,
-    StructField,
     StructType,
     VariantVal,
     _make_type_verifier,
@@ -60,7 +59,6 @@ from pyspark.sql.types import (
     _has_nulltype,
     _merge_type,
     _create_converter,
-    _from_numpy_type,
 )
 from pyspark.errors.exceptions.captured import install_exception_handler
 from pyspark.sql.utils import (

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1581,18 +1581,20 @@ class SparkSession(SparkConversionMixin):
                 col_names = schema.names
             elif isinstance(schema, list):
                 col_names = schema
+            elif data.ndim == 1 or data.shape[1] == 1:
+                col_names = ["value"]
+            else:
+                col_names = [f"_{i + 1}" for i in range(0, data.shape[1])]
 
             if data.ndim == 1:
-                col_names = col_names or ["value"]
                 data = pa.Table.from_arrays(arrays=[pa.array(data)], names=col_names)
             elif data.shape[1] == 1:
-                col_names = col_names or ["value"]
                 data = pa.Table.from_arrays(arrays=[pa.array(data.squeeze())], names=col_names)
             else:
-                n_cols = data.shape[1]
-                arrow_columns = [pa.array(data[::, i]) for i in range(0, n_cols)]
-                col_names = col_names or [f"_{i + 1}" for i in range(0, n_cols)]
-                data = pa.Table.from_arrays(arrays=arrow_columns, names=col_names)
+                data = pa.Table.from_arrays(
+                    arrays=[pa.array(data[::, i]) for i in range(0, data.shape[1])],
+                    names=col_names,
+                )
 
         if has_pandas and isinstance(data, pd.DataFrame):
             # Create a DataFrame from pandas DataFrame.


### PR DESCRIPTION

### What changes were proposed in this pull request?
Avoid unnecessary pandas conversion in create dataframe from ndarray


### Why are the changes needed?
before:
ndarray -> pandas dataframe -> arrow data

after:
ndarray -> arrow data

and will be consistent with connect mode:
https://github.com/apache/spark/blob/40ba971b7319d74670ba86cc1f280a8a0f7a1dbb/python/pyspark/sql/connect/session.py#L675-L706

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no