### PR TITLE
[SPARK-54642][BUILD] Upgrade AWS SDK v2 to 2.35.4

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -30,7 +30,7 @@ azure-storage/7.0.1//azure-storage-7.0.1.jar
 blas/3.0.4//blas-3.0.4.jar
 breeze-macros_2.13/2.1.0//breeze-macros_2.13-2.1.0.jar
 breeze_2.13/2.1.0//breeze_2.13-2.1.0.jar
-bundle/2.29.52//bundle-2.29.52.jar
+bundle/2.35.4//bundle-2.35.4.jar
 cats-kernel_2.13/2.8.0//cats-kernel_2.13-2.8.0.jar
 chill-java/0.10.0//chill-java-0.10.0.jar
 chill_2.13/0.10.0//chill_2.13-0.10.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
     <aws.kinesis.client.version>1.15.3</aws.kinesis.client.version>
     <!-- Should be consistent with Kinesis client dependency -->
     <aws.java.sdk.version>1.12.681</aws.java.sdk.version>
-    <aws.java.sdk.v2.version>2.29.52</aws.java.sdk.v2.version>
+    <aws.java.sdk.v2.version>2.35.4</aws.java.sdk.v2.version>
     <!-- the producer is used in tests -->
     <aws.kinesis.producer.version>1.0.5</aws.kinesis.producer.version>
     <!-- Do not use 3.0.0: https://github.com/GoogleCloudDataproc/hadoop-connectors/issues/1114 -->


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `AWS SDK v2` to 2.35.4.

### Why are the changes needed?

To be ready for Apache Hadoop 3.4.3 and 3.5.0 release:
- [HADOOP-19654 Upgrade AWS SDK to 2.35.4](https://issues.apache.org/jira/browse/HADOOP-19654)

### Does this PR introduce _any_ user-facing change?

No Spark behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.