### PR TITLE
[SPARK-54777][SQL] Changed dropTable error handling in JDBCTableCatalog.dropTable(...)

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1768,6 +1768,11 @@
           "Drop the namespace <namespace>."
         ]
       },
+      "DROP_TABLE" : {
+        "message" : [
+          "Drop the table <tableName>."
+        ]
+      },
       "GET_TABLES" : {
         "message" : [
           "Get tables from the namespace: <namespace>."

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -117,6 +117,8 @@ class JDBCTableCatalog extends TableCatalog
         JdbcUtils.dropTable(conn, getTableName(ident), options)
         true
       } catch {
+        // TableCatalog.dropTable API is designed to return
+        // false only in case table does not exist.
         case e: SQLException if dialect.isObjectNotFoundException(e) =>
           false
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -113,14 +113,24 @@ class JDBCTableCatalog extends TableCatalog
   override def dropTable(ident: Identifier): Boolean = {
     checkNamespace(ident.namespace())
     JdbcUtils.withConnection(options) { conn =>
-      try {
-        JdbcUtils.dropTable(conn, getTableName(ident), options)
-        true
-      } catch {
-        // TableCatalog.dropTable API is designed to return
-        // false only in case table does not exist.
-        case e: SQLException if dialect.isObjectNotFoundException(e) =>
-          false
+      JdbcUtils.classifyException(
+        condition = "FAILED_JDBC.DROP_TABLE",
+        messageParameters = Map(
+          "url" -> options.getRedactUrl(),
+          "tableName" -> toSQLId(ident)),
+        dialect,
+        description = s"Failed to drop table: $ident",
+        isRuntime = false) {
+        try {
+          JdbcUtils.dropTable(conn, getTableName(ident), options)
+          true
+        } catch {
+          // TableCatalog.dropTable API is designed to return false
+          // only in case table does not exist.
+          case e: SQLException if dialect.isObjectNotFoundException(e) =>
+            false
+          // All other SQLExceptions get classified and propagated
+        }
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -120,7 +120,7 @@ class JDBCTableCatalog extends TableCatalog
           "tableName" -> toSQLId(ident)),
         dialect,
         description = s"Failed to drop table: $ident",
-        isRuntime = false) {
+        isRuntime = true) {
         try {
           JdbcUtils.dropTable(conn, getTableName(ident), options)
           true

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -117,7 +117,8 @@ class JDBCTableCatalog extends TableCatalog
         JdbcUtils.dropTable(conn, getTableName(ident), options)
         true
       } catch {
-        case _: SQLException => false
+        case e: SQLException if dialect.isObjectNotFoundException(e) =>
+          false
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -139,15 +139,15 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       }
 
       // Try to drop the base table while view exists - H2 should prevent this
-      val e = intercept[SparkRuntimeException] {
-        sql("DROP TABLE h2.test.base_table")
-      }
-
       // Verify the exception is properly classified with FAILED_JDBC.DROP_TABLE
-      assert(e.getErrorClass == "FAILED_JDBC.DROP_TABLE")
-      assert(e.getMessage.contains("Failed JDBC"))
-      assert(e.getMessage.contains("Drop the table"))
-      assert(e.getMessage.contains("base_table"))
+      checkErrorMatchPVals(
+        exception = intercept[SparkRuntimeException] {
+          sql("DROP TABLE h2.test.base_table")
+        },
+        condition = "FAILED_JDBC.DROP_TABLE",
+        parameters = Map(
+          "url" -> "jdbc:.*",
+          "tableName" -> "`test`.`base_table`"))
     } finally {
       withConnection { conn =>
         conn.prepareStatement("""DROP VIEW IF EXISTS "test"."dependent_view"""").executeUpdate()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -23,7 +23,7 @@ import scala.jdk.CollectionConverters._
 
 import org.apache.logging.log4j.Level
 
-import org.apache.spark.{SparkConf, SparkIllegalArgumentException}
+import org.apache.spark.{SparkConf, SparkIllegalArgumentException, SparkRuntimeException}
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.catalyst.analysis.{NoSuchNamespaceException, TableAlreadyExistsException}
 import org.apache.spark.sql.catalyst.parser.ParseException
@@ -121,6 +121,38 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
         sql(s"DROP TABLE $table")
       }
       checkErrorTableNotFound(e, expected)
+    }
+  }
+
+  test("drop table with dependent view fails with classified exception") {
+    // Test that classifyException in dropTable properly wraps SQLException
+    // when dropping a table fails due to dependent objects
+    try {
+      withConnection { conn =>
+        // Create a table
+        conn.prepareStatement(
+          """CREATE TABLE "test"."base_table" (id INTEGER, name VARCHAR(50))""").executeUpdate()
+        // Create a view that depends on it
+        conn.prepareStatement(
+            """CREATE VIEW "test"."dependent_view" AS SELECT * FROM "test"."base_table"""")
+          .executeUpdate()
+      }
+
+      // Try to drop the base table while view exists - H2 should prevent this
+      val e = intercept[SparkRuntimeException] {
+        sql("DROP TABLE h2.test.base_table")
+      }
+
+      // Verify the exception is properly classified with FAILED_JDBC.DROP_TABLE
+      assert(e.getErrorClass == "FAILED_JDBC.DROP_TABLE")
+      assert(e.getMessage.contains("Failed JDBC"))
+      assert(e.getMessage.contains("Drop the table"))
+      assert(e.getMessage.contains("base_table"))
+    } finally {
+      withConnection { conn =>
+        conn.prepareStatement("""DROP VIEW IF EXISTS "test"."dependent_view"""").executeUpdate()
+        conn.prepareStatement("""DROP TABLE IF EXISTS "test"."base_table"""").executeUpdate()
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Modified `JDBCTableCatalog.dropTable()` to selectively catch only "object not found" SQLExceptions instead of catching all SQLExceptions. Now only table/schema not found errors return false, while all other errors (permission denied, constraint violations, etc.) propagate to the caller.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The previous implementation had a critical bug in foreign table drop operations, because if drop table fails on foreign system, `JDBCTableCatalog.dropTable()` catches the permission SQLException and silently returns false, and user will think DROP TABLE succeeded when it actually didn't.

And we want to return false if table does not exists, because it is aligned with TableCatalog API, and else we want to propagate the error so user can see that drop table didn't succeed.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. Users will now receive proper error messages when DROP TABLE fails due to insufficient privileges or other database constraints, instead of the operation silently succeeding, while failing in the foreign system. 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No