### PR TITLE
[SPARK-54581][SQL] Making fetchsize option case-insensitive for Postgres connector

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -27,6 +27,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.SQL_TEXT
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.execution.datasources.{DataSourceMetricsMixin, ExternalEngineDatasourceRDD}
 import org.apache.spark.sql.execution.datasources.v2.TableSampleInfo
@@ -306,7 +307,7 @@ class JDBCRDD(
     val part = thePart.asInstanceOf[JDBCPartition]
     conn = getConnection(part.idx)
     import scala.jdk.CollectionConverters._
-    dialect.beforeFetch(conn, options.asProperties.asScala.toMap)
+    dialect.beforeFetch(conn, CaseInsensitiveMap(options.asProperties.asScala.toMap))
 
     // This executes a generic SQL statement (or PL/SQL block) before reading
     // the table/query via JDBC. Use this feature to initialize the database

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -27,7 +27,6 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.SQL_TEXT
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.execution.datasources.{DataSourceMetricsMixin, ExternalEngineDatasourceRDD}
 import org.apache.spark.sql.execution.datasources.v2.TableSampleInfo
@@ -306,8 +305,7 @@ class JDBCRDD(
     val inputMetrics = context.taskMetrics().inputMetrics
     val part = thePart.asInstanceOf[JDBCPartition]
     conn = getConnection(part.idx)
-    import scala.jdk.CollectionConverters._
-    dialect.beforeFetch(conn, CaseInsensitiveMap(options.asProperties.asScala.toMap))
+    dialect.beforeFetch(conn, options)
 
     // This executes a generic SQL statement (or PL/SQL block) before reading
     // the table/query via JDBC. Use this feature to initialize the database

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -342,7 +342,18 @@ abstract class JdbcDialect extends Serializable with Logging {
    * @param connection The connection object
    * @param properties The connection properties.  This is passed through from the relation.
    */
+  @deprecated("Use beforeFetch(Connection, JDBCOptions) instead", "4.0.0")
   def beforeFetch(connection: Connection, properties: Map[String, String]): Unit = {
+  }
+
+  /**
+   * Override connection specific properties to run before a select is made.  This is in place to
+   * allow dialects that need special treatment to optimize behavior.
+   * @param connection The connection object
+   * @param options The JDBC options for the connection.
+   */
+  def beforeFetch(connection: Connection, options: JDBCOptions): Unit = {
+    beforeFetch(connection, options.parameters)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -342,7 +342,7 @@ abstract class JdbcDialect extends Serializable with Logging {
    * @param connection The connection object
    * @param properties The connection properties.  This is passed through from the relation.
    */
-  @deprecated("Use beforeFetch(Connection, JDBCOptions) instead", "4.0.0")
+  @deprecated("Use beforeFetch(Connection, JDBCOptions) instead", "4.2.0")
   def beforeFetch(connection: Connection, properties: Map[String, String]): Unit = {
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.spark.sql.jdbc
+
+import java.sql.Connection
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito._
+import org.scalatestplus.mockito.MockitoSugar
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JDBCPartition, JDBCRDD}
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types._
+
+class PostgresDialectSuite extends SparkFunSuite with MockitoSugar with SharedSparkSession {
+
+  gridTest("PostgresDialect sets autoCommit correctly with fetchSize option")(
+    Seq(
+      ("fetchsize", Some("100"), true),
+      ("fetchSize", Some("100"), true),
+      ("FETCHSIZE", Some("100"), true),
+      ("fetchsize", Some("0"), false),
+      ("fetchsize", None, false)
+    )
+  ) { case (optionKey: String, optionValue: Option[String], shouldSetAutoCommit: Boolean) =>
+    val conn = mock[Connection]
+    when(conn.prepareStatement(any[String], any[Int], any[Int]))
+      .thenReturn(mock[java.sql.PreparedStatement])
+
+    val optionsMap = Map(
+      "url" -> "jdbc:postgresql://localhost/test",
+      "dbtable" -> "test_table"
+    ) ++ optionValue.map(v => Map(optionKey -> v)).getOrElse(Map.empty)
+
+    val options = new JDBCOptions(CaseInsensitiveMap(optionsMap), None)
+
+    val schema = StructType(Seq(StructField("id", IntegerType)))
+    val partition = new JDBCPartition(null, 0)
+    val rdd = new JDBCRDD(
+      spark.sparkContext,
+      _ => conn,
+      schema,
+      Array.empty,
+      Array.empty,
+      Array(partition),
+      "jdbc:postgresql://localhost/test",
+      options,
+      Some(PostgresDialect()),
+      None,
+      None,
+      0,
+      Array.empty,
+      0,
+      Map.empty
+    )
+
+    try {
+      rdd.compute(partition, org.apache.spark.TaskContext.empty())
+    } catch {
+      case _: Exception => // Expected to fail, we just want beforeFetch to be called
+    }
+
+    if (shouldSetAutoCommit) {
+      verify(conn).setAutoCommit(false)
+    } else {
+      verify(conn, never()).setAutoCommit(false)
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
@@ -26,7 +26,7 @@ import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
-import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JDBCPartition, JDBCRDD}
+import org.apache.spark.sql.execution.datasources.jdbc.{JDBCDatabaseMetadata, JDBCOptions, JDBCPartition, JDBCRDD}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
@@ -40,7 +40,7 @@ class PostgresDialectSuite extends SparkFunSuite with MockitoSugar with SharedSp
       ("fetchsize", Some("0"), false),
       ("fetchsize", None, false)
     )
-  ) { case (optionKey: String, optionValue: Option[String], shouldSetAutoCommit: Boolean) =>
+  ) { case (optionKey, optionValue, shouldSetAutoCommit) =>
     val conn = mock[Connection]
     when(conn.prepareStatement(any[String], any[Int], any[Int]))
       .thenReturn(mock[java.sql.PreparedStatement])
@@ -50,7 +50,7 @@ class PostgresDialectSuite extends SparkFunSuite with MockitoSugar with SharedSp
       "dbtable" -> "test_table"
     ) ++ optionValue.map(v => Map(optionKey -> v)).getOrElse(Map.empty)
 
-    val options = new JDBCOptions(CaseInsensitiveMap(optionsMap), None)
+    val options = new JDBCOptions(CaseInsensitiveMap(optionsMap))
 
     val schema = StructType(Seq(StructField("id", IntegerType)))
     val partition = new JDBCPartition(null, 0)
@@ -63,7 +63,7 @@ class PostgresDialectSuite extends SparkFunSuite with MockitoSugar with SharedSp
       Array(partition),
       "jdbc:postgresql://localhost/test",
       options,
-      Some(PostgresDialect()),
+      JDBCDatabaseMetadata(None, None, None, None),
       None,
       None,
       0,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Making new API for `beforeFetch` in `JDBCDialect`, where it accepts options as `JDBCOptions` instead of `Map[String, String]`, and deprecating the old API starting from Spark version `4.2.0`.  [Spark docs](https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html#data-source-option) state that options are case insensitive, so this will make it easier for dialects to respect that. Even if we have some edge case where we need the original casing, we can access the original map inside the `JDBCOptions` object.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The option `fetchsize` requires another option, `autocommit` to be set to `false` for the Postgres connector. We have logic for this:

https://github.com/apache/spark/blob/415f50511463a8e73af77cf9f70cba4292c1331d/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala#L203-L205

However, this logic is case-sensitive, and will only work for lowercased `fetchsize`. When passing `fetchSize` for example, the correct value for the fetchsize will be set on the Postgres driver, but it won't have `autocommit -> false`, so the fetch size will be ignored.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

New test: `PostgresDialectSuite`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Yes, partly generated-by: claude code.
