### PR TITLE
Revert [SPARK-54758][SQL] Fix generator resolution order in Project

### DIFF
--- a/sql/core/src/test/resources/sql-tests/analyzer-results/generators-resolution-edge-cases.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/generators-resolution-edge-cases.sql.out
@@ -460,3 +460,21 @@ Project [col#x, count(1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FO
          +- Window [count(1) windowspecdefinition(specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS count(1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)#xL]
             +- Aggregate [count(1) AS count(1)#xL]
                +- OneRowRelation
+
+
+-- !query
+SELECT explode(array(array(0), array(1), array(2))) as arr, explode(arr) as col
+-- !query analysis
+Project [arr#x, col#x]
++- Generate explode(arr#x), false, [col#x]
+   +- Generate explode(array(array(0), array(1), array(2))), false, [arr#x]
+      +- OneRowRelation
+
+
+-- !query
+SELECT explode(arr) as col, explode(array(array(0), array(1), array(2))) as arr
+-- !query analysis
+Project [col#x, arr#x]
++- Generate explode(arr#x), false, [col#x]
+   +- Generate explode(array(array(0), array(1), array(2))), false, [arr#x]
+      +- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/generators-resolution-edge-cases.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/generators-resolution-edge-cases.sql.out
@@ -38,8 +38,8 @@ Project [col#x, col#x]
 SELECT explode(array(sin(0), 1, 2)), explode(array(10, 20))
 -- !query analysis
 Project [col#x, col#x]
-+- Generate explode(array(10, 20)), false, [col#x]
-   +- Generate explode(array(SIN(cast(0 as double)), cast(1 as double), cast(2 as double))), false, [col#x]
++- Generate explode(array(SIN(cast(0 as double)), cast(1 as double), cast(2 as double))), false, [col#x]
+   +- Generate explode(array(10, 20)), false, [col#x]
       +- OneRowRelation
 
 

--- a/sql/core/src/test/resources/sql-tests/inputs/generators-resolution-edge-cases.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/generators-resolution-edge-cases.sql
@@ -127,3 +127,9 @@ SELECT explode(array(1, 2, 3)) as col, count(*) OVER ();
 
 -- generator with window function and aggregate together resolves in order Aggregate -> Window -> Generator
 SELECT explode(array(1, 2, 3)), count(*) OVER (), count(*);
+
+-- generator LCA left-to-right should work
+SELECT explode(array(array(0), array(1), array(2))) as arr, explode(arr) as col;
+
+-- generator LCA right-to-left should work
+SELECT explode(arr) as col, explode(array(array(0), array(1), array(2))) as arr;

--- a/sql/core/src/test/resources/sql-tests/inputs/generators-resolution-edge-cases.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/generators-resolution-edge-cases.sql
@@ -7,7 +7,7 @@ SELECT 1 + explode(array(1, 2, 3));
 -- multiple generators should work
 SELECT explode(array(0, 1, 2)), explode(array(10, 20));
 
--- multiple generators are processed in left-to-right order regardless of internal rule ordering
+-- multiple generators' order is not fixed and depends on rule ordering
 SELECT explode(array(sin(0), 1, 2)), explode(array(10, 20));
 
 -- multiple generators in aggregate should fail

--- a/sql/core/src/test/resources/sql-tests/results/generators-resolution-edge-cases.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/generators-resolution-edge-cases.sql.out
@@ -460,3 +460,23 @@ struct<col:int,count(1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOL
 1	1	1
 2	1	1
 3	1	1
+
+
+-- !query
+SELECT explode(array(array(0), array(1), array(2))) as arr, explode(arr) as col
+-- !query schema
+struct<arr:array<int>,col:int>
+-- !query output
+[0]	0
+[1]	1
+[2]	2
+
+
+-- !query
+SELECT explode(arr) as col, explode(array(array(0), array(1), array(2))) as arr
+-- !query schema
+struct<col:int,arr:array<int>>
+-- !query output
+0	[0]
+1	[1]
+2	[2]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->
 
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Reverting my previous PR, because it broke LCA resolution https://github.com/apache/spark/pull/53527

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
There are 2 problems with LCA:
1. Current implementation breaks a number of queries because it creates a circular dependancy: `Generator` waits for `UnresolvedFunction` and `UnresolvedFunction` waits for generator's LCA which waits `Generator` resolution. I have an idea how to do it properly, but first I want to revert this.
2. A more fundamental problem is that currently generators' LCA could be resolved from right to left, e.g., `SELECT explode(arr) as col, explode(array(array(0), array(1), array(2))) as arr` works. This is quite bizarre, but I will need to break this behavior if I want to enforce left-to-right resolution.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
'No'

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Add new tests to golden files

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Cursor 2.2.14