### PR TITLE
[SPARK-54781][ML][CONNECT] Return model cache information in JSON format

### DIFF
--- a/python/pyspark/ml/tests/connect/test_connect_cache.py
+++ b/python/pyspark/ml/tests/connect/test_connect_cache.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import json
 import unittest
 
 from pyspark.ml.linalg import Vectors
@@ -44,8 +45,9 @@ class MLConnectCacheTests(ReusedConnectTestCase):
 
         cache_info = spark.client._get_ml_cache_info()
         self.assertEqual(len(cache_info), 1)
-        self.assertTrue(
-            "obj: class org.apache.spark.ml.classification.LinearSVCModel" in cache_info[0],
+        self.assertEqual(
+            json.loads(cache_info[0])["class"],
+            "org.apache.spark.ml.classification.LinearSVCModel",
             cache_info,
         )
         # the `model._summary` holds another ref to the remote model.
@@ -100,7 +102,7 @@ class MLConnectCacheTests(ReusedConnectTestCase):
         self.assertEqual(len(cache_info), 3)
         self.assertTrue(
             all(
-                "obj: class org.apache.spark.ml.classification.LinearSVCModel" in c
+                json.loads(c)["class"] == "org.apache.spark.ml.classification.LinearSVCModel"
                 for c in cache_info
             ),
             cache_info,

--- a/python/pyspark/ml/tests/connect/test_connect_model_offloading.py
+++ b/python/pyspark/ml/tests/connect/test_connect_model_offloading.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+import json
 import unittest
 
 import numpy as np
@@ -82,10 +84,14 @@ class ModelOffloadingTests(ReusedConnectTestCase):
             self.assertEqual(summary.labels, [0.0, 1.0])
 
         # model is cached!
-        # 'id: xxx, obj: class org.apache.spark.ml.classification.LinearSVCModel, size: xxx'
+        # '{"id":"xxx","class":"org.apache.spark.ml.classification.LinearSVCModel","size":xxx}'
         cached = self.spark.client._get_ml_cache_info()
         self.assertEqual(len(cached), 1, cached)
-        self.assertIn("class org.apache.spark.ml.classification.LinearSVCModel", cached[0])
+        self.assertEqual(
+            json.loads(cached[0])["class"],
+            "org.apache.spark.ml.classification.LinearSVCModel",
+            cached,
+        )
 
         check_model(model)
 
@@ -137,10 +143,14 @@ class ModelOffloadingTests(ReusedConnectTestCase):
             self.assertEqual(summary.predictions.count(), 4)
 
         # model is cached!
-        # 'id: xxx, obj: class org.apache.spark.ml.regression.LinearRegressionModel, size: xxx'
+        # '{"id":"xxx","class":"org.apache.spark.ml.regression.LinearRegressionModel","size":xxx}'
         cached = self.spark.client._get_ml_cache_info()
         self.assertEqual(len(cached), 1, cached)
-        self.assertIn("class org.apache.spark.ml.regression.LinearRegressionModel", cached[0])
+        self.assertEqual(
+            json.loads(cached[0])["class"],
+            "org.apache.spark.ml.regression.LinearRegressionModel",
+            cached,
+        )
 
         check_model(model)
 
@@ -191,24 +201,30 @@ class ModelOffloadingTests(ReusedConnectTestCase):
             self.assertEqual(output.count(), 2)
 
         # model is cached!
-        # 'id: xxx, obj: class org.apache.spark.ml.regression.LinearRegressionModel, size: xxx'
+        # '{"id":"xxx","class":"org.apache.spark.ml.clustering.DistributedLDAModel","size":xxx}'
         cached = self.spark.client._get_ml_cache_info()
         self.assertEqual(len(cached), 1, cached)
-        self.assertIn("class org.apache.spark.ml.clustering.DistributedLDAModel", cached[0])
+        self.assertEqual(
+            json.loads(cached[0])["class"],
+            "org.apache.spark.ml.clustering.DistributedLDAModel",
+            cached,
+        )
 
         check_model(model)
 
         # both model and local_model are is cached!
         local_model = model.toLocal()
-        # 'id: xxx, obj: class org.apache.spark.ml.clustering.LocalLDAModel, size: xxx'
-        # 'id: xxx, obj: class org.apache.spark.ml.clustering.DistributedLDAModel, size: xxx'
+        # '{"id":"xxx","class":"org.apache.spark.ml.clustering.LocalLDAModel","size":xxx}'
+        # '{"id":"xxx","class":"org.apache.spark.ml.clustering.DistributedLDAModel","size":xxx}'
         cached = self.spark.client._get_ml_cache_info()
         self.assertEqual(len(cached), 2, cached)
-        self.assertTrue(
-            any("class org.apache.spark.ml.clustering.LocalLDAModel" in c for c in cached)
-        )
-        self.assertTrue(
-            any("class org.apache.spark.ml.clustering.DistributedLDAModel" in c for c in cached)
+        self.assertEqual(
+            sorted([json.loads(c)["class"] for c in cached]),
+            [
+                "org.apache.spark.ml.clustering.DistributedLDAModel",
+                "org.apache.spark.ml.clustering.LocalLDAModel",
+            ],
+            cached,
         )
 
         def check_local_model(m):
@@ -272,10 +288,14 @@ class ModelOffloadingTests(ReusedConnectTestCase):
             self.assertEqual(output.count(), 6)
 
         # model is cached!
-        # 'id: xxx, obj: class org.apache.spark.ml.fpm.FPGrowthModel, size: xxx'
+        # '{"id":"xxx","class":"org.apache.spark.ml.fpm.FPGrowthModel","size":xxx}'
         cached = self.spark.client._get_ml_cache_info()
         self.assertEqual(len(cached), 1, cached)
-        self.assertIn("class org.apache.spark.ml.fpm.FPGrowthModel", cached[0])
+        self.assertEqual(
+            json.loads(cached[0])["class"],
+            "org.apache.spark.ml.fpm.FPGrowthModel",
+            cached,
+        )
 
         check_model(model)
 

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLCache.scala
@@ -26,6 +26,8 @@ import scala.collection.mutable
 import scala.util.control.NonFatal
 
 import com.google.common.cache.{CacheBuilder, RemovalNotification}
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
 
 import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
@@ -272,7 +274,9 @@ private[connect] class MLCache(sessionHolder: SessionHolder) extends Logging {
   def getInfo(): Array[String] = this.synchronized {
     val info = mutable.ArrayBuilder.make[String]
     cachedModel.forEach { case (key, value) =>
-      info += s"id: $key, obj: ${value.obj.getClass}, size: ${value.sizeBytes}"
+      info += compact(
+        render(("id" -> key) ~ ("class" -> value.obj.getClass.getName) ~
+          ("size" -> value.sizeBytes)))
     }
     info.result()
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Return model cache information in JSON format


### Why are the changes needed?
so that the clients can parse the information easily

### Does this PR introduce _any_ user-facing change?
no, this protobuf message is only used in tests


### How was this patch tested?
updated tests


### Was this patch authored or co-authored using generative AI tooling?
no
