### PR TITLE
[SPARK-54868][PYTHON][INFRA] Fail hanging tests and log the tracebacks 

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -48,7 +48,7 @@ on:
           in this file, e.g., build. See precondition job below.
         required: false
         type: string
-        default: ''
+        default: '{"pyspark": "true", "pyspark-pandas": "true"}'
     secrets:
       codecov_token:
         description: The upload token of codecov.

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -566,6 +566,7 @@ jobs:
       SKIP_PACKAGING: true
       METASPACE_SIZE: 1g
       BRANCH: ${{ inputs.branch }}
+      PYSPARK_TEST_TIMEOUT: 100
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v4

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -48,7 +48,7 @@ on:
           in this file, e.g., build. See precondition job below.
         required: false
         type: string
-        default: '{"pyspark": "true", "pyspark-pandas": "true"}'
+        default: ''
     secrets:
       codecov_token:
         description: The upload token of codecov.
@@ -566,7 +566,7 @@ jobs:
       SKIP_PACKAGING: true
       METASPACE_SIZE: 1g
       BRANCH: ${{ inputs.branch }}
-      PYSPARK_TEST_TIMEOUT: 100
+      PYSPARK_TEST_TIMEOUT: 300
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v4

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -182,7 +182,6 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
     def setUpClass(cls):
         if os.environ.get("PYSPARK_TEST_TIMEOUT"):
             faulthandler.register(signal.SIGTERM, file=sys.__stderr__, all_threads=True)
-            # faulthandler.register(signal.SIGUSR1, file=sys.__stderr__, all_threads=True)
 
         # This environment variable is for interrupting hanging ML-handler and making the
         # tests fail fast.
@@ -206,7 +205,6 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
     def tearDownClass(cls):
         if os.environ.get("PYSPARK_TEST_TIMEOUT"):
             faulthandler.unregister(signal.SIGTERM)
-            # faulthandler.unregister(signal.SIGUSR1)
 
         shutil.rmtree(cls.tempdir.name, ignore_errors=True)
         cls.spark.stop()

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -181,8 +181,7 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
     @classmethod
     def setUpClass(cls):
         if os.environ.get("PYSPARK_TEST_TIMEOUT"):
-            faulthandler.enable(file=sys.__stderr__)
-            faulthandler.register(signal.SIGUSR1, file=sys.__stderr__, all_threads=True)
+            faulthandler.register(signal.SIGTERM, file=sys.__stderr__, all_threads=True)
 
         # This environment variable is for interrupting hanging ML-handler and making the
         # tests fail fast.
@@ -205,8 +204,7 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
     @classmethod
     def tearDownClass(cls):
         if os.environ.get("PYSPARK_TEST_TIMEOUT"):
-            faulthandler.disable()
-            faulthandler.unregister(signal.SIGUSR1)
+            faulthandler.unregister(signal.SIGTERM)
 
         shutil.rmtree(cls.tempdir.name, ignore_errors=True)
         cls.spark.stop()

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -182,6 +182,7 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
     def setUpClass(cls):
         if os.environ.get("PYSPARK_TEST_TIMEOUT"):
             faulthandler.register(signal.SIGTERM, file=sys.__stderr__, all_threads=True)
+            # faulthandler.register(signal.SIGUSR1, file=sys.__stderr__, all_threads=True)
 
         # This environment variable is for interrupting hanging ML-handler and making the
         # tests fail fast.
@@ -205,6 +206,7 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
     def tearDownClass(cls):
         if os.environ.get("PYSPARK_TEST_TIMEOUT"):
             faulthandler.unregister(signal.SIGTERM)
+            # faulthandler.unregister(signal.SIGUSR1)
 
         shutil.rmtree(cls.tempdir.name, ignore_errors=True)
         cls.spark.stop()

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -17,6 +17,9 @@
 import shutil
 import tempfile
 import os
+import sys
+import signal
+import faulthandler
 import functools
 import unittest
 import uuid
@@ -194,6 +197,8 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
         os.unlink(cls.tempdir.name)
         cls.testData = [Row(key=i, value=str(i)) for i in range(100)]
         cls.df = cls.spark.createDataFrame(cls.testData)
+        faulthandler.enable(file=sys.__stderr__)
+        faulthandler.register(signal.SIGUSR1, file=sys.__stderr__, all_threads=True)
 
     @classmethod
     def tearDownClass(cls):

--- a/python/pyspark/tests/test_util.py
+++ b/python/pyspark/tests/test_util.py
@@ -199,6 +199,11 @@ class HandleWorkerExceptionTests(unittest.TestCase):
         self.assertIn(self.exception_bytes, result)
         self.assertNotIn(self.traceback_bytes, result)
 
+    # @unittest.skip("temporary test for PYSPARK_TEST_TIMEOUT")
+    def test_timeout(self):
+        import time
+
+        time.sleep(100)
 
 if __name__ == "__main__":
     from pyspark.tests.test_util import *  # noqa: F401

--- a/python/pyspark/tests/test_util.py
+++ b/python/pyspark/tests/test_util.py
@@ -199,11 +199,6 @@ class HandleWorkerExceptionTests(unittest.TestCase):
         self.assertIn(self.exception_bytes, result)
         self.assertNotIn(self.traceback_bytes, result)
 
-    # @unittest.skip("temporary test for PYSPARK_TEST_TIMEOUT")
-    def test_timeout(self):
-        import time
-
-        time.sleep(100)
 
 if __name__ == "__main__":
     from pyspark.tests.test_util import *  # noqa: F401

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -266,7 +266,9 @@ def run_individual_python_test(target_dir, test_name, pyspark_python, keep_test_
                 shutil.rmtree(tmp_dir, ignore_errors=True)
     except subprocess.TimeoutExpired:
         if timeout and proc:
-            LOGGER.exception("Got TimeoutExpired while running %s with %s", test_name, pyspark_python)
+            LOGGER.exception(
+                "Got TimeoutExpired while running %s with %s", test_name, pyspark_python
+            )
             proc.terminate()
             proc.communicate(timeout=60)
         else:

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -235,11 +235,10 @@ def run_individual_python_test(target_dir, test_name, pyspark_python, keep_test_
 
     env["PYSPARK_SUBMIT_ARGS"] = " ".join(spark_args)
 
-    timeout = int(os.environ.get("PYSPARK_TEST_TIMEOUT", 100))
-    if timeout == 0:
-        timeout = None
-    else:
-        env["PYSPARK_TEST_TIMEOUT"] = str(timeout)
+    timeout = os.environ.get("PYSPARK_TEST_TIMEOUT")
+    if timeout is not None:
+        env["PYSPARK_TEST_TIMEOUT"] = timeout
+        timeout = int(timeout)
 
     output_prefix = get_valid_filename(pyspark_python + "__" + test_name + "__").lstrip("_")
     # Delete is always set to False since the cleanup will be either done by removing the
@@ -265,10 +264,8 @@ def run_individual_python_test(target_dir, test_name, pyspark_python, keep_test_
                 shutil.rmtree(tmp_dir, ignore_errors=True)
     except subprocess.TimeoutExpired:
         LOGGER.exception("Got TimeoutExpired while running %s with %s", test_name, pyspark_python)
-        proc.send_signal(signal.SIGUSR1)
-        time.sleep(1)
         proc.terminate()
-        outs, errs = proc.communicate()
+        proc.communicate()
     except BaseException:
         LOGGER.exception("Got exception while running %s with %s", test_name, pyspark_python)
         # Here, we use os._exit() instead of sys.exit() in order to force Python to exit even if

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -235,7 +235,7 @@ def run_individual_python_test(target_dir, test_name, pyspark_python, keep_test_
 
     env["PYSPARK_SUBMIT_ARGS"] = " ".join(spark_args)
 
-    timeout = int(os.environ.get("PYSPARK_TEST_TIMEOUT", 300))
+    timeout = int(os.environ.get("PYSPARK_TEST_TIMEOUT", 100))
     if timeout == 0:
         timeout = None
     else:

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -22,7 +22,6 @@ import logging
 from argparse import ArgumentParser
 import os
 import io
-import signal
 import platform
 import pty
 import re
@@ -268,10 +267,8 @@ def run_individual_python_test(target_dir, test_name, pyspark_python, keep_test_
     except subprocess.TimeoutExpired:
         if timeout and proc:
             LOGGER.exception("Got TimeoutExpired while running %s with %s", test_name, pyspark_python)
-            # proc.send_signal(signal.SIGUSR1)
-            # time.sleep(3)
             proc.terminate()
-            proc.communicate(timeout=3)
+            proc.communicate(timeout=60)
         else:
             raise
     except BaseException:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fail hanging tests and log the tracebacks
The timeout is set by env `PYSPARK_TEST_TIMEOUT`


### Why are the changes needed?
when a test gets stuck, there is no useful information


### Does this PR introduce _any_ user-facing change?
no, dev-only


### How was this patch tested?
1, PR builder with 
```
PYSPARK_TEST_TIMEOUT: 100
```

https://github.com/zhengruifeng/spark/actions/runs/20522703690/job/58962106131

2, manually check
```
(spark_dev_313) ➜  spark git:(py_test_timeout) PYSPARK_TEST_TIMEOUT=15 python/run-tests -k --python-executables python3 --testnames 'pyspark.ml.tests.connect.test_parity_clustering'
Running PySpark tests. Output is in /Users/ruifeng.zheng/spark/python/unit-tests.log
Will test against the following Python executables: ['python3']
Will test the following Python tests: ['pyspark.ml.tests.connect.test_parity_clustering']
python3 python_implementation is CPython
python3 version is: Python 3.13.5
Starting test(python3): pyspark.ml.tests.connect.test_parity_clustering (temp output: /Users/ruifeng.zheng/spark/python/target/c014880c-80d2-49db-8fb1-a26ab4e5246d/python3__pyspark.ml.tests.connect.test_parity_clustering__u8n7t6zc.log)
Got TimeoutExpired while running pyspark.ml.tests.connect.test_parity_clustering with python3
Traceback (most recent call last):
  File "/Users/ruifeng.zheng/spark/./python/run-tests.py", line 157, in run_individual_python_test
    retcode = proc.wait(timeout=timeout)
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/subprocess.py", line 1280, in wait
    return self._wait(timeout=timeout)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/subprocess.py", line 2058, in _wait
    raise TimeoutExpired(self.args, timeout)
subprocess.TimeoutExpired: Command '['/Users/ruifeng.zheng/spark/bin/pyspark', 'pyspark.ml.tests.connect.test_parity_clustering']' timed out after 15 seconds

Running tests...
----------------------------------------------------------------------
WARNING: Using incubator modules: jdk.incubator.vector
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/conf.py:64: UserWarning: Failed to set spark.connect.execute.reattachable.senderMaxStreamDuration to Some(1s) due to [CANNOT_MODIFY_STATIC_CONFIG] Cannot modify the value of the static Spark config: "spark.connect.execute.reattachable.senderMaxStreamDuration". SQLSTATE: 46110
  warnings.warn(warn)
/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/conf.py:64: UserWarning: Failed to set spark.connect.execute.reattachable.senderMaxStreamSize to Some(123) due to [CANNOT_MODIFY_STATIC_CONFIG] Cannot modify the value of the static Spark config: "spark.connect.execute.reattachable.senderMaxStreamSize". SQLSTATE: 46110
  warnings.warn(warn)
/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/conf.py:64: UserWarning: Failed to set spark.connect.authenticate.token to Some(deadbeef) due to [CANNOT_MODIFY_STATIC_CONFIG] Cannot modify the value of the static Spark config: "spark.connect.authenticate.token". SQLSTATE: 46110
  warnings.warn(warn)
  test_assert_remote_mode (pyspark.ml.tests.connect.test_parity_clustering.ClusteringParityTests.test_assert_remote_mode) ... ok (0.450s)
/Users/ruifeng.zheng/spark/python/pyspark/ml/clustering.py:1016: FutureWarning: Deprecated in 3.0.0. It will be removed in future versions. Use ClusteringEvaluator instead. You can also get the cost on the training dataset in the summary.
  warnings.warn(
ok (6.541s)
  test_distributed_lda (pyspark.ml.tests.connect.test_parity_clustering.ClusteringParityTests.test_distributed_lda) ... Thread 0x0000000173083000 (most recent call first):
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/site-packages/grpc/_channel.py", line 1727 in channel_spin
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/threading.py", line 994 in run
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/threading.py", line 1043 in _bootstrap_inner
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/threading.py", line 1014 in _bootstrap

Thread 0x000000017509b000 (most recent call first):
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/concurrent/futures/thread.py", line 90 in _worker
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/threading.py", line 994 in run
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/threading.py", line 1043 in _bootstrap_inner
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/threading.py", line 1014 in _bootstrap

Thread 0x000000017408f000 (most recent call first):
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/concurrent/futures/thread.py", line 90 in _worker
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/threading.py", line 994 in run
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/threading.py", line 1043 in _bootstrap_inner
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/threading.py", line 1014 in _bootstrap

Thread 0x00000001719e7000 (most recent call first):
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/selectors.py", line 398 in select
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/socketserver.py", line 235 in serve_forever
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/threading.py", line 994 in run
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/threading.py", line 1043 in _bootstrap_inner
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/threading.py", line 1014 in _bootstrap

Thread 0x00000001709db000 (most recent call first):
  File "/Users/ruifeng.zheng/spark/python/lib/py4j-0.10.9.9-src.zip/py4j/clientserver.py", line 58 in run
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/threading.py", line 1043 in _bootstrap_inner
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/threading.py", line 1014 in _bootstrap

Current thread 0x00000001f372e200 (most recent call first):
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/threading.py", line 363 in wait
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/site-packages/grpc/_common.py", line 114 in _wait_once
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/site-packages/grpc/_common.py", line 154 in wait
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/site-packages/grpc/_channel.py", line 953 in _next
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/site-packages/grpc/_channel.py", line 538 in __next__
  File "/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/client/reattach.py", line 164 in <lambda>
  File "/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/client/reattach.py", line 266 in _call_iter
  File "/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/client/reattach.py", line 163 in _has_next
  File "/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/client/reattach.py", line 139 in send
  File "<frozen _collections_abc>", line 360 in __next__
  File "/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/client/core.py", line 1625 in _execute_and_fetch_as_iterator
  File "/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/client/core.py", line 1664 in _execute_and_fetch
  File "/Users/ruifeng.zheng/spark/python/pyspark/sql/connect/client/core.py", line 1162 in execute_command
  File "/Users/ruifeng.zheng/spark/python/pyspark/ml/util.py", line 308 in remote_call
  File "/Users/ruifeng.zheng/spark/python/pyspark/ml/util.py", line 322 in wrapped
  File "/Users/ruifeng.zheng/spark/python/pyspark/ml/clustering.py", line 1548 in toLocal
  File "/Users/ruifeng.zheng/spark/python/pyspark/ml/tests/test_clustering.py", line 449 in test_distributed_lda
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/unittest/case.py", line 606 in _callTestMethod
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/unittest/case.py", line 651 in run
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/unittest/case.py", line 707 in __call__
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/unittest/suite.py", line 122 in run
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/unittest/suite.py", line 84 in __call__
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/unittest/suite.py", line 122 in run
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/unittest/suite.py", line 84 in __call__
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/site-packages/xmlrunner/runner.py", line 67 in run
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/unittest/main.py", line 270 in runTests
  File "/Users/ruifeng.zheng/.dev/miniconda3/envs/spark_dev_313/lib/python3.13/unittest/main.py", line 104 in __init__
  File "/Users/ruifeng.zheng/spark/python/pyspark/testing/__init__.py", line 30 in unittest_main
  File "/Users/ruifeng.zheng/spark/python/pyspark/ml/tests/connect/test_parity_clustering.py", line 37 in <module>
  File "<frozen runpy>", line 88 in _run_code
  File "<frozen runpy>", line 198 in _run_module_as_main

Had test failures in pyspark.ml.tests.connect.test_parity_clustering with python3; see logs.
```


### Was this patch authored or co-authored using generative AI tooling?
no
