### PR TITLE
[SPARK-54340][PYTHON][FOLLOW-UP] Add link and examples for `run-with-viztracer`

### DIFF
--- a/python/run-with-viztracer
+++ b/python/run-with-viztracer
@@ -37,6 +37,17 @@ Environment:
 
 Requirements:
   - viztracer must be installed (pip install viztracer)
+
+Check the following documentation for more information on using viztracer:
+
+  https://viztracer.readthedocs.io/en/latest/
+
+Examples:
+  - Start pyspark shell
+    $0 bin/pyspark --conf spark.driver.memory=16g
+
+  - Start pyspark shell in Connect mode
+    $0 bin/pyspark --remote local
 EOF
   exit 0
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add link and examples for `run-with-viztracer`


### Why are the changes needed?
to make it easier for developers to have a try


### Does this PR introduce _any_ user-facing change?
dev-only changes


### How was this patch tested?
manually check
```sh
(spark_dev_313) ➜  spark git:(doc_viz) python/run-with-viztracer -h
Usage:
  run-with-viztracer your_original_commands

To view the profiling results, run:
  vizviewer pyspark_*.json

Environment:
  If SPARK_VIZTRACER_OUTPUT_DIR is set, the output will be saved to the directory.
  Otherwise, it will be saved to the current directory.

Requirements:
  - viztracer must be installed (pip install viztracer)

Check the following documentation for more information on using viztracer:

  https://viztracer.readthedocs.io/en/latest/

Examples:
  - Start pyspark shell
    python/run-with-viztracer bin/pyspark --conf spark.driver.memory=16g

  - Start pyspark shell in Connect mode
    python/run-with-viztracer bin/pyspark --remote local
```


### Was this patch authored or co-authored using generative AI tooling?
no