### PR TITLE
[SPARK-54688][SQL] Introduce ArrowBatch case class to encapsulate Arrow batch metadata

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/SparkConnectPlanExecution.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/SparkConnectPlanExecution.scala
@@ -127,7 +127,7 @@ private[execution] class SparkConnectPlanExecution(executeHolder: ExecuteHolder)
       timeZoneId,
       errorOnDuplicatedFieldNames,
       largeVarTypes)
-    batches.map(b => b -> batches.rowCountInLastBatch)
+    batches.map(b => b.batch -> b.rowCount.toLong)
   }
 
   def processAsArrowBatches(

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -3032,9 +3032,9 @@ class SparkConnectPlanner(
           errorOnDuplicatedFieldNames = false,
           largeVarTypes = largeVarTypes)
         assert(batches.hasNext)
-        val bytes = batches.next()
+        val arrowBatch = batches.next()
         assert(!batches.hasNext, s"remaining batches: ${batches.size}")
-        bytes
+        arrowBatch.batch
       }
 
       result.setRelation(

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
@@ -95,7 +95,7 @@ trait SparkConnectPlanTest extends SharedSparkSession {
       schema: Option[StructType] = None): proto.Relation = {
     val localRelationBuilder = proto.LocalRelation.newBuilder()
 
-    val bytes = ArrowConverters
+    val arrowBatch = ArrowConverters
       .toBatchWithSchemaIterator(
         data.iterator,
         DataTypeUtils.fromAttributes(attrs.map(_.toAttribute)),
@@ -106,7 +106,7 @@ trait SparkConnectPlanTest extends SharedSparkSession {
         false)
       .next()
 
-    localRelationBuilder.setData(ByteString.copyFrom(bytes))
+    localRelationBuilder.setData(ByteString.copyFrom(arrowBatch.batch))
     schema.foreach(s => localRelationBuilder.setSchema(s.json))
     proto.Relation.newBuilder().setLocalRelation(localRelationBuilder.build()).build()
   }

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
@@ -1118,7 +1118,7 @@ class SparkConnectProtoSuite extends PlanTest with SparkConnectPlanTest {
     val localRelationBuilder = proto.LocalRelation.newBuilder()
 
     val attributes = attrs.map(exp => AttributeReference(exp.name, exp.dataType)())
-    val buffer = ArrowConverters
+    val arrowBatch = ArrowConverters
       .toBatchWithSchemaIterator(
         Iterator.empty,
         DataTypeUtils.fromAttributes(attributes),
@@ -1130,7 +1130,7 @@ class SparkConnectProtoSuite extends PlanTest with SparkConnectPlanTest {
       .next()
     proto.Relation
       .newBuilder()
-      .setLocalRelation(localRelationBuilder.setData(ByteString.copyFrom(buffer)).build())
+      .setLocalRelation(localRelationBuilder.setData(ByteString.copyFrom(arrowBatch.batch)).build())
       .build()
   }
 

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
@@ -1130,7 +1130,8 @@ class SparkConnectProtoSuite extends PlanTest with SparkConnectPlanTest {
       .next()
     proto.Relation
       .newBuilder()
-      .setLocalRelation(localRelationBuilder.setData(ByteString.copyFrom(arrowBatch.batch)).build())
+      .setLocalRelation(
+        localRelationBuilder.setData(ByteString.copyFrom(arrowBatch.batch)).build())
       .build()
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
@@ -2356,7 +2356,7 @@ class Dataset[T] private[sql](
         timeZoneId,
         errorOnDuplicatedFieldNames,
         largeVarTypes,
-        context)
+        context).map(_.batch)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/arrowcollect/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/arrowcollect/package.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+package object arrowcollect {
+
+  /**
+   * A case class representing an Arrow batch with metadata.
+   *
+   * @param rowCount The number of rows in this batch.
+   * @param batch The serialized Arrow batch data.
+   */
+  private[sql] case class ArrowBatch(rowCount: Int, batch: Array[Byte])
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowConvertersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowConvertersSuite.scala
@@ -1414,7 +1414,7 @@ class ArrowConvertersSuite extends SharedSparkSession {
 
     val ctx = TaskContext.empty()
     val batchIter = ArrowConverters.toBatchIterator(
-      inputRows.iterator, schema, 5, null, true, false, ctx)
+      inputRows.iterator, schema, 5, null, true, false, ctx).map(_.batch)
     val outputRowIter = ArrowConverters.fromBatchIterator(
       batchIter, schema, null, true, false, ctx)
 
@@ -1437,7 +1437,7 @@ class ArrowConvertersSuite extends SharedSparkSession {
     val schema = StructType(Seq(StructField("int", IntegerType, nullable = true)))
     val ctx = TaskContext.empty()
     val batchIter = ArrowConverters.toBatchIterator(
-      inputRows.iterator, schema, 5, null, true, false, ctx)
+      inputRows.iterator, schema, 5, null, true, false, ctx).map(_.batch)
 
     // Write batches to Arrow stream format as a byte array
     val out = new ByteArrayOutputStream()
@@ -1482,8 +1482,9 @@ class ArrowConvertersSuite extends SharedSparkSession {
     }
     val ctx = TaskContext.empty()
     val batchIter = ArrowConverters.toBatchWithSchemaIterator(
-      inputRows.iterator, schema, 5, 1024 * 1024, null, true, false)
-    val (outputRowIter, outputType) = ArrowConverters.fromBatchWithSchemaIterator(batchIter, ctx)
+      inputRows.iterator, schema, 5, 1024 * 1024, null, true, false).map(_.batch)
+    val (outputRowIter, outputType) =
+      ArrowConverters.fromBatchWithSchemaIterator(batchIter, ctx)
 
     var count = 0
     outputRowIter.zipWithIndex.foreach { case (row, i) =>
@@ -1502,8 +1503,9 @@ class ArrowConvertersSuite extends SharedSparkSession {
     val ctx = TaskContext.empty()
     val batchIter =
       ArrowConverters.toBatchWithSchemaIterator(
-        Iterator.empty, schema, 5, 1024 * 1024, null, true, false)
-    val (outputRowIter, outputType) = ArrowConverters.fromBatchWithSchemaIterator(batchIter, ctx)
+        Iterator.empty, schema, 5, 1024 * 1024, null, true, false).map(_.batch)
+    val (outputRowIter, outputType) =
+      ArrowConverters.fromBatchWithSchemaIterator(batchIter, ctx)
 
     assert(0 == outputRowIter.length)
     assert(outputType == null)
@@ -1516,7 +1518,7 @@ class ArrowConvertersSuite extends SharedSparkSession {
       proj(row).copy()
     }
     val batchIter1 = ArrowConverters.toBatchWithSchemaIterator(
-      inputRows1.iterator, schema1, 5, 1024 * 1024, null, true, false)
+      inputRows1.iterator, schema1, 5, 1024 * 1024, null, true, false).map(_.batch)
 
     val schema2 = StructType(Seq(StructField("field2", IntegerType, nullable = true)))
     val inputRows2 = Array(InternalRow(1)).map { row =>
@@ -1524,7 +1526,7 @@ class ArrowConvertersSuite extends SharedSparkSession {
       proj(row).copy()
     }
     val batchIter2 = ArrowConverters.toBatchWithSchemaIterator(
-      inputRows2.iterator, schema2, 5, 1024 * 1024, null, true, false)
+      inputRows2.iterator, schema2, 5, 1024 * 1024, null, true, false).map(_.batch)
 
     val iter = batchIter1.toArray ++ batchIter2
 
@@ -1540,7 +1542,7 @@ class ArrowConvertersSuite extends SharedSparkSession {
     val ctx = TaskContext.empty()
 
     val batchIter = ArrowConverters.toBatchIterator(
-      inputRows.iterator, schema, 10, null, true, false, ctx)
+      inputRows.iterator, schema, 10, null, true, false, ctx).map(_.batch)
 
     // Write batches to Arrow IPC stream format
     val out = new ByteArrayOutputStream()
@@ -1583,7 +1585,7 @@ class ArrowConvertersSuite extends SharedSparkSession {
 
     // Create multiple batches with small batch size
     val batchIter = ArrowConverters.toBatchIterator(
-      inputRows.iterator, schema, 5, null, true, false, ctx)
+      inputRows.iterator, schema, 5, null, true, false, ctx).map(_.batch)
 
     val out = new ByteArrayOutputStream()
     Utils.tryWithResource(new DataOutputStream(out)) { dataOut =>
@@ -1617,7 +1619,7 @@ class ArrowConvertersSuite extends SharedSparkSession {
     val ctx = TaskContext.empty()
 
     val batchIter = ArrowConverters.toBatchIterator(
-      inputRows.iterator, schema, 7, null, true, false, ctx)
+      inputRows.iterator, schema, 7, null, true, false, ctx).map(_.batch)
 
     val out = new ByteArrayOutputStream()
     Utils.tryWithResource(new DataOutputStream(out)) { dataOut =>
@@ -1654,7 +1656,7 @@ class ArrowConvertersSuite extends SharedSparkSession {
 
     // Create multiple batches
     val batchIter = ArrowConverters.toBatchIterator(
-      inputRows.iterator, schema, 4, null, true, false, ctx)
+      inputRows.iterator, schema, 4, null, true, false, ctx).map(_.batch)
 
     val out = new ByteArrayOutputStream()
     Utils.tryWithResource(new DataOutputStream(out)) { dataOut =>
@@ -1690,7 +1692,7 @@ class ArrowConvertersSuite extends SharedSparkSession {
     testCases.foreach { case (rowCount, batchSize) =>
       val inputRows = (0 until rowCount).map(InternalRow(_))
       val batchIter = ArrowConverters.toBatchIterator(
-        inputRows.iterator, schema, batchSize, null, true, false, ctx)
+        inputRows.iterator, schema, batchSize, null, true, false, ctx).map(_.batch)
 
       val out = new ByteArrayOutputStream()
       Utils.tryWithResource(new DataOutputStream(out)) { dataOut =>
@@ -1733,7 +1735,7 @@ class ArrowConvertersSuite extends SharedSparkSession {
     val ctx = TaskContext.empty()
 
     val batchIter = ArrowConverters.toBatchIterator(
-      Iterator.empty, schema, 10, null, true, false, ctx)
+      Iterator.empty, schema, 10, null, true, false, ctx).map(_.batch)
 
     val out = new ByteArrayOutputStream()
     Utils.tryWithResource(new DataOutputStream(out)) { dataOut =>
@@ -1779,7 +1781,7 @@ class ArrowConvertersSuite extends SharedSparkSession {
     val ctx = TaskContext.empty()
 
     val batchIter = ArrowConverters.toBatchIterator(
-      inputRows.iterator, schema, 10, null, true, false, ctx)
+      inputRows.iterator, schema, 10, null, true, false, ctx).map(_.batch)
 
     val out = new ByteArrayOutputStream()
     Utils.tryWithResource(new DataOutputStream(out)) { dataOut =>
@@ -1806,7 +1808,7 @@ class ArrowConvertersSuite extends SharedSparkSession {
 
     // Create many small batches
     val batchIter = ArrowConverters.toBatchIterator(
-      inputRows.iterator, schema, 3, null, true, false, ctx)
+      inputRows.iterator, schema, 3, null, true, false, ctx).map(_.batch)
 
     val out = new ByteArrayOutputStream()
     Utils.tryWithResource(new DataOutputStream(out)) { dataOut =>
@@ -1875,7 +1877,7 @@ class ArrowConvertersSuite extends SharedSparkSession {
 
     // Use small batch size to create many batches
     val batchIter = ArrowConverters.toBatchIterator(
-      projectedRows.iterator, schema, 7, null, true, false, ctx)
+      projectedRows.iterator, schema, 7, null, true, false, ctx).map(_.batch)
 
     val out = new ByteArrayOutputStream()
     Utils.tryWithResource(new DataOutputStream(out)) { dataOut =>
@@ -1911,7 +1913,7 @@ class ArrowConvertersSuite extends SharedSparkSession {
     val batchSize = 7
 
     val batchIter = ArrowConverters.toBatchIterator(
-      inputRows.iterator, schema, batchSize, null, true, false, ctx)
+      inputRows.iterator, schema, batchSize, null, true, false, ctx).map(_.batch)
 
     val out = new ByteArrayOutputStream()
     Utils.tryWithResource(new DataOutputStream(out)) { dataOut =>
@@ -1991,5 +1993,51 @@ class ArrowConvertersSuite extends SharedSparkSession {
     arrowRecordBatch.close()
     arrowRoot.close()
     allocator.close()
+  }
+
+  test("ArrowBatch case class basic functionality") {
+    import org.apache.spark.sql.execution.arrowcollect.ArrowBatch
+
+    // Test creation and field access
+    val testData = Array[Byte](1, 2, 3, 4, 5)
+    val batch = ArrowBatch(rowCount = 10, batch = testData)
+
+    assert(batch.rowCount == 10)
+    assert(batch.batch.sameElements(testData))
+
+    // Test copy
+    val batchCopy = batch.copy(rowCount = 20)
+    assert(batchCopy.rowCount == 20)
+    assert(batchCopy.batch.sameElements(testData))
+
+    // Test equality (note: Array equality is referential)
+    val batch2 = ArrowBatch(rowCount = 10, batch = testData)
+    assert(batch.rowCount == batch2.rowCount)
+  }
+
+  test("ArrowBatch iterator from toBatchIterator") {
+    import org.apache.spark.sql.execution.arrowcollect.ArrowBatch
+
+    val inputRows = (0 until 25).map(InternalRow(_))
+    val schema = StructType(Seq(StructField("int", IntegerType, nullable = true)))
+    val ctx = TaskContext.empty()
+
+    val batchIter: Iterator[ArrowBatch] = ArrowConverters.toBatchIterator(
+      inputRows.iterator, schema, 10, null, true, false, ctx)
+
+    val batches = batchIter.toList
+    // With 25 rows and batch size 10, we expect 3 batches (10 + 10 + 5)
+    assert(batches.length == 3)
+    assert(batches(0).rowCount == 10)
+    assert(batches(1).rowCount == 10)
+    assert(batches(2).rowCount == 5)
+
+    // Verify total row count
+    assert(batches.map(_.rowCount).sum == 25)
+
+    // Verify batch data is non-empty
+    batches.foreach { batch =>
+      assert(batch.batch.nonEmpty)
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR introduces an `ArrowBatch` case class to encapsulate Arrow batch metadata alongside the serialized batch data.

Changes:
1. **Added `ArrowBatch` case class** - A new case class in `org.apache.spark.sql.execution.arrowcollect` package that holds `rowCount` and `batch` (byte array)
2. **Updated `ArrowBatchIterator` return type** - Changed from `Iterator[Array[Byte]]` to `Iterator[ArrowBatch]`
3. **Updated `ArrowBatchWithSchemaIterator` return type** - Similarly changed to return `ArrowBatch`
4. **Updated call sites** - Modified `Dataset.scala` and other call sites to extract `.batch` when only bytes are needed
5. **Added tests** - New tests for `ArrowBatch` functionality and verifying row counts from the iterator

### Why are the changes needed?

Currently, the Arrow batch iterators only return the serialized byte arrays, discarding useful metadata like the row count. This information is computed during batch creation but not exposed to callers.

By returning `ArrowBatch` with both `rowCount` and `batch`, downstream consumers can:
- Know the exact number of rows in each batch without deserializing
- Make better decisions about batch processing and memory management
- Enable future optimizations that rely on batch-level metadata

### Does this PR introduce _any_ user-facing change?

No. This is an internal API change. The `ArrowBatch` class is marked as `private[sql]`.

### How was this patch tested?

1. Updated existing unit tests in `ArrowConvertersSuite` to work with new return type
2. Added new tests:
   - `ArrowBatch case class basic functionality` - Tests creation, field access, and copy
   - `ArrowBatch iterator from toBatchIterator` - Verifies row counts are correctly reported

### Was this patch authored or co-authored using generative AI tooling?

No.
