### PR TITLE
[SPARK-54824] Add support for multiGet and deleteRange for Rocksdb State Store

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -81,6 +81,10 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
 
     override def get(key: UnsafeRow, colFamilyName: String): UnsafeRow = map.get(key)
 
+    override def multiGet(keys: Array[UnsafeRow], colFamilyName: String): Iterator[UnsafeRow] = {
+      keys.iterator.map(key => get(key, colFamilyName))
+    }
+
     override def iterator(colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
       val iter = map.iterator()
       new StateStoreIterator(iter)
@@ -164,6 +168,11 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
     override def get(key: UnsafeRow, colFamilyName: String): UnsafeRow = {
       assertUseOfDefaultColFamily(colFamilyName)
       mapToUpdate.get(key)
+    }
+
+    override def multiGet(keys: Array[UnsafeRow], colFamilyName: String): Iterator[UnsafeRow] = {
+      assertUseOfDefaultColFamily(colFamilyName)
+      keys.iterator.map(key => mapToUpdate.get(key))
     }
 
     override def put(key: UnsafeRow, value: UnsafeRow, colFamilyName: String): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -1036,10 +1036,10 @@ class RocksDB(
     updateMemoryUsageIfNeeded()
     // Prepare keys
     val finalKeys = if (useColumnFamilies) {
-        keys.map(encodeStateRowWithPrefix(_, cfName))
-      } else {
-        keys
-      }
+      keys.map(encodeStateRowWithPrefix(_, cfName))
+    } else {
+      keys
+    }
 
     val keysList = java.util.Arrays.asList(finalKeys: _*)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -1045,7 +1045,7 @@ class RocksDB(
     val keysList = java.util.Arrays.asList(finalKeys: _*)
 
     // Call RocksDB multiGet
-    val valuesList = db.multiGet(readOptions, keysList)
+    val valuesList = db.multiGetAsList(readOptions, keysList)
 
     // Convert to Array[Array[Byte]] in one line
     valuesList.toArray(new Array[Array[Byte]](valuesList.size()))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -1035,8 +1035,7 @@ class RocksDB(
       cfName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Iterator[Array[Byte]] = {
     updateMemoryUsageIfNeeded()
     // Prepare keys
-    val finalKeys =
-      if (useColumnFamilies) {
+    val finalKeys = if (useColumnFamilies) {
         keys.map(encodeStateRowWithPrefix(_, cfName))
       } else {
         keys
@@ -1049,13 +1048,11 @@ class RocksDB(
 
     // Decode and verify checksums if enabled, then return iterator
     if (conf.rowChecksumEnabled) {
-      valuesList.asScala.iterator.zipWithIndex.map { case (value, idx) =>
-        if (value != null) {
+      valuesList.asScala.iterator.zipWithIndex.map {
+        case (value, idx) if value != null =>
           KeyValueChecksumEncoder.decodeAndVerifyValueRowWithChecksum(
             readVerifier, finalKeys(idx), value)
-        } else {
-          null
-        }
+        case _ => null
       }
     } else {
       valuesList.asScala.iterator

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -25,7 +25,7 @@ import java.util.concurrent.{ConcurrentHashMap, ConcurrentLinkedQueue}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong}
 
 import scala.collection.{mutable, Map}
-import scala.jdk.CollectionConverters.ConcurrentMapHasAsScala
+import scala.jdk.CollectionConverters.{ConcurrentMapHasAsScala, ListHasAsScala}
 import scala.util.Try
 import scala.util.control.NonFatal
 
@@ -1032,7 +1032,7 @@ class RocksDB(
    */
   def multiGet(
       keys: Array[Array[Byte]],
-      cfName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Array[Array[Byte]] = {
+      cfName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Iterator[Array[Byte]] = {
     updateMemoryUsageIfNeeded()
     // Prepare keys
     val finalKeys =
@@ -1044,11 +1044,8 @@ class RocksDB(
 
     val keysList = java.util.Arrays.asList(finalKeys: _*)
 
-    // Call RocksDB multiGet
-    val valuesList = db.multiGetAsList(readOptions, keysList)
-
-    // Convert to Array[Array[Byte]] in one line
-    valuesList.toArray(new Array[Array[Byte]](valuesList.size()))
+    // Call RocksDB multiGetAsList and return iterator directly
+    db.multiGetAsList(readOptions, keysList).asScala.iterator
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
@@ -44,6 +44,7 @@ import org.apache.spark.unsafe.Platform
 
 sealed trait RocksDBKeyStateEncoder {
   def supportPrefixKeyScan: Boolean
+  def supportsDeleteRange: Boolean
   def encodePrefixKey(prefixKey: UnsafeRow): Array[Byte]
   def encodeKey(row: UnsafeRow): Array[Byte]
   def decodeKey(keyBytes: Array[Byte]): UnsafeRow
@@ -1472,6 +1473,8 @@ class PrefixKeyScanStateEncoder(
   }
 
   override def supportPrefixKeyScan: Boolean = true
+
+  override def supportsDeleteRange: Boolean = false
 }
 
 /**
@@ -1669,6 +1672,8 @@ class RangeKeyScanStateEncoder(
   }
 
   override def supportPrefixKeyScan: Boolean = true
+
+  override def supportsDeleteRange: Boolean = true
 }
 
 /**
@@ -1698,6 +1703,8 @@ class NoPrefixKeyStateEncoder(
   }
 
   override def supportPrefixKeyScan: Boolean = false
+
+  override def supportsDeleteRange: Boolean = false
 
   override def encodePrefixKey(prefixKey: UnsafeRow): Array[Byte] = {
     throw new IllegalStateException("This encoder doesn't support prefix key!")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -268,7 +268,7 @@ private[sql] class RocksDBStateStoreProvider
       val kvEncoder = keyValueEncoderMap.get(colFamilyName)
       val encodedKeys = keys.map(kvEncoder._1.encodeKey)
       val encodedValues = rocksDB.multiGet(encodedKeys, colFamilyName)
-      encodedValues.iterator.map(kvEncoder._2.decodeValue)
+      encodedValues.map(kvEncoder._2.decodeValue)
     }
 
     override def keyExists(key: UnsafeRow, colFamilyName: String): Boolean = {
@@ -409,6 +409,8 @@ private[sql] class RocksDBStateStoreProvider
       verifyColFamilyOperations("deleteRange", colFamilyName)
 
       val kvEncoder = keyValueEncoderMap.get(colFamilyName)
+      verify(kvEncoder._1.supportsDeleteRange,
+        "deleteRange requires a RangeKeyScanStateEncoderSpec for ordered key encoding")
       val encodedBeginKey = kvEncoder._1.encodeKey(beginKey)
       val encodedEndKey = kvEncoder._1.encodeKey(endKey)
       rocksDB.deleteRange(encodedBeginKey, encodedEndKey, colFamilyName)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -259,6 +259,18 @@ private[sql] class RocksDBStateStoreProvider
       value
     }
 
+    override def multiGet(
+        keys: Array[UnsafeRow],
+        colFamilyName: String): Iterator[UnsafeRow] = {
+      validateAndTransitionState(UPDATE)
+      verify(keys != null && keys.forall(_ != null), "Keys cannot be null")
+      verifyColFamilyOperations("multiGet", colFamilyName)
+      val kvEncoder = keyValueEncoderMap.get(colFamilyName)
+      val encodedKeys = keys.map(kvEncoder._1.encodeKey)
+      val encodedValues = rocksDB.multiGet(encodedKeys, colFamilyName)
+      encodedValues.iterator.map(kvEncoder._2.decodeValue)
+    }
+
     override def keyExists(key: UnsafeRow, colFamilyName: String): Boolean = {
       validateAndTransitionState(UPDATE)
       verify(key != null, "Key cannot be null")
@@ -291,8 +303,9 @@ private[sql] class RocksDBStateStoreProvider
       "that supports multiple values for a single key.")
 
       if (storeConf.rowChecksumEnabled) {
-        // multiGet provides better perf for row checksum, since it avoids copying values
-        val encodedValuesIterator = rocksDB.multiGet(keyEncoder.encodeKey(key), colFamilyName)
+        // getMergedValues provides better perf for row checksum, since it avoids copying values
+        val encodedValuesIterator =
+          rocksDB.getMergedValues(keyEncoder.encodeKey(key), colFamilyName)
         valueEncoder.decodeValues(encodedValuesIterator)
       } else {
         val encodedValues = rocksDB.get(keyEncoder.encodeKey(key), colFamilyName)
@@ -383,6 +396,22 @@ private[sql] class RocksDBStateStoreProvider
 
       val kvEncoder = keyValueEncoderMap.get(colFamilyName)
       rocksDB.remove(kvEncoder._1.encodeKey(key), colFamilyName)
+    }
+
+    override def deleteRange(
+        beginKey: UnsafeRow,
+        endKey: UnsafeRow,
+        colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit = {
+      validateAndTransitionState(UPDATE)
+      verify(state == UPDATING, "Cannot deleteRange after already committed or aborted")
+      verify(beginKey != null, "Begin key cannot be null")
+      verify(endKey != null, "End key cannot be null")
+      verifyColFamilyOperations("deleteRange", colFamilyName)
+
+      val kvEncoder = keyValueEncoderMap.get(colFamilyName)
+      val encodedBeginKey = kvEncoder._1.encodeKey(beginKey)
+      val encodedEndKey = kvEncoder._1.encodeKey(endKey)
+      rocksDB.deleteRange(encodedBeginKey, encodedEndKey, colFamilyName)
     }
 
     override def iterator(colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -115,6 +115,10 @@ trait ReadStateStore {
       key: UnsafeRow,
       colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): UnsafeRow
 
+  def multiGet(keys: Array[UnsafeRow], colFamilyName: String): Iterator[UnsafeRow] = {
+    keys.iterator.map(key => get(key, colFamilyName))
+  }
+
   /**
    * Check if a key exists in the store, with 100% guarantee of a correct result.
    *
@@ -248,6 +252,22 @@ trait StateStore extends ReadStateStore {
   def remove(
       key: UnsafeRow,
       colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit
+
+  /**
+   * Delete all keys in the range [beginKey, endKey).
+   * Uses RocksDB's native deleteRange for efficient bulk deletion.
+   *
+   * @note This operation is NOT recorded in the changelog.
+   * @param beginKey      The start key of the range (inclusive)
+   * @param endKey        The end key of the range (exclusive)
+   * @param colFamilyName The column family name
+   */
+  def deleteRange(
+      beginKey: UnsafeRow,
+      endKey: UnsafeRow,
+      colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit = {
+    throw new UnsupportedOperationException("deleteRange is not supported by this StateStore")
+  }
 
   /**
    * Merges the provided value with existing values of a non-null key. If a existing

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -115,8 +115,17 @@ trait ReadStateStore {
       key: UnsafeRow,
       colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): UnsafeRow
 
+  /**
+   * Get the values for multiple keys in a single batch operation.
+   * Default implementation throws UnsupportedOperationException.
+   * Providers that support batch retrieval should override this method.
+   *
+   * @param keys          Array of keys to look up
+   * @param colFamilyName The column family name
+   * @return Iterator of values corresponding to the keys (null for keys that don't exist)
+   */
   def multiGet(keys: Array[UnsafeRow], colFamilyName: String): Iterator[UnsafeRow] = {
-    keys.iterator.map(key => get(key, colFamilyName))
+    throw new UnsupportedOperationException("multiGet is not supported by this StateStore")
   }
 
   /**
@@ -348,6 +357,10 @@ class WrappedReadStateStore(store: StateStore) extends ReadStateStore {
   override def get(key: UnsafeRow,
     colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): UnsafeRow = store.get(key,
     colFamilyName)
+
+  override def multiGet(keys: Array[UnsafeRow], colFamilyName: String): Iterator[UnsafeRow] = {
+    store.multiGet(keys, colFamilyName)
+  }
 
   override def keyExists(
       key: UnsafeRow,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -2910,3 +2910,4 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
 @ExtendedSQLTest
 class RocksDBStateStoreSuiteWithRowChecksum extends RocksDBStateStoreSuite
   with EnableStateStoreRowChecksum
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -2401,42 +2401,6 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
     }
   }
 
-  test("multiGet - batch retrieval of multiple keys") {
-    tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
-      val store = provider.getStore(0)
-      try {
-        // Put multiple key-value pairs
-        put(store, "a", 1, 10)
-        put(store, "b", 2, 20)
-        put(store, "c", 3, 30)
-        put(store, "d", 4, 40)
-
-        // Create keys array for multiGet
-        val keys = Array(
-          dataToKeyRow("a", 1),
-          dataToKeyRow("b", 2),
-          dataToKeyRow("c", 3),
-          dataToKeyRow("nonexistent", 999) // Key that doesn't exist
-        )
-
-        // Perform multiGet
-        // Note: multiGet returns an iterator that reuses the underlying UnsafeRow,
-        // so we must copy each row when collecting to an array
-        val results = store.multiGet(keys, StateStore.DEFAULT_COL_FAMILY_NAME)
-          .map(row => if (row != null) row.copy() else null).toArray
-
-        // Verify results
-        assert(results.length === 4)
-        assert(valueRowToData(results(0)) === 10)
-        assert(valueRowToData(results(1)) === 20)
-        assert(valueRowToData(results(2)) === 30)
-        assert(results(3) === null) // Non-existent key should return null
-      } finally {
-        if (!store.hasCommitted) store.abort()
-      }
-    }
-  }
-
   test("deleteRange - bulk deletion of keys in range") {
     tryWithProviderResource(
       newStoreProvider(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add support for multiGet and deleteRange for Rocksdb State Store


### Why are the changes needed?
For some streaming operators, using multiGet and deleteRange can improve the read/write performance.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT


### Was this patch authored or co-authored using generative AI tooling?
No
