### PR TITLE
[SPARK-54532][PYTHON] Add sqlstate for a set of PySparkException error classes

### DIFF
--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -22,7 +22,8 @@
   "ATTRIBUTE_NOT_SUPPORTED": {
     "message": [
       "Attribute `<attr_name>` is not supported."
-    ]
+    ],
+    "sqlState": "0A000"
   },
   "AXIS_LENGTH_MISMATCH": {
     "message": [
@@ -102,22 +103,26 @@
   "CANNOT_INFER_EMPTY_SCHEMA": {
     "message": [
       "Can not infer schema from an empty dataset."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "CANNOT_INFER_SCHEMA_FOR_TYPE": {
     "message": [
       "Can not infer schema for type: `<data_type>`."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "CANNOT_INFER_TYPE_FOR_FIELD": {
     "message": [
       "Unable to infer the type of the field `<field_name>`."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "CANNOT_MERGE_TYPE": {
     "message": [
       "Can not merge type `<data_type1>` and `<data_type2>`."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "CANNOT_OPEN_SOCKET": {
     "message": [
@@ -157,7 +162,8 @@
   "CLASSIC_OPERATION_NOT_SUPPORTED_ON_DF": {
     "message": [
       "Calling property or member '<member>' is not supported in PySpark Classic, please use Spark Connect instead."
-    ]
+    ],
+    "sqlState": "0A000"
   },
   "COLLATION_INVALID_PROVIDER": {
     "message": [
@@ -527,7 +533,8 @@
   "JVM_ATTRIBUTE_NOT_SUPPORTED": {
     "message": [
       "Attribute `<attr_name>` is not supported in Spark Connect as it depends on the JVM. If you need to use this attribute, do not use Spark Connect when creating your session. Visit https://spark.apache.org/docs/latest/sql-getting-started.html#starting-point-sparksession for creating regular Spark Session in detail."
-    ]
+    ],
+    "sqlState": "0A000"
   },
   "KEY_NOT_EXISTS": {
     "message": [
@@ -602,137 +609,164 @@
   "NOT_BOOL": {
     "message": [
       "Argument `<arg_name>` should be a bool, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_LIST_OR_STR_OR_TUPLE": {
     "message": [
       "Argument `<arg_name>` should be a bool, dict, float, int, str or tuple, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_STR": {
     "message": [
       "Argument `<arg_name>` should be a bool, dict, float, int or str, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_BOOL_OR_FLOAT_OR_INT": {
     "message": [
       "Argument `<arg_name>` should be a bool, float or int, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_BOOL_OR_FLOAT_OR_INT_OR_LIST_OR_NONE_OR_STR_OR_TUPLE": {
     "message": [
       "Argument `<arg_name>` should be a bool, float, int, list, None, str or tuple, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_BOOL_OR_FLOAT_OR_INT_OR_STR": {
     "message": [
       "Argument `<arg_name>` should be a bool, float, int or str, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_BOOL_OR_LIST": {
     "message": [
       "Argument `<arg_name>` should be a bool or list, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_BOOL_OR_STR": {
     "message": [
       "Argument `<arg_name>` should be a bool or str, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_CALLABLE": {
     "message": [
       "Argument `<arg_name>` should be a callable, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_COLUMN": {
     "message": [
       "Argument `<arg_name>` should be a Column, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_COLUMN_OR_DATATYPE_OR_STR": {
     "message": [
       "Argument `<arg_name>` should be a Column, str or DataType, but got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_COLUMN_OR_FLOAT_OR_INT_OR_LIST_OR_STR": {
     "message": [
       "Argument `<arg_name>` should be a Column, float, integer, list or string, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_COLUMN_OR_INT": {
     "message": [
       "Argument `<arg_name>` should be a Column or int, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_COLUMN_OR_INT_OR_LIST_OR_STR_OR_TUPLE": {
     "message": [
       "Argument `<arg_name>` should be a Column, int, list, str or tuple, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_COLUMN_OR_INT_OR_STR": {
     "message": [
       "Argument `<arg_name>` should be a Column, int or str, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_COLUMN_OR_LIST_OR_STR": {
     "message": [
       "Argument `<arg_name>` should be a Column, list or str, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_COLUMN_OR_STR": {
     "message": [
       "Argument `<arg_name>` should be a Column or str, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_COLUMN_OR_STR_OR_STRUCT": {
     "message": [
       "Argument `<arg_name>` should be a StructType, Column or str, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_DATAFRAME": {
     "message": [
       "Argument `<arg_name>` should be a DataFrame, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_DATATYPE_OR_STR": {
     "message": [
       "Argument `<arg_name>` should be a DataType or str, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_DICT": {
     "message": [
       "Argument `<arg_name>` should be a dict, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_EXPRESSION": {
     "message": [
       "Argument `<arg_name>` should be an Expression, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_FLOAT_OR_INT": {
     "message": [
       "Argument `<arg_name>` should be a float or int, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_FLOAT_OR_INT_OR_LIST_OR_STR": {
     "message": [
       "Argument `<arg_name>` should be a float, int, list or str, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_IMPLEMENTED": {
     "message": [
       "<feature> is not implemented."
-    ]
+    ],
+    "sqlState": "0A000"
   },
   "NOT_INT": {
     "message": [
       "Argument `<arg_name>` should be an int, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_INT_OR_SLICE_OR_STR": {
     "message": [
       "Argument `<arg_name>` should be an int, slice or str, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_IN_BARRIER_STAGE": {
     "message": [
@@ -742,87 +776,104 @@
   "NOT_ITERABLE": {
     "message": [
       "<objectName> is not iterable."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_LIST": {
     "message": [
       "Argument `<arg_name>` should be a list, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_LIST_OF_COLUMN": {
     "message": [
       "Argument `<arg_name>` should be a list[Column]."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_LIST_OF_COLUMN_OR_STR": {
     "message": [
       "Argument `<arg_name>` should be a list[Column]."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_LIST_OF_FLOAT_OR_INT": {
     "message": [
       "Argument `<arg_name>` should be a list[float, int], got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_LIST_OF_STR": {
     "message": [
       "Argument `<arg_name>` should be a list[str], got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_LIST_OR_NONE_OR_STRUCT": {
     "message": [
       "Argument `<arg_name>` should be a list, None or StructType, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_LIST_OR_STR_OR_TUPLE": {
     "message": [
       "Argument `<arg_name>` should be a list, str or tuple, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_LIST_OR_TUPLE": {
     "message": [
       "Argument `<arg_name>` should be a list or tuple, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_NUMERIC_COLUMNS": {
     "message": [
       "Numeric aggregation function can only be applied on numeric columns, got <invalid_columns>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_OBSERVATION_OR_STR": {
     "message": [
       "Argument `<arg_name>` should be an Observation or str, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_SAME_TYPE": {
     "message": [
       "Argument `<arg_name1>` and `<arg_name2>` should be the same type, got <arg_type1> and <arg_type2>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_STR": {
     "message": [
       "Argument `<arg_name>` should be a str, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_STRUCT": {
     "message": [
       "Argument `<arg_name>` should be a struct type, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_STR_OR_LIST_OF_RDD": {
     "message": [
       "Argument `<arg_name>` should be a str or list[RDD], got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_STR_OR_STRUCT": {
     "message": [
       "Argument `<arg_name>` should be a str or struct type, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NOT_WINDOWSPEC": {
     "message": [
       "Argument `<arg_name>` should be a WindowSpec, got <arg_type>."
-    ]
+    ],
+    "sqlState": "42K09"
   },
   "NO_ACTIVE_EXCEPTION": {
     "message": [
@@ -832,12 +883,14 @@
   "NO_ACTIVE_OR_DEFAULT_SESSION": {
     "message": [
       "No active or default Spark session found. Please create a new Spark session before running the code."
-    ]
+    ],
+    "sqlState": "08003"
   },
   "NO_ACTIVE_SESSION": {
     "message": [
       "No active Spark session found. Please create a new Spark session before running the code."
-    ]
+    ],
+    "sqlState": "08003"
   },
   "NO_OBSERVE_BEFORE_GET": {
     "message": [
@@ -862,7 +915,8 @@
   "ONLY_SUPPORTED_WITH_SPARK_CONNECT": {
     "message": [
       "<feature> is only supported with Spark Connect; however, the current Spark session does not use Spark Connect."
-    ]
+    ],
+    "sqlState": "0A000"
   },
   "PACKAGE_NOT_INSTALLED": {
     "message": [
@@ -1025,7 +1079,8 @@
   "SESSION_ALREADY_EXIST": {
     "message": [
       "Cannot start a remote Spark session because there is a regular Spark session already running."
-    ]
+    ],
+    "sqlState": "08002"
   },
   "SESSION_MUTATION_IN_DECLARATIVE_PIPELINE": {
     "message": [


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Following https://github.com/apache/spark/pull/53241 I am adding sql states for a set of PySparkException error classes.

I chose the following sql states mappings:
- `42K09` - "Data type mismatch"
  - a long list of error classes like NOT_LIST_OR_STR_OR_TUPLE, quite self-explanatory
- `0A000` - "feature not supported"
  - ATTRIBUTE_NOT_SUPPORTED, CLASSIC_OPERATION_NOT_SUPPORTED_ON_DF, JVM_ATTRIBUTE_NOT_SUPPORTED, NOT_IMPLEMENTED, ONLY_SUPPORTED_WITH_SPARK_CONNECT
- `08003` - "connection does not exist"
  - NO_ACTIVE_SESSION, NO_ACTIVE_OR_DEFAULT_SESSION
  - The 08003 SQL state is a standard ANSI/ISO state meaning "connection does not exist". A Spark session is conceptually similar to a database connection. If there is no active session, a connection doesn't exist.
- `08002` - "connection name in use" ([spark](https://github.com/apache/spark/blob/d587eec2e25c79a860f7ae07947276f1394ee17a/common/utils/src/main/resources/error/error-states.json#L908)) / "connection already exists" [(IBM DB2)](https://www.ibm.com/docs/en/db2-for-zos/12.0.0?topic=codes-sqlstate-values-common-error)
  - SESSION_ALREADY_EXIST
  - "Connection already exists" would map perfectly to the error class, "connection name in use" sounds a bit confusing but semantically 08002 is still the best sql state for SESSION_ALREADY_EXIST, especially if we choose 08003 for NO_ACTIVE_SESSION.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
sql states allow to better categorize and understand exceptions coming from pyspark

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Users will be able to read the newly populated sql states using `e.getSqlState()`


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
NA, mapping changes.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No