### PR TITLE
[SPARK-54575][PYTHON][TESTS] Reenable test `SparkConnectCreationTests.test_with_none_and_nan`

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_creation.py
+++ b/python/pyspark/sql/tests/connect/test_connect_creation.py
@@ -228,7 +228,6 @@ class SparkConnectCreationTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
                 self.assertEqual(sdf.schema, cdf.schema)
                 self.assert_eq(sdf.toPandas(), cdf.toPandas())
 
-    @unittest.skip("TODO(SPARK-54575): Re-enable this test")
     def test_with_none_and_nan(self):
         # SPARK-41855: make createDataFrame support None and NaN
         # SPARK-41814: test with eqNullSafe


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
There was a bug in create dataframe from ndarray containing NaN values:
NaN was incorrectly converted to Null when arrow-optimization is on, it happened to be resolved in https://github.com/apache/spark/pull/53280


### Why are the changes needed?
for test coverage


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no