### PR TITLE
[SPARK-54684][SS] Introduce stream-stream join operations microbenchmark

### DIFF
--- a/sql/core/benchmarks/StreamStreamJoinOneSideOperationsBenchmark-results.txt
+++ b/sql/core/benchmarks/StreamStreamJoinOneSideOperationsBenchmark-results.txt
@@ -1,0 +1,180 @@
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-window Join] Append 1000000 rows (changelog checkpoint: true):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                       5847           5847           0          0.2        5846.8       1.0X
+state format version: 2                                                       5894           5894           0          0.2        5893.8       1.0X
+state format version: 3                                                       5983           5983           0          0.2        5982.8       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-window Join] Append 1000000 rows (changelog checkpoint: false):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                        5440           5440           0          0.2        5439.9       1.0X
+state format version: 2                                                        5923           5923           0          0.2        5922.9       0.9X
+state format version: 3                                                        5881           5881           0          0.2        5880.9       0.9X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-window Join] GetJoinedRows 100000 from 1000000 rows (changelog checkpoint: true):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                                          1032           1084          46          0.1       10320.3       1.0X
+state format version: 2                                                                           993           1125         148          0.1        9931.8       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-window Join] GetJoinedRows 100000 from 1000000 rows (changelog checkpoint: false):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                                            910            915           5          0.1        9096.4       1.0X
+state format version: 2                                                                            889            904          21          0.1        8889.8       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-window Join] Eviction with 100 from 1000000 rows (changelog checkpoint: true):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                                        305            309           3          0.0     3054322.5       1.0X
+state format version: 2                                                                        313            319           8          0.0     3126385.0       1.0X
+state format version: 3                                                                        411            432          26          0.0     4113978.8       0.7X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-window Join] Eviction with 100 from 1000000 rows (changelog checkpoint: false):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                                         304            306           3          0.0     3040710.0       1.0X
+state format version: 2                                                                         302            310          10          0.0     3020641.3       1.0X
+state format version: 3                                                                         413            417           2          0.0     4131814.2       0.7X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-window Join] Eviction with 300000 from 1000000 rows (changelog checkpoint: true):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                                          1294           1335          59          0.2        4312.5       1.0X
+state format version: 2                                                                          1325           1395          99          0.2        4417.1       1.0X
+state format version: 3                                                                          1645           1680          31          0.2        5483.5       0.8X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-window Join] Eviction with 300000 from 1000000 rows (changelog checkpoint: false):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                                           1129           1133           5          0.3        3762.5       1.0X
+state format version: 2                                                                           1171           1204          55          0.3        3903.6       1.0X
+state format version: 3                                                                           1610           1645          48          0.2        5366.9       0.7X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-window Join] Eviction with 600000 from 1000000 rows (changelog checkpoint: true):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                                          2200           2220          35          0.3        3665.9       1.0X
+state format version: 2                                                                          2371           2389          16          0.3        3952.4       0.9X
+state format version: 3                                                                          2926           2987         105          0.2        4875.9       0.8X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-window Join] Eviction with 600000 from 1000000 rows (changelog checkpoint: false):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                                           1928           1934           6          0.3        3213.2       1.0X
+state format version: 2                                                                           1999           2034          48          0.3        3331.9       1.0X
+state format version: 3                                                                           2808           2871          95          0.2        4680.6       0.7X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-window Join] Eviction with 900000 from 1000000 rows (changelog checkpoint: true):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                                          3029           3058          30          0.3        3365.9       1.0X
+state format version: 2                                                                          3102           3155          85          0.3        3447.0       1.0X
+state format version: 3                                                                          4106           4177          78          0.2        4562.3       0.7X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-window Join] Eviction with 900000 from 1000000 rows (changelog checkpoint: false):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                                           2744           2790          42          0.3        3049.0       1.0X
+state format version: 2                                                                           2740           2832         142          0.3        3044.2       1.0X
+state format version: 3                                                                           4016           4045          49          0.2        4462.6       0.7X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-interval Join] Append 1000000 rows (changelog checkpoint: true):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                         3532           3532           0          0.3        3531.6       1.0X
+state format version: 2                                                         3655           3655           0          0.3        3654.7       1.0X
+state format version: 3                                                         3870           3870           0          0.3        3870.4       0.9X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-interval Join] Append 1000000 rows (changelog checkpoint: false):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                          3308           3308           0          0.3        3308.0       1.0X
+state format version: 2                                                          3649           3649           0          0.3        3649.4       0.9X
+state format version: 3                                                          3596           3596           0          0.3        3595.7       0.9X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-interval Join] GetJoinedRows 10000 from 1000000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                             25828          26048         205          0.0     2582839.2       1.0X
+state format version: 2                                             13590          13666         121          0.0     1358999.8       1.9X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-interval Join] GetJoinedRows 10000 from 1000000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                             24435          24898         796          0.0     2443472.6       1.0X
+state format version: 2                                             14788          14838          44          0.0     1478761.8       1.7X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-interval Join] Eviction with 100 from 1000000 rows (changelog checkpoint: true):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                                         1351           1421         109          0.0    13509112.9       1.0X
+state format version: 2                                                                         1310           1445         118          0.0    13095082.5       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-interval Join] Eviction with 100 from 1000000 rows (changelog checkpoint: false):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                                          1239           1270          27          0.0    12389847.1       1.0X
+state format version: 2                                                                          1265           1310          70          0.0    12648639.6       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-interval Join] Eviction with 300000 from 1000000 rows (changelog checkpoint: true):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                                            2302           2394         144          0.1        7673.0       1.0X
+state format version: 2                                                                            2348           2409          59          0.1        7826.5       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-interval Join] Eviction with 300000 from 1000000 rows (changelog checkpoint: false):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                                             2310           2416         120          0.1        7700.0       1.0X
+state format version: 2                                                                             2397           2457          54          0.1        7990.1       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-interval Join] Eviction with 600000 from 1000000 rows (changelog checkpoint: true):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                                            3186           3291         108          0.2        5309.4       1.0X
+state format version: 2                                                                            3309           3418         124          0.2        5515.8       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-interval Join] Eviction with 600000 from 1000000 rows (changelog checkpoint: false):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                                             3211           3266          88          0.2        5352.0       1.0X
+state format version: 2                                                                             3170           3251          73          0.2        5282.5       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-interval Join] Eviction with 900000 from 1000000 rows (changelog checkpoint: true):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                                            4081           4244         214          0.2        4534.1       1.0X
+state format version: 2                                                                            4099           4160         100          0.2        4554.9       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.7.1
+Apple M3 Max
+[Time-interval Join] Eviction with 900000 from 1000000 rows (changelog checkpoint: false):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+state format version: 1                                                                             4018           4111          95          0.2        4464.2       1.0X
+state format version: 2                                                                             3982           4071          90          0.2        4424.9       1.0X
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/StreamStreamJoinOneSideOperationsBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/StreamStreamJoinOneSideOperationsBenchmark.scala
@@ -1,0 +1,757 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.benchmark
+
+import java.util.UUID
+
+import scala.collection.mutable
+import scala.util.Random
+
+import org.apache.hadoop.conf.Configuration
+
+import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, GenericInternalRow, JoinedRow, UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.execution.streaming.operators.stateful.StatefulOperatorStateInfo
+import org.apache.spark.sql.execution.streaming.operators.stateful.join.{JoinStateManagerStoreGenerator, SymmetricHashJoinStateManager}
+import org.apache.spark.sql.execution.streaming.operators.stateful.join.StreamingSymmetricHashJoinHelper.LeftSide
+import org.apache.spark.sql.execution.streaming.runtime.StreamExecution
+import org.apache.spark.sql.execution.streaming.state.{RocksDBStateStoreProvider, StateStoreConf}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{IntegerType, LongType, StructField, StructType, TimestampType}
+import org.apache.spark.util.Utils
+
+
+/**
+ * Synthetic benchmark for Stream-Stream join operations.
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class>
+ *        --jars <spark core test jar>,<spark catalyst test jar> <sql core test jar>
+ *   2. build/sbt "sql/Test/runMain <this class>"
+ *   3. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
+ *      Results will be written to:
+ *      "sql/core/benchmarks/StreamStreamJoinOneSideOperationsBenchmark-results.txt".
+ * }}}
+ */
+object StreamStreamJoinOneSideOperationsBenchmark extends SqlBasedBenchmark {
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    runTestWithTimeWindowJoin()
+    runTestWithTimeIntervalJoin()
+  }
+
+  case class StateOpInfo(
+      queryRunId: UUID,
+      checkpointLocation: String,
+      operatorId: Int)
+
+  private def runTestWithTimeWindowJoin(): Unit = {
+    val (joinKeys, inputAttributes) = getAttributesForTimeWindowJoin()
+    val stateFormatVersions = Seq(1, 2, 3)
+
+    testWithTimeWindowJoin(
+      inputAttributes = inputAttributes,
+      joinKeys = joinKeys,
+      stateFormatVersions = stateFormatVersions
+    )
+  }
+
+  private def runTestWithTimeIntervalJoin(): Unit = {
+    val (joinKeys, inputAttributes) = getAttributesForTimeIntervalJoin()
+    val stateFormatVersions = Seq(1, 2, 3)
+
+    testWithTimeIntervalJoin(
+      inputAttributes = inputAttributes,
+      joinKeys = joinKeys,
+      stateFormatVersions = stateFormatVersions
+    )
+  }
+
+  private def testWithTimeWindowJoin(
+      inputAttributes: Seq[Attribute],
+      joinKeys: Seq[Expression],
+      stateFormatVersions: Seq[Int]): Unit = {
+    val numRowsInStateStore = 1000000
+
+    val inputData = prepareInputDataForTimeWindowJoin(
+      joinKeys = joinKeys,
+      inputAttributes = inputAttributes,
+      numRows = numRowsInStateStore
+    )
+
+    val stateFormatVersionToStateOpInfo = mutable.HashMap[Int, StateOpInfo]()
+    stateFormatVersions.foreach { stateFormatVersion =>
+      val queryRunId = UUID.randomUUID()
+      val checkpointDir = newDir()
+      val operatorId = Random.nextInt()
+
+      stateFormatVersionToStateOpInfo.put(
+        stateFormatVersion,
+        StateOpInfo(
+          queryRunId = queryRunId,
+          checkpointLocation = checkpointDir,
+          operatorId = operatorId
+        )
+      )
+    }
+
+    testAppendWithTimeWindowJoin(
+      inputData = inputData,
+      joinKeys = joinKeys,
+      inputAttributes = inputAttributes,
+      stateFormatVersions = stateFormatVersions,
+      stateFormatVersionToStateOpInfo = stateFormatVersionToStateOpInfo
+    )
+
+    testGetJoinedRowsWithTimeWindowJoin(
+      inputData = inputData,
+      joinKeys = joinKeys,
+      inputAttributes = inputAttributes,
+      stateFormatVersions = stateFormatVersions,
+      stateFormatVersionToStateOpInfo = stateFormatVersionToStateOpInfo,
+      numKeysToGet = 100000
+    )
+
+    testEvictionRowsWithTimeWindowJoin(
+      inputData = inputData,
+      joinKeys = joinKeys,
+      inputAttributes = inputAttributes,
+      stateFormatVersions = stateFormatVersions,
+      stateFormatVersionToStateOpInfo = stateFormatVersionToStateOpInfo,
+      // almost no eviction
+      evictionRate = 0.0001
+    )
+
+    testEvictionRowsWithTimeWindowJoin(
+      inputData = inputData,
+      joinKeys = joinKeys,
+      inputAttributes = inputAttributes,
+      stateFormatVersions = stateFormatVersions,
+      stateFormatVersionToStateOpInfo = stateFormatVersionToStateOpInfo,
+      evictionRate = 0.3
+    )
+
+    testEvictionRowsWithTimeWindowJoin(
+      inputData = inputData,
+      joinKeys = joinKeys,
+      inputAttributes = inputAttributes,
+      stateFormatVersions = stateFormatVersions,
+      stateFormatVersionToStateOpInfo = stateFormatVersionToStateOpInfo,
+      evictionRate = 0.6
+    )
+
+    testEvictionRowsWithTimeWindowJoin(
+      inputData = inputData,
+      joinKeys = joinKeys,
+      inputAttributes = inputAttributes,
+      stateFormatVersions = stateFormatVersions,
+      stateFormatVersionToStateOpInfo = stateFormatVersionToStateOpInfo,
+      evictionRate = 0.9
+    )
+  }
+
+  private def testAppendWithTimeWindowJoin(
+      inputData: List[(UnsafeRow, UnsafeRow)],
+      joinKeys: Seq[Expression],
+      inputAttributes: Seq[Attribute],
+      stateFormatVersions: Seq[Int],
+      stateFormatVersionToStateOpInfo: mutable.HashMap[Int, StateOpInfo]): Unit = {
+    val numInputRows = inputData.size
+    val benchmarkForPut = new Benchmark(
+      s"[Time-window Join] Append $numInputRows rows - ",
+      numInputRows,
+      minNumIters = 3,
+      output = output)
+
+    stateFormatVersions.foreach { stateFormatVersion =>
+      val stateOpInfo = stateFormatVersionToStateOpInfo(stateFormatVersion)
+
+      benchmarkForPut.addTimerCase(
+        s"state format version: $stateFormatVersion") { timer =>
+
+        val joinStateManager = createJoinStateManager(
+          queryRunId = stateOpInfo.queryRunId,
+          checkpointLocation = stateOpInfo.checkpointLocation,
+          operatorId = stateOpInfo.operatorId,
+          storeVersion = 0,
+          inputAttributes = inputAttributes,
+          joinKeys = joinKeys,
+          stateFormatVersion = stateFormatVersion)
+
+        timer.startTiming()
+        inputData.foreach { case (keyRow, valueRow) =>
+          joinStateManager.append(keyRow, valueRow, matched = false)
+        }
+        timer.stopTiming()
+
+        joinStateManager.commit()
+      }
+    }
+
+    benchmarkForPut.run()
+  }
+
+  private def testGetJoinedRowsWithTimeWindowJoin(
+      inputData: List[(UnsafeRow, UnsafeRow)],
+      joinKeys: Seq[Expression],
+      inputAttributes: Seq[Attribute],
+      stateFormatVersions: Seq[Int],
+      stateFormatVersionToStateOpInfo: mutable.HashMap[Int, StateOpInfo],
+      numKeysToGet: Int): Unit = {
+
+    val numRowsInStateStore = inputData.size
+
+    val benchmarkForGetJoinedRows = new Benchmark(
+      s"[Time-window Join] GetJoinedRows $numKeysToGet from $numRowsInStateStore rows",
+      numKeysToGet,
+      minNumIters = 3,
+      output = output)
+
+    val shuffledInputDataForJoinedRows = Random.shuffle(inputData).take(numKeysToGet)
+
+    // FIXME: state format version 3 raises an exception
+    //  Exception in thread "main" java.lang.NullPointerException:
+    //  Cannot invoke "org.apache.spark.sql.catalyst.expressions.SpecializedGetters.getInt(int)"
+    //  because "<parameter1>" is null
+    //  Need to fix this after testing.
+    stateFormatVersions.diff(Seq(3)).foreach { stateFormatVersion =>
+      val stateOpInfo = stateFormatVersionToStateOpInfo(stateFormatVersion)
+
+      benchmarkForGetJoinedRows.addTimerCase(
+        s"state format version: $stateFormatVersion") { timer =>
+
+        val joinStateManagerVer1 = createJoinStateManager(
+          queryRunId = stateOpInfo.queryRunId,
+          checkpointLocation = stateOpInfo.checkpointLocation,
+          operatorId = stateOpInfo.operatorId,
+          storeVersion = 1,
+          inputAttributes = inputAttributes,
+          joinKeys = joinKeys,
+          stateFormatVersion = stateFormatVersion)
+
+        val joinedRow = new JoinedRow()
+
+        timer.startTiming()
+        shuffledInputDataForJoinedRows.foreach { case (keyRow, valueRow) =>
+          val joinedRows = joinStateManagerVer1.getJoinedRows(
+            keyRow,
+            thatRow => joinedRow.withLeft(valueRow).withRight(thatRow),
+            _ => true,
+            excludeRowsAlreadyMatched = false)
+          joinedRows.foreach { _ =>
+            // no-op, just to consume the iterator
+          }
+        }
+        timer.stopTiming()
+
+        joinStateManagerVer1.abortIfNeeded()
+      }
+    }
+
+    benchmarkForGetJoinedRows.run()
+  }
+
+  private def testEvictionRowsWithTimeWindowJoin(
+      inputData: List[(UnsafeRow, UnsafeRow)],
+      joinKeys: Seq[Expression],
+      inputAttributes: Seq[Attribute],
+      stateFormatVersions: Seq[Int],
+      stateFormatVersionToStateOpInfo: mutable.HashMap[Int, StateOpInfo],
+      evictionRate: Double): Unit = {
+
+    assert(evictionRate >= 0.0 && evictionRate < 1.0,
+      s"Eviction rate must be between 0.0 and 1.0, but got $evictionRate")
+
+    val totalStateRows = inputData.size
+    val numTargetEvictRows = (totalStateRows * evictionRate).toInt
+
+    val orderedInputDataByTime = inputData.sortBy { case (keyRow, _) =>
+      // extract window end time from the key row
+      val windowRow = keyRow.getStruct(1, 2)
+      windowRow.getLong(1)
+    }
+
+    val windowEndForEviction = orderedInputDataByTime.take(numTargetEvictRows).last
+      ._1.getStruct(1, 2).getLong(1)
+
+    val actualNumRows = inputData.count { case (keyRow, _) =>
+      val windowRow = keyRow.getStruct(1, 2)
+      val windowEnd = windowRow.getLong(1)
+      windowEnd <= windowEndForEviction
+    }
+
+    val benchmarkForEviction = new Benchmark(
+      s"[Time-window Join] Eviction with $actualNumRows from $totalStateRows rows",
+      actualNumRows,
+      minNumIters = 3,
+      output = output)
+
+    stateFormatVersions.foreach { stateFormatVersion =>
+      val stateOpInfo = stateFormatVersionToStateOpInfo(stateFormatVersion)
+
+      benchmarkForEviction.addTimerCase(
+        s"state format version: $stateFormatVersion") { timer =>
+
+        val joinStateManagerVer1 = createJoinStateManager(
+          queryRunId = stateOpInfo.queryRunId,
+          checkpointLocation = stateOpInfo.checkpointLocation,
+          operatorId = stateOpInfo.operatorId,
+          storeVersion = 1,
+          inputAttributes = inputAttributes,
+          joinKeys = joinKeys,
+          stateFormatVersion = stateFormatVersion)
+
+        timer.startTiming()
+        val evictedRows = joinStateManagerVer1.removeByKeyCondition {
+          keyRow =>
+            val windowRow = keyRow.getStruct(1, 2)
+            val windowEnd = windowRow.getLong(1)
+            windowEnd <= windowEndForEviction
+        }
+        evictedRows.foreach { _ =>
+          // no-op, just to consume the iterator
+        }
+        timer.stopTiming()
+
+        joinStateManagerVer1.abortIfNeeded()
+      }
+    }
+
+    benchmarkForEviction.run()
+  }
+
+  private def prepareInputDataForTimeWindowJoin(
+      joinKeys: Seq[Expression],
+      inputAttributes: Seq[Attribute],
+      numRows: Int): List[(UnsafeRow, UnsafeRow)] = {
+    val rowsToAppend = mutable.ArrayBuffer[(UnsafeRow, UnsafeRow)]()
+    val keyProj = UnsafeProjection.create(joinKeys, inputAttributes)
+    val valueProj = UnsafeProjection.create(inputAttributes, inputAttributes)
+
+    0.until(numRows).foreach { i =>
+      val deptId = i % 10
+      val windowStart = (i / 10) * 1000L
+      val windowEnd = (i / 10) * 1000L + 1000L
+
+      val sum = Random.nextInt(100)
+      val count = Random.nextInt(10)
+
+      val row = new GenericInternalRow(
+        Array[Any](
+          deptId,
+          new GenericInternalRow(
+            Array[Any](windowStart, windowEnd)
+          ),
+          sum.toLong,
+          count.toLong)
+      )
+
+      val keyUnsafeRow = keyProj(row).copy()
+      val valueUnsafeRow = valueProj(row).copy()
+      rowsToAppend.append((keyUnsafeRow, valueUnsafeRow))
+    }
+
+    rowsToAppend.toList
+  }
+
+  private def testWithTimeIntervalJoin(
+      inputAttributes: Seq[Attribute],
+      joinKeys: Seq[Expression],
+      stateFormatVersions: Seq[Int]): Unit = {
+    val numRowsInStateStore = 1000000
+
+    val inputData = prepareInputDataForTimeIntervalJoin(
+      joinKeys = joinKeys,
+      inputAttributes = inputAttributes,
+      numRows = numRowsInStateStore
+    )
+
+    val stateFormatVersionToStateOpInfo = mutable.HashMap[Int, StateOpInfo]()
+    stateFormatVersions.foreach { stateFormatVersion =>
+      val queryRunId = UUID.randomUUID()
+      val checkpointDir = newDir()
+      val operatorId = Random.nextInt()
+
+      stateFormatVersionToStateOpInfo.put(
+        stateFormatVersion,
+        StateOpInfo(
+          queryRunId = queryRunId,
+          checkpointLocation = checkpointDir,
+          operatorId = operatorId
+        )
+      )
+    }
+
+    testAppendWithTimeIntervalJoin(
+      inputData = inputData,
+      joinKeys = joinKeys,
+      inputAttributes = inputAttributes,
+      stateFormatVersions = stateFormatVersions,
+      stateFormatVersionToStateOpInfo = stateFormatVersionToStateOpInfo
+    )
+
+    testGetJoinedRowsWithTimeIntervalJoin(
+      inputData = inputData,
+      joinKeys = joinKeys,
+      inputAttributes = inputAttributes,
+      stateFormatVersions = stateFormatVersions,
+      stateFormatVersionToStateOpInfo = stateFormatVersionToStateOpInfo,
+      numKeysToGet = 10000
+    )
+
+    testEvictionRowsWithTimeIntervalJoin(
+      inputData = inputData,
+      joinKeys = joinKeys,
+      inputAttributes = inputAttributes,
+      stateFormatVersions = stateFormatVersions,
+      stateFormatVersionToStateOpInfo = stateFormatVersionToStateOpInfo,
+      // almost no eviction
+      evictionRate = 0.0001
+    )
+
+    testEvictionRowsWithTimeIntervalJoin(
+      inputData = inputData,
+      joinKeys = joinKeys,
+      inputAttributes = inputAttributes,
+      stateFormatVersions = stateFormatVersions,
+      stateFormatVersionToStateOpInfo = stateFormatVersionToStateOpInfo,
+      evictionRate = 0.3
+    )
+
+    testEvictionRowsWithTimeIntervalJoin(
+      inputData = inputData,
+      joinKeys = joinKeys,
+      inputAttributes = inputAttributes,
+      stateFormatVersions = stateFormatVersions,
+      stateFormatVersionToStateOpInfo = stateFormatVersionToStateOpInfo,
+      evictionRate = 0.6
+    )
+
+    testEvictionRowsWithTimeIntervalJoin(
+      inputData = inputData,
+      joinKeys = joinKeys,
+      inputAttributes = inputAttributes,
+      stateFormatVersions = stateFormatVersions,
+      stateFormatVersionToStateOpInfo = stateFormatVersionToStateOpInfo,
+      evictionRate = 0.9
+    )
+  }
+
+  private def testAppendWithTimeIntervalJoin(
+      inputData: List[(UnsafeRow, UnsafeRow)],
+      joinKeys: Seq[Expression],
+      inputAttributes: Seq[Attribute],
+      stateFormatVersions: Seq[Int],
+      stateFormatVersionToStateOpInfo: mutable.HashMap[Int, StateOpInfo]): Unit = {
+    val numInputRows = inputData.size
+    val benchmarkForPut = new Benchmark(
+      s"[Time-interval Join] Append $numInputRows rows",
+      numInputRows,
+      minNumIters = 3,
+      output = output)
+
+    stateFormatVersions.foreach { stateFormatVersion =>
+      val stateOpInfo = stateFormatVersionToStateOpInfo(stateFormatVersion)
+
+      benchmarkForPut.addTimerCase(
+        s"state format version: $stateFormatVersion") { timer =>
+
+        val joinStateManager = createJoinStateManager(
+          queryRunId = stateOpInfo.queryRunId,
+          checkpointLocation = stateOpInfo.checkpointLocation,
+          operatorId = stateOpInfo.operatorId,
+          storeVersion = 0,
+          inputAttributes = inputAttributes,
+          joinKeys = joinKeys,
+          stateFormatVersion = stateFormatVersion)
+
+        timer.startTiming()
+        inputData.foreach { case (keyRow, valueRow) =>
+          joinStateManager.append(keyRow, valueRow, matched = false)
+        }
+        timer.stopTiming()
+
+        joinStateManager.commit()
+      }
+    }
+
+    benchmarkForPut.run()
+  }
+
+  private def testGetJoinedRowsWithTimeIntervalJoin(
+      inputData: List[(UnsafeRow, UnsafeRow)],
+      joinKeys: Seq[Expression],
+      inputAttributes: Seq[Attribute],
+      stateFormatVersions: Seq[Int],
+      stateFormatVersionToStateOpInfo: mutable.HashMap[Int, StateOpInfo],
+      numKeysToGet: Int): Unit = {
+
+    val numRowsInStateStore = inputData.size
+
+    val benchmarkForGetJoinedRows = new Benchmark(
+      s"[Time-interval Join] GetJoinedRows $numKeysToGet from $numRowsInStateStore rows",
+      numKeysToGet,
+      minNumIters = 3,
+      output = output)
+
+    val shuffledInputDataForJoinedRows = Random.shuffle(inputData).take(numKeysToGet)
+
+    // FIXME: state format version 3 raises an exception
+    //  Exception in thread "main" java.lang.NullPointerException:
+    //  Cannot invoke "org.apache.spark.sql.catalyst.expressions.SpecializedGetters.getInt(int)"
+    //  because "<parameter1>" is null
+    //  Need to fix this after testing.
+    stateFormatVersions.diff(Seq(3)).foreach { stateFormatVersion =>
+      val stateOpInfo = stateFormatVersionToStateOpInfo(stateFormatVersion)
+
+      benchmarkForGetJoinedRows.addTimerCase(
+        s"state format version: $stateFormatVersion") { timer =>
+
+        val joinStateManagerVer1 = createJoinStateManager(
+          queryRunId = stateOpInfo.queryRunId,
+          checkpointLocation = stateOpInfo.checkpointLocation,
+          operatorId = stateOpInfo.operatorId,
+          storeVersion = 1,
+          inputAttributes = inputAttributes,
+          joinKeys = joinKeys,
+          stateFormatVersion = stateFormatVersion)
+
+        val joinedRow = new JoinedRow()
+
+        timer.startTiming()
+        shuffledInputDataForJoinedRows.foreach { case (keyRow, valueRow) =>
+          val joinedRows = joinStateManagerVer1.getJoinedRows(
+            keyRow,
+            thatRow => joinedRow.withLeft(valueRow).withRight(thatRow),
+            _ => true,
+            excludeRowsAlreadyMatched = false)
+          joinedRows.foreach { _ =>
+            // no-op, just to consume the iterator
+          }
+        }
+        timer.stopTiming()
+
+        joinStateManagerVer1.abortIfNeeded()
+      }
+    }
+
+    benchmarkForGetJoinedRows.run()
+  }
+
+  private def testEvictionRowsWithTimeIntervalJoin(
+      inputData: List[(UnsafeRow, UnsafeRow)],
+      joinKeys: Seq[Expression],
+      inputAttributes: Seq[Attribute],
+      stateFormatVersions: Seq[Int],
+      stateFormatVersionToStateOpInfo: mutable.HashMap[Int, StateOpInfo],
+      evictionRate: Double): Unit = {
+
+    assert(evictionRate >= 0.0 && evictionRate < 1.0,
+      s"Eviction rate must be between 0.0 and 1.0, but got $evictionRate")
+
+    val totalStateRows = inputData.size
+    val numTargetEvictRows = (totalStateRows * evictionRate).toInt
+
+    val orderedInputDataByTime = inputData.sortBy { case (_, valueRow) =>
+      // impressionTimestamp is at index 1 in value row
+      valueRow.getLong(1)
+    }
+
+    val tsForEviction = orderedInputDataByTime.take(numTargetEvictRows).last
+      ._2.getLong(1)
+
+    val actualNumRows = inputData.count { case (_, valueRow) =>
+      valueRow.getLong(1) <= tsForEviction
+    }
+
+    val benchmarkForEviction = new Benchmark(
+      s"[Time-interval Join] Eviction with $actualNumRows from $totalStateRows rows",
+      actualNumRows,
+      minNumIters = 3,
+      output = output)
+
+    // scalastyle:off line.size.limit
+    // FIXME: state format version 3 has some issue with this -
+    //  java.lang.NullPointerException: Cannot invoke
+    //  "org.apache.spark.sql.execution.streaming.operators.stateful.join.SymmetricHashJoinStateManager$ValueAndMatchPair.value()"
+    //  because "valuePair" is null
+    // scalastyle:on line.size.limit
+    stateFormatVersions.diff(Seq(3)).foreach { stateFormatVersion =>
+      val stateOpInfo = stateFormatVersionToStateOpInfo(stateFormatVersion)
+
+      benchmarkForEviction.addTimerCase(
+        s"state format version: $stateFormatVersion") { timer =>
+
+        val joinStateManagerVer1 = createJoinStateManager(
+          queryRunId = stateOpInfo.queryRunId,
+          checkpointLocation = stateOpInfo.checkpointLocation,
+          operatorId = stateOpInfo.operatorId,
+          storeVersion = 1,
+          inputAttributes = inputAttributes,
+          joinKeys = joinKeys,
+          stateFormatVersion = stateFormatVersion)
+
+        timer.startTiming()
+        val evictedRows = joinStateManagerVer1.removeByValueCondition { valueRow =>
+          valueRow.getLong(1) <= tsForEviction
+        }
+        evictedRows.foreach { _ =>
+          // no-op, just to consume the iterator
+        }
+        timer.stopTiming()
+
+        joinStateManagerVer1.abortIfNeeded()
+      }
+    }
+
+    benchmarkForEviction.run()
+  }
+
+  private def prepareInputDataForTimeIntervalJoin(
+      joinKeys: Seq[Expression],
+      inputAttributes: Seq[Attribute],
+      numRows: Int): List[(UnsafeRow, UnsafeRow)] = {
+    val rowsToAppend = mutable.ArrayBuffer[(UnsafeRow, UnsafeRow)]()
+    val keyProj = UnsafeProjection.create(joinKeys, inputAttributes)
+    val valueProj = UnsafeProjection.create(inputAttributes, inputAttributes)
+
+    0.until(numRows).foreach { i =>
+      val adId = i % 1000
+
+      val impressionTimestamp = (i / 100) * 1000L
+
+      // Below twos are effectively not used in join criteria and does not impact the benchmark
+      val userId = Random.nextInt(1000)
+      val campaignId = Random.nextInt(10000)
+
+      val row = new GenericInternalRow(
+        Array[Any](
+          adId,
+          impressionTimestamp,
+          userId,
+          campaignId)
+      )
+
+      val keyUnsafeRow = keyProj(row).copy()
+      val valueUnsafeRow = valueProj(row).copy()
+      rowsToAppend.append((keyUnsafeRow, valueUnsafeRow))
+    }
+
+    rowsToAppend.toList
+  }
+
+  private def getAttributesForTimeWindowJoin(): (Seq[Expression], Seq[Attribute]) = {
+    val inputAttributes = Seq(
+      AttributeReference("deptId", IntegerType, nullable = false)(),
+      AttributeReference(
+        "window",
+        StructType(
+          Seq(
+            StructField("start", TimestampType, nullable = false),
+            StructField("end", TimestampType, nullable = false))),
+        nullable = false)(),
+      AttributeReference("sum", LongType, nullable = false)(),
+      AttributeReference("count", LongType, nullable = false)()
+    )
+
+    val joinKeys = Seq(
+      inputAttributes(0), // deptId
+      inputAttributes(1)  // window
+    )
+
+    (joinKeys, inputAttributes)
+  }
+
+  private def getAttributesForTimeIntervalJoin(): (Seq[Expression], Seq[Attribute]) = {
+    val inputAttributes = Seq(
+      AttributeReference("adId", IntegerType, nullable = false)(),
+      AttributeReference("impressionTimestamp", TimestampType, nullable = false)(),
+      AttributeReference("userId", IntegerType, nullable = false)(),
+      AttributeReference("campaignId", IntegerType, nullable = false)()
+    )
+    val joinKeys = Seq(
+      inputAttributes(0) // adId
+    )
+    (joinKeys, inputAttributes)
+  }
+
+  final def skip(benchmarkName: String)(func: => Any): Unit = {
+    output.foreach(_.write(s"$benchmarkName is skipped".getBytes))
+  }
+
+  private def createJoinStateManager(
+      inputAttributes: Seq[Attribute],
+      joinKeys: Seq[Expression],
+      queryRunId: UUID,
+      checkpointLocation: String,
+      operatorId: Int,
+      storeVersion: Int,
+      stateFormatVersion: Int): SymmetricHashJoinStateManager = {
+    val joinSide = LeftSide
+    val partitionId = 0
+
+    val stateInfo = Some(
+      StatefulOperatorStateInfo(
+        checkpointLocation = checkpointLocation,
+        queryRunId = queryRunId,
+        operatorId = operatorId,
+        storeVersion = storeVersion,
+        numPartitions = 1,
+        stateSchemaMetadata = None,
+        stateStoreCkptIds = None
+      )
+    )
+
+    val sqlConf = new SQLConf()
+    // We are only interested with RocksDB state store provider here
+    sqlConf.setConfString("spark.sql.streaming.stateStore.providerClass",
+      classOf[RocksDBStateStoreProvider].getName)
+    sqlConf.setConfString("spark.sql.streaming.stateStore.rocksdb.changelogCheckpointing.enabled",
+      true.toString)
+    sqlConf.setConfString("spark.sql.streaming.stateStore.rocksdb.trackTotalNumberOfRows",
+      false.toString)
+    sqlConf.setConfString("spark.sql.streaming.stateStore.coordinatorReportSnapshotUploadLag",
+      false.toString)
+    val storeConf = new StateStoreConf(sqlConf)
+
+    val hadoopConf = new Configuration
+    hadoopConf.set(StreamExecution.RUN_ID_KEY, queryRunId.toString)
+
+    val joinStoreGenerator = new JoinStateManagerStoreGenerator()
+
+    SymmetricHashJoinStateManager(
+      joinSide = joinSide,
+      inputValueAttributes = inputAttributes,
+      joinKeys = joinKeys,
+      stateInfo = stateInfo,
+      storeConf = storeConf,
+      hadoopConf = hadoopConf,
+      partitionId = partitionId,
+      keyToNumValuesStateStoreCkptId = None,
+      keyWithIndexToValueStateStoreCkptId = None,
+      snapshotOptions = None,
+      stateFormatVersion = stateFormatVersion,
+      skippedNullValueCount = None,
+      joinStoreGenerator = joinStoreGenerator,
+      useStateStoreCoordinator = false
+    )
+  }
+
+  private def newDir(): String = Utils.createTempDir().toString
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to introduce stream-stream join operations microbenchmark.

### Why are the changes needed?

This would give visibility of the performance on the existing implementation of stream-stream join, and provide comparison when we are going to improve this area. Note that this is "microbenchmark" and e2e benchmarking (including checkpointing) needs to be done with different approach. (Not very sure benchmark tool in Apache Spark is stable for e2e benchmarking.)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran benchmark locally and the output file is included in the PR.

### Was this patch authored or co-authored using generative AI tooling?

No.