### PR TITLE
[SPARK-54797][SS][TESTS] Fix deprecation warning in `GlobalSyncClockClient.getTimeMillis`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/util/GlobalSingletonManualClock.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/util/GlobalSingletonManualClock.scala
@@ -115,7 +115,7 @@ class GlobalSyncClockClient(driverEndpointName: String)
     SparkEnv.get.rpcEnv)
 
   override def getTimeMillis(): Long = {
-    val result = endpoint.askSync[Long]()
+    val result = endpoint.askSync[Long](())
     result
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to fix the following compilation warning:

```
[warn] /home/runner/work/spark/spark/sql/core/src/test/scala/org/apache/spark/sql/streaming/util/GlobalSingletonManualClock.scala:118:40: adaptation of an empty argument list by inserting () is deprecated: this is unlikely to be what you want
[warn]         signature: RpcEndpointRef.askSync[T](message: Any)(implicit evidence$4: scala.reflect.ClassTag[T]): T
[warn]   given arguments: <none>
[warn]  after adaptation: RpcEndpointRef.askSync((): Unit)
[warn] Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=deprecation, site=org.apache.spark.sql.streaming.util.GlobalSyncClockClient.getTimeMillis.result, origin=org.apache.spark.rpc.RpcEndpointRef.askSync, version=2.11.0
[warn]     val result = endpoint.askSync[Long]()
 ```

### Why are the changes needed?
Fix compilation warning

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
