### PR TITLE
[SPARK-52764][ML][CONNECT][TESTS] Restore `test_parity_classification` and `test_parity_regression`

### DIFF
--- a/python/pyspark/ml/tests/connect/test_parity_classification.py
+++ b/python/pyspark/ml/tests/connect/test_parity_classification.py
@@ -20,6 +20,7 @@ import unittest
 from pyspark.ml.tests.test_classification import ClassificationTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
+
 class ClassificationParityTests(ClassificationTestsMixin, ReusedConnectTestCase):
     pass
 

--- a/python/pyspark/ml/tests/connect/test_parity_classification.py
+++ b/python/pyspark/ml/tests/connect/test_parity_classification.py
@@ -20,9 +20,6 @@ import unittest
 from pyspark.ml.tests.test_classification import ClassificationTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
-
-# TODO(SPARK-52764): Re-enable this test after fixing the flakiness.
-@unittest.skip("Disabled due to flakiness, should be enabled after fixing the issue")
 class ClassificationParityTests(ClassificationTestsMixin, ReusedConnectTestCase):
     pass
 

--- a/python/pyspark/ml/tests/connect/test_parity_regression.py
+++ b/python/pyspark/ml/tests/connect/test_parity_regression.py
@@ -21,8 +21,6 @@ from pyspark.ml.tests.test_regression import RegressionTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
-# TODO(SPARK-52764): Re-enable this test after fixing the flakiness.
-@unittest.skip("Disabled due to flakiness, should be enabled after fixing the issue")
 class RegressionParityTests(RegressionTestsMixin, ReusedConnectTestCase):
     pass
 

--- a/python/pyspark/ml/tests/test_classification.py
+++ b/python/pyspark/ml/tests/test_classification.py
@@ -55,7 +55,6 @@ from pyspark.ml.classification import (
     MultilayerPerceptronClassificationTrainingSummary,
 )
 from pyspark.ml.regression import DecisionTreeRegressionModel
-from pyspark.sql import is_remote
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 
 
@@ -276,9 +275,6 @@ class ClassificationTestsMixin:
             self.assertAlmostEqual(s.weightedFMeasure(1.0), 1.0, 2)
 
         check_summary()
-        if is_remote():
-            self.spark.client._delete_ml_cache([model._java_obj._ref_id], evict_only=True)
-            check_summary()
 
         s = model.summary
         # test evaluation (with training dataset) produces a summary with same values
@@ -329,9 +325,6 @@ class ClassificationTestsMixin:
             self.assertAlmostEqual(s.weightedFMeasure(1.0), 0.65, 2)
 
         check_summary()
-        if is_remote():
-            self.spark.client._delete_ml_cache([model._java_obj._ref_id], evict_only=True)
-            check_summary()
 
         s = model.summary
         # test evaluation (with training dataset) produces a summary with same values
@@ -455,9 +448,6 @@ class ClassificationTestsMixin:
             self.assertEqual(summary.predictions.columns, expected_cols)
 
         check_summary()
-        if is_remote():
-            self.spark.client._delete_ml_cache([model._java_obj._ref_id], evict_only=True)
-            check_summary()
 
         summary2 = model.evaluate(df)
         self.assertIsInstance(summary2, LinearSVCSummary)
@@ -560,9 +550,6 @@ class ClassificationTestsMixin:
             self.assertEqual(summary.predictions.columns, expected_cols)
 
         check_summary()
-        if is_remote():
-            self.spark.client._delete_ml_cache([model._java_obj._ref_id], evict_only=True)
-            check_summary()
 
         summary2 = model.evaluate(df)
         self.assertIsInstance(summary2, FMClassificationSummary)
@@ -814,9 +801,6 @@ class ClassificationTestsMixin:
             self.assertEqual(summary.predictions.columns, expected_cols)
 
         check_summary()
-        if is_remote():
-            self.spark.client._delete_ml_cache([model._java_obj._ref_id], evict_only=True)
-            check_summary()
 
         summary2 = model.evaluate(df)
         self.assertTrue(isinstance(summary2, BinaryRandomForestClassificationSummary))
@@ -905,9 +889,6 @@ class ClassificationTestsMixin:
             self.assertEqual(summary.predictions.columns, expected_cols)
 
         check_summary()
-        if is_remote():
-            self.spark.client._delete_ml_cache([model._java_obj._ref_id], evict_only=True)
-            check_summary()
 
         summary2 = model.evaluate(df)
         self.assertTrue(isinstance(summary2, RandomForestClassificationSummary))
@@ -1006,9 +987,6 @@ class ClassificationTestsMixin:
             self.assertEqual(summary.predictions.columns, expected_cols)
 
         check_summary()
-        if is_remote():
-            self.spark.client._delete_ml_cache([model._java_obj._ref_id], evict_only=True)
-            check_summary()
 
         summary2 = model.evaluate(df)
         self.assertIsInstance(summary2, MultilayerPerceptronClassificationSummary)

--- a/python/pyspark/ml/tests/test_regression.py
+++ b/python/pyspark/ml/tests/test_regression.py
@@ -43,7 +43,6 @@ from pyspark.ml.regression import (
     GBTRegressor,
     GBTRegressionModel,
 )
-from pyspark.sql import is_remote
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 
 
@@ -243,9 +242,6 @@ class RegressionTestsMixin:
             self.assertTrue(np.allclose(summary.r2adj, -0.6718362282878414, atol=1e-4))
 
         check_summary()
-        if is_remote():
-            self.spark.client._delete_ml_cache([model._java_obj._ref_id], evict_only=True)
-            check_summary()
 
         summary2 = model.evaluate(df)
         self.assertTrue(isinstance(summary2, LinearRegressionSummary))
@@ -359,9 +355,6 @@ class RegressionTestsMixin:
             self.assertEqual(summary.residuals().count(), 4)
 
         check_summary()
-        if is_remote():
-            self.spark.client._delete_ml_cache([model._java_obj._ref_id], evict_only=True)
-            check_summary()
 
         summary = model.summary
         summary2 = model.evaluate(df)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Restore `test_parity_classification` and `test_parity_regression`

the changes for model summary offloading in https://github.com/apache/spark/commit/fd74b5ec6bd662ca51ea6bec06c4432503e566d4#diff-50ad4e7f2b34a05cb38c56cd47491239b09002d1f95e59b6a1d0b257e9ec5b8e seems problematical, and cause dead lock in the python side.

```py
  test_multinomial_logistic_regression_with_bound (pyspark.ml.tests.connect.test_parity_classification.ClassificationParityTests.test_multinomial_logistic_regression_with_bound) ... Exception ignored in: <function JavaWrapper.__del__ at 0x108b5e020>
Traceback (most recent call last):
  File "/Users/ruifeng.zheng/spark/python/pyspark/ml/util.py", line 379, in wrapped
    self._remote_model_obj.release_ref()
  File "/Users/ruifeng.zheng/spark/python/pyspark/ml/util.py", line 162, in release_ref
    del_remote_cache(self.ref_id)
  File "/Users/ruifeng.zheng/spark/python/pyspark/ml/util.py", line 358, in del_remote_cache
    session.client._delete_ml_cache([ref_id])
  File "/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/client/core.py", line 2133, in _delete_ml_cache
    (_, properties, _) = self.execute_command(command)
  File "/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/client/core.py", line 1158, in execute_command
    data, _, metrics, observed_metrics, properties = self._execute_and_fetch(
  File "/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/client/core.py", line 1660, in _execute_and_fetch
    for response in self._execute_and_fetch_as_iterator(
  File "/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/client/core.py", line 1635, in _execute_and_fetch_as_iterator
    raise kb
  File "/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/client/core.py", line 1617, in _execute_and_fetch_as_iterator
    generator = ExecutePlanResponseReattachableIterator(
  File "/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/client/reattach.py", line 127, in __init__
    self._stub.ExecutePlan(self._initial_request, metadata=metadata)
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/site-packages/grpc/_channel.py", line 1396, in __call__
    call = self._managed_call(
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/site-packages/grpc/_channel.py", line 1784, in create
    with state.lock:
  File "/Users/ruifeng.zheng/spark/python/pyspark/core/context.py", line 409, in signal_handler
    raise KeyboardInterrupt()
KeyboardInterrupt:
```


I plan to add dedicated test for model summary offloading in separate PR, this PR is to restore the basic coverage

### Why are the changes needed?
for test coverage


### Does this PR introduce _any_ user-facing change?
no,test-only


### How was this patch tested?
Manually run the test in my local, the hanging issue doesn't occur in successive 10 runs




### Was this patch authored or co-authored using generative AI tooling?
no
