### PR TITLE
[SPARK-52764][ML][CONNECT] Make `RemoteModelRef.release_ref` async

### DIFF
--- a/python/pyspark/ml/tests/connect/test_parity_classification.py
+++ b/python/pyspark/ml/tests/connect/test_parity_classification.py
@@ -21,8 +21,6 @@ from pyspark.ml.tests.test_classification import ClassificationTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
-# TODO(SPARK-52764): Re-enable this test after fixing the flakiness.
-@unittest.skip("Disabled due to flakiness, should be enabled after fixing the issue")
 class ClassificationParityTests(ClassificationTestsMixin, ReusedConnectTestCase):
     pass
 

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import asyncio
 import json
 import logging
 import os
@@ -154,12 +155,16 @@ class RemoteModelRef:
             self._ref_count += 1
 
     def release_ref(self) -> None:
+        should_del = False
         with self._lock:
             assert self._ref_count > 0
             self._ref_count -= 1
             if self._ref_count == 0:
-                # Delete the model if possible
-                del_remote_cache(self.ref_id)
+                should_del = True
+
+        if should_del:
+            # Delete the model if possible
+            asyncio.run(del_remote_cache(self.ref_id))
 
     def __str__(self) -> str:
         return self.ref_id

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -353,7 +353,7 @@ def try_remote_call(f: FuncT) -> FuncT:
 
 
 # delete the object from the ml cache eagerly
-def del_remote_cache(ref_id: str) -> None:
+def del_remote_cache(ref_id: str):
     if ref_id is not None and "." not in ref_id:
         try:
             from pyspark.sql.connect.session import SparkSession


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Make `RemoteModelRef.release_ref` async


### Why are the changes needed?
the test `pyspark.ml.tests.connect.test_parity_classification` was flaky and got stuck occasionally, the traceback is like
```
Traceback (most recent call last):
  File "/Users/ruifeng.zheng/spark/python/pyspark/ml/util.py", line 379, in wrapped
    self._remote_model_obj.release_ref()
  File "/Users/ruifeng.zheng/spark/python/pyspark/ml/util.py", line 162, in release_ref
    del_remote_cache(self.ref_id)
  File "/Users/ruifeng.zheng/spark/python/pyspark/ml/util.py", line 358, in del_remote_cache
    session.client._delete_ml_cache([ref_id])
  File "/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/client/core.py", line 2133, in _delete_ml_cache
    (_, properties, _) = self.execute_command(command)
  File "/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/client/core.py", line 1158, in execute_command
    data, _, metrics, observed_metrics, properties = self._execute_and_fetch(
  File "/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/client/core.py", line 1660, in _execute_and_fetch
    for response in self._execute_and_fetch_as_iterator(
  File "/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/client/core.py", line 1635, in _execute_and_fetch_as_iterator
    raise kb
  File "/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/client/core.py", line 1617, in _execute_and_fetch_as_iterator
    generator = ExecutePlanResponseReattachableIterator(
  File "/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/client/reattach.py", line 127, in __init__
    self._stub.ExecutePlan(self._initial_request, metadata=metadata)
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/site-packages/grpc/_channel.py", line 1396, in __call__
    call = self._managed_call(
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/site-packages/grpc/_channel.py", line 1784, in create
    with state.lock:
  File "/Users/ruifeng.zheng/spark/python/pyspark/core/context.py", line 409, in signal_handler
    raise KeyboardInterrupt()
```

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manually run the test in my local, the hanging issue doesn't occur in successive 10 runs


### Was this patch authored or co-authored using generative AI tooling?
No
