### PR TITLE
[SPARK-54614][BUILD] Upgrade `tink` to 1.19.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -278,7 +278,7 @@ stax-api/1.0.1//stax-api-1.0.1.jar
 stream/2.9.8//stream-2.9.8.jar
 super-csv/2.2.0//super-csv-2.2.0.jar
 threeten-extra/1.8.0//threeten-extra-1.8.0.jar
-tink/1.16.0//tink-1.16.0.jar
+tink/1.19.0//tink-1.19.0.jar
 transaction-api/1.1//transaction-api-1.1.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar
 vertx-auth-common/4.5.14//vertx-auth-common-4.5.14.jar

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.10.0</commons-cli.version>
     <bouncycastle.version>1.82</bouncycastle.version>
-    <tink.version>1.16.0</tink.version>
+    <tink.version>1.19.0</tink.version>
     <datasketches.version>6.2.0</datasketches.version>
     <netty.version>4.2.7.Final</netty.version>
     <netty-tcnative.version>2.0.74.Final</netty-tcnative.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `tink` to 1.19.0.

### Why are the changes needed?

To bring the latest bug fixes.
- https://github.com/tink-crypto/tink-java/releases/tag/v1.19.0 (2025-10-25)
  - Tink no longer supports Java 8. The minimum version starting from 1.19.0 is Java 11.
- https://github.com/tink-crypto/tink-java/releases/tag/v1.18.0 (2025-06-18)
  - Improved performance of AES-GCM-SIV.
- https://github.com/tink-crypto/tink-java/releases/tag/v1.17.0 (2025-03-13)
  - https://github.com/tink-crypto/tink-java/issues/53

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.