### PR TITLE
[SPARK-54087][CORE][FOLLOWUP] Spark Executor launch task failed return task killed message should not special handling OOM

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -407,10 +407,6 @@ private[spark] class Executor(
             TaskState.FAILED,
             env.closureSerializer.newInstance().serialize(new ExceptionFailure(t, Seq.empty)))
         } catch {
-          case oom: OutOfMemoryError =>
-            logError(log"Executor update launching task ${MDC(TASK_NAME, taskDescription.name)} " +
-              log"failed status failed, reason: ${MDC(REASON, oom.getMessage)}")
-            System.exit(SparkExitCode.OOM)
           case t: Throwable =>
             logError(log"Executor update launching task ${MDC(TASK_NAME, taskDescription.name)} " +
               log"failed status failed, reason: ${MDC(REASON, t.getMessage)}")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Follow comment https://github.com/apache/spark/pull/52792#discussion_r2594690824


### Why are the changes needed?
Follow comment


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
No need


### Was this patch authored or co-authored using generative AI tooling?
No
