### PR TITLE
[SPARK-54726][SQL] Improve a bit of performance for InsertAdaptiveSparkPlan

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
@@ -98,17 +98,14 @@ case class InsertAdaptiveSparkPlan(
     conf.getConf(SQLConf.ADAPTIVE_EXECUTION_FORCE_APPLY) || isSubquery || {
       plan.exists {
         case _: Exchange => true
-        case p if !p.requiredChildDistribution.forall(_ == UnspecifiedDistribution) => true
+        case p if p.requiredChildDistribution.exists(_ != UnspecifiedDistribution) => true
         // AQE framework has a different way to update the query plan in the UI: it updates the plan
         // at the end of execution, while non-AQE updates the plan before execution. If the cached
         // plan is already AQEed, the current plan must be AQEed as well so that the UI can get plan
         // update correctly.
         case i: InMemoryTableScanExec
             if i.relation.cachedPlan.isInstanceOf[AdaptiveSparkPlanExec] => true
-        case p => p.expressions.exists(_.exists {
-          case _: SubqueryExpression => true
-          case _ => false
-        })
+        case p => p.expressions.exists(_.exists(_.isInstanceOf[SubqueryExpression]))
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to improve a bit of performance for `InsertAdaptiveSparkPlan` and simplify some code.


### Why are the changes needed?
Improve a bit of performance for `InsertAdaptiveSparkPlan`


### Does this PR introduce _any_ user-facing change?
'No'.
Just inner change.


### How was this patch tested?
GA tests.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
