### PR TITLE
[SPARK-54769][PYTHON] Remove dead code in conversion.py

### DIFF
--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -436,11 +436,8 @@ class LocalDataToArrowConversion:
                 return value
 
             return convert_other
-        else:
-            if none_on_identity:
-                return None
-            else:
-                return lambda value: value
+        else:  # pragma: no cover
+            assert False, f"Need converter for {dataType} but failed to find one."
 
     @staticmethod
     def convert(data: Sequence[Any], schema: StructType, use_large_var_types: bool) -> "pa.Table":
@@ -613,23 +610,16 @@ class ArrowTableToRowsConversion:
                 dataType.elementType, none_on_identity=True, binary_as_bytes=binary_as_bytes
             )
 
-            if element_conv is None:
+            assert (
+                element_conv is not None
+            ), f"_need_converter() returned True for ArrayType of {dataType.elementType}"
 
-                def convert_array(value: Any) -> Any:
-                    if value is None:
-                        return None
-                    else:
-                        assert isinstance(value, list)
-                        return value
-
-            else:
-
-                def convert_array(value: Any) -> Any:
-                    if value is None:
-                        return None
-                    else:
-                        assert isinstance(value, list)
-                        return [element_conv(v) for v in value]
+            def convert_array(value: Any) -> Any:
+                if value is None:
+                    return None
+                else:
+                    assert isinstance(value, list)
+                    return [element_conv(v) for v in value]
 
             return convert_array
 
@@ -793,11 +783,8 @@ class ArrowTableToRowsConversion:
 
             return convert_geometry
 
-        else:
-            if none_on_identity:
-                return None
-            else:
-                return lambda value: value
+        else:  # pragma: no cover
+            assert False, f"Need converter for {dataType} but failed to find one."
 
     @overload
     @staticmethod


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Dead code is removed and replaced with assertions.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

There are two kinds of dead code in this PR:
1. The else case. We already confirmed that we need a converter for this `dataType`, `else` case should not ever happen, unless we made a mistake in our code.
2. If `ArrayType` has an `elementType` that does not need a converter, the `ArrayType` itself should not need a converter and we should never ask for one.

assertion has clear semantics that this should never happen, but also provides a reasonable and reproducible fallback behavior when unexpected happens. We can catch our code failure faster.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

CI

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No