### PR TITLE
[SPARK-54616][SQL][4.1] Mark `SupportsPushDownVariants` as `Experimental`

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownVariants.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownVariants.java
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.connector.read;
 
-import org.apache.spark.annotation.Evolving;
+import org.apache.spark.annotation.Experimental;
 
 /**
  * A mix-in interface for {@link Scan}. Data sources can implement this interface to
@@ -39,7 +39,7 @@ import org.apache.spark.annotation.Evolving;
  *
  * @since 4.1.0
  */
-@Evolving
+@Experimental
 public interface SupportsPushDownVariants extends Scan {
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to mark `SupportsPushDownVariants` as `Experimental` instead of `Evolving` in Apache Spark 4.1.x.

### Why are the changes needed?

During Apache Spark 4.1.0 RC2, it turns out that this new `Variant` improvement feature still needs more time to stabilize.

- https://github.com/apache/spark/pull/52522
- https://github.com/apache/spark/pull/52578 
- https://github.com/apache/spark/pull/53276
- [[VOTE] Release Spark 4.1.0 (RC2)](https://lists.apache.org/thread/og4dn0g7r92qj22fdsmqoqs518k324q5)

We had better mark this interface itself as `Experimental` in Apache Spark 4.1.0 while keeping it `Evolving` in `master` branch.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.