### PR TITLE
[SPARK-54776][SQL] Improved the logs message regarding lambda function with SQL UDF

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -6770,6 +6770,11 @@
           "Lambda function with Python UDF <funcName> in a higher order function."
         ]
       },
+      "LAMBDA_FUNCTION_WITH_SQL_UDF" : {
+        "message" : [
+          "Lambda function with SQL UDF <funcName> in a higher order function."
+        ]
+      },
       "LATERAL_COLUMN_ALIAS_IN_AGGREGATE_FUNC" : {
         "message" : [
           "Referencing a lateral column alias <lca> in the aggregate function <aggFunc>."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -1644,15 +1644,10 @@ class SessionCatalog(
         }.isDefined
       }
       if (hasLambdaVar) {
-        val formattedInputs = input.map {
-          case v: NamedLambdaVariable => "lambda " + v.name
-          case v: UnresolvedNamedLambdaVariable => "lambda " + v.name
-          case e => e.sql
-        }.mkString(", ")
         throw new AnalysisException(
           errorClass = "UNSUPPORTED_FEATURE.LAMBDA_FUNCTION_WITH_SQL_UDF",
           messageParameters = Map(
-            "funcName" -> ("\"" + function.name.unquotedString + "(" + formattedInputs + ")\"")))
+            "funcName" -> function.name.unquotedString))
       }
       val args = rearrangeArguments(function.inputParam, input, function.name.toString)
       val returnType = function.getScalarFuncReturnType
@@ -1742,15 +1737,10 @@ class SessionCatalog(
         }.isDefined
       }
       if (hasLambdaVar) {
-        val formattedInputs = input.map {
-          case v: NamedLambdaVariable => "lambda " + v.name
-          case v: UnresolvedNamedLambdaVariable => "lambda " + v.name
-          case e => e.sql
-        }.mkString(", ")
         throw new AnalysisException(
           errorClass = "UNSUPPORTED_FEATURE.LAMBDA_FUNCTION_WITH_SQL_UDF",
           messageParameters = Map(
-            "funcName" -> ("\"" + function.name.unquotedString + "(" + formattedInputs + ")\"")))
+            "funcName" -> function.name.unquotedString))
       }
 
       val inputs = inputParam.map { param =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -38,6 +38,8 @@ import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
 import org.apache.spark.sql.catalyst.analysis.TableFunctionRegistry.TableFunctionBuilder
 import org.apache.spark.sql.catalyst.catalog.SQLFunction.parseDefault
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, Cast, Expression, ExpressionInfo, LateralSubquery, NamedArgumentExpression, NamedExpression, OuterReference, ScalarSubquery, UpCast}
+import org.apache.spark.sql.catalyst.expressions.NamedLambdaVariable
+import org.apache.spark.sql.catalyst.expressions.UnresolvedNamedLambdaVariable
 import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParserInterface}
 import org.apache.spark.sql.catalyst.plans.Inner
 import org.apache.spark.sql.catalyst.plans.logical.{FunctionSignature, InputParameter, LateralJoin, LogicalPlan, NamedParametersSupport, OneRowRelation, Project, SubqueryAlias, View}
@@ -1633,6 +1635,25 @@ class SessionCatalog(
       throw UserDefinedFunctionErrors.notAScalarFunction(function.name.nameParts)
     }
     (input: Seq[Expression]) => {
+      // Check if any input contains a lambda variable
+      val hasLambdaVar = input.exists { expr =>
+        expr.find {
+          case _: NamedLambdaVariable => true
+          case _: UnresolvedNamedLambdaVariable => true
+          case _ => false
+        }.isDefined
+      }
+      if (hasLambdaVar) {
+        val formattedInputs = input.map {
+          case v: NamedLambdaVariable => "lambda " + v.name
+          case v: UnresolvedNamedLambdaVariable => "lambda " + v.name
+          case e => e.sql
+        }.mkString(", ")
+        throw new AnalysisException(
+          errorClass = "UNSUPPORTED_FEATURE.LAMBDA_FUNCTION_WITH_SQL_UDF",
+          messageParameters = Map(
+            "funcName" -> ("\"" + function.name.unquotedString + "(" + formattedInputs + ")\"")))
+      }
       val args = rearrangeArguments(function.inputParam, input, function.name.toString)
       val returnType = function.getScalarFuncReturnType
       SQLFunctionExpression(
@@ -1710,6 +1731,26 @@ class SessionCatalog(
       if (input.size > paramSize) {
         throw QueryCompilationErrors.wrongNumArgsError(
           name, paramSize.toString, input.size)
+      }
+
+      // Check if any input contains a lambda variable
+      val hasLambdaVar = input.exists { expr =>
+        expr.find {
+          case _: NamedLambdaVariable => true
+          case _: UnresolvedNamedLambdaVariable => true
+          case _ => false
+        }.isDefined
+      }
+      if (hasLambdaVar) {
+        val formattedInputs = input.map {
+          case v: NamedLambdaVariable => "lambda " + v.name
+          case v: UnresolvedNamedLambdaVariable => "lambda " + v.name
+          case e => e.sql
+        }.mkString(", ")
+        throw new AnalysisException(
+          errorClass = "UNSUPPORTED_FEATURE.LAMBDA_FUNCTION_WITH_SQL_UDF",
+          messageParameters = Map(
+            "funcName" -> ("\"" + function.name.unquotedString + "(" + formattedInputs + ")\"")))
       }
 
       val inputs = inputParam.map { param =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -32,6 +32,7 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.{SparkException, SparkThrowable}
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst._
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLFunctionSuite.scala
@@ -104,8 +104,6 @@ class SQLFunctionSuite extends QueryTest with SharedSparkSession {
         s"but got ${exception.getCondition}: ${exception.getMessage}")
       assert(exception.getMessage.contains("test_lower_udf"),
         s"Error message should contain function name: ${exception.getMessage}")
-      assert(exception.getMessage.contains("lambda x"),
-        s"Error message should contain 'lambda x': ${exception.getMessage}")
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLFunctionSuite.scala
@@ -102,7 +102,12 @@ class SQLFunctionSuite extends QueryTest with SharedSparkSession {
           sql("SELECT transform(array('A', 'B', 'C'), x -> test_lower_udf(x))").collect()
         },
         condition = "UNSUPPORTED_FEATURE.LAMBDA_FUNCTION_WITH_SQL_UDF",
-        parameters = Map("funcName" -> "test_lower_udf")
+        parameters = Map("funcName" -> "spark_catalog.default.test_lower_udf"),
+        context = ExpectedContext(
+          fragment = "test_lower_udf(x)",
+          start = 44,
+          stop = 60
+        )
       )
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

**Changes made:**

Added new error condition in error-conditions.json:
UNSUPPORTED_FEATURE.LAMBDA_FUNCTION_WITH_SQL_UDF - A clear error message for SQL UDFs used in lambda functions.




### Why are the changes needed?

Currently, when a SQL UDF is used inside a higher-order function like transform, the error message is confusing:
```

CREATE FUNCTION lower_udf(s STRING) RETURNS STRING RETURN lower(s);
SELECT transform(array('A', 'B'), x -> lower_udf(x));

```
**Before (confusing error):**

[MISSING_ATTRIBUTES.RESOLVED_ATTRIBUTE_MISSING_FROM_INPUT] 
Resolved attribute(s) "x" missing from in operator !Project [cast(lambda x#20395 as string) AS s#20397]. 
SQLSTATE: XX000

<img width="1728" height="427" alt="Screenshot 2025-12-18 at 6 13 29 PM" src="https://github.com/user-attachments/assets/8d7e79dd-bd86-4199-8b16-fae0b9313d46" />


This error doesn't explain why the attribute is missing or what the user should do.

**After (clear error):**

[UNSUPPORTED_FEATURE.LAMBDA_FUNCTION_WITH_SQL_UDF] The feature is not supported: Lambda function with SQL UDF "spark_catalog.default.lower_udf(lambda x)" in a higher order function. SQLSTATE: 0A000

<img width="1728" height="314" alt="Screenshot 2025-12-18 at 6 14 11 PM" src="https://github.com/user-attachments/assets/76b30d2d-1c3a-4a8d-8feb-65a5295d6d35" />


This is consistent with the existing error message for Python UDFs in the same scenario (UNSUPPORTED_FEATURE.LAMBDA_FUNCTION_WITH_PYTHON_UDF).



### Does this PR introduce _any_ user-facing change?
Yes. Users will now see a clearer, more actionable error message when attempting to use a SQL UDF inside a higher-order function's lambda expression.

### How was this patch tested?
**Test 1:**

Added a new test case "SQL UDF in higher-order function should fail with clear error message" in SQLFunctionSuite.scala that:
Creates a SQL UDF
Attempts to use it in a transform higher-order function
Verifies the error condition is UNSUPPORTED_FEATURE.LAMBDA_FUNCTION_WITH_SQL_UDF
Verifies the error message contains the function name and lambda x

**Test 2:**
Manual testing
spark.sql("CREATE OR REPLACE FUNCTION test_lower_udf(s STRING) RETURNS STRING RETURN lower(s)") spark.sql("SELECT transform(array('A', 'B'), x -> test_lower_udf(x))").show()


### Was this patch authored or co-authored using generative AI tooling?
No

