### PR TITLE
[SPARK-54832][UI] Spark executor page show driver gc times

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -961,6 +961,10 @@ private[spark] class AppStatusListener(
     event.executorUpdates.foreach { case (key, peakUpdates) =>
       liveExecutors.get(event.execId).foreach { exec =>
         if (exec.peakExecutorMetrics.compareAndUpdatePeakValues(peakUpdates)) {
+          if (exec.executorId == "driver") {
+            exec.totalGcTime = exec.peakExecutorMetrics.getMetricValue("MinorGCTime") +
+              exec.peakExecutorMetrics.getMetricValue("MajorGCTime")
+          }
           update(exec, now)
         }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Spark jobs driver side some times show below message
```
java.lang.OutOfMemoryError: GC overhead limit exceeded
```

But Spark executor page didn't show driver GC metrics,  When Driver GC is heavy, all executors may be waiting for scheduling, resulting in wasted resources. We need to optimize for heavy GC scenarios. We need to know this information very easily.

We can add it

<img width="1728" height="528" alt="截屏2025-12-24 17 52 44" src="https://github.com/user-attachments/assets/4ff725e5-c38a-488e-b19f-e4df2b816ef7" />

### Why are the changes needed?
To help users better understand their assignments

### Does this PR introduce _any_ user-facing change?
User can know driver side gc time in executors page


### How was this patch tested?

**Before**
<img width="1728" height="528" alt="截屏2025-12-24 17 52 44" src="https://github.com/user-attachments/assets/4ff725e5-c38a-488e-b19f-e4df2b816ef7" />

**After**
<img width="1721" height="495" alt="截屏2025-12-24 17 49 07" src="https://github.com/user-attachments/assets/f96aad8c-8d48-4fd4-b054-d7d0d66eea94" />


### Was this patch authored or co-authored using generative AI tooling?
No
