### PR TITLE
[SPARK-54838][SQL] A new feature to optimize partition size and count

### DIFF
--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -633,6 +633,19 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             self.sparkSession,
         )
 
+    def optimizePartitions(self, targetMB: Optional[int] = None) -> "DataFrame":
+        """
+        Optimizes the partition count based on dataset size.
+        """
+        target_size = targetMB if targetMB is not None else 128
+        if target_size <= 0:
+            raise PySparkValueError(
+                errorClass="VALUE_NOT_POSITIVE",
+                messageParameters={"arg_name": "targetMB", "arg_value": str(target_size)},
+            )
+        jdf = self._jdf.optimizePartitions(int(target_size))
+        return DataFrame(jdf, self.sparkSession)
+
     def distinct(self) -> ParentDataFrame:
         return DataFrame(self._jdf.distinct(), self.sparkSession)
 

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -475,6 +475,12 @@ class DataFrame(ParentDataFrame):
         res._cached_schema = self._cached_schema
         return res
 
+    def optimizePartitions(self, targetMB: Optional[int] = None) -> "DataFrame":
+        raise PySparkNotImplementedError(
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "optimizePartitions for Spark Connect"},
+        )
+
     def dropDuplicates(self, subset: Optional[List[str]] = None) -> ParentDataFrame:
         if subset is not None and not isinstance(subset, (list, tuple)):
             raise PySparkTypeError(
@@ -2380,6 +2386,7 @@ def _test() -> None:
     if not is_remote_only():
         del pyspark.sql.dataframe.DataFrame.toJSON.__doc__
         del pyspark.sql.dataframe.DataFrame.rdd.__doc__
+        del pyspark.sql.dataframe.DataFrame.optimizePartitions.__doc__
 
     if not have_pandas or not have_pyarrow:
         del pyspark.sql.dataframe.DataFrame.toPandas.__doc__

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2011,6 +2011,45 @@ class DataFrame:
         ...
 
     @dispatch_df_method
+    def optimizePartitions(self, targetMB: Optional[int] = None) -> "DataFrame":
+        """
+        Proactively optimizes the partition count of this DataFrame based on its estimated size.
+
+        Best Practice: Use on Ingest
+        This method is best used immediately after reading a dataset to ensure the initial
+        parallelism matches the data size. This prevents "Small File" issues (too many partitions)
+        or "Giant Partition" issues (too few partitions) before heavy transformations begin.
+
+        .. versionadded:: 4.2.0
+
+        Parameters
+        ----------
+        targetMB : int, optional
+            The target partition size in Megabytes. Defaults to 128MB.
+
+        Returns
+        -------
+        :class:`DataFrame`
+            Repartitioned DataFrame.
+
+        Notes
+        -----
+        This method uses Round Robin partitioning (random shuffle) to balance sizes.
+        If used immediately before writing to a partitioned table, it may degrade performance
+        by breaking data locality.
+
+        Examples
+        --------
+        >>> df = spark.range(1000000).repartition(8)
+        >>> df.rdd.getNumPartitions()
+        8
+        >>> df_opt = df.optimizePartitions(64)
+        >>> df_opt.rdd.getNumPartitions()  # e.g., 1 (depending on data size)
+        1
+        """
+        ...
+
+    @dispatch_df_method
     def distinct(self) -> "DataFrame":
         """Returns a new :class:`DataFrame` containing the distinct rows in this :class:`DataFrame`.
 

--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -38,6 +38,10 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedConnectTestCase):
     def test_to_json(self):
         pass
 
+    @unittest.skip("optimizePartitions is not implemented in Spark Connect")
+    def test_optimize_partitions(self):
+        super().test_optimize_partitions()
+
 
 if __name__ == "__main__":
     from pyspark.testing import main

--- a/sql/api/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -3013,6 +3013,37 @@ abstract class Dataset[T] extends Serializable {
   def repartitionById(numPartitions: Int, partitionIdExpr: Column): Dataset[T]
 
   /**
+   * Proactively optimizes the partition count of this Dataset based on its estimated size.
+   *
+   * ==Best Practice: Use on Ingest==
+   * This method is best used immediately after reading a dataset to ensure the initial
+   * parallelism matches the data size. This prevents "Small File" issues (too many partitions) or
+   * "Giant Partition" issues (too few partitions) before heavy transformations begin.
+   *
+   * {{{
+   * val raw = spark.read.parquet("...")
+   * val optimized = raw.optimizePartitions() // Perfect start for transformations
+   * optimized.filter(...).groupBy(...)
+   * }}}
+   *
+   * ==Warning: Use on Write==
+   * This method uses Round Robin partitioning (random shuffle) to balance sizes. If used
+   * immediately before writing to a partitioned table (e.g., `write.partitionBy("city")`), it may
+   * degrade performance by breaking data locality, causing the writer to create many small files
+   * across directories.
+   *
+   * @param targetMB
+   *   The target partition size in Megabytes. Defaults to 128MB.
+   * @group typedrel
+   * @since 4.2.0
+   */
+  def optimizePartitions(targetMB: Int = 128): Dataset[T] = {
+    throw new UnsupportedOperationException(
+      "This method is implemented in " +
+        "the concrete Dataset classes")
+  }
+
+  /**
    * Returns a new Dataset that has exactly `numPartitions` partitions, when the fewer partitions
    * are requested. If a larger number of partitions is requested, it will stay at the current
    * number of partitions. Similar to coalesce defined on an `RDD`, this operation results in a

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizePartitionsRule.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizePartitionsRule.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, OptimizePartitionsCommand, Repartition}
+import org.apache.spark.sql.catalyst.rules.Rule
+
+/**
+ * Proactively optimizes the partition count of a Dataset based on its estimated size.
+ * This rule transforms the custom OptimizePartitionsCommand into standard Spark operations.
+ */
+object OptimizePartitionsRule extends Rule[LogicalPlan] {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.transform {
+    case OptimizePartitionsCommand(child, targetMB, currentPartitions) =>
+
+      require(targetMB > 0, s"targetMB must be positive. Got $targetMB")
+      val targetBytes = targetMB.toLong * 1024L * 1024L
+
+      // Get the estimated size from Catalyst Statistics
+      val sizeInBytes: BigInt = child.stats.sizeInBytes
+
+      // Calculate Optimal Partition Count (N)
+      val count = math.ceil(sizeInBytes.toDouble / targetBytes).toInt
+      val calculatedN: Int = if (count <= 1) 1 else count
+
+      // Smart Switch: Coalesce vs Repartition
+      if (calculatedN < currentPartitions) {
+        // DOWNSCALING: Use Coalesce (shuffle = false)
+        Repartition(calculatedN, shuffle = false, child)
+      } else if (calculatedN > currentPartitions) {
+        // UPSCALING: Use Repartition (shuffle = true)
+        Repartition(calculatedN, shuffle = true, child)
+      } else {
+        // OPTIMAL
+        child
+      }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/OptimizePartitionsCommand.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/OptimizePartitionsCommand.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+/**
+ * A logical command that hints to the optimizer that we want to
+ * automatically repartition the data based on statistics.
+ */
+case class OptimizePartitionsCommand(child: LogicalPlan,
+                                     targetMB: Int,
+                                     currentPartitions: Int) extends UnaryNode {
+
+  override def output: Seq[Attribute] = child.output
+
+  override protected def withNewChildInternal(newChild: LogicalPlan): OptimizePartitionsCommand =
+    copy(child = newChild)
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
@@ -1562,6 +1562,14 @@ class Dataset[T] private[sql](
     }
   }
 
+  override def optimizePartitions(targetMB: Int): Dataset[T] = {
+    val currentPartitions = rdd.getNumPartitions
+
+    withTypedPlan {
+      OptimizePartitionsCommand(logicalPlan, targetMB, currentPartitions)
+    }
+  }
+
   /** @inheritdoc */
   def coalesce(numPartitions: Int): Dataset[T] = withSameTypedPlan {
     Repartition(numPartitions, shuffle = false, logicalPlan)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
@@ -96,7 +96,8 @@ class SparkOptimizer(
       ConstantFolding,
       EliminateLimits),
     Batch("User Provided Optimizers", fixedPoint, experimentalMethods.extraOptimizations: _*),
-    Batch("Replace CTE with Repartition", Once, ReplaceCTERefWithRepartition)))
+    Batch("Replace CTE with Repartition", Once, ReplaceCTERefWithRepartition),
+    Batch("Optimizer Partitions", Once, OptimizePartitionsRule)))
 
   override def nonExcludableRules: Seq[String] = super.nonExcludableRules ++
     Seq(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/OptimizePartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/OptimizePartitionsSuite.scala
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.test.SharedSparkSession
+
+class OptimizePartitionsSuite extends SparkFunSuite with SharedSparkSession {
+
+  test("TEST 1: Downscaling (Coalesce behavior)") {
+    val rowCount = 10000
+    // Force 100 partitions on tiny data (~80KB)
+    val initialDF = spark.range(rowCount).repartition(100)
+    assert(initialDF.rdd.getNumPartitions == 100)
+
+    // Optimize with default 128MB. Should drop to 1 partition.
+    val optimizedDF = initialDF.optimizePartitions()
+
+    // Check Partition Count
+    assert(optimizedDF.rdd.getNumPartitions == 1,
+      s"Expected 1 partition, got ${optimizedDF.rdd.getNumPartitions}.")
+
+    // Check Data Integrity (Crucial!)
+    assert(optimizedDF.count() == rowCount, "Data loss detected after optimization!")
+  }
+
+  test("TEST 2: Upscaling (Repartition behavior)") {
+    val rowCount = 500000
+    // 500,000 Longs (8 bytes) = ~4,000,000 bytes (approx 3.8 MB)
+    // We force it into 1 partition initially
+    val initialDF = spark.range(rowCount).repartition(1)
+
+    // We set target to 2MB.
+    // Logic: 4MB Total / 2MB Target = 2 Partitions needed.
+    val optimizedDF = initialDF.optimizePartitions(2)
+
+    // Check Partition Count
+    assert(optimizedDF.rdd.getNumPartitions == 2,
+      s"Expected scaling up to 2 partitions, got ${optimizedDF.rdd.getNumPartitions}.")
+
+    // Check Data Integrity
+    assert(optimizedDF.count() == rowCount, "Data count mismatch after scaling up!")
+  }
+
+  test("TEST 3: Idempotency (Already Optimal)") {
+    // Data is ~4MB. Current partitions = 2. Target = 2MB.
+    // 4MB / 2MB = 2.
+    // Since Calculated (2) == Current (2), the rule should do nothing (return child).
+    val rowCount = 500000
+    val initialDF = spark.range(rowCount).repartition(2)
+
+    val optimizedDF = initialDF.optimizePartitions(2)
+
+    assert(optimizedDF.rdd.getNumPartitions == 2)
+    assert(optimizedDF.count() == rowCount)
+
+    // Optional: Verify the plan didn't change (Optimization overhead check)
+    // We compare logical plans to see if a new Repartition node was added
+    assert(initialDF.queryExecution.optimizedPlan == optimizedDF.queryExecution.optimizedPlan,
+      "Plan should not change if partition count is already optimal")
+  }
+
+  test("TEST 4: Edge Case - Zero or Negative Target") {
+    val initialDF = spark.range(100)
+
+    // 1. Check for Zero
+    // We expect the code to throw IllegalArgumentException
+    val e1 = intercept[IllegalArgumentException] {
+      // We call .rdd or .collect() to force the optimizer to run (if validation is in the Rule)
+      initialDF.optimizePartitions(0).rdd
+    }
+    assert(e1.getMessage.contains("targetMB must be positive"))
+
+    // 2. Check for Negative
+    val e2 = intercept[IllegalArgumentException] {
+      initialDF.optimizePartitions(-5).rdd
+    }
+    assert(e2.getMessage.contains("targetMB must be positive"))
+  }
+
+  test("TEST 5: Edge Case - Empty DataFrame") {
+    val emptyDF = spark.range(0).repartition(10)
+
+    // Optimization should recognize size is 0.
+    // It might return 1 (your rule) or 0 (PropagateEmptyRelation optimization).
+    // Both are valid "optimized" states compared to 10.
+    val optimizedDF = emptyDF.optimizePartitions()
+
+    val finalPartitions = optimizedDF.rdd.getNumPartitions
+    assert(finalPartitions <= 1, s"Expected <= 1 partition for empty data, got $finalPartitions")
+
+    assert(optimizedDF.count() == 0)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->
### What changes were proposed in this pull request?
I am proposing to add a new function in Dataset class to fix small file problem. We have noticed that if the source data our spark job reads have many small files (KB size), it creates lot of partitions. This PR adds a new function named optimizePartition which when used creates partitions of size 128MB if no size passed. You can pass your own desired partition size.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
### Why are the changes needed?
The changes are needed to solve small file problem. It also helps in reducing the number of files that gets written back to sink.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
It does not introduce any change in any existing feature/functions of Dataset. It is a brand new function.
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
I have added number of unit tests that covers the scenario of lot of small partitions and when this function is called, it either coalesces to reduce partition count or uses repartition to increase partition count if partition size is too big. Also tested it locally using a dockerized environment containing spark cluster.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
I did most of the coding. I used Gemini along to help me walk through the process of opening PRs, jira ticket and using linters/formatters. This PR does not have lot of code change.
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
