### PR TITLE
[SPARK-46166][PS] Implementation of pandas.DataFrame.any with axis=None

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -11267,9 +11267,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             )
         else:
             # axis=None case - return single boolean value
-            first_pass: "Series" = self.any(axis=1, bool_only=bool_only, skipna=skipna)
-            result: bool = first_pass.any()
-            return result
+            return bool(self.any(axis=1, bool_only=bool_only, skipna=skipna).any())  # type: ignore
 
     def _bool_column_labels(self, column_labels: List[Label]) -> List[Label]:
         """

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -11142,8 +11142,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         return self._result_aggregated(column_labels, applied)
 
     def any(
-        self, axis: Optional[Axis] = 0, bool_only: Optional[bool] = None, skipna: bool = True,
-            **kwargs: Any
+        self,
+        axis: Optional[Axis] = 0,
+        bool_only: Optional[bool] = None,
+        skipna: bool = True,
+        **kwargs: Any,
     ) -> "Series":
         """
         Return whether any element is True.

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -11147,7 +11147,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         bool_only: Optional[bool] = None,
         skipna: bool = True,
         **kwargs: Any,
-    ) -> "Series":
+    ) -> Union["Series", bool]:
         """
         Return whether any element is True.
 

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -11267,7 +11267,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             )
         else:
             # axis=None case - return single boolean value
-            return self.any(axis=1).any()
+            first_pass: "Series" = self.any(axis=1, bool_only=bool_only, skipna=skipna)
+            return first_pass.any()  # type: bool
 
     def _bool_column_labels(self, column_labels: List[Label]) -> List[Label]:
         """

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -11268,7 +11268,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         else:
             # axis=None case - return single boolean value
             first_pass: "Series" = self.any(axis=1, bool_only=bool_only, skipna=skipna)
-            return first_pass.any()  # type: bool
+            result: bool = first_pass.any()
+            return result
 
     def _bool_column_labels(self, column_labels: List[Label]) -> List[Label]:
         """

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -11141,9 +11141,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         return self._result_aggregated(column_labels, applied)
 
-    # TODO(SPARK-46166): axis and **kwargs should be implemented.
     def any(
-        self, axis: Axis = 0, bool_only: Optional[bool] = None, skipna: bool = True
+        self, axis: Optional[Axis] = 0, bool_only: Optional[bool] = None, skipna: bool = True,
+            **kwargs: Any
     ) -> "Series":
         """
         Return whether any element is True.
@@ -11153,11 +11153,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Parameters
         ----------
-        axis : {0 or 'index'}, default 0
+        axis : {0, 'index', 1, 'columns' or None}, default 0
             Indicate which axis or axes should be reduced.
 
             * 0 / 'index' : reduce the index, return a Series whose index is the
               original column labels.
+            * 1 / 'columns' : reduce the columns, return a Series whose index is the
+              original row index.
+            * None : reduce all dimensions, return a single boolean value.
 
         bool_only : bool, default None
             Include only boolean columns. If None, will attempt to use everything,
@@ -11167,6 +11170,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             Exclude NA/null values. If the entire row/column is NA and skipna is True,
             then the result will be False, as for an empty row/column. If skipna is False,
             then NA are treated as True, because these are not equal to zero.
+
+        **kwargs: Any, default None
+            Additional keywords have no effect but might be accepted for compatibility with
+            NumPy.
 
         Returns
         -------
@@ -11207,7 +11214,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> df[[]].any()
         Series([], dtype: bool)
         """
-        axis = validate_axis(axis)
+        if axis is not None:
+            axis = validate_axis(axis)
         column_labels = self._internal.column_labels
         if bool_only:
             column_labels = self._bool_column_labels(column_labels)
@@ -11256,7 +11264,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             )
         else:
             # axis=None case - return single boolean value
-            raise NotImplementedError('axis should be 0, 1, "index", or "columns" currently.')
+            return self.any(axis=1).any()
 
     def _bool_column_labels(self, column_labels: List[Label]) -> List[Label]:
         """

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -11146,7 +11146,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         axis: Optional[Axis] = 0,
         bool_only: Optional[bool] = None,
         skipna: bool = True,
-        **kwargs: Any,
     ) -> Union["Series", bool]:
         """
         Return whether any element is True.
@@ -11173,10 +11172,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             Exclude NA/null values. If the entire row/column is NA and skipna is True,
             then the result will be False, as for an empty row/column. If skipna is False,
             then NA are treated as True, because these are not equal to zero.
-
-        **kwargs: Any, default None
-            Additional keywords have no effect but might be accepted for compatibility with
-            NumPy.
 
         Returns
         -------

--- a/python/pyspark/pandas/tests/computation/test_any_all.py
+++ b/python/pyspark/pandas/tests/computation/test_any_all.py
@@ -158,6 +158,11 @@ class FrameAnyAllMixin:
             psdf.any(axis="columns", bool_only=False), pdf.any(axis="columns", bool_only=False)
         )
 
+        # Test axis=None
+        self.assert_eq(psdf.any(axis=None), pdf.any(axis=None))
+        self.assert_eq(psdf.any(axis=None, bool_only=True), pdf.any(axis=None, bool_only=True))
+        self.assert_eq(psdf.any(axis=None, bool_only=False), pdf.any(axis=None, bool_only=False))
+
         columns.names = ["X", "Y"]
         pdf.columns = columns
         psdf.columns = columns
@@ -170,6 +175,11 @@ class FrameAnyAllMixin:
         self.assert_eq(psdf.any(axis=1), pdf.any(axis=1))
         self.assert_eq(psdf.any(axis=1, bool_only=True), pdf.any(axis=1, bool_only=True))
         self.assert_eq(psdf.any(axis=1, bool_only=False), pdf.any(axis=1, bool_only=False))
+
+        # Test axis=None
+        self.assert_eq(psdf.any(axis=None), pdf.any(axis=None))
+        self.assert_eq(psdf.any(axis=None, bool_only=True), pdf.any(axis=None, bool_only=True))
+        self.assert_eq(psdf.any(axis=None, bool_only=False), pdf.any(axis=None, bool_only=False))
 
         # Test skipna parameter
         pdf = pd.DataFrame(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Support for `axis=None` in `pandas.DataFrame.any`.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
New API


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
New parameter support for an existing API.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
CI / local


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
