### PR TITLE
[SPARK-54582][SQL] Add Time Type Statistics Collection Support

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -1034,6 +1034,10 @@ object CatalogColumnStat extends Logging {
       forTimestampNTZ = forTimestampNTZ)
   }
 
+  def getTimeFormatter(isParsing: Boolean): TimeFormatter = {
+    TimeFormatter.getFractionFormatter()
+  }
+
   /**
    * Converts from string representation of data type to the corresponding Catalyst data type.
    */
@@ -1047,6 +1051,7 @@ object CatalogColumnStat extends Logging {
       case TimestampType => getTimestampFormatter(isParsing = true).parse(s)
       case TimestampNTZType =>
         getTimestampFormatter(isParsing = true, forTimestampNTZ = true).parse(s)
+      case _: TimeType => getTimeFormatter(isParsing = true).parse(s)
       case ByteType => s.toByte
       case ShortType => s.toShort
       case IntegerType => s.toInt
@@ -1073,6 +1078,7 @@ object CatalogColumnStat extends Logging {
       case TimestampNTZType =>
         getTimestampFormatter(isParsing = false, forTimestampNTZ = true)
           .format(v.asInstanceOf[Long])
+      case _: TimeType => getTimeFormatter(isParsing = false).format(v.asInstanceOf[Long])
       case BooleanType | _: IntegralType | FloatType | DoubleType => v
       case _: DecimalType => v.asInstanceOf[Decimal].toJavaBigDecimal
       // This version of Spark does not use min/max for binary/string types so we ignore it.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -1034,7 +1034,7 @@ object CatalogColumnStat extends Logging {
       forTimestampNTZ = forTimestampNTZ)
   }
 
-  def getTimeFormatter(isParsing: Boolean): TimeFormatter = {
+  def getTimeFormatter(): TimeFormatter = {
     TimeFormatter.getFractionFormatter()
   }
 
@@ -1051,7 +1051,7 @@ object CatalogColumnStat extends Logging {
       case TimestampType => getTimestampFormatter(isParsing = true).parse(s)
       case TimestampNTZType =>
         getTimestampFormatter(isParsing = true, forTimestampNTZ = true).parse(s)
-      case _: TimeType => getTimeFormatter(isParsing = true).parse(s)
+      case _: TimeType => getTimeFormatter().parse(s)
       case ByteType => s.toByte
       case ShortType => s.toShort
       case IntegerType => s.toInt
@@ -1078,7 +1078,7 @@ object CatalogColumnStat extends Logging {
       case TimestampNTZType =>
         getTimestampFormatter(isParsing = false, forTimestampNTZ = true)
           .format(v.asInstanceOf[Long])
-      case _: TimeType => getTimeFormatter(isParsing = false).format(v.asInstanceOf[Long])
+      case _: TimeType => getTimeFormatter().format(v.asInstanceOf[Long])
       case BooleanType | _: IntegralType | FloatType | DoubleType => v
       case _: DecimalType => v.asInstanceOf[Decimal].toJavaBigDecimal
       // This version of Spark does not use min/max for binary/string types so we ignore it.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/UnionEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/UnionEstimation.scala
@@ -38,7 +38,7 @@ object UnionEstimation {
   private def isTypeSupported(dt: DataType): Boolean = dt match {
     case ByteType | IntegerType | ShortType | FloatType | LongType |
          DoubleType | DateType | _: DecimalType | TimestampType | TimestampNTZType |
-         _: AnsiIntervalType => true
+         _: AnsiIntervalType | _: TimeType => true
     case _ => false
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/UnionEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/UnionEstimationSuite.scala
@@ -339,6 +339,27 @@ class UnionEstimationSuite extends StatsEstimationTestBase {
       "distinctCount should be capped at rowCount=6, not max(500,300)=500")
   }
 
+  test("SPARK-54582: propagate min/max stats for TimeType columns") {
+    val sz = Some(BigInt(1024))
+    val attrTime = AttributeReference("ctime", TimeType())()
+    val columnInfo = AttributeMap(Seq(
+      attrTime -> ColumnStat(min = Some(1L), max = Some(4L))))
+    val columnInfo1 = AttributeMap(Seq(
+      AttributeReference("ctime1", TimeType())() -> ColumnStat(min = Some(2L), max = Some(6L))))
+
+    val child1 = StatsTestPlan(
+      outputList = columnInfo.keys.toSeq, rowCount = 2,
+      attributeStats = columnInfo, size = sz)
+    val child2 = StatsTestPlan(
+      outputList = columnInfo1.keys.toSeq, rowCount = 2,
+      attributeStats = columnInfo1, size = sz)
+
+    val union = Union(Seq(child1, child2))
+    val keyStat = union.stats.attributeStats(union.output.head)
+    assert(keyStat.min === Some(1L))
+    assert(keyStat.max === Some(6L))
+  }
+
   test("SPARK-56047: hasCountStats is true when both distinctCount and nullCount propagated") {
     val sz = Some(BigInt(1024))
     val attrInt = AttributeReference("cint", IntegerType)()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
@@ -371,7 +371,6 @@ object CommandUtils extends Logging {
     case _: IntegralType => true
     case _: DecimalType => true
     case DoubleType | FloatType => true
-    case _: TimeType => false  // TimeType doesn't support histogram
     case _: DatetimeType => true
     case _ => false
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
@@ -371,6 +371,7 @@ object CommandUtils extends Logging {
     case _: IntegralType => true
     case _: DecimalType => true
     case DoubleType | FloatType => true
+    case _: TimeType => false  // TimeType doesn't support histogram
     case _: DatetimeType => true
     case _ => false
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
@@ -601,7 +601,7 @@ class StatisticsCollectionSuite extends StatisticsCollectionTestBase with Shared
   test("TimeType column statistics collection and precisions") {
     val table = "time_stats_table"
     withTable(table) {
-      // Test all precisions (0-6) with NULL handling
+      // Test all precisions (0-9) with NULL handling
       sql(s"""
         CREATE TABLE $table (
           id INT,
@@ -611,30 +611,83 @@ class StatisticsCollectionSuite extends StatisticsCollectionTestBase with Shared
           time_p3 TIME(3),
           time_p4 TIME(4),
           time_p5 TIME(5),
-          time_p6 TIME(6)
+          time_p6 TIME(6),
+          time_p7 TIME(7),
+          time_p8 TIME(8),
+          time_p9 TIME(9)
         ) USING parquet
       """)
 
       sql(s"""
         INSERT INTO $table VALUES
-          (1, TIME '08:30:00', TIME '08:30:00.1', TIME '08:30:00.12',
-              TIME '08:30:00.123', TIME '08:30:00.1234', TIME '08:30:00.12345',
-              TIME '08:30:00.123456'),
-          (2, TIME '17:45:30', TIME '17:45:30.9', TIME '17:45:30.98',
-              TIME '17:45:30.987', TIME '17:45:30.9876', TIME '17:45:30.98765',
-              TIME '17:45:30.987654'),
-          (3, TIME '12:00:00', TIME '12:00:00.5', TIME '12:00:00.5',
-              TIME '12:00:00.5', TIME '12:00:00.5', TIME '12:00:00.5',
-              TIME '12:00:00.5'),
-          (4, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+          (1,
+           CAST(TIME '08:30:00' AS TIME(0)),
+           CAST(TIME '08:30:00.1' AS TIME(1)),
+           CAST(TIME '08:30:00.12' AS TIME(2)),
+           CAST(TIME '08:30:00.123' AS TIME(3)),
+           CAST(TIME '08:30:00.1234' AS TIME(4)),
+           CAST(TIME '08:30:00.12345' AS TIME(5)),
+           CAST(TIME '08:30:00.123456' AS TIME(6)),
+           CAST(TIME '08:30:00.1234567' AS TIME(7)),
+           CAST(TIME '08:30:00.12345678' AS TIME(8)),
+           CAST(TIME '08:30:00.123456789' AS TIME(9))),
+          (2,
+           CAST(TIME '17:45:30' AS TIME(0)),
+           CAST(TIME '17:45:30.9' AS TIME(1)),
+           CAST(TIME '17:45:30.98' AS TIME(2)),
+           CAST(TIME '17:45:30.987' AS TIME(3)),
+           CAST(TIME '17:45:30.9876' AS TIME(4)),
+           CAST(TIME '17:45:30.98765' AS TIME(5)),
+           CAST(TIME '17:45:30.987654' AS TIME(6)),
+           CAST(TIME '17:45:30.9876543' AS TIME(7)),
+           CAST(TIME '17:45:30.98765432' AS TIME(8)),
+           CAST(TIME '17:45:30.987654321' AS TIME(9))),
+          (3,
+           CAST(TIME '12:00:00' AS TIME(0)),
+           CAST(TIME '12:00:00.5' AS TIME(1)),
+           CAST(TIME '12:00:00.5' AS TIME(2)),
+           CAST(TIME '12:00:00.5' AS TIME(3)),
+           CAST(TIME '12:00:00.5' AS TIME(4)),
+           CAST(TIME '12:00:00.5' AS TIME(5)),
+           CAST(TIME '12:00:00.5' AS TIME(6)),
+           CAST(TIME '12:00:00.5' AS TIME(7)),
+           CAST(TIME '12:00:00.5' AS TIME(8)),
+           CAST(TIME '12:00:00.5' AS TIME(9))),
+          (4, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
       """)
 
       sql(s"""ANALYZE TABLE $table COMPUTE STATISTICS FOR COLUMNS
-        time_p0, time_p1, time_p2, time_p3, time_p4, time_p5, time_p6""")
+        time_p0, time_p1, time_p2, time_p3, time_p4, time_p5, time_p6,
+        time_p7, time_p8, time_p9""")
 
       val catalogTable = getCatalogTable(table)
 
-      for (precision <- 0 to 6) {
+      val expectedMins = Map(
+        0 -> "08:30:00",
+        1 -> "08:30:00.1",
+        2 -> "08:30:00.12",
+        3 -> "08:30:00.123",
+        4 -> "08:30:00.1234",
+        5 -> "08:30:00.12345",
+        6 -> "08:30:00.123456",
+        7 -> "08:30:00.1234567",
+        8 -> "08:30:00.12345678",
+        9 -> "08:30:00.123456789"
+      )
+      val expectedMaxs = Map(
+        0 -> "17:45:30",
+        1 -> "17:45:30.9",
+        2 -> "17:45:30.98",
+        3 -> "17:45:30.987",
+        4 -> "17:45:30.9876",
+        5 -> "17:45:30.98765",
+        6 -> "17:45:30.987654",
+        7 -> "17:45:30.9876543",
+        8 -> "17:45:30.98765432",
+        9 -> "17:45:30.987654321"
+      )
+
+      for (precision <- 0 to 9) {
         val col = s"time_p$precision"
         val stats = catalogTable.stats.get.colStats(col)
 
@@ -646,13 +699,11 @@ class StatisticsCollectionSuite extends StatisticsCollectionTestBase with Shared
         assert(stats.avgLen == Some(8), s"Avg length should be 8 bytes for $col")
         assert(stats.maxLen == Some(8), s"Max length should be 8 bytes for $col")
 
-        // Verify format for each precision
+        // Verify exact min/max values for each precision
         val minStr = stats.min.get.asInstanceOf[String]
         val maxStr = stats.max.get.asInstanceOf[String]
-        assert(minStr.matches("\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?"),
-          s"Min should be time format for $col, got: $minStr")
-        assert(maxStr.matches("\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?"),
-          s"Max should be time format for $col, got: $maxStr")
+        assert(minStr == expectedMins(precision), s"Wrong min for $col: $minStr")
+        assert(maxStr == expectedMaxs(precision), s"Wrong max for $col: $maxStr")
 
         // Test plan stats conversion for ALL precisions
         val planStat = stats.toPlanStat(col, TimeType(precision))
@@ -716,6 +767,34 @@ class StatisticsCollectionSuite extends StatisticsCollectionTestBase with Shared
       // For all-null columns, min and max are not computed (None)
       assert(stats.min.isEmpty, "Min should be None for all-null column")
       assert(stats.max.isEmpty, "Max should be None for all-null column")
+    }
+  }
+
+  test("TimeType column statistics histogram") {
+    val table = "time_histogram_test"
+    withTable(table) {
+      sql(s"CREATE TABLE $table (time_col TIME(6)) USING parquet")
+      sql(s"""INSERT INTO $table VALUES
+        (TIME '08:00:00.000001'),
+        (TIME '12:00:00.000000'),
+        (TIME '18:00:00.000001'),
+        (TIME '20:00:00.000000'),
+        (NULL)""")
+      withSQLConf(
+        SQLConf.HISTOGRAM_ENABLED.key -> "true",
+        SQLConf.HISTOGRAM_NUM_BINS.key -> "2") {
+        sql(s"ANALYZE TABLE $table COMPUTE STATISTICS FOR COLUMNS time_col")
+        val stats = getCatalogTable(table).stats.get.colStats("time_col")
+        assert(stats.histogram.isDefined, "Histogram should be generated for TIME column")
+        val hgm = stats.histogram.get
+        assert(hgm.bins.length == 2, "Should have 2 bins")
+      }
+      // Histogram disabled: should produce None
+      withSQLConf(SQLConf.HISTOGRAM_ENABLED.key -> "false") {
+        sql(s"ANALYZE TABLE $table COMPUTE STATISTICS FOR COLUMNS time_col")
+        val stats = getCatalogTable(table).stats.get.colStats("time_col")
+        assert(stats.histogram.isEmpty, "Histogram should be None when disabled")
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionTestBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionTestBase.scala
@@ -32,7 +32,6 @@ import org.apache.spark.sql.catalyst.expressions.AttributeMap
 import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, Histogram, HistogramBin, HistogramSerializer, LogicalPlan, Statistics}
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
-import org.apache.spark.sql.catalyst.util.SparkDateTimeUtils.localTimeToNanos
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
@@ -71,10 +70,10 @@ abstract class StatisticsCollectionTestBase extends QueryTest {
   // Time test values
   private val time1Str = "10:30:45.123456"
   private val time1 = LocalTime.parse(time1Str)
-  private val time1Internal = localTimeToNanos(time1)
+  private val time1Internal = DateTimeUtils.localTimeToNanos(time1)
   private val time2Str = "14:45:30.987654"
   private val time2 = LocalTime.parse(time2Str)
-  private val time2Internal = localTimeToNanos(time2)
+  private val time2Internal = DateTimeUtils.localTimeToNanos(time2)
 
   private val double1 = 1.123456789
   private val double2 = 6.987654321
@@ -155,6 +154,9 @@ abstract class StatisticsCollectionTestBase extends QueryTest {
     colStats.update("ctimestamp_ntz", stats("ctimestamp_ntz").copy(histogram =
       Some(Histogram(1, Array(HistogramBin(t1Internal.toDouble, t1Internal.toDouble, 1),
         HistogramBin(t1Internal.toDouble, t2Internal.toDouble, 1))))))
+    colStats.update("ctime", stats("ctime").copy(histogram =
+      Some(Histogram(1, Array(HistogramBin(time1Internal.toDouble, time1Internal.toDouble, 1),
+        HistogramBin(time1Internal.toDouble, time2Internal.toDouble, 1))))))
     colStats
   }
 
@@ -276,7 +278,9 @@ abstract class StatisticsCollectionTestBase extends QueryTest {
     "spark.sql.statistics.colStats.ctimestamp.histogram" ->
       HistogramSerializer.serialize(statsWithHgms("ctimestamp").histogram.get),
     "spark.sql.statistics.colStats.ctimestamp_ntz.histogram" ->
-      HistogramSerializer.serialize(statsWithHgms("ctimestamp_ntz").histogram.get)
+      HistogramSerializer.serialize(statsWithHgms("ctimestamp_ntz").histogram.get),
+    "spark.sql.statistics.colStats.ctime.histogram" ->
+      HistogramSerializer.serialize(statsWithHgms("ctime").histogram.get)
   )
 
   private val randomName = new Random(31)

--- a/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionTestBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionTestBase.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql
 import java.{lang => jl}
 import java.io.File
 import java.sql.{Date, Timestamp}
-import java.time.LocalDateTime
+import java.time.{LocalDateTime, LocalTime}
 
 import scala.collection.mutable
 import scala.util.Random
@@ -32,6 +32,7 @@ import org.apache.spark.sql.catalyst.expressions.AttributeMap
 import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, Histogram, HistogramBin, HistogramSerializer, LogicalPlan, Statistics}
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.catalyst.util.SparkDateTimeUtils.localTimeToNanos
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
@@ -67,6 +68,14 @@ abstract class StatisticsCollectionTestBase extends QueryTest {
   t2.setNanos(987654000)
   private val tsNTZ2 = LocalDateTime.parse(t2Str.replace(" ", "T"))
 
+  // Time test values
+  private val time1Str = "10:30:45.123456"
+  private val time1 = LocalTime.parse(time1Str)
+  private val time1Internal = localTimeToNanos(time1)
+  private val time2Str = "14:45:30.987654"
+  private val time2 = LocalTime.parse(time2Str)
+  private val time2Internal = localTimeToNanos(time2)
+
   private val double1 = 1.123456789
   private val double2 = 6.987654321
 
@@ -77,14 +86,14 @@ abstract class StatisticsCollectionTestBase extends QueryTest {
   protected val data = Seq[
     (jl.Boolean, jl.Byte, jl.Short, jl.Integer, jl.Long,
       jl.Double, jl.Float, java.math.BigDecimal,
-      String, Array[Byte], Date, Timestamp, LocalDateTime,
+      String, Array[Byte], Date, Timestamp, LocalDateTime, LocalTime,
       Seq[Int])](
     // scalastyle:off nonascii
     (false, 1.toByte, 1.toShort, 1, 1L, double1, 1.12345f,
-      dec1, "string escrito en español", "b1".getBytes, d1, t1, tsNTZ1, null),
+      dec1, "string escrito en español", "b1".getBytes, d1, t1, tsNTZ1, time1, null),
     (true, 2.toByte, 30000.toShort, 40000000, 5536453629L, double2, 7.54321f,
-      dec2, "日本語で書かれたstring", "a string full of bytes".getBytes, d2, t2, tsNTZ2, null),
-    (null, null, null, null, null, null, null, null, null, null, null, null, null, null)
+      dec2, "日本語で書かれたstring", "a string full of bytes".getBytes, d2, t2, tsNTZ2, time2, null),
+    (null, null, null, null, null, null, null, null, null, null, null, null, null, null, null)
     // scalastyle:on nonascii
   )
 
@@ -108,7 +117,9 @@ abstract class StatisticsCollectionTestBase extends QueryTest {
     "ctimestamp" -> CatalogColumnStat(Some(2), Some(t1Str),
       Some(t2Str), Some(1), Some(8), Some(8)),
     "ctimestamp_ntz" -> CatalogColumnStat(Some(2), Some(t1Str),
-      Some(t2Str), Some(1), Some(8), Some(8))
+      Some(t2Str), Some(1), Some(8), Some(8)),
+    "ctime" -> CatalogColumnStat(Some(2), Some(time1Str),
+      Some(time2Str), Some(1), Some(8), Some(8))
   )
 
   /**
@@ -235,7 +246,14 @@ abstract class StatisticsCollectionTestBase extends QueryTest {
     "spark.sql.statistics.colStats.ctimestamp_ntz.maxLen" -> "8",
     "spark.sql.statistics.colStats.ctimestamp_ntz.min" -> "2016-05-08 00:00:01.123456",
     "spark.sql.statistics.colStats.ctimestamp_ntz.nullCount" -> "1",
-    "spark.sql.statistics.colStats.ctimestamp_ntz.version" -> strVersion
+    "spark.sql.statistics.colStats.ctimestamp_ntz.version" -> strVersion,
+    "spark.sql.statistics.colStats.ctime.avgLen" -> "8",
+    "spark.sql.statistics.colStats.ctime.distinctCount" -> "2",
+    "spark.sql.statistics.colStats.ctime.max" -> "14:45:30.987654",
+    "spark.sql.statistics.colStats.ctime.maxLen" -> "8",
+    "spark.sql.statistics.colStats.ctime.min" -> "10:30:45.123456",
+    "spark.sql.statistics.colStats.ctime.nullCount" -> "1",
+    "spark.sql.statistics.colStats.ctime.version" -> strVersion
   )
 
   val expectedSerializedHistograms = Map(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds column statistics collection support for the TIME data type, enabling the Spark optimizer to use TIME column statistics for query planning.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Without statistics support for TIME columns, the Spark optimizer cannot make informed decisions for queries involving TIME predicates or joins, leading to sub-optimal query plans. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Users can now collect and use statistics for TIME columns via `ANALYZE TABLE ... COMPUTE STATISTICS FOR COLUMNS`.
Before this PR:
```
CREATE TABLE events (id INT, event_time TIME(6)) USING parquet;
ANALYZE TABLE events COMPUTE STATISTICS FOR COLUMNS event_time;
-- No statistics collected for TIME columns
```
After this PR:
```
CREATE TABLE events (id INT, event_time TIME(6)) USING parquet;
ANALYZE TABLE events COMPUTE STATISTICS FOR COLUMNS event_time;

DESCRIBE EXTENDED events event_time;
-- col_name:          event_time
-- min:               08:00:00.000000
-- max:               18:00:00.000000
-- num_nulls:         5
-- distinct_count:    1000
-- avg_col_len:       8
-- max_col_len:       8
-- histogram:         height: 0.5, num_of_bins: 2, ...
```

Statistics are supported for all precisions TIME(0)–TIME(9). TIME columns are excluded from Hive metastore statistics (same as TimestampNTZ) since Hive does not support the TIME type.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added tests in `StatisticsCollectionSuite, StatisticsCollectionTestBase, StatisticsSuite `

Manual Testing:
```
spark-sql --conf spark.sql.catalogImplementation=in-memory --conf spark.sql.timeType.enabled=true
                
    -- Test all precisions TIME(0)–TIME(9)
    CREATE TABLE time_test (
      t0 TIME(0), t1 TIME(1), t2 TIME(2),
      t3 TIME(3), t4 TIME(4), t5 TIME(5),
      t6 TIME(6), t7 TIME(7), t8 TIME(8), t9 TIME(9)
    ) USING parquet;

     INSERT INTO time_test VALUES
      (CAST(TIME '08:30:00' AS TIME(0)),
       CAST(TIME '08:30:00.1' AS TIME(1)),
       CAST(TIME '08:30:00.12' AS TIME(2)),
       CAST(TIME '08:30:00.123' AS TIME(3)),
       CAST(TIME '08:30:00.1234' AS TIME(4)),                                                                                                 CAST(TIME '08:30:00.12345' AS TIME(5)),
       CAST(TIME '08:30:00.123456' AS TIME(6)),
       CAST(TIME '08:30:00.1234567' AS TIME(7)),                                                                                               CAST(TIME '08:30:00.12345678' AS TIME(8)),
       CAST(TIME '08:30:00.123456789' AS TIME(9))),
      (CAST(TIME '17:45:30' AS TIME(0)),
       CAST(TIME '17:45:30.9' AS TIME(1)),
       CAST(TIME '17:45:30.98' AS TIME(2)),
       CAST(TIME '17:45:30.987' AS TIME(3)),
       CAST(TIME '17:45:30.9876' AS TIME(4)),
       CAST(TIME '17:45:30.98765' AS TIME(5)),
       CAST(TIME '17:45:30.987654' AS TIME(6)),
       CAST(TIME '17:45:30.9876543' AS TIME(7)),
       CAST(TIME '17:45:30.98765432' AS TIME(8)),
       CAST(TIME '17:45:30.987654321' AS TIME(9))),
       (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

    -- Enable histogram collection
    SET spark.sql.statistics.histogram.enabled=true;
    SET spark.sql.statistics.histogram.numBins=5;
    ANALYZE TABLE time_test COMPUTE STATISTICS FOR COLUMNS t0, t1, t2, t3, t4, t5, t6, t7, t8, t9;                                                                                                                   

    -- Verify statistics for each precision 
    DESCRIBE EXTENDED time_test t0;
    DESCRIBE EXTENDED time_test t6;
    DESCRIBE EXTENDED time_test t9;
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes.   Generated-by:  Claude code (Sonnet 4.6)