### PR TITLE
[SPARK-54774][CORE] Submit failed should keep same exit code with app exit code in K8s mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -1047,7 +1047,7 @@ private[spark] class SparkSubmit extends Logging {
           !isSqlShell(args.mainClass) && !isThriftServer(args.mainClass) &&
           !isConnectServer(args.mainClass)) {
         try {
-          SparkContext.getActive.foreach(_.stop())
+          SparkContext.getActive.foreach(_.stop(exitCode))
         } catch {
           case e: Throwable => logError("Failed to close SparkContext", e)
         }

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -1631,6 +1631,22 @@ class SparkSubmitSuite
     assertResult(3)(runSparkSubmit(args, expectFailure = true))
   }
 
+  test("SPARK-54774: k8s submit failed should keep same exit code with user code") {
+    val unusedJar = TestUtils.createJarWithClasses(Seq.empty)
+    val args = Seq(
+      "--class", K8sExitCodeTestApplication.getClass.getName.stripSuffix("$"),
+      "--name", "testApp",
+      "--master", "k8s://host:port",
+      "--conf", "spark.ui.enabled=false",
+      "--conf", "spark.master.rest.enabled=false",
+      "--conf", "spark.kubernetes.authenticate.driver.serviceAccountName=default",
+      unusedJar.toString
+    )
+    // The test application throws SparkUserAppException with exit code 42,
+    // so SparkContext.stop(42) should be called in k8s mode
+    assertResult(42)(runSparkSubmit(args, expectFailure = true))
+  }
+
   private def testRemoteResources(
       enableHttpFs: Boolean,
       forceDownloadSchemes: Seq[String] = Nil): Unit = {
@@ -2037,4 +2053,24 @@ class TestSparkApplication extends SparkApplication with Matchers {
     throw new SparkException(args(0))
   }
 
+}
+
+object K8sExitCodeTestApplication {
+  def main(args: Array[String]): Unit = {
+    TestUtils.configTestLog4j2("INFO")
+    // Use local master to ensure SparkContext can be created in test environment
+    // The k8s master is set in SparkSubmit args, which triggers the finally block logic
+    val conf = new SparkConf().setMaster("local[2]")
+    val sc = new SparkContext(conf)
+    try {
+      // Create a simple RDD to ensure SparkContext is active
+      sc.parallelize(1 to 10).count()
+      // Throw SparkUserAppException with a specific exit code
+      // This simulates a user application failure
+      throw new SparkUserAppException(42)
+    } finally {
+      // Note: In k8s mode, SparkSubmit should call sc.stop(42) in the finally block
+      // We don't call stop() here to let SparkSubmit handle it
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
When submit failed, k8s case will stop  SparkContext. 
Here we already know the exit code, so here we stop SC should also pass the exitcode too.


### Why are the changes needed?
keep same exit code for SC and whole app, help when checking the log


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added UT


### Was this patch authored or co-authored using generative AI tooling?
No
