### PR TITLE
[SPARK-54669][SQL] Remove redundant casting in rCTEs

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionBase.scala
@@ -262,7 +262,11 @@ abstract class TypeCoercionBase extends TypeCoercionHelper {
             case (attr, dt) =>
               val widerType = findWiderTypeForTwo(attr.dataType, dt)
               if (widerType.isDefined && widerType.get == dt) {
-                Alias(Cast(attr, dt), attr.name)()
+                if (attr.dataType != dt) {
+                  Alias(Cast(attr, dt, Some(conf.sessionLocalTimeZone)), attr.name)()
+                } else {
+                  attr
+                }
               } else {
                 throw cannotMergeIncompatibleDataTypesError(dt, attr.dataType)
               }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionBase.scala
@@ -263,7 +263,7 @@ abstract class TypeCoercionBase extends TypeCoercionHelper {
               val widerType = findWiderTypeForTwo(attr.dataType, dt)
               if (widerType.isDefined && widerType.get == dt) {
                 if (attr.dataType != dt) {
-                  Alias(Cast(attr, dt, Some(conf.sessionLocalTimeZone)), attr.name)()
+                  Alias(Cast(attr, dt), attr.name)()
                 } else {
                   attr
                 }

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
@@ -1937,13 +1937,29 @@ org.apache.spark.SparkException
 
 
 -- !query
-WITH RECURSIVE t1(n, stamp) AS (
-    SELECT 1, CAST(DATE '2024-01-15' AS TIMESTAMP)
+WITH RECURSIVE t1(n, str, ts) AS (
+    SELECT 1, '2024-01-15 00:00:00' ,CAST('2024-01-15 00:00:00' AS TIMESTAMP)
     UNION ALL
-    SELECT n+1, stamp FROM t1 WHERE n < 5)
+    SELECT n + 1, str, str FROM t1 WHERE n < 5
+)
 SELECT * FROM t1
 -- !query analysis
-[Analyzer test output redacted due to nondeterminism]
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t1
+:     +- Project [1#x AS n#x, 2024-01-15 00:00:00#x AS str#x, CAST(2024-01-15 00:00:00 AS TIMESTAMP)#x AS ts#x]
+:        +- UnionLoop xxxx
+:           :- Project [1 AS 1#x, 2024-01-15 00:00:00 AS 2024-01-15 00:00:00#x, cast(2024-01-15 00:00:00 as timestamp) AS CAST(2024-01-15 00:00:00 AS TIMESTAMP)#x]
+:           :  +- OneRowRelation
+:           +- Project [(n + 1)#x, str#x, cast(str#x as timestamp) AS str#x]
+:              +- Project [(n#x + 1) AS (n + 1)#x, str#x, str#x]
+:                 +- Filter (n#x < 5)
+:                    +- SubqueryAlias t1
+:                       +- Project [1#x AS n#x, 2024-01-15 00:00:00#x AS str#x, CAST(2024-01-15 00:00:00 AS TIMESTAMP)#x AS ts#x]
+:                          +- UnionLoopRef xxxx, [1#x, 2024-01-15 00:00:00#x, CAST(2024-01-15 00:00:00 AS TIMESTAMP)#x], false
++- Project [n#x, str#x, ts#x]
+   +- SubqueryAlias t1
+      +- CTERelationRef xxxx, true, [n#x, str#x, ts#x], false, false
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
@@ -704,6 +704,12 @@ WithCTE
 
 
 -- !query
+SET spark.sql.legacy.ctePrecedencePolicy=EXCEPTION
+-- !query analysis
+SetCommand (spark.sql.legacy.ctePrecedencePolicy,Some(EXCEPTION))
+
+
+-- !query
 WITH RECURSIVE r(level, data) AS (
   VALUES (0, 0)
   UNION ALL
@@ -1928,6 +1934,16 @@ org.apache.spark.SparkException
     "right" : "\"BIGINT\""
   }
 }
+
+
+-- !query
+WITH RECURSIVE t1(n, stamp) AS (
+    SELECT 1, CAST(DATE '2024-01-15' AS TIMESTAMP)
+    UNION ALL
+    SELECT n+1, stamp FROM t1 WHERE n < 5)
+SELECT * FROM t1
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
@@ -704,12 +704,6 @@ WithCTE
 
 
 -- !query
-SET spark.sql.legacy.ctePrecedencePolicy=EXCEPTION
--- !query analysis
-SetCommand (spark.sql.legacy.ctePrecedencePolicy,Some(EXCEPTION))
-
-
--- !query
 WITH RECURSIVE r(level, data) AS (
   VALUES (0, 0)
   UNION ALL
@@ -1907,7 +1901,7 @@ WithCTE
 :        +- UnionLoop xxxx
 :           :- Project [1 AS 1#x, cast(1 as bigint) AS CAST(1 AS BIGINT)#xL]
 :           :  +- OneRowRelation
-:           +- Project [cast((n + 1)#x as int) AS (n + 1)#x, cast((n + 1)#x as bigint) AS (n + 1)#xL]
+:           +- Project [(n + 1)#x, cast((n + 1)#x as bigint) AS (n + 1)#xL]
 :              +- Project [(n#x + 1) AS (n + 1)#x, (n#x + 1) AS (n + 1)#x]
 :                 +- Filter (n#x < 5)
 :                    +- SubqueryAlias t1

--- a/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
@@ -729,10 +729,11 @@ WITH RECURSIVE t1(n, m) AS (
 SELECT * FROM t1;
 
 -- Type coercion with timeZone sensitive type
-WITH RECURSIVE t1(n, stamp) AS (
-    SELECT 1, CAST(DATE '2024-01-15' AS TIMESTAMP)
+WITH RECURSIVE t1(n, str, ts) AS (
+    SELECT 1, '2024-01-15 00:00:00' ,CAST('2024-01-15 00:00:00' AS TIMESTAMP)
     UNION ALL
-    SELECT n+1, stamp FROM t1 WHERE n < 5)
+    SELECT n + 1, str, str FROM t1 WHERE n < 5
+)
 SELECT * FROM t1;
 
 -- Recursive CTE with nullable recursion and non-recursive anchor

--- a/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
@@ -248,6 +248,7 @@ WITH
     SELECT * FROM t1
   )
 SELECT * FROM t2;
+SET spark.sql.legacy.ctePrecedencePolicy=EXCEPTION;
 
 -- recursive reference can't be used multiple times in a recursive term
 WITH RECURSIVE r(level, data) AS (
@@ -725,6 +726,13 @@ WITH RECURSIVE t1(n, m) AS (
     SELECT 1, 1
     UNION ALL
     SELECT n+1, CAST(n+1 AS BIGINT) FROM t1 WHERE n < 5)
+SELECT * FROM t1;
+
+-- Type coercion with timeZone sensitive type
+WITH RECURSIVE t1(n, stamp) AS (
+    SELECT 1, CAST(DATE '2024-01-15' AS TIMESTAMP)
+    UNION ALL
+    SELECT n+1, stamp FROM t1 WHERE n < 5)
 SELECT * FROM t1;
 
 -- Recursive CTE with nullable recursion and non-recursive anchor

--- a/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
@@ -248,7 +248,6 @@ WITH
     SELECT * FROM t1
   )
 SELECT * FROM t2;
-SET spark.sql.legacy.ctePrecedencePolicy=EXCEPTION;
 
 -- recursive reference can't be used multiple times in a recursive term
 WITH RECURSIVE r(level, data) AS (

--- a/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
@@ -902,14 +902,6 @@ struct<level:int>
 
 
 -- !query
-SET spark.sql.legacy.ctePrecedencePolicy=EXCEPTION
--- !query schema
-struct<key:string,value:string>
--- !query output
-spark.sql.legacy.ctePrecedencePolicy	EXCEPTION
-
-
--- !query
 WITH RECURSIVE r(level, data) AS (
   VALUES (0, 0)
   UNION ALL

--- a/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
@@ -1998,19 +1998,20 @@ org.apache.spark.SparkException
 
 
 -- !query
-WITH RECURSIVE t1(n, stamp) AS (
-    SELECT 1, CAST(DATE '2024-01-15' AS TIMESTAMP)
+WITH RECURSIVE t1(n, str, ts) AS (
+    SELECT 1, '2024-01-15 00:00:00' ,CAST('2024-01-15 00:00:00' AS TIMESTAMP)
     UNION ALL
-    SELECT n+1, stamp FROM t1 WHERE n < 5)
+    SELECT n + 1, str, str FROM t1 WHERE n < 5
+)
 SELECT * FROM t1
 -- !query schema
-struct<n:int,stamp:timestamp>
+struct<n:int,str:string,ts:timestamp>
 -- !query output
-1	2024-01-15 00:00:00
-2	2024-01-15 00:00:00
-3	2024-01-15 00:00:00
-4	2024-01-15 00:00:00
-5	2024-01-15 00:00:00
+1	2024-01-15 00:00:00	2024-01-15 00:00:00
+2	2024-01-15 00:00:00	2024-01-15 00:00:00
+3	2024-01-15 00:00:00	2024-01-15 00:00:00
+4	2024-01-15 00:00:00	2024-01-15 00:00:00
+5	2024-01-15 00:00:00	2024-01-15 00:00:00
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
@@ -902,6 +902,14 @@ struct<level:int>
 
 
 -- !query
+SET spark.sql.legacy.ctePrecedencePolicy=EXCEPTION
+-- !query schema
+struct<key:string,value:string>
+-- !query output
+spark.sql.legacy.ctePrecedencePolicy	EXCEPTION
+
+
+-- !query
 WITH RECURSIVE r(level, data) AS (
   VALUES (0, 0)
   UNION ALL
@@ -1987,6 +1995,22 @@ org.apache.spark.SparkException
     "right" : "\"BIGINT\""
   }
 }
+
+
+-- !query
+WITH RECURSIVE t1(n, stamp) AS (
+    SELECT 1, CAST(DATE '2024-01-15' AS TIMESTAMP)
+    UNION ALL
+    SELECT n+1, stamp FROM t1 WHERE n < 5)
+SELECT * FROM t1
+-- !query schema
+struct<n:int,stamp:timestamp>
+-- !query output
+1	2024-01-15 00:00:00
+2	2024-01-15 00:00:00
+3	2024-01-15 00:00:00
+4	2024-01-15 00:00:00
+5	2024-01-15 00:00:00
 
 
 -- !query


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change TypeCoercionBase so that the only outputs that are casted are the ones that need to be casted.

### Why are the changes needed?

Remove redundant CAST.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing golden file test cte-recursion.

### Was this patch authored or co-authored using generative AI tooling?

No.