### PR TITLE
[SPARK-54603][PYTHON][DOCS] Fix typo in contributing.rst

### DIFF
--- a/python/docs/source/development/contributing.rst
+++ b/python/docs/source/development/contributing.rst
@@ -230,7 +230,7 @@ Doctest Conventions
 In general, doctests should be grouped logically by separating a newline.
 
 For instance, the first block is for the statements for preparation, the second block is for using the function with a specific argument,
-and third block is for another argument. As a example, please refer `DataFrame.rsub <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.rsub.html#pandas.DataFrame.rsub>`_ in pandas.
+and third block is for another argument. As an example, please refer `DataFrame.rsub <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.rsub.html#pandas.DataFrame.rsub>`_ in pandas.
 
 These blocks should be consistently separated in PySpark doctests, and more doctests should be added if the coverage of the doctests or the number of examples to show is not enough.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Found typo "a example" -> "an example"

### Why are the changes needed?
Fix grammar

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?


### Was this patch authored or co-authored using generative AI tooling?
No
