### PR TITLE
[SPARK-54636][BUILD][YARN] Correctly relocate Netty native libs for YARN ESS

### DIFF
--- a/common/network-yarn/pom.xml
+++ b/common/network-yarn/pom.xml
@@ -171,18 +171,25 @@
             <phase>package</phase>
             <configuration>
               <target>
+                <!-- Follow https://github.com/netty/netty/blob/netty-4.2.7.Final/testsuite-shading/pom.xml to skip processing MS Windows DLLs -->
                 <echo message="Shade netty native libraries to ${spark.shade.native.packageName}" />
                 <unzip src="${shuffle.jar}" dest="${project.build.directory}/exploded/" />
                 <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_epoll_x86_64.so"
                   tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_epoll_x86_64.so" />
+                <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_io_uring42_x86_64.so"
+                  tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_io_uring42_x86_64.so" />
                 <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_kqueue_x86_64.jnilib"
                   tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_kqueue_x86_64.jnilib" />
                 <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_epoll_aarch_64.so"
                   tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_epoll_aarch_64.so" />
+                <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_io_uring42_aarch_64.so"
+                  tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_io_uring42_aarch_64.so" />
                 <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_kqueue_aarch_64.jnilib"
                   tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_kqueue_aarch_64.jnilib" />
                 <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_epoll_riscv64.so"
                   tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_epoll_riscv64.so" />
+                <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_io_uring42_riscv64.so"
+                  tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_io_uring42_riscv64.so" />
                 <move file="${project.build.directory}/exploded/META-INF/native/libnetty_tcnative_linux_x86_64.so"
                   tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_tcnative_linux_x86_64.so" />
                 <move file="${project.build.directory}/exploded/META-INF/native/libnetty_tcnative_linux_aarch_64.so"
@@ -191,6 +198,14 @@
                   tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_tcnative_osx_x86_64.jnilib" />
                 <move file="${project.build.directory}/exploded/META-INF/native/libnetty_tcnative_osx_aarch_64.jnilib"
                   tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_tcnative_osx_aarch_64.jnilib" />
+                <move file="${project.build.directory}/exploded/META-INF/native/libnetty_quiche42_linux_x86_64.so"
+                      tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_quiche42_linux_x86_64.so" />
+                <move file="${project.build.directory}/exploded/META-INF/native/libnetty_quiche42_linux_aarch_64.so"
+                      tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_quiche42_linux_aarch_64.so" />
+                <move file="${project.build.directory}/exploded/META-INF/native/libnetty_quiche42_osx_x86_64.jnilib"
+                      tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_quiche42_osx_x86_64.jnilib" />
+                <move file="${project.build.directory}/exploded/META-INF/native/libnetty_quiche42_osx_aarch_64.jnilib"
+                      tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_quiche42_osx_aarch_64.jnilib" />
                 <jar destfile="${shuffle.jar}" basedir="${project.build.directory}/exploded" />
               </target>
             </configuration>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Spark upgrade to Netty 4.2 since SPARK-53849, which brings several additional native libs, YARN ESS should correctly relocate them as it did for other existing Netty native libs.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix potential classpath conflicts issues for YARN ESS.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, Spark upgrades to Netty 4.2 in 4.1.0, which has not been released yet.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Spark 4.0.1
```
$ jar tf spark-4.0.1-yarn-shuffle.jar | grep META-INF/native/ | grep netty
META-INF/native/liborg_sparkproject_netty_tcnative_linux_aarch_64.so
META-INF/native/liborg_sparkproject_netty_tcnative_linux_x86_64.so
META-INF/native/liborg_sparkproject_netty_tcnative_osx_aarch_64.jnilib
META-INF/native/liborg_sparkproject_netty_tcnative_osx_x86_64.jnilib
META-INF/native/liborg_sparkproject_netty_transport_native_epoll_aarch_64.so
META-INF/native/liborg_sparkproject_netty_transport_native_epoll_riscv64.so
META-INF/native/liborg_sparkproject_netty_transport_native_epoll_x86_64.so
META-INF/native/liborg_sparkproject_netty_transport_native_kqueue_aarch_64.jnilib
META-INF/native/liborg_sparkproject_netty_transport_native_kqueue_x86_64.jnilib
META-INF/native/netty_tcnative_windows_x86_64.dll
```

master branch
```
$ jar tf spark-4.2.0-SNAPSHOT-yarn-shuffle.jar | grep META-INF/native/ | grep netty
META-INF/native/libnetty_quiche42_linux_aarch_64.so
META-INF/native/libnetty_quiche42_linux_x86_64.so
META-INF/native/libnetty_quiche42_osx_aarch_64.jnilib
META-INF/native/libnetty_quiche42_osx_x86_64.jnilib
META-INF/native/libnetty_transport_native_io_uring42_aarch_64.so
META-INF/native/libnetty_transport_native_io_uring42_riscv64.so
META-INF/native/libnetty_transport_native_io_uring42_x86_64.so
META-INF/native/liborg_sparkproject_netty_tcnative_linux_aarch_64.so
META-INF/native/liborg_sparkproject_netty_tcnative_linux_x86_64.so
META-INF/native/liborg_sparkproject_netty_tcnative_osx_aarch_64.jnilib
META-INF/native/liborg_sparkproject_netty_tcnative_osx_x86_64.jnilib
META-INF/native/liborg_sparkproject_netty_transport_native_epoll_aarch_64.so
META-INF/native/liborg_sparkproject_netty_transport_native_epoll_riscv64.so
META-INF/native/liborg_sparkproject_netty_transport_native_epoll_x86_64.so
META-INF/native/liborg_sparkproject_netty_transport_native_kqueue_aarch_64.jnilib
META-INF/native/liborg_sparkproject_netty_transport_native_kqueue_x86_64.jnilib
META-INF/native/netty_quiche42_windows_x86_64.dll
META-INF/native/netty_tcnative_windows_x86_64.dll
```

this PR
```
$ jar tf spark-4.2.0-SNAPSHOT-yarn-shuffle.jar | grep META-INF/native/ | grep netty
META-INF/native/liborg_sparkproject_netty_quiche42_linux_aarch_64.so
META-INF/native/liborg_sparkproject_netty_quiche42_linux_x86_64.so
META-INF/native/liborg_sparkproject_netty_quiche42_osx_aarch_64.jnilib
META-INF/native/liborg_sparkproject_netty_quiche42_osx_x86_64.jnilib
META-INF/native/liborg_sparkproject_netty_tcnative_linux_aarch_64.so
META-INF/native/liborg_sparkproject_netty_tcnative_linux_x86_64.so
META-INF/native/liborg_sparkproject_netty_tcnative_osx_aarch_64.jnilib
META-INF/native/liborg_sparkproject_netty_tcnative_osx_x86_64.jnilib
META-INF/native/liborg_sparkproject_netty_transport_native_epoll_aarch_64.so
META-INF/native/liborg_sparkproject_netty_transport_native_epoll_riscv64.so
META-INF/native/liborg_sparkproject_netty_transport_native_epoll_x86_64.so
META-INF/native/liborg_sparkproject_netty_transport_native_io_uring42_aarch_64.so
META-INF/native/liborg_sparkproject_netty_transport_native_io_uring42_riscv64.so
META-INF/native/liborg_sparkproject_netty_transport_native_io_uring42_x86_64.so
META-INF/native/liborg_sparkproject_netty_transport_native_kqueue_aarch_64.jnilib
META-INF/native/liborg_sparkproject_netty_transport_native_kqueue_x86_64.jnilib
META-INF/native/netty_quiche42_windows_x86_64.dll
META-INF/native/netty_tcnative_windows_x86_64.dll
```

Manually tested with Hadoop YARN (v3.4.2), with ESS enabled.

<img width="1585" height="983" alt="image" src="https://github.com/user-attachments/assets/e7cfc0c9-05e5-4480-bd35-29946d1c17e9" />

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.