### PR TITLE
[SPARK-54618][SQL] Promote `LocalScan` to `Stable`

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/LocalScan.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/LocalScan.java
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.connector.read;
 
-import org.apache.spark.annotation.Experimental;
+import org.apache.spark.annotation.Stable;
 import org.apache.spark.sql.catalyst.InternalRow;
 
 /**
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.InternalRow;
  *
  * @since 3.2.0
  */
-@Experimental
+@Stable
 public interface LocalScan extends Scan {
   InternalRow[] rows();
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to promote `LocalScan` to `Stable` at Apache Spark 4.2.0.

### Why are the changes needed?

- Since SPARK-35535 introduced `LocalScan` at Apache Spark 3.2.0, this interface has been serving stably over 4 years without any change.
  - #32678
  - #33826

- We had better define this `Stable` at Apache Spark 4.2.0 because this is no longer experimental.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.