### PR TITLE
handle command return code in launch_gateway function

### DIFF
--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -104,8 +104,15 @@ def launch_gateway(conf=None, popen_kwargs=None):
                 proc = Popen(command, **popen_kwargs)
 
             # Wait for the file to appear, or for the process to exit, whichever happens first.
-            while not proc.poll() and not os.path.isfile(conn_info_file):
+            while proc.poll() is None and not os.path.isfile(conn_info_file):
                 time.sleep(0.1)
+
+            return_code = proc.poll()
+            if return_code is not None and return_code != 0:
+                raise PySparkRuntimeError(
+                    errorClass="JAVA_GATEWAY_EXITED",
+                    messageParameters={"command": " ".join(command), "return_code": return_code},
+                )
 
             if not os.path.isfile(conn_info_file):
                 raise PySparkRuntimeError(


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Stop waiting loop when the gateway process exits and raise `PySparkRuntimeError` on non-zero return codes.
- Include command and return code in the error message for easier diagnosis.
- Keep the existing check for missing connection info file.

### Why are the changes needed?
- Previously the loop could spin until the timeout even if the gateway had already failed.
- Without surfacing the return code/command, diagnosing startup failures was harder.

### Does this PR introduce _any_ user-facing change?
- No API changes; failure now surfaces earlier with clearer error details when the gateway process dies.

### How was this patch tested?
- Manual reasoning; no automated tests added (gateway startup is exercised by existing suites).

### Was this patch authored or co-authored using generative AI tooling?
- No.