### PR TITLE
[SPARK-54555][PYTHON][TESTS] Set `spark.sql.execution.pandas.structHandlingMode` in pyspark pandas doctest

### DIFF
--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -1367,7 +1367,9 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
                     ('falcon', 'length')],
                    )
 
-        >>> s.index.value_counts().sort_index() # doctest: +SKIP
+        >>> spark.conf.set('spark.sql.execution.pandas.structHandlingMode', 'row')
+
+        >>> s.index.value_counts().sort_index()
         (cow, length)       1
         (cow, weight)       2
         (falcon, length)    2
@@ -1375,7 +1377,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         (lama, weight)      3
         Name: count, dtype: int64
 
-        >>> s.index.value_counts(normalize=True).sort_index() # doctest: +SKIP
+        >>> s.index.value_counts(normalize=True).sort_index()
         (cow, length)       0.111111
         (cow, weight)       0.222222
         (falcon, length)    0.222222

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -1745,7 +1745,7 @@ def _test() -> None:
     spark = (
         SparkSession.builder.master("local[4]").appName("pyspark.pandas.base tests").getOrCreate()
     )
-    spark.conf.set('spark.sql.execution.pandas.structHandlingMode', 'row')
+    spark.conf.set("spark.sql.execution.pandas.structHandlingMode", "row")
     (failure_count, test_count) = doctest.testmod(
         pyspark.pandas.base,
         globs=globs,

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -1367,8 +1367,6 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
                     ('falcon', 'length')],
                    )
 
-        >>> spark.conf.set('spark.sql.execution.pandas.structHandlingMode', 'row')
-
         >>> s.index.value_counts().sort_index()
         (cow, length)       1
         (cow, weight)       2
@@ -1747,6 +1745,7 @@ def _test() -> None:
     spark = (
         SparkSession.builder.master("local[4]").appName("pyspark.pandas.base tests").getOrCreate()
     )
+    spark.conf.set('spark.sql.execution.pandas.structHandlingMode', 'row')
     (failure_count, test_count) = doctest.testmod(
         pyspark.pandas.base,
         globs=globs,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

After https://github.com/apache/spark/pull/53299, explicitly set conf `spark.sql.execution.pandas.structHandlingMode` to `row`. This is needed because when Arrow optimization was previously disabled, structHandlingMode converted to Row object by default, but when Arrow optimization is enabled, it converts to dict or raise an Exception if duplicated nested field names. 

To match the docs behavior after enabling arrow by default, we explicitly set this conf to row.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Fix pyspark-pandas doctest and remove the skip of doctests


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

CI running pyspark-pandas doctest


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
