### PR TITLE
[SPARK-54754][SQL] OrcSerializer should not parse the schema every time it is serialized

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcSerializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcSerializer.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.catalyst.expressions.SpecializedGetters
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.types._
 
-
 /**
  * A serializer to serialize Spark rows to ORC structs.
  */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcSerializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcSerializer.scala
@@ -17,7 +17,10 @@
 
 package org.apache.spark.sql.execution.datasources.orc
 
+import scala.jdk.CollectionConverters._
+
 import org.apache.hadoop.io._
+import org.apache.orc.TypeDescription
 import org.apache.orc.mapred.{OrcList, OrcMap, OrcStruct, OrcTimestamp}
 
 import org.apache.spark.SparkException
@@ -26,13 +29,18 @@ import org.apache.spark.sql.catalyst.expressions.SpecializedGetters
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.types._
 
+
 /**
  * A serializer to serialize Spark rows to ORC structs.
  */
 class OrcSerializer(dataSchema: StructType) {
-
-  private val result = createOrcValue(dataSchema).asInstanceOf[OrcStruct]
-  private val converters = dataSchema.map(_.dataType).map(newConverter(_)).toArray
+  private val resultTypeDescription = OrcUtils.orcTypeDescription(dataSchema)
+  private val result = OrcStruct.createValue(resultTypeDescription).asInstanceOf[OrcStruct]
+  private val converters =
+    dataSchema.map(_.dataType).zip(resultTypeDescription.getChildren.asScala).map {
+      case (dt, orcType) =>
+        newConverter(dt, orcType)
+    }.toArray
 
   def serialize(row: InternalRow): OrcStruct = {
     var i = 0
@@ -54,6 +62,7 @@ class OrcSerializer(dataSchema: StructType) {
    */
   private def newConverter(
       dataType: DataType,
+      orcType: TypeDescription,
       reuseObj: Boolean = true): Converter = dataType match {
     case NullType => (getter, ordinal) => null
 
@@ -151,8 +160,11 @@ class OrcSerializer(dataSchema: StructType) {
       OrcShimUtils.getHiveDecimalWritable(precision, scale)
 
     case st: StructType => (getter, ordinal) =>
-      val result = createOrcValue(st).asInstanceOf[OrcStruct]
-      val fieldConverters = st.map(_.dataType).map(newConverter(_)).toArray
+      val result = OrcStruct.createValue(orcType).asInstanceOf[OrcStruct]
+      val fieldConverters = st.map(_.dataType).zip(orcType.getChildren.asScala).map {
+        case (dt, orcType) =>
+          newConverter(dt, orcType)
+      }
       val numFields = st.length
       val struct = getter.getStruct(ordinal, numFields)
       var i = 0
@@ -167,9 +179,10 @@ class OrcSerializer(dataSchema: StructType) {
       result
 
     case ArrayType(elementType, _) => (getter, ordinal) =>
-      val result = createOrcValue(dataType).asInstanceOf[OrcList[WritableComparable[_]]]
+      val result = OrcStruct.createValue(orcType)
+        .asInstanceOf[OrcList[WritableComparable[_]]]
       // Need to put all converted values to a list, can't reuse object.
-      val elementConverter = newConverter(elementType, reuseObj = false)
+      val elementConverter = newConverter(elementType, orcType.getChildren.get(0), reuseObj = false)
       val array = getter.getArray(ordinal)
       var i = 0
       while (i < array.numElements()) {
@@ -183,11 +196,12 @@ class OrcSerializer(dataSchema: StructType) {
       result
 
     case MapType(keyType, valueType, _) => (getter, ordinal) =>
-      val result = createOrcValue(dataType)
+      val result = OrcStruct.createValue(orcType)
         .asInstanceOf[OrcMap[WritableComparable[_], WritableComparable[_]]]
       // Need to put all converted values to a list, can't reuse object.
-      val keyConverter = newConverter(keyType, reuseObj = false)
-      val valueConverter = newConverter(valueType, reuseObj = false)
+      val orcChildSchema = orcType.getChildren
+      val keyConverter = newConverter(keyType, orcChildSchema.get(0), reuseObj = false)
+      val valueConverter = newConverter(valueType, orcChildSchema.get(1), reuseObj = false)
       val map = getter.getMap(ordinal)
       val keyArray = map.keyArray()
       val valueArray = map.valueArray()
@@ -203,15 +217,8 @@ class OrcSerializer(dataSchema: StructType) {
       }
       result
 
-    case udt: UserDefinedType[_] => newConverter(udt.sqlType)
+    case udt: UserDefinedType[_] => newConverter(udt.sqlType, orcType)
 
     case _ => throw SparkException.internalError(s"Unsupported data type $dataType.")
-  }
-
-  /**
-   * Return a Orc value object for the given Spark schema.
-   */
-  private def createOrcValue(dataType: DataType) = {
-    OrcStruct.createValue(OrcUtils.orcTypeDescription(dataType))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcSerializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcSerializer.scala
@@ -163,7 +163,7 @@ class OrcSerializer(dataSchema: StructType) {
       val fieldConverters = st.map(_.dataType).zip(orcType.getChildren.asScala).map {
         case (dt, orcType) =>
           newConverter(dt, orcType)
-      }
+      }.toArray
       val numFields = st.length
       val struct = getter.getStruct(ordinal, numFields)
       var i = 0

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -526,4 +526,26 @@ object OrcUtils extends Logging {
       resultRow
     }
   }
+
+  def orcTypeDescription(dt: DataType): TypeDescription = {
+    dt match {
+      case s: StructType =>
+        val result = new TypeDescription(TypeDescription.Category.STRUCT)
+        s.fields.foreach { f =>
+          result.addField(f.name, orcTypeDescription(f.dataType))
+        }
+        result
+      case a: ArrayType =>
+        val result = new TypeDescription(TypeDescription.Category.LIST)
+        result.addChild(orcTypeDescription(a.elementType))
+        result
+      case m: MapType =>
+        val result = new TypeDescription(TypeDescription.Category.MAP)
+        result.addChild(orcTypeDescription(m.keyType))
+        result.addChild(orcTypeDescription(m.valueType))
+        result
+      case other =>
+        TypeDescription.fromString(other.catalogString)
+    }
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -526,26 +526,4 @@ object OrcUtils extends Logging {
       resultRow
     }
   }
-
-  def orcTypeDescription(dt: DataType): TypeDescription = {
-    dt match {
-      case s: StructType =>
-        val result = new TypeDescription(TypeDescription.Category.STRUCT)
-        s.fields.foreach { f =>
-          result.addField(f.name, orcTypeDescription(f.dataType))
-        }
-        result
-      case a: ArrayType =>
-        val result = new TypeDescription(TypeDescription.Category.LIST)
-        result.addChild(orcTypeDescription(a.elementType))
-        result
-      case m: MapType =>
-        val result = new TypeDescription(TypeDescription.Category.MAP)
-        result.addChild(orcTypeDescription(m.keyType))
-        result.addChild(orcTypeDescription(m.valueType))
-        result
-      case other =>
-        TypeDescription.fromString(other.catalogString)
-    }
-  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
For maps, arrays, and structs, calling `OrcUtils.orcTypeDescription(dataType)` during each serialization process is quite time-consuming. We can reuse `TypeDescription`.

I tested calling OrcSerializer#serialize with the 10k/100k/1m  rows of data, the schema of which is as follows:
  ```
private val schema: StructType = StructType(Seq(
    StructField("id", LongType, nullable = false),
    StructField("attrs",
      MapType(StringType, MapType(StringType, IntegerType, valueContainsNull = false),
        valueContainsNull = true),
      nullable = true)
  ))
```

Test result:
row count | master | pr | time saving
 -- | -- | -- | --
10k | 16 ms | 8 ms | 50%
100k | 201 ms | 143 ms | 29%
1m | 1799 ms | 1056 ms | 41%

The above benchmarks were run on my local machine. 


### Why are the changes needed?
Improve performance of OrcSerializer#serialize.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing UTs.
New benchmark (in a separate PR)

### Was this patch authored or co-authored using generative AI tooling?
No.
