### PR TITLE
[SPARK-54720][SQL] Add SparkSession.emptyDataFrame with a schema

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -210,8 +210,14 @@ abstract class SparkSession extends Serializable with Closeable {
    *
    * @since 2.0.0
    */
-  @transient
   def emptyDataFrame: DataFrame
+
+  /**
+   * Returns a `DataFrame` with schema `schema`and no rows.
+   *
+   * @since 4.2.0
+   */
+  def emptyDataFrame(schema: StructType): DataFrame = emptyDataset(Encoders.row(schema))
 
   /**
    * Creates a `DataFrame` from a local Seq of Product.

--- a/sql/api/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -213,7 +213,7 @@ abstract class SparkSession extends Serializable with Closeable {
   def emptyDataFrame: DataFrame
 
   /**
-   * Returns a `DataFrame` with schema `schema`and no rows.
+   * Returns a `DataFrame` with schema `schema` and no rows.
    *
    * @since 4.2.0
    */

--- a/sql/api/src/test/scala/org/apache/spark/sql/SparkSessionBuilderImplementationBindingSuite.scala
+++ b/sql/api/src/test/scala/org/apache/spark/sql/SparkSessionBuilderImplementationBindingSuite.scala
@@ -22,6 +22,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.functions.{max, sum}
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 /**
  * Test suite for SparkSession implementation binding.
@@ -69,5 +70,19 @@ trait SparkSessionBuilderImplementationBindingSuite
     import ctx.implicits._
     val df = ctx.createDataset(1 to 11).select(max("value").as[Long])
     assert(df.head() == 11)
+  }
+
+  test("emptyDataFrame with Schema") {
+    val session = SparkSession.builder().getOrCreate()
+    val schema = new StructType(Array(
+      StructField("a", IntegerType),
+      StructField("b", StringType)))
+    val df = session.emptyDataFrame(schema)
+    assert(df.schema == schema)
+    assert(df.isEmpty)
+    val derivedSchema = new StructType(Array(StructField("a", IntegerType)))
+    val derivedDf = df.select("a")
+    assert(derivedDf.schema == derivedSchema)
+    assert(derivedDf.isEmpty)
   }
 }

--- a/sql/api/src/test/scala/org/apache/spark/sql/SparkSessionBuilderImplementationBindingSuite.scala
+++ b/sql/api/src/test/scala/org/apache/spark/sql/SparkSessionBuilderImplementationBindingSuite.scala
@@ -74,9 +74,8 @@ trait SparkSessionBuilderImplementationBindingSuite
 
   test("emptyDataFrame with Schema") {
     val session = SparkSession.builder().getOrCreate()
-    val schema = new StructType(Array(
-      StructField("a", IntegerType),
-      StructField("b", StringType)))
+    val schema =
+      new StructType(Array(StructField("a", IntegerType), StructField("b", StringType)))
     val df = session.emptyDataFrame(schema)
     assert(df.schema == schema)
     assert(df.isEmpty)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds a version of `SparkSession.emptyDataFrame` that takes a schema.

### Why are the changes needed?
It makes it easier to create an empty DataFrame in Scala. 

### Does this PR introduce _any_ user-facing change?
Yes, it adds a new API.

### How was this patch tested?
I have added a test case.

### Was this patch authored or co-authored using generative AI tooling?
No.