### PR TITLE
[SPARK-54589][PYTHON] Consolidate ArrowStreamAggPandasIterUDFSerializer into ArrowStreamAggPandasUDFSerializer

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -1135,62 +1135,9 @@ class ArrowStreamAggArrowUDFSerializer(ArrowStreamArrowUDFSerializer):
         return "ArrowStreamAggArrowUDFSerializer"
 
 
-# Serializer for SQL_GROUPED_AGG_PANDAS_UDF and SQL_WINDOW_AGG_PANDAS_UDF
+# Serializer for SQL_GROUPED_AGG_PANDAS_UDF, SQL_WINDOW_AGG_PANDAS_UDF,
+# and SQL_GROUPED_AGG_PANDAS_ITER_UDF
 class ArrowStreamAggPandasUDFSerializer(ArrowStreamPandasUDFSerializer):
-    def __init__(
-        self,
-        timezone,
-        safecheck,
-        assign_cols_by_name,
-        int_to_decimal_coercion_enabled,
-    ):
-        super().__init__(
-            timezone=timezone,
-            safecheck=safecheck,
-            assign_cols_by_name=assign_cols_by_name,
-            df_for_struct=False,
-            struct_in_pandas="dict",
-            ndarray_as_list=False,
-            arrow_cast=True,
-            input_types=None,
-            int_to_decimal_coercion_enabled=int_to_decimal_coercion_enabled,
-        )
-
-    def load_stream(self, stream):
-        """
-        Deserialize Grouped ArrowRecordBatches and yield as a list of pandas.Series.
-        """
-        import pyarrow as pa
-
-        dataframes_in_group = None
-
-        while dataframes_in_group is None or dataframes_in_group > 0:
-            dataframes_in_group = read_int(stream)
-
-            if dataframes_in_group == 1:
-                yield (
-                    [
-                        self.arrow_to_pandas(c, i)
-                        for i, c in enumerate(
-                            pa.Table.from_batches(
-                                ArrowStreamSerializer.load_stream(self, stream)
-                            ).itercolumns()
-                        )
-                    ]
-                )
-
-            elif dataframes_in_group != 0:
-                raise PySparkValueError(
-                    errorClass="INVALID_NUMBER_OF_DATAFRAMES_IN_GROUP",
-                    messageParameters={"dataframes_in_group": str(dataframes_in_group)},
-                )
-
-    def __repr__(self):
-        return "ArrowStreamAggPandasUDFSerializer"
-
-
-# Serializer for SQL_GROUPED_AGG_PANDAS_ITER_UDF
-class ArrowStreamAggPandasIterUDFSerializer(ArrowStreamPandasUDFSerializer):
     def __init__(
         self,
         timezone,
@@ -1241,7 +1188,7 @@ class ArrowStreamAggPandasIterUDFSerializer(ArrowStreamPandasUDFSerializer):
                 )
 
     def __repr__(self):
-        return "ArrowStreamAggPandasIterUDFSerializer"
+        return "ArrowStreamAggPandasUDFSerializer"
 
 
 # Serializer for SQL_GROUPED_MAP_PANDAS_UDF, SQL_GROUPED_MAP_PANDAS_ITER_UDF

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -3378,9 +3378,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf):
                 for i in range(num_columns)
             ]
 
-            result = tuple(
-                f(*[concatenated[o] for o in arg_offsets]) for arg_offsets, f in udfs
-            )
+            result = tuple(f(*[concatenated[o] for o in arg_offsets]) for arg_offsets, f in udfs)
             # In the special case of a single UDF this will return a single result rather
             # than a tuple of results; this is the format that the JVM side expects.
             if len(result) == 1:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR consolidates `ArrowStreamAggPandasIterUDFSerializer` into `ArrowStreamAggPandasUDFSerializer` for `SQL_GROUPED_AGG_PANDAS`.

Changes:
1. **Removed `ArrowStreamAggPandasIterUDFSerializer`** - The class was nearly identical to `ArrowStreamAggPandasUDFSerializer`
2. **Unified serializer** - `ArrowStreamAggPandasUDFSerializer` now serves `SQL_GROUPED_AGG_PANDAS_UDF`, `SQL_GROUPED_AGG_PANDAS_ITER_UDF`, and `SQL_WINDOW_AGG_PANDAS_UDF`
3. **Added mapper for non-iter UDFs** - A new mapper in `worker.py` handles batch concatenation for `SQL_GROUPED_AGG_PANDAS_UDF` and `SQL_WINDOW_AGG_PANDAS_UDF`

### Why are the changes needed?

Similar to SPARK-54316, the two serializer classes had nearly identical implementations:
- Identical `__init__` methods
- Same base class (`ArrowStreamPandasUDFSerializer`)
- Only `load_stream` differed slightly in output format

### Does this PR introduce _any_ user-facing change?

No. It's an internal refactor.

### How was this patch tested?

Existing unit tests:
- `python/pyspark/sql/tests/pandas/test_pandas_udf_grouped_agg.py`
- `python/pyspark/sql/tests/pandas/test_pandas_udf_window.py`

### Was this patch authored or co-authored using generative AI tooling?

No.