### PR TITLE
[SPARK-52837][PYTHON][FOLLOWUP] Add `versionadded` to `TimeType` doc

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -401,7 +401,11 @@ class AnyTimeType(DatetimeType):
 
 
 class TimeType(AnyTimeType):
-    """Time (datetime.time) data type."""
+    """
+    Time (datetime.time) data type.
+
+    .. versionadded:: 4.1.0
+    """
 
     def __init__(self, precision: int = 6):
         self.precision = precision


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `versionadded` to `TimeType`.

### Why are the changes needed?

For `Scala/Java` documentation, we have `@since` information.

https://github.com/apache/spark/blob/22e26598785e11303409f43fc08ce627053dadb4/sql/api/src/main/scala/org/apache/spark/sql/types/TimeType.scala#L31-L34

We had better provide a correct information for the newly added `TimeType` in Python documentation.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.