### PR TITLE
[SPARK-54643][PYTHON][TESTS][FOLLOW-UP] Restore classic only workflows

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,14 +41,14 @@ on:
         description: Additional environment variables to set when running the tests. Should be in JSON format.
         required: false
         type: string
-        default: '{"PYSPARK_IMAGE_TO_TEST": "python-311-classic-only", "PYTHON_TO_TEST": "python3.11"}'
+        default: '{"PYSPARK_IMAGE_TO_TEST": "python-311", "PYTHON_TO_TEST": "python3.11"}'
       jobs:
         description: >-
           Jobs to run, and should be in JSON format. The values should be matched with the job's key defined
           in this file, e.g., build. See precondition job below.
         required: false
         type: string
-        default: '{"pyspark": "true", "pyspark-pandas": "true"}'
+        default: ''
     secrets:
       codecov_token:
         description: The upload token of codecov.

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,14 +41,14 @@ on:
         description: Additional environment variables to set when running the tests. Should be in JSON format.
         required: false
         type: string
-        default: '{"PYSPARK_IMAGE_TO_TEST": "python-311", "PYTHON_TO_TEST": "python3.11"}'
+        default: '{"PYSPARK_IMAGE_TO_TEST": "python-311-classic-only", "PYTHON_TO_TEST": "python3.11"}'
       jobs:
         description: >-
           Jobs to run, and should be in JSON format. The values should be matched with the job's key defined
           in this file, e.g., build. See precondition job below.
         required: false
         type: string
-        default: ''
+        default: '{"pyspark": "true", "pyspark-pandas": "true"}'
     secrets:
       codecov_token:
         description: The upload token of codecov.

--- a/python/pyspark/pipelines/tests/test_spark_connect.py
+++ b/python/pyspark/pipelines/tests/test_spark_connect.py
@@ -21,22 +21,24 @@ Tests that run Pipelines against a Spark Connect server.
 
 import unittest
 
-from pyspark.errors.exceptions.connect import AnalysisException
-from pyspark.pipelines.graph_element_registry import graph_element_registration_context
-from pyspark.pipelines.spark_connect_graph_element_registry import (
-    SparkConnectGraphElementRegistry,
-)
-from pyspark.pipelines.spark_connect_pipeline import (
-    create_dataflow_graph,
-    start_run,
-    handle_pipeline_events,
-)
 from pyspark import pipelines as dp
 from pyspark.testing.connectutils import (
     ReusedConnectTestCase,
     should_test_connect,
     connect_requirement_message,
 )
+
+if should_test_connect:
+    from pyspark.errors.exceptions.connect import AnalysisException
+    from pyspark.pipelines.graph_element_registry import graph_element_registration_context
+    from pyspark.pipelines.spark_connect_graph_element_registry import (
+        SparkConnectGraphElementRegistry,
+    )
+    from pyspark.pipelines.spark_connect_pipeline import (
+        create_dataflow_graph,
+        start_run,
+        handle_pipeline_events,
+    )
 
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
restore classic-only workflows, see https://github.com/apache/spark/actions/runs/20110097373/job/57705084088

### Why are the changes needed?
to fix CI


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
PR builder with
```
default: '{"PYSPARK_IMAGE_TO_TEST": "python-311-classic-only", "PYTHON_TO_TEST": "python3.11"}'     
```

https://github.com/zhengruifeng/spark/actions/runs/20124816930/job/57754435568

### Was this patch authored or co-authored using generative AI tooling?
No
