### PR TITLE
[SPARK-54799] [SQL] Refactor `UnpivotCoercion`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionBase.scala
@@ -155,25 +155,7 @@ abstract class TypeCoercionBase extends TypeCoercionHelper {
    */
   object UnpivotCoercion extends Rule[LogicalPlan] {
     override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
-      case up: Unpivot if up.canBeCoercioned && !up.valuesTypeCoercioned =>
-        // get wider data type of inner values at same idx
-        val valueDataTypes = up.values.get.head.zipWithIndex.map {
-          case (_, idx) => findWiderTypeWithoutStringPromotion(up.values.get.map(_(idx).dataType))
-        }
-
-        // cast inner values to type according to their idx
-        val values = up.values.get.map(
-          values =>
-            values.zipWithIndex.map {
-              case (value, idx) => (value, valueDataTypes(idx))
-            } map {
-              case (value, Some(valueType)) if value.dataType != valueType =>
-                Alias(Cast(value, valueType), value.name)()
-              case (value, _) => value
-            }
-        )
-
-        up.copy(values = Some(values))
+      case up: Unpivot if up.canBeCoercioned && !up.valuesTypeCoercioned => UnpivotTypeCoercion(up)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnpivotTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnpivotTypeCoercion.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.catalyst.SQLConfHelper
+import org.apache.spark.sql.catalyst.expressions.{Alias, Cast}
+import org.apache.spark.sql.catalyst.plans.logical.Unpivot
+
+/**
+ * Singleton object performing the type coercion on the given [[Unpivot]] node. Do that by:
+ *  1. Get wider data type of inner values at same index.
+ *  2. Cast inner values to type according to their index.
+ */
+object UnpivotTypeCoercion extends SQLConfHelper {
+  def apply(unpivot: Unpivot): Unpivot = {
+    val valueDataTypes = unpivot.values.get.head.zipWithIndex.map {
+      case (_, index) =>
+        TypeCoercion.findWiderTypeWithoutStringPromotion(
+          unpivot.values.get.map(_(index).dataType)
+        )
+    }
+
+    val values = unpivot.values.get.map(
+      values =>
+        values.zipWithIndex.map {
+          case (value, index) => (value, valueDataTypes(index))
+        } map {
+          case (value, Some(valueType)) if value.dataType != valueType =>
+            val cast = Cast(value, valueType)
+            Alias(cast.withTimeZone(conf.sessionLocalTimeZone), value.name)()
+          case (value, _) => value
+        }
+    )
+
+    unpivot.copy(values = Some(values))
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR I propose to refactor `UnpivotCoercion`.

### Why are the changes needed?
It's needed to make it reusable in the single-pass resolver. In addition to this change, we add timezone to the `Cast` in the rule in place to avoid traversing the tree later in the single-pass and thus make it slower.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.