### PR TITLE
[SPARK-54630][SQL] Add timestamp_bucket function for temporal bucketing

### DIFF
--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -3692,6 +3692,18 @@ def timestamp_add(unit: str, quantity: "ColumnOrName", ts: "ColumnOrName") -> Co
 timestamp_add.__doc__ = pysparkfuncs.timestamp_add.__doc__
 
 
+def timestamp_bucket(
+    bucket_width: "ColumnOrName", timestamp: "ColumnOrName", origin: Optional["ColumnOrName"] = None
+) -> Column:
+    if origin is None:
+        return _invoke_function_over_columns("timestamp_bucket", bucket_width, timestamp)
+    else:
+        return _invoke_function_over_columns("timestamp_bucket", bucket_width, timestamp, origin)
+
+
+timestamp_bucket.__doc__ = pysparkfuncs.timestamp_bucket.__doc__
+
+
 def window(
     timeColumn: "ColumnOrName",
     windowDuration: str,

--- a/python/pyspark/sql/functions/__init__.py
+++ b/python/pyspark/sql/functions/__init__.py
@@ -244,6 +244,7 @@ __all__ = [  # noqa: F405
     "second",
     "session_window",
     "timestamp_add",
+    "timestamp_bucket",
     "timestamp_diff",
     "timestamp_micros",
     "timestamp_millis",

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -6881,7 +6881,8 @@ object functions {
    *   The temporal value to bucket. Accepts DATE, TIMESTAMP, or TIMESTAMP_NTZ. DATE values are
    *   implicitly cast to TIMESTAMP at midnight.
    * @return
-   *   The start timestamp of the bucket (TIMESTAMP type).
+   *   The start timestamp of the bucket. DATE input returns TIMESTAMP. TIMESTAMP and
+   *   TIMESTAMP_NTZ inputs preserve their types.
    * @group datetime_funcs
    * @since 4.2.0
    */
@@ -6906,7 +6907,8 @@ object functions {
    *   The timestamp to align buckets to. Must be a constant/foldable TIMESTAMP. For example, use
    *   TIMESTAMP'1970-01-05' for Monday-aligned weeks.
    * @return
-   *   The start timestamp of the bucket (TIMESTAMP type).
+   *   The start timestamp of the bucket. DATE input returns TIMESTAMP. TIMESTAMP and
+   *   TIMESTAMP_NTZ inputs preserve their types.
    * @group datetime_funcs
    * @since 4.2.0
    */

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -6868,6 +6868,52 @@ object functions {
     Column.internalFn("timestampadd", lit(unit), quantity, ts)
 
   /**
+   * Returns the start of the timestamp bucket containing the input timestamp, aligned to the Unix
+   * epoch (1970-01-01 00:00:00 UTC).
+   *
+   * Buckets are fixed-width intervals specified by the `bucketWidth` parameter. For example,
+   * hourly (INTERVAL '1' HOUR), 6-hour (INTERVAL '6' HOUR), or weekly (INTERVAL '7' DAY) buckets.
+   *
+   * @param bucketWidth
+   *   A day-time interval expression specifying the width of each bucket. Must be a
+   *   constant/foldable positive interval.
+   * @param timestamp
+   *   The temporal value to bucket. Accepts DATE, TIMESTAMP, or TIMESTAMP_NTZ. DATE values are
+   *   implicitly cast to TIMESTAMP at midnight.
+   * @return
+   *   The start timestamp of the bucket (TIMESTAMP type).
+   * @group datetime_funcs
+   * @since 4.2.0
+   */
+  def timestamp_bucket(bucketWidth: Column, timestamp: Column): Column =
+    Column.fn("timestamp_bucket", bucketWidth, timestamp)
+
+  /**
+   * Returns the start of the timestamp bucket containing the input timestamp, aligned to the
+   * specified origin.
+   *
+   * Buckets are fixed-width intervals specified by the `bucketWidth` parameter, and aligned
+   * relative to the `origin` timestamp. This allows custom bucket boundaries such as
+   * Monday-aligned weeks, fiscal year starts, or shift times.
+   *
+   * @param bucketWidth
+   *   A day-time interval expression specifying the width of each bucket. Must be a
+   *   constant/foldable positive interval.
+   * @param timestamp
+   *   The temporal value to bucket. Accepts DATE, TIMESTAMP, or TIMESTAMP_NTZ. DATE values are
+   *   implicitly cast to TIMESTAMP at midnight.
+   * @param origin
+   *   The timestamp to align buckets to. Must be a constant/foldable TIMESTAMP. For example, use
+   *   TIMESTAMP'1970-01-05' for Monday-aligned weeks.
+   * @return
+   *   The start timestamp of the bucket (TIMESTAMP type).
+   * @group datetime_funcs
+   * @since 4.2.0
+   */
+  def timestamp_bucket(bucketWidth: Column, timestamp: Column, origin: Column): Column =
+    Column.fn("timestamp_bucket", bucketWidth, timestamp, origin)
+
+  /**
    * Returns the difference between two times, measured in specified units. Throws a
    * SparkIllegalArgumentException, in case the specified unit is not supported.
    *

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -659,6 +659,7 @@ object FunctionRegistry {
     expression[LocalTimestamp]("localtimestamp"),
     expression[DateDiff]("datediff"),
     expression[DateDiff]("date_diff", setAlias = true, Some("3.4.0")),
+    expression[TimestampBucket]("timestamp_bucket"),
     expression[DateAdd]("date_add"),
     expression[DateAdd]("dateadd", setAlias = true, Some("3.4.0")),
     expression[DateFormatClass]("date_format"),

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -371,6 +371,7 @@
 | org.apache.spark.sql.catalyst.expressions.TimeToSeconds | time_to_seconds | SELECT time_to_seconds(TIME'00:00:00') | struct<time_to_seconds(TIME '00:00:00'):decimal(14,6)> |
 | org.apache.spark.sql.catalyst.expressions.TimeTrunc | time_trunc | SELECT time_trunc('HOUR', TIME'09:32:05.359') | struct<time_trunc(HOUR, TIME '09:32:05.359'):time(6)> |
 | org.apache.spark.sql.catalyst.expressions.TimeWindow | window | SELECT a, window.start, window.end, count(*) as cnt FROM VALUES ('A1', '2021-01-01 00:00:00'), ('A1', '2021-01-01 00:04:30'), ('A1', '2021-01-01 00:06:00'), ('A2', '2021-01-01 00:01:00') AS tab(a, b) GROUP by a, window(b, '5 minutes') ORDER BY a, start | struct<a:string,start:timestamp,end:timestamp,cnt:bigint> |
+| org.apache.spark.sql.catalyst.expressions.TimestampBucket | timestamp_bucket | SELECT timestamp_bucket(INTERVAL '1' HOUR, TIMESTAMP'2024-12-04 14:30:00', TIMESTAMP'2024-12-04 00:00:00') | struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '2024-12-04 00:00:00'):timestamp> |
 | org.apache.spark.sql.catalyst.expressions.ToBinary | to_binary | SELECT to_binary('abc', 'utf-8') | struct<to_binary(abc, utf-8):binary> |
 | org.apache.spark.sql.catalyst.expressions.ToCharacterBuilder | to_char | SELECT to_char(454, '999') | struct<to_char(454, 999):string> |
 | org.apache.spark.sql.catalyst.expressions.ToCharacterBuilder | to_varchar | SELECT to_varchar(454, '999') | struct<to_char(454, 999):string> |

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/date.sql.out
@@ -953,3 +953,145 @@ org.apache.spark.sql.catalyst.parser.ParseException
     "fragment" : "datediff('YEAR', date'2022-02-25', date'2023-02-25')"
   } ]
 }
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' DAY, timestamp'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, timestamp'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '15' MINUTE, timestamp'2024-12-04 14:47:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04', timestamp'1970-01-05 00:00:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04', timestamp'1970-01-04 00:00:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2024-12-04 14:30:00', timestamp'2024-12-04 03:00:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp_ntz'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'1969-12-31 23:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2023-12-31 22:00:00', timestamp'2024-01-01 00:00:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, CAST(NULL AS TIMESTAMP))
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(CAST(NULL AS INTERVAL DAY), timestamp'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04', CAST(NULL AS TIMESTAMP))
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '0' SECOND, timestamp'2024-12-04')
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "currentValue" : "0",
+    "exprName" : "bucket_width",
+    "sqlExpr" : "\"timestamp_bucket(INTERVAL '00' SECOND, TIMESTAMP '2024-12-04 00:00:00', TIMESTAMP '1969-12-31 16:00:00')\"",
+    "valueRange" : "(0, 9223372036854775807]"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 67,
+    "fragment" : "timestamp_bucket(INTERVAL '0' SECOND, timestamp'2024-12-04')"
+  } ]
+}
+
+
+-- !query
+select timestamp_bucket(INTERVAL '-1' HOUR, timestamp'2024-12-04')
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "currentValue" : "-3600000000",
+    "exprName" : "bucket_width",
+    "sqlExpr" : "\"timestamp_bucket(INTERVAL '-01' HOUR, TIMESTAMP '2024-12-04 00:00:00', TIMESTAMP '1969-12-31 16:00:00')\"",
+    "valueRange" : "(0, 9223372036854775807]"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 66,
+    "fragment" : "timestamp_bucket(INTERVAL '-1' HOUR, timestamp'2024-12-04')"
+  } ]
+}

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/datetime-legacy.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/datetime-legacy.sql.out
@@ -956,6 +956,148 @@ org.apache.spark.sql.catalyst.parser.ParseException
 
 
 -- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' DAY, timestamp'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, timestamp'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '15' MINUTE, timestamp'2024-12-04 14:47:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04', timestamp'1970-01-05 00:00:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04', timestamp'1970-01-04 00:00:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2024-12-04 14:30:00', timestamp'2024-12-04 03:00:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp_ntz'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'1969-12-31 23:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2023-12-31 22:00:00', timestamp'2024-01-01 00:00:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, CAST(NULL AS TIMESTAMP))
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(CAST(NULL AS INTERVAL DAY), timestamp'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04', CAST(NULL AS TIMESTAMP))
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '0' SECOND, timestamp'2024-12-04')
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "currentValue" : "0",
+    "exprName" : "bucket_width",
+    "sqlExpr" : "\"timestamp_bucket(INTERVAL '00' SECOND, TIMESTAMP '2024-12-04 00:00:00', TIMESTAMP '1969-12-31 16:00:00')\"",
+    "valueRange" : "(0, 9223372036854775807]"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 67,
+    "fragment" : "timestamp_bucket(INTERVAL '0' SECOND, timestamp'2024-12-04')"
+  } ]
+}
+
+
+-- !query
+select timestamp_bucket(INTERVAL '-1' HOUR, timestamp'2024-12-04')
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "currentValue" : "-3600000000",
+    "exprName" : "bucket_width",
+    "sqlExpr" : "\"timestamp_bucket(INTERVAL '-01' HOUR, TIMESTAMP '2024-12-04 00:00:00', TIMESTAMP '1969-12-31 16:00:00')\"",
+    "valueRange" : "(0, 9223372036854775807]"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 66,
+    "fragment" : "timestamp_bucket(INTERVAL '-1' HOUR, timestamp'2024-12-04')"
+  } ]
+}
+
+
+-- !query
 select timestamp '2019-01-01\t'
 -- !query analysis
 [Analyzer test output redacted due to nondeterminism]

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/nonansi/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/nonansi/date.sql.out
@@ -1028,3 +1028,145 @@ org.apache.spark.sql.catalyst.parser.ParseException
     "fragment" : "datediff('YEAR', date'2022-02-25', date'2023-02-25')"
   } ]
 }
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' DAY, timestamp'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, timestamp'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '15' MINUTE, timestamp'2024-12-04 14:47:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04', timestamp'1970-01-05 00:00:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04', timestamp'1970-01-04 00:00:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2024-12-04 14:30:00', timestamp'2024-12-04 03:00:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp_ntz'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'1969-12-31 23:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2023-12-31 22:00:00', timestamp'2024-01-01 00:00:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, CAST(NULL AS TIMESTAMP))
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(CAST(NULL AS INTERVAL DAY), timestamp'2024-12-04 14:30:00')
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04', CAST(NULL AS TIMESTAMP))
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select timestamp_bucket(INTERVAL '0' SECOND, timestamp'2024-12-04')
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "currentValue" : "0",
+    "exprName" : "bucket_width",
+    "sqlExpr" : "\"timestamp_bucket(INTERVAL '00' SECOND, TIMESTAMP '2024-12-04 00:00:00', TIMESTAMP '1969-12-31 16:00:00')\"",
+    "valueRange" : "(0, 9223372036854775807]"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 67,
+    "fragment" : "timestamp_bucket(INTERVAL '0' SECOND, timestamp'2024-12-04')"
+  } ]
+}
+
+
+-- !query
+select timestamp_bucket(INTERVAL '-1' HOUR, timestamp'2024-12-04')
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "currentValue" : "-3600000000",
+    "exprName" : "bucket_width",
+    "sqlExpr" : "\"timestamp_bucket(INTERVAL '-01' HOUR, TIMESTAMP '2024-12-04 00:00:00', TIMESTAMP '1969-12-31 16:00:00')\"",
+    "valueRange" : "(0, 9223372036854775807]"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 66,
+    "fragment" : "timestamp_bucket(INTERVAL '-1' HOUR, timestamp'2024-12-04')"
+  } ]
+}

--- a/sql/core/src/test/resources/sql-tests/inputs/date.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/date.sql
@@ -171,3 +171,43 @@ select date_diff(YEAR, date'2022-02-25', date'2023-02-25');
 
 select date_diff('MILLISECOND', timestamp'2022-02-25 01:02:03.456', timestamp'2022-02-25 01:02:03.455');
 select datediff('YEAR', date'2022-02-25', date'2023-02-25');
+
+-- timestamp_bucket: group timestamps into time buckets with default origin (epoch)
+-- hourly bucketing
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04 14:30:00');
+-- 6-hour bucketing
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2024-12-04 14:30:00');
+-- daily bucketing
+select timestamp_bucket(INTERVAL '1' DAY, timestamp'2024-12-04 14:30:00');
+-- weekly bucketing
+select timestamp_bucket(INTERVAL '7' DAY, timestamp'2024-12-04 14:30:00');
+-- 15-minute bucketing
+select timestamp_bucket(INTERVAL '15' MINUTE, timestamp'2024-12-04 14:47:00');
+
+-- timestamp_bucket with custom origin
+-- Monday-aligned weeks (1970-01-05 was Monday)
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04', timestamp'1970-01-05 00:00:00');
+-- Sunday-aligned weeks (1970-01-04 was Sunday)
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04', timestamp'1970-01-04 00:00:00');
+-- Custom time origin (6-hour buckets starting at 3 AM)
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2024-12-04 14:30:00', timestamp'2024-12-04 03:00:00');
+
+-- timestamp_bucket accepts date, timestamp, and timestamp_ntz inputs
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04');
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04 14:30:00');
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp_ntz'2024-12-04 14:30:00');
+
+-- timestamp_bucket with timestamps before origin (epoch)
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'1969-12-31 23:30:00');
+-- timestamp before custom origin
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2023-12-31 22:00:00', timestamp'2024-01-01 00:00:00');
+
+-- timestamp_bucket null handling
+select timestamp_bucket(INTERVAL '1' HOUR, CAST(NULL AS TIMESTAMP));
+select timestamp_bucket(CAST(NULL AS INTERVAL DAY), timestamp'2024-12-04 14:30:00');
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04', CAST(NULL AS TIMESTAMP));
+
+-- timestamp_bucket validation errors: zero interval
+select timestamp_bucket(INTERVAL '0' SECOND, timestamp'2024-12-04');
+-- timestamp_bucket validation errors: negative interval
+select timestamp_bucket(INTERVAL '-1' HOUR, timestamp'2024-12-04');

--- a/sql/core/src/test/resources/sql-tests/results/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/date.sql.out
@@ -1217,3 +1217,181 @@ org.apache.spark.sql.catalyst.parser.ParseException
     "fragment" : "datediff('YEAR', date'2022-02-25', date'2023-02-25')"
   } ]
 }
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-12-04 14:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '06' HOUR, TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-12-04 10:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' DAY, timestamp'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '1' DAY, TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-12-03 16:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, timestamp'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '7' DAY, TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-11-27 16:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '15' MINUTE, timestamp'2024-12-04 14:47:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '15' MINUTE, TIMESTAMP '2024-12-04 14:47:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-12-04 14:45:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04', timestamp'1970-01-05 00:00:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '7' DAY, DATE '2024-12-04', TIMESTAMP '1970-01-05 00:00:00'):timestamp>
+-- !query output
+2024-12-02 00:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04', timestamp'1970-01-04 00:00:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '7' DAY, DATE '2024-12-04', TIMESTAMP '1970-01-04 00:00:00'):timestamp>
+-- !query output
+2024-12-01 00:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2024-12-04 14:30:00', timestamp'2024-12-04 03:00:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '06' HOUR, TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '2024-12-04 03:00:00'):timestamp>
+-- !query output
+2024-12-04 09:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '7' DAY, DATE '2024-12-04', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-11-27 16:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-12-04 14:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp_ntz'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP_NTZ '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-12-04 06:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'1969-12-31 23:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP '1969-12-31 23:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+1969-12-31 23:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2023-12-31 22:00:00', timestamp'2024-01-01 00:00:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '06' HOUR, TIMESTAMP '2023-12-31 22:00:00', TIMESTAMP '2024-01-01 00:00:00'):timestamp>
+-- !query output
+2023-12-31 18:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, CAST(NULL AS TIMESTAMP))
+-- !query schema
+struct<timestamp_bucket(INTERVAL '01' HOUR, CAST(NULL AS TIMESTAMP), TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+NULL
+
+
+-- !query
+select timestamp_bucket(CAST(NULL AS INTERVAL DAY), timestamp'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(CAST(NULL AS INTERVAL DAY), TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+NULL
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04', CAST(NULL AS TIMESTAMP))
+-- !query schema
+struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP '2024-12-04 00:00:00', CAST(NULL AS TIMESTAMP)):timestamp>
+-- !query output
+NULL
+
+
+-- !query
+select timestamp_bucket(INTERVAL '0' SECOND, timestamp'2024-12-04')
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "currentValue" : "0",
+    "exprName" : "bucket_width",
+    "sqlExpr" : "\"timestamp_bucket(INTERVAL '00' SECOND, TIMESTAMP '2024-12-04 00:00:00', TIMESTAMP '1969-12-31 16:00:00')\"",
+    "valueRange" : "(0, 9223372036854775807]"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 67,
+    "fragment" : "timestamp_bucket(INTERVAL '0' SECOND, timestamp'2024-12-04')"
+  } ]
+}
+
+
+-- !query
+select timestamp_bucket(INTERVAL '-1' HOUR, timestamp'2024-12-04')
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "currentValue" : "-3600000000",
+    "exprName" : "bucket_width",
+    "sqlExpr" : "\"timestamp_bucket(INTERVAL '-01' HOUR, TIMESTAMP '2024-12-04 00:00:00', TIMESTAMP '1969-12-31 16:00:00')\"",
+    "valueRange" : "(0, 9223372036854775807]"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 66,
+    "fragment" : "timestamp_bucket(INTERVAL '-1' HOUR, timestamp'2024-12-04')"
+  } ]
+}

--- a/sql/core/src/test/resources/sql-tests/results/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/date.sql.out
@@ -1302,9 +1302,9 @@ struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP '2024-12-04 14:30:00', TIM
 -- !query
 select timestamp_bucket(INTERVAL '1' HOUR, timestamp_ntz'2024-12-04 14:30:00')
 -- !query schema
-struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP_NTZ '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP_NTZ '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp_ntz>
 -- !query output
-2024-12-04 06:00:00
+2024-12-04 14:00:00
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/datetime-legacy.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/datetime-legacy.sql.out
@@ -1275,9 +1275,9 @@ struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP '2024-12-04 14:30:00', TIM
 -- !query
 select timestamp_bucket(INTERVAL '1' HOUR, timestamp_ntz'2024-12-04 14:30:00')
 -- !query schema
-struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP_NTZ '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP_NTZ '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp_ntz>
 -- !query output
-2024-12-04 06:00:00
+2024-12-04 14:00:00
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/datetime-legacy.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/datetime-legacy.sql.out
@@ -1193,6 +1193,184 @@ org.apache.spark.sql.catalyst.parser.ParseException
 
 
 -- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-12-04 14:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '06' HOUR, TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-12-04 10:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' DAY, timestamp'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '1' DAY, TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-12-03 16:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, timestamp'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '7' DAY, TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-11-27 16:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '15' MINUTE, timestamp'2024-12-04 14:47:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '15' MINUTE, TIMESTAMP '2024-12-04 14:47:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-12-04 14:45:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04', timestamp'1970-01-05 00:00:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '7' DAY, DATE '2024-12-04', TIMESTAMP '1970-01-05 00:00:00'):timestamp>
+-- !query output
+2024-12-02 00:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04', timestamp'1970-01-04 00:00:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '7' DAY, DATE '2024-12-04', TIMESTAMP '1970-01-04 00:00:00'):timestamp>
+-- !query output
+2024-12-01 00:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2024-12-04 14:30:00', timestamp'2024-12-04 03:00:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '06' HOUR, TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '2024-12-04 03:00:00'):timestamp>
+-- !query output
+2024-12-04 09:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '7' DAY, DATE '2024-12-04', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-11-27 16:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-12-04 14:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp_ntz'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP_NTZ '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-12-04 06:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'1969-12-31 23:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP '1969-12-31 23:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+1969-12-31 23:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2023-12-31 22:00:00', timestamp'2024-01-01 00:00:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '06' HOUR, TIMESTAMP '2023-12-31 22:00:00', TIMESTAMP '2024-01-01 00:00:00'):timestamp>
+-- !query output
+2023-12-31 18:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, CAST(NULL AS TIMESTAMP))
+-- !query schema
+struct<timestamp_bucket(INTERVAL '01' HOUR, CAST(NULL AS TIMESTAMP), TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+NULL
+
+
+-- !query
+select timestamp_bucket(CAST(NULL AS INTERVAL DAY), timestamp'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(CAST(NULL AS INTERVAL DAY), TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+NULL
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04', CAST(NULL AS TIMESTAMP))
+-- !query schema
+struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP '2024-12-04 00:00:00', CAST(NULL AS TIMESTAMP)):timestamp>
+-- !query output
+NULL
+
+
+-- !query
+select timestamp_bucket(INTERVAL '0' SECOND, timestamp'2024-12-04')
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "currentValue" : "0",
+    "exprName" : "bucket_width",
+    "sqlExpr" : "\"timestamp_bucket(INTERVAL '00' SECOND, TIMESTAMP '2024-12-04 00:00:00', TIMESTAMP '1969-12-31 16:00:00')\"",
+    "valueRange" : "(0, 9223372036854775807]"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 67,
+    "fragment" : "timestamp_bucket(INTERVAL '0' SECOND, timestamp'2024-12-04')"
+  } ]
+}
+
+
+-- !query
+select timestamp_bucket(INTERVAL '-1' HOUR, timestamp'2024-12-04')
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "currentValue" : "-3600000000",
+    "exprName" : "bucket_width",
+    "sqlExpr" : "\"timestamp_bucket(INTERVAL '-01' HOUR, TIMESTAMP '2024-12-04 00:00:00', TIMESTAMP '1969-12-31 16:00:00')\"",
+    "valueRange" : "(0, 9223372036854775807]"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 66,
+    "fragment" : "timestamp_bucket(INTERVAL '-1' HOUR, timestamp'2024-12-04')"
+  } ]
+}
+
+
+-- !query
 select timestamp '2019-01-01\t'
 -- !query schema
 struct<TIMESTAMP '2019-01-01 00:00:00':timestamp>

--- a/sql/core/src/test/resources/sql-tests/results/nonansi/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/nonansi/date.sql.out
@@ -1221,3 +1221,181 @@ org.apache.spark.sql.catalyst.parser.ParseException
     "fragment" : "datediff('YEAR', date'2022-02-25', date'2023-02-25')"
   } ]
 }
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-12-04 14:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '06' HOUR, TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-12-04 10:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' DAY, timestamp'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '1' DAY, TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-12-03 16:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, timestamp'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '7' DAY, TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-11-27 16:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '15' MINUTE, timestamp'2024-12-04 14:47:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '15' MINUTE, TIMESTAMP '2024-12-04 14:47:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-12-04 14:45:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04', timestamp'1970-01-05 00:00:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '7' DAY, DATE '2024-12-04', TIMESTAMP '1970-01-05 00:00:00'):timestamp>
+-- !query output
+2024-12-02 00:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04', timestamp'1970-01-04 00:00:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '7' DAY, DATE '2024-12-04', TIMESTAMP '1970-01-04 00:00:00'):timestamp>
+-- !query output
+2024-12-01 00:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2024-12-04 14:30:00', timestamp'2024-12-04 03:00:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '06' HOUR, TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '2024-12-04 03:00:00'):timestamp>
+-- !query output
+2024-12-04 09:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '7' DAY, date'2024-12-04')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '7' DAY, DATE '2024-12-04', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-11-27 16:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-12-04 14:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp_ntz'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP_NTZ '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+2024-12-04 06:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'1969-12-31 23:30:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP '1969-12-31 23:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+1969-12-31 23:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '6' HOUR, timestamp'2023-12-31 22:00:00', timestamp'2024-01-01 00:00:00')
+-- !query schema
+struct<timestamp_bucket(INTERVAL '06' HOUR, TIMESTAMP '2023-12-31 22:00:00', TIMESTAMP '2024-01-01 00:00:00'):timestamp>
+-- !query output
+2023-12-31 18:00:00
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, CAST(NULL AS TIMESTAMP))
+-- !query schema
+struct<timestamp_bucket(INTERVAL '01' HOUR, CAST(NULL AS TIMESTAMP), TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+NULL
+
+
+-- !query
+select timestamp_bucket(CAST(NULL AS INTERVAL DAY), timestamp'2024-12-04 14:30:00')
+-- !query schema
+struct<timestamp_bucket(CAST(NULL AS INTERVAL DAY), TIMESTAMP '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+-- !query output
+NULL
+
+
+-- !query
+select timestamp_bucket(INTERVAL '1' HOUR, timestamp'2024-12-04', CAST(NULL AS TIMESTAMP))
+-- !query schema
+struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP '2024-12-04 00:00:00', CAST(NULL AS TIMESTAMP)):timestamp>
+-- !query output
+NULL
+
+
+-- !query
+select timestamp_bucket(INTERVAL '0' SECOND, timestamp'2024-12-04')
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "currentValue" : "0",
+    "exprName" : "bucket_width",
+    "sqlExpr" : "\"timestamp_bucket(INTERVAL '00' SECOND, TIMESTAMP '2024-12-04 00:00:00', TIMESTAMP '1969-12-31 16:00:00')\"",
+    "valueRange" : "(0, 9223372036854775807]"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 67,
+    "fragment" : "timestamp_bucket(INTERVAL '0' SECOND, timestamp'2024-12-04')"
+  } ]
+}
+
+
+-- !query
+select timestamp_bucket(INTERVAL '-1' HOUR, timestamp'2024-12-04')
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "currentValue" : "-3600000000",
+    "exprName" : "bucket_width",
+    "sqlExpr" : "\"timestamp_bucket(INTERVAL '-01' HOUR, TIMESTAMP '2024-12-04 00:00:00', TIMESTAMP '1969-12-31 16:00:00')\"",
+    "valueRange" : "(0, 9223372036854775807]"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 66,
+    "fragment" : "timestamp_bucket(INTERVAL '-1' HOUR, timestamp'2024-12-04')"
+  } ]
+}

--- a/sql/core/src/test/resources/sql-tests/results/nonansi/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/nonansi/date.sql.out
@@ -1306,9 +1306,9 @@ struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP '2024-12-04 14:30:00', TIM
 -- !query
 select timestamp_bucket(INTERVAL '1' HOUR, timestamp_ntz'2024-12-04 14:30:00')
 -- !query schema
-struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP_NTZ '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp>
+struct<timestamp_bucket(INTERVAL '01' HOUR, TIMESTAMP_NTZ '2024-12-04 14:30:00', TIMESTAMP '1969-12-31 16:00:00'):timestamp_ntz>
 -- !query output
-2024-12-04 06:00:00
+2024-12-04 14:00:00
 
 
 -- !query


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR introduces a new `timestamp_bucket` function for grouping temporal data into fixed-width intervals with configurable alignment.

**SQL Signature**
`timestamp_bucket(bucket_width, timestamp[, origin]) -> TIMESTAMP | TIMESTAMP_NTZ`

Parameters:
`bucket_width`: `INTERVAL DAY TO SECOND `  - The bucket width
`timestamp`: `DATE` | `TIMESTAMP` | `TIMESTAMP_NTZ` - The timestamp to bucket
`origin`: `TIMESTAMP` (optional) - The origin for bucket alignment (default: `TIMESTAMP'1970-01-01 00:00:00'`)

The return type depends on the input type:

- `DATE` input → returns `TIMESTAMP` (implicitly converted)
- `TIMESTAMP` input → returns `TIMESTAMP`
- `TIMESTAMP_NTZ` input → returns `TIMESTAMP_NTZ`

**Key Features**:
- Accepts `DATE`, `TIMESTAMP`, and `TIMESTAMP_NTZ` as input 
- Custom origin parameter for flexible bucket alignment (e.g., Monday-aligned weeks)


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Temporal bucketing is a common requirement in time-series analysis and data aggregation. 
Currently, users must:

- Write complex custom logic with floor division and date arithmetic
- Use workarounds like `date_trunc` which only supports fixed calendar units
- Lack flexibility for custom bucket alignments (e.g., fiscal weeks, shift schedules)

**Use Cases**:

- Arbitrary intervals: Bucket by 15 minutes, 6 hours, 7 days, etc. (not limited to calendar units)
- Custom alignment: Align weekly buckets to Monday instead of Thursday (epoch default)
- Time-series aggregation: Group sensor data, logs, or events into custom time windows
- Report generation: Create custom reporting periods aligned to business schedules

**Comparison to existing functions**:

- date_trunc: Limited to calendar units (year, month, day, hour), no custom alignment
- window: For streaming/windowing operations, different use case
- timestamp_bucket (this PR): Flexible intervals + custom alignment for batch analysis

**Comparison with Other Databases:**

- PostgreSQL: `date_bin(interval, timestamp, origin)`
- TimescaleDB: `time_bucket(interval, timestamp, origin)`
- This PR implementation: `timestamp_bucket(interval, timestamp, origin)`
The proposed function provides similar functionality to PostgreSQL's `date_bin` and TimescaleDB's `time_bucket`, making Spark more competitive for time-series analysis.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. This PR adds a new SQL function and API methods:

```sql
-- Hourly bucketing (default epoch alignment)
SELECT timestamp_bucket(INTERVAL '1' HOUR, TIMESTAMP'2024-12-04 14:30:00');
-- Result: 2024-12-04 14:00:00

-- Weekly bucketing with Monday alignment
SELECT timestamp_bucket(
  INTERVAL '7' DAY, 
  DATE'2024-12-04',
  TIMESTAMP'1970-01-05 00:00:00'  -- Monday origin
);
-- Result: 2024-12-02 00:00:00

-- Aggregation example
SELECT 
  timestamp_bucket(INTERVAL '15' MINUTE, event_time) AS bucket,
  COUNT(*) AS event_count
FROM events
GROUP BY bucket
ORDER BY bucket;
```

Scala API Example:

```scala
import org.apache.spark.sql.functions._

// 2-argument version (default origin)
df.select(timestamp_bucket(expr("INTERVAL '1' HOUR"), col("ts")))

// 3-argument version (custom origin)
df.select(timestamp_bucket(
  expr("INTERVAL '7' DAY"), 
  col("date_col"),
  expr("TIMESTAMP'1970-01-05 00:00:00'")
))
```

Python API Example:
```python
import pyspark.sql.functions as sf
import datetime

# 2-argument version
df.select(sf.timestamp_bucket(sf.expr("INTERVAL '1' HOUR"), "ts"))

# 3-argument version with custom origin
df.select(sf.timestamp_bucket(
    sf.expr("INTERVAL '7' DAY"),
    df.ts,
    sf.lit(datetime.datetime(1970, 1, 5))  # Monday origin
))
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added test `DateFunctionsSuite`, `date.sql`, 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No