### PR TITLE
[SPARK-54708][CONNECT][ML] Optimize ML cache cleanup with lazy directory creation

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
@@ -180,8 +180,8 @@ private[connect] class MLCache(sessionHolder: SessionHolder) extends Logging {
   }
 
   /**
-   * Closes the MLCache and cleans up resources. Only performs cleanup if ML directories were
-   * created during the session. Called by SessionHolder during session cleanup.
+   * Closes the MLCache and cleans up resources. Only performs cleanup if ML directories or models
+   * were created during the session. Called by SessionHolder during session cleanup.
    */
   def close(): Unit = {
     if (hasCreatedMLDirs.get() || cachedModel.size() > 0) {

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
@@ -180,9 +180,8 @@ private[connect] class MLCache(sessionHolder: SessionHolder) extends Logging {
   }
 
   /**
-   * Closes the MLCache and cleans up resources.
-   * Only performs cleanup if ML directories were created during the session.
-   * Called by SessionHolder during session cleanup.
+   * Closes the MLCache and cleans up resources. Only performs cleanup if ML directories were
+   * created during the session. Called by SessionHolder during session cleanup.
    */
   def close(): Unit = {
     if (hasCreatedMLDirs.get()) {

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
@@ -20,9 +20,10 @@ import java.io.File
 import java.nio.file.{Files, Path, Paths}
 import java.util.UUID
 import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap, TimeUnit}
-import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 
 import scala.collection.mutable
+import scala.util.control.NonFatal
 
 import com.google.common.cache.{CacheBuilder, RemovalNotification}
 
@@ -44,12 +45,17 @@ private[connect] class MLCache(sessionHolder: SessionHolder) extends Logging {
 
   private[ml] val totalMLCacheInMemorySizeBytes: AtomicLong = new AtomicLong(0)
 
-  val offloadedModelsDir: Path = {
-    val path = Paths.get(
+  // Track if ML directories were ever created in this session
+  private[ml] val hasCreatedMLDirs: AtomicBoolean = new AtomicBoolean(false)
+
+  lazy val offloadedModelsDir: Path = {
+    val dirPath = Paths.get(
       System.getProperty("java.io.tmpdir"),
       "spark_connect_model_cache",
       sessionHolder.sessionId)
-    Files.createDirectories(path)
+    val createdPath = Files.createDirectories(dirPath)
+    hasCreatedMLDirs.set(true)
+    createdPath
   }
   private[spark] def getMemoryControlEnabled: Boolean = {
     sessionHolder.session.conf.get(
@@ -170,6 +176,22 @@ private[connect] class MLCache(sessionHolder: SessionHolder) extends Logging {
     } catch {
       case _: IllegalArgumentException =>
         throw SparkException.internalError(s"The MLCache key $refId is invalid.")
+    }
+  }
+
+  /**
+   * Closes the MLCache and cleans up resources.
+   * Only performs cleanup if ML directories were created during the session.
+   * Called by SessionHolder during session cleanup.
+   */
+  def close(): Unit = {
+    if (hasCreatedMLDirs.get()) {
+      try {
+        clear()
+      } catch {
+        case NonFatal(e) =>
+          logWarning(log"Failed to cleanup ML cache resources", e)
+      }
     }
   }
 

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
@@ -184,7 +184,7 @@ private[connect] class MLCache(sessionHolder: SessionHolder) extends Logging {
    * created during the session. Called by SessionHolder during session cleanup.
    */
   def close(): Unit = {
-    if (hasCreatedMLDirs.get()) {
+    if (hasCreatedMLDirs.get() || cachedModel.size() > 0) {
       try {
         clear()
       } catch {

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -378,7 +378,8 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
     // remove all executions and no new executions will be added in the meanwhile.
     SparkConnectService.executionManager.removeAllExecutionsForSession(this.key)
 
-    mlCache.clear()
+    // Clean up ML cache (only if ML models were created)
+    mlCache.close()
 
     session.cleanupPythonWorkerLogs()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

In current implementation, during the session holder cleanup of non-ML sessions, in mlCache.clear() ([code link](https://github.com/apache/spark/blob/43f7936d7b3a4701e3d0fdb44663006cbe0db70b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala#L381)) , the offloadedModelsDir is still eagerly created and will need to be deleted, which will cause ~10 ms unnecessary latency.

In this PR, we are making the directory creation lazy to avoid deleting empty directories when there is no SparkML operations in sessions.

### Why are the changes needed?

Improve the performance of ReleaseSession RPC by ~10ms.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New test and existing tests.


### Was this patch authored or co-authored using generative AI tooling?

No.
