### PR TITLE
[SPARK-54823] Add SupportsUpdateV2 and UpdateTableExec

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsUpdateV2.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsUpdateV2.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.catalog;
+
+import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
+
+/**
+ * A mix-in interface for {@link Table} update support. Data sources can implement this
+ * interface to provide the ability to update data in tables that matches filter expressions.
+ * <p>
+ * This interface enables push-down of UPDATE operations to the data source, similar to how
+ * {@link SupportsDeleteV2} enables push-down of DELETE operations.
+ *
+ * @since 3.4.0
+ */
+@Evolving
+public interface SupportsUpdateV2 extends Table {
+
+  /**
+   * Represents a column assignment for an UPDATE operation.
+   * Contains the column name and the new value expression as a string.
+   */
+  class Assignment {
+    private final String column;
+    private final String value;
+
+    public Assignment(String column, String value) {
+      this.column = column;
+      this.value = value;
+    }
+
+    public String getColumn() {
+      return column;
+    }
+
+    public String getValue() {
+      return value;
+    }
+  }
+
+  /**
+   * Checks whether it is possible to update data in a data source table that matches filter
+   * expressions with the given assignments.
+   * <p>
+   * Rows should be updated in the data source iff all of the filter expressions match.
+   * That is, the expressions must be interpreted as a set of filters that are ANDed together.
+   * <p>
+   * Spark will call this method at planning time to check whether {@link #updateWhere}
+   * would reject the update operation because it requires significant effort. If this method
+   * returns false, Spark will not call {@link #updateWhere} and will try to rewrite
+   * the update operation using row-level operations if the data source table supports it.
+   *
+   * @param predicates V2 filter expressions, used to select rows to update when all expressions
+   *                   match
+   * @param assignments the column assignments to apply to matching rows
+   * @return true if the update operation can be performed
+   */
+  default boolean canUpdateWhere(Predicate[] predicates, Assignment[] assignments) {
+    return true;
+  }
+
+  /**
+   * Update data in a data source table that matches filter expressions. Note that this method
+   * will be invoked only if {@link #canUpdateWhere} returns true.
+   * <p>
+   * Rows are updated in the data source iff all of the filter expressions match. That is, the
+   * expressions must be interpreted as a set of filters that are ANDed together.
+   * <p>
+   * Implementations may reject an update operation if the update isn't possible without significant
+   * effort. To reject an update, implementations should throw {@link IllegalArgumentException}
+   * with a clear error message that identifies which expression or assignment was rejected.
+   *
+   * @param predicates predicate expressions, used to select rows to update when all expressions
+   *                   match
+   * @param assignments the column assignments to apply to matching rows
+   * @throws IllegalArgumentException If the update is rejected due to required effort
+   */
+  void updateWhere(Predicate[] predicates, Assignment[] assignments);
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsUpdateV2.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsUpdateV2.java
@@ -27,7 +27,7 @@ import org.apache.spark.sql.connector.expressions.filter.Predicate;
  * This interface enables push-down of UPDATE operations to the data source, similar to how
  * {@link SupportsDeleteV2} enables push-down of DELETE operations.
  *
- * @since 3.4.0
+ * @since 4.1.0
  */
 @Evolving
 public interface SupportsUpdateV2 extends Table {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1471,6 +1471,12 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("condition" -> condition.toString))
   }
 
+  def unsupportedUpdateByConditionWithSubqueryError(condition: Expression): Throwable = {
+    new AnalysisException(
+      errorClass = "_LEGACY_ERROR_TEMP_1108",
+      messageParameters = Map("condition" -> condition.toString))
+  }
+
   def cannotTranslateExpressionToSourceFilterError(f: Expression): Throwable = {
     new AnalysisException(
       errorClass = "_LEGACY_ERROR_TEMP_1109",
@@ -1482,6 +1488,14 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       errorClass = "_LEGACY_ERROR_TEMP_1110",
       messageParameters = Map(
         "table" -> table.name,
+        "filters" -> filters.mkString("[", ", ", "]")))
+  }
+
+  def cannotUpdateTableWhereFiltersError(table: Table, filters: Array[Predicate]): Throwable = {
+    new AnalysisException(
+      errorClass = "_LEGACY_ERROR_TEMP_1110",
+      messageParameters = Map(
+        "table" -> s"Cannot update table ${table.name}",
         "filters" -> filters.mkString("[", ", ", "]")))
   }
 
@@ -1601,6 +1615,10 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def tableDoesNotSupportDeletesError(table: Table): Throwable = {
     tableDoesNotSupportError("deletes", table)
+  }
+
+  def tableDoesNotSupportUpdatesError(table: Table): Throwable = {
+    tableDoesNotSupportError("updates", table)
   }
 
   def tableDoesNotSupportTruncatesError(table: Table): Throwable = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/UpdateTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/UpdateTableExec.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.connector.catalog.SupportsUpdateV2
+import org.apache.spark.sql.connector.expressions.filter.Predicate
+
+case class UpdateTableExec(
+    table: SupportsUpdateV2,
+    condition: Array[Predicate],
+    assignments: Array[SupportsUpdateV2.Assignment],
+    refreshCache: () => Unit) extends LeafV2CommandExec {
+
+  override protected def run(): Seq[InternalRow] = {
+    table.updateWhere(condition, assignments)
+    refreshCache()
+    Seq.empty
+  }
+
+  override def output: Seq[Attribute] = Nil
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add a new SupportsUpdateV2 interface and UpdateTableExec so DataSource V2 tables can handle UPDATE TABLE.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To let V2 data sources support UPDATE.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, adds SupportsUpdateV2.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.