### PR TITLE
[SPARK-54645][BUILD] Upgrade Scala to 2.13.18

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -260,11 +260,11 @@ py4j/0.10.9.9//py4j-0.10.9.9.jar
 remotetea-oncrpc/1.1.2//remotetea-oncrpc-1.1.2.jar
 roaringbitmap/1.5.3//roaringbitmap-1.5.3.jar
 rocksdbjni/9.8.4//rocksdbjni-9.8.4.jar
-scala-compiler/2.13.17//scala-compiler-2.13.17.jar
-scala-library/2.13.17//scala-library-2.13.17.jar
+scala-compiler/2.13.18//scala-compiler-2.13.18.jar
+scala-library/2.13.18//scala-library-2.13.18.jar
 scala-parallel-collections_2.13/1.2.0//scala-parallel-collections_2.13-1.2.0.jar
 scala-parser-combinators_2.13/2.4.0//scala-parser-combinators_2.13-2.4.0.jar
-scala-reflect/2.13.17//scala-reflect-2.13.17.jar
+scala-reflect/2.13.18//scala-reflect-2.13.18.jar
 scala-xml_2.13/2.4.0//scala-xml_2.13-2.4.0.jar
 slf4j-api/2.0.17//slf4j-api-2.0.17.jar
 snakeyaml-engine/2.10//snakeyaml-engine-2.10.jar

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -22,7 +22,7 @@ include:
 SPARK_VERSION: 4.1.0-SNAPSHOT
 SPARK_VERSION_SHORT: 4.1.0
 SCALA_BINARY_VERSION: "2.13"
-SCALA_VERSION: "2.13.17"
+SCALA_VERSION: "2.13.18"
 SPARK_ISSUE_TRACKER_URL: https://issues.apache.org/jira/browse/SPARK
 SPARK_GITHUB_URL: https://github.com/apache/spark
 # Before a new release, we should:

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
     <commons.httpcore.version>4.4.16</commons.httpcore.version>
     <commons.math3.version>3.6.1</commons.math3.version>
     <commons.collections4.version>4.5.0</commons.collections4.version>
-    <scala.version>2.13.17</scala.version>
+    <scala.version>2.13.18</scala.version>
     <scala.binary.version>2.13</scala.binary.version>
     <scalatest-maven-plugin.version>2.2.0</scalatest-maven-plugin.version>
     <scala-maven-plugin.version>4.9.7</scala-maven-plugin.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `Scala` to `2.13.18`.

### Why are the changes needed?

To bring the latest bug fixed version.
- https://github.com/scala/scala/releases/tag/v2.13.18
  - Fixes for false positive warnings
  - https://github.com/scala/scala/pull/11165 for Scala 3
  - https://github.com/scala/scala/pull/11175
  - https://github.com/scala/scala/pull/11172

### Does this PR introduce _any_ user-facing change?

Yes, this is a user-facing Scala version change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.