### PR TITLE
[SPARK-54572][PYTHON] Support VSCode breakpoints for pyspark

### DIFF
--- a/python/conf_vscode/README.md
+++ b/python/conf_vscode/README.md
@@ -1,0 +1,36 @@
+# VSCode Debugger Support
+
+This directory is to support [VSCode Python debugger](https://code.visualstudio.com/docs/python/debugging)
+for PySpark.
+
+## Usage
+
+First of all, you need to install `debugpy`.
+
+```
+pip install debugpy
+```
+
+Set a breakpoint in VSCode normally by clicking the red dot on the left of the line number. You can
+set the breakpoint in user code, UDF code or PySpark engine code.
+
+Then, instead of run your script with
+
+```
+python your_script.py
+```
+
+Run it with the script wrapper we provided
+
+```
+python/run-with-vscode-breakpoints python your_script.py
+```
+
+Your VSCode debugger should be brought up automatically when the breakpoint is hit.
+
+This also works for `run-tests` or any other scripts - under the hood it just sets two environment variables.
+If you want, you can set them manually.
+
+```
+python/run-with-vscode-breakpoints python/run-tests --testnames="..."
+```

--- a/python/conf_vscode/sitecustomize.py
+++ b/python/conf_vscode/sitecustomize.py
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Note that this 'sitecustomize' module is a built-in feature in Python.
+# If this module is defined, it's executed when the Python session begins.
+# `coverage.process_startup()` seeks if COVERAGE_PROCESS_START environment
+# variable is set or not. If set, it starts to run the coverage.
+
+try:
+    import debugpy
+    import sys
+    import os
+    if "DEBUGPY_ADAPTER_ENDPOINTS" in os.environ and not any("debugpy" in arg for arg in sys.argv):
+        debugpy.listen(0)
+        debugpy.wait_for_client()
+        try:
+            os.remove(os.getenv("DEBUGPY_ADAPTER_ENDPOINTS"))
+        except Exception:
+            pass
+except ImportError:
+    pass

--- a/python/conf_vscode/sitecustomize.py
+++ b/python/conf_vscode/sitecustomize.py
@@ -15,11 +15,6 @@
 # limitations under the License.
 #
 
-# Note that this 'sitecustomize' module is a built-in feature in Python.
-# If this module is defined, it's executed when the Python session begins.
-# `coverage.process_startup()` seeks if COVERAGE_PROCESS_START environment
-# variable is set or not. If set, it starts to run the coverage.
-
 try:
     import debugpy
     import sys

--- a/python/run-with-vscode-breakpoints
+++ b/python/run-with-vscode-breakpoints
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -o pipefail
+set -e
+
+FWDIR="$(cd "`dirname $0`"; pwd)"
+
+# Function to display help message
+function usage {
+  cat <<EOF
+Usage:
+  $(basename $0) your_original_commands
+
+Requirements:
+  - debugpy must be installed (pip install debugpy)
+EOF
+  exit 0
+}
+
+# Check for help flags or no arguments
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  usage
+fi
+
+if ! python3 -c "import debugpy" 2>/dev/null; then
+  echo "Error: debugpy is not installed. Please install it using 'pip install debugpy'."
+  exit 1
+fi
+
+export DEBUGPY_ADAPTER_ENDPOINTS=$VSCODE_DEBUGPY_ADAPTER_ENDPOINTS
+export PYTHONPATH="$FWDIR/conf_vscode:$PYTHONPATH"
+
+exec "$@"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds a script and a supporting directory for users to have native debugging experience with VSCode (Cursor) for not only driver code, but UDF/workers/daemon.

<img width="2324" height="1010" alt="image" src="https://github.com/user-attachments/assets/57d1bbae-53c6-48e9-8910-25a47e4f0e24" />


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

So user can debug their (local) code with VSCode debugger.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Locally works. This does not touch spark code, it's just a dev tool.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No