### PR TITLE
[SPARK-54650][PYTHON][FOLLOW-UP] Apply `pandas.api.types.is_integer_dtype` to check the series dtype

### DIFF
--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -1277,7 +1277,7 @@ def _create_converter_from_pandas(
             #     lambda x: Decimal(x))).cast(pa.decimal128(1))
 
             def convert_int_to_decimal(pser: pd.Series) -> pd.Series:
-                if pd.api.types.is_integer_dtype(pser):
+                if pd.api.types.is_integer_dtype(pser):  # type: ignore[attr-defined]
                     return pser.apply(  # type: ignore[return-value]
                         lambda x: Decimal(x) if pd.notna(x) else None
                     )

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -1277,7 +1277,7 @@ def _create_converter_from_pandas(
             #     lambda x: Decimal(x))).cast(pa.decimal128(1))
 
             def convert_int_to_decimal(pser: pd.Series) -> pd.Series:
-                if pser.dtype.kind in ["i", "u"]:
+                if pd.api.types.is_integer_dtype(pser):
                     return pser.apply(  # type: ignore[return-value]
                         lambda x: Decimal(x) if pd.notna(x) else None
                     )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Apply `pandas.api.types.is_integer_dtype` to check the series dtype


### Why are the changes needed?
`pandas.api.types.is_integer_dtype` is a public pandas API, which is the standard way to check the dtype

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
