### PR TITLE
[WIP][PYTHON] Zero Copy Pandas UDF

### DIFF
--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -867,6 +867,7 @@ def _create_converter_to_pandas(
     error_on_duplicated_field_names: bool = True,
     timestamp_utc_localized: bool = True,
     ndarray_as_list: bool = False,
+    pandas_backend: str = "numpy",
 ) -> Callable[["pd.Series"], "pd.Series"]:
     """
     Create a converter of pandas Series that is created from Spark's Python objects,
@@ -895,6 +896,9 @@ def _create_converter_to_pandas(
         whereas the ones from `df.collect()` are localized to the local timezone.
     ndarray_as_list : bool, optional
         Whether `np.ndarray` is converted to a list or not (default ``False``).
+    pandas_backend : str, (default ``numpy``)
+        (Experimental) Back-end data type applied to the pandas DataFrame or Series.
+        Supported options are: numpy and pyarrow.
 
     Returns
     -------
@@ -902,6 +906,15 @@ def _create_converter_to_pandas(
     """
     import numpy as np
     import pandas as pd
+
+    if pandas_backend == "pyarrow":
+
+        def convert_pyarrow(pser: pd.Series) -> pd.Series:
+            # Assert that the result series is PyArrow-backed
+            assert isinstance(pser.dtype, pd.ArrowDtype), pser.dtype
+            return pser
+
+        return convert_pyarrow
 
     pandas_type = _to_corrected_pandas_type(data_type)
 
@@ -1227,6 +1240,7 @@ def _create_converter_from_pandas(
     error_on_duplicated_field_names: bool = True,
     ignore_unexpected_complex_type_values: bool = False,
     int_to_decimal_coercion_enabled: bool = False,
+    pandas_backend: str = "numpy",
 ) -> Callable[["pd.Series"], "pd.Series"]:
     """
     Create a converter of pandas Series to create Spark DataFrame with Arrow optimization.
@@ -1251,12 +1265,25 @@ def _create_converter_from_pandas(
         and raise an AssertionError when the given value is not the expected type.
         If ``True``, just ignore and return the give value.
         (default ``False``)
+    pandas_backend : str, (default ``numpy``)
+        (Experimental) Back-end data type applied to the pandas DataFrame or Series.
+        Supported options are: numpy and pyarrow.
 
     Returns
     -------
     The converter of `pandas.Series`
     """
     import pandas as pd
+
+    if pandas_backend == "pyarrow":
+        arrow_type = to_arrow_type(data_type, error_on_duplicated_field_names)
+
+        def convert_pyarrow(pser: pd.Series) -> pd.Series:
+            arrow_pser = pser.astype(pd.ArrowDtype(arrow_type))
+            assert isinstance(arrow_pser.dtype, pd.ArrowDtype), arrow_pser.dtype
+            return arrow_pser
+
+        return convert_pyarrow
 
     if isinstance(data_type, TimestampType):
         assert timezone is not None

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -175,6 +175,10 @@ class RunnerConf:
         return self.get("spark.sql.execution.pandas.convertToArrowArraySafely", "false") == "true"
 
     @property
+    def pandas_backend(self) -> str:
+        return self.get("spark.sql.execution.pandas.backend", "numpy")
+
+    @property
     def int_to_decimal_coercion_enabled(self) -> bool:
         return (
             self.get("spark.sql.execution.pythonUDF.pandas.intToDecimalCoercionEnabled", "false")
@@ -2760,6 +2764,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf):
                 runner_conf.safecheck,
                 runner_conf.assign_cols_by_name,
                 runner_conf.int_to_decimal_coercion_enabled,
+                pandas_backend=runner_conf.pandas_backend,
             )
         elif (
             eval_type == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF
@@ -2770,6 +2775,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf):
                 runner_conf.safecheck,
                 runner_conf.assign_cols_by_name,
                 runner_conf.int_to_decimal_coercion_enabled,
+                pandas_backend=runner_conf.pandas_backend,
             )
         elif eval_type == PythonEvalType.SQL_COGROUPED_MAP_ARROW_UDF:
             ser = CogroupArrowUDFSerializer(runner_conf.assign_cols_by_name)
@@ -2780,6 +2786,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf):
                 runner_conf.assign_cols_by_name,
                 int_to_decimal_coercion_enabled=runner_conf.int_to_decimal_coercion_enabled,
                 arrow_cast=True,
+                pandas_backend=runner_conf.pandas_backend,
             )
         elif eval_type == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF_WITH_STATE:
             ser = ApplyInPandasWithStateSerializer(
@@ -2869,6 +2876,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf):
                 True,
                 input_types,
                 int_to_decimal_coercion_enabled=runner_conf.int_to_decimal_coercion_enabled,
+                pandas_backend=runner_conf.pandas_backend,
             )
     else:
         batch_size = int(os.environ.get("PYTHON_UDF_BATCH_SIZE", "100"))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4246,6 +4246,15 @@ object SQLConf {
       .checkValues(Set("legacy", "row", "dict"))
       .createWithDefaultString("legacy")
 
+  val PANDAS_EXECUTION_BACKEND =
+    buildConf("spark.sql.execution.pandas.backend")
+      .doc("(Experimental) The backend of Pandas Series/DataFrame in Python execution. " +
+        "This configuration applies to Pandas UDFs.")
+      .version("4.2.0")
+      .stringConf
+      .checkValues(Set("numpy", "pyarrow"))
+      .createWithDefaultString("numpy")
+
   val PYSPARK_HIDE_TRACEBACK =
     buildConf("spark.sql.execution.pyspark.udf.hideTraceback.enabled")
       .doc(
@@ -7626,6 +7635,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def pandasUDFBufferSize: Int = getConf(PANDAS_UDF_BUFFER_SIZE)
 
   def pandasStructHandlingMode: String = getConf(PANDAS_STRUCT_HANDLING_MODE)
+
+  def pandasExecutionBackend: String = getConf(PANDAS_EXECUTION_BACKEND)
 
   def pysparkHideTraceback: Boolean = getConf(PYSPARK_HIDE_TRACEBACK)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowPythonRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowPythonRunner.scala
@@ -151,6 +151,8 @@ object ArrowPythonRunner {
     val timeZoneConf = Seq(SQLConf.SESSION_LOCAL_TIMEZONE.key -> conf.sessionLocalTimeZone)
     val pandasColsByName = Seq(SQLConf.PANDAS_GROUPED_MAP_ASSIGN_COLUMNS_BY_NAME.key ->
       conf.pandasGroupedMapAssignColumnsByName.toString)
+    val pandasBackend = Seq(
+      SQLConf.PANDAS_EXECUTION_BACKEND.key -> conf.pandasExecutionBackend)
     val arrowSafeTypeCheck = Seq(SQLConf.PANDAS_ARROW_SAFE_TYPE_CONVERSION.key ->
       conf.arrowSafeTypeConversion.toString)
     val arrowAyncParallelism = conf.pythonUDFArrowConcurrencyLevel.map(v =>
@@ -170,7 +172,8 @@ object ArrowPythonRunner {
     val binaryAsBytes = Seq(
       SQLConf.PYSPARK_BINARY_AS_BYTES.key ->
       conf.pysparkBinaryAsBytes.toString)
-    Map(timeZoneConf ++ pandasColsByName ++ arrowSafeTypeCheck ++
+    Map(timeZoneConf ++ pandasColsByName ++
+      pandasBackend ++ arrowSafeTypeCheck ++
       arrowAyncParallelism ++ useLargeVarTypes ++
       intToDecimalCoercion ++ binaryAsBytes ++
       legacyPandasConversion ++ legacyPandasConversionUDF: _*)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a config `spark.sql.execution.pandas.backend`, when set `pyarrow`, provide pyarrow-backed Pandas Series to UDF execution.

1, pre-execution arrow->pandas conversion: convert to pyarrow-backed pandas data, will be zero copy;
2, UDF execution: if the operation is compatible with pyarrow (e.g. ser -> ser + 1), then the computation result will also be pyarrow-backed; otherwise, it will fallback to a numpy-backed one (e.g. ser -> ser.apply always generate a numpy-backed ser);
3, post-execution pandas->arrow conversion: if the computation result is a pyarrow-backed instance, then the conversion will be zero copy; 


### Why are the changes needed?
Pandas is moving forward to pyarrow-backend, in the coming 3.0 release, it starts to use arrow-backed string type. see https://pandas.pydata.org/docs/dev/whatsnew/v3.0.0.html#dedicated-string-data-type-by-default

> Starting with pandas 3.0, a dedicated string data type is enabled by default (backed by PyArrow under the hood, if installed, otherwise falling back to being backed by NumPy object-dtype).


### Does this PR introduce _any_ user-facing change?
the config is disabled by default, but the behavior change is unknown right now



### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
