### PR TITLE
[SPARK-54682][SQL] Support showing parameters in DESCRIBE PROCEDURE

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2284,10 +2284,13 @@ class Analyzer(
   object ResolveProcedures extends Rule[LogicalPlan] {
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsWithPruning(
       _.containsPattern(UNRESOLVED_PROCEDURE), ruleId) {
-      case Call(UnresolvedProcedure(CatalogAndIdentifier(catalog, ident)), args, execute) =>
-        val procedureCatalog = catalog.asProcedureCatalog
+      case UnresolvedProcedure(CatalogAndIdentifier(catalog, ident)) =>
+        if (!catalog.isInstanceOf[ProcedureCatalog]) {
+          throw QueryCompilationErrors.missingCatalogProceduresAbilityError(catalog)
+        }
+        val procedureCatalog = catalog.asInstanceOf[ProcedureCatalog]
         val procedure = load(procedureCatalog, ident)
-        Call(ResolvedProcedure(procedureCatalog, ident, procedure), args, execute)
+        ResolvedProcedure(procedureCatalog, ident, procedure)
     }
 
     private def load(catalog: ProcedureCatalog, ident: Identifier): UnboundProcedure = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2285,10 +2285,7 @@ class Analyzer(
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsWithPruning(
       _.containsPattern(UNRESOLVED_PROCEDURE), ruleId) {
       case UnresolvedProcedure(CatalogAndIdentifier(catalog, ident)) =>
-        if (!catalog.isInstanceOf[ProcedureCatalog]) {
-          throw QueryCompilationErrors.missingCatalogProceduresAbilityError(catalog)
-        }
-        val procedureCatalog = catalog.asInstanceOf[ProcedureCatalog]
+        val procedureCatalog = catalog.asProcedureCatalog
         val procedure = load(procedureCatalog, ident)
         ResolvedProcedure(procedureCatalog, ident, procedure)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -29,7 +29,8 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{CurrentNamespace, GlobalTempView, LocalTempView,
   PersistedView, PlanWithUnresolvedIdentifier, SchemaEvolution, SchemaTypeEvolution,
-  UnresolvedAttribute, UnresolvedFunctionName, UnresolvedIdentifier, UnresolvedNamespace}
+  UnresolvedAttribute, UnresolvedFunctionName, UnresolvedIdentifier, UnresolvedNamespace,
+  UnresolvedProcedure}
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
 import org.apache.spark.sql.catalyst.parser._
@@ -1399,7 +1400,7 @@ class SparkSqlAstBuilder extends AstBuilder {
   override def visitDescribeProcedure(
       ctx: DescribeProcedureContext): LogicalPlan = withOrigin(ctx) {
     withIdentClause(ctx.identifierReference(), procIdentifier =>
-      DescribeProcedureCommand(UnresolvedIdentifier(procIdentifier)))
+      DescribeProcedureCommand(UnresolvedProcedure(procIdentifier)))
   }
 
   override def visitCreatePipelineInsertIntoFlow(

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ProcedureSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ProcedureSuite.scala
@@ -518,47 +518,64 @@ class ProcedureSuite extends QueryTest with SharedSparkSession with BeforeAndAft
       checkAnswer(
         sql("DESC PROCEDURE cat.ns.foo"),
         Row("Procedure:   sum") ::
-          Row("Description: sum integers") :: Nil)
+          Row("Description: sum integers") ::
+          Row("Parameters:  IN in1 INT") ::
+          Row("             IN in2 INT") :: Nil)
 
       checkAnswer(
         // use DESCRIBE instead of DESC
         sql("DESCRIBE PROCEDURE cat.ns.foo"),
         Row("Procedure:   sum") ::
-          Row("Description: sum integers") :: Nil)
+          Row("Description: sum integers") ::
+          Row("Parameters:  IN in1 INT") ::
+          Row("             IN in2 INT") :: Nil)
 
       checkAnswer(
         // use default catalog
         sql("DESC PROCEDURE ns.foo"),
         Row("Procedure:   sum") ::
-          Row("Description: sum integers") :: Nil)
+          Row("Description: sum integers") ::
+          Row("Parameters:  IN in1 INT") ::
+          Row("             IN in2 INT") :: Nil)
 
       checkAnswer(
         // use multi-part namespace
         sql("DESCRIBE PROCEDURE cat.ns.db.abc"),
         Row("Procedure:   long_sum") ::
-          Row("Description: sum longs") :: Nil)
+          Row("Description: sum longs") ::
+          Row("Parameters:  IN in1 BIGINT") ::
+          Row("             IN in2 BIGINT") :: Nil)
 
       checkAnswer(
         // use multi-part namespace with default catalog
         sql("DESCRIBE PROCEDURE ns.db.abc"),
         Row("Procedure:   long_sum") ::
-          Row("Description: sum longs") :: Nil)
+          Row("Description: sum longs") ::
+          Row("Parameters:  IN in1 BIGINT") ::
+          Row("             IN in2 BIGINT") :: Nil)
 
       checkAnswer(
         sql("DESC PROCEDURE cat.``.xyz"),
         Row("Procedure:   complex") ::
-          Row("Description: complex procedure") :: Nil)
+          Row("Description: complex procedure") ::
+          Row("Parameters:  IN in1 STRING DEFAULT 'A'") ::
+          Row("             IN in2 STRING DEFAULT 'B'") ::
+          Row("             IN in3 INT    DEFAULT 1 + 1 - 1") :: Nil)
 
       checkAnswer(
         sql("DESC PROCEDURE cat.xxx"),
         Row("Procedure:   struct_input") ::
-          Row("Description: struct procedure") :: Nil)
+          Row("Description: struct procedure") ::
+          Row("Parameters:  IN in1 STRUCT<nested1: INT, nested2: STRING>") ::
+          Row("             IN in2 STRING                               ") :: Nil)
 
       checkAnswer(
         // check across catalogs
         sql("DESC PROCEDURE cat2.ns_1.db_1.foo"),
         Row("Procedure:   void") ::
-          Row("Description: void procedure") :: Nil)
+          Row("Description: void procedure") ::
+          Row("Parameters:  IN in1 STRING") ::
+          Row("             IN in2 STRING") :: Nil)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ProcedureSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ProcedureSuite.scala
@@ -594,20 +594,6 @@ class ProcedureSuite extends QueryTest with SharedSparkSession with BeforeAndAft
     }
   }
 
-  object UnboundZeroParameterProcedure extends UnboundProcedure {
-    override def name: String = "zero_params"
-    override def description: String = "zero parameter procedure"
-    override def bind(inputType: StructType): BoundProcedure = ZeroParameterProcedure
-  }
-
-  object ZeroParameterProcedure extends BoundProcedure {
-    override def name: String = "zero_params"
-    override def description: String = "zero parameter procedure"
-    override def isDeterministic: Boolean = true
-    override def parameters: Array[ProcedureParameter] = Array.empty
-    override def call(input: InternalRow): java.util.Iterator[Scan] = Collections.emptyIterator
-  }
-
   object UnboundVoidProcedure extends UnboundProcedure {
     override def name: String = "void"
     override def description: String = "void procedure"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR updates the DESCRIBE PROCEDURE command to correctly resolve V2 procedures and display detailed parameter information.
Previously, DESCRIBE PROCEDURE did not provide parameter details. This change enhances the command to:
- Properly resolve procedure identifiers using the ResolveProcedures analyzer rule.
- Bind the procedure to retrieve its schema.
- Display a comprehensive list of input parameters, including their mode (IN/OUT), name, data type, default values, and comments.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Users need to know the parameter signatures of stored procedures to call them correctly. Without this change, DESCRIBE PROCEDURE provided insufficient information for using a procedure. This change also makes the command more like DESCRIBE FUNCTION.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, DESCRIBE PROCEDURE output now includes a "Parameters" section listing all arguments with their types and defaults.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes