### PR TITLE
[SPARK-54827][SQL] Add helper function `TreeNode.containsTag`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AliasResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AliasResolution.scala
@@ -70,7 +70,7 @@ object AliasResolution {
   private def extractOnly(e: Expression): Boolean = e match {
     case _: ExtractValue => e.children.forall(extractOnly)
     case _: Literal => true
-    case attr: Attribute if attr.getTagValue(ResolverTag.SINGLE_PASS_IS_LCA).isEmpty => true
+    case attr: Attribute if !attr.containsTag(ResolverTag.SINGLE_PASS_IS_LCA) => true
     case _ => false
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ApplyDefaultCollationToStringType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ApplyDefaultCollationToStringType.scala
@@ -268,7 +268,7 @@ object ApplyDefaultCollationToStringType extends Rule[LogicalPlan] {
       newType => columnDef.copy(dataType = replaceDefaultStringType(columnDef.dataType, newType))
 
     case cast: Cast if hasDefaultStringType(cast.dataType) &&
-      cast.getTagValue(Cast.USER_SPECIFIED_CAST).isDefined =>
+      cast.containsTag(Cast.USER_SPECIFIED_CAST) =>
       newType => cast.copy(dataType = replaceDefaultStringType(cast.dataType, newType))
 
     case Literal(value, dt) if hasDefaultStringType(dt) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -898,7 +898,7 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
                 "invalidExprSqls" -> invalidExprSqls.mkString(", ")))
 
           case j @ LateralJoin(_, right, _, _)
-              if j.getTagValue(LateralJoin.BY_TABLE_ARGUMENT).isEmpty =>
+              if !j.containsTag(LateralJoin.BY_TABLE_ARGUMENT) =>
             right.plan.foreach {
               case Generate(pyudtf: PythonUDTF, _, _, _, _, _)
                   if pyudtf.evalType == PythonEvalType.SQL_ARROW_UDTF =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
@@ -36,7 +36,7 @@ object CollationTypeCoercion extends SQLConfHelper {
   private val COLLATION_CONTEXT_TAG = new TreeNodeTag[DataType]("collationContext")
 
   private def hasCollationContextTag(expr: Expression): Boolean = {
-    expr.getTagValue(COLLATION_CONTEXT_TAG).isDefined
+    expr.containsTag(COLLATION_CONTEXT_TAG)
   }
 
   def apply(expression: Expression): Expression = expression match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -140,8 +140,7 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
           }
           matched(ordinal)
 
-        case u @ UnresolvedAttribute(nameParts)
-          if u.getTagValue(LogicalPlan.PLAN_ID_TAG).isEmpty =>
+        case u @ UnresolvedAttribute(nameParts) if !u.containsTag(LogicalPlan.PLAN_ID_TAG) =>
           // UnresolvedAttribute with PLAN_ID_TAG should be resolved in resolveDataFrameColumn
           val result = withPosition(u) {
             resolveColumnByName(nameParts)
@@ -451,7 +450,7 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
       u: UnresolvedAttribute,
       q: LogicalPlan,
       includeLastResort: Boolean = false): Option[Expression] = {
-    assert(u.getTagValue(LogicalPlan.PLAN_ID_TAG).nonEmpty,
+    assert(u.containsTag(LogicalPlan.PLAN_ID_TAG),
       s"UnresolvedAttribute $u should have a Plan Id tag")
 
     resolveDataFrameColumn(u, q.children).map { r =>
@@ -524,7 +523,7 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
     val planId = planIdOpt.get
     logDebug(s"Extract plan_id $planId from $u")
 
-    val isMetadataAccess = u.getTagValue(LogicalPlan.IS_METADATA_COL).nonEmpty
+    val isMetadataAccess = u.containsTag(LogicalPlan.IS_METADATA_COL)
 
     val (resolved, matched) = resolveDataFrameColumnByPlanId(
       u, planId, isMetadataAccess, q, 0)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDataFrameDropColumns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDataFrameDropColumns.scala
@@ -36,7 +36,7 @@ class ResolveDataFrameDropColumns(val catalogManager: CatalogManager)
       //   df.drop(col("non-existing-column"))
       val dropped = d.dropList.flatMap {
         case u: UnresolvedAttribute =>
-          if (u.getTagValue(LogicalPlan.PLAN_ID_TAG).nonEmpty) {
+          if (u.containsTag(LogicalPlan.PLAN_ID_TAG)) {
             // Plan Id comes from Spark Connect,
             // Here we ignore the `UnresolvedAttribute` if its Plan Id can be found
             // but column not found.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionValidation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionValidation.scala
@@ -92,8 +92,7 @@ object TypeCoercionValidation extends QueryErrorsBase {
       var issueFixedIfAnsiOff = true
       getAllExpressions(nonAnsiPlan).foreach(_.foreachUp {
         case e: Expression
-            if e.getTagValue(DATA_TYPE_MISMATCH_ERROR).isDefined &&
-            e.checkInputDataTypes().isFailure =>
+            if e.containsTag(DATA_TYPE_MISMATCH_ERROR) && e.checkInputDataTypes().isFailure =>
           e.checkInputDataTypes() match {
             case TypeCheckResult.TypeCheckFailure(_) | _: TypeCheckResult.DataTypeMismatch =>
               issueFixedIfAnsiOff = false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/DefaultCollationTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/DefaultCollationTypeCoercion.scala
@@ -92,7 +92,7 @@ object DefaultCollationTypeCoercion {
    * we should change all its occurrences to [[StringType]] with default collation.
    */
   private def shouldApplyCollationToCast(cast: Cast): Boolean = {
-    cast.getTagValue(Cast.USER_SPECIFIED_CAST).isDefined &&
+    cast.containsTag(Cast.USER_SPECIFIED_CAST) &&
     hasDefaultStringType(cast.dataType)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/JoinResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/JoinResolver.scala
@@ -208,7 +208,7 @@ class JoinResolver(resolver: Resolver, expressionResolver: ExpressionResolver)
       scopes.current.hiddenOutput.filter(_.qualifiedAccessOnly)
 
     val newProjectList =
-      if (unresolvedJoin.getTagValue(ResolverTag.TOP_LEVEL_OPERATOR).isEmpty) {
+      if (!unresolvedJoin.containsTag(ResolverTag.TOP_LEVEL_OPERATOR)) {
         newOutputList ++ qualifiedAccessOnlyColumnsFromHiddenOutput
       } else {
         newOutputList

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ResolverGuard.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ResolverGuard.scala
@@ -328,7 +328,7 @@ class ResolverGuard(catalogManager: CatalogManager) extends SQLConfHelper {
 
   private def checkUnresolvedAttribute(unresolvedAttribute: UnresolvedAttribute) =
     !ResolverGuard.UNSUPPORTED_ATTRIBUTE_NAMES.contains(unresolvedAttribute.nameParts.head) &&
-    !unresolvedAttribute.getTagValue(LogicalPlan.PLAN_ID_TAG).isDefined
+    !unresolvedAttribute.containsTag(LogicalPlan.PLAN_ID_TAG)
 
   private def checkUnresolvedPredicate(unresolvedPredicate: Predicate) = unresolvedPredicate match {
     case inSubquery: InSubquery =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -575,7 +575,7 @@ case class Cast(
 
   private def typeCheckFailureInCast: DataTypeMismatch = evalMode match {
     case EvalMode.ANSI =>
-      if (getTagValue(Cast.BY_TABLE_INSERTION).isDefined) {
+      if (containsTag(Cast.BY_TABLE_INSERTION)) {
         Cast.typeCheckFailureMessage(child.dataType, dataType,
           Some(SQLConf.STORE_ASSIGNMENT_POLICY.key ->
             SQLConf.StoreAssignmentPolicy.LEGACY.toString))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -417,7 +417,7 @@ case class PrettyAttribute(
 
   override def toString: String = name
   override def sql: String = {
-    if (getTagValue(ResolverTag.SINGLE_PASS_IS_LCA).nonEmpty) {
+    if (containsTag(ResolverTag.SINGLE_PASS_IS_LCA)) {
       // For a query like:
       //
       // {{{ select 1 as a, a + 1 }}}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelation.scala
@@ -148,7 +148,7 @@ abstract class PropagateEmptyRelationBase extends Rule[LogicalPlan] with CastSup
       case _: LocalLimit if !p.isStreaming => empty(p)
       case _: Offset => empty(p)
       case _: RepartitionOperation =>
-        if (p.getTagValue(ROOT_REPARTITION).isEmpty) {
+        if (!p.containsTag(ROOT_REPARTITION)) {
           empty(p)
         } else {
           p.unsetTagValue(ROOT_REPARTITION)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -88,7 +88,7 @@ object ConstantFolding extends Rule[LogicalPlan] {
     case Size(c: CreateMap, _) if c.children.forall(hasNoSideEffect) =>
       Literal(c.children.length / 2)
 
-    case e if e.getTagValue(FAILED_TO_EVALUATE).isDefined => e
+    case e if e.containsTag(FAILED_TO_EVALUATE) => e
 
     // Fold expressions that are foldable.
     case e if e.foldable => tryFold(e, isConditionalBranch)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/NormalizePlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/NormalizePlan.scala
@@ -157,7 +157,7 @@ object NormalizePlan extends PredicateHelper {
             .reduce(And)
         Join(left, right, newJoinType, Some(newCondition), hint)
       case project: Project
-          if project.getTagValue(ResolverTag.PROJECT_FOR_EXPRESSION_ID_DEDUPLICATION).isDefined =>
+          if project.containsTag(ResolverTag.PROJECT_FOR_EXPRESSION_ID_DEDUPLICATION) =>
         project.child
 
       case aggregate @ Aggregate(_, _, innerProject: Project, _) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -196,6 +196,10 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
     tags(tag) = value
   }
 
+  def containsTag[T](tag: TreeNodeTag[T]): Boolean = {
+    getTagValue[T](tag).isDefined
+  }
+
   def getTagValue[T](tag: TreeNodeTag[T]): Option[T] = {
     if (isTagsEmpty) {
       None

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
@@ -116,7 +116,7 @@ package object util extends Logging {
         ),
         dataType = r.dataType
       )
-    case c: Cast if c.getTagValue(Cast.USER_SPECIFIED_CAST).isEmpty =>
+    case c: Cast if !c.containsTag(Cast.USER_SPECIFIED_CAST) =>
       PrettyAttribute(usePrettyExpression(c.child, shouldTrimTempResolvedColumn).sql, c.dataType)
     case p: PythonFuncExpression => PrettyPythonUDF(p.name, p.dataType, p.children)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -122,7 +122,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
 
   private def setLogicalLink(logicalPlan: LogicalPlan, inherited: Boolean = false): Unit = {
     // Stop at a descendant which is the root of a sub-tree transformed from another logical node.
-    if (inherited && getTagValue(SparkPlan.LOGICAL_PLAN_TAG).isDefined) {
+    if (inherited && containsTag(SparkPlan.LOGICAL_PLAN_TAG)) {
       return
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEPropagateEmptyRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEPropagateEmptyRelation.scala
@@ -43,7 +43,7 @@ object AQEPropagateEmptyRelation extends PropagateEmptyRelationBase {
   override protected def empty(plan: LogicalPlan): LogicalPlan = EmptyRelation(plan)
 
   private def isRootRepartition(plan: LogicalPlan): Boolean = plan match {
-    case l: LogicalQueryStage if l.getTagValue(ROOT_REPARTITION).isDefined => true
+    case l: LogicalQueryStage if l.containsTag(ROOT_REPARTITION) => true
     case _ => false
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -718,7 +718,7 @@ case class AdaptiveSparkPlanExec(
   private def setLogicalLinkForNewQueryStage(stage: QueryStageExec, plan: SparkPlan): Unit = {
     val link = plan.getTagValue(TEMP_LOGICAL_PLAN_TAG).orElse(
       plan.logicalLink.orElse(plan.collectFirst {
-        case p if p.getTagValue(TEMP_LOGICAL_PLAN_TAG).isDefined =>
+        case p if p.containsTag(TEMP_LOGICAL_PLAN_TAG) =>
           p.getTagValue(TEMP_LOGICAL_PLAN_TAG).get
         case p if p.logicalLink.isDefined => p.logicalLink.get
       }))
@@ -835,7 +835,7 @@ case class AdaptiveSparkPlanExec(
    */
   private def cleanUpTempTags(plan: SparkPlan): Unit = {
     plan.foreach {
-      case plan: SparkPlan if plan.getTagValue(TEMP_LOGICAL_PLAN_TAG).isDefined =>
+      case plan: SparkPlan if plan.containsTag(TEMP_LOGICAL_PLAN_TAG) =>
         plan.unsetTagValue(TEMP_LOGICAL_PLAN_TAG)
       case _ =>
     }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -264,7 +264,7 @@ case class RelationConversions(
         tableDesc, _, query, overwrite, ifPartitionNotExists, _, _, _, _, _, _)
           if query.resolved && DDLUtils.isHiveTable(tableDesc) &&
             tableDesc.partitionColumnNames.isEmpty && isConvertible(tableDesc) &&
-            conf.getConf(HiveUtils.CONVERT_METASTORE_CTAS) && i.getTagValue(BY_CTAS).isDefined =>
+            conf.getConf(HiveUtils.CONVERT_METASTORE_CTAS) && i.containsTag(BY_CTAS) =>
         // validation is required to be done here before relation conversion.
         DDLUtils.checkTableColumns(tableDesc.copy(schema = query.schema))
         val hiveTable = DDLUtils.readHiveTable(tableDesc)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add helper function `TreeNode.containsTag`


### Why are the changes needed?
In many places, we don't care the tag value, we only need to check whether a tag exists.
This new function can help simplify the code a bit, e.g.

`getTagValue(Cast.BY_TABLE_INSERTION).isDefined` -> `containsTag(Cast.BY_TABLE_INSERTION)`

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
