### PR TITLE
[SPARK-54714][PYTHON][TEST] Add more coverage tests to conversion

### DIFF
--- a/python/pyspark/sql/tests/test_conversion.py
+++ b/python/pyspark/sql/tests/test_conversion.py
@@ -17,7 +17,10 @@
 import unittest
 
 from pyspark.errors import PySparkValueError
-from pyspark.sql.conversion import ArrowTableToRowsConversion, LocalDataToArrowConversion
+from pyspark.sql.conversion import (
+    ArrowTableToRowsConversion,
+    LocalDataToArrowConversion,
+)
 from pyspark.sql.types import (
     ArrayType,
     BinaryType,
@@ -62,20 +65,23 @@ class Score:
 class ConversionTests(unittest.TestCase):
     def test_conversion(self):
         data = [
-            # Schema, Test cases (Before, After)
-            (NullType(), (None, None)),
-            (IntegerType(), (1, 1), (None, None)),
-            ((IntegerType(), {"nullable": False}), (1, 1)),
-            (StringType(), ("a", "a")),
-            (BinaryType(), (b"a", b"a")),
-            (GeographyType("ANY"), (None, None)),
-            (GeometryType("ANY"), (None, None)),
-            (ArrayType(IntegerType()), ([1, None], [1, None])),
-            (ArrayType(IntegerType(), containsNull=False), ([1, 2], [1, 2])),
-            (ArrayType(BinaryType()), ([b"a", b"b"], [b"a", b"b"])),
-            (MapType(StringType(), IntegerType()), ({"a": 1, "b": None}, {"a": 1, "b": None})),
-            (MapType(StringType(), IntegerType(), valueContainsNull=False), ({"a": 1}, {"a": 1})),
-            (MapType(StringType(), BinaryType()), ({"a": b"a"}, {"a": b"a"})),
+            # Schema, Test cases (Before, After_If_Different)
+            (NullType(), (None,)),
+            (IntegerType(), (1,), (None,)),
+            ((IntegerType(), {"nullable": False}), (1,)),
+            (StringType(), ("a",)),
+            (BinaryType(), (b"a",)),
+            (GeographyType("ANY"), (None,)),
+            (GeometryType("ANY"), (None,)),
+            (ArrayType(IntegerType()), ([1, None],)),
+            (ArrayType(IntegerType(), containsNull=False), ([1, 2],)),
+            (ArrayType(BinaryType()), ([b"a", b"b"],)),
+            (MapType(StringType(), IntegerType()), ({"a": 1, "b": None},)),
+            (
+                MapType(StringType(), IntegerType(), valueContainsNull=False),
+                ({"a": 1},),
+            ),
+            (MapType(StringType(), BinaryType()), ({"a": b"a"},)),
             (
                 StructType(
                     [
@@ -92,8 +98,8 @@ class ConversionTests(unittest.TestCase):
                     Row(i=1, i_n=None, ii=1, s="a", b=b"a"),
                 ),
             ),
-            (ExamplePointUDT(), (ExamplePoint(1.0, 1.0), ExamplePoint(1.0, 1.0))),
-            (ScoreUDT(), (Score(1), Score(1))),
+            (ExamplePointUDT(), (ExamplePoint(1.0, 1.0),)),
+            (ScoreUDT(), (Score(1),)),
         ]
 
         schema = StructType()
@@ -108,7 +114,10 @@ class ConversionTests(unittest.TestCase):
             else:
                 kwargs = {}
             for test in tests:
-                before, after = test
+                if len(test) == 1:
+                    before, after = test[0], test[0]
+                else:
+                    before, after = test
                 schema.add(f"{row_schema.simpleString()}_{index}", row_schema, **kwargs)
                 input_row.append(before)
                 expected.append(after)

--- a/python/pyspark/sql/tests/test_conversion.py
+++ b/python/pyspark/sql/tests/test_conversion.py
@@ -16,98 +16,132 @@
 #
 import unittest
 
+from pyspark.errors import PySparkValueError
 from pyspark.sql.conversion import ArrowTableToRowsConversion, LocalDataToArrowConversion
 from pyspark.sql.types import (
     ArrayType,
     BinaryType,
+    GeographyType,
+    GeometryType,
     IntegerType,
     MapType,
+    NullType,
     Row,
     StringType,
+    StructField,
     StructType,
+    UserDefinedType,
 )
 from pyspark.testing.objects import ExamplePoint, ExamplePointUDT
 from pyspark.testing.utils import have_pyarrow, pyarrow_requirement_message
+
+
+class ScoreUDT(UserDefinedType):
+    @classmethod
+    def sqlType(cls):
+        return IntegerType()
+
+    def serialize(self, obj):
+        return obj.score
+
+    def deserialize(self, datum):
+        return Score(datum)
+
+
+class Score:
+    __UDT__ = ScoreUDT()
+
+    def __init__(self, score):
+        self.score = score
+
+    def __eq__(self, other):
+        return self.score == other.score
 
 
 @unittest.skipIf(not have_pyarrow, pyarrow_requirement_message)
 class ConversionTests(unittest.TestCase):
     def test_conversion(self):
         data = [
+            # Schema, Test cases (Before, After)
+            (NullType(), (None, None)),
+            (IntegerType(), (1, 1), (None, None)),
+            ((IntegerType(), {"nullable": False}), (1, 1)),
+            (StringType(), ("a", "a")),
+            (BinaryType(), (b"a", b"a")),
+            (GeographyType("ANY"), (None, None)),
+            (GeometryType("ANY"), (None, None)),
+            (ArrayType(IntegerType()), ([1, None], [1, None])),
+            (ArrayType(IntegerType(), containsNull=False), ([1, 2], [1, 2])),
+            (ArrayType(BinaryType()), ([b"a", b"b"], [b"a", b"b"])),
+            (MapType(StringType(), IntegerType()), ({"a": 1, "b": None}, {"a": 1, "b": None})),
+            (MapType(StringType(), IntegerType(), valueContainsNull=False), ({"a": 1}, {"a": 1})),
+            (MapType(StringType(), BinaryType()), ({"a": b"a"}, {"a": b"a"})),
             (
-                i if i % 2 == 0 else None,
-                str(i),
-                i,
-                str(i).encode(),
-                [j if j % 2 == 0 else None for j in range(i)],
-                list(range(i)),
-                [str(j).encode() for j in range(i)],
-                {str(j): j if j % 2 == 0 else None for j in range(i)},
-                {str(j): j for j in range(i)},
-                {str(j): str(j).encode() for j in range(i)},
-                (i if i % 2 == 0 else None, str(i), i, str(i).encode()),
-                {"i": i if i % 2 == 0 else None, "s": str(i), "ii": i, "b": str(i).encode()},
-                ExamplePoint(float(i), float(i)),
-            )
-            for i in range(5)
+                StructType(
+                    [
+                        StructField("i", IntegerType()),
+                        StructField("i_n", IntegerType()),
+                        StructField("ii", IntegerType(), nullable=False),
+                        StructField("s", StringType()),
+                        StructField("b", BinaryType()),
+                    ]
+                ),
+                ((1, None, 1, "a", b"a"), Row(i=1, i_n=None, ii=1, s="a", b=b"a")),
+                (
+                    {"b": b"a", "s": "a", "ii": 1, "in": None, "i": 1},
+                    Row(i=1, i_n=None, ii=1, s="a", b=b"a"),
+                ),
+            ),
+            (ExamplePointUDT(), (ExamplePoint(1.0, 1.0), ExamplePoint(1.0, 1.0))),
+            (ScoreUDT(), (Score(1), Score(1))),
         ]
-        schema = (
-            StructType()
-            .add("i", IntegerType())
-            .add("s", StringType())
-            .add("ii", IntegerType(), nullable=False)
-            .add("b", BinaryType())
-            .add("arr_i", ArrayType(IntegerType()))
-            .add("arr_ii", ArrayType(IntegerType(), containsNull=False))
-            .add("arr_b", ArrayType(BinaryType()))
-            .add("map_i", MapType(StringType(), IntegerType()))
-            .add("map_ii", MapType(StringType(), IntegerType(), valueContainsNull=False))
-            .add("map_b", MapType(StringType(), BinaryType()))
-            .add(
-                "struct_t",
-                StructType()
-                .add("i", IntegerType())
-                .add("s", StringType())
-                .add("ii", IntegerType(), nullable=False)
-                .add("b", BinaryType()),
-            )
-            .add(
-                "struct_d",
-                StructType()
-                .add("i", IntegerType())
-                .add("s", StringType())
-                .add("ii", IntegerType(), nullable=False)
-                .add("b", BinaryType()),
-            )
-            .add("udt", ExamplePointUDT())
-        )
 
-        tbl = LocalDataToArrowConversion.convert(data, schema, use_large_var_types=False)
+        schema = StructType()
+
+        input_row = []
+        expected = []
+
+        index = 0
+        for row_schema, *tests in data:
+            if isinstance(row_schema, tuple):
+                row_schema, kwargs = row_schema
+            else:
+                kwargs = {}
+            for test in tests:
+                before, after = test
+                schema.add(f"{row_schema.simpleString()}_{index}", row_schema, **kwargs)
+                input_row.append(before)
+                expected.append(after)
+                index += 1
+
+        tbl = LocalDataToArrowConversion.convert(
+            [tuple(input_row)], schema, use_large_var_types=False
+        )
         actual = ArrowTableToRowsConversion.convert(tbl, schema)
 
         for a, e in zip(
-            actual,
-            [
-                Row(
-                    i=i if i % 2 == 0 else None,
-                    s=str(i),
-                    ii=i,
-                    b=str(i).encode(),
-                    arr_i=[j if j % 2 == 0 else None for j in range(i)],
-                    arr_ii=list(range(i)),
-                    arr_b=[str(j).encode() for j in range(i)],
-                    map_i={str(j): j if j % 2 == 0 else None for j in range(i)},
-                    map_ii={str(j): j for j in range(i)},
-                    map_b={str(j): str(j).encode() for j in range(i)},
-                    struct_t=Row(i=i if i % 2 == 0 else None, s=str(i), ii=i, b=str(i).encode()),
-                    struct_d=Row(i=i if i % 2 == 0 else None, s=str(i), ii=i, b=str(i).encode()),
-                    udt=ExamplePoint(float(i), float(i)),
-                )
-                for i in range(5)
-            ],
+            actual[0],
+            expected,
         ):
             with self.subTest(expected=e):
                 self.assertEqual(a, e)
+
+    def test_none_as_row(self):
+        schema = StructType([StructField("x", IntegerType())])
+        tbl = LocalDataToArrowConversion.convert([None], schema, use_large_var_types=False)
+        actual = ArrowTableToRowsConversion.convert(tbl, schema)
+        self.assertEqual(actual[0], Row(x=None))
+
+    def test_return_as_tuples(self):
+        schema = StructType([StructField("x", IntegerType())])
+        tbl = LocalDataToArrowConversion.convert([(1,)], schema, use_large_var_types=False)
+        actual = ArrowTableToRowsConversion.convert(tbl, schema, return_as_tuples=True)
+        self.assertEqual(actual[0], (1,))
+
+        schema = StructType()
+        tbl = LocalDataToArrowConversion.convert([tuple()], schema, use_large_var_types=False)
+        actual = ArrowTableToRowsConversion.convert(tbl, schema, return_as_tuples=True)
+        self.assertEqual(actual[0], tuple())
 
     def test_binary_as_bytes_conversion(self):
         data = [
@@ -145,6 +179,18 @@ class ConversionTests(unittest.TestCase):
                     self.assertIsInstance(value, expected_type)
                 # Struct field
                 self.assertIsInstance(row.struct_b.b, expected_type)
+
+    def test_invalid_conversion(self):
+        data = [
+            (NullType(), 1),
+            (ArrayType(IntegerType(), containsNull=False), [1, None]),
+            (ArrayType(ScoreUDT(), containsNull=False), [None]),
+        ]
+
+        for row_schema, value in data:
+            schema = StructType([StructField("x", row_schema)])
+            with self.assertRaises(PySparkValueError):
+                LocalDataToArrowConversion.convert([(value,)], schema, use_large_var_types=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

More coverage tests for `conversion.py`

Also the framework is restructured during this process. It's not easy to add extra test cases to the previous framework because you need to count the number.

Now the schema, input and output are grouped together so anyone can just add new test cases in a single place.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To improve coverage and make it easier to add test cases in the future.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

After framework change, confirmed that the coverage is exactly the same as previous. Then confirmed the coverage rate is better after new test cases.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No