### PR TITLE
[SPARK-54831][SQL] Add COMMENT ON COLUMN support to set and remove column comments

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -806,6 +806,12 @@
     ],
     "sqlState" : "22003"
   },
+  "COMMENT_ON_COLUMN_REQUIRES_TABLE_NAME" : {
+    "message" : [
+      "COMMENT ON COLUMN requires at least table name and column name (e.g., table.column, database.table.column, or catalog.database.table.column). Found: <columnRef>."
+    ],
+    "sqlState" : "42601"
+  },
   "COMPARATOR_RETURNS_NULL" : {
     "message" : [
       "The comparator has returned a NULL for a comparison between <firstValue> and <secondValue>.",

--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -379,6 +379,7 @@ statement
     | COMMENT ON namespace identifierReference IS
         comment                                                        #commentNamespace
     | COMMENT ON TABLE identifierReference IS comment                  #commentTable
+    | COMMENT ON COLUMN multipartIdentifier IS comment                 #commentColumn
     | REFRESH TABLE identifierReference                                #refreshTable
     | REFRESH FUNCTION identifierReference                             #refreshFunction
     | REFRESH (stringLit | .*?)                                        #refreshResource

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -831,6 +831,19 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
   }
 
   /**
+   * Indicates that COMMENT ON COLUMN must specify a table name along with column name.
+   *
+   * @throws ParseException
+   *   Always throws this exception
+   */
+  def commentOnColumnRequiresTableNameError(ctx: ParserRuleContext): Nothing = {
+    throw new ParseException(
+      errorClass = "COMMENT_ON_COLUMN_REQUIRES_TABLE_NAME",
+      messageParameters = Map("columnRef" -> ctx.getText),
+      ctx = ctx)
+  }
+
+  /**
    * Throws an internal error for unexpected parameter markers found during AST building. This
    * should be unreachable in normal operation due to grammar-level blocking.
    *

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StructField.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StructField.scala
@@ -149,13 +149,16 @@ case class StructField(
   }
 
   /**
-   * Updates the StructField with a new comment value.
+   * Updates the StructField with a new comment value. If the comment is null, the comment key is
+   * removed from metadata.
    */
   def withComment(comment: String): StructField = {
-    val newMetadata = new MetadataBuilder()
-      .withMetadata(metadata)
-      .putString("comment", comment)
-      .build()
+    val builder = new MetadataBuilder().withMetadata(metadata)
+    val newMetadata = if (comment == null) {
+      builder.remove("comment").build()
+    } else {
+      builder.putString("comment", comment).build()
+    }
     copy(metadata = newMetadata)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2AlterTableCommands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2AlterTableCommands.scala
@@ -59,6 +59,28 @@ case class CommentOnTable(table: LogicalPlan, comment: String) extends AlterTabl
 }
 
 /**
+ * The logical plan that defines or changes the comment of a COLUMN for v2 catalogs.
+ *
+ * {{{
+ *   COMMENT ON COLUMN catalog.namespace.table.column IS ('text' | NULL)
+ * }}}
+ *
+ * where the `text` is the new comment written as a string literal; or `NULL` to drop the comment.
+ */
+case class CommentOnColumn(
+    table: LogicalPlan,
+    column: FieldName,
+    comment: String) extends AlterTableCommand {
+  override def changes: Seq[TableChange] = {
+    require(column.resolved, "FieldName should be resolved before it's converted to TableChange.")
+    Seq(TableChange.updateColumnComment(column.name.toArray, comment))
+  }
+  override protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan =
+    copy(table = newChild)
+}
+
+
+/**
  * The logical plan of the ALTER TABLE ... SET LOCATION command.
  */
 case class SetTableLocation(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

This PR adds support for the COMMENT ON COLUMN SQL syntax to set, update, and remove comments on table columns. 

The syntax follows the SQL standard:

`COMMENT ON COLUMN [catalog.][[database.]table.]column IS { 'comment_text' | NULL }`


**Key features:**

Set/Update comment: `COMMENT ON COLUMN table.column IS 'text'` - Sets or updates a column comment
Remove comment: `COMMENT ON COLUMN table.column IS NULL` - Removes the comment

Flexible qualification: Supports table.column, database.table.column, and catalog.database.table.column formats

Implementation highlights:
* Added CommentOnColumn logical plan node in v2AlterTableCommands.scala
* Parser support in SqlBaseParser.g4 and AstBuilder.scala
* Works with both V2 DataSource tables and V1/session catalog tables

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently, Spark only supports setting column comments via:
1. CREATE TABLE with COMMENT clause
2. ALTER TABLE ... ALTER COLUMN ... COMMENT (doesn't support removal)

This PR provides a standard SQL syntax (COMMENT ON COLUMN) that:
* Follows SQL standard conventions (consistent with existing COMMENT ON TABLE)
* Allows explicit removal of column comments via IS NULL
* Provides cleaner, more intuitive syntax for managing column-level documentation

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. New SQL syntax:

```
-- Set a column comment
COMMENT ON COLUMN my_table.my_column IS 'This is a column comment';

-- Update a column comment  
COMMENT ON COLUMN my_table.my_column IS 'Updated comment';

-- Remove a column comment
COMMENT ON COLUMN my_table.my_column IS NULL;

-- Set empty string comment
COMMENT ON COLUMN my_table.my_column IS '';

-- Works with qualified names
COMMENT ON COLUMN my_catalog.my_db.my_table.my_column IS 'comment';
```


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added comprehensive parser tests in DDLParserSuite.scala covering:
* Various qualification levels (table.column, database.table.column, etc.)
* NULL handling for comment removal

Added integration tests in DataSourceV2SQLSuite.scala covering:
* Setting, updating, and removing comments on V1 and V2 tables
* NULL vs. empty string behavior
* Different qualification formats
* Error cases (column not found)


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No