### PR TITLE
[SPARK-54738][PYTHON] Add Profiler Support for Pandas Grouped Iter Aggregate UDF

### DIFF
--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -439,6 +439,7 @@ class UserDefinedFunction:
                 PythonEvalType.SQL_MAP_PANDAS_ITER_UDF,
                 PythonEvalType.SQL_MAP_ARROW_ITER_UDF,
                 PythonEvalType.SQL_GROUPED_AGG_ARROW_ITER_UDF,
+                PythonEvalType.SQL_GROUPED_AGG_PANDAS_ITER_UDF,
             ]:
                 warnings.warn(
                     "Profiling UDFs with iterators input/output is not supported.",


### PR DESCRIPTION
### What changes were proposed in this pull request?

- `spark.python.profile`: Add `SQL_GROUPED_AGG_PANDAS_ITER_UDF` to the profiler warning list in `udf.py` so that when `spark.python.profile` is enabled, users will see appropriate warnings consistent with other iterator-based UDFs.
- `spark.sql.pyspark.udf.profiler`: No changes needed. This UDF type already works correctly because it returns scalar (not iterator), so it uses the non-iterator profiler branch in `wrap_perf_profiler` and `wrap_memory_profiler`.

### Why are the changes needed?

To make profilers support for `SQL_GROUPED_AGG_PANDAS_ITER_UDF` consistent with other UDFs.

### Does this PR introduce _any_ user-facing change?

Yes. When users enable `spark.python.profile` with `SQL_GROUPED_AGG_PANDAS_ITER_UDF`, they will now see a warning message consistent with other iterator-based UDFs.

### How was this patch tested?

Added a test case `test_perf_profiler_pandas_udf_grouped_agg_iter` to verify that `spark.sql.pyspark.udf.profiler` works correctly with this UDF type. Also verified that the `spark.python.profile` profiler warning is triggered correctly in `test_unsupported`.

### Was this patch authored or co-authored using generative AI tooling?

No.
