### PR TITLE
[SPARK-54124][SQL] Add SHOW VIEWS AS JSON support

### DIFF
--- a/docs/sql-ref-syntax-aux-show-views.md
+++ b/docs/sql-ref-syntax-aux-show-views.md
@@ -30,7 +30,7 @@ regardless of a given database.
 
 ### Syntax
 ```sql
-SHOW VIEWS [ { FROM | IN } database_name ] [ LIKE regex_pattern ]
+SHOW VIEWS [ { FROM | IN } database_name ] [ LIKE regex_pattern ] [ AS JSON ]
 ```
 
 ### Parameters
@@ -46,6 +46,10 @@ SHOW VIEWS [ { FROM | IN } database_name ] [ LIKE regex_pattern ]
      * `*` alone matches 0 or more characters and `|` is used to separate multiple different regular expressions,
        any of which can match.
      * The leading and trailing blanks are trimmed in the input pattern before processing. The pattern match is case-insensitive.
+
+* **AS JSON**
+
+     Returns the output in JSON format. The output contains a single column named `namespace` with a JSON string representing all views. Each view is represented as a JSON object with fields: `namespace`, `viewName`, and `isTemporary`.
 
 ### Examples
 ```sql
@@ -108,6 +112,30 @@ SHOW VIEWS LIKE 'sam|suj|temp*';
 | default     | suj        | false        |
 |             | temp2      | true         |
 +-------------+------------+--------------+
+
+-- List all views in JSON format
+SHOW VIEWS AS JSON;
++-------------------------------------------------------------------------------------+
+| namespace                                                                           |
++-------------------------------------------------------------------------------------+
+|{"views":[{"namespace":"default","viewName":"sam","isTemporary":false},{"namespace":"default","viewName":"sam1","isTemporary":false},{"namespace":"default","viewName":"suj","isTemporary":false},{"namespace":"","viewName":"temp2","isTemporary":true}]}|
++-------------------------------------------------------------------------------------+
+
+-- List views from userdb database in JSON format
+SHOW VIEWS FROM userdb AS JSON;
++-------------------------------------------------------------------------------------+
+| namespace                                                                           |
++-------------------------------------------------------------------------------------+
+|{"views":[{"namespace":"userdb","viewName":"user1","isTemporary":false},{"namespace":"userdb","viewName":"user2","isTemporary":false},{"namespace":"","viewName":"temp2","isTemporary":true}]}|
++-------------------------------------------------------------------------------------+
+
+-- List views matching pattern in JSON format
+SHOW VIEWS LIKE 'sam*' AS JSON;
++-------------------------------------------------------------------------------------+
+| namespace                                                                           |
++-------------------------------------------------------------------------------------+
+|{"views":[{"namespace":"default","viewName":"sam","isTemporary":false},{"namespace":"default","viewName":"sam1","isTemporary":false}]}|
++-------------------------------------------------------------------------------------+
 ```
 
 ### Related statements

--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -353,7 +353,7 @@ statement
     | SHOW COLUMNS (FROM | IN) table=identifierReference
         ((FROM | IN) ns=multipartIdentifier)?                          #showColumns
     | SHOW VIEWS ((FROM | IN) identifierReference)?
-        (LIKE? pattern=stringLit)?                                        #showViews
+        (LIKE? pattern=stringLit)? (AS JSON)?                             #showViews
     | SHOW PARTITIONS identifierReference partitionSpec?               #showPartitions
     | SHOW functionScope=simpleIdentifier? FUNCTIONS ((FROM | IN) ns=identifierReference)?
         (LIKE? (legacy=multipartIdentifier | pattern=stringLit))?      #showFunctions

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -5293,7 +5293,13 @@ class AstBuilder extends DataTypeAstBuilder
     } else {
       CurrentNamespace
     }
-    ShowViews(ns, Option(ctx.pattern).map(x => string(visitStringLit(x))))
+    val pattern = Option(ctx.pattern).map(x => string(visitStringLit(x)))
+
+    if (ctx.JSON != null) {
+      ShowViewsJson(ns, pattern)
+    } else {
+      ShowViews(ns, pattern)
+    }
   }
 
   override def visitColPosition(ctx: ColPositionContext): ColumnPosition = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -1289,6 +1289,20 @@ object ShowViews {
     AttributeReference("isTemporary", BooleanType, nullable = false)())
 }
 
+case class ShowViewsJson(
+    namespace: LogicalPlan,
+    pattern: Option[String],
+    override val output: Seq[Attribute] = ShowViewsJson.getOutputAttrs) extends UnaryCommand {
+  override def child: LogicalPlan = namespace
+  override protected def withNewChildInternal(newChild: LogicalPlan): ShowViewsJson =
+    copy(namespace = newChild)
+}
+
+object ShowViewsJson {
+  def getOutputAttrs: Seq[Attribute] = Seq(
+    AttributeReference("namespace", StringType, nullable = false)())
+}
+
 /**
  * The logical plan of the USE command.
  */

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -448,6 +448,13 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
           throw QueryCompilationErrors.missingCatalogViewsAbilityError(ns.catalog)
       }
 
+    case ShowViewsJson(ns: ResolvedNamespace, pattern, output) =>
+      ns match {
+        case ResolvedDatabaseInSessionCatalog(db) => ShowViewsJsonCommand(db, pattern, output)
+        case _ =>
+          throw QueryCompilationErrors.missingCatalogViewsAbilityError(ns.catalog)
+      }
+
     // If target is view, force use v1 command
     case ShowTableProperties(ResolvedViewIdentifier(ident), propertyKey, output) =>
       ShowTablePropertiesCommand(ident, propertyKey, output)

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/show-views.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/show-views.sql.out
@@ -114,6 +114,54 @@ org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException
 
 
 -- !query
+SHOW VIEWS AS JSON
+-- !query analysis
+ShowViewsJsonCommand showdb, [namespace#x]
+
+
+-- !query
+SHOW VIEWS FROM showdb AS JSON
+-- !query analysis
+ShowViewsJsonCommand showdb, [namespace#x]
+
+
+-- !query
+SHOW VIEWS IN showdb AS JSON
+-- !query analysis
+ShowViewsJsonCommand showdb, [namespace#x]
+
+
+-- !query
+SHOW VIEWS IN global_temp AS JSON
+-- !query analysis
+ShowViewsJsonCommand global_temp, [namespace#x]
+
+
+-- !query
+SHOW VIEWS 'view_*' AS JSON
+-- !query analysis
+ShowViewsJsonCommand showdb, view_*, [namespace#x]
+
+
+-- !query
+SHOW VIEWS LIKE 'view_1*|view_2*' AS JSON
+-- !query analysis
+ShowViewsJsonCommand showdb, view_1*|view_2*, [namespace#x]
+
+
+-- !query
+SHOW VIEWS IN showdb 'view_*' AS JSON
+-- !query analysis
+ShowViewsJsonCommand showdb, view_*, [namespace#x]
+
+
+-- !query
+SHOW VIEWS IN showdb LIKE 'view_*' AS JSON
+-- !query analysis
+ShowViewsJsonCommand showdb, view_*, [namespace#x]
+
+
+-- !query
 DROP VIEW global_temp.view_3
 -- !query analysis
 DropTempViewCommand global_temp.view_3

--- a/sql/core/src/test/resources/sql-tests/inputs/show-views.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/show-views.sql
@@ -21,6 +21,18 @@ SHOW VIEWS IN showdb LIKE 'view_*';
 -- Error when database not exists
 SHOW VIEWS IN wrongdb LIKE 'view_*';
 
+-- SHOW VIEWS AS JSON
+SHOW VIEWS AS JSON;
+SHOW VIEWS FROM showdb AS JSON;
+SHOW VIEWS IN showdb AS JSON;
+SHOW VIEWS IN global_temp AS JSON;
+
+-- SHOW VIEWS AS JSON WITH wildcard match
+SHOW VIEWS 'view_*' AS JSON;
+SHOW VIEWS LIKE 'view_1*|view_2*' AS JSON;
+SHOW VIEWS IN showdb 'view_*' AS JSON;
+SHOW VIEWS IN showdb LIKE 'view_*' AS JSON;
+
 -- Clean Up
 DROP VIEW global_temp.view_3;
 DROP VIEW view_4;

--- a/sql/core/src/test/resources/sql-tests/results/show-views.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/show-views.sql.out
@@ -149,6 +149,70 @@ org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException
 
 
 -- !query
+SHOW VIEWS AS JSON
+-- !query schema
+struct<namespace:string>
+-- !query output
+{"views":[{"namespace":"showdb","viewName":"view_1","isTemporary":false},{"namespace":"showdb","viewName":"view_2","isTemporary":false},{"namespace":"","viewName":"view_4","isTemporary":true}]}
+
+
+-- !query
+SHOW VIEWS FROM showdb AS JSON
+-- !query schema
+struct<namespace:string>
+-- !query output
+{"views":[{"namespace":"showdb","viewName":"view_1","isTemporary":false},{"namespace":"showdb","viewName":"view_2","isTemporary":false},{"namespace":"","viewName":"view_4","isTemporary":true}]}
+
+
+-- !query
+SHOW VIEWS IN showdb AS JSON
+-- !query schema
+struct<namespace:string>
+-- !query output
+{"views":[{"namespace":"showdb","viewName":"view_1","isTemporary":false},{"namespace":"showdb","viewName":"view_2","isTemporary":false},{"namespace":"","viewName":"view_4","isTemporary":true}]}
+
+
+-- !query
+SHOW VIEWS IN global_temp AS JSON
+-- !query schema
+struct<namespace:string>
+-- !query output
+{"views":[{"namespace":"global_temp","viewName":"view_3","isTemporary":true},{"namespace":"","viewName":"view_4","isTemporary":true}]}
+
+
+-- !query
+SHOW VIEWS 'view_*' AS JSON
+-- !query schema
+struct<namespace:string>
+-- !query output
+{"views":[{"namespace":"showdb","viewName":"view_1","isTemporary":false},{"namespace":"showdb","viewName":"view_2","isTemporary":false},{"namespace":"","viewName":"view_4","isTemporary":true}]}
+
+
+-- !query
+SHOW VIEWS LIKE 'view_1*|view_2*' AS JSON
+-- !query schema
+struct<namespace:string>
+-- !query output
+{"views":[{"namespace":"showdb","viewName":"view_1","isTemporary":false},{"namespace":"showdb","viewName":"view_2","isTemporary":false}]}
+
+
+-- !query
+SHOW VIEWS IN showdb 'view_*' AS JSON
+-- !query schema
+struct<namespace:string>
+-- !query output
+{"views":[{"namespace":"showdb","viewName":"view_1","isTemporary":false},{"namespace":"showdb","viewName":"view_2","isTemporary":false},{"namespace":"","viewName":"view_4","isTemporary":true}]}
+
+
+-- !query
+SHOW VIEWS IN showdb LIKE 'view_*' AS JSON
+-- !query schema
+struct<namespace:string>
+-- !query output
+{"views":[{"namespace":"showdb","viewName":"view_1","isTemporary":false},{"namespace":"showdb","viewName":"view_2","isTemporary":false},{"namespace":"","viewName":"view_4","isTemporary":true}]}
+
+
+-- !query
 DROP VIEW global_temp.view_3
 -- !query schema
 struct<>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds support for `SHOW VIEWS AS JSON` command, which returns view information in JSON format instead of the traditional tabular format.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
JSON format makes it easier for applications and tools to parse view metadata programmatically

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. This PR introduces a new SQL syntax:
**New Syntax**:
```sql
SHOW VIEWS [ { FROM | IN } database_name ] [ LIKE regex_pattern ] [ AS JSON ]
```
**Examples**:
```sql
-- Show all views in JSON format
SHOW VIEWS AS JSON;

-- Show views from specific database in JSON format
SHOW VIEWS FROM mydb AS JSON;

-- Show views matching pattern in JSON format
SHOW VIEWS LIKE 'sales_*' AS JSON;
```
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added test `show-views.sql`

Manual Testing:
```sql
sql("USE showdb")
sql("CREATE TABLE tbl(a STRING, b INT, c STRING, d STRING) USING parquet")
sql("CREATE VIEW view_1 AS SELECT * FROM tbl")
sql("CREATE VIEW view_2 AS SELECT * FROM tbl WHERE c='a'")

sql("SHOW VIEWS in showdb AS JSON").show(false)
+-----------------------------------------------------------------------------------------------------------------------------------------+
|namespace                                                                                                                                |
+-----------------------------------------------------------------------------------------------------------------------------------------+
|{"views":[{"namespace":"showdb","viewName":"view_1","isTemporary":false},{"namespace":"showdb","viewName":"view_2","isTemporary":false}]}|
+-----------------------------------------------------------------------------------------------------------------------------------------+

sql("SHOW VIEWS in showdb").show(false)
+---------+--------+-----------+
|namespace|viewName|isTemporary|
+---------+--------+-----------+
|showdb   |view_1  |false      |
|showdb   |view_2  |false      |
+---------+--------+-----------+
```



### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
