### PR TITLE
[SPARK-54598][PYTHON] Extract logic to read UDFs

### DIFF
--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2922,9 +2922,7 @@ def read_udfs(pickleSer, infile, eval_type):
     # Read all UDFs
     num_udfs = read_int(infile)
     udfs = [
-        read_single_udf(
-            pickleSer, infile, eval_type, runner_conf, udf_index=i, profiler=profiler
-        )
+        read_single_udf(pickleSer, infile, eval_type, runner_conf, udf_index=i, profiler=profiler)
         for i in range(num_udfs)
     ]
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2955,7 +2955,6 @@ def read_udfs(pickleSer, infile, eval_type):
     else:
         profiler = None
 
-    # Read all UDFs upfront to avoid duplication across different eval_type branches
     udfs = read_all_udfs(pickleSer, infile, eval_type, runner_conf, profiler)
     num_udfs = len(udfs)
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2921,13 +2921,12 @@ def read_udfs(pickleSer, infile, eval_type):
 
     # Read all UDFs
     num_udfs = read_int(infile)
-    udfs = []
-    for i in range(num_udfs):
-        udfs.append(
-            read_single_udf(
-                pickleSer, infile, eval_type, runner_conf, udf_index=i, profiler=profiler
-            )
+    udfs = [
+        read_single_udf(
+            pickleSer, infile, eval_type, runner_conf, udf_index=i, profiler=profiler
         )
+        for i in range(num_udfs)
+    ]
 
     is_scalar_iter = eval_type in (
         PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF,


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR refactors the UDF reading logic in `read_udfs()` to eliminate code duplication. Currently, the logic for reading UDFs (functions and their argument offsets) is duplicated across multiple `eval_type` branches, with different patterns for single UDF vs. multiple UDFs cases.

### Why are the changes needed?

This duplication makes the code harder to maintain and increases the risk of inconsistencies. By centralizing the UDF reading logic at the beginning of `read_udfs()`, we can:
- Reduce code duplication
- Ensure consistent UDF reading behavior across all eval types
- Make it easier to add new eval types in the future


### Does this PR introduce _any_ user-facing change?
No, this is an internal refactoring that maintains backward compatibility. The API behavior remains the same from the user's perspective.

### How was this patch tested?
Existing Tests

### Was this patch authored or co-authored using generative AI tooling?
No
