### PR TITLE
[SPARK-54698][SQL] Support hashing for all data types for ArraySetLike operations

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -4424,8 +4424,14 @@ trait ArraySetLike {
     case _ => false
   }
 
-  @transient protected lazy val ordering: Ordering[Any] =
-    TypeUtils.getInterpretedOrdering(et)
+  // If the element type supports proper equals, we use the values directly for comparison,
+  // otherwise we use the generic comparable wrapper so all types support hash-based operations
+  @transient protected lazy val keyGenerator: (Any => Any) =
+    if (TypeUtils.typeWithProperEquals(et)) {
+      identity
+    } else {
+      GenericComparableWrapper.getGenericComparableWrapperFactory(et)
+    }
 
   protected def resultArrayElementNullable = dt.asInstanceOf[ArrayType].containsNull
 
@@ -4539,62 +4545,32 @@ case class ArrayDistinct(child: Expression)
     }
   }
 
-  override def nullSafeEval(array: Any): Any = {
-    val data = array.asInstanceOf[ArrayData]
-    doEvaluation(data)
-  }
-
-  @transient private lazy val doEvaluation = if (TypeUtils.typeWithProperEquals(elementType)) {
-    (array: ArrayData) =>
-      val arrayBuffer = new scala.collection.mutable.ArrayBuffer[Any]
-      val hs = new SQLOpenHashSet[Any]()
-      val withNaNCheckFunc = SQLOpenHashSet.withNaNCheckFunc(elementType, hs,
-        (value: Any) =>
-          if (!hs.contains(value)) {
-            if (arrayBuffer.size > ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH) {
-              throw QueryExecutionErrors.arrayFunctionWithElementsExceedLimitError(
-                prettyName, arrayBuffer.size)
-            }
-            arrayBuffer += value
-            hs.add(value)
-          },
-        (valueNaN: Any) => arrayBuffer += valueNaN)
-      val withNullCheckFunc = SQLOpenHashSet.withNullCheckFunc(elementType, hs,
-        (value: Any) => withNaNCheckFunc(value),
-        () => arrayBuffer += null)
-      var i = 0
-      while (i < array.numElements()) {
-        withNullCheckFunc(array, i)
-        i += 1
-      }
-      new GenericArrayData(arrayBuffer)
-  } else {
-    (data: ArrayData) => {
-      val array = data.toArray[AnyRef](elementType)
-      val arrayBuffer = new scala.collection.mutable.ArrayBuffer[AnyRef]
-      var alreadyStoredNull = false
-      for (i <- array.indices) {
-        if (array(i) != null) {
-          var found = false
-          var j = 0
-          while (!found && j < arrayBuffer.size) {
-            val va = arrayBuffer(j)
-            found = (va != null) && ordering.equiv(va, array(i))
-            j += 1
+  override def nullSafeEval(input: Any): Any = {
+    val array = input.asInstanceOf[ArrayData]
+    val arrayBuffer = new scala.collection.mutable.ArrayBuffer[Any]
+    val hs = new SQLOpenHashSet[Any]()
+    val withNaNCheckFunc = SQLOpenHashSet.withNaNCheckFunc(elementType, hs,
+      (value: Any) => {
+        val key = keyGenerator(value)
+        if (!hs.contains(key)) {
+          if (arrayBuffer.size > ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH) {
+            throw QueryExecutionErrors.arrayFunctionWithElementsExceedLimitError(
+              prettyName, arrayBuffer.size)
           }
-          if (!found) {
-            arrayBuffer += array(i)
-          }
-        } else {
-          // De-duplicate the null values.
-          if (!alreadyStoredNull) {
-            arrayBuffer += array(i)
-            alreadyStoredNull = true
-          }
+          arrayBuffer += value
+          hs.add(key)
         }
-      }
-      new GenericArrayData(arrayBuffer)
+      },
+      (valueNaN: Any) => arrayBuffer += valueNaN)
+    val withNullCheckFunc = SQLOpenHashSet.withNullCheckFunc(elementType, hs,
+      (value: Any) => withNaNCheckFunc(value),
+      () => arrayBuffer += null)
+    var i = 0
+    while (i < array.numElements()) {
+      withNullCheckFunc(array, i)
+      i += 1
     }
+    new GenericArrayData(arrayBuffer)
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
@@ -4726,74 +4702,37 @@ case class ArrayUnion(left: Expression, right: Expression) extends ArrayBinaryLi
 
   final override val nodePatterns: Seq[TreePattern] = Seq(ARRAY_UNION)
 
-  @transient lazy val evalUnion: (ArrayData, ArrayData) => ArrayData = {
-    if (TypeUtils.typeWithProperEquals(elementType)) {
-      (array1, array2) =>
-        val arrayBuffer = new scala.collection.mutable.ArrayBuffer[Any]
-        val hs = new SQLOpenHashSet[Any]()
-        val withNaNCheckFunc = SQLOpenHashSet.withNaNCheckFunc(elementType, hs,
-          (value: Any) =>
-            if (!hs.contains(value)) {
-              if (arrayBuffer.size > ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH) {
-                throw QueryExecutionErrors.arrayFunctionWithElementsExceedLimitError(
-                  prettyName, arrayBuffer.size)
-              }
-              arrayBuffer += value
-              hs.add(value)
-            },
-          (valueNaN: Any) => arrayBuffer += valueNaN)
-        val withNullCheckFunc = SQLOpenHashSet.withNullCheckFunc(elementType, hs,
-          (value: Any) => withNaNCheckFunc(value),
-          () => arrayBuffer += null
-        )
-        Seq(array1, array2).foreach { array =>
-          var i = 0
-          while (i < array.numElements()) {
-            withNullCheckFunc(array, i)
-            i += 1
-          }
-        }
-        new GenericArrayData(arrayBuffer)
-    } else {
-      (array1, array2) =>
-        val arrayBuffer = new scala.collection.mutable.ArrayBuffer[Any]
-        var alreadyIncludeNull = false
-        Seq(array1, array2).foreach(_.foreach(elementType, (_, elem) => {
-          var found = false
-          if (elem == null) {
-            if (alreadyIncludeNull) {
-              found = true
-            } else {
-              alreadyIncludeNull = true
-            }
-          } else {
-            // check elem is already stored in arrayBuffer or not?
-            var j = 0
-            while (!found && j < arrayBuffer.size) {
-              val va = arrayBuffer(j)
-              if (va != null && ordering.equiv(va, elem)) {
-                found = true
-              }
-              j = j + 1
-            }
-          }
-          if (!found) {
-            if (arrayBuffer.length > ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH) {
-              throw QueryExecutionErrors.arrayFunctionWithElementsExceedLimitError(
-                prettyName, arrayBuffer.length)
-            }
-            arrayBuffer += elem
-          }
-        }))
-        new GenericArrayData(arrayBuffer)
-    }
-  }
-
   override def nullSafeEval(input1: Any, input2: Any): Any = {
     val array1 = input1.asInstanceOf[ArrayData]
     val array2 = input2.asInstanceOf[ArrayData]
 
-    evalUnion(array1, array2)
+    val arrayBuffer = new scala.collection.mutable.ArrayBuffer[Any]
+    val hs = new SQLOpenHashSet[Any]()
+    val withNaNCheckFunc = SQLOpenHashSet.withNaNCheckFunc(elementType, hs,
+      (value: Any) => {
+        val key = keyGenerator(value)
+        if (!hs.contains(key)) {
+          if (arrayBuffer.size > ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH) {
+            throw QueryExecutionErrors.arrayFunctionWithElementsExceedLimitError(
+              prettyName, arrayBuffer.size)
+          }
+          arrayBuffer += value
+          hs.add(key)
+        }
+      },
+      (valueNaN: Any) => arrayBuffer += valueNaN)
+    val withNullCheckFunc = SQLOpenHashSet.withNullCheckFunc(elementType, hs,
+      (value: Any) => withNaNCheckFunc(value),
+      () => arrayBuffer += null
+    )
+    Seq(array1, array2).foreach { array =>
+      var i = 0
+      while (i < array.numElements()) {
+        withNullCheckFunc(array, i)
+        i += 1
+      }
+    }
+    new GenericArrayData(arrayBuffer)
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
@@ -4919,108 +4858,55 @@ case class ArrayIntersect(left: Expression, right: Expression) extends ArrayBina
 
   override def dataType: DataType = internalDataType
 
-  @transient lazy val evalIntersect: (ArrayData, ArrayData) => ArrayData = {
-    if (TypeUtils.typeWithProperEquals(elementType)) {
-      (array1, array2) =>
-        if (array1.numElements() != 0 && array2.numElements() != 0) {
-          val hs = new SQLOpenHashSet[Any]
-          val hsResult = new SQLOpenHashSet[Any]
-          val arrayBuffer = new scala.collection.mutable.ArrayBuffer[Any]
-          val withArray2NaNCheckFunc = SQLOpenHashSet.withNaNCheckFunc(elementType, hs,
-            (value: Any) => hs.add(value),
-            (valueNaN: Any) => {} )
-          val withArray2NullCheckFunc = SQLOpenHashSet.withNullCheckFunc(elementType, hs,
-            (value: Any) => withArray2NaNCheckFunc(value),
-            () => {}
-          )
-          val withArray1NaNCheckFunc = SQLOpenHashSet.withNaNCheckFunc(elementType, hsResult,
-            (value: Any) =>
-              if (hs.contains(value) && !hsResult.contains(value)) {
-                arrayBuffer += value
-                hsResult.add(value)
-              },
-            (valueNaN: Any) =>
-              if (hs.containsNaN()) {
-                arrayBuffer += valueNaN
-              })
-          val withArray1NullCheckFunc = SQLOpenHashSet.withNullCheckFunc(elementType, hsResult,
-            (value: Any) => withArray1NaNCheckFunc(value),
-            () =>
-              if (hs.containsNull()) {
-                arrayBuffer += null
-              }
-          )
-
-          var i = 0
-          while (i < array2.numElements()) {
-            withArray2NullCheckFunc(array2, i)
-            i += 1
-          }
-          i = 0
-          while (i < array1.numElements()) {
-            withArray1NullCheckFunc(array1, i)
-            i += 1
-          }
-          new GenericArrayData(arrayBuffer)
-        } else {
-          new GenericArrayData(Array.emptyObjectArray)
-        }
-    } else {
-      (array1, array2) =>
-        if (array1.numElements() != 0 && array2.numElements() != 0) {
-          val arrayBuffer = new scala.collection.mutable.ArrayBuffer[Any]
-          var alreadySeenNull = false
-          var i = 0
-          while (i < array1.numElements()) {
-            var found = false
-            val elem1 = array1.get(i, elementType)
-            if (array1.isNullAt(i)) {
-              if (!alreadySeenNull) {
-                var j = 0
-                while (!found && j < array2.numElements()) {
-                  found = array2.isNullAt(j)
-                  j += 1
-                }
-                // array2 is scanned only once for null element
-                alreadySeenNull = true
-              }
-            } else {
-              var j = 0
-              while (!found && j < array2.numElements()) {
-                if (!array2.isNullAt(j)) {
-                  val elem2 = array2.get(j, elementType)
-                  if (ordering.equiv(elem1, elem2)) {
-                    // check whether elem1 is already stored in arrayBuffer
-                    var foundArrayBuffer = false
-                    var k = 0
-                    while (!foundArrayBuffer && k < arrayBuffer.size) {
-                      val va = arrayBuffer(k)
-                      foundArrayBuffer = (va != null) && ordering.equiv(va, elem1)
-                      k += 1
-                    }
-                    found = !foundArrayBuffer
-                  }
-                }
-                j += 1
-              }
-            }
-            if (found) {
-              arrayBuffer += elem1
-            }
-            i += 1
-          }
-          new GenericArrayData(arrayBuffer)
-        } else {
-          new GenericArrayData(Array.emptyObjectArray)
-        }
-    }
-  }
-
   override def nullSafeEval(input1: Any, input2: Any): Any = {
     val array1 = input1.asInstanceOf[ArrayData]
     val array2 = input2.asInstanceOf[ArrayData]
 
-    evalIntersect(array1, array2)
+    if (array1.numElements() != 0 && array2.numElements() != 0) {
+      val hs = new SQLOpenHashSet[Any]
+      val hsResult = new SQLOpenHashSet[Any]
+      val arrayBuffer = new scala.collection.mutable.ArrayBuffer[Any]
+      val withArray2NaNCheckFunc = SQLOpenHashSet.withNaNCheckFunc(elementType, hs,
+        (value: Any) => hs.add(keyGenerator(value)),
+        (valueNaN: Any) => {} )
+      val withArray2NullCheckFunc = SQLOpenHashSet.withNullCheckFunc(elementType, hs,
+        (value: Any) => withArray2NaNCheckFunc(value),
+        () => {}
+      )
+      val withArray1NaNCheckFunc = SQLOpenHashSet.withNaNCheckFunc(elementType, hsResult,
+        (value: Any) => {
+          val key = keyGenerator(value)
+          if (hs.contains(key) && !hsResult.contains(key)) {
+            arrayBuffer += value
+            hsResult.add(key)
+          }
+        },
+        (valueNaN: Any) =>
+          if (hs.containsNaN()) {
+            arrayBuffer += valueNaN
+          })
+      val withArray1NullCheckFunc = SQLOpenHashSet.withNullCheckFunc(elementType, hsResult,
+        (value: Any) => withArray1NaNCheckFunc(value),
+        () =>
+          if (hs.containsNull()) {
+            arrayBuffer += null
+          }
+      )
+
+      var i = 0
+      while (i < array2.numElements()) {
+        withArray2NullCheckFunc(array2, i)
+        i += 1
+      }
+      i = 0
+      while (i < array1.numElements()) {
+        withArray1NullCheckFunc(array1, i)
+        i += 1
+      }
+      new GenericArrayData(arrayBuffer)
+    } else {
+      new GenericArrayData(Array.emptyObjectArray)
+    }
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
@@ -5160,93 +5046,43 @@ case class ArrayExcept(left: Expression, right: Expression) extends ArrayBinaryL
 
   override def dataType: DataType = internalDataType
 
-  @transient lazy val evalExcept: (ArrayData, ArrayData) => ArrayData = {
-    if (TypeUtils.typeWithProperEquals(elementType)) {
-      (array1, array2) =>
-        val hs = new SQLOpenHashSet[Any]
-        val arrayBuffer = new scala.collection.mutable.ArrayBuffer[Any]
-        val withArray2NaNCheckFunc = SQLOpenHashSet.withNaNCheckFunc(elementType, hs,
-          (value: Any) => hs.add(value),
-          (valueNaN: Any) => {})
-        val withArray2NullCheckFunc = SQLOpenHashSet.withNullCheckFunc(elementType, hs,
-          (value: Any) => withArray2NaNCheckFunc(value),
-          () => {}
-        )
-        val withArray1NaNCheckFunc = SQLOpenHashSet.withNaNCheckFunc(elementType, hs,
-          (value: Any) =>
-            if (!hs.contains(value)) {
-              arrayBuffer += value
-              hs.add(value)
-            },
-          (valueNaN: Any) => arrayBuffer += valueNaN)
-        val withArray1NullCheckFunc = SQLOpenHashSet.withNullCheckFunc(elementType, hs,
-          (value: Any) => withArray1NaNCheckFunc(value),
-          () => arrayBuffer += null
-        )
-        var i = 0
-        while (i < array2.numElements()) {
-          withArray2NullCheckFunc(array2, i)
-          i += 1
-        }
-        i = 0
-        while (i < array1.numElements()) {
-          withArray1NullCheckFunc(array1, i)
-          i += 1
-        }
-        new GenericArrayData(arrayBuffer)
-    } else {
-      (array1, array2) =>
-        val arrayBuffer = new scala.collection.mutable.ArrayBuffer[Any]
-        var scannedNullElements = false
-        var i = 0
-        while (i < array1.numElements()) {
-          var found = false
-          val elem1 = array1.get(i, elementType)
-          if (elem1 == null) {
-            if (!scannedNullElements) {
-              var j = 0
-              while (!found && j < array2.numElements()) {
-                found = array2.isNullAt(j)
-                j += 1
-              }
-              // array2 is scanned only once for null element
-              scannedNullElements = true
-            } else {
-              found = true
-            }
-          } else {
-            var j = 0
-            while (!found && j < array2.numElements()) {
-              val elem2 = array2.get(j, elementType)
-              if (elem2 != null) {
-                found = ordering.equiv(elem1, elem2)
-              }
-              j += 1
-            }
-            if (!found) {
-              // check whether elem1 is already stored in arrayBuffer
-              var k = 0
-              while (!found && k < arrayBuffer.size) {
-                val va = arrayBuffer(k)
-                found = (va != null) && ordering.equiv(va, elem1)
-                k += 1
-              }
-            }
-          }
-          if (!found) {
-            arrayBuffer += elem1
-          }
-          i += 1
-        }
-        new GenericArrayData(arrayBuffer)
-    }
-  }
-
   override def nullSafeEval(input1: Any, input2: Any): Any = {
     val array1 = input1.asInstanceOf[ArrayData]
     val array2 = input2.asInstanceOf[ArrayData]
 
-    evalExcept(array1, array2)
+    val hs = new SQLOpenHashSet[Any]
+    val arrayBuffer = new scala.collection.mutable.ArrayBuffer[Any]
+    val withArray2NaNCheckFunc = SQLOpenHashSet.withNaNCheckFunc(elementType, hs,
+      (value: Any) => hs.add(keyGenerator(value)),
+      (valueNaN: Any) => {})
+    val withArray2NullCheckFunc = SQLOpenHashSet.withNullCheckFunc(elementType, hs,
+      (value: Any) => withArray2NaNCheckFunc(value),
+      () => {}
+    )
+    val withArray1NaNCheckFunc = SQLOpenHashSet.withNaNCheckFunc(elementType, hs,
+      (value: Any) => {
+        val key = keyGenerator(value)
+        if (!hs.contains(key)) {
+          arrayBuffer += value
+          hs.add(key)
+        }
+      },
+      (valueNaN: Any) => arrayBuffer += valueNaN)
+    val withArray1NullCheckFunc = SQLOpenHashSet.withNullCheckFunc(elementType, hs,
+      (value: Any) => withArray1NaNCheckFunc(value),
+      () => arrayBuffer += null
+    )
+    var i = 0
+    while (i < array2.numElements()) {
+      withArray2NullCheckFunc(array2, i)
+      i += 1
+    }
+    i = 0
+    while (i < array1.numElements()) {
+      withArray1NullCheckFunc(array1, i)
+      i += 1
+    }
+    new GenericArrayData(arrayBuffer)
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/GenericComparableWrapper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/GenericComparableWrapper.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import org.apache.spark.sql.catalyst.expressions.Murmur3HashFunction
+import org.apache.spark.sql.types.DataType
+
+/**
+ * Wraps any internal Spark type with the corresponding [[DataType]] to make it comparable with
+ * other values.
+ * It uses Spark's internal murmur hash to compute hash code, and uses PhysicalDataType ordering
+ * to perform equality checks.
+ *
+ * @param dataType the data type for the value
+ */
+class GenericComparableWrapper private (
+    val value: Any,
+    val dataType: DataType,
+    val ordering: Ordering[Any]) {
+
+  override def hashCode(): Int = Murmur3HashFunction.hash(
+    value,
+    dataType,
+    42L,
+    isCollationAware = true,
+    // legacyCollationAwareHashing only matters when isCollationAware is false.
+    legacyCollationAwareHashing = false).toInt
+
+  override def equals(other: Any): Boolean = {
+    if (!other.isInstanceOf[GenericComparableWrapper]) {
+      return false
+    }
+    val otherWrapper = other.asInstanceOf[GenericComparableWrapper]
+    if (!otherWrapper.dataType.equals(this.dataType)) {
+      return false
+    }
+    ordering.equiv(value, otherWrapper.value)
+  }
+}
+
+object GenericComparableWrapper {
+  /** Creates a shared factory method for a given data type */
+  def getGenericComparableWrapperFactory(
+      dataType: DataType): Any => GenericComparableWrapper = {
+    val ordering = TypeUtils.getInterpretedOrdering(dataType)
+    value: Any => new GenericComparableWrapper(value, dataType, ordering)
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollationExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollationExpressionSuite.scala
@@ -88,6 +88,7 @@ class CollationExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
       (Seq("a"), Seq("a"), true, "UTF8_BINARY"),
       (Seq("a"), Seq("b"), false, "UTF8_BINARY"),
       (Seq("a"), Seq("A"), false, "UTF8_BINARY"),
+      (Seq("a"), Seq("a "), true, "UTF8_BINARY_RTRIM"),
       (Seq("a"), Seq("A"), true, "UTF8_LCASE"),
       (Seq("a", "B"), Seq("A", "b"), true, "UTF8_LCASE"),
       (Seq("a"), Seq("A"), false, "UNICODE"),
@@ -106,6 +107,7 @@ class CollationExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     val distinct = Seq(
       (Seq("a", "b", "c"), Seq("a", "b", "c"), "UTF8_BINARY"),
       (Seq("a", "a", "a"), Seq("a"), "UTF8_BINARY"),
+      (Seq("a", "a "), Seq("a"), "UTF8_BINARY_RTRIM"),
       (Seq("aaa", "AAA", "Aaa", "aAa"), Seq("aaa", "AAA", "Aaa", "aAa"), "UTF8_BINARY"),
       (Seq("aaa", "AAA", "Aaa", "aAa"), Seq("aaa"), "UTF8_LCASE"),
       (Seq("aaa", "AAA", "Aaa", "aAa", "b"), Seq("aaa", "b"), "UTF8_LCASE"),
@@ -119,6 +121,7 @@ class CollationExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
       (Seq("a"), Seq("a"), Seq("a"), "UTF8_BINARY"),
       (Seq("a"), Seq("b"), Seq("a", "b"), "UTF8_BINARY"),
       (Seq("a"), Seq("A"), Seq("a", "A"), "UTF8_BINARY"),
+      (Seq("a"), Seq("a "), Seq("a"), "UTF8_BINARY_RTRIM"),
       (Seq("a"), Seq("A"), Seq("a"), "UTF8_LCASE"),
       (Seq("a", "B"), Seq("A", "b"), Seq("a", "B"), "UTF8_LCASE"),
       (Seq("a"), Seq("A"), Seq("a", "A"), "UNICODE"),
@@ -135,6 +138,7 @@ class CollationExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
       (Seq("a"), Seq("a"), Seq("a"), "UTF8_BINARY"),
       (Seq("a"), Seq("b"), Seq.empty, "UTF8_BINARY"),
       (Seq("a"), Seq("A"), Seq.empty, "UTF8_BINARY"),
+      (Seq("a"), Seq("a "), Seq("a"), "UTF8_BINARY_RTRIM"),
       (Seq("a"), Seq("A"), Seq("a"), "UTF8_LCASE"),
       (Seq("a", "B"), Seq("A", "b"), Seq("a", "B"), "UTF8_LCASE"),
       (Seq("a"), Seq("A"), Seq.empty, "UNICODE"),
@@ -151,6 +155,7 @@ class CollationExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
       (Seq("a"), Seq("a"), Seq.empty, "UTF8_BINARY"),
       (Seq("a"), Seq("b"), Seq("a"), "UTF8_BINARY"),
       (Seq("a"), Seq("A"), Seq("a"), "UTF8_BINARY"),
+      (Seq("a"), Seq("a "), Seq.empty, "UTF8_BINARY_RTRIM"),
       (Seq("a"), Seq("A"), Seq.empty, "UTF8_LCASE"),
       (Seq("a", "B"), Seq("A", "b"), Seq.empty, "UTF8_LCASE"),
       (Seq("a"), Seq("A"), Seq("a"), "UNICODE"),
@@ -161,6 +166,34 @@ class CollationExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
       val right = arrayLiteral(inRight, collName)
       checkEvaluation(ArrayExcept(left, right), out)
     }
+  }
+
+  test("Array operations on nested collated strings") {
+    val collatedStringType = StringType(
+      CollationFactory.collationNameToId("UTF8_BINARY_RTRIM"))
+    val structType = StructType(Seq(StructField("value", collatedStringType)))
+    val structArrayType = ArrayType(structType)
+    val structLeft = Literal.create(Seq(create_row("a")), structArrayType)
+    val structRight = Literal.create(Seq(create_row("a ")), structArrayType)
+
+    checkEvaluation(
+      ArrayDistinct(Literal.create(
+        Seq(create_row("a"), create_row("a ")), structArrayType)),
+      Seq(create_row("a")))
+    checkEvaluation(ArrayUnion(structLeft, structRight), Seq(create_row("a")))
+    checkEvaluation(ArrayIntersect(structLeft, structRight), Seq(create_row("a")))
+    checkEvaluation(ArrayExcept(structLeft, structRight), Seq.empty)
+
+    val nestedArrayType = ArrayType(ArrayType(collatedStringType))
+    val nestedLeft = Literal.create(Seq(Seq("a")), nestedArrayType)
+    val nestedRight = Literal.create(Seq(Seq("a ")), nestedArrayType)
+
+    checkEvaluation(
+      ArrayDistinct(Literal.create(Seq(Seq("a"), Seq("a ")), nestedArrayType)),
+      Seq(Seq("a")))
+    checkEvaluation(ArrayUnion(nestedLeft, nestedRight), Seq(Seq("a")))
+    checkEvaluation(ArrayIntersect(nestedLeft, nestedRight), Seq(Seq("a")))
+    checkEvaluation(ArrayExcept(nestedLeft, nestedRight), Seq.empty)
   }
 
   test("CollationKey generates correct collation key for collated string") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -2649,6 +2649,29 @@ class CollectionExpressionsSuite
       Seq[Int](4, 5)))
     checkEvaluation(ArrayDistinct(c4), Seq[Seq[Int]](null, Seq[Int](1, 2), Seq[Int](3, 4),
       Seq[Int](4, 5)))
+
+    val structType = StructType(Seq(StructField("a", IntegerType, nullable = true)))
+    val d0 = Literal.create(Seq(create_row(1), create_row(2), create_row(1), create_row(2)),
+      ArrayType(structType))
+    val d1 = Literal.create(Seq(null, create_row(2), null, create_row(2)),
+      ArrayType(structType))
+    checkEvaluation(ArrayDistinct(d0), Seq(create_row(1), create_row(2)))
+    checkEvaluation(ArrayDistinct(d1), Seq(null, create_row(2)))
+
+    val nestedStructType = ArrayType(ArrayType(structType))
+    val e0 = Literal.create(Seq(
+      Seq(create_row(1), create_row(2)),
+      Seq(create_row(3)),
+      Seq(create_row(1), create_row(2))),
+      nestedStructType)
+    val e1 = Literal.create(Seq(
+      Seq(create_row(1), create_row(2)),
+      Seq(create_row(4))),
+      nestedStructType)
+    checkEvaluation(ArrayDistinct(e0),
+      Seq(Seq(create_row(1), create_row(2)), Seq(create_row(3))))
+    checkEvaluation(ArrayDistinct(e1),
+      Seq(Seq(create_row(1), create_row(2)), Seq(create_row(4))))
   }
 
   test("Array Union") {
@@ -2739,6 +2762,29 @@ class CollectionExpressionsSuite
     assert(ArrayUnion(a00, a02).dataType.asInstanceOf[ArrayType].containsNull)
     assert(ArrayUnion(a20, a21).dataType.asInstanceOf[ArrayType].containsNull === false)
     assert(ArrayUnion(a20, a22).dataType.asInstanceOf[ArrayType].containsNull)
+
+    val structType = StructType(Seq(StructField("a", IntegerType, nullable = true)))
+    val structArray0 = Literal.create(Seq(create_row(1), create_row(2), null),
+      ArrayType(structType))
+    val structArray1 = Literal.create(Seq(create_row(2), create_row(3), null),
+      ArrayType(structType))
+    checkEvaluation(ArrayUnion(structArray0, structArray1),
+      Seq(create_row(1), create_row(2), null, create_row(3)))
+
+    val nestedStructType = ArrayType(ArrayType(structType))
+    val nestedStructArray0 = Literal.create(Seq(
+      Seq(create_row(1), create_row(2)),
+      Seq(create_row(3))),
+      nestedStructType)
+    val nestedStructArray1 = Literal.create(Seq(
+      Seq(create_row(1), create_row(2)),
+      Seq(create_row(3), create_row(4))),
+      nestedStructType)
+    checkEvaluation(ArrayUnion(nestedStructArray0, nestedStructArray1), Seq(
+      Seq(create_row(1), create_row(2)),
+      Seq(create_row(3)),
+      Seq(create_row(3), create_row(4))
+    ))
   }
 
   test("Shuffle") {
@@ -2923,6 +2969,29 @@ class CollectionExpressionsSuite
     assert(ArrayExcept(a04, a05).dataType.asInstanceOf[ArrayType].containsNull)
     assert(ArrayExcept(a20, a21).dataType.asInstanceOf[ArrayType].containsNull === false)
     assert(ArrayExcept(a24, a22).dataType.asInstanceOf[ArrayType].containsNull)
+
+    val structType = StructType(Seq(StructField("a", IntegerType, nullable = true)))
+    val structArray0 = Literal.create(Seq(create_row(1), create_row(2), null, create_row(1)),
+      ArrayType(structType))
+    val structArray1 = Literal.create(Seq(create_row(2), create_row(3), null),
+      ArrayType(structType))
+    checkEvaluation(ArrayExcept(structArray0, structArray1), Seq(create_row(1)))
+    checkEvaluation(ArrayExcept(structArray1, structArray0), Seq(create_row(3)))
+
+    val nestedStructType = ArrayType(ArrayType(structType))
+    val nestedStructArray0 = Literal.create(Seq(
+      Seq(create_row(1), create_row(2)),
+      Seq(create_row(3)),
+      Seq(create_row(1), create_row(2))),
+      nestedStructType)
+    val nestedStructArray1 = Literal.create(Seq(
+      Seq(create_row(3)),
+      Seq(create_row(4))),
+      nestedStructType)
+    checkEvaluation(ArrayExcept(nestedStructArray0, nestedStructArray1),
+      Seq(Seq(create_row(1), create_row(2))))
+    checkEvaluation(ArrayExcept(nestedStructArray1, nestedStructArray0),
+      Seq(Seq(create_row(4))))
   }
 
   test("Array Except - null handling") {
@@ -3191,6 +3260,29 @@ class CollectionExpressionsSuite
     assert(ArrayIntersect(a04, a05).dataType.asInstanceOf[ArrayType].containsNull)
     assert(ArrayIntersect(a20, a21).dataType.asInstanceOf[ArrayType].containsNull === false)
     assert(ArrayIntersect(a23, a24).dataType.asInstanceOf[ArrayType].containsNull)
+
+    val structType = StructType(Seq(StructField("a", IntegerType, nullable = true)))
+    val structArray0 = Literal.create(Seq(create_row(1), create_row(2), null, create_row(1)),
+      ArrayType(structType))
+    val structArray1 = Literal.create(Seq(create_row(2), create_row(3), null),
+      ArrayType(structType))
+    checkEvaluation(ArrayIntersect(structArray0, structArray1), Seq(create_row(2), null))
+    checkEvaluation(ArrayIntersect(structArray1, structArray0), Seq(create_row(2), null))
+
+    val nestedStructType = ArrayType(ArrayType(structType))
+    val nestedStructArray0 = Literal.create(Seq(
+      Seq(create_row(1), create_row(2)),
+      Seq(create_row(3)),
+      Seq(create_row(1), create_row(2))),
+      nestedStructType)
+    val nestedStructArray1 = Literal.create(Seq(
+      Seq(create_row(3)),
+      Seq(create_row(4))),
+      nestedStructType)
+    checkEvaluation(ArrayIntersect(nestedStructArray0, nestedStructArray1),
+      Seq(Seq(create_row(3))))
+    checkEvaluation(ArrayIntersect(nestedStructArray1, nestedStructArray0),
+      Seq(Seq(create_row(3))))
   }
 
   test("Array Intersect - null handling") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -3315,6 +3315,35 @@ class CollectionExpressionsSuite
       Seq(1d))
   }
 
+  test("Array set operations normalize nested floating-point values") {
+    val structType = StructType(Seq(StructField("value", DoubleType)))
+    val arrayType = ArrayType(structType, containsNull = false)
+    val nonCanonicalNaN = java.lang.Double.longBitsToDouble(0x7ff0000000000001L)
+    val anotherNonCanonicalNaN = java.lang.Double.longBitsToDouble(0x7ff0000000000002L)
+
+    def row(value: Double): InternalRow = create_row(value)
+    def array(values: Double*): Literal = Literal.create(values.map(row), arrayType)
+
+    checkEvaluation(
+      ArrayDistinct(array(-0.0, 0.0, nonCanonicalNaN, anotherNonCanonicalNaN, 1.0)),
+      Seq(row(-0.0), row(Double.NaN), row(1.0)))
+    checkEvaluation(
+      ArrayUnion(
+        array(-0.0, nonCanonicalNaN),
+        array(0.0, anotherNonCanonicalNaN, 1.0)),
+      Seq(row(-0.0), row(Double.NaN), row(1.0)))
+    checkEvaluation(
+      ArrayIntersect(
+        array(-0.0, nonCanonicalNaN, 1.0),
+        array(0.0, anotherNonCanonicalNaN, 2.0)),
+      Seq(row(-0.0), row(Double.NaN)))
+    checkEvaluation(
+      ArrayExcept(
+        array(-0.0, nonCanonicalNaN, 1.0),
+        array(0.0, anotherNonCanonicalNaN)),
+      Seq(row(1.0)))
+  }
+
   test("SPARK-31980: Start and end equal in month range") {
     checkEvaluation(new Sequence(
       Literal(Date.valueOf("2018-01-01")),

--- a/sql/core/benchmarks/ArraySetLikeBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/ArraySetLikeBenchmark-jdk21-results.txt
@@ -2,23 +2,23 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 Array Distinct:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-array_distinct                                      277            361          85          0.0      276524.9       1.0X
+array_distinct                                      736            806          99          0.0      735969.4       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 Array Union:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-array_union                                         297            368          67          0.0      297262.3       1.0X
+array_union                                         700            706           7          0.0      699948.5       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 Array Except:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-array_except                                        104            126          19          0.0      104153.1       1.0X
+array_except                                        251            257           5          0.0      250521.1       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 Array Intersect:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-array_intersect                                      99            120          20          0.0       99423.2       1.0X
+array_intersect                                     244            258          12          0.0      244202.0       1.0X
 

--- a/sql/core/benchmarks/ArraySetLikeBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/ArraySetLikeBenchmark-jdk21-results.txt
@@ -1,0 +1,24 @@
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 7763 64-Core Processor
+Array Distinct:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+array_distinct                                      277            361          85          0.0      276524.9       1.0X
+
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 7763 64-Core Processor
+Array Union:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+array_union                                         297            368          67          0.0      297262.3       1.0X
+
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 7763 64-Core Processor
+Array Except:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+array_except                                        104            126          19          0.0      104153.1       1.0X
+
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 7763 64-Core Processor
+Array Intersect:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+array_intersect                                      99            120          20          0.0       99423.2       1.0X
+

--- a/sql/core/benchmarks/ArraySetLikeBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/ArraySetLikeBenchmark-jdk25-results.txt
@@ -1,0 +1,24 @@
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 7763 64-Core Processor
+Array Distinct:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+array_distinct                                      247            357          89          0.0      247078.5       1.0X
+
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 7763 64-Core Processor
+Array Union:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+array_union                                         371            450          65          0.0      370727.1       1.0X
+
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 7763 64-Core Processor
+Array Except:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+array_except                                        101            123          24          0.0      100625.3       1.0X
+
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 7763 64-Core Processor
+Array Intersect:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+array_intersect                                      96            121          23          0.0       96226.8       1.0X
+

--- a/sql/core/benchmarks/ArraySetLikeBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/ArraySetLikeBenchmark-jdk25-results.txt
@@ -2,23 +2,23 @@ OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 Array Distinct:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-array_distinct                                      247            357          89          0.0      247078.5       1.0X
+array_distinct                                      695            767          82          0.0      694741.2       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 Array Union:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-array_union                                         371            450          65          0.0      370727.1       1.0X
+array_union                                         665            670           6          0.0      665061.0       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 Array Except:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-array_except                                        101            123          24          0.0      100625.3       1.0X
+array_except                                        234            243           6          0.0      234088.6       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 Array Intersect:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-array_intersect                                      96            121          23          0.0       96226.8       1.0X
+array_intersect                                     232            243           6          0.0      232387.9       1.0X
 

--- a/sql/core/benchmarks/ArraySetLikeBenchmark-results.txt
+++ b/sql/core/benchmarks/ArraySetLikeBenchmark-results.txt
@@ -1,0 +1,24 @@
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Array Distinct:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+array_distinct                                      333            459         121          0.0      333282.9       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Array Union:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+array_union                                         313            361          64          0.0      313316.3       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Array Except:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+array_except                                         98            107           9          0.0       97939.7       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Array Intersect:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+array_intersect                                      95            106          13          0.0       94730.0       1.0X
+

--- a/sql/core/benchmarks/ArraySetLikeBenchmark-results.txt
+++ b/sql/core/benchmarks/ArraySetLikeBenchmark-results.txt
@@ -2,23 +2,23 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Array Distinct:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-array_distinct                                      333            459         121          0.0      333282.9       1.0X
+array_distinct                                      706            756          72          0.0      705893.3       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Array Union:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-array_union                                         313            361          64          0.0      313316.3       1.0X
+array_union                                         650            677          30          0.0      649536.8       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Array Except:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-array_except                                         98            107           9          0.0       97939.7       1.0X
+array_except                                        235            248          11          0.0      235416.3       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Array Intersect:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-array_intersect                                      95            106          13          0.0       94730.0       1.0X
+array_intersect                                     236            245           6          0.0      236324.9       1.0X
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/array.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/array.sql.out
@@ -1021,3 +1021,39 @@ select trim_array(array(1, 2, 3), CAST(null AS INT))
 -- !query analysis
 Project [trim_array(array(1, 2, 3), cast(null as int)) AS trim_array(array(1, 2, 3), CAST(NULL AS INT))#x]
 +- OneRowRelation
+
+
+-- !query
+select array_union(
+  array(named_struct('a', -0.0D), named_struct('a', DOUBLE('NaN'))),
+  array(named_struct('a', 0.0D), named_struct('a', DOUBLE('NaN')), named_struct('a', 1.0D)))
+-- !query analysis
+Project [array_union(array(named_struct(a, -0.0), named_struct(a, cast(NaN as double))), array(named_struct(a, 0.0), named_struct(a, cast(NaN as double)), named_struct(a, 1.0))) AS array_union(array(named_struct(a, -0.0), named_struct(a, NaN)), array(named_struct(a, 0.0), named_struct(a, NaN), named_struct(a, 1.0)))#x]
++- OneRowRelation
+
+
+-- !query
+select array_distinct(
+  array(named_struct('a', -0.0D), named_struct('a', 0.0D),
+    named_struct('a', DOUBLE('NaN')), named_struct('a', DOUBLE('NaN'))))
+-- !query analysis
+Project [array_distinct(array(named_struct(a, -0.0), named_struct(a, 0.0), named_struct(a, cast(NaN as double)), named_struct(a, cast(NaN as double)))) AS array_distinct(array(named_struct(a, -0.0), named_struct(a, 0.0), named_struct(a, NaN), named_struct(a, NaN)))#x]
++- OneRowRelation
+
+
+-- !query
+select array_except(
+  array(named_struct('a', -0.0D), named_struct('a', DOUBLE('NaN')), named_struct('a', 1.0D)),
+  array(named_struct('a', 0.0D), named_struct('a', DOUBLE('NaN'))))
+-- !query analysis
+Project [array_except(array(named_struct(a, -0.0), named_struct(a, cast(NaN as double)), named_struct(a, 1.0)), array(named_struct(a, 0.0), named_struct(a, cast(NaN as double)))) AS array_except(array(named_struct(a, -0.0), named_struct(a, NaN), named_struct(a, 1.0)), array(named_struct(a, 0.0), named_struct(a, NaN)))#x]
++- OneRowRelation
+
+
+-- !query
+select array_intersect(
+  array(named_struct('a', -0.0D), named_struct('a', DOUBLE('NaN')), named_struct('a', 1.0D)),
+  array(named_struct('a', 0.0D), named_struct('a', DOUBLE('NaN')), named_struct('a', 2.0D)))
+-- !query analysis
+Project [array_intersect(array(named_struct(a, -0.0), named_struct(a, cast(NaN as double)), named_struct(a, 1.0)), array(named_struct(a, 0.0), named_struct(a, cast(NaN as double)), named_struct(a, 2.0))) AS array_intersect(array(named_struct(a, -0.0), named_struct(a, NaN), named_struct(a, 1.0)), array(named_struct(a, 0.0), named_struct(a, NaN), named_struct(a, 2.0)))#x]
++- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/nonansi/array.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/nonansi/array.sql.out
@@ -1021,3 +1021,39 @@ select trim_array(array(1, 2, 3), CAST(null AS INT))
 -- !query analysis
 Project [trim_array(array(1, 2, 3), cast(null as int)) AS trim_array(array(1, 2, 3), CAST(NULL AS INT))#x]
 +- OneRowRelation
+
+
+-- !query
+select array_union(
+  array(named_struct('a', -0.0D), named_struct('a', DOUBLE('NaN'))),
+  array(named_struct('a', 0.0D), named_struct('a', DOUBLE('NaN')), named_struct('a', 1.0D)))
+-- !query analysis
+Project [array_union(array(named_struct(a, -0.0), named_struct(a, cast(NaN as double))), array(named_struct(a, 0.0), named_struct(a, cast(NaN as double)), named_struct(a, 1.0))) AS array_union(array(named_struct(a, -0.0), named_struct(a, NaN)), array(named_struct(a, 0.0), named_struct(a, NaN), named_struct(a, 1.0)))#x]
++- OneRowRelation
+
+
+-- !query
+select array_distinct(
+  array(named_struct('a', -0.0D), named_struct('a', 0.0D),
+    named_struct('a', DOUBLE('NaN')), named_struct('a', DOUBLE('NaN'))))
+-- !query analysis
+Project [array_distinct(array(named_struct(a, -0.0), named_struct(a, 0.0), named_struct(a, cast(NaN as double)), named_struct(a, cast(NaN as double)))) AS array_distinct(array(named_struct(a, -0.0), named_struct(a, 0.0), named_struct(a, NaN), named_struct(a, NaN)))#x]
++- OneRowRelation
+
+
+-- !query
+select array_except(
+  array(named_struct('a', -0.0D), named_struct('a', DOUBLE('NaN')), named_struct('a', 1.0D)),
+  array(named_struct('a', 0.0D), named_struct('a', DOUBLE('NaN'))))
+-- !query analysis
+Project [array_except(array(named_struct(a, -0.0), named_struct(a, cast(NaN as double)), named_struct(a, 1.0)), array(named_struct(a, 0.0), named_struct(a, cast(NaN as double)))) AS array_except(array(named_struct(a, -0.0), named_struct(a, NaN), named_struct(a, 1.0)), array(named_struct(a, 0.0), named_struct(a, NaN)))#x]
++- OneRowRelation
+
+
+-- !query
+select array_intersect(
+  array(named_struct('a', -0.0D), named_struct('a', DOUBLE('NaN')), named_struct('a', 1.0D)),
+  array(named_struct('a', 0.0D), named_struct('a', DOUBLE('NaN')), named_struct('a', 2.0D)))
+-- !query analysis
+Project [array_intersect(array(named_struct(a, -0.0), named_struct(a, cast(NaN as double)), named_struct(a, 1.0)), array(named_struct(a, 0.0), named_struct(a, cast(NaN as double)), named_struct(a, 2.0))) AS array_intersect(array(named_struct(a, -0.0), named_struct(a, NaN), named_struct(a, 1.0)), array(named_struct(a, 0.0), named_struct(a, NaN), named_struct(a, 2.0)))#x]
++- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/inputs/array.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/array.sql
@@ -206,3 +206,17 @@ select trim_array(array(1, 2, 3), 4);
 -- trim_array with NULL array or NULL n returns NULL
 select trim_array(CAST(null AS ARRAY<INT>), 1);
 select trim_array(array(1, 2, 3), CAST(null AS INT));
+
+-- SPARK-54698: Confirm 0.0, -0.0, and NaN are handled appropriately for complex types.
+select array_union(
+  array(named_struct('a', -0.0D), named_struct('a', DOUBLE('NaN'))),
+  array(named_struct('a', 0.0D), named_struct('a', DOUBLE('NaN')), named_struct('a', 1.0D)));
+select array_distinct(
+  array(named_struct('a', -0.0D), named_struct('a', 0.0D),
+    named_struct('a', DOUBLE('NaN')), named_struct('a', DOUBLE('NaN'))));
+select array_except(
+  array(named_struct('a', -0.0D), named_struct('a', DOUBLE('NaN')), named_struct('a', 1.0D)),
+  array(named_struct('a', 0.0D), named_struct('a', DOUBLE('NaN'))));
+select array_intersect(
+  array(named_struct('a', -0.0D), named_struct('a', DOUBLE('NaN')), named_struct('a', 1.0D)),
+  array(named_struct('a', 0.0D), named_struct('a', DOUBLE('NaN')), named_struct('a', 2.0D)));

--- a/sql/core/src/test/resources/sql-tests/results/array.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/array.sql.out
@@ -1252,3 +1252,43 @@ select trim_array(array(1, 2, 3), CAST(null AS INT))
 struct<trim_array(array(1, 2, 3), CAST(NULL AS INT)):array<int>>
 -- !query output
 NULL
+
+
+-- !query
+select array_union(
+  array(named_struct('a', -0.0D), named_struct('a', DOUBLE('NaN'))),
+  array(named_struct('a', 0.0D), named_struct('a', DOUBLE('NaN')), named_struct('a', 1.0D)))
+-- !query schema
+struct<array_union(array(named_struct(a, -0.0), named_struct(a, NaN)), array(named_struct(a, 0.0), named_struct(a, NaN), named_struct(a, 1.0))):array<struct<a:double>>>
+-- !query output
+[{"a":0.0},{"a":NaN},{"a":1.0}]
+
+
+-- !query
+select array_distinct(
+  array(named_struct('a', -0.0D), named_struct('a', 0.0D),
+    named_struct('a', DOUBLE('NaN')), named_struct('a', DOUBLE('NaN'))))
+-- !query schema
+struct<array_distinct(array(named_struct(a, -0.0), named_struct(a, 0.0), named_struct(a, NaN), named_struct(a, NaN))):array<struct<a:double>>>
+-- !query output
+[{"a":0.0},{"a":NaN}]
+
+
+-- !query
+select array_except(
+  array(named_struct('a', -0.0D), named_struct('a', DOUBLE('NaN')), named_struct('a', 1.0D)),
+  array(named_struct('a', 0.0D), named_struct('a', DOUBLE('NaN'))))
+-- !query schema
+struct<array_except(array(named_struct(a, -0.0), named_struct(a, NaN), named_struct(a, 1.0)), array(named_struct(a, 0.0), named_struct(a, NaN))):array<struct<a:double>>>
+-- !query output
+[{"a":1.0}]
+
+
+-- !query
+select array_intersect(
+  array(named_struct('a', -0.0D), named_struct('a', DOUBLE('NaN')), named_struct('a', 1.0D)),
+  array(named_struct('a', 0.0D), named_struct('a', DOUBLE('NaN')), named_struct('a', 2.0D)))
+-- !query schema
+struct<array_intersect(array(named_struct(a, -0.0), named_struct(a, NaN), named_struct(a, 1.0)), array(named_struct(a, 0.0), named_struct(a, NaN), named_struct(a, 2.0))):array<struct<a:double>>>
+-- !query output
+[{"a":0.0},{"a":NaN}]

--- a/sql/core/src/test/resources/sql-tests/results/nonansi/array.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/nonansi/array.sql.out
@@ -1110,3 +1110,43 @@ select trim_array(array(1, 2, 3), CAST(null AS INT))
 struct<trim_array(array(1, 2, 3), CAST(NULL AS INT)):array<int>>
 -- !query output
 NULL
+
+
+-- !query
+select array_union(
+  array(named_struct('a', -0.0D), named_struct('a', DOUBLE('NaN'))),
+  array(named_struct('a', 0.0D), named_struct('a', DOUBLE('NaN')), named_struct('a', 1.0D)))
+-- !query schema
+struct<array_union(array(named_struct(a, -0.0), named_struct(a, NaN)), array(named_struct(a, 0.0), named_struct(a, NaN), named_struct(a, 1.0))):array<struct<a:double>>>
+-- !query output
+[{"a":0.0},{"a":NaN},{"a":1.0}]
+
+
+-- !query
+select array_distinct(
+  array(named_struct('a', -0.0D), named_struct('a', 0.0D),
+    named_struct('a', DOUBLE('NaN')), named_struct('a', DOUBLE('NaN'))))
+-- !query schema
+struct<array_distinct(array(named_struct(a, -0.0), named_struct(a, 0.0), named_struct(a, NaN), named_struct(a, NaN))):array<struct<a:double>>>
+-- !query output
+[{"a":0.0},{"a":NaN}]
+
+
+-- !query
+select array_except(
+  array(named_struct('a', -0.0D), named_struct('a', DOUBLE('NaN')), named_struct('a', 1.0D)),
+  array(named_struct('a', 0.0D), named_struct('a', DOUBLE('NaN'))))
+-- !query schema
+struct<array_except(array(named_struct(a, -0.0), named_struct(a, NaN), named_struct(a, 1.0)), array(named_struct(a, 0.0), named_struct(a, NaN))):array<struct<a:double>>>
+-- !query output
+[{"a":1.0}]
+
+
+-- !query
+select array_intersect(
+  array(named_struct('a', -0.0D), named_struct('a', DOUBLE('NaN')), named_struct('a', 1.0D)),
+  array(named_struct('a', 0.0D), named_struct('a', DOUBLE('NaN')), named_struct('a', 2.0D)))
+-- !query schema
+struct<array_intersect(array(named_struct(a, -0.0), named_struct(a, NaN), named_struct(a, 1.0)), array(named_struct(a, 0.0), named_struct(a, NaN), named_struct(a, 2.0))):array<struct<a:double>>>
+-- !query output
+[{"a":0.0},{"a":NaN}]

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ArraySetLikeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ArraySetLikeBenchmark.scala
@@ -36,45 +36,49 @@ object ArraySetLikeBenchmark extends SqlBasedBenchmark {
   private val N = 1000L
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
-    val arrayDistinctBenchmark = new Benchmark("Array Distinct", 1000, output = output)
+    val range1 = lit((1 to 20000).map(x => Array(x, x)).toArray)
+    val range2 = lit((10001 to 30000).map(x => Array(x, x)).toArray)
+
+
+    val arrayDistinctBenchmark = new Benchmark("Array Distinct", N, output = output)
     arrayDistinctBenchmark.addCase("array_distinct") { _ =>
       spark.range(N)
-        .select(concat(sequence(lit(1), lit(10000)), sequence(lit(1), lit(10000))).alias("arr"))
+        .select(concat(range1, range2).alias("arr"))
         .select(array_distinct(col("arr")))
-        .collect()
+        .noop()
     }
     arrayDistinctBenchmark.run()
 
-    val arrayUnionBenchmark = new Benchmark("Array Union", 1000, output = output)
+    val arrayUnionBenchmark = new Benchmark("Array Union", N, output = output)
     arrayUnionBenchmark.addCase("array_union") { _ =>
       spark.range(N)
         .select(
-          sequence(lit(1), lit(10000)).alias("arr1"),
-          sequence(lit(5001), lit(15000)).alias("arr2"))
+          range1.alias("arr1"),
+          range2.alias("arr2"))
         .select(array_union(col("arr1"), col("arr2")))
-        .collect()
+        .noop()
     }
     arrayUnionBenchmark.run()
 
-    val arrayExceptBenchmark = new Benchmark("Array Except", 1000, output = output)
+    val arrayExceptBenchmark = new Benchmark("Array Except", N, output = output)
     arrayExceptBenchmark.addCase("array_except") { _ =>
       spark.range(N)
         .select(
-          sequence(lit(1), lit(10000)).alias("arr1"),
-          sequence(lit(5001), lit(15000)).alias("arr2"))
+          range1.alias("arr1"),
+          range2.alias("arr2"))
         .select(array_except(col("arr1"), col("arr2")))
-        .collect()
+        .noop()
     }
     arrayExceptBenchmark.run()
 
-    val arrayIntersectBenchmark = new Benchmark("Array Intersect", 1000, output = output)
+    val arrayIntersectBenchmark = new Benchmark("Array Intersect", N, output = output)
     arrayIntersectBenchmark.addCase("array_intersect") { _ =>
       spark.range(N)
         .select(
-          sequence(lit(1), lit(10000)).alias("arr1"),
-          sequence(lit(5001), lit(15000)).alias("arr2"))
+          range1.alias("arr1"),
+          range2.alias("arr2"))
         .select(array_intersect(col("arr1"), col("arr2")))
-        .collect()
+        .noop()
     }
     arrayIntersectBenchmark.run()
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ArraySetLikeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ArraySetLikeBenchmark.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.benchmark
+
+import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.functions._
+
+/**
+ * Benchmark for measuring perf of array set-like operations.
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class> --jars <spark core test jar> <sql core test jar>
+ *   2. build/sbt "sql/Test/runMain <this class>"
+ *   3. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
+ *      Results will be written to "benchmarks/ArraySetLikeBenchmark-results.txt".
+ * }}}
+ */
+object ArraySetLikeBenchmark extends SqlBasedBenchmark {
+  private val N = 1000L
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    val arrayDistinctBenchmark = new Benchmark("Array Distinct", 1000, output = output)
+    arrayDistinctBenchmark.addCase("array_distinct") { _ =>
+      spark.range(N)
+        .select(concat(sequence(lit(1), lit(10000)), sequence(lit(1), lit(10000))).alias("arr"))
+        .select(array_distinct(col("arr")))
+        .collect()
+    }
+    arrayDistinctBenchmark.run()
+
+    val arrayUnionBenchmark = new Benchmark("Array Union", 1000, output = output)
+    arrayUnionBenchmark.addCase("array_union") { _ =>
+      spark.range(N)
+        .select(
+          sequence(lit(1), lit(10000)).alias("arr1"),
+          sequence(lit(5001), lit(15000)).alias("arr2"))
+        .select(array_union(col("arr1"), col("arr2")))
+        .collect()
+    }
+    arrayUnionBenchmark.run()
+
+    val arrayExceptBenchmark = new Benchmark("Array Except", 1000, output = output)
+    arrayExceptBenchmark.addCase("array_except") { _ =>
+      spark.range(N)
+        .select(
+          sequence(lit(1), lit(10000)).alias("arr1"),
+          sequence(lit(5001), lit(15000)).alias("arr2"))
+        .select(array_except(col("arr1"), col("arr2")))
+        .collect()
+    }
+    arrayExceptBenchmark.run()
+
+    val arrayIntersectBenchmark = new Benchmark("Array Intersect", 1000, output = output)
+    arrayIntersectBenchmark.addCase("array_intersect") { _ =>
+      spark.range(N)
+        .select(
+          sequence(lit(1), lit(10000)).alias("arr1"),
+          sequence(lit(5001), lit(15000)).alias("arr2"))
+        .select(array_intersect(col("arr1"), col("arr2")))
+        .collect()
+    }
+    arrayIntersectBenchmark.run()
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Update all array set-like expressions to use hashing for all data types. Currently complex types and certain string collations fallback to a nested comparison loop that is O(n^2) for the size of the array, which can get really expensive for larger arrays. Instead, this borrows the idea from `InternalRowComparableWrapper` and creates a `GenericComparableWrapper` that works for any data type, using `Murmur3HashFunction` for the hash code and `InterpretedOrdering` for equals.

Additionally, since there is just one code path for these expressions now, I moved the eval logic directly into the `nullSafeEval` function instead of keeping the transient function call.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To improve performance of array set-like operations for complex types.

Local benchmark results:

Before

```
[info] Running benchmark: Array Distinct
[info]   Running case: array_distinct
[info]   Stopped after 2 iterations, 9548 ms
[info] OpenJDK 64-Bit Server VM 17.0.17+10-LTS on Linux 4.18.0-553.89.1.el8_10.x86_64
[info] AMD EPYC Processor (with IBPB)
[info] Array Distinct:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] array_distinct                                     4638           4774         192          0.0     4638443.2       1.0X
[info] Running benchmark: Array Union
[info]   Running case: array_union
[info]   Stopped after 2 iterations, 9092 ms
[info] OpenJDK 64-Bit Server VM 17.0.17+10-LTS on Linux 4.18.0-553.89.1.el8_10.x86_64
[info] AMD EPYC Processor (with IBPB)
[info] Array Union:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] array_union                                        4310           4546         334          0.0     4309904.1       1.0X
[info] Running benchmark: Array Except
[info]   Running case: array_except
[info]   Stopped after 2 iterations, 4260 ms
[info] OpenJDK 64-Bit Server VM 17.0.17+10-LTS on Linux 4.18.0-553.89.1.el8_10.x86_64
[info] AMD EPYC Processor (with IBPB)
[info] Array Except:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] array_except                                       2043           2130         123          0.0     2042714.3       1.0X
[info] Running benchmark: Array Intersect
[info]   Running case: array_intersect
[info]   Stopped after 2 iterations, 4847 ms
[info] OpenJDK 64-Bit Server VM 17.0.17+10-LTS on Linux 4.18.0-553.89.1.el8_10.x86_64
[info] AMD EPYC Processor (with IBPB)
[info] Array Intersect:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] array_intersect                                    2324           2424         142          0.0     2323510.6       1.0X
```

After

```
[info] Running benchmark: Array Distinct
[info]   Running case: array_distinct
[info]   Stopped after 2 iterations, 2108 ms
[info] OpenJDK 64-Bit Server VM 17.0.17+10-LTS on Linux 4.18.0-553.89.1.el8_10.x86_64
[info] AMD EPYC Processor (with IBPB)
[info] Array Distinct:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] array_distinct                                      947           1054         152          0.0      946800.6       1.0X
[info] Running benchmark: Array Union
[info]   Running case: array_union
[info]   Stopped after 2 iterations, 2772 ms
[info] OpenJDK 64-Bit Server VM 17.0.17+10-LTS on Linux 4.18.0-553.89.1.el8_10.x86_64
[info] AMD EPYC Processor (with IBPB)
[info] Array Union:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] array_union                                         929           1386         646          0.0      929444.2       1.0X
[info] Running benchmark: Array Except
[info]   Running case: array_except
[info]   Stopped after 6 iterations, 2194 ms
[info] OpenJDK 64-Bit Server VM 17.0.17+10-LTS on Linux 4.18.0-553.89.1.el8_10.x86_64
[info] AMD EPYC Processor (with IBPB)
[info] Array Except:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] array_except                                        331            366          49          0.0      330820.6       1.0X
[info] Running benchmark: Array Intersect
[info]   Running case: array_intersect
[info]   Stopped after 7 iterations, 2013 ms
[info] OpenJDK 64-Bit Server VM 17.0.17+10-LTS on Linux 4.18.0-553.89.1.el8_10.x86_64
[info] AMD EPYC Processor (with IBPB)
[info] Array Intersect:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] array_intersect                                     261            288          16          0.0      260571.4       1.0X
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Set-like operations for complex types now enforce some limitations, such as the max array size, that were not enforced earlier, though it may have been unreachable in practice previously. Otherwise just performance improvement.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New UTs for complex data.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Tests and benchmark created with GPT-5.4