### PR TITLE
[SPARK-54772][Shuffle] Introduce failedChunks metrics in ChunkFetchHandler

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
@@ -83,6 +83,8 @@ public class TransportContext implements Closeable {
   @Nullable private final SSLFactory sslFactory;
   // Number of registered connections to the shuffle service
   private Counter registeredConnections = new Counter();
+  private ChunkFetchRequestHandler.ChunkFetchMetrics chunkFetchMetrics =
+      new ChunkFetchRequestHandler.ChunkFetchMetrics();
 
   /**
    * Force to create MessageEncoder and MessageDecoder so that we can make sure they will be created
@@ -239,7 +241,7 @@ public class TransportContext implements Closeable {
       if (chunkFetchWorkers != null) {
         ChunkFetchRequestHandler chunkFetchHandler = new ChunkFetchRequestHandler(
           channelHandler.getClient(), rpcHandler.getStreamManager(),
-          conf.maxChunksBeingTransferred(), true /* syncModeEnabled */);
+          conf.maxChunksBeingTransferred(), true /* syncModeEnabled */, chunkFetchMetrics);
         pipeline.addLast(chunkFetchWorkers, "chunkFetchHandler", chunkFetchHandler);
       }
       return channelHandler;
@@ -294,7 +296,7 @@ public class TransportContext implements Closeable {
     if (!separateChunkFetchRequest) {
       chunkFetchRequestHandler = new ChunkFetchRequestHandler(
         client, rpcHandler.getStreamManager(),
-        conf.maxChunksBeingTransferred(), false /* syncModeEnabled */);
+        conf.maxChunksBeingTransferred(), false /* syncModeEnabled */, chunkFetchMetrics);
     }
     TransportRequestHandler requestHandler = new TransportRequestHandler(channel, client,
       rpcHandler, conf.maxChunksBeingTransferred(), chunkFetchRequestHandler);
@@ -306,6 +308,10 @@ public class TransportContext implements Closeable {
 
   public Counter getRegisteredConnections() {
     return registeredConnections;
+  }
+
+  public ChunkFetchRequestHandler.ChunkFetchMetrics getChunkFetchMetrics() {
+    return chunkFetchMetrics;
   }
 
   @Override

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
@@ -20,11 +20,14 @@ package org.apache.spark.network.server;
 import java.io.Closeable;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricSet;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -156,7 +159,12 @@ public class TransportServer implements Closeable {
   }
 
   public MetricSet getAllMetrics() {
-    return metrics;
+    return () -> {
+      Map<String, Metric> allMetrics = new HashMap<>();
+      allMetrics.putAll(metrics.getMetrics());
+      allMetrics.putAll(context.getChunkFetchMetrics().getMetrics());
+      return allMetrics;
+    };
   }
 
   @Override

--- a/common/network-common/src/test/java/org/apache/spark/network/ChunkFetchRequestHandlerSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/ChunkFetchRequestHandlerSuite.java
@@ -67,7 +67,8 @@ public class ChunkFetchRequestHandlerSuite {
     long streamId = streamManager.registerStream("test-app", managedBuffers.iterator(), channel);
     TransportClient reverseClient = mock(TransportClient.class);
     ChunkFetchRequestHandler requestHandler = new ChunkFetchRequestHandler(reverseClient,
-      rpcHandler.getStreamManager(), 2L, false);
+      rpcHandler.getStreamManager(), 2L, false,
+      new ChunkFetchRequestHandler.ChunkFetchMetrics());
 
     RequestMessage request0 = new ChunkFetchRequest(new StreamChunkId(streamId, 0));
     requestHandler.channelRead(context, request0);

--- a/core/src/test/scala/org/apache/spark/deploy/ExternalShuffleServiceMetricsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/ExternalShuffleServiceMetricsSuite.scala
@@ -67,7 +67,8 @@ class ExternalShuffleServiceMetricsSuite extends SparkFunSuite {
         "shuffle-server.usedDirectMemory",
         "shuffle-server.usedHeapMemory",
         "finalizeShuffleMergeLatencyMillis",
-        "fetchMergedBlocksMetaLatencyMillis").sorted
+        "fetchMergedBlocksMetaLatencyMillis",
+        "failedChunks").sorted
     )
   }
 }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
@@ -1091,7 +1091,8 @@ abstract class YarnShuffleServiceSuite extends SparkFunSuite with Matchers {
       "finalizeShuffleMergeLatencyMillis",
       "shuffle-server.usedDirectMemory",
       "shuffle-server.usedHeapMemory",
-      "fetchMergedBlocksMetaLatencyMillis"
+      "fetchMergedBlocksMetaLatencyMillis",
+      "failedChunks"
     ).sorted)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce failedChunks metrics in ChunkFetchHandler.


### Why are the changes needed?
ChunkFetchHandler often processes ChunkFetchRequests slowly for various reasons, Client may close the connection. When ChunkFetchRequest returns a response to the client, it will print an error log ([code](https://github.com/apache/spark/blob/master/common/network-common/src/main/java/org/apache/spark/network/server/ChunkFetchRequestHandler.java#L154)). we can introduce a new metric to discover this problem more intuitively


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
UTs.


### Was this patch authored or co-authored using generative AI tooling?
No.
