### PR TITLE
[SPARK-54690][PS] Make `Frame.__repr__` insensitive to arrow optimization

### DIFF
--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -1745,7 +1745,6 @@ def _test() -> None:
     spark = (
         SparkSession.builder.master("local[4]").appName("pyspark.pandas.base tests").getOrCreate()
     )
-    spark.conf.set("spark.sql.execution.pandas.structHandlingMode", "row")
     (failure_count, test_count) = doctest.testmod(
         pyspark.pandas.base,
         globs=globs,

--- a/python/pyspark/pandas/internal.py
+++ b/python/pyspark/pandas/internal.py
@@ -1064,7 +1064,7 @@ class InternalFrame:
     def to_pandas_frame(self) -> pd.DataFrame:
         """Return as pandas DataFrame."""
         sdf = self.to_internal_spark_frame
-        pdf = sdf.toPandas()
+        pdf = sdf._to_pandas(pandasStructHandlingMode="row")
         if len(pdf) == 0 and len(sdf.schema) > 0:
             pdf = pdf.astype(
                 {field.name: spark_type_to_pandas_dtype(field.dataType) for field in sdf.schema}

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1843,6 +1843,9 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def toPandas(self) -> "PandasDataFrameLike":
         return PandasConversionMixin.toPandas(self)
 
+    def _to_pandas(self, **kwargs) -> "PandasDataFrameLike":
+        return PandasConversionMixin.toPandas(self, **kwargs)
+
     def transpose(self, indexColumn: Optional["ColumnOrName"] = None) -> ParentDataFrame:
         if indexColumn is not None:
             return DataFrame(self._jdf.transpose(_to_java_column(indexColumn)), self.sparkSession)

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1841,7 +1841,7 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         return PandasConversionMixin.toArrow(self)
 
     def toPandas(self) -> "PandasDataFrameLike":
-        return PandasConversionMixin.toPandas(self)
+        return self._to_pandas()
 
     def _to_pandas(self, **kwargs) -> "PandasDataFrameLike":
         return PandasConversionMixin.toPandas(self, **kwargs)

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1841,10 +1841,10 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         return PandasConversionMixin.toArrow(self)
 
     def toPandas(self) -> "PandasDataFrameLike":
-        return self._to_pandas()
+        return PandasConversionMixin._to_pandas(self)
 
     def _to_pandas(self, **kwargs) -> "PandasDataFrameLike":
-        return PandasConversionMixin.toPandas(self, **kwargs)
+        return PandasConversionMixin._to_pandas(self, **kwargs)
 
     def transpose(self, indexColumn: Optional["ColumnOrName"] = None) -> ParentDataFrame:
         if indexColumn is not None:

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1843,7 +1843,7 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def toPandas(self) -> "PandasDataFrameLike":
         return PandasConversionMixin._to_pandas(self)
 
-    def _to_pandas(self, **kwargs) -> "PandasDataFrameLike":
+    def _to_pandas(self, **kwargs: Any) -> "PandasDataFrameLike":
         return PandasConversionMixin._to_pandas(self, **kwargs)
 
     def transpose(self, indexColumn: Optional["ColumnOrName"] = None) -> ParentDataFrame:

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -987,7 +987,7 @@ class SparkConnectClient(object):
         return table, schema, ei
 
     def to_pandas(
-        self, plan: pb2.Plan, observations: Dict[str, Observation], **kwargs
+        self, plan: pb2.Plan, observations: Dict[str, Observation], **kwargs: Any
     ) -> Tuple["pd.DataFrame", "ExecutionInfo"]:
         """
         Return given plan as a pandas DataFrame.

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -987,7 +987,7 @@ class SparkConnectClient(object):
         return table, schema, ei
 
     def to_pandas(
-        self, plan: pb2.Plan, observations: Dict[str, Observation]
+        self, plan: pb2.Plan, observations: Dict[str, Observation], **kwargs
     ) -> Tuple["pd.DataFrame", "ExecutionInfo"]:
         """
         Return given plan as a pandas DataFrame.
@@ -1009,6 +1009,10 @@ class SparkConnectClient(object):
             "spark.sql.execution.pandas.structHandlingMode",
             "spark.sql.execution.arrow.pyspark.selfDestruct.enabled",
         )
+
+        # if pandasStructHandlingMode is explicitly set, override the runtime config
+        if "pandasStructHandlingMode" in kwargs:
+            structHandlingMode = str(kwargs["pandasStructHandlingMode"])
 
         table, schema, metrics, observed_metrics, _ = self._execute_and_fetch(
             req, observations, selfDestruct == "true"

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1845,12 +1845,6 @@ class DataFrame(ParentDataFrame):
         return table.cast(schema)
 
     def toPandas(self) -> "PandasDataFrameLike":
-        query = self._plan.to_proto(self._session.client)
-        pdf, ei = self._session.client.to_pandas(query, self._plan.observations)
-        self._execution_info = ei
-        return pdf
-
-    def toPandas(self) -> "PandasDataFrameLike":
         return self._to_pandas()
 
     def _to_pandas(self, **kwargs) -> "PandasDataFrameLike":

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1850,6 +1850,15 @@ class DataFrame(ParentDataFrame):
         self._execution_info = ei
         return pdf
 
+    def toPandas(self) -> "PandasDataFrameLike":
+        return self._to_pandas()
+
+    def _to_pandas(self, **kwargs) -> "PandasDataFrameLike":
+        query = self._plan.to_proto(self._session.client)
+        pdf, ei = self._session.client.to_pandas(query, self._plan.observations, **kwargs)
+        self._execution_info = ei
+        return pdf
+
     def transpose(self, indexColumn: Optional["ColumnOrName"] = None) -> ParentDataFrame:
         return DataFrame(
             plan.Transpose(self._plan, [F._to_col(indexColumn)] if indexColumn is not None else []),

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1847,7 +1847,7 @@ class DataFrame(ParentDataFrame):
     def toPandas(self) -> "PandasDataFrameLike":
         return self._to_pandas()
 
-    def _to_pandas(self, **kwargs) -> "PandasDataFrameLike":
+    def _to_pandas(self, **kwargs: Any) -> "PandasDataFrameLike":
         query = self._plan.to_proto(self._session.client)
         pdf, ei = self._session.client.to_pandas(query, self._plan.observations, **kwargs)
         self._execution_info = ei

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -175,7 +175,7 @@ class PandasConversionMixin:
     :class:`DataFrame` can use this class.
     """
 
-    def toPandas(self, **kwargs) -> "PandasDataFrameLike":
+    def _to_pandas(self, **kwargs: Any) -> "PandasDataFrameLike":
         from pyspark.sql.dataframe import DataFrame
 
         assert isinstance(self, DataFrame)

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -175,7 +175,7 @@ class PandasConversionMixin:
     :class:`DataFrame` can use this class.
     """
 
-    def toPandas(self) -> "PandasDataFrameLike":
+    def toPandas(self, **kwargs) -> "PandasDataFrameLike":
         from pyspark.sql.dataframe import DataFrame
 
         assert isinstance(self, DataFrame)
@@ -204,6 +204,11 @@ class PandasConversionMixin:
                 "spark.sql.execution.pandas.structHandlingMode",
             ]
         )
+
+        # if pandasStructHandlingMode is explicitly set, override the runtime config
+        if "pandasStructHandlingMode" in kwargs:
+            pandasStructHandlingMode = str(kwargs["pandasStructHandlingMode"])
+
         prefers_large_var_types = arrowUseLargeVarTypes == "true"
 
         if arrowPySparkEnabled == "true":


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Make `Frame.__repr__` should be insensitive to config `spark.sql.execution.pandas.structHandlingMode`


### Why are the changes needed?
the `__repr__` might be broken when arrow-optimization is on


### Does this PR introduce _any_ user-facing change?
yes, the `__repr__` will not be affected by this config


### How was this patch tested?
enabled doctests


### Was this patch authored or co-authored using generative AI tooling?
no
