### PR TITLE
[SPARK-54653][DOCS] Add cross-session note to cache/persist public APIs

### DIFF
--- a/docs/sql-ref-syntax-aux-cache-cache-table.md
+++ b/docs/sql-ref-syntax-aux-cache-cache-table.md
@@ -24,6 +24,8 @@ license: |
 `CACHE TABLE` statement caches contents of a table or output of a query with the given storage level. If a query is cached, then a temp view will be created for this query.
 This reduces scanning of the original files in future queries. 
 
+**Note:** Cached data is shared across all Spark sessions on the cluster. 
+
 ### Syntax
 
 ```sql

--- a/docs/sql-ref-syntax-aux-cache-refresh.md
+++ b/docs/sql-ref-syntax-aux-cache-refresh.md
@@ -23,7 +23,10 @@ license: |
 
 `REFRESH` is used to invalidate and refresh all the cached data (and the associated metadata) for
 all Datasets that contains the given data source path. Path matching is by prefix, i.e. "/" would
-invalidate everything that is cached. 
+invalidate everything that is cached.
+
+**Note:** Cached data is shared across all Spark sessions on the cluster, so refreshing it
+affects all sessions.
 
 ### Syntax
 

--- a/docs/sql-ref-syntax-aux-cache-uncache-table.md
+++ b/docs/sql-ref-syntax-aux-cache-uncache-table.md
@@ -24,6 +24,8 @@ license: |
 `UNCACHE TABLE` removes the entries and associated data from the in-memory and/or on-disk cache for a given table or view. The
 underlying entries should already have been brought to cache by previous `CACHE TABLE` operation. `UNCACHE TABLE` on a non-existent table throws an exception if `IF EXISTS` is not specified.
 
+**Note:** Cached data is shared across all Spark sessions on the cluster, so uncaching it affects all sessions.
+
 ### Syntax
 
 ```sql

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -1019,6 +1019,10 @@ class Catalog:
             .. versionchanged:: 3.5.0
                 Allow to specify storage level.
 
+        Notes
+        -----
+        Cached data is shared across all Spark sessions on the cluster.
+
         Examples
         --------
         >>> _ = spark.sql("DROP TABLE IF EXISTS tbl1")
@@ -1061,6 +1065,11 @@ class Catalog:
             .. versionchanged:: 3.4.0
                 Allow ``tableName`` to be qualified with catalog name.
 
+        Notes
+        -----
+        Cached data is shared across all Spark sessions on the cluster, so uncaching it
+        affects all sessions.
+
         Examples
         --------
         >>> _ = spark.sql("DROP TABLE IF EXISTS tbl1")
@@ -1090,6 +1099,11 @@ class Catalog:
         """Removes all cached tables from the in-memory cache.
 
         .. versionadded:: 2.0.0
+
+        Notes
+        -----
+        Cached data is shared across all Spark sessions on the cluster, so clearing
+        the cache affects all sessions.
 
         Examples
         --------

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1515,6 +1515,8 @@ class DataFrame:
         -----
         The default storage level has changed to `MEMORY_AND_DISK_DESER` to match Scala in 3.0.
 
+        Cached data is shared across all Spark sessions on the cluster.
+
         Returns
         -------
         :class:`DataFrame`
@@ -1550,6 +1552,8 @@ class DataFrame:
         Notes
         -----
         The default storage level has changed to `MEMORY_AND_DISK_DESER` to match Scala in 3.0.
+
+        Cached data is shared across all Spark sessions on the cluster.
 
         Parameters
         ----------
@@ -1620,6 +1624,9 @@ class DataFrame:
         Notes
         -----
         `blocking` default has changed to ``False`` to match Scala in 2.0.
+
+        Cached data is shared across all Spark sessions on the cluster, so unpersisting it
+        affects all sessions.
 
         Parameters
         ----------

--- a/sql/api/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -3018,6 +3018,8 @@ abstract class Dataset[T] extends Serializable {
   /**
    * Persist this Dataset with the default storage level (`MEMORY_AND_DISK`).
    *
+   * @note
+   *   Cached data is shared across all Spark sessions on the cluster.
    * @group basic
    * @since 1.6.0
    */
@@ -3026,6 +3028,8 @@ abstract class Dataset[T] extends Serializable {
   /**
    * Persist this Dataset with the default storage level (`MEMORY_AND_DISK`).
    *
+   * @note
+   *   Cached data is shared across all Spark sessions on the cluster.
    * @group basic
    * @since 1.6.0
    */
@@ -3037,6 +3041,8 @@ abstract class Dataset[T] extends Serializable {
    * @param newLevel
    *   One of: `MEMORY_ONLY`, `MEMORY_AND_DISK`, `MEMORY_ONLY_SER`, `MEMORY_AND_DISK_SER`,
    *   `DISK_ONLY`, `MEMORY_ONLY_2`, `MEMORY_AND_DISK_2`, etc.
+   * @note
+   *   Cached data is shared across all Spark sessions on the cluster.
    * @group basic
    * @since 1.6.0
    */
@@ -3056,6 +3062,9 @@ abstract class Dataset[T] extends Serializable {
    *
    * @param blocking
    *   Whether to block until all blocks are deleted.
+   * @note
+   *   Cached data is shared across all Spark sessions on the cluster, so unpersisting it affects
+   *   all sessions.
    * @group basic
    * @since 1.6.0
    */
@@ -3065,6 +3074,9 @@ abstract class Dataset[T] extends Serializable {
    * Mark the Dataset as non-persistent, and remove all blocks for it from memory and disk. This
    * will not un-persist any cached data that is built upon this Dataset.
    *
+   * @note
+   *   Cached data is shared across all Spark sessions on the cluster, so unpersisting it affects
+   *   all sessions.
    * @group basic
    * @since 1.6.0
    */

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
@@ -593,6 +593,8 @@ abstract class Catalog {
    *   is either a qualified or unqualified name that designates a table/view. If no database
    *   identifier is provided, it refers to a temporary view or a table/view in the current
    *   database.
+   * @note
+   *   Cached data is shared across all Spark sessions on the cluster.
    * @since 2.0.0
    */
   def cacheTable(tableName: String): Unit
@@ -606,6 +608,8 @@ abstract class Catalog {
    *   database.
    * @param storageLevel
    *   storage level to cache table.
+   * @note
+   *   Cached data is shared across all Spark sessions on the cluster.
    * @since 2.3.0
    */
   def cacheTable(tableName: String, storageLevel: StorageLevel): Unit
@@ -617,6 +621,9 @@ abstract class Catalog {
    *   is either a qualified or unqualified name that designates a table/view. If no database
    *   identifier is provided, it refers to a temporary view or a table/view in the current
    *   database.
+   * @note
+   *   Cached data is shared across all Spark sessions on the cluster, so uncaching it affects all
+   *   sessions.
    * @since 2.0.0
    */
   def uncacheTable(tableName: String): Unit
@@ -624,6 +631,9 @@ abstract class Catalog {
   /**
    * Removes all cached tables from the in-memory cache.
    *
+   * @note
+   *   Cached data is shared across all Spark sessions on the cluster, so clearing the cache
+   *   affects all sessions.
    * @since 2.0.0
    */
   def clearCache(): Unit


### PR DESCRIPTION
Document that cached data is shared across all Spark sessions within an application for DataFrame/Dataset cache/persist methods and Catalog.cacheTable methods.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This change updates docs and comments to mention about the nature of dataframe cache being cross-session. Only public and newer apis docs are updated, e.g. `SQLContext` could be in scope but since it is a legacy api, no change was made to it. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To further clarify the existing behavior for the cache api. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Rebuild the entire project. 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
