### PR TITLE
[SPARK-53991][SQL][FOLLOWUP] Remove wrong comments added in PR #53463

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/kllExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/kllExpressions.scala
@@ -469,7 +469,6 @@ abstract class KllSketchGetQuantileBase
   protected def outputDataType: DataType
 
   // The rank argument must be foldable (compile-time constant).
-  // This enables Photon to efficiently handle array outputs with a known constant size.
   override def checkInputDataTypes(): TypeCheckResult = {
     if (!right.foldable) {
       TypeCheckResult.DataTypeMismatch(
@@ -635,7 +634,6 @@ abstract class KllSketchGetRankBase
   protected def kllSketchGetRank(memory: Memory, quantile: Any): Double
 
   // The quantile argument must be foldable (compile-time constant).
-  // This enables Photon to efficiently handle array outputs with a known constant size.
   override def checkInputDataTypes(): TypeCheckResult = {
     if (!right.foldable) {
       TypeCheckResult.DataTypeMismatch(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes two wrong comment lines added in [PR #53463](https://github.com/apache/spark/pull/53463).

### Why are the changes needed?

These two accidental comment lines don't apply to Apache Spark and will be removed.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

N/A, comment changes only

### Was this patch authored or co-authored using generative AI tooling?

No