### PR TITLE
[DOCS] Fix Missing Documentation for SparkSession in Declarative Pipelines (Python)

### DIFF
--- a/docs/declarative-pipelines-programming-guide.md
+++ b/docs/declarative-pipelines-programming-guide.md
@@ -9,9 +9,9 @@ license: |
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
- 
+
      http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,14 +19,15 @@ license: |
   limitations under the License.
 ---
 
-* Table of contents
-{:toc}
+- Table of contents
+  {:toc}
 
 ## What is Spark Declarative Pipelines (SDP)?
 
 Spark Declarative Pipelines (SDP) is a declarative framework for building reliable, maintainable, and testable data pipelines on Spark. SDP simplifies ETL development by allowing you to focus on the transformations you want to apply to your data, rather than the mechanics of pipeline execution.
 
 SDP is designed for both batch and streaming data processing, supporting common use cases such as:
+
 - Data ingestion from cloud storage (Amazon S3, Azure ADLS Gen2, Google Cloud Storage)
 - Data ingestion from message buses (Apache Kafka, Amazon Kinesis, Google Pub/Sub, Azure EventHub)
 - Incremental batch and streaming transformations
@@ -77,6 +78,7 @@ A pipeline is the primary unit of development and execution in SDP. A pipeline c
 A pipeline project is a set of source files that contain code that define the datasets and flows that make up a pipeline. These source files can be `.py` or `.sql` files.
 
 A YAML-formatted pipeline spec file contains the top-level configuration for the pipeline project. It supports the following fields:
+
 - **libraries** (Required) - Paths where source files can be found.
 - **storage** (Required) – A directory where checkpoints can be stored for streams within the pipeline.
 - **database** (Optional) - The default target database for pipeline outputs. **schema** can alternatively be used as an alias.
@@ -100,7 +102,6 @@ It's conventional to name pipeline spec files `spark-pipeline.yml`.
 
 The `spark-pipelines init` command, described below, makes it easy to generate a pipeline project with default configuration and directory structure.
 
-
 ## The `spark-pipelines` Command Line Interface
 
 The `spark-pipelines` command line interface (CLI) is the primary way to execute a pipeline. It also contains an `init` subcommand for generating a pipeline project and a `dry-run` subcommand for validating a pipeline.
@@ -118,6 +119,7 @@ The `spark-pipelines` command line interface (CLI) is the primary way to execute
 ### `spark-pipelines dry-run`
 
 `spark-pipelines dry-run` launches an execution of a pipeline that doesn't write or read any data, but catches many kinds of errors that would be caught if the pipeline were to actually run. E.g.
+
 - Syntax errors – e.g. invalid Python or SQL code
 - Analysis errors – e.g. selecting from a table that doesn't exist or selecting a column that doesn't exist
 - Graph validation errors - e.g. cyclic dependencies
@@ -128,6 +130,17 @@ SDP Python functions are defined in the `pyspark.pipelines` module. Your pipelin
 
 ```python
 from pyspark import pipelines as dp
+```
+
+Note that SDP creates and manages the `SparkSession` used by all transformations. Python functions must use this session rather than creating a new one.
+
+To access the session inside Python transformations, use:
+
+```python
+from pyspark.sql import SparkSession
+
+# Use the session created by spark-pipelines
+spark = SparkSession.getActiveSession()
 ```
 
 ### Creating a Materialized View with Python
@@ -413,6 +426,7 @@ SELECT * FROM STREAM(customers_us_east);
 - Never use methods that save or write to files or tables as part of your SDP dataset code.
 
 Examples of Apache Spark operations that should never be used in SDP code:
+
 - `collect()`
 - `count()`
 - `toPandas()`


### PR DESCRIPTION
Signed-off-by: Avril Aysha <68642378+avriiil@users.noreply.github.com>

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

I’m experimenting with the new Declarative Pipelines API in Spark 4.1 (preview), and I noticed a gap in the documentation regarding how Python transformations are expected to obtain a SparkSession.

This PR adds documentation to the Python transformation section to show how to access the existing Spark session inside each transformation. 


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Without the `getActiveSession` line, the `spark-pipelines run...` command throws a `NameError: name 'spark' is not defined`.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Docs were built locally

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No