### PR TITLE
[SPARK-52326][SQL] Add partitions related ExternalCatalogEvent and post them in corresponding operations

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
@@ -204,7 +204,10 @@ class ExternalCatalogWithListener(delegate: ExternalCatalog)
       table: String,
       parts: Seq[CatalogTablePartition],
       ignoreIfExists: Boolean): Unit = {
+    val partSpecs = parts.map(_.spec)
+    postToAll(CreatePartitionsPreEvent(db, table, partSpecs))
     delegate.createPartitions(db, table, parts, ignoreIfExists)
+    postToAll(CreatePartitionsEvent(db, table, partSpecs))
   }
 
   override def dropPartitions(
@@ -214,7 +217,9 @@ class ExternalCatalogWithListener(delegate: ExternalCatalog)
       ignoreIfNotExists: Boolean,
       purge: Boolean,
       retainData: Boolean): Unit = {
+    postToAll(DropPartitionsPreEvent(db, table, partSpecs))
     delegate.dropPartitions(db, table, partSpecs, ignoreIfNotExists, purge, retainData)
+    postToAll(DropPartitionsEvent(db, table, partSpecs))
   }
 
   override def renamePartitions(
@@ -222,14 +227,19 @@ class ExternalCatalogWithListener(delegate: ExternalCatalog)
       table: String,
       specs: Seq[TablePartitionSpec],
       newSpecs: Seq[TablePartitionSpec]): Unit = {
+    postToAll(RenamePartitionsPreEvent(db, table, specs, newSpecs))
     delegate.renamePartitions(db, table, specs, newSpecs)
+    postToAll(RenamePartitionsEvent(db, table, specs, newSpecs))
   }
 
   override def alterPartitions(
       db: String,
       table: String,
       parts: Seq[CatalogTablePartition]): Unit = {
+    val partSpecs = parts.map(_.spec)
+    postToAll(AlterPartitionsPreEvent(db, table, partSpecs))
     delegate.alterPartitions(db, table, parts)
+    postToAll(AlterPartitionsEvent(db, table, partSpecs))
   }
 
   override def getPartition(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/events.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/events.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.catalyst.catalog
 
 import org.apache.spark.scheduler.SparkListenerEvent
+import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 
 /**
  * Event emitted by the external catalog when it is modified. Events are either fired before or
@@ -203,3 +204,87 @@ case class RenameFunctionEvent(
     name: String,
     newName: String)
   extends FunctionEvent
+
+/**
+ * Event fired when some partitions (of a table) are created, dropped, renamed, altered.
+ */
+trait PartitionsEvent extends TableEvent {
+  /**
+   * Specs of the partitions which are touched.
+   */
+  val partSpecs: Seq[TablePartitionSpec]
+}
+
+/**
+ * Event fired before some partitions (of a table) are created.
+ */
+case class CreatePartitionsPreEvent(
+    database: String,
+    name /* of table */: String,
+    partSpecs: Seq[TablePartitionSpec])
+  extends PartitionsEvent
+
+/**
+ * Event fired after some partitions (of a table) have been created.
+ */
+case class CreatePartitionsEvent(
+    database: String,
+    name /* of table */: String,
+    partSpecs: Seq[TablePartitionSpec])
+  extends PartitionsEvent
+
+/**
+ * Event fired before some partitions (of a table) are dropped.
+ */
+case class DropPartitionsPreEvent(
+    database: String,
+    name /* of table */ : String,
+    partSpecs: Seq[TablePartitionSpec])
+  extends PartitionsEvent
+
+/**
+ * Event fired after some partitions (of a table) have been dropped.
+ */
+case class DropPartitionsEvent(
+    database: String,
+    name /* of table */ : String,
+    partSpecs: Seq[TablePartitionSpec])
+  extends PartitionsEvent
+
+/**
+ * Event fired before some partitions (of a table) are renamed.
+ */
+case class RenamePartitionsPreEvent(
+    database: String,
+    name /* of table */ : String,
+    partSpecs: Seq[TablePartitionSpec],
+    newPartSpecs: Seq[TablePartitionSpec])
+  extends PartitionsEvent
+
+/**
+ * Event fired after some partitions (of a table) have been renamed.
+ */
+case class RenamePartitionsEvent(
+    database: String,
+    name /* of table */ : String,
+    partSpecs: Seq[TablePartitionSpec],
+    newPartSpecs: Seq[TablePartitionSpec])
+  extends PartitionsEvent
+
+/**
+ * Event fired before some partitions (of a table) are altered.
+ */
+case class AlterPartitionsPreEvent(
+    database: String,
+    name /* of table */ : String,
+    partSpecs: Seq[TablePartitionSpec])
+  extends PartitionsEvent
+
+/**
+ * Event fired after some partitions (of a table) have been altered.
+ */
+case class AlterPartitionsEvent(
+    database: String,
+    name /* of table */ : String,
+    partSpecs: Seq[TablePartitionSpec])
+  extends PartitionsEvent


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Add `partitions` related events, for the following external catalog operations: create / drop / alter / rename. A base "PartitionsEvent" is added by extending "TableEvent". One "PartitionsEvent" (and its subs) could contain the operation for one or more partitions. So it is named as "Partition`s`Event" (in the plural form of partition), so are its subs.

2. Post those events in the corresponding external catalog operations

### Why are the changes needed?
The operation list extracted from Spark events are of great help for user to summarize what have been done against a db/table/function/partition, for the purpose of logging and/or auditing.
In [ExternalCatalogWithListener](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala), there are events posted against db, table and function for all registered listeners. But those operations against partition(s) do not have their events posted.

### Does this PR introduce _any_ user-facing change?
With this change, partition(s) related operations are posted into register listener as events

### How was this patch tested?
Enrich UT and also tested on local cluster

### Was this patch authored or co-authored using generative AI tooling?
No