### PR TITLE
[SPARK-54767][K8S][INFRA] Update K8s IT CI to use K8s 1.35

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1349,7 +1349,7 @@ jobs:
       - name: Start Minikube
         uses: medyagh/setup-minikube@v0.0.20
         with:
-          kubernetes-version: "1.34.0"
+          kubernetes-version: "1.35.0"
           # Github Action limit cpu:2, memory: 6947MB, limit to 2U6G for better resource statistic
           cpus: 2
           memory: 6144m


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to increase the maximum K8s test version to 1.35

### Why are the changes needed?

To improve the test coverage because K8s 1.35.0 was released on 2025-12-17.
- https://kubernetes.io/blog/2025/12/17/kubernetes-v1-35-release/
- https://kubernetes.io/releases/#release-v1-35

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and check the log.

- https://github.com/dongjoon-hyun/spark/actions/runs/20355951389/job/58491444390

    > Downloading Kubernetes v1.35.0 preload ...

### Was this patch authored or co-authored using generative AI tooling?

No.