### PR TITLE
[SPARK-54617][PYTHON][SQL] Enable Arrow Grouped Iter Aggregate UDF registration for SQL

### DIFF
--- a/python/pyspark/sql/connect/udf.py
+++ b/python/pyspark/sql/connect/udf.py
@@ -295,6 +295,7 @@ class UDFRegistration:
                 PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF,
                 PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF,
                 PythonEvalType.SQL_GROUPED_AGG_ARROW_UDF,
+                PythonEvalType.SQL_GROUPED_AGG_ARROW_ITER_UDF,
             ]:
                 raise PySparkTypeError(
                     errorClass="INVALID_UDF_EVAL_TYPE",
@@ -302,7 +303,8 @@ class UDFRegistration:
                         "eval_type": "SQL_BATCHED_UDF, SQL_ARROW_BATCHED_UDF, "
                         "SQL_SCALAR_PANDAS_UDF, SQL_SCALAR_ARROW_UDF, "
                         "SQL_SCALAR_PANDAS_ITER_UDF, SQL_SCALAR_ARROW_ITER_UDF, "
-                        "SQL_GROUPED_AGG_PANDAS_UDF or SQL_GROUPED_AGG_ARROW_UDF"
+                        "SQL_GROUPED_AGG_PANDAS_UDF, SQL_GROUPED_AGG_ARROW_UDF or "
+                        "SQL_GROUPED_AGG_ARROW_ITER_UDF"
                     },
                 )
             self.sparkSession._client.register_udf(

--- a/python/pyspark/sql/tests/arrow/test_arrow_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf_grouped_agg.py
@@ -1259,7 +1259,8 @@ class GroupedAggArrowUDFTestsMixin:
 
             # Test SQL query with GROUP BY and multiple columns
             result_sql = self.spark.sql(
-                "SELECT id, arrow_weighted_mean_iter(v, w) as wm FROM test_table GROUP BY id ORDER BY id"
+                "SELECT id, arrow_weighted_mean_iter(v, w) as wm "
+                "FROM test_table GROUP BY id ORDER BY id"
             )
 
             # Expected weighted means:
@@ -1284,13 +1285,12 @@ class GroupedAggArrowUDFTestsMixin:
                 total += pa.compute.sum(v).as_py()
             return total
 
-        self.assertEqual(arrow_sum_iter.evalType, PythonEvalType.SQL_GROUPED_AGG_ARROW_ITER_UDF)
+        expected_eval_type = PythonEvalType.SQL_GROUPED_AGG_ARROW_ITER_UDF
+        self.assertEqual(arrow_sum_iter.evalType, expected_eval_type)
 
         with self.temp_func("arrow_sum_iter"):
             registered_udf = self.spark.udf.register("arrow_sum_iter", arrow_sum_iter)
-            self.assertEqual(
-                registered_udf.evalType, PythonEvalType.SQL_GROUPED_AGG_ARROW_ITER_UDF
-            )
+            self.assertEqual(registered_udf.evalType, expected_eval_type)
 
             # Test SQL query
             q = """

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -212,7 +212,8 @@ class ApplyInPandasTestsMixin:
                     "eval_type": "SQL_BATCHED_UDF, SQL_ARROW_BATCHED_UDF, "
                     "SQL_SCALAR_PANDAS_UDF, SQL_SCALAR_ARROW_UDF, "
                     "SQL_SCALAR_PANDAS_ITER_UDF, SQL_SCALAR_ARROW_ITER_UDF, "
-                    "SQL_GROUPED_AGG_PANDAS_UDF or SQL_GROUPED_AGG_ARROW_UDF"
+                    "SQL_GROUPED_AGG_PANDAS_UDF, SQL_GROUPED_AGG_ARROW_UDF or "
+                    "SQL_GROUPED_AGG_ARROW_ITER_UDF"
                 },
             )
 

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -680,6 +680,7 @@ class UDFRegistration:
                 PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF,
                 PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF,
                 PythonEvalType.SQL_GROUPED_AGG_ARROW_UDF,
+                PythonEvalType.SQL_GROUPED_AGG_ARROW_ITER_UDF,
             ]:
                 raise PySparkTypeError(
                     errorClass="INVALID_UDF_EVAL_TYPE",
@@ -687,7 +688,8 @@ class UDFRegistration:
                         "eval_type": "SQL_BATCHED_UDF, SQL_ARROW_BATCHED_UDF, "
                         "SQL_SCALAR_PANDAS_UDF, SQL_SCALAR_ARROW_UDF, "
                         "SQL_SCALAR_PANDAS_ITER_UDF, SQL_SCALAR_ARROW_ITER_UDF, "
-                        "SQL_GROUPED_AGG_PANDAS_UDF or SQL_GROUPED_AGG_ARROW_UDF"
+                        "SQL_GROUPED_AGG_PANDAS_UDF, SQL_GROUPED_AGG_ARROW_UDF or "
+                        "SQL_GROUPED_AGG_ARROW_ITER_UDF"
                     },
                 )
             source_udf = _create_udf(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR enables Arrow grouped iter aggregate UDFs to be registered and used in SQL queries. Previously, Arrow iter aggregate UDFs could only be used via DataFrame API, but not in SQL.

The main change is adding `SQL_GROUPED_AGG_ARROW_ITER_UDF` to the allowed eval types in `UDFRegistration.register()` method, along with comprehensive test cases.

### Why are the changes needed?

Arrow iter aggregate UDFs provide a memory-efficient way to perform grouped aggregations by processing data in batches iteratively. However, they could only be used via DataFrame API, not in SQL queries. This limitation prevented users from using these UDFs in SQL-based workflows.

### Does this PR introduce _any_ user-facing change?

Yes. Users can now register Arrow grouped iter aggregate UDFs and use them in SQL queries. 

Example:
```python
from typing import Iterator
from pyspark.sql.functions import arrow_udf
import pyarrow as pa

@arrow_udf("double")
def arrow_mean_iter(it: Iterator[pa.Array]) -> float:
    sum_val = 0.0
    cnt = 0
    for v in it:
        sum_val += pa.compute.sum(v).as_py()
        cnt += len(v)
    return sum_val / cnt if cnt > 0 else 0.0

# Now this works:
spark.udf.register("arrow_mean_iter", arrow_mean_iter)
spark.sql("SELECT id, arrow_mean_iter(v) as mean FROM test_table GROUP BY id").show()
```

### How was this patch tested?

Added comprehensive test cases covering:
- Single column Arrow iter aggregate UDF in SQL
- Multiple columns Arrow iter aggregate UDF in SQL

### Was this patch authored or co-authored using generative AI tooling?

No.
