### PR TITLE
[SPARK-54761][SQL] Throw unsupportedTableOperation for constraint operation on DSv1/HMS table

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -21,7 +21,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.internal.LogKeys.CONFIG
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
-import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType, CatalogUtils, ClusterBySpec}
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType, CatalogUtils, ClusterBySpec, HiveTableRelation}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -31,7 +31,7 @@ import org.apache.spark.sql.connector.catalog.{CatalogExtension, CatalogManager,
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.command._
-import org.apache.spark.sql.execution.datasources.{CreateTable => CreateTableV1}
+import org.apache.spark.sql.execution.datasources.{CreateTable => CreateTableV1, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Utils
 import org.apache.spark.sql.internal.{HiveSerDe, SQLConf}
 import org.apache.spark.sql.internal.connector.V1Function
@@ -128,6 +128,25 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
     case DropColumns(ResolvedV1TableIdentifier(ident), _, _) =>
       throw QueryCompilationErrors.unsupportedTableOperationError(ident, "DROP COLUMN")
 
+    // V1 tables do not support table constraints
+    case AddConstraint(ResolvedV1TableIdentifier(ident), _) =>
+      throw QueryCompilationErrors.unsupportedTableOperationError(ident, "ADD CONSTRAINT")
+
+    case DropConstraint(ResolvedV1TableIdentifier(ident), _, _, _) =>
+      throw QueryCompilationErrors.unsupportedTableOperationError(ident, "DROP CONSTRAINT")
+
+    case a: AddCheckConstraint
+        if a.child.exists {
+          case _: LogicalRelation => true
+          case _: HiveTableRelation => true
+          case _ => false
+        } =>
+      val tableIdent = a.child.collectFirst {
+        case l: LogicalRelation => l.catalogTable.get.identifier
+        case h: HiveTableRelation => h.tableMeta.identifier
+      }.get
+      throw QueryCompilationErrors.unsupportedTableOperationError(tableIdent, "ADD CONSTRAINT")
+
     case SetTableProperties(ResolvedV1TableIdentifier(ident), props) =>
       AlterTableSetPropertiesCommand(ident, props, isView = false)
 
@@ -187,6 +206,10 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
         c.tableSpec.provider, tableSpec.options, c.tableSpec.location, c.tableSpec.serde,
         ctas = false)
       if (!isV2Provider(provider)) {
+        if (tableSpec.constraints.nonEmpty) {
+          throw QueryCompilationErrors.unsupportedTableOperationError(
+            ident, "CONSTRAINT")
+        }
         constructV1TableCmd(None, c.tableSpec, ident, c.tableSchema, c.partitioning,
           c.ignoreIfExists, storageFormat, provider)
       } else {
@@ -203,6 +226,10 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
         ctas = true)
 
       if (!isV2Provider(provider)) {
+        if (tableSpec.constraints.nonEmpty) {
+          throw QueryCompilationErrors.unsupportedTableOperationError(
+            ident, "CONSTRAINT")
+        }
         constructV1TableCmd(Some(c.query), c.tableSpec, ident, new StructType, c.partitioning,
           c.ignoreIfExists, storageFormat, provider)
       } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -128,7 +128,7 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
     case DropColumns(ResolvedV1TableIdentifier(ident), _, _) =>
       throw QueryCompilationErrors.unsupportedTableOperationError(ident, "DROP COLUMN")
 
-    // V1 tables do not support table constraints
+    // V1 and hive tables do not support constraints
     case AddConstraint(ResolvedV1TableIdentifier(ident), _) =>
       throw QueryCompilationErrors.unsupportedTableOperationError(ident, "ADD CONSTRAINT")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/TableConstraintSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/TableConstraintSuite.scala
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.command.v1
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.execution.command.DDLCommandTestUtils
+
+/**
+ * This base suite contains unified tests for table constraints (CHECK, PRIMARY KEY, UNIQUE,
+ * FOREIGN KEY) that check V1 table catalogs. V1 tables do not support table constraints.
+ * The tests that cannot run for all V1 catalogs are located in more specific test suites:
+ *
+ *   - V1 In-Memory catalog:
+ *     `org.apache.spark.sql.execution.command.v1.TableConstraintSuite`
+ *   - V1 Hive External catalog:
+ *     `org.apache.spark.sql.hive.execution.command.TableConstraintSuite`
+ */
+trait TableConstraintSuiteBase extends DDLCommandTestUtils {
+  override val command = "TABLE CONSTRAINT"
+
+  private val constraintTypes = Seq(
+    "CHECK (id > 0)",
+    "PRIMARY KEY (id)",
+    "UNIQUE (id)",
+    "FOREIGN KEY (id) REFERENCES t2(id)"
+  )
+
+  gridTest("create table with constraint: should fail")(constraintTypes) { constraint =>
+    withNamespaceAndTable("ns", "table_1") { t =>
+      val createTableSql = s"CREATE TABLE $t (id INT, CONSTRAINT c1 $constraint) $defaultUsing"
+      val error = intercept[AnalysisException] {
+        sql(createTableSql)
+      }
+      checkError(
+        exception = error,
+        condition = "UNSUPPORTED_FEATURE.TABLE_OPERATION",
+        parameters = Map(
+          "tableName" -> s"`$catalog`.`ns`.`table_1`",
+          "operation" -> "CONSTRAINT"
+        )
+      )
+    }
+  }
+
+  gridTest("alter table add constraint: should fail")(constraintTypes) { constraint =>
+    withNamespaceAndTable("ns", "table_1") { t =>
+      sql(s"CREATE TABLE $t (id INT) $defaultUsing")
+      val alterTableSql = s"ALTER TABLE $t ADD CONSTRAINT c1 $constraint"
+      val error = intercept[AnalysisException] {
+        sql(alterTableSql)
+      }
+      checkError(
+        exception = error,
+        condition = "UNSUPPORTED_FEATURE.TABLE_OPERATION",
+        parameters = Map(
+          "tableName" -> s"`$catalog`.`ns`.`table_1`",
+          "operation" -> "ADD CONSTRAINT"
+        )
+      )
+    }
+  }
+
+  test("alter table drop constraint: should fail") {
+    withNamespaceAndTable("ns", "table_1") { t =>
+      sql(s"CREATE TABLE $t (id INT) $defaultUsing")
+      val error = intercept[AnalysisException] {
+        sql(s"ALTER TABLE $t DROP CONSTRAINT c1")
+      }
+      checkError(
+        exception = error,
+        condition = "UNSUPPORTED_FEATURE.TABLE_OPERATION",
+        parameters = Map(
+          "tableName" -> s"`$catalog`.`ns`.`table_1`",
+          "operation" -> "DROP CONSTRAINT"
+        )
+      )
+    }
+  }
+}
+
+/**
+ * The class contains tests for table constraints to check V1 In-Memory table catalog.
+ */
+class TableConstraintSuite extends TableConstraintSuiteBase with CommandSuiteBase
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
@@ -217,10 +217,10 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase
 
   test("desc table constraints") {
     withNamespaceAndTable("ns", "pk_table", nonPartitionCatalog) { tbl =>
-      withTable("fk_table") {
+      withNamespaceAndTable("ns", "fk_table", nonPartitionCatalog) { fkTable =>
         sql(
           s"""
-             |CREATE TABLE fk_table (id INT PRIMARY KEY) USING parquet
+             |CREATE TABLE $fkTable (id INT PRIMARY KEY) $defaultUsing
         """.stripMargin)
         sql(
           s"""
@@ -230,7 +230,7 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase
              |  b STRING,
              |  c STRING,
              |  PRIMARY KEY (id),
-             |  CONSTRAINT fk_a FOREIGN KEY (a) REFERENCES fk_table(id) RELY,
+             |  CONSTRAINT fk_a FOREIGN KEY (a) REFERENCES $fkTable(id) RELY,
              |  CONSTRAINT uk_b UNIQUE (b),
              |  CONSTRAINT uk_a_c UNIQUE (a, c),
              |  CONSTRAINT c1 CHECK (c IS NOT NULL),
@@ -243,7 +243,7 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase
         var expectedConstraintsDdl = Array(
           "# Constraints,,",
           "pk_table_pk,PRIMARY KEY (id) NOT ENFORCED,",
-          "fk_a,FOREIGN KEY (a) REFERENCES fk_table (id) NOT ENFORCED RELY,",
+          s"fk_a,FOREIGN KEY (a) REFERENCES $fkTable (id) NOT ENFORCED RELY,",
           "uk_b,UNIQUE (b) NOT ENFORCED,",
           "uk_a_c,UNIQUE (a, c) NOT ENFORCED,",
           "c1,CHECK (c IS NOT NULL) ENFORCED,",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowCreateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowCreateTableSuite.scala
@@ -184,13 +184,13 @@ class ShowCreateTableSuite extends command.ShowCreateTableSuiteBase with Command
 
   test("show table constraints") {
     withNamespaceAndTable("ns", "tbl", nonPartitionCatalog) { t =>
-      withTable("other_table") {
+      withNamespaceAndTable("ns", "other_table", nonPartitionCatalog) { otherTable =>
         sql(
           s"""
-             |CREATE TABLE other_table (
+             |CREATE TABLE $otherTable (
              |  id STRING PRIMARY KEY
              |)
-             |USING parquet
+             |$defaultUsing
         """.stripMargin)
         sql(
           s"""
@@ -200,7 +200,7 @@ class ShowCreateTableSuite extends command.ShowCreateTableSuiteBase with Command
              |  c STRING,
              |  PRIMARY KEY (a),
              |  CONSTRAINT uk_b UNIQUE (b),
-             |  CONSTRAINT fk_c FOREIGN KEY (c) REFERENCES other_table(id) RELY,
+             |  CONSTRAINT fk_c FOREIGN KEY (c) REFERENCES $otherTable(id) RELY,
              |  CONSTRAINT c1 CHECK (c IS NOT NULL),
              |  CONSTRAINT c2 CHECK (a > 0)
              |)
@@ -214,7 +214,7 @@ class ShowCreateTableSuite extends command.ShowCreateTableSuiteBase with Command
           "c STRING,",
           "CONSTRAINT tbl_pk PRIMARY KEY (a) NOT ENFORCED NORELY,",
           "CONSTRAINT uk_b UNIQUE (b) NOT ENFORCED NORELY,",
-          "CONSTRAINT fk_c FOREIGN KEY (c) REFERENCES other_table (id) NOT ENFORCED RELY,",
+          s"CONSTRAINT fk_c FOREIGN KEY (c) REFERENCES $otherTable (id) NOT ENFORCED RELY,",
           "CONSTRAINT c1 CHECK (c IS NOT NULL) ENFORCED NORELY,"
         )
         assert(showDDL === expectedDDLPrefix ++ Array(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/TableConstraintSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/TableConstraintSuite.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.execution.command
+
+import org.apache.spark.sql.execution.command.v1
+
+/**
+ * The class contains tests for table constraints to check V1 Hive external table catalog.
+ */
+class TableConstraintSuite extends v1.TableConstraintSuiteBase with CommandSuiteBase
+


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR throws unsupportedTableOperation for constraint operations on DSv1/HMS table. The operations include:
- CreateTable/CreateTableAsSelect with constraint
- AddConstraint
- DropConstraint
- AddCheckConstraint

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Constraints (DSv2) are not supported on DSv1/HMS tables. Currently, it does not throw exceptions and causes [confusion](https://github.com/apache/spark/pull/50761#issuecomment-3664237003).


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

New unit tests on dsv1 and hive table. 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: claude-4.5-opus