### PR TITLE
[SPARK-54705][BUILD][TESTS] Upgrade js-yaml to `3.14.2`

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "dev",
       "devDependencies": {
         "ansi-regex": "^5.0.1",
         "brace-expansion": "^1.1.12",
@@ -797,9 +798,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "dependencies": {
         "argparse": "^1.0.7",
@@ -1836,9 +1837,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to upgrade `js-yaml` which is used for the JS linter to `3.14.2`.
This change is done by `npm --prefix dev audit fix`.

### Why are the changes needed?
To suppress a warning.
When we run lint-js, we will see the following warning.
```
$ dev/lint-js             

added 113 packages, and audited 114 packages in 623ms

15 packages are looking for funding
  run `npm fund` for details

1 moderate severity vulnerability

To address all issues, run:
  npm audit fix

Run `npm audit` for details.
lint-js checks passed.
```

The reason is that there is a known security issue in js-yaml 3.14.1.
The issue itself has almost no effect to on Spark because lint-js is used only in test phase.

```
$ npm --prefix dev/ audit
# npm audit report

js-yaml  <3.14.2
Severity: moderate
js-yaml has prototype pollution in merge (<<) - https://github.com/advisories/GHSA-mh29-5h37-fv8m
fix available via `npm audit fix`
node_modules/js-yaml

1 moderate severity vulnerability

To address all issues, run:
  npm audit fix
```

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
After upgrading `js-yaml`, we don't see the warning.
```
$ npm --prefix dev audit
found 0 vulnerabilities
```

### Was this patch authored or co-authored using generative AI tooling?
No.
