### PR TITLE
[SPARK-54718][SQL] Preserve attributes names during CTE newInstance()

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/cteOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/cteOperators.scala
@@ -217,7 +217,11 @@ case class CTERelationRef(
     // attributes `a` have the same id, but `Project('a, CTERelationRef(a#2, a#3))` can't be
     // resolved.
     val oldAttrToNewAttr = AttributeMap(output.zip(output.map(_.newInstance())))
-    copy(output = output.map(attr => oldAttrToNewAttr(attr)))
+    if (conf.getConf(SQLConf.LEGACY_CTE_DUPLICATE_ATTRIBUTE_NAMES)) {
+      copy(output = output.map(attr => oldAttrToNewAttr(attr)))
+    } else {
+      copy(output = output.map(attr => attr.withExprId(oldAttrToNewAttr(attr).exprId)))
+    }
   }
 
   def withNewStats(statsOpt: Option[Statistics]): CTERelationRef = copy(statsOpt = statsOpt)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5414,6 +5414,16 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val LEGACY_CTE_DUPLICATE_ATTRIBUTE_NAMES =
+    buildConf("spark.sql.legacy.cteDuplicateAttributeNames")
+      .internal()
+      .doc("When true, CTE references sometimes (e.g., self-joins) may incorrectly unify column" +
+        "names that differ only in casing (e.g., COLNAME and colname become the same). This is" +
+        "the legacy behavior. When false, column name casing is preserved correctly.")
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val LEGACY_TIME_PARSER_POLICY = buildConf(SqlApiConfHelper.LEGACY_TIME_PARSER_POLICY_KEY)
     .internal()
     .doc("When LEGACY, java.text.SimpleDateFormat is used for formatting and parsing " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5420,7 +5420,7 @@ object SQLConf {
       .doc("When true, CTE references sometimes (e.g., self-joins) may incorrectly unify column" +
         "names that differ only in casing (e.g., COLNAME and colname become the same). This is" +
         "the legacy behavior. When false, column name casing is preserved correctly.")
-      .version("4.1.0")
+      .version("4.2.0")
       .booleanConf
       .createWithDefault(false)
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte.sql.out
@@ -1126,6 +1126,62 @@ Project [col1#x]
 
 
 -- !query
+WITH cte AS (SELECT 1 AS id, 'test' AS COLNAME),
+     cte2 AS (SELECT id, COLNAME, colname FROM cte)
+SELECT * FROM cte2 a JOIN cte2 b ON (a.id = b.id)
+-- !query analysis
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias cte
+:     +- Project [1 AS id#x, test AS COLNAME#x]
+:        +- OneRowRelation
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias cte2
+:     +- Project [id#x, COLNAME#x, colname#x]
+:        +- SubqueryAlias cte
+:           +- CTERelationRef xxxx, true, [id#x, COLNAME#x], false, false, 1
++- Project [id#x, COLNAME#x, colname#x, id#x, COLNAME#x, colname#x]
+   +- Join Inner, (id#x = id#x)
+      :- SubqueryAlias a
+      :  +- SubqueryAlias cte2
+      :     +- CTERelationRef xxxx, true, [id#x, COLNAME#x, colname#x], false, false, 1
+      +- SubqueryAlias b
+         +- SubqueryAlias cte2
+            +- CTERelationRef xxxx, true, [id#x, COLNAME#x, colname#x], false, false, 1
+
+
+-- !query
+WITH cte AS (SELECT 1 AS id, 'test' AS COLNAME),
+     cte2 AS (SELECT id, COLNAME, colname FROM cte),
+     cte3 AS (SELECT id, COLNAME, colname FROM cte)
+SELECT * FROM cte2 a JOIN cte2 b ON (a.id = b.id)
+-- !query analysis
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias cte
+:     +- Project [1 AS id#x, test AS COLNAME#x]
+:        +- OneRowRelation
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias cte2
+:     +- Project [id#x, COLNAME#x, colname#x]
+:        +- SubqueryAlias cte
+:           +- CTERelationRef xxxx, true, [id#x, COLNAME#x], false, false, 1
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias cte3
+:     +- Project [id#x, COLNAME#x, colname#x]
+:        +- SubqueryAlias cte
+:           +- CTERelationRef xxxx, true, [id#x, COLNAME#x], false, false, 1
++- Project [id#x, COLNAME#x, colname#x, id#x, COLNAME#x, colname#x]
+   +- Join Inner, (id#x = id#x)
+      :- SubqueryAlias a
+      :  +- SubqueryAlias cte2
+      :     +- CTERelationRef xxxx, true, [id#x, COLNAME#x, colname#x], false, false, 1
+      +- SubqueryAlias b
+         +- SubqueryAlias cte2
+            +- CTERelationRef xxxx, true, [id#x, COLNAME#x, colname#x], false, false, 1
+
+
+-- !query
 DROP VIEW IF EXISTS t
 -- !query analysis
 DropTempViewCommand t

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte.sql.out
@@ -1153,7 +1153,7 @@ WithCTE
 -- !query
 WITH cte AS (SELECT 1 AS id, 'test' AS COLNAME),
      cte2 AS (SELECT id, COLNAME, colname FROM cte),
-     cte3 AS (SELECT id, COLNAME, colname FROM cte)
+     cte3 AS (SELECT id, COLNAME, colname FROM cte2)
 SELECT * FROM cte2 a JOIN cte2 b ON (a.id = b.id)
 -- !query analysis
 WithCTE
@@ -1169,8 +1169,8 @@ WithCTE
 :- CTERelationDef xxxx, false
 :  +- SubqueryAlias cte3
 :     +- Project [id#x, COLNAME#x, colname#x]
-:        +- SubqueryAlias cte
-:           +- CTERelationRef xxxx, true, [id#x, COLNAME#x], false, false, 1
+:        +- SubqueryAlias cte2
+:           +- CTERelationRef xxxx, true, [id#x, COLNAME#x, colname#x], false, false, 1
 +- Project [id#x, COLNAME#x, colname#x, id#x, COLNAME#x, colname#x]
    +- Join Inner, (id#x = id#x)
       :- SubqueryAlias a

--- a/sql/core/src/test/resources/sql-tests/inputs/cte.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cte.sql
@@ -286,6 +286,17 @@ SELECT * FROM (
   WITH cte1 AS (SELECT * FROM t4) SELECT cte1.col1 FROM cte1 JOIN t4 USING (col1)
 );
 
+-- Column reference with different casing should preserve alias casing in self-join
+WITH cte AS (SELECT 1 AS id, 'test' AS COLNAME),
+     cte2 AS (SELECT id, COLNAME, colname FROM cte)
+SELECT * FROM cte2 a JOIN cte2 b ON (a.id = b.id);
+
+-- Same test with an unused CTE, used to return all columns in lower case
+WITH cte AS (SELECT 1 AS id, 'test' AS COLNAME),
+     cte2 AS (SELECT id, COLNAME, colname FROM cte),
+     cte3 AS (SELECT id, COLNAME, colname FROM cte2)
+SELECT * FROM cte2 a JOIN cte2 b ON (a.id = b.id);
+
 -- Clean up
 DROP VIEW IF EXISTS t;
 DROP VIEW IF EXISTS t2;

--- a/sql/core/src/test/resources/sql-tests/results/cte.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte.sql.out
@@ -787,7 +787,7 @@ struct<id:int,COLNAME:string,colname:string,id:int,COLNAME:string,colname:string
 -- !query
 WITH cte AS (SELECT 1 AS id, 'test' AS COLNAME),
      cte2 AS (SELECT id, COLNAME, colname FROM cte),
-     cte3 AS (SELECT id, COLNAME, colname FROM cte)
+     cte3 AS (SELECT id, COLNAME, colname FROM cte2)
 SELECT * FROM cte2 a JOIN cte2 b ON (a.id = b.id)
 -- !query schema
 struct<id:int,COLNAME:string,colname:string,id:int,COLNAME:string,colname:string>

--- a/sql/core/src/test/resources/sql-tests/results/cte.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte.sql.out
@@ -775,6 +775,27 @@ struct<col1:timestamp>
 
 
 -- !query
+WITH cte AS (SELECT 1 AS id, 'test' AS COLNAME),
+     cte2 AS (SELECT id, COLNAME, colname FROM cte)
+SELECT * FROM cte2 a JOIN cte2 b ON (a.id = b.id)
+-- !query schema
+struct<id:int,COLNAME:string,colname:string,id:int,COLNAME:string,colname:string>
+-- !query output
+1	test	test	1	test	test
+
+
+-- !query
+WITH cte AS (SELECT 1 AS id, 'test' AS COLNAME),
+     cte2 AS (SELECT id, COLNAME, colname FROM cte),
+     cte3 AS (SELECT id, COLNAME, colname FROM cte)
+SELECT * FROM cte2 a JOIN cte2 b ON (a.id = b.id)
+-- !query schema
+struct<id:int,COLNAME:string,colname:string,id:int,COLNAME:string,colname:string>
+-- !query output
+1	test	test	1	test	test
+
+
+-- !query
 DROP VIEW IF EXISTS t
 -- !query schema
 struct<>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
New implementation of `CTERelationRef.newInstance()` that preserves attributes' names (see tests).
To control this small behavior change added the flag `LEGACY_CTE_DUPLICATE_ATTRIBUTE_NAMES`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The output schema is much more predictable and does not depend on query shape.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, the column names case in the output schema has changed in case. Only affects queries with CTE that have several attributes with the same exprId but different names.

Example of current output of tests (without fix, after fix you can see in golden files).

```
WITH cte AS (SELECT 1 AS id, 'test' AS COLNAME),
     cte2 AS (SELECT id, COLNAME, colname FROM cte)
SELECT * FROM cte2 a JOIN cte2 b ON (a.id = b.id);

+---+-------+-------+---+-------+-------+
| id|COLNAME|colname| id|colname|colname|
+---+-------+-------+---+-------+-------+
|  1|   test|   test|  1|   test|   test|
+---+-------+-------+---+-------+-------+

WITH cte AS (SELECT 1 AS id, 'test' AS COLNAME),
     cte2 AS (SELECT id, COLNAME, colname FROM cte),
     cte3 AS (SELECT id, COLNAME, colname FROM cte2)
SELECT * FROM cte2 a JOIN cte2 b ON (a.id = b.id)

+---+-------+-------+---+-------+-------+
| id|colname|colname| id|colname|colname|
+---+-------+-------+---+-------+-------+
|  1|   test|   test|  1|   test|   test|
+---+-------+-------+---+-------+-------+
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New tests + existing tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Cursor 2.2.20