### PR TITLE
[SPARK-54626][BUILD] Upgrade gson to `2.13.2`

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -65,7 +65,7 @@ failureaccess/1.0.3//failureaccess-1.0.3.jar
 flatbuffers-java/25.2.10//flatbuffers-java-25.2.10.jar
 gcs-connector/hadoop3-2.2.28/shaded/gcs-connector-hadoop3-2.2.28-shaded.jar
 gmetric4j/1.0.10//gmetric4j-1.0.10.jar
-gson/2.11.0//gson-2.11.0.jar
+gson/2.13.2//gson-2.13.2.jar
 guava/33.4.8-jre//guava-33.4.8-jre.jar
 hadoop-aliyun/3.4.2//hadoop-aliyun-3.4.2.jar
 hadoop-annotations/3.4.2//hadoop-annotations-3.4.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
     <datanucleus-core.version>4.1.17</datanucleus-core.version>
     <guava.version>33.4.8-jre</guava.version>
     <guava.failureaccess.version>1.0.3</guava.failureaccess.version>
-    <gson.version>2.11.0</gson.version>
+    <gson.version>2.13.2</gson.version>
     <janino.version>3.1.9</janino.version>
     <jersey.version>3.0.18</jersey.version>
     <joda.version>2.14.0</joda.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to upgrade gson from `2.11.0` to `2.13.2`

Changes after `2.11.0`:
* 2.12.0: https://github.com/google/gson/releases/tag/gson-parent-2.12.0
* 2.12.1: https://github.com/google/gson/releases/tag/gson-parent-2.12.1
* 2.13.0: https://github.com/google/gson/releases/tag/gson-parent-2.13.0
* 2.13.1: https://github.com/google/gson/releases/tag/gson-parent-2.13.1
* 2.13.2: https://github.com/google/gson/releases/tag/gson-parent-2.13.2

### Why are the changes needed?
To keep the dependency latest.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
No.
