### PR TITLE
[SPARK-54570][PYTHON] Propagate the error class correctly in Spark Connect

### DIFF
--- a/python/pyspark/errors/exceptions/connect.py
+++ b/python/pyspark/errors/exceptions/connect.py
@@ -99,6 +99,10 @@ def _convert_exception(
     if resp and resp.HasField("root_error_idx"):
         root_error = resp.errors[resp.root_error_idx]
         if hasattr(root_error, "spark_throwable"):
+            # Extract errorClass from FetchErrorDetailsResponse if not in metadata
+            if (error_class is None and
+                    root_error.spark_throwable.HasField("error_class")):
+                error_class = root_error.spark_throwable.error_class
             message_parameters = dict(root_error.spark_throwable.message_parameters)
             contexts = [
                 SQLQueryContext(c)

--- a/python/pyspark/errors/exceptions/connect.py
+++ b/python/pyspark/errors/exceptions/connect.py
@@ -100,8 +100,7 @@ def _convert_exception(
         root_error = resp.errors[resp.root_error_idx]
         if hasattr(root_error, "spark_throwable"):
             # Extract errorClass from FetchErrorDetailsResponse if not in metadata
-            if (error_class is None and
-                    root_error.spark_throwable.HasField("error_class")):
+            if error_class is None and root_error.spark_throwable.HasField("error_class"):
                 error_class = root_error.spark_throwable.error_class
             message_parameters = dict(root_error.spark_throwable.message_parameters)
             contexts = [

--- a/python/pyspark/errors/tests/test_connect_errors_conversion.py
+++ b/python/pyspark/errors/tests/test_connect_errors_conversion.py
@@ -408,6 +408,7 @@ class ConnectErrorsTest(unittest.TestCase):
 if __name__ == "__main__":
     import unittest
     from pyspark.errors.tests.test_errors import *  # noqa: F401
+    from pyspark.errors.tests.test_connect_errors_conversion import *  # noqa: F401
 
     try:
         import xmlrunner

--- a/python/pyspark/errors/tests/test_connect_errors_conversion.py
+++ b/python/pyspark/errors/tests/test_connect_errors_conversion.py
@@ -365,6 +365,45 @@ class ConnectErrorsTest(unittest.TestCase):
         self.assertEqual(breaking_change_info["needs_audit"], True)
         self.assertNotIn("mitigation_config", breaking_change_info)
 
+    def test_convert_exception_error_class_from_fetch_error_details(self):
+        """Test that errorClass is extracted from FetchErrorDetailsResponse
+        when not present in ErrorInfo metadata (e.g., when messageParameters exceed limit)."""
+        import pyspark.sql.connect.proto as pb2
+        from google.rpc.error_details_pb2 import ErrorInfo
+        from grpc import StatusCode
+
+        # Create mock FetchErrorDetailsResponse with errorClass
+        resp = pb2.FetchErrorDetailsResponse()
+        resp.root_error_idx = 0
+
+        error = resp.errors.add()
+        error.message = "Test error"
+        error.error_type_hierarchy.append("org.apache.spark.sql.AnalysisException")
+
+        # Add SparkThrowable with errorClass and messageParameters
+        spark_throwable = error.spark_throwable
+        spark_throwable.error_class = "TEST_ERROR_CLASS_FROM_RESPONSE"
+        spark_throwable.message_parameters["param1"] = "value1"
+        spark_throwable.message_parameters["param2"] = "value2"
+
+        # Create ErrorInfo WITHOUT errorClass in metadata
+        # (simulating the case where messageParameters exceeded maxMetadataSize)
+        info = ErrorInfo()
+        info.reason = "org.apache.spark.sql.AnalysisException"
+        info.metadata["classes"] = '["org.apache.spark.sql.AnalysisException"]'
+
+        exception = convert_exception(
+            info=info,
+            truncated_message="Test error",
+            resp=resp,
+            grpc_status_code=StatusCode.INTERNAL,
+        )
+
+        # Verify errorClass was extracted from FetchErrorDetailsResponse
+        self.assertIsInstance(exception, AnalysisException)
+        self.assertEqual(exception._errorClass, "TEST_ERROR_CLASS_FROM_RESPONSE")
+        # Verify messageParameters were also extracted from FetchErrorDetailsResponse
+        self.assertEqual(exception._messageParameters, {"param1": "value1", "param2": "value2"})
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/errors/tests/test_connect_errors_conversion.py
+++ b/python/pyspark/errors/tests/test_connect_errors_conversion.py
@@ -408,7 +408,6 @@ class ConnectErrorsTest(unittest.TestCase):
 
 if __name__ == "__main__":
     import unittest
-    from pyspark.errors.tests.test_errors import *  # noqa: F401
     from pyspark.errors.tests.test_connect_errors_conversion import *  # noqa: F401
 
     try:

--- a/python/pyspark/errors/tests/test_connect_errors_conversion.py
+++ b/python/pyspark/errors/tests/test_connect_errors_conversion.py
@@ -405,6 +405,7 @@ class ConnectErrorsTest(unittest.TestCase):
         # Verify messageParameters were also extracted from FetchErrorDetailsResponse
         self.assertEqual(exception._messageParameters, {"param1": "value1", "param2": "value2"})
 
+
 if __name__ == "__main__":
     import unittest
     from pyspark.errors.tests.test_errors import *  # noqa: F401


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When `spark.sql.connect.enrichError.enabled` is enabled (default), `message_parameters` is retrieved from `root_error.spark_throwable` and set correctly. However, `error_class` was not being retrieved/set in the same way, causing the error class information to be lost on the PySpark Connect client side. This PR fixes it by propagating the error class correctly.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix a bug.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes