### PR TITLE
[SPARK-54553][K8S] Support `spark.kubernetes.scheduler.volcano.podGroupTemplateJson`

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1991,6 +1991,7 @@ Volcano defines PodGroup spec using [CRD yaml](https://volcano.sh/en/docs/podgro
 
 Similar to [Pod template](#pod-template), Spark users can use Volcano PodGroup Template to define the PodGroup spec configurations.
 Below is an example of PodGroup template:
+
 ```yaml
 apiVersion: scheduling.volcano.sh/v1beta1
 kind: PodGroup
@@ -2009,13 +2010,13 @@ spec:
   queue: default
 ```
 
-You have two options to provide the PodGroup template in spark.
+You have two options to provide the PodGroup template in spark. If both are provided, the `podGroupTemplateFile` will takes precedence.
 1. Use `spark.kubernetes.scheduler.volcano.podGroupTemplateFile` to point to files accessible to the `spark-submit` process
 ```bash
 --conf spark.kubernetes.scheduler.volcano.podGroupTemplateFile=/path/to/podgroup
 ```
 
-2. Use `spark.kubernetes.scheduler.volcano.podGroupTemplateJson` to provide the template in json format.
+2. Use `spark.kubernetes.scheduler.volcano.podGroupTemplateJson` to pass the template directly in JSON format:.
 ```bash
 --conf spark.kubernetes.scheduler.volcano.podGroupTemplateJson={"spec": {"minMember": 1,"minResources": {"cpu": "2","memory": "3Gi"},"priorityClassName": "system-node-critical","queue": "default"}}
 ```

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1990,9 +1990,7 @@ Note that currently only driver/job level PodGroup is supported in Volcano Featu
 Volcano defines PodGroup spec using [CRD yaml](https://volcano.sh/en/docs/podgroup/#example).
 
 Similar to [Pod template](#pod-template), Spark users can use Volcano PodGroup Template to define the PodGroup spec configurations.
-To do so, specify the Spark property `spark.kubernetes.scheduler.volcano.podGroupTemplateFile` to point to files accessible to the `spark-submit` process.
 Below is an example of PodGroup template:
-
 ```yaml
 apiVersion: scheduling.volcano.sh/v1beta1
 kind: PodGroup
@@ -2009,6 +2007,17 @@ spec:
   priorityClassName: system-node-critical
   # Specify the queue, indicates the resource queue which the job should be submitted to
   queue: default
+```
+
+You have two options to provide the PodGroup template in spark.
+1. Use `spark.kubernetes.scheduler.volcano.podGroupTemplateFile` to point to files accessible to the `spark-submit` process
+```bash
+--conf spark.kubernetes.scheduler.volcano.podGroupTemplateFile=/path/to/podgroup
+```
+
+2. Use `spark.kubernetes.scheduler.volcano.podGroupTemplateJson` to provide the template in json format.
+```bash
+--conf spark.kubernetes.scheduler.volcano.podGroupTemplateJson={"spec": {"minMember": 1,"minResources": {"cpu": "2","memory": "3Gi"},"priorityClassName": "system-node-critical","queue": "default"}}
 ```
 
 #### Using Apache YuniKorn as Customized Scheduler for Spark on Kubernetes

--- a/resource-managers/kubernetes/core/volcano/src/main/scala/org/apache/spark/deploy/k8s/features/VolcanoFeatureStep.scala
+++ b/resource-managers/kubernetes/core/volcano/src/main/scala/org/apache/spark/deploy/k8s/features/VolcanoFeatureStep.scala
@@ -18,6 +18,7 @@ package org.apache.spark.deploy.k8s.features
 
 import java.io.ByteArrayInputStream
 
+import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import io.fabric8.kubernetes.api.model._
@@ -89,7 +90,7 @@ private[spark] class VolcanoFeatureStep extends KubernetesDriverCustomFeatureCon
           .load(new ByteArrayInputStream(templateYaml.getBytes()))
           .item()
       } catch {
-        case e: Exception =>
+        case e: JsonParseException =>
           throw new SparkException(f"The ${POD_GROUP_TEMPLATE_JSON_KEY} provided is invalid", e)
       }
     }

--- a/resource-managers/kubernetes/core/volcano/src/test/scala/org/apache/spark/deploy/k8s/features/VolcanoFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/volcano/src/test/scala/org/apache/spark/deploy/k8s/features/VolcanoFeatureStepSuite.scala
@@ -34,8 +34,7 @@ class VolcanoFeatureStepSuite extends SparkFunSuite {
 
     val annotations = configuredPod.pod.getMetadata.getAnnotations
 
-    assert(
-      annotations.get("scheduling.k8s.io/group-name") === s"${kubernetesConf.appId}-podgroup")
+    assert(annotations.get("scheduling.k8s.io/group-name") === s"${kubernetesConf.appId}-podgroup")
     val podGroup = step.getAdditionalPreKubernetesResources().head.asInstanceOf[PodGroup]
     assert(podGroup.getMetadata.getName === s"${kubernetesConf.appId}-podgroup")
   }
@@ -47,13 +46,12 @@ class VolcanoFeatureStepSuite extends SparkFunSuite {
     step.init(kubernetesConf)
     val configuredPod = step.configurePod(SparkPod.initialPod())
     val annotations = configuredPod.pod.getMetadata.getAnnotations
-    assert(
-      annotations.get("scheduling.k8s.io/group-name") === s"${kubernetesConf.appId}-podgroup")
+    assert(annotations.get("scheduling.k8s.io/group-name") === s"${kubernetesConf.appId}-podgroup")
   }
 
   test("SPARK-38455: Support driver podgroup template") {
-    val templatePath =
-      new File(getClass.getResource("/driver-podgroup-template.yml").getFile).getAbsolutePath
+    val templatePath = new File(
+      getClass.getResource("/driver-podgroup-template.yml").getFile).getAbsolutePath
     val sparkConf = new SparkConf()
       .set(VolcanoFeatureStep.POD_GROUP_TEMPLATE_FILE_KEY, templatePath)
     val kubernetesConf = KubernetesTestConf.createDriverConf(sparkConf)
@@ -69,7 +67,7 @@ class VolcanoFeatureStepSuite extends SparkFunSuite {
     assert(podGroup.getSpec.getQueue == "driver-queue")
   }
 
-  test("SPARK-38455: Support create driver podgroup by attributes") {
+  test("SPARK-54553: Support create driver podgroup by attributes") {
     val sparkConf = new SparkConf()
       .set(
         VolcanoFeatureStep.POD_GROUP_TEMPLATE_JSON_KEY,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add a new configuration option spark.kubernetes.scheduler.volcano.podGroupTemplateJson for cases where Volcano is used as the Kubernetes scheduler.
This option allows users to provide the PodGroup configuration directly as a JSON string.
If podGroupTemplateFile is not specified, Spark will fall back to using podGroupTemplateJson.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
- Currently, we need to create a temporary podgroup file for each task. This makes it difficult for us to use tools like kyuubi to submit spark with volcano. After this PR, we can directly provide podgroup configurations via parameters rather than create a tmp file firstly.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes.

Use below conf can work

```java
--conf spark.kubernetes.driver.pod.featureSteps=org.apache.spark.deploy.k8s.features.VolcanoFeatureStep \
--conf spark.kubernetes.executor.pod.featureSteps=org.apache.spark.deploy.k8s.features.VolcanoFeatureStep \
--conf spark.kubernetes.scheduler.name=volcano \
--conf spark.kubernetes.scheduler.volcano.podGroupTemplateJson={"spec": {"minMember": 1,"minResources": {"cpu": "2","memory": "3Gi"},"queue": "bigdata"}} \
```

The podgroup has been created correctly
```
Name:         spark-40cd4561661d4298a3f08cc7477cdc3c-podgroup
Namespace:    spark
API Version:  scheduling.volcano.sh/v1beta1
Kind:         PodGroup
Metadata:
  Creation Timestamp:  2025-12-05T09:18:35Z
  Generation:          7
  Owner References:
    API Version:     v1
    Controller:      true
    Kind:            Pod
    Name:            kyuubi-cql-test-ds-35faf46f-c4f9-44d3-8288-d1875e8a074d-driver
    UID:             8fd2d875-9c17-4bf2-8787-fdd4f9e2e79b
  Resource Version:  2230406043
  UID:               adaeb0a8-c6f6-4c29-92e8-480d8e01d89a
Spec:
  Min Member:  1
  Min Resources:
    Cpu:     2
    Memory:  3Gi
  Queue:     bigdata
```


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
- Test by UT


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
NO
