### PR TITLE
[SPARK-54624][UI] Ensure user name in historypage get escaped

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -216,7 +216,11 @@ $(document).ready(function() {
             data: 'duration',
             render: (id, type, row) => `<span title="${row.durationMillisec}">${row.duration}</span>`
           },
-          {name: 'user', data: 'sparkUser' },
+          {
+            name: 'user',
+            data: 'sparkUser',
+            render: (name) => escapeHtml(name)
+          },
           {name: 'lastUpdated', data: 'lastUpdated' },
           {
             name: 'eventLog',


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to escape user name displayed in historypage.

### Why are the changes needed?
Similar to the issue resolved in #52851, user name should also get escaped because arbitrary user name can be set through the env var `SPARK_USER`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
User name displayed in historypage is escaped even if the name is like `<script>alert('XSS')</script>`

### Was this patch authored or co-authored using generative AI tooling?
No.
