### PR TITLE
[SPARK-51920][SS][PYTHON] Fix type handling of namedTuple for transfromWithState

### DIFF
--- a/python/pyspark/sql/streaming/stateful_processor_api_client.py
+++ b/python/pyspark/sql/streaming/stateful_processor_api_client.py
@@ -496,6 +496,7 @@ class StatefulProcessorApiClient:
 
         if have_numpy:
             import numpy as np
+            from pyspark.sql import Row
 
             def normalize_value(v: Any) -> Any:
                 # Convert NumPy types to Python primitive types.
@@ -504,7 +505,10 @@ class StatefulProcessorApiClient:
                 # Named tuples (collections.namedtuple or typing.NamedTuple) have a
                 # _fields attribute. Spark Row has __fields__. Both require positional
                 # arguments and cannot be instantiated with a generator expression.
-                if hasattr(v, '_fields') or hasattr(v, '__fields__'):
+                if (
+                    isinstance(v, Row) or
+                    (isinstance(v, tuple) and hasattr(v, "_fields"))
+                ):
                     return type(v)(*[normalize_value(e) for e in v])
                 # List / tuple: recursively normalize each element
                 if isinstance(v, (list, tuple)):

--- a/python/pyspark/sql/streaming/stateful_processor_api_client.py
+++ b/python/pyspark/sql/streaming/stateful_processor_api_client.py
@@ -496,7 +496,6 @@ class StatefulProcessorApiClient:
 
         if have_numpy:
             import numpy as np
-            from pyspark.sql import Row
 
             def normalize_value(v: Any) -> Any:
                 # Convert NumPy types to Python primitive types.

--- a/python/pyspark/sql/streaming/stateful_processor_api_client.py
+++ b/python/pyspark/sql/streaming/stateful_processor_api_client.py
@@ -502,9 +502,9 @@ class StatefulProcessorApiClient:
                 # Convert NumPy types to Python primitive types.
                 if isinstance(v, np.generic):
                     return v.tolist()
-                # Named tuples (collections.namedtuple or typing.NamedTuple) have a
-                # _fields attribute. Spark Row has __fields__. Both require positional
-                # arguments and cannot be instantiated with a generator expression.
+                # Named tuples (collections.namedtuple or typing.NamedTuple) and Row both
+                # require positional arguments and cannot be instantiated
+                # with a generator expression.
                 if (
                     isinstance(v, Row) or
                     (isinstance(v, tuple) and hasattr(v, "_fields"))

--- a/python/pyspark/sql/streaming/stateful_processor_api_client.py
+++ b/python/pyspark/sql/streaming/stateful_processor_api_client.py
@@ -505,10 +505,7 @@ class StatefulProcessorApiClient:
                 # Named tuples (collections.namedtuple or typing.NamedTuple) and Row both
                 # require positional arguments and cannot be instantiated
                 # with a generator expression.
-                if (
-                    isinstance(v, Row) or
-                    (isinstance(v, tuple) and hasattr(v, "_fields"))
-                ):
+                if isinstance(v, Row) or (isinstance(v, tuple) and hasattr(v, "_fields")):
                     return type(v)(*[normalize_value(e) for e in v])
                 # List / tuple: recursively normalize each element
                 if isinstance(v, (list, tuple)):

--- a/python/pyspark/sql/streaming/stateful_processor_api_client.py
+++ b/python/pyspark/sql/streaming/stateful_processor_api_client.py
@@ -501,6 +501,11 @@ class StatefulProcessorApiClient:
                 # Convert NumPy types to Python primitive types.
                 if isinstance(v, np.generic):
                     return v.tolist()
+                # Named tuples (collections.namedtuple or typing.NamedTuple) have a
+                # _fields attribute. Spark Row has __fields__. Both require positional
+                # arguments and cannot be instantiated with a generator expression.
+                if hasattr(v, '_fields') or hasattr(v, '__fields__'):
+                    return type(v)(*[normalize_value(e) for e in v])
                 # List / tuple: recursively normalize each element
                 if isinstance(v, (list, tuple)):
                     return type(v)(normalize_value(e) for e in v)

--- a/python/pyspark/sql/tests/pandas/helper/helper_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/helper/helper_pandas_transform_with_state.py
@@ -1718,7 +1718,7 @@ class PandasStatefulProcessorCompositeType(StatefulProcessor):
             ids, tags, metadata, address = self.obj_state.get()
             assert tags == self.TAGS, f"Tag mismatch: {tags}"
             assert metadata == [Row(**m) for m in self.METADATA], f"Metadata mismatch: {metadata}"
-            assert address == [Row(**e) for e in self.ADDRESS], f"Address mismatch: {address}"
+            assert address == [Row(**e._asdict()) for e in self.ADDRESS], f"Address mismatch: {address}"
             ids = [int(x + total_temperature) for x in ids]
         else:
             ids = [0]
@@ -1728,13 +1728,13 @@ class PandasStatefulProcessorCompositeType(StatefulProcessor):
     def _update_list_state(self, total_temperature, initial_obj):
         existing_list = self.list_state.get()
         updated_list = []
-        for ids, tags, metadata in existing_list:
+        for ids, tags, metadata, address in existing_list:
             ids.append(total_temperature)
-            updated_list.append((ids, tags, [row.asDict() for row in metadata]))
+            updated_list.append((ids, tags, [row.asDict() for row in metadata], address))
         if not updated_list:
             updated_list.append(initial_obj)
         self.list_state.put(updated_list)
-        return [id_val for ids, _, _ in updated_list for id_val in ids]
+        return [id_val for ids, _, _, _ in updated_list for id_val in ids]
 
     def _update_map_state(self, key, total_temperature):
         if not self.map_state.containsKey(key):
@@ -1752,7 +1752,7 @@ class PandasStatefulProcessorCompositeType(StatefulProcessor):
 
         updated_ids = self._update_obj_state(total_temperature)
         flattened_ids = self._update_list_state(
-            total_temperature, (updated_ids, self.TAGS, self.METADATA)
+            total_temperature, (updated_ids, self.TAGS, self.METADATA, self.ADDRESS)
         )
         attributes_map, confs_map = self._update_map_state(key, total_temperature)
 
@@ -1838,7 +1838,7 @@ class RowStatefulProcessorCompositeType(StatefulProcessor):
             ids, tags, metadata, address = self.obj_state.get()
             assert tags == self.TAGS, f"Tag mismatch: {tags}"
             assert metadata == [Row(**m) for m in self.METADATA], f"Metadata mismatch: {metadata}"
-            assert address == [Row(**e) for e in self.ADDRESS], f"Metadata mismatch: {address}"
+            assert address == [Row(**e._asdict()) for e in self.ADDRESS], f"Address mismatch: {address}"
             ids = [int(x + total_temperature) for x in ids]
         else:
             ids = [0]
@@ -1848,13 +1848,13 @@ class RowStatefulProcessorCompositeType(StatefulProcessor):
     def _update_list_state(self, total_temperature, initial_obj):
         existing_list = self.list_state.get()
         updated_list = []
-        for ids, tags, metadata in existing_list:
+        for ids, tags, metadata, address in existing_list:
             ids.append(total_temperature)
-            updated_list.append((ids, tags, [row.asDict() for row in metadata]))
+            updated_list.append((ids, tags, [row.asDict() for row in metadata], address))
         if not updated_list:
             updated_list.append(initial_obj)
         self.list_state.put(updated_list)
-        return [id_val for ids, _, _ in updated_list for id_val in ids]
+        return [id_val for ids, _, _, _ in updated_list for id_val in ids]
 
     def _update_map_state(self, key, total_temperature):
         if not self.map_state.containsKey(key):
@@ -1872,7 +1872,7 @@ class RowStatefulProcessorCompositeType(StatefulProcessor):
 
         updated_ids = self._update_obj_state(total_temperature)
         flattened_ids = self._update_list_state(
-            total_temperature, (updated_ids, self.TAGS, self.METADATA)
+            total_temperature, (updated_ids, self.TAGS, self.METADATA, self.ADDRESS)
         )
         attributes_map, confs_map = self._update_map_state(key, total_temperature)
 

--- a/python/pyspark/sql/tests/pandas/helper/helper_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/helper/helper_pandas_transform_with_state.py
@@ -17,7 +17,10 @@
 
 from abc import abstractmethod
 import sys
-from typing import Iterator
+from typing import (
+    Iterator,
+    NamedTuple,
+)
 import unittest
 from pyspark.errors import PySparkRuntimeError
 from pyspark.sql.streaming import StatefulProcessor, StatefulProcessorHandle
@@ -1663,7 +1666,6 @@ class RowMinEventTimeStatefulProcessor(StatefulProcessor):
 
 # A stateful processor that contains composite python type inside Value, List and Map state variable
 class PandasStatefulProcessorCompositeType(StatefulProcessor):
-    from typing import NamedTuple
 
     class Address(NamedTuple):
         road_id: int
@@ -1788,7 +1790,6 @@ class PandasStatefulProcessorCompositeType(StatefulProcessor):
 
 
 class RowStatefulProcessorCompositeType(StatefulProcessor):
-    from typing import NamedTuple
 
     class Address(NamedTuple):
         road_id: int

--- a/python/pyspark/sql/tests/pandas/helper/helper_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/helper/helper_pandas_transform_with_state.py
@@ -1663,10 +1663,17 @@ class RowMinEventTimeStatefulProcessor(StatefulProcessor):
 
 # A stateful processor that contains composite python type inside Value, List and Map state variable
 class PandasStatefulProcessorCompositeType(StatefulProcessor):
+
+    from typing import NamedTuple
+    class Address(NamedTuple):
+        road_id: int
+        block_id: int
+
     TAGS = [["dummy1", "dummy2"], ["dummy3"]]
     METADATA = [{"key": "env", "value": "prod"}, {"key": "region", "value": "us-west"}]
     ATTRIBUTES_MAP = {"key1": [1], "key2": [10]}
     CONFS_MAP = {"e1": {"e2": 5, "e3": 10}}
+    ADDRESS = [Address(1, 2), Address(3, 4)]
 
     def init(self, handle: StatefulProcessorHandle) -> None:
         obj_schema = StructType(
@@ -1678,6 +1685,14 @@ class PandasStatefulProcessorCompositeType(StatefulProcessor):
                     ArrayType(
                         StructType(
                             [StructField("key", StringType()), StructField("value", StringType())]
+                        )
+                    ),
+                ),
+                StructField(
+                    "address",
+                    ArrayType(
+                        StructType(
+                            [StructField("road_id", IntegerType()), StructField("block_id", IntegerType())]
                         )
                     ),
                 ),
@@ -1700,13 +1715,14 @@ class PandasStatefulProcessorCompositeType(StatefulProcessor):
 
     def _update_obj_state(self, total_temperature):
         if self.obj_state.exists():
-            ids, tags, metadata = self.obj_state.get()
+            ids, tags, metadata, address = self.obj_state.get()
             assert tags == self.TAGS, f"Tag mismatch: {tags}"
             assert metadata == [Row(**m) for m in self.METADATA], f"Metadata mismatch: {metadata}"
+            assert address == [Row(**e) for e in self.ADDRESS], f"Address mismatch: {address}"
             ids = [int(x + total_temperature) for x in ids]
         else:
             ids = [0]
-        self.obj_state.update((ids, self.TAGS, self.METADATA))
+        self.obj_state.update((ids, self.TAGS, self.METADATA, self.ADDRESS))
         return ids
 
     def _update_list_state(self, total_temperature, initial_obj):
@@ -1767,10 +1783,17 @@ class PandasStatefulProcessorCompositeType(StatefulProcessor):
 
 
 class RowStatefulProcessorCompositeType(StatefulProcessor):
+
+    from typing import NamedTuple
+    class Address(NamedTuple):
+        road_id: int
+        block_id: int
+
     TAGS = [["dummy1", "dummy2"], ["dummy3"]]
     METADATA = [{"key": "env", "value": "prod"}, {"key": "region", "value": "us-west"}]
     ATTRIBUTES_MAP = {"key1": [1], "key2": [10]}
     CONFS_MAP = {"e1": {"e2": 5, "e3": 10}}
+    ADDRESS = [Address(1, 2), Address(3, 4)]
 
     def init(self, handle: StatefulProcessorHandle) -> None:
         obj_schema = StructType(
@@ -1782,6 +1805,14 @@ class RowStatefulProcessorCompositeType(StatefulProcessor):
                     ArrayType(
                         StructType(
                             [StructField("key", StringType()), StructField("value", StringType())]
+                        )
+                    ),
+                ),
+                StructField(
+                    "address",
+                    ArrayType(
+                        StructType(
+                            [StructField("road_id", IntegerType()), StructField("block_id", IntegerType())]
                         )
                     ),
                 ),
@@ -1804,13 +1835,14 @@ class RowStatefulProcessorCompositeType(StatefulProcessor):
 
     def _update_obj_state(self, total_temperature):
         if self.obj_state.exists():
-            ids, tags, metadata = self.obj_state.get()
+            ids, tags, metadata, address = self.obj_state.get()
             assert tags == self.TAGS, f"Tag mismatch: {tags}"
             assert metadata == [Row(**m) for m in self.METADATA], f"Metadata mismatch: {metadata}"
+            assert address == [Row(**e) for e in self.ADDRESS], f"Metadata mismatch: {address}"
             ids = [int(x + total_temperature) for x in ids]
         else:
             ids = [0]
-        self.obj_state.update((ids, self.TAGS, self.METADATA))
+        self.obj_state.update((ids, self.TAGS, self.METADATA, self.ADDRESS))
         return ids
 
     def _update_list_state(self, total_temperature, initial_obj):

--- a/python/pyspark/sql/tests/pandas/helper/helper_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/helper/helper_pandas_transform_with_state.py
@@ -1666,7 +1666,6 @@ class RowMinEventTimeStatefulProcessor(StatefulProcessor):
 
 # A stateful processor that contains composite python type inside Value, List and Map state variable
 class PandasStatefulProcessorCompositeType(StatefulProcessor):
-
     class Address(NamedTuple):
         road_id: int
         city: str
@@ -1790,7 +1789,6 @@ class PandasStatefulProcessorCompositeType(StatefulProcessor):
 
 
 class RowStatefulProcessorCompositeType(StatefulProcessor):
-
     class Address(NamedTuple):
         road_id: int
         city: str

--- a/python/pyspark/sql/tests/pandas/helper/helper_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/helper/helper_pandas_transform_with_state.py
@@ -1663,8 +1663,8 @@ class RowMinEventTimeStatefulProcessor(StatefulProcessor):
 
 # A stateful processor that contains composite python type inside Value, List and Map state variable
 class PandasStatefulProcessorCompositeType(StatefulProcessor):
-
     from typing import NamedTuple
+
     class Address(NamedTuple):
         road_id: int
         city: str
@@ -1692,7 +1692,10 @@ class PandasStatefulProcessorCompositeType(StatefulProcessor):
                     "address",
                     ArrayType(
                         StructType(
-                            [StructField("road_id", IntegerType()), StructField("city", StringType())]
+                            [
+                                StructField("road_id", IntegerType()),
+                                StructField("city", StringType()),
+                            ]
                         )
                     ),
                 ),
@@ -1718,7 +1721,9 @@ class PandasStatefulProcessorCompositeType(StatefulProcessor):
             ids, tags, metadata, address = self.obj_state.get()
             assert tags == self.TAGS, f"Tag mismatch: {tags}"
             assert metadata == [Row(**m) for m in self.METADATA], f"Metadata mismatch: {metadata}"
-            assert address == [Row(**e._asdict()) for e in self.ADDRESS], f"Address mismatch: {address}"
+            assert address == [
+                Row(**e._asdict()) for e in self.ADDRESS
+            ], f"Address mismatch: {address}"
             ids = [int(x + total_temperature) for x in ids]
         else:
             ids = [0]
@@ -1783,8 +1788,8 @@ class PandasStatefulProcessorCompositeType(StatefulProcessor):
 
 
 class RowStatefulProcessorCompositeType(StatefulProcessor):
-
     from typing import NamedTuple
+
     class Address(NamedTuple):
         road_id: int
         city: str
@@ -1812,7 +1817,10 @@ class RowStatefulProcessorCompositeType(StatefulProcessor):
                     "address",
                     ArrayType(
                         StructType(
-                            [StructField("road_id", IntegerType()), StructField("city", StringType())]
+                            [
+                                StructField("road_id", IntegerType()),
+                                StructField("city", StringType()),
+                            ]
                         )
                     ),
                 ),
@@ -1838,7 +1846,9 @@ class RowStatefulProcessorCompositeType(StatefulProcessor):
             ids, tags, metadata, address = self.obj_state.get()
             assert tags == self.TAGS, f"Tag mismatch: {tags}"
             assert metadata == [Row(**m) for m in self.METADATA], f"Metadata mismatch: {metadata}"
-            assert address == [Row(**e._asdict()) for e in self.ADDRESS], f"Address mismatch: {address}"
+            assert address == [
+                Row(**e._asdict()) for e in self.ADDRESS
+            ], f"Address mismatch: {address}"
             ids = [int(x + total_temperature) for x in ids]
         else:
             ids = [0]

--- a/python/pyspark/sql/tests/pandas/helper/helper_pandas_transform_with_state.py
+++ b/python/pyspark/sql/tests/pandas/helper/helper_pandas_transform_with_state.py
@@ -1667,13 +1667,13 @@ class PandasStatefulProcessorCompositeType(StatefulProcessor):
     from typing import NamedTuple
     class Address(NamedTuple):
         road_id: int
-        block_id: int
+        city: str
 
     TAGS = [["dummy1", "dummy2"], ["dummy3"]]
     METADATA = [{"key": "env", "value": "prod"}, {"key": "region", "value": "us-west"}]
     ATTRIBUTES_MAP = {"key1": [1], "key2": [10]}
     CONFS_MAP = {"e1": {"e2": 5, "e3": 10}}
-    ADDRESS = [Address(1, 2), Address(3, 4)]
+    ADDRESS = [Address(1, "Seattle"), Address(3, "SF")]
 
     def init(self, handle: StatefulProcessorHandle) -> None:
         obj_schema = StructType(
@@ -1692,7 +1692,7 @@ class PandasStatefulProcessorCompositeType(StatefulProcessor):
                     "address",
                     ArrayType(
                         StructType(
-                            [StructField("road_id", IntegerType()), StructField("block_id", IntegerType())]
+                            [StructField("road_id", IntegerType()), StructField("city", StringType())]
                         )
                     ),
                 ),
@@ -1787,13 +1787,13 @@ class RowStatefulProcessorCompositeType(StatefulProcessor):
     from typing import NamedTuple
     class Address(NamedTuple):
         road_id: int
-        block_id: int
+        city: str
 
     TAGS = [["dummy1", "dummy2"], ["dummy3"]]
     METADATA = [{"key": "env", "value": "prod"}, {"key": "region", "value": "us-west"}]
     ATTRIBUTES_MAP = {"key1": [1], "key2": [10]}
     CONFS_MAP = {"e1": {"e2": 5, "e3": 10}}
-    ADDRESS = [Address(1, 2), Address(3, 4)]
+    ADDRESS = [Address(1, "Seattle"), Address(3, "SF")]
 
     def init(self, handle: StatefulProcessorHandle) -> None:
         obj_schema = StructType(
@@ -1812,7 +1812,7 @@ class RowStatefulProcessorCompositeType(StatefulProcessor):
                     "address",
                     ArrayType(
                         StructType(
-                            [StructField("road_id", IntegerType()), StructField("block_id", IntegerType())]
+                            [StructField("road_id", IntegerType()), StructField("city", StringType())]
                         )
                     ),
                 ),


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix type handling of namedTuple for transfromWithState

### Why are the changes needed?
We hit the issue when using namedTuple as value of structType like

```
class Person(NamedTuple):
    age: Integer
    name: String
    
 def handleInputRows(
        self, 
        key: Any, 
        rows: Iterator[Row], 
        timerValues: TimerValues
    ) -> Iterator[Row]:             
        person: Person = Person(age = 1, name= "peter")
        person_list = []
        person_list.append(person)
        self.person_list.update((person_list,))    
```

The `_serialize_to_bytes` cannot construct the namedTuple correctly and hit
```
File "/databricks/spark/python/pyspark/sql/streaming/stateful_processor_api_client.py", line 575, in normalize_value
    return type(v)(normalize_value(e) for e in v)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Person.__new__() missing 2 required positional arguments: 'age' and 'name'
```
It's because NamedTuple cannot accept generator as parameter.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT


### Was this patch authored or co-authored using generative AI tooling?
No
