### PR TITLE
[SPARK-54709][BUILD] Upgrade Derby to 10.16.1.2

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -56,9 +56,9 @@ datanucleus-core/4.1.17//datanucleus-core-4.1.17.jar
 datanucleus-rdbms/4.1.19//datanucleus-rdbms-4.1.19.jar
 datasketches-java/6.2.0//datasketches-java-6.2.0.jar
 datasketches-memory/3.0.2//datasketches-memory-3.0.2.jar
-derby/10.16.1.1//derby-10.16.1.1.jar
-derbyshared/10.16.1.1//derbyshared-10.16.1.1.jar
-derbytools/10.16.1.1//derbytools-10.16.1.1.jar
+derby/10.16.1.2//derby-10.16.1.2.jar
+derbyshared/10.16.1.2//derbyshared-10.16.1.2.jar
+derbytools/10.16.1.2//derbytools-10.16.1.2.jar
 dropwizard-metrics-hadoop-metrics2-reporter/0.1.2//dropwizard-metrics-hadoop-metrics2-reporter-0.1.2.jar
 esdk-obs-java/3.20.4.2//esdk-obs-java-3.20.4.2.jar
 failureaccess/1.0.3//failureaccess-1.0.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
     <!-- note that this should be compatible with Kafka brokers version 0.10 and up -->
     <kafka.version>3.9.1</kafka.version>
     <!-- After 10.17.1.0, the minimum required version is JDK19 -->
-    <derby.version>10.16.1.1</derby.version>
+    <derby.version>10.16.1.2</derby.version>
     <parquet.version>1.16.0</parquet.version>
     <orc.version>2.2.1</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade Derby from 10.16.1.1 to 10.16.1.2


### Why are the changes needed?
To fix the [GHSA-rcjc-c4pj-xxrp](https://osv.dev/vulnerability/GHSA-rcjc-c4pj-xxrp) security vulnerability


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
