### PR TITLE
[SPARK-54591][BUILD] Upgrade `commons-lang3` to 3.20.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -43,7 +43,7 @@ commons-crypto/1.1.0//commons-crypto-1.1.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar
 commons-io/2.21.0//commons-io-2.21.0.jar
 commons-lang/2.6//commons-lang-2.6.jar
-commons-lang3/3.19.0//commons-lang3-3.19.0.jar
+commons-lang3/3.20.0//commons-lang3-3.20.0.jar
 commons-math3/3.6.1//commons-math3-3.6.1.jar
 commons-pool/1.5.4//commons-pool-1.5.4.jar
 commons-text/1.14.0//commons-text-1.14.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
     <!-- To support Hive UDF jars built by Hive 2.0.0 ~ 2.3.9 and 3.0.0 ~ 3.1.3. -->
     <commons-lang2.version>2.6</commons-lang2.version>
     <!-- org.apache.commons/commons-lang3/-->
-    <commons-lang3.version>3.19.0</commons-lang3.version>
+    <commons-lang3.version>3.20.0</commons-lang3.version>
     <!-- org.apache.commons/commons-pool2/-->
     <commons-pool2.version>2.12.1</commons-pool2.version>
     <datanucleus-core.version>4.1.17</datanucleus-core.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `commons-lang3` from 3.19.0 to 3.20.0.


### Why are the changes needed?
The new version is a Java 25-tested version:

- https://github.com/apache/commons-lang/pull/1485

Additionally, it includes a bug fix related to `MethodUtils.invokeMethod`:

- https://issues.apache.org/jira/browse/LANG-1789

The full release notes as follows:

- https://commons.apache.org/proper/commons-lang/changes.html#a3.20.0


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.