### PR TITLE
[SPARK-54627][PYTHON] Remove redundant initializations in serializers

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -1138,13 +1138,9 @@ class ArrowStreamAggArrowUDFSerializer(ArrowStreamArrowUDFSerializer):
         super().__init__(
             timezone=timezone,
             safecheck=safecheck,
-            assign_cols_by_name=False,
-            arrow_cast=True,
+            assign_cols_by_name=assign_cols_by_name,
+            arrow_cast=arrow_cast,
         )
-        self._timezone = timezone
-        self._safecheck = safecheck
-        self._assign_cols_by_name = assign_cols_by_name
-        self._arrow_cast = arrow_cast
 
     def load_stream(self, stream):
         """
@@ -1189,13 +1185,9 @@ class ArrowStreamAggArrowIterUDFSerializer(ArrowStreamArrowUDFSerializer):
         super().__init__(
             timezone=timezone,
             safecheck=safecheck,
-            assign_cols_by_name=False,
-            arrow_cast=True,
+            assign_cols_by_name=assign_cols_by_name,
+            arrow_cast=arrow_cast,
         )
-        self._timezone = timezone
-        self._safecheck = safecheck
-        self._assign_cols_by_name = assign_cols_by_name
-        self._arrow_cast = arrow_cast
 
     def load_stream(self, stream):
         """
@@ -1241,7 +1233,7 @@ class ArrowStreamAggPandasUDFSerializer(ArrowStreamPandasUDFSerializer):
         super(ArrowStreamAggPandasUDFSerializer, self).__init__(
             timezone=timezone,
             safecheck=safecheck,
-            assign_cols_by_name=False,
+            assign_cols_by_name=assign_cols_by_name,
             df_for_struct=False,
             struct_in_pandas="dict",
             ndarray_as_list=False,
@@ -1249,9 +1241,6 @@ class ArrowStreamAggPandasUDFSerializer(ArrowStreamPandasUDFSerializer):
             input_types=None,
             int_to_decimal_coercion_enabled=int_to_decimal_coercion_enabled,
         )
-        self._timezone = timezone
-        self._safecheck = safecheck
-        self._assign_cols_by_name = assign_cols_by_name
 
     def load_stream(self, stream):
         """


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove redundant `self._timezone` and `self._safecheck` assignments in three serializer classes (`ArrowStreamAggArrowUDFSerializer`, `ArrowStreamAggArrowIterUDFSerializer`, `ArrowStreamAggPandasUDFSerializer`).

Also improve parameter passing by directly passing `assign_cols_by_name` and `arrow_cast` to parent class instead of passing fixed values and then overriding them.

### Why are the changes needed?

Improves code clarity and consistency by removing redundant code that was already set by parent classes.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
