### PR TITLE
[SPARK-54735][SQL] Properly preserve column comments in view with SCHEMA EVOLUTION

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -235,6 +235,7 @@ object AnalysisContext {
 object Analyzer {
   // List of configurations that should be passed on when resolving views and SQL UDF.
   private val RETAINED_ANALYSIS_FLAGS = Seq(
+    "spark.sql.view.schemaEvolution.preserveUserComments",
     // retainedHiveConfigs
     // TODO: remove these Hive-related configs after the `RelationConversions` is moved to
     // optimization phase.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2189,7 +2189,7 @@ object SQLConf {
       .doc("When enabled, views with SCHEMA EVOLUTION mode will preserve user-set view comments " +
         "when the underlying table schema evolves. When disabled, view comments will be " +
         "overwritten with table comments on every schema sync.")
-      .version("4.0.0")
+      .version("4.2.0")
       .booleanConf
       .createWithDefault(true)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2183,6 +2183,16 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val VIEW_SCHEMA_EVOLUTION_PRESERVE_USER_COMMENTS =
+    buildConf("spark.sql.view.schemaEvolution.preserveUserComments")
+      .internal()
+      .doc("When enabled, views with SCHEMA EVOLUTION mode will preserve user-set view comments " +
+        "when the underlying table schema evolves. When disabled, view comments will be " +
+        "overwritten with table comments on every schema sync.")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val OUTPUT_COMMITTER_CLASS = buildConf("spark.sql.sources.outputCommitterClass")
     .version("1.4.0")
     .internal()
@@ -7466,6 +7476,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def viewSchemaBindingEnabled: Boolean = getConf(VIEW_SCHEMA_BINDING_ENABLED)
 
   def viewSchemaCompensation: Boolean = getConf(VIEW_SCHEMA_COMPENSATION)
+
+  def viewSchemaEvolutionPreserveUserComments: Boolean =
+    getConf(VIEW_SCHEMA_EVOLUTION_PRESERVE_USER_COMMENTS)
 
   def defaultCacheStorageLevel: StorageLevel =
     StorageLevel.fromString(getConf(DEFAULT_CACHE_STORAGE_LEVEL).name())

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -701,9 +701,10 @@ object ViewSyncSchemaToMetaStore extends (LogicalPlan => Unit) {
                   field.getComment() != planField.getComment()))))
         }
 
+        lazy val viewFieldsByName = viewFields.map(f => f.name -> f).toMap
+
         if (redo) {
           val newSchema = if (viewSchemaMode == SchemaTypeEvolution) {
-            val viewFieldsByName = viewFields.map(f => f.name -> f).toMap
             val newFields = viewQuery.schema.map {
               case StructField(name, dataType, nullable, _) =>
                 StructField(name, dataType, nullable,
@@ -712,7 +713,6 @@ object ViewSyncSchemaToMetaStore extends (LogicalPlan => Unit) {
             StructType(newFields)
           } else if (session.sessionState.conf.viewSchemaEvolutionPreserveUserComments) {
             // Adopt types/nullable/names from query, but preserve view comments.
-            val viewFieldsByName = viewFields.map(f => f.name -> f).toMap
             val newFields = viewQuery.schema.map { planField =>
               val metadataToUse = viewFieldsByName.get(planField.name) match {
                 case Some(viewField) =>

--- a/sql/core/src/test/resources/sql-tests/results/view-schema-evolution.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/view-schema-evolution.sql.out
@@ -897,8 +897,8 @@ DESCRIBE EXTENDED v
 -- !query schema
 struct<col_name:string,data_type:string,comment:string>
 -- !query output
-c1                  	bigint              	c1 6e               
-c2                  	string              	c2 6e               
+c1                  	bigint              	c1 6d               
+c2                  	string              	c2 6d               
                     	                    	                    
 # Detailed Table Information	                    	                    
 Catalog             	spark_catalog       	                    

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAM
 import org.apache.spark.sql.errors.DataTypeErrors.toSQLId
 import org.apache.spark.sql.internal.SQLConf._
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
-import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
+import org.apache.spark.sql.types.{DoubleType, IntegerType, StringType, StructField, StructType}
 import org.apache.spark.util.ArrayImplicits._
 
 /**
@@ -861,6 +861,81 @@ class PersistedViewTestSuite extends SQLViewTestSuite with SharedSparkSession {
         assert(updatedTable.properties.get(VIEW_SCHEMA_MODE) === Some("EVOLUTION"))
         assert(!updatedTable.properties.exists(_._1.startsWith(VIEW_QUERY_OUTPUT_PREFIX)))
         assert(!updatedTable.properties.exists(_._1.startsWith(VIEW_QUERY_OUTPUT_NUM_COLUMNS)))
+      }
+    }
+  }
+
+  test("Schema evolution views should preserve manually set comments") {
+    withTable("t") {
+      withView("v") {
+        // Create table with comments.
+        sql("CREATE TABLE t (c1 INT COMMENT " +
+          "'table comment 1', c2 STRING COMMENT 'table comment 2')")
+        sql("INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+
+        // Create view with schema evolution (no column list) - initially adopts table comments.
+        sql("CREATE VIEW v WITH SCHEMA EVOLUTION AS SELECT * FROM t")
+
+        // Verify initial comments from table are adopted.
+        val descInitial = sql("DESCRIBE EXTENDED v").collect()
+        val c1CommentInitial = descInitial.filter(r => r.getString(0) == "c1")
+        val c2CommentInitial = descInitial.filter(r => r.getString(0) == "c2")
+        assert(c1CommentInitial.nonEmpty && c1CommentInitial(0).getString(2) == "table comment 1",
+          "Initial c1 comment should be 'table comment 1' from table")
+        assert(c2CommentInitial.nonEmpty && c2CommentInitial(0).getString(2) == "table comment 2",
+          "Initial c2 comment should be 'table comment 2' from table")
+
+        // Simulate user manually changing view comments (via UI or ALTER COLUMN).
+        val catalog = spark.sessionState.catalog
+        val viewMeta = catalog.getTableMetadata(TableIdentifier("v"))
+        val newSchema = StructType(Seq(
+          StructField("c1", IntegerType, nullable = true).withComment("user comment 1"),
+          StructField("c2", StringType, nullable = true).withComment("user comment 2")
+        ))
+        catalog.alterTable(viewMeta.copy(schema = newSchema))
+
+        // Verify manually set comments.
+        val descManual = sql("DESCRIBE EXTENDED v").collect()
+        val c1CommentManual = descManual.filter(r => r.getString(0) == "c1")
+        val c2CommentManual = descManual.filter(r => r.getString(0) == "c2")
+        assert(c1CommentManual.nonEmpty && c1CommentManual(0).getString(2) == "user comment 1",
+          "c1 comment should be 'user comment 1'")
+        assert(c2CommentManual.nonEmpty && c2CommentManual(0).getString(2) == "user comment 2",
+          "c2 comment should be 'user comment 2'")
+
+        // SELECT from view (triggers ViewSyncSchemaToMetaStore).
+        checkAnswer(sql("SELECT * FROM v"), Seq(Row(1, "a"), Row(2, "b"), Row(3, "c")))
+
+        // Verify manually set comments are PRESERVED (not reverted to table comments).
+        val descAfterSelect = sql("DESCRIBE EXTENDED v").collect()
+        val c1CommentAfter = descAfterSelect.filter(r => r.getString(0) == "c1")
+        val c2CommentAfter = descAfterSelect.filter(r => r.getString(0) == "c2")
+        assert(c1CommentAfter.nonEmpty && c1CommentAfter(0).getString(2) == "user comment 1",
+          "c1 comment should still be 'user comment 1' after SELECT (bug: was reverted)")
+        assert(c2CommentAfter.nonEmpty && c2CommentAfter(0).getString(2) == "user comment 2",
+          "c2 comment should still be 'user comment 2' after SELECT (bug: was reverted)")
+
+        // Verify that type changes are still adopted.
+        sql("DROP TABLE t")
+        sql("CREATE TABLE t (c1 BIGINT COMMENT 'table comment changed', " +
+          "c2 DOUBLE COMMENT 'table comment changed 2')")
+        sql("INSERT INTO t VALUES (4, 5.0), (6, 7.0)")
+
+        // SELECT from view - should adopt new types but preserve view comments.
+        checkAnswer(sql("SELECT * FROM v"), Seq(Row(4, 5.0), Row(6, 7.0)))
+
+        // Verify types changed but comments preserved.
+        val descAfterTypeChange = sql("DESCRIBE EXTENDED v").collect()
+        val c1Final = descAfterTypeChange.filter(r => r.getString(0) == "c1")
+        val c2Final = descAfterTypeChange.filter(r => r.getString(0) == "c2")
+        assert(c1Final.nonEmpty && c1Final(0).getString(1) == "bigint",
+          "c1 type should be updated to bigint")
+        assert(c2Final.nonEmpty && c2Final(0).getString(1) == "double",
+          "c2 type should be updated to double")
+        assert(c1Final.nonEmpty && c1Final(0).getString(2) == "user comment 1",
+          "c1 comment should still be 'user comment 1' (preserved)")
+        assert(c2Final.nonEmpty && c2Final(0).getString(2) == "user comment 2",
+          "c2 comment should still be 'user comment 2' (preserved)")
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -941,7 +941,7 @@ class PersistedViewTestSuite extends SQLViewTestSuite with SharedSparkSession {
   }
 
   test("Schema evolution comments legacy behavior with preserveUserComments=false") {
-    withSQLConf(SQLConf.VIEW_SCHEMA_EVOLUTION_PRESERVE_USER_COMMENTS.key -> "false") {
+    withSQLConf(VIEW_SCHEMA_EVOLUTION_PRESERVE_USER_COMMENTS.key -> "false") {
       withTable("t") {
         withView("v") {
           // Create table with comments.
@@ -1004,7 +1004,7 @@ class PersistedViewTestSuite extends SQLViewTestSuite with SharedSparkSession {
         catalog.alterTable(viewMeta.copy(schema = newSchema))
 
         // Test with flag ENABLED (default) - should preserve.
-        withSQLConf(SQLConf.VIEW_SCHEMA_EVOLUTION_PRESERVE_USER_COMMENTS.key -> "true") {
+        withSQLConf(VIEW_SCHEMA_EVOLUTION_PRESERVE_USER_COMMENTS.key -> "true") {
           checkAnswer(sql("SELECT * FROM v"), Seq(Row(1, "a")))
           val descEnabled = sql("DESCRIBE EXTENDED v").collect()
           val c1Enabled = descEnabled.filter(r => r.getString(0) == "c1")
@@ -1016,7 +1016,7 @@ class PersistedViewTestSuite extends SQLViewTestSuite with SharedSparkSession {
         catalog.alterTable(viewMeta.copy(schema = newSchema))
 
         // Test with flag DISABLED - should revert.
-        withSQLConf(SQLConf.VIEW_SCHEMA_EVOLUTION_PRESERVE_USER_COMMENTS.key -> "false") {
+        withSQLConf(VIEW_SCHEMA_EVOLUTION_PRESERVE_USER_COMMENTS.key -> "false") {
           checkAnswer(sql("SELECT * FROM v"), Seq(Row(1, "a")))
           val descDisabled = sql("DESCRIBE EXTENDED v").collect()
           val c1Disabled = descDisabled.filter(r => r.getString(0) == "c1")


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR I propose a fix to avoid overwriting user defined comments in views that have schema evolution enabled.

### Why are the changes needed?
When user creates a view with `SCHEMA EVOLUTION`, and then changes the comments on view columns, by using `DESCRIBE`, they are able to see new comments, but after executing a query on a view, comment values are reversed to a values from the underlying table (schema evolution enabled).


In the proposed fix, if the column name is changed, comments from the table will be adopted (consistent with evolution semantics).


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit test in `SQLViewTestSuite`.


### Was this patch authored or co-authored using generative AI tooling?
No.
