### PR TITLE
[SPARK-54597][BUILD] Upgrade `lz4-java` to 1.10.0

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -204,6 +204,7 @@
 This project bundles some components that are also licensed under the Apache
 License Version 2.0:
 
+at.yawk.lz4:lz4-java
 com.clearspring.analytics:stream
 com.fasterxml.jackson.core:jackson-annotations
 com.fasterxml.jackson.core:jackson-core
@@ -388,7 +389,6 @@ org.json4s:json4s-core_2.13
 org.json4s:json4s-jackson-core_2.13
 org.json4s:json4s-jackson_2.13
 org.json4s:json4s-scalap_2.13
-org.lz4:lz4-java
 org.objenesis:objenesis
 org.roaringbitmap:RoaringBitmap
 org.rocksdb:rocksdbjni

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -205,7 +205,7 @@ and decompression library written by Adrien Grand. It can be obtained at:
   * LICENSE:
     * license/LICENSE.lz4.txt (Apache License 2.0)
   * HOMEPAGE:
-    * https://github.com/jpountz/lz4-java
+    * https://github.com/yawkat/lz4-java
 
 This product optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:

--- a/connector/kafka-0-10-assembly/pom.xml
+++ b/connector/kafka-0-10-assembly/pom.xml
@@ -65,7 +65,7 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.lz4</groupId>
+      <groupId>at.yawk.lz4</groupId>
       <artifactId>lz4-java</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/connector/kafka-0-10-sql/pom.xml
+++ b/connector/kafka-0-10-sql/pom.xml
@@ -87,6 +87,10 @@
           <groupId>com.github.luben</groupId>
           <artifactId>zstd-jni</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.lz4</groupId>
+          <artifactId>lz4-java</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/connector/kafka-0-10-token-provider/pom.xml
+++ b/connector/kafka-0-10-token-provider/pom.xml
@@ -57,6 +57,10 @@
           <groupId>com.github.luben</groupId>
           <artifactId>zstd-jni</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.lz4</groupId>
+          <artifactId>lz4-java</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/connector/kafka-0-10/pom.xml
+++ b/connector/kafka-0-10/pom.xml
@@ -72,6 +72,10 @@
           <groupId>com.github.luben</groupId>
           <artifactId>zstd-jni</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.lz4</groupId>
+          <artifactId>lz4-java</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/connector/kinesis-asl/pom.xml
+++ b/connector/kinesis-asl/pom.xml
@@ -73,6 +73,10 @@
           <groupId>com.kjetland</groupId>
           <artifactId>mbknor-jackson-jsonschema_2.12</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.lz4</groupId>
+          <artifactId>lz4-java</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <!-- manage this up explicitly to match Spark; com.amazonaws:aws-java-sdk-pom specifies

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -232,7 +232,7 @@
       <artifactId>snappy-java</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.lz4</groupId>
+      <groupId>at.yawk.lz4</groupId>
       <artifactId>lz4-java</artifactId>
     </dependency>
     <dependency>

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -186,7 +186,7 @@ log4j-api/2.24.3//log4j-api-2.24.3.jar
 log4j-core/2.24.3//log4j-core-2.24.3.jar
 log4j-layout-template-json/2.24.3//log4j-layout-template-json-2.24.3.jar
 log4j-slf4j2-impl/2.24.3//log4j-slf4j2-impl-2.24.3.jar
-lz4-java/1.8.0//lz4-java-1.8.0.jar
+lz4-java/1.10.0//lz4-java-1.10.0.jar
 metrics-core/4.2.37//metrics-core-4.2.37.jar
 metrics-graphite/4.2.37//metrics-graphite-4.2.37.jar
 metrics-jmx/4.2.37//metrics-jmx-4.2.37.jar

--- a/pom.xml
+++ b/pom.xml
@@ -2653,6 +2653,7 @@
                       <exclude>org.jboss.netty</exclude>
                       <exclude>org.codehaus.groovy</exclude>
                       <exclude>com.amazonaws:aws-java-sdk-bundle</exclude>
+                      <exclude>org.lz4:lz4-java</exclude>
                       <exclude>*:*_2.12</exclude>
                       <exclude>*:*_2.11</exclude>
                       <exclude>*:*_2.10</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -879,9 +879,9 @@
         <version>${snappy.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.lz4</groupId>
+        <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>
-        <version>1.8.0</version>
+        <version>1.10.0</version>
       </dependency>
       <dependency>
         <groupId>com.github.luben</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `lz4-java` to 1.10.0 and exclude the legacy groupID version.

### Why are the changes needed?

Since `lz4-java` changed its repository, we had better depend on the live repository for future maintenance.
- https://github.com/lz4/lz4-java (Archived with the last release on 2021-06-19)
   - https://github.com/lz4/lz4-java/releases/tag/1.8.0 (2021-06-19)
- https://github.com/yawkat/lz4-java (New Fork)
   - https://github.com/yawkat/lz4-java/releases/tag/v1.9.0
       - Update lz4 to v1.10.0
   - https://github.com/yawkat/lz4-java/releases/tag/v1.10.0
       - https://github.com/yawkat/lz4-java/pull/3

### Does this PR introduce _any_ user-facing change?

No Spark behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.