### PR TITLE
[SPARK-54743][SS] Fix NullPointerException in stream-stream join with state format v2/v3

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/SymmetricHashJoinStateManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/SymmetricHashJoinStateManager.scala
@@ -147,6 +147,8 @@ abstract class SymmetricHashJoinStateManager(
     val numValues = keyToNumValues.get(key)
     keyWithIndexToValue.getAll(key, numValues).filterNot { keyIdxToValue =>
       excludeRowsAlreadyMatched && keyIdxToValue.matched
+    }.filter { keyIdxToValue =>
+      keyIdxToValue.value != null
     }.map { keyIdxToValue =>
       val joinedRow = generateJoinedRow(keyIdxToValue.value)
       if (predicate(joinedRow)) {
@@ -714,9 +716,13 @@ SnapshotOptions
     }
 
     override def convertToValueRow(value: UnsafeRow, matched: Boolean): UnsafeRow = {
-      val row = valueWithMatchedRowGenerator(value)
-      row.setBoolean(indexOrdinalInValueWithMatchedRow, matched)
-      row
+      if (value == null) {
+        null
+      } else {
+        val row = valueWithMatchedRowGenerator(value)
+        row.setBoolean(indexOrdinalInValueWithMatchedRow, matched)
+        row
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR fixes a NullPointerException that occurs in stream-stream joins when using state format versions 2 or 3. The issue arises when null values are present in the state store during join operations.

The fix includes:
1. Adding null filtering in `getJoinedRows()` to skip null values before processing
2. Adding null check in `convertToValueRow()` to handle null input gracefully
3. Comprehensive test coverage for null handling in `SymmetricHashJoinStateManagerSuite`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When state format v2/v3 is used, null values can be stored in the state. The `getJoinedRows()` method did not handle these null values properly, leading to NullPointerException when attempting to generate joined rows. This causes stream-stream join queries to fail unexpectedly.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added new test `testGetJoinedRowsWithNulls` in `SymmetricHashJoinStateManagerSuite` that:
  - Creates a state with valid values
  - Artificially introduces null values in the state
  - Verifies that `getJoinedRows()` correctly skips nulls without throwing NPE
  - Tests various predicates and edge cases
  - Verifies the fix works for both state format versions 2 and 3

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No