### PR TITLE
[SPARK-54622][SQL] Promote `RequiresDistributionAndOrdering` and its required interfaces to `Evolving`

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/distributions/ClusteredDistribution.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/distributions/ClusteredDistribution.java
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.connector.distributions;
 
-import org.apache.spark.annotation.Experimental;
+import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.expressions.Expression;
 
 /**
@@ -26,7 +26,7 @@ import org.apache.spark.sql.connector.expressions.Expression;
  *
  * @since 3.2.0
  */
-@Experimental
+@Evolving
 public interface ClusteredDistribution extends Distribution {
   /**
    * Returns clustering expressions.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/distributions/Distribution.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/distributions/Distribution.java
@@ -17,12 +17,12 @@
 
 package org.apache.spark.sql.connector.distributions;
 
-import org.apache.spark.annotation.Experimental;
+import org.apache.spark.annotation.Evolving;
 
 /**
  * An interface that defines how data is distributed across partitions.
  *
  * @since 3.2.0
  */
-@Experimental
+@Evolving
 public interface Distribution {}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/distributions/Distributions.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/distributions/Distributions.java
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.connector.distributions;
 
-import org.apache.spark.annotation.Experimental;
+import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.sql.connector.expressions.SortOrder;
 
@@ -26,7 +26,7 @@ import org.apache.spark.sql.connector.expressions.SortOrder;
  *
  * @since 3.2.0
  */
-@Experimental
+@Evolving
 public class Distributions {
   private Distributions() {
   }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/distributions/OrderedDistribution.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/distributions/OrderedDistribution.java
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.connector.distributions;
 
-import org.apache.spark.annotation.Experimental;
+import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.expressions.SortOrder;
 
 /**
@@ -26,7 +26,7 @@ import org.apache.spark.sql.connector.expressions.SortOrder;
  *
  * @since 3.2.0
  */
-@Experimental
+@Evolving
 public interface OrderedDistribution extends Distribution {
   /**
    * Returns ordering expressions.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/distributions/UnspecifiedDistribution.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/distributions/UnspecifiedDistribution.java
@@ -17,12 +17,12 @@
 
 package org.apache.spark.sql.connector.distributions;
 
-import org.apache.spark.annotation.Experimental;
+import org.apache.spark.annotation.Evolving;
 
 /**
  * A distribution where no promises are made about co-location of data.
  *
  * @since 3.2.0
  */
-@Experimental
+@Evolving
 public interface UnspecifiedDistribution extends Distribution {}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/NullOrdering.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/NullOrdering.java
@@ -17,14 +17,14 @@
 
 package org.apache.spark.sql.connector.expressions;
 
-import org.apache.spark.annotation.Experimental;
+import org.apache.spark.annotation.Evolving;
 
 /**
  * A null order used in sorting expressions.
  *
  * @since 3.2.0
  */
-@Experimental
+@Evolving
 public enum NullOrdering {
   NULLS_FIRST, NULLS_LAST;
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/SortDirection.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/SortDirection.java
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.connector.expressions;
 
-import org.apache.spark.annotation.Experimental;
+import org.apache.spark.annotation.Evolving;
 
 import static org.apache.spark.sql.connector.expressions.NullOrdering.NULLS_FIRST;
 import static org.apache.spark.sql.connector.expressions.NullOrdering.NULLS_LAST;
@@ -30,7 +30,7 @@ import static org.apache.spark.sql.connector.expressions.NullOrdering.NULLS_LAST
  *
  * @since 3.2.0
  */
-@Experimental
+@Evolving
 public enum SortDirection {
   ASCENDING(NULLS_FIRST), DESCENDING(NULLS_LAST);
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/SortOrder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/SortOrder.java
@@ -17,14 +17,14 @@
 
 package org.apache.spark.sql.connector.expressions;
 
-import org.apache.spark.annotation.Experimental;
+import org.apache.spark.annotation.Evolving;
 
 /**
  * Represents a sort order in the public expression API.
  *
  * @since 3.2.0
  */
-@Experimental
+@Evolving
 public interface SortOrder extends Expression {
   /**
    * Returns the sort expression.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RequiresDistributionAndOrdering.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RequiresDistributionAndOrdering.java
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.connector.write;
 
-import org.apache.spark.annotation.Experimental;
+import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.distributions.Distribution;
 import org.apache.spark.sql.connector.distributions.UnspecifiedDistribution;
 import org.apache.spark.sql.connector.expressions.SortOrder;
@@ -27,7 +27,7 @@ import org.apache.spark.sql.connector.expressions.SortOrder;
  *
  * @since 3.2.0
  */
-@Experimental
+@Evolving
 public interface RequiresDistributionAndOrdering extends Write {
   /**
    * Returns the distribution required by this write.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to promote `RequiresDistributionAndOrdering` and its required interfaces to `Evolving` from `Experimental`.

### Why are the changes needed?

Since Apache Spark 3.2.0, `RequiresDistributionAndOrdering` and its required interfaces have been served stably over 5 years like the following. In Apache Spark 4.2.0, we had better promote this to `Evolving` because these are no longer `Experimental`.
- #30706

| Interface | Description |
| - | - |
| org.apache.spark.sql.connector.distributions.ClusteredDistribution | Unchange |
| org.apache.spark.sql.connector.distributions.Distribution | Unchange |
| org.apache.spark.sql.connector.distributions.Distributions | Unchange |
| org.apache.spark.sql.connector.distributions.OrderedDistribution | Unchange |
| org.apache.spark.sql.connector.distributions.UnspecifiedDistribution | Unchange |
| org.apache.spark.sql.connector.expressions.NullOrdering | No Functional Change |
| org.apache.spark.sql.connector.expressions.SortDirection | No Functional Change |
| org.apache.spark.sql.connector.expressions.SortOrder | Stably Evolving |
| org.apache.spark.sql.connector.write.RequiresDistributionAndOrdering | Stably Evolving |

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.