### PR TITLE
[SPARK-54572][PYTHON][FOLLOWUP] Add a file lock for the VSCode magic file

### DIFF
--- a/python/conf_vscode/README.md
+++ b/python/conf_vscode/README.md
@@ -34,3 +34,10 @@ If you want, you can set them manually.
 ```
 python/run-with-vscode-breakpoints python/run-tests --testnames="..."
 ```
+
+`daemon` is not tracked by default because of potential issues for fork. However if you need to debug `daemon`
+you can do
+
+```
+python/run-with-vscode-breakpoints --hook-daemon your_script.py
+```

--- a/python/run-with-vscode-breakpoints
+++ b/python/run-with-vscode-breakpoints
@@ -44,6 +44,22 @@ if ! python3 -c "import debugpy" 2>/dev/null; then
   exit 1
 fi
 
+# If --hook-daemon is in the arguments, set the env variable to hook the daemon process
+# Daemon is not hooked by default to avoid potential fork issues
+new_args=()
+for arg in "$@"; do
+  case "$arg" in
+    --hook-daemon)
+      export PYSPARK_DEBUGPY_HOOK_DAEMON=1
+      # skip this arg
+      ;;
+    *)
+      new_args+=("$arg")
+      ;;
+  esac
+done
+set -- "${new_args[@]}"
+
 export DEBUGPY_ADAPTER_ENDPOINTS=$VSCODE_DEBUGPY_ADAPTER_ENDPOINTS
 export PYTHONPATH="$FWDIR/conf_vscode:$PYTHONPATH"
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add a lock to access the VSCode magic file so only one process is allowed to write it and wait for connection from VSCode.

Also we do not track daemon by default because fork could cause issues. We add an option `--hook-daemon` when the user needs to.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

If multiple processes are writing the file at the same time, VSCode will fail to establish the connection to the debugger server.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Manually confirmed that `run-tests` works after the patch.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No