### PR TITLE
[SPARK-54588][SQL] Add time_format function to convert TIME values to formatted string representations

### DIFF
--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -3767,6 +3767,13 @@ def time_diff(unit: "ColumnOrName", start: "ColumnOrName", end: "ColumnOrName") 
 time_diff.__doc__ = pysparkfuncs.time_diff.__doc__
 
 
+def time_format(time: "ColumnOrName", format: str) -> Column:
+    return _invoke_function("time_format", _to_col(time), lit(format))
+
+
+time_format.__doc__ = pysparkfuncs.time_format.__doc__
+
+
 def time_trunc(unit: "ColumnOrName", time: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("time_trunc", unit, time)
 

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -3950,6 +3950,13 @@ def time_diff(unit: "ColumnOrName", start: "ColumnOrName", end: "ColumnOrName") 
 time_diff.__doc__ = pysparkfuncs.time_diff.__doc__
 
 
+def time_format(time: "ColumnOrName", format: str) -> Column:
+    return _invoke_function("time_format", _to_col(time), lit(format))
+
+
+time_format.__doc__ = pysparkfuncs.time_format.__doc__
+
+
 def time_trunc(unit: "ColumnOrName", time: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("time_trunc", unit, time)
 

--- a/python/pyspark/sql/functions/__init__.py
+++ b/python/pyspark/sql/functions/__init__.py
@@ -252,6 +252,7 @@ __all__ = [  # noqa: F405
     "timestamp_seconds",
     "time_bucket",
     "time_diff",
+    "time_format",
     "time_from_micros",
     "time_from_millis",
     "time_from_seconds",

--- a/python/pyspark/sql/functions/__init__.py
+++ b/python/pyspark/sql/functions/__init__.py
@@ -250,6 +250,7 @@ __all__ = [  # noqa: F405
     "session_window",
     "time_bucket",
     "time_diff",
+    "time_format",
     "time_from_micros",
     "time_from_millis",
     "time_from_seconds",

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -13067,7 +13067,7 @@ def time_format(time: "ColumnOrName", format: str) -> Column:
     A pattern could be for instance `HH:mm:ss` and could return a string like '14:30:45'.
     Time-related pattern letters of `datetime pattern`_ can be used.
 
-    .. versionadded:: 4.2.0
+    .. versionadded:: 4.3.0
 
     Parameters
     ----------

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -13059,6 +13059,78 @@ def time_diff(unit: "ColumnOrName", start: "ColumnOrName", end: "ColumnOrName") 
 
 
 @_try_remote_functions
+def time_format(time: "ColumnOrName", format: str) -> Column:
+    """
+    Converts a time to a value of string in the format specified by the time
+    format given by the second argument.
+
+    A pattern could be for instance `HH:mm:ss` and could return a string like '14:30:45'.
+    Time-related pattern letters of `datetime pattern`_ can be used.
+
+    .. versionadded:: 4.2.0
+
+    Parameters
+    ----------
+    time : :class:`~pyspark.sql.Column` or column name
+        input column of TIME values to format.
+    format: literal string
+        format to use to represent time values.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        string value representing formatted time.
+
+    See Also
+    --------
+    :meth:`pyspark.sql.functions.to_time`
+    :meth:`pyspark.sql.functions.try_to_time`
+    :meth:`pyspark.sql.functions.date_format`
+
+    Examples
+    --------
+    Example 1: Basic 24-hour format
+
+    >>> from pyspark.sql import functions as sf
+    >>> df = spark.sql("SELECT TIME'14:30:45' as time_col")
+    >>> df.select("*", sf.time_format('time_col', 'HH:mm:ss')).show()
+    +--------+-------------------------------+
+    |time_col|time_format(time_col, HH:mm:ss)|
+    +--------+-------------------------------+
+    |14:30:45|                       14:30:45|
+    +--------+-------------------------------+
+    <BLANKLINE>
+
+    Example 2: 12-hour format with AM/PM
+
+    >>> from pyspark.sql import functions as sf
+    >>> df = spark.sql("SELECT TIME'14:30:45' as time_col")
+    >>> df.select("*", sf.time_format('time_col', 'hh:mm:ss a')).show()
+    +--------+---------------------------------+
+    |time_col|time_format(time_col, hh:mm:ss a)|
+    +--------+---------------------------------+
+    |14:30:45|                      02:30:45 PM|
+    +--------+---------------------------------+
+    <BLANKLINE>
+
+    Example 3: With microseconds
+
+    >>> from pyspark.sql import functions as sf
+    >>> df = spark.sql("SELECT TIME'14:30:45.123456' as time_col")
+    >>> df.select("*", sf.time_format('time_col', 'HH:mm:ss.SSSSSS')).show()
+    +---------------+--------------------------------------+
+    |       time_col|time_format(time_col, HH:mm:ss.SSSSSS)|
+    +---------------+--------------------------------------+
+    |14:30:45.123456|                       14:30:45.123456|
+    +---------------+--------------------------------------+
+    <BLANKLINE>
+    """
+    from pyspark.sql.classic.column import _to_java_column
+
+    return _invoke_function("time_format", _to_java_column(time), _enum_to_value(format))
+
+
+@_try_remote_functions
 def time_trunc(unit: "ColumnOrName", time: "ColumnOrName") -> Column:
     """
     Returns `time` truncated to the `unit`.

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -13984,6 +13984,78 @@ def time_diff(unit: "ColumnOrName", start: "ColumnOrName", end: "ColumnOrName") 
 
 
 @_try_remote_functions
+def time_format(time: "ColumnOrName", format: str) -> Column:
+    """
+    Converts a time to a value of string in the format specified by the time
+    format given by the second argument.
+
+    A pattern could be for instance `HH:mm:ss` and could return a string like '14:30:45'.
+    Time-related pattern letters of `datetime pattern`_ can be used.
+
+    .. versionadded:: 4.2.0
+
+    Parameters
+    ----------
+    time : :class:`~pyspark.sql.Column` or column name
+        input column of TIME values to format.
+    format: literal string
+        format to use to represent time values.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        string value representing formatted time.
+
+    See Also
+    --------
+    :meth:`pyspark.sql.functions.to_time`
+    :meth:`pyspark.sql.functions.try_to_time`
+    :meth:`pyspark.sql.functions.date_format`
+
+    Examples
+    --------
+    Example 1: Basic 24-hour format
+
+    >>> from pyspark.sql import functions as sf
+    >>> df = spark.sql("SELECT TIME'14:30:45' as time_col")
+    >>> df.select("*", sf.time_format('time_col', 'HH:mm:ss')).show()
+    +--------+-------------------------------+
+    |time_col|time_format(time_col, HH:mm:ss)|
+    +--------+-------------------------------+
+    |14:30:45|                       14:30:45|
+    +--------+-------------------------------+
+    <BLANKLINE>
+
+    Example 2: 12-hour format with AM/PM
+
+    >>> from pyspark.sql import functions as sf
+    >>> df = spark.sql("SELECT TIME'14:30:45' as time_col")
+    >>> df.select("*", sf.time_format('time_col', 'hh:mm:ss a')).show()
+    +--------+---------------------------------+
+    |time_col|time_format(time_col, hh:mm:ss a)|
+    +--------+---------------------------------+
+    |14:30:45|                      02:30:45 PM|
+    +--------+---------------------------------+
+    <BLANKLINE>
+
+    Example 3: With microseconds
+
+    >>> from pyspark.sql import functions as sf
+    >>> df = spark.sql("SELECT TIME'14:30:45.123456' as time_col")
+    >>> df.select("*", sf.time_format('time_col', 'HH:mm:ss.SSSSSS')).show()
+    +---------------+--------------------------------------+
+    |       time_col|time_format(time_col, HH:mm:ss.SSSSSS)|
+    +---------------+--------------------------------------+
+    |14:30:45.123456|                       14:30:45.123456|
+    +---------------+--------------------------------------+
+    <BLANKLINE>
+    """
+    from pyspark.sql.classic.column import _to_java_column
+
+    return _invoke_function("time_format", _to_java_column(time), _enum_to_value(format))
+
+
+@_try_remote_functions
 def time_trunc(unit: "ColumnOrName", time: "ColumnOrName") -> Column:
     """
     Returns `time` truncated to the `unit`.

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -13992,7 +13992,7 @@ def time_format(time: "ColumnOrName", format: str) -> Column:
     A pattern could be for instance `HH:mm:ss` and could return a string like '14:30:45'.
     Time-related pattern letters of `datetime pattern`_ can be used.
 
-    .. versionadded:: 4.2.0
+    .. versionadded:: 4.4.0
 
     Parameters
     ----------

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -8738,7 +8738,7 @@ object functions {
    * @return
    *   String representation of the time in the specified format.
    * @group datetime_funcs
-   * @since 4.2.0
+   * @since 4.3.0
    */
   def time_format(time: Column, format: String): Column = {
     Column.fn("time_format", time, lit(format))

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -8726,6 +8726,22 @@ object functions {
   }
 
   /**
+   * Converts a time to a string in the specified format.
+   *
+   * @param time
+   *   A column of time values to be formatted.
+   * @param format
+   *   A time format string. for valid patterns.
+   * @return
+   *   String representation of the time in the specified format.
+   * @group datetime_funcs
+   * @since 4.2.0
+   */
+  def time_format(time: Column, format: String): Column = {
+    Column.fn("time_format", time, lit(format))
+  }
+
+  /**
    * Returns `time` truncated to the `unit`.
    *
    * @param unit

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -8731,7 +8731,10 @@ object functions {
    * @param time
    *   A column of time values to be formatted.
    * @param format
-   *   A time format string. for valid patterns.
+   *   A time format string. See <a
+   *   href="https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html">Datetime
+   *   Patterns</a> for valid patterns. Note: only time-related patterns (H, h, m, s, S, a) are
+   *   meaningful for TIME values; date fields (y, M, d, etc.) raise an error.
    * @return
    *   String representation of the time in the specified format.
    * @group datetime_funcs

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -13359,6 +13359,22 @@ object functions {
   }
 
   /**
+   * Converts a time to a string in the specified format.
+   *
+   * @param time
+   *   A column of time values to be formatted.
+   * @param format
+   *   A time format string. for valid patterns.
+   * @return
+   *   String representation of the time in the specified format.
+   * @group datetime_funcs
+   * @since 4.2.0
+   */
+  def time_format(time: Column, format: String): Column = {
+    Column.fn("time_format", time, lit(format))
+  }
+
+  /**
    * Returns `time` truncated to the `unit`.
    *
    * @param unit

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -13364,7 +13364,10 @@ object functions {
    * @param time
    *   A column of time values to be formatted.
    * @param format
-   *   A time format string. for valid patterns.
+   *   A time format string. See <a
+   *   href="https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html">Datetime
+   *   Patterns</a> for valid patterns. Note: only time-related patterns (H, h, m, s, S, a) are
+   *   meaningful for TIME values; date fields (y, M, d, etc.) raise an error.
    * @return
    *   String representation of the time in the specified format.
    * @group datetime_funcs

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -13371,7 +13371,7 @@ object functions {
    * @return
    *   String representation of the time in the specified format.
    * @group datetime_funcs
-   * @since 4.2.0
+   * @since 4.4.0
    */
   def time_format(time: Column, format: String): Column = {
     Column.fn("time_format", time, lit(format))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -726,6 +726,7 @@ object FunctionRegistry {
     expression[ParseToTimestamp]("to_timestamp"),
     expression[ParseToDate]("to_date"),
     expression[TimeDiff]("time_diff"),
+    expression[TimeFormat]("time_format"),
     expression[ToTime]("to_time"),
     expression[ToBinary]("to_binary"),
     expression[ToUnixTimestamp]("to_unix_timestamp"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -653,6 +653,7 @@ object FunctionRegistry {
     expression[ParseToTimestamp]("to_timestamp"),
     expression[ParseToDate]("to_date"),
     expression[TimeDiff]("time_diff"),
+    expression[TimeFormat]("time_format"),
     expression[ToTime]("to_time"),
     expression[ToUnixTimestamp]("to_unix_timestamp"),
     expression[ToUTCTimestamp]("to_utc_timestamp"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.util.TypeUtils.ordinalNumber
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.types.StringTypeWithCollation
-import org.apache.spark.sql.types.{AbstractDataType, AnyTimeType, ByteType, DataType, DayTimeIntervalType, DecimalType, IntegerType, IntegralType, LongType, NumericType, ObjectType, TimestampLTZNanosType, TimestampNTZNanosType, TimestampNTZType, TimestampType, TimeType}
+import org.apache.spark.sql.types.{AbstractDataType, AnyTimeType, ByteType, DataType, DayTimeIntervalType, DecimalType, IntegerType, IntegralType, LongType, NumericType, ObjectType, StringType, TimestampLTZNanosType, TimestampNTZNanosType, TimestampNTZType, TimestampType, TimeType}
 import org.apache.spark.sql.types.DayTimeIntervalType.{HOUR, SECOND}
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -1022,4 +1022,83 @@ case class TimeToMicros(child: Expression) extends TimeToBase {
 
   override protected def withNewChildInternal(newChild: Expression): TimeToMicros =
     copy(child = newChild)
+}
+
+// scalastyle:off line.size.limit
+@ExpressionDescription(
+  usage = "_FUNC_(time, format) - Converts a time to a value of string in the format specified by the date format given by the second argument.",
+  arguments = """
+    Arguments:
+      * time - A time value to be converted to string.
+      * format - Time format pattern to follow. See <a href="https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html">Datetime Patterns</a> for valid
+                 time format patterns. Note: Only time-related patterns (H, h, m, s, S, a) are meaningful for TIME values.
+  """,
+  examples = """
+    Examples:
+      > SELECT _FUNC_(TIME'14:30:45', 'HH:mm:ss');
+       14:30:45
+      > SELECT _FUNC_(TIME'14:30:45', 'hh:mm:ss a');
+       02:30:45 PM
+      > SELECT _FUNC_(TIME'14:30:45.123456', 'HH:mm:ss.SSSSSS');
+       14:30:45.123456
+      > SELECT _FUNC_(TIME'09:05:00', 'h:mm a');
+       9:05 AM
+  """,
+  group = "datetime_funcs",
+  since = "4.2.0")
+// scalastyle:on line.size.limit
+case class TimeFormat(left: Expression, right: Expression)
+  extends BinaryExpression
+  with ImplicitCastInputTypes {
+
+  override def nullIntolerant: Boolean = true
+
+  override def inputTypes: Seq[AbstractDataType] =
+    Seq(AnyTimeType, StringTypeWithCollation(supportsTrimCollation = true))
+
+  override def dataType: DataType = StringType
+
+  // Cache the formatter if the format string is a foldable expression
+  @transient private lazy val formatterOption: Option[TimeFormatter] =
+    if (right.foldable) {
+      Option(right.eval()).map { format =>
+        TimeFormatter(format.toString, TimeFormatter.defaultLocale, isParsing = false)
+      }
+    } else {
+      None
+    }
+
+  override protected def nullSafeEval(time: Any, format: Any): Any = {
+    val nanos = time.asInstanceOf[Long]
+    val formatter = formatterOption.getOrElse {
+      TimeFormatter(format.toString, TimeFormatter.defaultLocale, isParsing = false)
+    }
+    UTF8String.fromString(formatter.format(nanos))
+  }
+
+  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    formatterOption.map { tf =>
+      val timeFormatter = ctx.addReferenceObj("timeFormatter", tf)
+      defineCodeGen(ctx, ev, (time, _) => {
+        s"""UTF8String.fromString($timeFormatter.format($time))"""
+      })
+    }.getOrElse {
+      val tfClass = TimeFormatter.getClass.getName.stripSuffix("$")
+      val locale = ctx.addReferenceObj(
+        "locale", TimeFormatter.defaultLocale, classOf[Locale].getName)
+      defineCodeGen(ctx, ev, (time, format) => {
+        s"""|UTF8String.fromString($tfClass$$.MODULE$$.apply(
+            |  $format.toString(),
+            |  $locale,
+            |  false)
+            |.format($time))""".stripMargin
+      })
+    }
+  }
+
+  override def prettyName: String = "time_format"
+
+  override protected def withNewChildrenInternal(
+      newLeft: Expression, newRight: Expression): TimeFormat =
+    copy(left = newLeft, right = newRight)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -1046,7 +1046,7 @@ case class TimeToMicros(child: Expression) extends TimeToBase {
        9:05 AM
   """,
   group = "datetime_funcs",
-  since = "4.2.0")
+  since = "4.3.0")
 // scalastyle:on line.size.limit
 case class TimeFormat(left: Expression, right: Expression)
   extends BinaryExpression

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -20,11 +20,12 @@ package org.apache.spark.sql.catalyst.expressions
 import java.time.DateTimeException
 import java.util.Locale
 
-import org.apache.spark.SparkException
+import org.apache.spark.{SparkException, SparkRuntimeException}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{ExpressionBuilder, TypeCheckResult}
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.{DataTypeMismatch, TypeCheckSuccess}
 import org.apache.spark.sql.catalyst.expressions.Cast.{toSQLExpr, toSQLId, toSQLType, toSQLValue}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.expressions.objects.{Invoke, StaticInvoke}
 import org.apache.spark.sql.catalyst.trees.TreePattern.{CURRENT_LIKE, TreePattern}
@@ -1026,7 +1027,7 @@ case class TimeToMicros(child: Expression) extends TimeToBase {
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(time, format) - Converts a time to a value of string in the format specified by the date format given by the second argument.",
+  usage = "_FUNC_(time, format) - Converts a time to a value of string in the format specified by the time format given by the second argument.",
   arguments = """
     Arguments:
       * time - A time value to be converted to string.
@@ -1070,28 +1071,38 @@ case class TimeFormat(left: Expression, right: Expression)
 
   override protected def nullSafeEval(time: Any, format: Any): Any = {
     val nanos = time.asInstanceOf[Long]
+    val pattern = if (right.foldable) right.eval().toString else format.toString
     val formatter = formatterOption.getOrElse {
-      TimeFormatter(format.toString, TimeFormatter.defaultLocale, isParsing = false)
+      TimeFormatter(pattern, TimeFormatter.defaultLocale, isParsing = false)
     }
-    UTF8String.fromString(formatter.format(nanos))
+    TimeFormat.formatWithError(formatter, nanos, prettyName, pattern)
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     formatterOption.map { tf =>
       val timeFormatter = ctx.addReferenceObj("timeFormatter", tf)
+      val funcName = ctx.addReferenceObj("funcName", prettyName)
+      val fmtStr = ctx.addReferenceObj("fmtStr", right.eval().toString)
       defineCodeGen(ctx, ev, (time, _) => {
-        s"""UTF8String.fromString($timeFormatter.format($time))"""
+        s"""|((org.apache.spark.unsafe.types.UTF8String)
+            |org.apache.spark.sql.catalyst.expressions
+            |.TimeFormat.formatWithError(
+            |$timeFormatter, $time,
+            |$funcName, $fmtStr))""".stripMargin.replaceAll("\n", "")
       })
     }.getOrElse {
       val tfClass = TimeFormatter.getClass.getName.stripSuffix("$")
       val locale = ctx.addReferenceObj(
         "locale", TimeFormatter.defaultLocale, classOf[Locale].getName)
+      val funcName = ctx.addReferenceObj("funcName", prettyName)
       defineCodeGen(ctx, ev, (time, format) => {
-        s"""|UTF8String.fromString($tfClass$$.MODULE$$.apply(
-            |  $format.toString(),
-            |  $locale,
-            |  false)
-            |.format($time))""".stripMargin
+        s"""|((org.apache.spark.unsafe.types.UTF8String)
+            |org.apache.spark.sql.catalyst.expressions
+            |.TimeFormat.formatWithError(
+            |$tfClass$$.MODULE$$.apply(
+            |  $format.toString(), $locale, false),
+            |$time, $funcName,
+            |$format.toString()))""".stripMargin.replaceAll("\n", "")
       })
     }
   }
@@ -1101,4 +1112,22 @@ case class TimeFormat(left: Expression, right: Expression)
   override protected def withNewChildrenInternal(
       newLeft: Expression, newRight: Expression): TimeFormat =
     copy(left = newLeft, right = newRight)
+}
+
+object TimeFormat {
+  def formatWithError(
+      tf: TimeFormatter, nanos: Long, funcName: String, pattern: String): UTF8String = {
+    try {
+      UTF8String.fromString(tf.format(nanos))
+    } catch {
+      case e: DateTimeException =>
+        throw new SparkRuntimeException(
+          errorClass = "INVALID_PARAMETER_VALUE.PATTERN",
+          messageParameters = Map(
+            "parameter" -> toSQLId("format"),
+            "functionName" -> toSQLId(funcName),
+            "value" -> toSQLValue(pattern, StringType)),
+          cause = e)
+    }
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -20,11 +20,12 @@ package org.apache.spark.sql.catalyst.expressions
 import java.time.DateTimeException
 import java.util.Locale
 
-import org.apache.spark.SparkException
+import org.apache.spark.{SparkException, SparkRuntimeException}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{ExpressionBuilder, TypeCheckResult}
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.{DataTypeMismatch, TypeCheckSuccess}
 import org.apache.spark.sql.catalyst.expressions.Cast.{toSQLExpr, toSQLId, toSQLType, toSQLValue}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.expressions.objects.{Invoke, StaticInvoke}
 import org.apache.spark.sql.catalyst.trees.TreePattern.{CURRENT_LIKE, TreePattern}
@@ -1056,7 +1057,7 @@ case class TimeToMicros(child: Expression) extends TimeToBase {
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(time, format) - Converts a time to a value of string in the format specified by the date format given by the second argument.",
+  usage = "_FUNC_(time, format) - Converts a time to a value of string in the format specified by the time format given by the second argument.",
   arguments = """
     Arguments:
       * time - A time value to be converted to string.
@@ -1100,28 +1101,38 @@ case class TimeFormat(left: Expression, right: Expression)
 
   override protected def nullSafeEval(time: Any, format: Any): Any = {
     val nanos = time.asInstanceOf[Long]
+    val pattern = if (right.foldable) right.eval().toString else format.toString
     val formatter = formatterOption.getOrElse {
-      TimeFormatter(format.toString, TimeFormatter.defaultLocale, isParsing = false)
+      TimeFormatter(pattern, TimeFormatter.defaultLocale, isParsing = false)
     }
-    UTF8String.fromString(formatter.format(nanos))
+    TimeFormat.formatWithError(formatter, nanos, prettyName, pattern)
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     formatterOption.map { tf =>
       val timeFormatter = ctx.addReferenceObj("timeFormatter", tf)
+      val funcName = ctx.addReferenceObj("funcName", prettyName)
+      val fmtStr = ctx.addReferenceObj("fmtStr", right.eval().toString)
       defineCodeGen(ctx, ev, (time, _) => {
-        s"""UTF8String.fromString($timeFormatter.format($time))"""
+        s"""|((org.apache.spark.unsafe.types.UTF8String)
+            |org.apache.spark.sql.catalyst.expressions
+            |.TimeFormat.formatWithError(
+            |$timeFormatter, $time,
+            |$funcName, $fmtStr))""".stripMargin.replaceAll("\n", "")
       })
     }.getOrElse {
       val tfClass = TimeFormatter.getClass.getName.stripSuffix("$")
       val locale = ctx.addReferenceObj(
         "locale", TimeFormatter.defaultLocale, classOf[Locale].getName)
+      val funcName = ctx.addReferenceObj("funcName", prettyName)
       defineCodeGen(ctx, ev, (time, format) => {
-        s"""|UTF8String.fromString($tfClass$$.MODULE$$.apply(
-            |  $format.toString(),
-            |  $locale,
-            |  false)
-            |.format($time))""".stripMargin
+        s"""|((org.apache.spark.unsafe.types.UTF8String)
+            |org.apache.spark.sql.catalyst.expressions
+            |.TimeFormat.formatWithError(
+            |$tfClass$$.MODULE$$.apply(
+            |  $format.toString(), $locale, false),
+            |$time, $funcName,
+            |$format.toString()))""".stripMargin.replaceAll("\n", "")
       })
     }
   }
@@ -1131,4 +1142,22 @@ case class TimeFormat(left: Expression, right: Expression)
   override protected def withNewChildrenInternal(
       newLeft: Expression, newRight: Expression): TimeFormat =
     copy(left = newLeft, right = newRight)
+}
+
+object TimeFormat {
+  def formatWithError(
+      tf: TimeFormatter, nanos: Long, funcName: String, pattern: String): UTF8String = {
+    try {
+      UTF8String.fromString(tf.format(nanos))
+    } catch {
+      case e: DateTimeException =>
+        throw new SparkRuntimeException(
+          errorClass = "INVALID_PARAMETER_VALUE.PATTERN",
+          messageParameters = Map(
+            "parameter" -> toSQLId("format"),
+            "functionName" -> toSQLId(funcName),
+            "value" -> toSQLValue(pattern, StringType)),
+          cause = e)
+    }
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.util.TypeUtils.ordinalNumber
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.types.StringTypeWithCollation
-import org.apache.spark.sql.types.{AbstractDataType, AnyTimeType, ByteType, DataType, DayTimeIntervalType, DecimalType, IntegerType, IntegralType, LongType, NumericType, ObjectType, TimestampLTZNanosType, TimestampNTZNanosType, TimestampNTZType, TimestampType, TimeType}
+import org.apache.spark.sql.types.{AbstractDataType, AnyTimeType, ByteType, DataType, DayTimeIntervalType, DecimalType, IntegerType, IntegralType, LongType, NumericType, ObjectType, StringType, TimestampLTZNanosType, TimestampNTZNanosType, TimestampNTZType, TimestampType, TimeType}
 import org.apache.spark.sql.types.DayTimeIntervalType.{HOUR, SECOND}
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -1052,4 +1052,83 @@ case class TimeToMicros(child: Expression) extends TimeToBase {
 
   override protected def withNewChildInternal(newChild: Expression): TimeToMicros =
     copy(child = newChild)
+}
+
+// scalastyle:off line.size.limit
+@ExpressionDescription(
+  usage = "_FUNC_(time, format) - Converts a time to a value of string in the format specified by the date format given by the second argument.",
+  arguments = """
+    Arguments:
+      * time - A time value to be converted to string.
+      * format - Time format pattern to follow. See <a href="https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html">Datetime Patterns</a> for valid
+                 time format patterns. Note: Only time-related patterns (H, h, m, s, S, a) are meaningful for TIME values.
+  """,
+  examples = """
+    Examples:
+      > SELECT _FUNC_(TIME'14:30:45', 'HH:mm:ss');
+       14:30:45
+      > SELECT _FUNC_(TIME'14:30:45', 'hh:mm:ss a');
+       02:30:45 PM
+      > SELECT _FUNC_(TIME'14:30:45.123456', 'HH:mm:ss.SSSSSS');
+       14:30:45.123456
+      > SELECT _FUNC_(TIME'09:05:00', 'h:mm a');
+       9:05 AM
+  """,
+  group = "datetime_funcs",
+  since = "4.2.0")
+// scalastyle:on line.size.limit
+case class TimeFormat(left: Expression, right: Expression)
+  extends BinaryExpression
+  with ImplicitCastInputTypes {
+
+  override def nullIntolerant: Boolean = true
+
+  override def inputTypes: Seq[AbstractDataType] =
+    Seq(AnyTimeType, StringTypeWithCollation(supportsTrimCollation = true))
+
+  override def dataType: DataType = StringType
+
+  // Cache the formatter if the format string is a foldable expression
+  @transient private lazy val formatterOption: Option[TimeFormatter] =
+    if (right.foldable) {
+      Option(right.eval()).map { format =>
+        TimeFormatter(format.toString, TimeFormatter.defaultLocale, isParsing = false)
+      }
+    } else {
+      None
+    }
+
+  override protected def nullSafeEval(time: Any, format: Any): Any = {
+    val nanos = time.asInstanceOf[Long]
+    val formatter = formatterOption.getOrElse {
+      TimeFormatter(format.toString, TimeFormatter.defaultLocale, isParsing = false)
+    }
+    UTF8String.fromString(formatter.format(nanos))
+  }
+
+  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    formatterOption.map { tf =>
+      val timeFormatter = ctx.addReferenceObj("timeFormatter", tf)
+      defineCodeGen(ctx, ev, (time, _) => {
+        s"""UTF8String.fromString($timeFormatter.format($time))"""
+      })
+    }.getOrElse {
+      val tfClass = TimeFormatter.getClass.getName.stripSuffix("$")
+      val locale = ctx.addReferenceObj(
+        "locale", TimeFormatter.defaultLocale, classOf[Locale].getName)
+      defineCodeGen(ctx, ev, (time, format) => {
+        s"""|UTF8String.fromString($tfClass$$.MODULE$$.apply(
+            |  $format.toString(),
+            |  $locale,
+            |  false)
+            |.format($time))""".stripMargin
+      })
+    }
+  }
+
+  override def prettyName: String = "time_format"
+
+  override protected def withNewChildrenInternal(
+      newLeft: Expression, newRight: Expression): TimeFormat =
+    copy(left = newLeft, right = newRight)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -1076,7 +1076,7 @@ case class TimeToMicros(child: Expression) extends TimeToBase {
        9:05 AM
   """,
   group = "datetime_funcs",
-  since = "4.2.0")
+  since = "4.4.0")
 // scalastyle:on line.size.limit
 case class TimeFormat(left: Expression, right: Expression)
   extends BinaryExpression

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
@@ -717,6 +717,11 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(
       TimeFormat(timeLit, Literal("HH:mm:ss.SSSSSS")),
       "14:30:45.123456")
+    // Nanosecond precision: 9-digit fractional-second pattern (SSSSSSSSS)
+    val timeWithNanos = localTimeToNanos(LocalTime.of(14, 30, 45, 123456789))
+    checkEvaluation(
+      TimeFormat(Literal(timeWithNanos, TimeType()), Literal("HH:mm:ss.SSSSSSSSS")),
+      "14:30:45.123456789")
 
     // Non-foldable format - formatter created per evaluation
     val nonFoldableExpr = TimeFormat(timeLit, NonFoldableLiteral("HH:mm:ss", StringType))
@@ -727,6 +732,11 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(
       TimeFormat(timeLit, NonFoldableLiteral("HH:mm:ss.SSSSSS", StringType)),
       "14:30:45.123456")
+    checkEvaluation(
+      TimeFormat(
+        Literal(timeWithNanos, TimeType()),
+        NonFoldableLiteral("HH:mm:ss.SSSSSSSSS", StringType)),
+      "14:30:45.123456789")
 
     // Multiple formats on same time
     Seq("HH:mm:ss", "hh:mm a", "HH:mm", "HH").zip(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
@@ -703,4 +703,66 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val timeVal = TimeFromSeconds(Literal(secondsValue))
     checkEvaluation(TimeToMicros(timeVal), 14500000L)
   }
+
+  test("TimeFormat - foldable and non-foldable formats with codegen") {
+    val time = localTime(14, 30, 45, 123456)
+    val timeLit = Literal(time, TimeType())
+
+    // Foldable format - formatter cached at planning time
+    val foldableExpr = TimeFormat(timeLit, Literal("HH:mm:ss"))
+    checkEvaluation(foldableExpr, "14:30:45")
+    checkEvaluation(
+      TimeFormat(Literal(localTime(9, 5, 0), TimeType()), Literal("hh:mm:ss a")),
+      "09:05:00 AM")
+    checkEvaluation(
+      TimeFormat(timeLit, Literal("HH:mm:ss.SSSSSS")),
+      "14:30:45.123456")
+
+    // Non-foldable format - formatter created per evaluation
+    val nonFoldableExpr = TimeFormat(timeLit, NonFoldableLiteral("HH:mm:ss", StringType))
+    checkEvaluation(nonFoldableExpr, "14:30:45")
+    checkEvaluation(
+      TimeFormat(timeLit, NonFoldableLiteral("hh:mm:ss a", StringType)),
+      "02:30:45 PM")
+    checkEvaluation(
+      TimeFormat(timeLit, NonFoldableLiteral("HH:mm:ss.SSSSSS", StringType)),
+      "14:30:45.123456")
+
+    // Multiple formats on same time
+    Seq("HH:mm:ss", "hh:mm a", "HH:mm", "HH").zip(
+      Seq("14:30:45", "02:30 PM", "14:30", "14")
+    ).foreach { case (format, expected) =>
+      checkEvaluation(
+        TimeFormat(timeLit, NonFoldableLiteral(format, StringType)),
+        expected)
+    }
+
+    // Edge cases
+    checkEvaluation(
+      TimeFormat(Literal(localTime(0, 0, 0), TimeType()), Literal("HH:mm:ss")),
+      "00:00:00")
+    checkEvaluation(
+      TimeFormat(Literal(localTime(23, 59, 59, 999999), TimeType()),
+        Literal("HH:mm:ss.SSSSSS")),
+      "23:59:59.999999")
+
+    // Null handling
+    checkEvaluation(
+      TimeFormat(Literal.create(null, TimeType()), Literal("HH:mm:ss")),
+      null)
+    checkEvaluation(
+      TimeFormat(timeLit, Literal.create(null, StringType)),
+      null)
+    checkEvaluation(
+      TimeFormat(Literal.create(null, TimeType()), NonFoldableLiteral("HH:mm:ss", StringType)),
+      null)
+    checkEvaluation(
+      TimeFormat(timeLit, NonFoldableLiteral(null, StringType)),
+      null)
+
+    // Verify foldable and non-foldable produce same result
+    val foldableResult = foldableExpr.eval()
+    val nonFoldableResult = nonFoldableExpr.eval()
+    assert(foldableResult == nonFoldableResult)
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
@@ -730,4 +730,66 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val timeVal = TimeFromSeconds(Literal(secondsValue))
     checkEvaluation(TimeToMicros(timeVal), 14500000L)
   }
+
+  test("TimeFormat - foldable and non-foldable formats with codegen") {
+    val time = localTime(14, 30, 45, 123456)
+    val timeLit = Literal(time, TimeType())
+
+    // Foldable format - formatter cached at planning time
+    val foldableExpr = TimeFormat(timeLit, Literal("HH:mm:ss"))
+    checkEvaluation(foldableExpr, "14:30:45")
+    checkEvaluation(
+      TimeFormat(Literal(localTime(9, 5, 0), TimeType()), Literal("hh:mm:ss a")),
+      "09:05:00 AM")
+    checkEvaluation(
+      TimeFormat(timeLit, Literal("HH:mm:ss.SSSSSS")),
+      "14:30:45.123456")
+
+    // Non-foldable format - formatter created per evaluation
+    val nonFoldableExpr = TimeFormat(timeLit, NonFoldableLiteral("HH:mm:ss", StringType))
+    checkEvaluation(nonFoldableExpr, "14:30:45")
+    checkEvaluation(
+      TimeFormat(timeLit, NonFoldableLiteral("hh:mm:ss a", StringType)),
+      "02:30:45 PM")
+    checkEvaluation(
+      TimeFormat(timeLit, NonFoldableLiteral("HH:mm:ss.SSSSSS", StringType)),
+      "14:30:45.123456")
+
+    // Multiple formats on same time
+    Seq("HH:mm:ss", "hh:mm a", "HH:mm", "HH").zip(
+      Seq("14:30:45", "02:30 PM", "14:30", "14")
+    ).foreach { case (format, expected) =>
+      checkEvaluation(
+        TimeFormat(timeLit, NonFoldableLiteral(format, StringType)),
+        expected)
+    }
+
+    // Edge cases
+    checkEvaluation(
+      TimeFormat(Literal(localTime(0, 0, 0), TimeType()), Literal("HH:mm:ss")),
+      "00:00:00")
+    checkEvaluation(
+      TimeFormat(Literal(localTime(23, 59, 59, 999999), TimeType()),
+        Literal("HH:mm:ss.SSSSSS")),
+      "23:59:59.999999")
+
+    // Null handling
+    checkEvaluation(
+      TimeFormat(Literal.create(null, TimeType()), Literal("HH:mm:ss")),
+      null)
+    checkEvaluation(
+      TimeFormat(timeLit, Literal.create(null, StringType)),
+      null)
+    checkEvaluation(
+      TimeFormat(Literal.create(null, TimeType()), NonFoldableLiteral("HH:mm:ss", StringType)),
+      null)
+    checkEvaluation(
+      TimeFormat(timeLit, NonFoldableLiteral(null, StringType)),
+      null)
+
+    // Verify foldable and non-foldable produce same result
+    val foldableResult = foldableExpr.eval()
+    val nonFoldableResult = nonFoldableExpr.eval()
+    assert(foldableResult == nonFoldableResult)
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
@@ -744,6 +744,11 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(
       TimeFormat(timeLit, Literal("HH:mm:ss.SSSSSS")),
       "14:30:45.123456")
+    // Nanosecond precision: 9-digit fractional-second pattern (SSSSSSSSS)
+    val timeWithNanos = localTimeToNanos(LocalTime.of(14, 30, 45, 123456789))
+    checkEvaluation(
+      TimeFormat(Literal(timeWithNanos, TimeType()), Literal("HH:mm:ss.SSSSSSSSS")),
+      "14:30:45.123456789")
 
     // Non-foldable format - formatter created per evaluation
     val nonFoldableExpr = TimeFormat(timeLit, NonFoldableLiteral("HH:mm:ss", StringType))
@@ -754,6 +759,11 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(
       TimeFormat(timeLit, NonFoldableLiteral("HH:mm:ss.SSSSSS", StringType)),
       "14:30:45.123456")
+    checkEvaluation(
+      TimeFormat(
+        Literal(timeWithNanos, TimeType()),
+        NonFoldableLiteral("HH:mm:ss.SSSSSSSSS", StringType)),
+      "14:30:45.123456789")
 
     // Multiple formats on same time
     Seq("HH:mm:ss", "hh:mm a", "HH:mm", "HH").zip(

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -369,6 +369,7 @@
 | org.apache.spark.sql.catalyst.expressions.ThetaUnion | theta_union | SELECT theta_sketch_estimate(theta_union(theta_sketch_agg(col1), theta_sketch_agg(col2))) FROM VALUES (1, 4), (1, 4), (2, 5), (2, 5), (3, 6) tab(col1, col2) | struct<theta_sketch_estimate(theta_union(theta_sketch_agg(col1, 12), theta_sketch_agg(col2, 12), 12)):bigint> |
 | org.apache.spark.sql.catalyst.expressions.TimeBucketExpressionBuilder | time_bucket | SELECT time_bucket(INTERVAL '15' MINUTE, TIMESTAMP '2024-01-01 11:27:00', TIMESTAMP '1970-01-01 00:00:00') | struct<time_bucket(INTERVAL '15' MINUTE, TIMESTAMP '2024-01-01 11:27:00', TIMESTAMP '1970-01-01 00:00:00'):timestamp> |
 | org.apache.spark.sql.catalyst.expressions.TimeDiff | time_diff | SELECT time_diff('HOUR', TIME'20:30:29', TIME'21:30:28') | struct<time_diff(HOUR, TIME '20:30:29', TIME '21:30:28'):bigint> |
+| org.apache.spark.sql.catalyst.expressions.TimeFormat | time_format | SELECT time_format(TIME'14:30:45', 'HH:mm:ss') | struct<time_format(TIME '14:30:45', HH:mm:ss):string> |
 | org.apache.spark.sql.catalyst.expressions.TimeFromMicros | time_from_micros | SELECT time_from_micros(0) | struct<time_from_micros(0):time(6)> |
 | org.apache.spark.sql.catalyst.expressions.TimeFromMillis | time_from_millis | SELECT time_from_millis(0) | struct<time_from_millis(0):time(6)> |
 | org.apache.spark.sql.catalyst.expressions.TimeFromSeconds | time_from_seconds | SELECT time_from_seconds(0) | struct<time_from_seconds(0):time(6)> |

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -379,6 +379,7 @@
 | org.apache.spark.sql.catalyst.expressions.ThetaUnion | theta_union | SELECT theta_sketch_estimate(theta_union(theta_sketch_agg(col1), theta_sketch_agg(col2))) FROM VALUES (1, 4), (1, 4), (2, 5), (2, 5), (3, 6) tab(col1, col2) | struct<theta_sketch_estimate(theta_union(theta_sketch_agg(col1, 12), theta_sketch_agg(col2, 12), 12)):bigint> |
 | org.apache.spark.sql.catalyst.expressions.TimeBucketExpressionBuilder | time_bucket | SELECT time_bucket(INTERVAL '15' MINUTE, TIMESTAMP '2024-01-01 11:27:00', TIMESTAMP '1970-01-01 00:00:00') | struct<time_bucket(INTERVAL '15' MINUTE, TIMESTAMP '2024-01-01 11:27:00', TIMESTAMP '1970-01-01 00:00:00'):timestamp> |
 | org.apache.spark.sql.catalyst.expressions.TimeDiff | time_diff | SELECT time_diff('HOUR', TIME'20:30:29', TIME'21:30:28') | struct<time_diff(HOUR, TIME '20:30:29', TIME '21:30:28'):bigint> |
+| org.apache.spark.sql.catalyst.expressions.TimeFormat | time_format | SELECT time_format(TIME'14:30:45', 'HH:mm:ss') | struct<time_format(TIME '14:30:45', HH:mm:ss):string> |
 | org.apache.spark.sql.catalyst.expressions.TimeFromMicros | time_from_micros | SELECT time_from_micros(0) | struct<time_from_micros(0):time(6)> |
 | org.apache.spark.sql.catalyst.expressions.TimeFromMillis | time_from_millis | SELECT time_from_millis(0) | struct<time_from_millis(0):time(6)> |
 | org.apache.spark.sql.catalyst.expressions.TimeFromSeconds | time_from_seconds | SELECT time_from_seconds(0) | struct<time_from_seconds(0):time(6)> |

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/time.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/time.sql.out
@@ -2513,3 +2513,468 @@ DROP TABLE time_narrow_tbl
 -- !query analysis
 DropTable false, false
 +- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.time_narrow_tbl
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss')
+-- !query analysis
+Project [time_format(14:30:45, HH:mm:ss) AS time_format(TIME '14:30:45', HH:mm:ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'hh:mm:ss a')
+-- !query analysis
+Project [time_format(14:30:45, hh:mm:ss a) AS time_format(TIME '14:30:45', hh:mm:ss a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'hh:mm:ss a')
+-- !query analysis
+Project [time_format(09:15:30, hh:mm:ss a) AS time_format(TIME '09:15:30', hh:mm:ss a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.123', 'HH:mm:ss.SSS')
+-- !query analysis
+Project [time_format(14:30:45.123, HH:mm:ss.SSS) AS time_format(TIME '14:30:45.123', HH:mm:ss.SSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.123456', 'HH:mm:ss.SSSSSS')
+-- !query analysis
+Project [time_format(14:30:45.123456, HH:mm:ss.SSSSSS) AS time_format(TIME '14:30:45.123456', HH:mm:ss.SSSSSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.1234567', 'HH:mm:ss.SSSSSSS')
+-- !query analysis
+Project [time_format(14:30:45.1234567, HH:mm:ss.SSSSSSS) AS time_format(TIME '14:30:45.1234567', HH:mm:ss.SSSSSSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.12345678', 'HH:mm:ss.SSSSSSSS')
+-- !query analysis
+Project [time_format(14:30:45.12345678, HH:mm:ss.SSSSSSSS) AS time_format(TIME '14:30:45.12345678', HH:mm:ss.SSSSSSSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.123456789', 'HH:mm:ss.SSSSSSSSS')
+-- !query analysis
+Project [time_format(14:30:45.123456789, HH:mm:ss.SSSSSSSSS) AS time_format(TIME '14:30:45.123456789', HH:mm:ss.SSSSSSSSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm')
+-- !query analysis
+Project [time_format(14:30:45, HH:mm) AS time_format(TIME '14:30:45', HH:mm)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH')
+-- !query analysis
+Project [time_format(14:30:45, HH) AS time_format(TIME '14:30:45', HH)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'09:05:00', 'H:mm a')
+-- !query analysis
+Project [time_format(09:05:00, H:mm a) AS time_format(TIME '09:05:00', H:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'00:00:00', 'HH:mm:ss')
+-- !query analysis
+Project [time_format(00:00:00, HH:mm:ss) AS time_format(TIME '00:00:00', HH:mm:ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'00:00:00', 'hh:mm:ss a')
+-- !query analysis
+Project [time_format(00:00:00, hh:mm:ss a) AS time_format(TIME '00:00:00', hh:mm:ss a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'12:00:00', 'HH:mm:ss')
+-- !query analysis
+Project [time_format(12:00:00, HH:mm:ss) AS time_format(TIME '12:00:00', HH:mm:ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'12:00:00', 'hh:mm:ss a')
+-- !query analysis
+Project [time_format(12:00:00, hh:mm:ss a) AS time_format(TIME '12:00:00', hh:mm:ss a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'23:59:59', 'HH:mm:ss')
+-- !query analysis
+Project [time_format(23:59:59, HH:mm:ss) AS time_format(TIME '23:59:59', HH:mm:ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'23:59:59.999999', 'HH:mm:ss.SSSSSS')
+-- !query analysis
+Project [time_format(23:59:59.999999, HH:mm:ss.SSSSSS) AS time_format(TIME '23:59:59.999999', HH:mm:ss.SSSSSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(NULL, 'HH:mm:ss')
+-- !query analysis
+Project [time_format(cast(null as time(6)), HH:mm:ss) AS time_format(NULL, HH:mm:ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', NULL)
+-- !query analysis
+Project [time_format(14:30:45, cast(null as string)) AS time_format(TIME '14:30:45', NULL)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(CAST(NULL AS TIME), 'HH:mm:ss')
+-- !query analysis
+Project [time_format(cast(null as time(6)), HH:mm:ss) AS time_format(CAST(NULL AS TIME(6)), HH:mm:ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'hh-mm-ss a')
+-- !query analysis
+Project [time_format(14:30:45, hh-mm-ss a) AS time_format(TIME '14:30:45', hh-mm-ss a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH.mm.ss')
+-- !query analysis
+Project [time_format(14:30:45, HH.mm.ss) AS time_format(TIME '14:30:45', HH.mm.ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH_mm_ss')
+-- !query analysis
+Project [time_format(14:30:45, HH_mm_ss) AS time_format(TIME '14:30:45', HH_mm_ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', '''Time:'' HH:mm:ss')
+-- !query analysis
+Project [time_format(14:30:45, 'Time:' HH:mm:ss) AS time_format(TIME '14:30:45', 'Time:' HH:mm:ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'02:20:30.040', 'H ''hours'' mm ''mins'' ss ''seconds'' SSS ''milliseconds''')
+-- !query analysis
+Project [time_format(02:20:30.04, H 'hours' mm 'mins' ss 'seconds' SSS 'milliseconds') AS time_format(TIME '02:20:30.04', H 'hours' mm 'mins' ss 'seconds' SSS 'milliseconds')#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:05:15', 'H ''hours,'' mm ''minutes and'' ss ''seconds''')
+-- !query analysis
+Project [time_format(14:05:15, H 'hours,' mm 'minutes and' ss 'seconds') AS time_format(TIME '14:05:15', H 'hours,' mm 'minutes and' ss 'seconds')#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'00:00:00', 'a')
+-- !query analysis
+Project [time_format(00:00:00, a) AS time_format(TIME '00:00:00', a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'11:59:59', 'a')
+-- !query analysis
+Project [time_format(11:59:59, a) AS time_format(TIME '11:59:59', a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'12:00:00', 'a')
+-- !query analysis
+Project [time_format(12:00:00, a) AS time_format(TIME '12:00:00', a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'13:00:00', 'a')
+-- !query analysis
+Project [time_format(13:00:00, a) AS time_format(TIME '13:00:00', a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'23:59:59', 'a')
+-- !query analysis
+Project [time_format(23:59:59, a) AS time_format(TIME '23:59:59', a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'00:00:00', 'hh:mm a')
+-- !query analysis
+Project [time_format(00:00:00, hh:mm a) AS time_format(TIME '00:00:00', hh:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'00:30:00', 'hh:mm a')
+-- !query analysis
+Project [time_format(00:30:00, hh:mm a) AS time_format(TIME '00:30:00', hh:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'01:00:00', 'hh:mm a')
+-- !query analysis
+Project [time_format(01:00:00, hh:mm a) AS time_format(TIME '01:00:00', hh:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'11:00:00', 'hh:mm a')
+-- !query analysis
+Project [time_format(11:00:00, hh:mm a) AS time_format(TIME '11:00:00', hh:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'12:00:00', 'hh:mm a')
+-- !query analysis
+Project [time_format(12:00:00, hh:mm a) AS time_format(TIME '12:00:00', hh:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'13:00:00', 'hh:mm a')
+-- !query analysis
+Project [time_format(13:00:00, hh:mm a) AS time_format(TIME '13:00:00', hh:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'H:mm:ss')
+-- !query analysis
+Project [time_format(09:15:30, H:mm:ss) AS time_format(TIME '09:15:30', H:mm:ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'HH:mm:ss')
+-- !query analysis
+Project [time_format(09:15:30, HH:mm:ss) AS time_format(TIME '09:15:30', HH:mm:ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'h:mm a')
+-- !query analysis
+Project [time_format(09:15:30, h:mm a) AS time_format(TIME '09:15:30', h:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'hh:mm a')
+-- !query analysis
+Project [time_format(09:15:30, hh:mm a) AS time_format(TIME '09:15:30', hh:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.1', 'HH:mm:ss.S')
+-- !query analysis
+Project [time_format(14:30:45.1, HH:mm:ss.S) AS time_format(TIME '14:30:45.1', HH:mm:ss.S)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.12', 'HH:mm:ss.SS')
+-- !query analysis
+Project [time_format(14:30:45.12, HH:mm:ss.SS) AS time_format(TIME '14:30:45.12', HH:mm:ss.SS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT coalesce(time_format(NULL, 'HH:mm'), 'N/A')
+-- !query analysis
+Project [coalesce(time_format(cast(null as time(6)), HH:mm), N/A) AS coalesce(time_format(NULL, HH:mm), N/A)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT coalesce(time_format(TIME'14:30:45', NULL), 'N/A')
+-- !query analysis
+Project [coalesce(time_format(14:30:45, cast(null as string)), N/A) AS coalesce(time_format(TIME '14:30:45', NULL), N/A)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT concat('The time is ', time_format(TIME'14:30:45', 'hh:mm a'))
+-- !query analysis
+Project [concat(The time is , time_format(14:30:45, hh:mm a)) AS concat(The time is , time_format(TIME '14:30:45', hh:mm a))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss (hh:mm:ss a)')
+-- !query analysis
+Project [time_format(14:30:45, HH:mm:ss (hh:mm:ss a)) AS time_format(TIME '14:30:45', HH:mm:ss (hh:mm:ss a))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'HH:mm (h:mm a)')
+-- !query analysis
+Project [time_format(09:15:30, HH:mm (h:mm a)) AS time_format(TIME '09:15:30', HH:mm (h:mm a))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'23:45:00', '''24hr:'' HH:mm ''12hr:'' hh:mm a')
+-- !query analysis
+Project [time_format(23:45:00, '24hr:' HH:mm '12hr:' hh:mm a) AS time_format(TIME '23:45:00', '24hr:' HH:mm '12hr:' hh:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'00:30:00', 'HH:mm:ss = hh:mm:ss a')
+-- !query analysis
+Project [time_format(00:30:00, HH:mm:ss = hh:mm:ss a) AS time_format(TIME '00:30:00', HH:mm:ss = hh:mm:ss a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss ''(24h)'' / hh:mm:ss a ''(12h)''')
+-- !query analysis
+Project [time_format(14:30:45, HH:mm:ss '(24h)' / hh:mm:ss a '(12h)') AS time_format(TIME '14:30:45', HH:mm:ss '(24h)' / hh:mm:ss a '(12h)')#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss'), time_format(TIME'14:30:45', 'hh:mm:ss a')
+-- !query analysis
+Project [time_format(14:30:45, HH:mm:ss) AS time_format(TIME '14:30:45', HH:mm:ss)#x, time_format(14:30:45, hh:mm:ss a) AS time_format(TIME '14:30:45', hh:mm:ss a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'HH:mm'), time_format(TIME'09:15:30', 'h:mm a')
+-- !query analysis
+Project [time_format(09:15:30, HH:mm) AS time_format(TIME '09:15:30', HH:mm)#x, time_format(09:15:30, h:mm a) AS time_format(TIME '09:15:30', h:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT
+  time_format(TIME'14:30:45.123456', 'HH:mm:ss') as format_24hr,
+  time_format(TIME'14:30:45.123456', 'hh:mm:ss a') as format_12hr,
+  time_format(TIME'14:30:45.123456', 'HH:mm:ss.SSSSSS') as format_with_micros
+-- !query analysis
+Project [time_format(14:30:45.123456, HH:mm:ss) AS format_24hr#x, time_format(14:30:45.123456, hh:mm:ss a) AS format_12hr#x, time_format(14:30:45.123456, HH:mm:ss.SSSSSS) AS format_with_micros#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss ''UTC''')
+-- !query analysis
+Project [time_format(14:30:45, HH:mm:ss 'UTC') AS time_format(TIME '14:30:45', HH:mm:ss 'UTC')#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', '[HH:mm:ss]')
+-- !query analysis
+Project [time_format(14:30:45, [HH:mm:ss]) AS time_format(TIME '14:30:45', [HH:mm:ss])#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH|mm|ss')
+-- !query analysis
+Project [time_format(14:30:45, HH|mm|ss) AS time_format(TIME '14:30:45', HH|mm|ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH-mm-ss')
+-- !query analysis
+Project [time_format(14:30:45, HH-mm-ss) AS time_format(TIME '14:30:45', HH-mm-ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:MM:ss')
+-- !query analysis
+Project [time_format(14:30:45, HH:MM:ss) AS time_format(TIME '14:30:45', HH:MM:ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.000', 'HH:mm:ss.SSS')
+-- !query analysis
+Project [time_format(14:30:45, HH:mm:ss.SSS) AS time_format(TIME '14:30:45', HH:mm:ss.SSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.999', 'HH:mm:ss.SSS')
+-- !query analysis
+Project [time_format(14:30:45.999, HH:mm:ss.SSS) AS time_format(TIME '14:30:45.999', HH:mm:ss.SSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.001', 'HH:mm:ss.SSS')
+-- !query analysis
+Project [time_format(14:30:45.001, HH:mm:ss.SSS) AS time_format(TIME '14:30:45.001', HH:mm:ss.SSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.000000', 'HH:mm:ss.SSSSSS')
+-- !query analysis
+Project [time_format(14:30:45, HH:mm:ss.SSSSSS) AS time_format(TIME '14:30:45', HH:mm:ss.SSSSSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.999999', 'HH:mm:ss.SSSSSS')
+-- !query analysis
+Project [time_format(14:30:45.999999, HH:mm:ss.SSSSSS) AS time_format(TIME '14:30:45.999999', HH:mm:ss.SSSSSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.000001', 'HH:mm:ss.SSSSSS')
+-- !query analysis
+Project [time_format(14:30:45.000001, HH:mm:ss.SSSSSS) AS time_format(TIME '14:30:45.000001', HH:mm:ss.SSSSSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT cast(time_format(TIME'14:30:45', 'HH:mm:ss') as string)
+-- !query analysis
+Project [cast(time_format(14:30:45, HH:mm:ss) as string) AS CAST(time_format(TIME '14:30:45', HH:mm:ss) AS STRING)#x]
++- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/time.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/time.sql.out
@@ -2527,3 +2527,468 @@ DROP TABLE time_narrow_tbl
 -- !query analysis
 DropTable false, false
 +- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.time_narrow_tbl
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss')
+-- !query analysis
+Project [time_format(14:30:45, HH:mm:ss) AS time_format(TIME '14:30:45', HH:mm:ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'hh:mm:ss a')
+-- !query analysis
+Project [time_format(14:30:45, hh:mm:ss a) AS time_format(TIME '14:30:45', hh:mm:ss a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'hh:mm:ss a')
+-- !query analysis
+Project [time_format(09:15:30, hh:mm:ss a) AS time_format(TIME '09:15:30', hh:mm:ss a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.123', 'HH:mm:ss.SSS')
+-- !query analysis
+Project [time_format(14:30:45.123, HH:mm:ss.SSS) AS time_format(TIME '14:30:45.123', HH:mm:ss.SSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.123456', 'HH:mm:ss.SSSSSS')
+-- !query analysis
+Project [time_format(14:30:45.123456, HH:mm:ss.SSSSSS) AS time_format(TIME '14:30:45.123456', HH:mm:ss.SSSSSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.1234567', 'HH:mm:ss.SSSSSSS')
+-- !query analysis
+Project [time_format(14:30:45.1234567, HH:mm:ss.SSSSSSS) AS time_format(TIME '14:30:45.1234567', HH:mm:ss.SSSSSSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.12345678', 'HH:mm:ss.SSSSSSSS')
+-- !query analysis
+Project [time_format(14:30:45.12345678, HH:mm:ss.SSSSSSSS) AS time_format(TIME '14:30:45.12345678', HH:mm:ss.SSSSSSSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.123456789', 'HH:mm:ss.SSSSSSSSS')
+-- !query analysis
+Project [time_format(14:30:45.123456789, HH:mm:ss.SSSSSSSSS) AS time_format(TIME '14:30:45.123456789', HH:mm:ss.SSSSSSSSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm')
+-- !query analysis
+Project [time_format(14:30:45, HH:mm) AS time_format(TIME '14:30:45', HH:mm)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH')
+-- !query analysis
+Project [time_format(14:30:45, HH) AS time_format(TIME '14:30:45', HH)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'09:05:00', 'H:mm a')
+-- !query analysis
+Project [time_format(09:05:00, H:mm a) AS time_format(TIME '09:05:00', H:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'00:00:00', 'HH:mm:ss')
+-- !query analysis
+Project [time_format(00:00:00, HH:mm:ss) AS time_format(TIME '00:00:00', HH:mm:ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'00:00:00', 'hh:mm:ss a')
+-- !query analysis
+Project [time_format(00:00:00, hh:mm:ss a) AS time_format(TIME '00:00:00', hh:mm:ss a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'12:00:00', 'HH:mm:ss')
+-- !query analysis
+Project [time_format(12:00:00, HH:mm:ss) AS time_format(TIME '12:00:00', HH:mm:ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'12:00:00', 'hh:mm:ss a')
+-- !query analysis
+Project [time_format(12:00:00, hh:mm:ss a) AS time_format(TIME '12:00:00', hh:mm:ss a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'23:59:59', 'HH:mm:ss')
+-- !query analysis
+Project [time_format(23:59:59, HH:mm:ss) AS time_format(TIME '23:59:59', HH:mm:ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'23:59:59.999999', 'HH:mm:ss.SSSSSS')
+-- !query analysis
+Project [time_format(23:59:59.999999, HH:mm:ss.SSSSSS) AS time_format(TIME '23:59:59.999999', HH:mm:ss.SSSSSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(NULL, 'HH:mm:ss')
+-- !query analysis
+Project [time_format(cast(null as time(6)), HH:mm:ss) AS time_format(NULL, HH:mm:ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', NULL)
+-- !query analysis
+Project [time_format(14:30:45, cast(null as string)) AS time_format(TIME '14:30:45', NULL)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(CAST(NULL AS TIME), 'HH:mm:ss')
+-- !query analysis
+Project [time_format(cast(null as time(6)), HH:mm:ss) AS time_format(CAST(NULL AS TIME(6)), HH:mm:ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'hh-mm-ss a')
+-- !query analysis
+Project [time_format(14:30:45, hh-mm-ss a) AS time_format(TIME '14:30:45', hh-mm-ss a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH.mm.ss')
+-- !query analysis
+Project [time_format(14:30:45, HH.mm.ss) AS time_format(TIME '14:30:45', HH.mm.ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH_mm_ss')
+-- !query analysis
+Project [time_format(14:30:45, HH_mm_ss) AS time_format(TIME '14:30:45', HH_mm_ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', '''Time:'' HH:mm:ss')
+-- !query analysis
+Project [time_format(14:30:45, 'Time:' HH:mm:ss) AS time_format(TIME '14:30:45', 'Time:' HH:mm:ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'02:20:30.040', 'H ''hours'' mm ''mins'' ss ''seconds'' SSS ''milliseconds''')
+-- !query analysis
+Project [time_format(02:20:30.04, H 'hours' mm 'mins' ss 'seconds' SSS 'milliseconds') AS time_format(TIME '02:20:30.04', H 'hours' mm 'mins' ss 'seconds' SSS 'milliseconds')#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:05:15', 'H ''hours,'' mm ''minutes and'' ss ''seconds''')
+-- !query analysis
+Project [time_format(14:05:15, H 'hours,' mm 'minutes and' ss 'seconds') AS time_format(TIME '14:05:15', H 'hours,' mm 'minutes and' ss 'seconds')#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'00:00:00', 'a')
+-- !query analysis
+Project [time_format(00:00:00, a) AS time_format(TIME '00:00:00', a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'11:59:59', 'a')
+-- !query analysis
+Project [time_format(11:59:59, a) AS time_format(TIME '11:59:59', a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'12:00:00', 'a')
+-- !query analysis
+Project [time_format(12:00:00, a) AS time_format(TIME '12:00:00', a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'13:00:00', 'a')
+-- !query analysis
+Project [time_format(13:00:00, a) AS time_format(TIME '13:00:00', a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'23:59:59', 'a')
+-- !query analysis
+Project [time_format(23:59:59, a) AS time_format(TIME '23:59:59', a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'00:00:00', 'hh:mm a')
+-- !query analysis
+Project [time_format(00:00:00, hh:mm a) AS time_format(TIME '00:00:00', hh:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'00:30:00', 'hh:mm a')
+-- !query analysis
+Project [time_format(00:30:00, hh:mm a) AS time_format(TIME '00:30:00', hh:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'01:00:00', 'hh:mm a')
+-- !query analysis
+Project [time_format(01:00:00, hh:mm a) AS time_format(TIME '01:00:00', hh:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'11:00:00', 'hh:mm a')
+-- !query analysis
+Project [time_format(11:00:00, hh:mm a) AS time_format(TIME '11:00:00', hh:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'12:00:00', 'hh:mm a')
+-- !query analysis
+Project [time_format(12:00:00, hh:mm a) AS time_format(TIME '12:00:00', hh:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'13:00:00', 'hh:mm a')
+-- !query analysis
+Project [time_format(13:00:00, hh:mm a) AS time_format(TIME '13:00:00', hh:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'H:mm:ss')
+-- !query analysis
+Project [time_format(09:15:30, H:mm:ss) AS time_format(TIME '09:15:30', H:mm:ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'HH:mm:ss')
+-- !query analysis
+Project [time_format(09:15:30, HH:mm:ss) AS time_format(TIME '09:15:30', HH:mm:ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'h:mm a')
+-- !query analysis
+Project [time_format(09:15:30, h:mm a) AS time_format(TIME '09:15:30', h:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'hh:mm a')
+-- !query analysis
+Project [time_format(09:15:30, hh:mm a) AS time_format(TIME '09:15:30', hh:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.1', 'HH:mm:ss.S')
+-- !query analysis
+Project [time_format(14:30:45.1, HH:mm:ss.S) AS time_format(TIME '14:30:45.1', HH:mm:ss.S)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.12', 'HH:mm:ss.SS')
+-- !query analysis
+Project [time_format(14:30:45.12, HH:mm:ss.SS) AS time_format(TIME '14:30:45.12', HH:mm:ss.SS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT coalesce(time_format(NULL, 'HH:mm'), 'N/A')
+-- !query analysis
+Project [coalesce(time_format(cast(null as time(6)), HH:mm), N/A) AS coalesce(time_format(NULL, HH:mm), N/A)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT coalesce(time_format(TIME'14:30:45', NULL), 'N/A')
+-- !query analysis
+Project [coalesce(time_format(14:30:45, cast(null as string)), N/A) AS coalesce(time_format(TIME '14:30:45', NULL), N/A)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT concat('The time is ', time_format(TIME'14:30:45', 'hh:mm a'))
+-- !query analysis
+Project [concat(The time is , time_format(14:30:45, hh:mm a)) AS concat(The time is , time_format(TIME '14:30:45', hh:mm a))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss (hh:mm:ss a)')
+-- !query analysis
+Project [time_format(14:30:45, HH:mm:ss (hh:mm:ss a)) AS time_format(TIME '14:30:45', HH:mm:ss (hh:mm:ss a))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'HH:mm (h:mm a)')
+-- !query analysis
+Project [time_format(09:15:30, HH:mm (h:mm a)) AS time_format(TIME '09:15:30', HH:mm (h:mm a))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'23:45:00', '''24hr:'' HH:mm ''12hr:'' hh:mm a')
+-- !query analysis
+Project [time_format(23:45:00, '24hr:' HH:mm '12hr:' hh:mm a) AS time_format(TIME '23:45:00', '24hr:' HH:mm '12hr:' hh:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'00:30:00', 'HH:mm:ss = hh:mm:ss a')
+-- !query analysis
+Project [time_format(00:30:00, HH:mm:ss = hh:mm:ss a) AS time_format(TIME '00:30:00', HH:mm:ss = hh:mm:ss a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss ''(24h)'' / hh:mm:ss a ''(12h)''')
+-- !query analysis
+Project [time_format(14:30:45, HH:mm:ss '(24h)' / hh:mm:ss a '(12h)') AS time_format(TIME '14:30:45', HH:mm:ss '(24h)' / hh:mm:ss a '(12h)')#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss'), time_format(TIME'14:30:45', 'hh:mm:ss a')
+-- !query analysis
+Project [time_format(14:30:45, HH:mm:ss) AS time_format(TIME '14:30:45', HH:mm:ss)#x, time_format(14:30:45, hh:mm:ss a) AS time_format(TIME '14:30:45', hh:mm:ss a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'HH:mm'), time_format(TIME'09:15:30', 'h:mm a')
+-- !query analysis
+Project [time_format(09:15:30, HH:mm) AS time_format(TIME '09:15:30', HH:mm)#x, time_format(09:15:30, h:mm a) AS time_format(TIME '09:15:30', h:mm a)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT
+  time_format(TIME'14:30:45.123456', 'HH:mm:ss') as format_24hr,
+  time_format(TIME'14:30:45.123456', 'hh:mm:ss a') as format_12hr,
+  time_format(TIME'14:30:45.123456', 'HH:mm:ss.SSSSSS') as format_with_micros
+-- !query analysis
+Project [time_format(14:30:45.123456, HH:mm:ss) AS format_24hr#x, time_format(14:30:45.123456, hh:mm:ss a) AS format_12hr#x, time_format(14:30:45.123456, HH:mm:ss.SSSSSS) AS format_with_micros#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss ''UTC''')
+-- !query analysis
+Project [time_format(14:30:45, HH:mm:ss 'UTC') AS time_format(TIME '14:30:45', HH:mm:ss 'UTC')#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', '[HH:mm:ss]')
+-- !query analysis
+Project [time_format(14:30:45, [HH:mm:ss]) AS time_format(TIME '14:30:45', [HH:mm:ss])#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH|mm|ss')
+-- !query analysis
+Project [time_format(14:30:45, HH|mm|ss) AS time_format(TIME '14:30:45', HH|mm|ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH-mm-ss')
+-- !query analysis
+Project [time_format(14:30:45, HH-mm-ss) AS time_format(TIME '14:30:45', HH-mm-ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:MM:ss')
+-- !query analysis
+Project [time_format(14:30:45, HH:MM:ss) AS time_format(TIME '14:30:45', HH:MM:ss)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.000', 'HH:mm:ss.SSS')
+-- !query analysis
+Project [time_format(14:30:45, HH:mm:ss.SSS) AS time_format(TIME '14:30:45', HH:mm:ss.SSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.999', 'HH:mm:ss.SSS')
+-- !query analysis
+Project [time_format(14:30:45.999, HH:mm:ss.SSS) AS time_format(TIME '14:30:45.999', HH:mm:ss.SSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.001', 'HH:mm:ss.SSS')
+-- !query analysis
+Project [time_format(14:30:45.001, HH:mm:ss.SSS) AS time_format(TIME '14:30:45.001', HH:mm:ss.SSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.000000', 'HH:mm:ss.SSSSSS')
+-- !query analysis
+Project [time_format(14:30:45, HH:mm:ss.SSSSSS) AS time_format(TIME '14:30:45', HH:mm:ss.SSSSSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.999999', 'HH:mm:ss.SSSSSS')
+-- !query analysis
+Project [time_format(14:30:45.999999, HH:mm:ss.SSSSSS) AS time_format(TIME '14:30:45.999999', HH:mm:ss.SSSSSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.000001', 'HH:mm:ss.SSSSSS')
+-- !query analysis
+Project [time_format(14:30:45.000001, HH:mm:ss.SSSSSS) AS time_format(TIME '14:30:45.000001', HH:mm:ss.SSSSSS)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT cast(time_format(TIME'14:30:45', 'HH:mm:ss') as string)
+-- !query analysis
+Project [cast(time_format(14:30:45, HH:mm:ss) as string) AS CAST(time_format(TIME '14:30:45', HH:mm:ss) AS STRING)#x]
++- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/inputs/time.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/time.sql
@@ -438,6 +438,9 @@ SELECT time_format(TIME'09:15:30', 'hh:mm:ss a');
 -- Test with different precisions
 SELECT time_format(TIME'14:30:45.123', 'HH:mm:ss.SSS');
 SELECT time_format(TIME'14:30:45.123456', 'HH:mm:ss.SSSSSS');
+SELECT time_format(TIME'14:30:45.1234567', 'HH:mm:ss.SSSSSSS');
+SELECT time_format(TIME'14:30:45.12345678', 'HH:mm:ss.SSSSSSSS');
+SELECT time_format(TIME'14:30:45.123456789', 'HH:mm:ss.SSSSSSSSS');
 
 -- Test various format patterns
 SELECT time_format(TIME'14:30:45', 'HH:mm');

--- a/sql/core/src/test/resources/sql-tests/inputs/time.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/time.sql
@@ -426,3 +426,120 @@ INSERT INTO time_narrow_tbl SELECT '01:02:03.456789' :: TIME(6);
 INSERT INTO time_narrow_tbl SELECT CAST('01:02:03.456789' :: TIME(6) AS TIME(3));
 SELECT typeof(t3), t3 FROM time_narrow_tbl;
 DROP TABLE time_narrow_tbl;
+
+-- TIME_FORMAT function tests
+-- Test basic 24-hour format
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss');
+
+-- Test 12-hour format with AM/PM
+SELECT time_format(TIME'14:30:45', 'hh:mm:ss a');
+SELECT time_format(TIME'09:15:30', 'hh:mm:ss a');
+
+-- Test with different precisions
+SELECT time_format(TIME'14:30:45.123', 'HH:mm:ss.SSS');
+SELECT time_format(TIME'14:30:45.123456', 'HH:mm:ss.SSSSSS');
+
+-- Test various format patterns
+SELECT time_format(TIME'14:30:45', 'HH:mm');
+SELECT time_format(TIME'14:30:45', 'HH');
+SELECT time_format(TIME'09:05:00', 'H:mm a');
+
+-- Test edge cases - midnight
+SELECT time_format(TIME'00:00:00', 'HH:mm:ss');
+SELECT time_format(TIME'00:00:00', 'hh:mm:ss a');
+
+-- Test edge cases - noon
+SELECT time_format(TIME'12:00:00', 'HH:mm:ss');
+SELECT time_format(TIME'12:00:00', 'hh:mm:ss a');
+
+-- Test edge cases - end of day
+SELECT time_format(TIME'23:59:59', 'HH:mm:ss');
+SELECT time_format(TIME'23:59:59.999999', 'HH:mm:ss.SSSSSS');
+
+-- Test null handling
+SELECT time_format(NULL, 'HH:mm:ss');
+SELECT time_format(TIME'14:30:45', NULL);
+SELECT time_format(CAST(NULL AS TIME), 'HH:mm:ss');
+
+-- Test custom formats with different separators
+SELECT time_format(TIME'14:30:45', 'hh-mm-ss a');
+SELECT time_format(TIME'14:30:45', 'HH.mm.ss');
+SELECT time_format(TIME'14:30:45', 'HH_mm_ss');
+
+-- Test with text literals
+SELECT time_format(TIME'14:30:45', '''Time:'' HH:mm:ss');
+
+-- Test verbose formats
+SELECT time_format(TIME'02:20:30.040', 'H ''hours'' mm ''mins'' ss ''seconds'' SSS ''milliseconds''');
+SELECT time_format(TIME'14:05:15', 'H ''hours,'' mm ''minutes and'' ss ''seconds''');
+
+-- Test AM/PM edge cases
+SELECT time_format(TIME'00:00:00', 'a');
+SELECT time_format(TIME'11:59:59', 'a');
+SELECT time_format(TIME'12:00:00', 'a');
+SELECT time_format(TIME'13:00:00', 'a');
+SELECT time_format(TIME'23:59:59', 'a');
+
+-- Test hour edge cases for 12-hour format
+SELECT time_format(TIME'00:00:00', 'hh:mm a');
+SELECT time_format(TIME'00:30:00', 'hh:mm a');
+SELECT time_format(TIME'01:00:00', 'hh:mm a');
+SELECT time_format(TIME'11:00:00', 'hh:mm a');
+SELECT time_format(TIME'12:00:00', 'hh:mm a');
+SELECT time_format(TIME'13:00:00', 'hh:mm a');
+
+-- Test single vs double digit hour (H vs HH)
+SELECT time_format(TIME'09:15:30', 'H:mm:ss');
+SELECT time_format(TIME'09:15:30', 'HH:mm:ss');
+SELECT time_format(TIME'09:15:30', 'h:mm a');
+SELECT time_format(TIME'09:15:30', 'hh:mm a');
+
+-- Test precision variations (additional subsecond formats)
+SELECT time_format(TIME'14:30:45.1', 'HH:mm:ss.S');
+SELECT time_format(TIME'14:30:45.12', 'HH:mm:ss.SS');
+
+-- Test with COALESCE
+SELECT coalesce(time_format(NULL, 'HH:mm'), 'N/A');
+SELECT coalesce(time_format(TIME'14:30:45', NULL), 'N/A');
+
+-- Test concatenation with formatted time
+SELECT concat('The time is ', time_format(TIME'14:30:45', 'hh:mm a'));
+
+-- Test single format showing both 24-hour and 12-hour in one output
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss (hh:mm:ss a)');
+SELECT time_format(TIME'09:15:30', 'HH:mm (h:mm a)');
+SELECT time_format(TIME'23:45:00', '''24hr:'' HH:mm ''12hr:'' hh:mm a');
+SELECT time_format(TIME'00:30:00', 'HH:mm:ss = hh:mm:ss a');
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss ''(24h)'' / hh:mm:ss a ''(12h)''');
+
+-- Test multiple formats in single query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss'), time_format(TIME'14:30:45', 'hh:mm:ss a');
+SELECT time_format(TIME'09:15:30', 'HH:mm'), time_format(TIME'09:15:30', 'h:mm a');
+SELECT
+  time_format(TIME'14:30:45.123456', 'HH:mm:ss') as format_24hr,
+  time_format(TIME'14:30:45.123456', 'hh:mm:ss a') as format_12hr,
+  time_format(TIME'14:30:45.123456', 'HH:mm:ss.SSSSSS') as format_with_micros;
+
+-- Test special characters and patterns
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss ''UTC''');
+SELECT time_format(TIME'14:30:45', '[HH:mm:ss]');
+SELECT time_format(TIME'14:30:45', 'HH|mm|ss');
+SELECT time_format(TIME'14:30:45', 'HH-mm-ss');
+
+-- Test common mistake: MM (month) vs mm (minute)
+-- MM is for month (a date field), mm is for minute. DATE fields are unsupported for TIME values
+-- and raise an error; only time-related patterns (H, h, m, s, S, a) are meaningful.
+SELECT time_format(TIME'14:30:45', 'HH:MM:ss');
+
+-- Test with millisecond precision edge cases
+SELECT time_format(TIME'14:30:45.000', 'HH:mm:ss.SSS');
+SELECT time_format(TIME'14:30:45.999', 'HH:mm:ss.SSS');
+SELECT time_format(TIME'14:30:45.001', 'HH:mm:ss.SSS');
+
+-- Test with microsecond precision edge cases
+SELECT time_format(TIME'14:30:45.000000', 'HH:mm:ss.SSSSSS');
+SELECT time_format(TIME'14:30:45.999999', 'HH:mm:ss.SSSSSS');
+SELECT time_format(TIME'14:30:45.000001', 'HH:mm:ss.SSSSSS');
+
+-- Test CAST behavior with formatted output
+SELECT cast(time_format(TIME'14:30:45', 'HH:mm:ss') as string);

--- a/sql/core/src/test/resources/sql-tests/inputs/time.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/time.sql
@@ -430,3 +430,120 @@ INSERT INTO time_narrow_tbl SELECT '01:02:03.456789' :: TIME(6);
 INSERT INTO time_narrow_tbl SELECT CAST('01:02:03.456789' :: TIME(6) AS TIME(3));
 SELECT typeof(t3), t3 FROM time_narrow_tbl;
 DROP TABLE time_narrow_tbl;
+
+-- TIME_FORMAT function tests
+-- Test basic 24-hour format
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss');
+
+-- Test 12-hour format with AM/PM
+SELECT time_format(TIME'14:30:45', 'hh:mm:ss a');
+SELECT time_format(TIME'09:15:30', 'hh:mm:ss a');
+
+-- Test with different precisions
+SELECT time_format(TIME'14:30:45.123', 'HH:mm:ss.SSS');
+SELECT time_format(TIME'14:30:45.123456', 'HH:mm:ss.SSSSSS');
+
+-- Test various format patterns
+SELECT time_format(TIME'14:30:45', 'HH:mm');
+SELECT time_format(TIME'14:30:45', 'HH');
+SELECT time_format(TIME'09:05:00', 'H:mm a');
+
+-- Test edge cases - midnight
+SELECT time_format(TIME'00:00:00', 'HH:mm:ss');
+SELECT time_format(TIME'00:00:00', 'hh:mm:ss a');
+
+-- Test edge cases - noon
+SELECT time_format(TIME'12:00:00', 'HH:mm:ss');
+SELECT time_format(TIME'12:00:00', 'hh:mm:ss a');
+
+-- Test edge cases - end of day
+SELECT time_format(TIME'23:59:59', 'HH:mm:ss');
+SELECT time_format(TIME'23:59:59.999999', 'HH:mm:ss.SSSSSS');
+
+-- Test null handling
+SELECT time_format(NULL, 'HH:mm:ss');
+SELECT time_format(TIME'14:30:45', NULL);
+SELECT time_format(CAST(NULL AS TIME), 'HH:mm:ss');
+
+-- Test custom formats with different separators
+SELECT time_format(TIME'14:30:45', 'hh-mm-ss a');
+SELECT time_format(TIME'14:30:45', 'HH.mm.ss');
+SELECT time_format(TIME'14:30:45', 'HH_mm_ss');
+
+-- Test with text literals
+SELECT time_format(TIME'14:30:45', '''Time:'' HH:mm:ss');
+
+-- Test verbose formats
+SELECT time_format(TIME'02:20:30.040', 'H ''hours'' mm ''mins'' ss ''seconds'' SSS ''milliseconds''');
+SELECT time_format(TIME'14:05:15', 'H ''hours,'' mm ''minutes and'' ss ''seconds''');
+
+-- Test AM/PM edge cases
+SELECT time_format(TIME'00:00:00', 'a');
+SELECT time_format(TIME'11:59:59', 'a');
+SELECT time_format(TIME'12:00:00', 'a');
+SELECT time_format(TIME'13:00:00', 'a');
+SELECT time_format(TIME'23:59:59', 'a');
+
+-- Test hour edge cases for 12-hour format
+SELECT time_format(TIME'00:00:00', 'hh:mm a');
+SELECT time_format(TIME'00:30:00', 'hh:mm a');
+SELECT time_format(TIME'01:00:00', 'hh:mm a');
+SELECT time_format(TIME'11:00:00', 'hh:mm a');
+SELECT time_format(TIME'12:00:00', 'hh:mm a');
+SELECT time_format(TIME'13:00:00', 'hh:mm a');
+
+-- Test single vs double digit hour (H vs HH)
+SELECT time_format(TIME'09:15:30', 'H:mm:ss');
+SELECT time_format(TIME'09:15:30', 'HH:mm:ss');
+SELECT time_format(TIME'09:15:30', 'h:mm a');
+SELECT time_format(TIME'09:15:30', 'hh:mm a');
+
+-- Test precision variations (additional subsecond formats)
+SELECT time_format(TIME'14:30:45.1', 'HH:mm:ss.S');
+SELECT time_format(TIME'14:30:45.12', 'HH:mm:ss.SS');
+
+-- Test with COALESCE
+SELECT coalesce(time_format(NULL, 'HH:mm'), 'N/A');
+SELECT coalesce(time_format(TIME'14:30:45', NULL), 'N/A');
+
+-- Test concatenation with formatted time
+SELECT concat('The time is ', time_format(TIME'14:30:45', 'hh:mm a'));
+
+-- Test single format showing both 24-hour and 12-hour in one output
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss (hh:mm:ss a)');
+SELECT time_format(TIME'09:15:30', 'HH:mm (h:mm a)');
+SELECT time_format(TIME'23:45:00', '''24hr:'' HH:mm ''12hr:'' hh:mm a');
+SELECT time_format(TIME'00:30:00', 'HH:mm:ss = hh:mm:ss a');
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss ''(24h)'' / hh:mm:ss a ''(12h)''');
+
+-- Test multiple formats in single query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss'), time_format(TIME'14:30:45', 'hh:mm:ss a');
+SELECT time_format(TIME'09:15:30', 'HH:mm'), time_format(TIME'09:15:30', 'h:mm a');
+SELECT
+  time_format(TIME'14:30:45.123456', 'HH:mm:ss') as format_24hr,
+  time_format(TIME'14:30:45.123456', 'hh:mm:ss a') as format_12hr,
+  time_format(TIME'14:30:45.123456', 'HH:mm:ss.SSSSSS') as format_with_micros;
+
+-- Test special characters and patterns
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss ''UTC''');
+SELECT time_format(TIME'14:30:45', '[HH:mm:ss]');
+SELECT time_format(TIME'14:30:45', 'HH|mm|ss');
+SELECT time_format(TIME'14:30:45', 'HH-mm-ss');
+
+-- Test common mistake: MM (month) vs mm (minute)
+-- MM is for month (a date field), mm is for minute. DATE fields are unsupported for TIME values
+-- and raise an error; only time-related patterns (H, h, m, s, S, a) are meaningful.
+SELECT time_format(TIME'14:30:45', 'HH:MM:ss');
+
+-- Test with millisecond precision edge cases
+SELECT time_format(TIME'14:30:45.000', 'HH:mm:ss.SSS');
+SELECT time_format(TIME'14:30:45.999', 'HH:mm:ss.SSS');
+SELECT time_format(TIME'14:30:45.001', 'HH:mm:ss.SSS');
+
+-- Test with microsecond precision edge cases
+SELECT time_format(TIME'14:30:45.000000', 'HH:mm:ss.SSSSSS');
+SELECT time_format(TIME'14:30:45.999999', 'HH:mm:ss.SSSSSS');
+SELECT time_format(TIME'14:30:45.000001', 'HH:mm:ss.SSSSSS');
+
+-- Test CAST behavior with formatted output
+SELECT cast(time_format(TIME'14:30:45', 'HH:mm:ss') as string);

--- a/sql/core/src/test/resources/sql-tests/inputs/time.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/time.sql
@@ -442,6 +442,9 @@ SELECT time_format(TIME'09:15:30', 'hh:mm:ss a');
 -- Test with different precisions
 SELECT time_format(TIME'14:30:45.123', 'HH:mm:ss.SSS');
 SELECT time_format(TIME'14:30:45.123456', 'HH:mm:ss.SSSSSS');
+SELECT time_format(TIME'14:30:45.1234567', 'HH:mm:ss.SSSSSSS');
+SELECT time_format(TIME'14:30:45.12345678', 'HH:mm:ss.SSSSSSSS');
+SELECT time_format(TIME'14:30:45.123456789', 'HH:mm:ss.SSSSSSSSS');
 
 -- Test various format patterns
 SELECT time_format(TIME'14:30:45', 'HH:mm');

--- a/sql/core/src/test/resources/sql-tests/results/time.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/time.sql.out
@@ -3018,3 +3018,543 @@ DROP TABLE time_narrow_tbl
 struct<>
 -- !query output
 
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH:mm:ss):string>
+-- !query output
+14:30:45
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'hh:mm:ss a')
+-- !query schema
+struct<time_format(TIME '14:30:45', hh:mm:ss a):string>
+-- !query output
+02:30:45 PM
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'hh:mm:ss a')
+-- !query schema
+struct<time_format(TIME '09:15:30', hh:mm:ss a):string>
+-- !query output
+09:15:30 AM
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.123', 'HH:mm:ss.SSS')
+-- !query schema
+struct<time_format(TIME '14:30:45.123', HH:mm:ss.SSS):string>
+-- !query output
+14:30:45.123
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.123456', 'HH:mm:ss.SSSSSS')
+-- !query schema
+struct<time_format(TIME '14:30:45.123456', HH:mm:ss.SSSSSS):string>
+-- !query output
+14:30:45.123456
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.1234567', 'HH:mm:ss.SSSSSSS')
+-- !query schema
+struct<time_format(TIME '14:30:45.1234567', HH:mm:ss.SSSSSSS):string>
+-- !query output
+14:30:45.1234567
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.12345678', 'HH:mm:ss.SSSSSSSS')
+-- !query schema
+struct<time_format(TIME '14:30:45.12345678', HH:mm:ss.SSSSSSSS):string>
+-- !query output
+14:30:45.12345678
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.123456789', 'HH:mm:ss.SSSSSSSSS')
+-- !query schema
+struct<time_format(TIME '14:30:45.123456789', HH:mm:ss.SSSSSSSSS):string>
+-- !query output
+14:30:45.123456789
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH:mm):string>
+-- !query output
+14:30
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH):string>
+-- !query output
+14
+
+
+-- !query
+SELECT time_format(TIME'09:05:00', 'H:mm a')
+-- !query schema
+struct<time_format(TIME '09:05:00', H:mm a):string>
+-- !query output
+9:05 AM
+
+
+-- !query
+SELECT time_format(TIME'00:00:00', 'HH:mm:ss')
+-- !query schema
+struct<time_format(TIME '00:00:00', HH:mm:ss):string>
+-- !query output
+00:00:00
+
+
+-- !query
+SELECT time_format(TIME'00:00:00', 'hh:mm:ss a')
+-- !query schema
+struct<time_format(TIME '00:00:00', hh:mm:ss a):string>
+-- !query output
+12:00:00 AM
+
+
+-- !query
+SELECT time_format(TIME'12:00:00', 'HH:mm:ss')
+-- !query schema
+struct<time_format(TIME '12:00:00', HH:mm:ss):string>
+-- !query output
+12:00:00
+
+
+-- !query
+SELECT time_format(TIME'12:00:00', 'hh:mm:ss a')
+-- !query schema
+struct<time_format(TIME '12:00:00', hh:mm:ss a):string>
+-- !query output
+12:00:00 PM
+
+
+-- !query
+SELECT time_format(TIME'23:59:59', 'HH:mm:ss')
+-- !query schema
+struct<time_format(TIME '23:59:59', HH:mm:ss):string>
+-- !query output
+23:59:59
+
+
+-- !query
+SELECT time_format(TIME'23:59:59.999999', 'HH:mm:ss.SSSSSS')
+-- !query schema
+struct<time_format(TIME '23:59:59.999999', HH:mm:ss.SSSSSS):string>
+-- !query output
+23:59:59.999999
+
+
+-- !query
+SELECT time_format(NULL, 'HH:mm:ss')
+-- !query schema
+struct<time_format(NULL, HH:mm:ss):string>
+-- !query output
+NULL
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', NULL)
+-- !query schema
+struct<time_format(TIME '14:30:45', NULL):string>
+-- !query output
+NULL
+
+
+-- !query
+SELECT time_format(CAST(NULL AS TIME), 'HH:mm:ss')
+-- !query schema
+struct<time_format(CAST(NULL AS TIME(6)), HH:mm:ss):string>
+-- !query output
+NULL
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'hh-mm-ss a')
+-- !query schema
+struct<time_format(TIME '14:30:45', hh-mm-ss a):string>
+-- !query output
+02-30-45 PM
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH.mm.ss')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH.mm.ss):string>
+-- !query output
+14.30.45
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH_mm_ss')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH_mm_ss):string>
+-- !query output
+14_30_45
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', '''Time:'' HH:mm:ss')
+-- !query schema
+struct<time_format(TIME '14:30:45', 'Time:' HH:mm:ss):string>
+-- !query output
+Time: 14:30:45
+
+
+-- !query
+SELECT time_format(TIME'02:20:30.040', 'H ''hours'' mm ''mins'' ss ''seconds'' SSS ''milliseconds''')
+-- !query schema
+struct<time_format(TIME '02:20:30.04', H 'hours' mm 'mins' ss 'seconds' SSS 'milliseconds'):string>
+-- !query output
+2 hours 20 mins 30 seconds 040 milliseconds
+
+
+-- !query
+SELECT time_format(TIME'14:05:15', 'H ''hours,'' mm ''minutes and'' ss ''seconds''')
+-- !query schema
+struct<time_format(TIME '14:05:15', H 'hours,' mm 'minutes and' ss 'seconds'):string>
+-- !query output
+14 hours, 05 minutes and 15 seconds
+
+
+-- !query
+SELECT time_format(TIME'00:00:00', 'a')
+-- !query schema
+struct<time_format(TIME '00:00:00', a):string>
+-- !query output
+AM
+
+
+-- !query
+SELECT time_format(TIME'11:59:59', 'a')
+-- !query schema
+struct<time_format(TIME '11:59:59', a):string>
+-- !query output
+AM
+
+
+-- !query
+SELECT time_format(TIME'12:00:00', 'a')
+-- !query schema
+struct<time_format(TIME '12:00:00', a):string>
+-- !query output
+PM
+
+
+-- !query
+SELECT time_format(TIME'13:00:00', 'a')
+-- !query schema
+struct<time_format(TIME '13:00:00', a):string>
+-- !query output
+PM
+
+
+-- !query
+SELECT time_format(TIME'23:59:59', 'a')
+-- !query schema
+struct<time_format(TIME '23:59:59', a):string>
+-- !query output
+PM
+
+
+-- !query
+SELECT time_format(TIME'00:00:00', 'hh:mm a')
+-- !query schema
+struct<time_format(TIME '00:00:00', hh:mm a):string>
+-- !query output
+12:00 AM
+
+
+-- !query
+SELECT time_format(TIME'00:30:00', 'hh:mm a')
+-- !query schema
+struct<time_format(TIME '00:30:00', hh:mm a):string>
+-- !query output
+12:30 AM
+
+
+-- !query
+SELECT time_format(TIME'01:00:00', 'hh:mm a')
+-- !query schema
+struct<time_format(TIME '01:00:00', hh:mm a):string>
+-- !query output
+01:00 AM
+
+
+-- !query
+SELECT time_format(TIME'11:00:00', 'hh:mm a')
+-- !query schema
+struct<time_format(TIME '11:00:00', hh:mm a):string>
+-- !query output
+11:00 AM
+
+
+-- !query
+SELECT time_format(TIME'12:00:00', 'hh:mm a')
+-- !query schema
+struct<time_format(TIME '12:00:00', hh:mm a):string>
+-- !query output
+12:00 PM
+
+
+-- !query
+SELECT time_format(TIME'13:00:00', 'hh:mm a')
+-- !query schema
+struct<time_format(TIME '13:00:00', hh:mm a):string>
+-- !query output
+01:00 PM
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'H:mm:ss')
+-- !query schema
+struct<time_format(TIME '09:15:30', H:mm:ss):string>
+-- !query output
+9:15:30
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'HH:mm:ss')
+-- !query schema
+struct<time_format(TIME '09:15:30', HH:mm:ss):string>
+-- !query output
+09:15:30
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'h:mm a')
+-- !query schema
+struct<time_format(TIME '09:15:30', h:mm a):string>
+-- !query output
+9:15 AM
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'hh:mm a')
+-- !query schema
+struct<time_format(TIME '09:15:30', hh:mm a):string>
+-- !query output
+09:15 AM
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.1', 'HH:mm:ss.S')
+-- !query schema
+struct<time_format(TIME '14:30:45.1', HH:mm:ss.S):string>
+-- !query output
+14:30:45.1
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.12', 'HH:mm:ss.SS')
+-- !query schema
+struct<time_format(TIME '14:30:45.12', HH:mm:ss.SS):string>
+-- !query output
+14:30:45.12
+
+
+-- !query
+SELECT coalesce(time_format(NULL, 'HH:mm'), 'N/A')
+-- !query schema
+struct<coalesce(time_format(NULL, HH:mm), N/A):string>
+-- !query output
+N/A
+
+
+-- !query
+SELECT coalesce(time_format(TIME'14:30:45', NULL), 'N/A')
+-- !query schema
+struct<coalesce(time_format(TIME '14:30:45', NULL), N/A):string>
+-- !query output
+N/A
+
+
+-- !query
+SELECT concat('The time is ', time_format(TIME'14:30:45', 'hh:mm a'))
+-- !query schema
+struct<concat(The time is , time_format(TIME '14:30:45', hh:mm a)):string>
+-- !query output
+The time is 02:30 PM
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss (hh:mm:ss a)')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH:mm:ss (hh:mm:ss a)):string>
+-- !query output
+14:30:45 (02:30:45 PM)
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'HH:mm (h:mm a)')
+-- !query schema
+struct<time_format(TIME '09:15:30', HH:mm (h:mm a)):string>
+-- !query output
+09:15 (9:15 AM)
+
+
+-- !query
+SELECT time_format(TIME'23:45:00', '''24hr:'' HH:mm ''12hr:'' hh:mm a')
+-- !query schema
+struct<time_format(TIME '23:45:00', '24hr:' HH:mm '12hr:' hh:mm a):string>
+-- !query output
+24hr: 23:45 12hr: 11:45 PM
+
+
+-- !query
+SELECT time_format(TIME'00:30:00', 'HH:mm:ss = hh:mm:ss a')
+-- !query schema
+struct<time_format(TIME '00:30:00', HH:mm:ss = hh:mm:ss a):string>
+-- !query output
+00:30:00 = 12:30:00 AM
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss ''(24h)'' / hh:mm:ss a ''(12h)''')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH:mm:ss '(24h)' / hh:mm:ss a '(12h)'):string>
+-- !query output
+14:30:45 (24h) / 02:30:45 PM (12h)
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss'), time_format(TIME'14:30:45', 'hh:mm:ss a')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH:mm:ss):string,time_format(TIME '14:30:45', hh:mm:ss a):string>
+-- !query output
+14:30:45	02:30:45 PM
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'HH:mm'), time_format(TIME'09:15:30', 'h:mm a')
+-- !query schema
+struct<time_format(TIME '09:15:30', HH:mm):string,time_format(TIME '09:15:30', h:mm a):string>
+-- !query output
+09:15	9:15 AM
+
+
+-- !query
+SELECT
+  time_format(TIME'14:30:45.123456', 'HH:mm:ss') as format_24hr,
+  time_format(TIME'14:30:45.123456', 'hh:mm:ss a') as format_12hr,
+  time_format(TIME'14:30:45.123456', 'HH:mm:ss.SSSSSS') as format_with_micros
+-- !query schema
+struct<format_24hr:string,format_12hr:string,format_with_micros:string>
+-- !query output
+14:30:45	02:30:45 PM	14:30:45.123456
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss ''UTC''')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH:mm:ss 'UTC'):string>
+-- !query output
+14:30:45 UTC
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', '[HH:mm:ss]')
+-- !query schema
+struct<time_format(TIME '14:30:45', [HH:mm:ss]):string>
+-- !query output
+14:30:45
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH|mm|ss')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH|mm|ss):string>
+-- !query output
+14|30|45
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH-mm-ss')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH-mm-ss):string>
+-- !query output
+14-30-45
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:MM:ss')
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkRuntimeException
+{
+  "errorClass" : "INVALID_PARAMETER_VALUE.PATTERN",
+  "sqlState" : "22023",
+  "messageParameters" : {
+    "functionName" : "`time_format`",
+    "parameter" : "`format`",
+    "value" : "'HH:MM:ss'"
+  }
+}
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.000', 'HH:mm:ss.SSS')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH:mm:ss.SSS):string>
+-- !query output
+14:30:45.000
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.999', 'HH:mm:ss.SSS')
+-- !query schema
+struct<time_format(TIME '14:30:45.999', HH:mm:ss.SSS):string>
+-- !query output
+14:30:45.999
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.001', 'HH:mm:ss.SSS')
+-- !query schema
+struct<time_format(TIME '14:30:45.001', HH:mm:ss.SSS):string>
+-- !query output
+14:30:45.001
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.000000', 'HH:mm:ss.SSSSSS')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH:mm:ss.SSSSSS):string>
+-- !query output
+14:30:45.000000
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.999999', 'HH:mm:ss.SSSSSS')
+-- !query schema
+struct<time_format(TIME '14:30:45.999999', HH:mm:ss.SSSSSS):string>
+-- !query output
+14:30:45.999999
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.000001', 'HH:mm:ss.SSSSSS')
+-- !query schema
+struct<time_format(TIME '14:30:45.000001', HH:mm:ss.SSSSSS):string>
+-- !query output
+14:30:45.000001
+
+
+-- !query
+SELECT cast(time_format(TIME'14:30:45', 'HH:mm:ss') as string)
+-- !query schema
+struct<CAST(time_format(TIME '14:30:45', HH:mm:ss) AS STRING):string>
+-- !query output
+14:30:45

--- a/sql/core/src/test/resources/sql-tests/results/time.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/time.sql.out
@@ -3034,3 +3034,543 @@ DROP TABLE time_narrow_tbl
 struct<>
 -- !query output
 
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH:mm:ss):string>
+-- !query output
+14:30:45
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'hh:mm:ss a')
+-- !query schema
+struct<time_format(TIME '14:30:45', hh:mm:ss a):string>
+-- !query output
+02:30:45 PM
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'hh:mm:ss a')
+-- !query schema
+struct<time_format(TIME '09:15:30', hh:mm:ss a):string>
+-- !query output
+09:15:30 AM
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.123', 'HH:mm:ss.SSS')
+-- !query schema
+struct<time_format(TIME '14:30:45.123', HH:mm:ss.SSS):string>
+-- !query output
+14:30:45.123
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.123456', 'HH:mm:ss.SSSSSS')
+-- !query schema
+struct<time_format(TIME '14:30:45.123456', HH:mm:ss.SSSSSS):string>
+-- !query output
+14:30:45.123456
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.1234567', 'HH:mm:ss.SSSSSSS')
+-- !query schema
+struct<time_format(TIME '14:30:45.1234567', HH:mm:ss.SSSSSSS):string>
+-- !query output
+14:30:45.1234567
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.12345678', 'HH:mm:ss.SSSSSSSS')
+-- !query schema
+struct<time_format(TIME '14:30:45.12345678', HH:mm:ss.SSSSSSSS):string>
+-- !query output
+14:30:45.12345678
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.123456789', 'HH:mm:ss.SSSSSSSSS')
+-- !query schema
+struct<time_format(TIME '14:30:45.123456789', HH:mm:ss.SSSSSSSSS):string>
+-- !query output
+14:30:45.123456789
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH:mm):string>
+-- !query output
+14:30
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH):string>
+-- !query output
+14
+
+
+-- !query
+SELECT time_format(TIME'09:05:00', 'H:mm a')
+-- !query schema
+struct<time_format(TIME '09:05:00', H:mm a):string>
+-- !query output
+9:05 AM
+
+
+-- !query
+SELECT time_format(TIME'00:00:00', 'HH:mm:ss')
+-- !query schema
+struct<time_format(TIME '00:00:00', HH:mm:ss):string>
+-- !query output
+00:00:00
+
+
+-- !query
+SELECT time_format(TIME'00:00:00', 'hh:mm:ss a')
+-- !query schema
+struct<time_format(TIME '00:00:00', hh:mm:ss a):string>
+-- !query output
+12:00:00 AM
+
+
+-- !query
+SELECT time_format(TIME'12:00:00', 'HH:mm:ss')
+-- !query schema
+struct<time_format(TIME '12:00:00', HH:mm:ss):string>
+-- !query output
+12:00:00
+
+
+-- !query
+SELECT time_format(TIME'12:00:00', 'hh:mm:ss a')
+-- !query schema
+struct<time_format(TIME '12:00:00', hh:mm:ss a):string>
+-- !query output
+12:00:00 PM
+
+
+-- !query
+SELECT time_format(TIME'23:59:59', 'HH:mm:ss')
+-- !query schema
+struct<time_format(TIME '23:59:59', HH:mm:ss):string>
+-- !query output
+23:59:59
+
+
+-- !query
+SELECT time_format(TIME'23:59:59.999999', 'HH:mm:ss.SSSSSS')
+-- !query schema
+struct<time_format(TIME '23:59:59.999999', HH:mm:ss.SSSSSS):string>
+-- !query output
+23:59:59.999999
+
+
+-- !query
+SELECT time_format(NULL, 'HH:mm:ss')
+-- !query schema
+struct<time_format(NULL, HH:mm:ss):string>
+-- !query output
+NULL
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', NULL)
+-- !query schema
+struct<time_format(TIME '14:30:45', NULL):string>
+-- !query output
+NULL
+
+
+-- !query
+SELECT time_format(CAST(NULL AS TIME), 'HH:mm:ss')
+-- !query schema
+struct<time_format(CAST(NULL AS TIME(6)), HH:mm:ss):string>
+-- !query output
+NULL
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'hh-mm-ss a')
+-- !query schema
+struct<time_format(TIME '14:30:45', hh-mm-ss a):string>
+-- !query output
+02-30-45 PM
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH.mm.ss')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH.mm.ss):string>
+-- !query output
+14.30.45
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH_mm_ss')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH_mm_ss):string>
+-- !query output
+14_30_45
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', '''Time:'' HH:mm:ss')
+-- !query schema
+struct<time_format(TIME '14:30:45', 'Time:' HH:mm:ss):string>
+-- !query output
+Time: 14:30:45
+
+
+-- !query
+SELECT time_format(TIME'02:20:30.040', 'H ''hours'' mm ''mins'' ss ''seconds'' SSS ''milliseconds''')
+-- !query schema
+struct<time_format(TIME '02:20:30.04', H 'hours' mm 'mins' ss 'seconds' SSS 'milliseconds'):string>
+-- !query output
+2 hours 20 mins 30 seconds 040 milliseconds
+
+
+-- !query
+SELECT time_format(TIME'14:05:15', 'H ''hours,'' mm ''minutes and'' ss ''seconds''')
+-- !query schema
+struct<time_format(TIME '14:05:15', H 'hours,' mm 'minutes and' ss 'seconds'):string>
+-- !query output
+14 hours, 05 minutes and 15 seconds
+
+
+-- !query
+SELECT time_format(TIME'00:00:00', 'a')
+-- !query schema
+struct<time_format(TIME '00:00:00', a):string>
+-- !query output
+AM
+
+
+-- !query
+SELECT time_format(TIME'11:59:59', 'a')
+-- !query schema
+struct<time_format(TIME '11:59:59', a):string>
+-- !query output
+AM
+
+
+-- !query
+SELECT time_format(TIME'12:00:00', 'a')
+-- !query schema
+struct<time_format(TIME '12:00:00', a):string>
+-- !query output
+PM
+
+
+-- !query
+SELECT time_format(TIME'13:00:00', 'a')
+-- !query schema
+struct<time_format(TIME '13:00:00', a):string>
+-- !query output
+PM
+
+
+-- !query
+SELECT time_format(TIME'23:59:59', 'a')
+-- !query schema
+struct<time_format(TIME '23:59:59', a):string>
+-- !query output
+PM
+
+
+-- !query
+SELECT time_format(TIME'00:00:00', 'hh:mm a')
+-- !query schema
+struct<time_format(TIME '00:00:00', hh:mm a):string>
+-- !query output
+12:00 AM
+
+
+-- !query
+SELECT time_format(TIME'00:30:00', 'hh:mm a')
+-- !query schema
+struct<time_format(TIME '00:30:00', hh:mm a):string>
+-- !query output
+12:30 AM
+
+
+-- !query
+SELECT time_format(TIME'01:00:00', 'hh:mm a')
+-- !query schema
+struct<time_format(TIME '01:00:00', hh:mm a):string>
+-- !query output
+01:00 AM
+
+
+-- !query
+SELECT time_format(TIME'11:00:00', 'hh:mm a')
+-- !query schema
+struct<time_format(TIME '11:00:00', hh:mm a):string>
+-- !query output
+11:00 AM
+
+
+-- !query
+SELECT time_format(TIME'12:00:00', 'hh:mm a')
+-- !query schema
+struct<time_format(TIME '12:00:00', hh:mm a):string>
+-- !query output
+12:00 PM
+
+
+-- !query
+SELECT time_format(TIME'13:00:00', 'hh:mm a')
+-- !query schema
+struct<time_format(TIME '13:00:00', hh:mm a):string>
+-- !query output
+01:00 PM
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'H:mm:ss')
+-- !query schema
+struct<time_format(TIME '09:15:30', H:mm:ss):string>
+-- !query output
+9:15:30
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'HH:mm:ss')
+-- !query schema
+struct<time_format(TIME '09:15:30', HH:mm:ss):string>
+-- !query output
+09:15:30
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'h:mm a')
+-- !query schema
+struct<time_format(TIME '09:15:30', h:mm a):string>
+-- !query output
+9:15 AM
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'hh:mm a')
+-- !query schema
+struct<time_format(TIME '09:15:30', hh:mm a):string>
+-- !query output
+09:15 AM
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.1', 'HH:mm:ss.S')
+-- !query schema
+struct<time_format(TIME '14:30:45.1', HH:mm:ss.S):string>
+-- !query output
+14:30:45.1
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.12', 'HH:mm:ss.SS')
+-- !query schema
+struct<time_format(TIME '14:30:45.12', HH:mm:ss.SS):string>
+-- !query output
+14:30:45.12
+
+
+-- !query
+SELECT coalesce(time_format(NULL, 'HH:mm'), 'N/A')
+-- !query schema
+struct<coalesce(time_format(NULL, HH:mm), N/A):string>
+-- !query output
+N/A
+
+
+-- !query
+SELECT coalesce(time_format(TIME'14:30:45', NULL), 'N/A')
+-- !query schema
+struct<coalesce(time_format(TIME '14:30:45', NULL), N/A):string>
+-- !query output
+N/A
+
+
+-- !query
+SELECT concat('The time is ', time_format(TIME'14:30:45', 'hh:mm a'))
+-- !query schema
+struct<concat(The time is , time_format(TIME '14:30:45', hh:mm a)):string>
+-- !query output
+The time is 02:30 PM
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss (hh:mm:ss a)')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH:mm:ss (hh:mm:ss a)):string>
+-- !query output
+14:30:45 (02:30:45 PM)
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'HH:mm (h:mm a)')
+-- !query schema
+struct<time_format(TIME '09:15:30', HH:mm (h:mm a)):string>
+-- !query output
+09:15 (9:15 AM)
+
+
+-- !query
+SELECT time_format(TIME'23:45:00', '''24hr:'' HH:mm ''12hr:'' hh:mm a')
+-- !query schema
+struct<time_format(TIME '23:45:00', '24hr:' HH:mm '12hr:' hh:mm a):string>
+-- !query output
+24hr: 23:45 12hr: 11:45 PM
+
+
+-- !query
+SELECT time_format(TIME'00:30:00', 'HH:mm:ss = hh:mm:ss a')
+-- !query schema
+struct<time_format(TIME '00:30:00', HH:mm:ss = hh:mm:ss a):string>
+-- !query output
+00:30:00 = 12:30:00 AM
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss ''(24h)'' / hh:mm:ss a ''(12h)''')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH:mm:ss '(24h)' / hh:mm:ss a '(12h)'):string>
+-- !query output
+14:30:45 (24h) / 02:30:45 PM (12h)
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss'), time_format(TIME'14:30:45', 'hh:mm:ss a')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH:mm:ss):string,time_format(TIME '14:30:45', hh:mm:ss a):string>
+-- !query output
+14:30:45	02:30:45 PM
+
+
+-- !query
+SELECT time_format(TIME'09:15:30', 'HH:mm'), time_format(TIME'09:15:30', 'h:mm a')
+-- !query schema
+struct<time_format(TIME '09:15:30', HH:mm):string,time_format(TIME '09:15:30', h:mm a):string>
+-- !query output
+09:15	9:15 AM
+
+
+-- !query
+SELECT
+  time_format(TIME'14:30:45.123456', 'HH:mm:ss') as format_24hr,
+  time_format(TIME'14:30:45.123456', 'hh:mm:ss a') as format_12hr,
+  time_format(TIME'14:30:45.123456', 'HH:mm:ss.SSSSSS') as format_with_micros
+-- !query schema
+struct<format_24hr:string,format_12hr:string,format_with_micros:string>
+-- !query output
+14:30:45	02:30:45 PM	14:30:45.123456
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:mm:ss ''UTC''')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH:mm:ss 'UTC'):string>
+-- !query output
+14:30:45 UTC
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', '[HH:mm:ss]')
+-- !query schema
+struct<time_format(TIME '14:30:45', [HH:mm:ss]):string>
+-- !query output
+14:30:45
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH|mm|ss')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH|mm|ss):string>
+-- !query output
+14|30|45
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH-mm-ss')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH-mm-ss):string>
+-- !query output
+14-30-45
+
+
+-- !query
+SELECT time_format(TIME'14:30:45', 'HH:MM:ss')
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkRuntimeException
+{
+  "errorClass" : "INVALID_PARAMETER_VALUE.PATTERN",
+  "sqlState" : "22023",
+  "messageParameters" : {
+    "functionName" : "`time_format`",
+    "parameter" : "`format`",
+    "value" : "'HH:MM:ss'"
+  }
+}
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.000', 'HH:mm:ss.SSS')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH:mm:ss.SSS):string>
+-- !query output
+14:30:45.000
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.999', 'HH:mm:ss.SSS')
+-- !query schema
+struct<time_format(TIME '14:30:45.999', HH:mm:ss.SSS):string>
+-- !query output
+14:30:45.999
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.001', 'HH:mm:ss.SSS')
+-- !query schema
+struct<time_format(TIME '14:30:45.001', HH:mm:ss.SSS):string>
+-- !query output
+14:30:45.001
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.000000', 'HH:mm:ss.SSSSSS')
+-- !query schema
+struct<time_format(TIME '14:30:45', HH:mm:ss.SSSSSS):string>
+-- !query output
+14:30:45.000000
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.999999', 'HH:mm:ss.SSSSSS')
+-- !query schema
+struct<time_format(TIME '14:30:45.999999', HH:mm:ss.SSSSSS):string>
+-- !query output
+14:30:45.999999
+
+
+-- !query
+SELECT time_format(TIME'14:30:45.000001', 'HH:mm:ss.SSSSSS')
+-- !query schema
+struct<time_format(TIME '14:30:45.000001', HH:mm:ss.SSSSSS):string>
+-- !query output
+14:30:45.000001
+
+
+-- !query
+SELECT cast(time_format(TIME'14:30:45', 'HH:mm:ss') as string)
+-- !query schema
+struct<CAST(time_format(TIME '14:30:45', HH:mm:ss) AS STRING):string>
+-- !query output
+14:30:45

--- a/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuiteBase.scala
@@ -21,7 +21,7 @@ import java.time.LocalDate
 import java.time.LocalTime
 import java.time.temporal.ChronoUnit
 
-import org.apache.spark.{SparkConf, SparkDateTimeException, SparkIllegalArgumentException}
+import org.apache.spark.{SparkConf, SparkDateTimeException, SparkIllegalArgumentException, SparkRuntimeException}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
@@ -786,93 +786,88 @@ abstract class TimeFunctionsSuiteBase extends SharedSparkSession {
 
   test("time_format") {
     // Basic formats: 24-hour and 12-hour with AM/PM
+    val df1 = Seq((LocalTime.of(14, 30, 45), LocalTime.of(9, 15, 30)))
+      .toDF("afternoon", "morning")
     checkAnswer(
-      sql("""
-        SELECT
-          time_format(TIME'14:30:45', 'HH:mm:ss') as format_24hr,
-          time_format(TIME'14:30:45', 'hh:mm:ss a') as format_12hr_pm,
-          time_format(TIME'09:15:30', 'hh:mm:ss a') as format_12hr_am
-      """),
-      Row("14:30:45", "02:30:45 PM", "09:15:30 AM")
-    )
+      df1.select(
+        time_format($"afternoon", "HH:mm:ss"),
+        time_format($"afternoon", "hh:mm:ss a"),
+        time_format($"morning", "hh:mm:ss a")),
+      Row("14:30:45", "02:30:45 PM", "09:15:30 AM"))
 
     // Precision: milliseconds, microseconds, single-digit hour
+    val df2 = Seq((LocalTime.of(14, 30, 45, 123000000), LocalTime.of(14, 30, 45, 123456000),
+      LocalTime.of(9, 5, 0))).toDF("millis", "micros", "single_digit")
     checkAnswer(
-      sql("""
-        SELECT
-          time_format(TIME'14:30:45.123', 'HH:mm:ss.SSS') as millis,
-          time_format(TIME'14:30:45.123456', 'HH:mm:ss.SSSSSS') as micros,
-          time_format(TIME'09:05:00', 'H:mm a') as single_digit
-      """),
-      Row("14:30:45.123", "14:30:45.123456", "9:05 AM")
-    )
+      df2.select(
+        time_format($"millis", "HH:mm:ss.SSS"),
+        time_format($"micros", "HH:mm:ss.SSSSSS"),
+        time_format($"single_digit", "H:mm a")),
+      Row("14:30:45.123", "14:30:45.123456", "9:05 AM"))
 
     // Edge cases: midnight, noon, max time, different patterns
+    val df3 = Seq((LocalTime.of(0, 0, 0), LocalTime.of(12, 0, 0),
+      LocalTime.of(23, 59, 59, 999999000), LocalTime.of(14, 30, 45)))
+      .toDF("midnight", "noon", "max_time", "afternoon")
     checkAnswer(
-      sql("""
-        SELECT
-          time_format(TIME'00:00:00', 'HH:mm:ss') as midnight_24hr,
-          time_format(TIME'00:00:00', 'hh:mm:ss a') as midnight_12hr,
-          time_format(TIME'12:00:00', 'hh:mm:ss a') as noon,
-          time_format(TIME'23:59:59.999999', 'HH:mm:ss.SSSSSS') as max_time,
-          time_format(TIME'14:30:45', 'HH:mm') as hour_min,
-          time_format(TIME'14:30:45', 'HH') as hour_only
-      """),
-      Row("00:00:00", "12:00:00 AM", "12:00:00 PM", "23:59:59.999999", "14:30", "14")
-    )
+      df3.select(
+        time_format($"midnight", "HH:mm:ss"),
+        time_format($"midnight", "hh:mm:ss a"),
+        time_format($"noon", "hh:mm:ss a"),
+        time_format($"max_time", "HH:mm:ss.SSSSSS"),
+        time_format($"afternoon", "HH:mm"),
+        time_format($"afternoon", "HH")),
+      Row("00:00:00", "12:00:00 AM", "12:00:00 PM", "23:59:59.999999", "14:30", "14"))
 
     // Custom separators and text literals
+    val df4 = Seq(LocalTime.of(14, 30, 45)).toDF("time_col")
     checkAnswer(
-      sql("""
-        SELECT
-          time_format(TIME'14:30:45', 'hh-mm-ss a') as hyphen,
-          time_format(TIME'14:30:45', 'HH.mm.ss') as dot,
-          time_format(TIME'14:30:45', '''Time:'' HH:mm:ss') as with_text
-      """),
-      Row("02-30-45 PM", "14.30.45", "Time: 14:30:45")
-    )
+      df4.select(
+        time_format($"time_col", "hh-mm-ss a"),
+        time_format($"time_col", "HH.mm.ss"),
+        time_format($"time_col", "'Time:' HH:mm:ss")),
+      Row("02-30-45 PM", "14.30.45", "Time: 14:30:45"))
 
     // Null handling
+    val df5 = Seq[(LocalTime, LocalTime)]((null, LocalTime.of(14, 30, 45)))
+      .toDF("null_time", "time_col")
     checkAnswer(
-      sql("""
-        SELECT
-          time_format(NULL, 'HH:mm:ss') as null_time,
-          time_format(TIME'14:30:45', NULL) as null_format
-      """),
-      Row(null, null)
-    )
+      df5.select(
+        time_format($"null_time", "HH:mm:ss"),
+        time_format($"time_col", null)),
+      Row(null, null))
 
-    // DataFrame API with column expressions
-    val df = Seq(
+    // Column expressions over multiple rows
+    val labeledDf = Seq(
       ("morning", LocalTime.of(9, 30, 0)),
       ("afternoon", LocalTime.of(14, 30, 45)),
       ("evening", LocalTime.of(19, 45, 30))
     ).toDF("label", "time_col")
-
     checkAnswer(
-      df.select($"label", time_format($"time_col", "hh:mm a")).orderBy($"label"),
+      labeledDf.select($"label", time_format($"time_col", "hh:mm a")).orderBy($"label"),
       Seq(
         Row("afternoon", "02:30 PM"),
         Row("evening", "07:45 PM"),
-        Row("morning", "09:30 AM")
-      )
-    )
+        Row("morning", "09:30 AM")))
 
     // Verbose format with natural language
+    val df6 = Seq(LocalTime.of(2, 20, 30, 40000000)).toDF("time_col")
     checkAnswer(
-      sql("SELECT time_format(TIME'02:20:30.040', " +
-        "'H ''hours'' mm ''mins'' ss ''seconds'' SSS ''milliseconds''')"),
-      Row("2 hours 20 mins 30 seconds 040 milliseconds")
-    )
+      df6.select(
+        time_format($"time_col", "H 'hours' mm 'mins' ss 'seconds' SSS 'milliseconds'")),
+      Row("2 hours 20 mins 30 seconds 040 milliseconds"))
 
     // Invalid format pattern should throw
-    val ex = intercept[Exception] {
-      sql("SELECT time_format(TIME'14:30:45', 'invalid[[[')").collect()
-    }
-    assert(ex.getMessage.contains("Illegal pattern") ||
-           ex.getMessage.contains("Unknown pattern") ||
-           ex.getMessage.contains("Invalid") ||
-           ex.getMessage.contains("Unrecognized datetime pattern"))
+    checkError(
+      exception = intercept[SparkRuntimeException] {
+        df6.select(time_format($"time_col", "invalid[[[")).collect()
+      },
+      condition = "INVALID_DATETIME_PATTERN.WITH_SUGGESTION",
+      parameters = Map(
+        "pattern" -> "'invalid[[['",
+        "docroot" -> "https://spark.apache.org/docs/latest"
+      )
+    )
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuiteBase.scala
@@ -783,6 +783,97 @@ abstract class TimeFunctionsSuiteBase extends SharedSparkSession {
     checkAnswer(result1, expected)
     checkAnswer(result2, expected)
   }
+
+  test("time_format") {
+    // Basic formats: 24-hour and 12-hour with AM/PM
+    checkAnswer(
+      sql("""
+        SELECT
+          time_format(TIME'14:30:45', 'HH:mm:ss') as format_24hr,
+          time_format(TIME'14:30:45', 'hh:mm:ss a') as format_12hr_pm,
+          time_format(TIME'09:15:30', 'hh:mm:ss a') as format_12hr_am
+      """),
+      Row("14:30:45", "02:30:45 PM", "09:15:30 AM")
+    )
+
+    // Precision: milliseconds, microseconds, single-digit hour
+    checkAnswer(
+      sql("""
+        SELECT
+          time_format(TIME'14:30:45.123', 'HH:mm:ss.SSS') as millis,
+          time_format(TIME'14:30:45.123456', 'HH:mm:ss.SSSSSS') as micros,
+          time_format(TIME'09:05:00', 'H:mm a') as single_digit
+      """),
+      Row("14:30:45.123", "14:30:45.123456", "9:05 AM")
+    )
+
+    // Edge cases: midnight, noon, max time, different patterns
+    checkAnswer(
+      sql("""
+        SELECT
+          time_format(TIME'00:00:00', 'HH:mm:ss') as midnight_24hr,
+          time_format(TIME'00:00:00', 'hh:mm:ss a') as midnight_12hr,
+          time_format(TIME'12:00:00', 'hh:mm:ss a') as noon,
+          time_format(TIME'23:59:59.999999', 'HH:mm:ss.SSSSSS') as max_time,
+          time_format(TIME'14:30:45', 'HH:mm') as hour_min,
+          time_format(TIME'14:30:45', 'HH') as hour_only
+      """),
+      Row("00:00:00", "12:00:00 AM", "12:00:00 PM", "23:59:59.999999", "14:30", "14")
+    )
+
+    // Custom separators and text literals
+    checkAnswer(
+      sql("""
+        SELECT
+          time_format(TIME'14:30:45', 'hh-mm-ss a') as hyphen,
+          time_format(TIME'14:30:45', 'HH.mm.ss') as dot,
+          time_format(TIME'14:30:45', '''Time:'' HH:mm:ss') as with_text
+      """),
+      Row("02-30-45 PM", "14.30.45", "Time: 14:30:45")
+    )
+
+    // Null handling
+    checkAnswer(
+      sql("""
+        SELECT
+          time_format(NULL, 'HH:mm:ss') as null_time,
+          time_format(TIME'14:30:45', NULL) as null_format
+      """),
+      Row(null, null)
+    )
+
+    // DataFrame API with column expressions
+    val df = Seq(
+      ("morning", LocalTime.of(9, 30, 0)),
+      ("afternoon", LocalTime.of(14, 30, 45)),
+      ("evening", LocalTime.of(19, 45, 30))
+    ).toDF("label", "time_col")
+
+    checkAnswer(
+      df.select($"label", time_format($"time_col", "hh:mm a")).orderBy($"label"),
+      Seq(
+        Row("afternoon", "02:30 PM"),
+        Row("evening", "07:45 PM"),
+        Row("morning", "09:30 AM")
+      )
+    )
+
+    // Verbose format with natural language
+    checkAnswer(
+      sql("SELECT time_format(TIME'02:20:30.040', " +
+        "'H ''hours'' mm ''mins'' ss ''seconds'' SSS ''milliseconds''')"),
+      Row("2 hours 20 mins 30 seconds 040 milliseconds")
+    )
+
+    // Invalid format pattern should throw
+    val ex = intercept[Exception] {
+      sql("SELECT time_format(TIME'14:30:45', 'invalid[[[')").collect()
+    }
+    assert(ex.getMessage.contains("Illegal pattern") ||
+           ex.getMessage.contains("Unknown pattern") ||
+           ex.getMessage.contains("Invalid") ||
+           ex.getMessage.contains("Unrecognized datetime pattern"))
+  }
 }
 
 // This class is used to run the same tests with ANSI mode enabled explicitly.

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationExpressionWalkerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationExpressionWalkerSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.collation
 
 import java.sql.Timestamp
+import java.time.LocalTime
 
 import org.apache.spark.sql.catalyst.analysis.ExpressionBuilder
 import org.apache.spark.sql.catalyst.expressions._
@@ -98,6 +99,7 @@ class CollationExpressionWalkerSuite extends SharedSparkSession {
     inputType match {
       // TODO: Try to make this a bit more random.
       case AnyTimestampType => Literal(Timestamp.valueOf("2009-07-30 12:58:59"))
+      case AnyTimeType => Literal(LocalTime.parse("03:25:45.678901"))
       case BinaryType => collationType match {
         case Utf8Binary =>
           Literal.create("dummy string".getBytes)
@@ -179,6 +181,7 @@ class CollationExpressionWalkerSuite extends SharedSparkSession {
     inputType match {
       // TODO: Try to make this a bit more random.
       case AnyTimestampType => "TIMESTAMP'2009-07-30 12:58:59'"
+      case AnyTimeType => "TIME'03:25:45.678901'"
       case BinaryType =>
         collationType match {
           case Utf8Binary => "Cast('dummy string' collate utf8_binary as BINARY)"
@@ -244,6 +247,7 @@ class CollationExpressionWalkerSuite extends SharedSparkSession {
       collationType: CollationType): String =
     inputType match {
       case AnyTimestampType => "TIMESTAMP"
+      case AnyTimeType => "TIME"
       case BinaryType => "BINARY"
       case BooleanType => "BOOLEAN"
       case ByteType => "TINYINT"
@@ -384,8 +388,7 @@ class CollationExpressionWalkerSuite extends SharedSparkSession {
       "sha2",
       "sha",
       "crc32",
-      "ascii",
-      "time_trunc"
+      "ascii"
     )
 
     logInfo("Total number of expression: " + expressionCounter)

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationExpressionWalkerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationExpressionWalkerSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.collation
 
 import java.sql.Timestamp
+import java.time.LocalTime
 
 import org.apache.spark.sql.catalyst.analysis.ExpressionBuilder
 import org.apache.spark.sql.catalyst.expressions._
@@ -97,6 +98,7 @@ class CollationExpressionWalkerSuite extends SharedSparkSession {
     inputType match {
       // TODO: Try to make this a bit more random.
       case AnyTimestampType => Literal(Timestamp.valueOf("2009-07-30 12:58:59"))
+      case AnyTimeType => Literal(LocalTime.parse("03:25:45.678901"))
       case BinaryType => collationType match {
         case Utf8Binary =>
           Literal.create("dummy string".getBytes)
@@ -178,6 +180,7 @@ class CollationExpressionWalkerSuite extends SharedSparkSession {
     inputType match {
       // TODO: Try to make this a bit more random.
       case AnyTimestampType => "TIMESTAMP'2009-07-30 12:58:59'"
+      case AnyTimeType => "TIME'03:25:45.678901'"
       case BinaryType =>
         collationType match {
           case Utf8Binary => "Cast('dummy string' collate utf8_binary as BINARY)"
@@ -243,6 +246,7 @@ class CollationExpressionWalkerSuite extends SharedSparkSession {
       collationType: CollationType): String =
     inputType match {
       case AnyTimestampType => "TIMESTAMP"
+      case AnyTimeType => "TIME"
       case BinaryType => "BINARY"
       case BooleanType => "BOOLEAN"
       case ByteType => "TINYINT"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds a new `time_format` function that converts TIME data type values to formatted string representations, providing functionality similar to date_format but specifically designed for TIME values.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Users need a standard way to format TIME values as strings for:

- Display purposes: Presenting time in user-friendly formats
- Reporting: Generating formatted output for reports and dashboards
- Data export: Converting TIME values to specific string formats for external systems
- Localization: Supporting different time display conventions (12-hour vs 24-hour)

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, this PR adds a new public API function.

Scala API
```scala
import org.apache.spark.sql.functions._

df.select(time_format($"time_col", "HH:mm:ss"))
df.select(time_format($"time_col", "hh:mm:ss a"))
```
Python API

```python
from pyspark.sql import functions as F

df.select(F.time_format("time_col", "HH:mm:ss"))
df.select(F.time_format("time_col", "hh:mm:ss a"))
```
SQL Usage
```sql
SELECT time_format(TIME'14:30:45', 'HH:mm:ss');           -- '14:30:45'
SELECT time_format(TIME'14:30:45.1234', 'hh-mm-ss.SS a');         -- '02-30-45.12 PM'
SELECT time_format(TIME'09:05:00', 'h:mm a');             -- '9:05 AM'
```

**Format Pattern Support**
| Pattern | Description | Example Output |
|---------|-------------|----------------|
| `HH:mm:ss` | 24-hour format | `14:30:45` |
| `hh:mm:ss a` | 12-hour with AM/PM | `02:30:45 PM` |
| `H:mm` | Single-digit hour | `9:15` |
| `HH:mm:ss.SSS` | With milliseconds | `14:30:45.123` |
| `HH:mm:ss.SSSSSS` | With microseconds | `14:30:45.123456` |
| `HH:mm:ss.SSSSSSSSS` | With nanoseconds | `14:30:45.123456789` |
| `HH-mm-ss` | Custom separator | `14-30-45` |
| `'Time:' HH:mm` | With text literal | `Time: 14:30` |

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added tests in TimeExpressionsSuite, TimeFunctionsSuiteBase

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes, Generated-by: Sonnet 5