### PR TITLE
[SPARK-54763][TEST] Accelerate test_udf_return_types with multi-threading

### DIFF
--- a/python/pyspark/sql/tests/udf_type_tests/test_udf_return_types.py
+++ b/python/pyspark/sql/tests/udf_type_tests/test_udf_return_types.py
@@ -218,8 +218,6 @@ class UDFReturnTypeTests(ReusedSQLTestCase):
             self.fail(f"Golden file created for {test_name}. Please review and re-run the test.")
 
     def _generate_udf_return_type_coercion_results(self, use_arrow):
-        results = []
-
         def work(spark_type):
             result = [spark_type.simpleString()]
             for value in self.test_data:

--- a/python/pyspark/sql/tests/udf_type_tests/test_udf_return_types.py
+++ b/python/pyspark/sql/tests/udf_type_tests/test_udf_return_types.py
@@ -254,7 +254,6 @@ class UDFReturnTypeTests(ReusedSQLTestCase):
         self._compare_or_create_golden_file(actual_output, golden_file, test_name)
 
     def _generate_pandas_udf_type_coercion_results(self):
-
         def work(spark_type):
             result = [spark_type.simpleString()]
             for value in self.pandas_test_data:

--- a/python/pyspark/sql/tests/udf_type_tests/test_udf_return_types.py
+++ b/python/pyspark/sql/tests/udf_type_tests/test_udf_return_types.py
@@ -16,6 +16,7 @@
 #
 
 import array
+import concurrent.futures
 import datetime
 import os
 import platform
@@ -219,7 +220,7 @@ class UDFReturnTypeTests(ReusedSQLTestCase):
     def _generate_udf_return_type_coercion_results(self, use_arrow):
         results = []
 
-        for spark_type in self.test_types:
+        def work(spark_type):
             result = [spark_type.simpleString()]
             for value in self.test_data:
                 try:
@@ -233,9 +234,10 @@ class UDFReturnTypeTests(ReusedSQLTestCase):
                 except Exception:
                     result_value = "X"
                 result.append(result_value)
-            results.append(result)
+            return result
 
-        return results
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+            return list(executor.map(work, self.test_types))
 
     def test_pandas_udf_return_type_coercion(self):
         golden_file = os.path.join(
@@ -252,9 +254,8 @@ class UDFReturnTypeTests(ReusedSQLTestCase):
         self._compare_or_create_golden_file(actual_output, golden_file, test_name)
 
     def _generate_pandas_udf_type_coercion_results(self):
-        results = []
 
-        for spark_type in self.test_types:
+        def work(spark_type):
             result = [spark_type.simpleString()]
             for value in self.pandas_test_data:
                 try:
@@ -276,9 +277,10 @@ class UDFReturnTypeTests(ReusedSQLTestCase):
                 except Exception:
                     ret_str = "X"
                 result.append(ret_str)
-            results.append(result)
+            return result
 
-        return results
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+            return list(executor.map(work, self.test_types))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Use multi-threading to accelerate `test_udf_return_types`. Locally it has more than 2x speed up (113s -> 50s).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`test_udf_return_types` is one of the slowest test we have. It took 300s on normal CI and even slower on coverage. This simple and straightforward fix can save us >50% of the time spent on this test.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Local speed up.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No