### PR TITLE
[SPARK-54798][BUILD] Upgrade commons-text to 1.15.0  

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -46,7 +46,7 @@ commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/3.20.0//commons-lang3-3.20.0.jar
 commons-math3/3.6.1//commons-math3-3.6.1.jar
 commons-pool/1.5.4//commons-pool-1.5.4.jar
-commons-text/1.14.0//commons-text-1.14.0.jar
+commons-text/1.15.0//commons-text-1.15.0.jar
 compress-lzf/1.1.2//compress-lzf-1.1.2.jar
 curator-client/5.9.0//curator-client-5.9.0.jar
 curator-framework/5.9.0//curator-framework-5.9.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -682,7 +682,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.14.0</version>
+        <version>1.15.0</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgarde Apache commons-text from 1.14.0 to 1.15.0.


### Why are the changes needed?
The full release notes as follows:
- https://github.com/apache/commons-text/blob/rel/commons-text-1.15.0/RELEASE-NOTES.txt


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No