### PR TITLE
[SPARK-54646][BUILD] Upgrade `gcs-connector` to 2.2.29

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -63,7 +63,7 @@ dropwizard-metrics-hadoop-metrics2-reporter/0.1.2//dropwizard-metrics-hadoop-met
 esdk-obs-java/3.20.4.2//esdk-obs-java-3.20.4.2.jar
 failureaccess/1.0.3//failureaccess-1.0.3.jar
 flatbuffers-java/25.2.10//flatbuffers-java-25.2.10.jar
-gcs-connector/hadoop3-2.2.28/shaded/gcs-connector-hadoop3-2.2.28-shaded.jar
+gcs-connector/hadoop3-2.2.29/shaded/gcs-connector-hadoop3-2.2.29-shaded.jar
 gmetric4j/1.0.10//gmetric4j-1.0.10.jar
 gson/2.13.2//gson-2.13.2.jar
 guava/33.4.8-jre//guava-33.4.8-jre.jar

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
     <!-- the producer is used in tests -->
     <aws.kinesis.producer.version>1.0.5</aws.kinesis.producer.version>
     <!-- Do not use 3.0.0: https://github.com/GoogleCloudDataproc/hadoop-connectors/issues/1114 -->
-    <gcs-connector.version>hadoop3-2.2.28</gcs-connector.version>
+    <gcs-connector.version>hadoop3-2.2.29</gcs-connector.version>
     <analyticsaccelerator-s3.version>1.3.0</analyticsaccelerator-s3.version>
     <!--  org.apache.httpcomponents/httpclient-->
     <commons.httpclient.version>4.5.14</commons.httpclient.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `gcs-connector` to 2.2.29.

### Why are the changes needed?

To bring the latest bug fixes.
- https://github.com/GoogleCloudDataproc/hadoop-connectors/releases/tag/v2.2.29
    > - Fix infinite loop issue when EOF is reached during a skip operation in ReadChannel.
    > - Enable move by default

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

```
$ dev/make-distribution.sh -Phadoop-cloud
$ cd dist
$ export KEYFILE=~/.ssh/apache-spark.json
$ export EMAIL=$(jq -r '.client_email' < $KEYFILE)
$ export PRIVATE_KEY_ID=$(jq -r '.private_key_id' < $KEYFILE)
$ export PRIVATE_KEY="$(jq -r '.private_key' < $KEYFILE)"
$ bin/spark-shell \
  -c spark.hadoop.fs.gs.auth.service.account.email=$EMAIL \
  -c spark.hadoop.fs.gs.auth.service.account.private.key.id=$PRIVATE_KEY_ID \
  -c spark.hadoop.fs.gs.auth.service.account.private.key="$PRIVATE_KEY"
WARNING: Using incubator modules: jdk.incubator.vector
Using Spark's default log4j profile: org/apache/spark/log4j2-defaults.properties
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 4.2.0-SNAPSHOT
      /_/

Using Scala version 2.13.17 (OpenJDK 64-Bit Server VM, Java 17.0.17)
Type in expressions to have them evaluated.
Type :help for more information.
25/12/08 15:34:53 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Spark context Web UI available at http://localhost:4040
Spark context available as 'sc' (master = local[*], app id = local-1765236893731).
Spark session available as 'spark'.

scala> spark.read.text("gs://apache-spark-bucket/README.md").count()
val res0: Long = 124

scala> spark.read.orc("examples/src/main/resources/users.orc").write.mode("overwrite").orc("gs://apache-spark-bucket/users.orc")
     |

scala> spark.read.orc("gs://apache-spark-bucket/users.orc").show()
+------+--------------+----------------+
|  name|favorite_color|favorite_numbers|
+------+--------------+----------------+
|Alyssa|          NULL|  [3, 9, 15, 20]|
|   Ben|           red|              []|
+------+--------------+----------------+


scala>
```

### Was this patch authored or co-authored using generative AI tooling?

No.