### PR TITLE
[SPARK-53482][SQL][FOLLOWUP] Rename `spark.sql.merge(.nested.type.coercion.enabled -> NestedTypeCoercion.enabled)`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -6704,7 +6704,7 @@ object SQLConf {
       .createWithDefault(true)
 
   val MERGE_INTO_NESTED_TYPE_COERCION_ENABLED =
-    buildConf("spark.sql.merge.nested.type.coercion.enabled")
+    buildConf("spark.sql.mergeNestedTypeCoercion.enabled")
       .internal()
       .doc("If enabled, allow MERGE INTO to coerce source nested types if they have less" +
         "nested fields than the target table's nested types. This is experimental and" +


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to rename `spark.sql.merge.nested.type.coercion.enabled` to follow the Apache Spark convention.

```
- spark.sql.merge.nested.type.coercion.enabled
+ spark.sql.mergeNestedTypeCoercion.enabled
```

### Why are the changes needed?

To avoid to create many naming spaces.

### Does this PR introduce _any_ user-facing change?

Yes, but this is not released as 4.1.0.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.