### PR TITLE
[SPARK-54607][CORE] Remove unused method `toStringHelper` from `AbstractFetchShuffleBlocks.java`

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/AbstractFetchShuffleBlocks.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/AbstractFetchShuffleBlocks.java
@@ -21,8 +21,6 @@ import java.util.Objects;
 
 import io.netty.buffer.ByteBuf;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.spark.network.protocol.Encoders;
 
 /**
@@ -43,15 +41,6 @@ public abstract class AbstractFetchShuffleBlocks extends BlockTransferMessage {
     this.execId = execId;
     this.shuffleId = shuffleId;
   }
-
-  // checkstyle.off: RegexpSinglelineJava
-  public ToStringBuilder toStringHelper() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-      .append("appId", appId)
-      .append("execId", execId)
-      .append("shuffleId", shuffleId);
-  }
-  // checkstyle.on: RegexpSinglelineJava
 
   /**
    * Returns number of blocks in the request.


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to remove the unused method `toStringHelper` from `AbstractFetchShuffleBlocks.java` because it is no longer used after https://github.com/apache/spark/pull/51572.


### Why are the changes needed?
Code cleanup.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass Github Actions


### Was this patch authored or co-authored using generative AI tooling?
No