### PR TITLE
[WIP][SPARK-54579][SPARK-54575] Fix NaN handling in `createDataFrame` with Arrow

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -452,7 +452,8 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
         if hasattr(series.array, "__arrow_array__"):
             mask = None
         else:
-            # For floating-point Arrow types, preserve NaN values instead of converting them to NULL.
+            # For floating-point Arrow types, preserve NaN values instead of
+            # converting them to NULL.
             # Only mask actual None values, not NaN values.
             import pyarrow.types as types
 
@@ -1092,7 +1093,8 @@ class ArrowStreamPandasUDTFSerializer(ArrowStreamPandasUDFSerializer):
             mask = None
         else:
             # SPARK-54579: Preserve NaN values as NaN (not NULL) for floating-point Arrow types.
-            # For floating-point Arrow types, preserve NaN values instead of converting them to NULL.
+            # For floating-point Arrow types, preserve NaN values instead of
+            # converting them to NULL.
             # Only mask actual None values, not NaN values.
             import pyarrow.types as types
 

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -361,7 +361,10 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
         """
         Create a mask for floating-point Arrow types that preserves NaN values.
 
-        For floating-point types, only mask None values (convert to NULL), not NaN values.
+        SPARK-54579: For floating-point types, only mask None values (convert to NULL),
+        not NaN values. NaN should be preserved as NaN (a valid floating-point value),
+        while only None should be converted to NULL.
+
         For non-floating types, mask both None and NaN as before.
 
         Parameters

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -455,14 +455,14 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
             # For floating-point Arrow types, preserve NaN values instead of converting them to NULL.
             # Only mask actual None values, not NaN values.
             import pyarrow.types as types
-            
+
             # Determine if this is a floating-point type
             is_floating_type = False
             if arrow_type is not None:
                 is_floating_type = types.is_floating(arrow_type)
             elif pd.api.types.is_float_dtype(series.dtype):
                 is_floating_type = True
-            
+
             if is_floating_type:
                 # For floating-point types, only mask None values, not NaN
                 if series.dtype == "object":
@@ -1095,13 +1095,13 @@ class ArrowStreamPandasUDTFSerializer(ArrowStreamPandasUDFSerializer):
             # For floating-point Arrow types, preserve NaN values instead of converting them to NULL.
             # Only mask actual None values, not NaN values.
             import pyarrow.types as types
-            
+
             is_floating_type = False
             if arrow_type is not None:
                 is_floating_type = types.is_floating(arrow_type)
             elif pd.api.types.is_float_dtype(series.dtype):
                 is_floating_type = True
-            
+
             if is_floating_type:
                 mask = pd.Series([False] * len(series), dtype=bool)
                 # For floating-point types, only mask None values, not NaN

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -499,12 +499,12 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
             if self._int_to_decimal_coercion_enabled:
                 series = self._apply_python_coercions(series, arrow_type)
 
-        if hasattr(series.array, "__arrow_array__"):
-            mask = None
-        else:
-            # SPARK-54579: Preserve NaN values as NaN (not NULL) for floating-point Arrow types.
-            series, mask = self._create_mask_for_floating_type(series, arrow_type)
         try:
+            if hasattr(series.array, "__arrow_array__"):
+                mask = None
+            else:
+                # SPARK-54579: Preserve NaN values as NaN (not NULL) for floating-point Arrow types.
+                series, mask = self._create_mask_for_floating_type(series, arrow_type)
             try:
                 return pa.Array.from_pandas(
                     series, mask=mask, type=arrow_type, safe=self._safecheck

--- a/python/pyspark/sql/tests/arrow/test_arrow.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow.py
@@ -1060,29 +1060,6 @@ class ArrowTestsMixin:
             df = self.spark.createDataFrame(pandas_df)
             assert_frame_equal(pandas_df, df.toPandas(), check_dtype=False)
 
-    def test_createDataFrame_pandas_preserve_nan_with_arrow(self):
-        # SPARK-54579: createDataFrame should preserve NaN values when arrow optimization is enabled
-        import numpy as np
-
-        with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": True}):
-            # Test case 1: object dtype with None and NaN
-            pdf1 = pd.DataFrame({"x": np.array([1.0, np.nan, None])})
-            df1 = self.spark.createDataFrame(pdf1)
-            result1 = df1.collect()
-            # Expected: [1.0, NaN, NULL]
-            self.assertEqual(result1[0][0], 1.0)
-            self.assertTrue(pd.isna(result1[1][0]) and result1[1][0] is not None)  # NaN
-            self.assertIsNone(result1[2][0])  # NULL
-
-            # Test case 2: float64 dtype with NaN (pandas converts None to NaN)
-            pdf2 = pd.DataFrame({"x": [1.0, np.nan, None]})
-            df2 = self.spark.createDataFrame(pdf2)
-            result2 = df2.collect()
-            # Expected: [1.0, NaN, NaN] (pandas converts None to NaN for float64)
-            self.assertEqual(result2[0][0], 1.0)
-            self.assertTrue(pd.isna(result2[1][0]) and result2[1][0] is not None)  # NaN
-            self.assertTrue(pd.isna(result2[2][0]) and result2[2][0] is not None)  # NaN
-
     def test_toPandas_with_map_type(self):
         with self.quiet():
             for arrow_enabled in [True, False]:

--- a/python/pyspark/sql/tests/arrow/test_arrow.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow.py
@@ -1060,6 +1060,29 @@ class ArrowTestsMixin:
             df = self.spark.createDataFrame(pandas_df)
             assert_frame_equal(pandas_df, df.toPandas(), check_dtype=False)
 
+    def test_createDataFrame_pandas_preserve_nan_with_arrow(self):
+        # SPARK-54579: createDataFrame should preserve NaN values when arrow optimization is enabled
+        import numpy as np
+
+        with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": True}):
+            # Test case 1: object dtype with None and NaN
+            pdf1 = pd.DataFrame({"x": np.array([1.0, np.nan, None])})
+            df1 = self.spark.createDataFrame(pdf1)
+            result1 = df1.collect()
+            # Expected: [1.0, NaN, NULL]
+            self.assertEqual(result1[0][0], 1.0)
+            self.assertTrue(pd.isna(result1[1][0]) and result1[1][0] is not None)  # NaN
+            self.assertIsNone(result1[2][0])  # NULL
+
+            # Test case 2: float64 dtype with NaN (pandas converts None to NaN)
+            pdf2 = pd.DataFrame({"x": [1.0, np.nan, None]})
+            df2 = self.spark.createDataFrame(pdf2)
+            result2 = df2.collect()
+            # Expected: [1.0, NaN, NaN] (pandas converts None to NaN for float64)
+            self.assertEqual(result2[0][0], 1.0)
+            self.assertTrue(pd.isna(result2[1][0]) and result2[1][0] is not None)  # NaN
+            self.assertTrue(pd.isna(result2[2][0]) and result2[2][0] is not None)  # NaN
+
     def test_toPandas_with_map_type(self):
         with self.quiet():
             for arrow_enabled in [True, False]:

--- a/python/pyspark/sql/tests/connect/test_connect_creation.py
+++ b/python/pyspark/sql/tests/connect/test_connect_creation.py
@@ -228,7 +228,6 @@ class SparkConnectCreationTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
                 self.assertEqual(sdf.schema, cdf.schema)
                 self.assert_eq(sdf.toPandas(), cdf.toPandas())
 
-    @unittest.skip("TODO(SPARK-54575): Re-enable this test")
     def test_with_none_and_nan(self):
         # SPARK-41855: make createDataFrame support None and NaN
         # SPARK-41814: test with eqNullSafe


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes SPARK-54579: `createDataFrame` incorrectly handles NaN in pandas DataFrame when arrow-optimization is enabled.  Also re-enabled `test_with_none_and_nan` for SPARK-54575.

1. For floating-point Arrow types (float32, float64):
   - For object dtype Series: Track positions that were originally `None`, convert the Series to float64, then create a mask that only masks those original `None` positions (not NaN positions)
   - For float64 dtype Series: Don't mask NaN values (use an all-False mask) to preserve NaN
2. For non-floating types: Continue to mask both `None` and `NaN` as before

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
