### PR TITLE
[SPARK-54780][K8S][DOCS] Drop K8s v1.32 Support

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -44,7 +44,7 @@ Cluster administrators should use the [Pod Security Admission Controller](https:
 
 # Prerequisites
 
-* A running Kubernetes cluster at version >= 1.32 with access configured to it using
+* A running Kubernetes cluster at version >= 1.33 with access configured to it using
 [kubectl](https://kubernetes.io/docs/reference/kubectl/).  If you do not already have a working Kubernetes cluster,
 you may set up a test cluster on your local machine using
 [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/).


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update K8s docs to recommend K8s v1.33+ at Apache Spark 4.2.0 to utilize more stable features like the following example features graduated to `Stable` at K8s v1.33.

- [KEP-3633: Introduce MatchLabelKeys to Pod Affinity and Pod Anti Affinity](https://github.com/kubernetes/enhancements/issues/3633)
- [KEP-4193: Bound service account token improvements](https://github.com/kubernetes/enhancements/issues/4193)
- [KEP-753: Sidecar Containers](https://github.com/kubernetes/enhancements/issues/753)
- [KEP-3857: Recursive Read-only (RRO) mounts](https://github.com/kubernetes/enhancements/issues/3857)

### Why are the changes needed?

**1. K8s v1.32 will enter the maintenance soon (2025-12-28) and will reach the end of support on 2026-02-28**
- https://kubernetes.io/releases/patch-releases/#1-32

**2. Default K8s Versions in Public Cloud environments**

The default K8s versions of public cloud providers are already moving to K8s 1.33+ like the following.

- EKS: v1.34 (Default)
- AKS: v1.34 (Default)
- GKE: v1.33 (Stable, v1.34 will be stable on 2026/1)

**3. End Of Support**

In addition, K8s 1.32 will reach the end of standard support before Apache Spark 4.2.0 release. 

| K8s  |   EKS   |  AKE  |  GKE  |
| ---- | ------- | ------- | ------- |
| 1.32 | 2026-03 | 2026-03 | 2026-04 |

- [EKS EOL Schedule](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar)
- [AKS EOL Schedule](https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar)
- [GKE EOL Schedule](https://cloud.google.com/kubernetes-engine/docs/release-schedule)

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only change about K8s versions.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.