### PR TITLE
SPARK-34519 ExecutorPodsAllocator applies exponential backoff delays …

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -252,6 +252,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
       case RegisterExecutor(executorId, executorRef, hostname, cores, logUrls,
           attributes, resources, resourceProfileId) =>
+        onRegisterExecutorMsgReceived(executorId)
         if (executorDataMap.contains(executorId)) {
           context.sendFailure(new IllegalStateException(s"Duplicate executor ID: $executorId"))
         } else if (scheduler.excludedNodes().contains(hostname) ||
@@ -371,6 +372,12 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
       case e =>
         logError(log"Received unexpected ask ${MDC(ERROR, e)}")
     }
+
+    /**
+     * Hook method called when RegisterExecutor message received.
+     * Subclasses can override this to perform additional actions.
+     */
+    protected def onRegisterExecutorMsgReceived(executorId: String): Unit = {}
 
     // Make fake resource offers on all executors
     private def makeOffers(): Unit = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -815,6 +815,50 @@ private[spark] object Config extends Logging {
       .booleanConf
       .createWithDefault(false)
 
+  val KUBERNETES_ALLOCATION_EXECUTOR_BACKOFF_ENABLED =
+    ConfigBuilder("spark.kubernetes.allocation.executor.backoff.enabled")
+      .doc("Enables a backoff mechanism for executor allocation failures. When enabled, " +
+        "executor pod requests are delayed exponentially if pods repeatedly fail to start. " +
+        "This helps reduce load on Kubernetes infrastructure (control plane, Istio, etc)")
+      .version("4.2.0")
+      .booleanConf
+      .createWithDefault(false)
+
+  val KUBERNETES_ALLOCATION_EXECUTOR_BACKOFF_FAILURE_THRESHOLD =
+    ConfigBuilder("spark.kubernetes.allocation.executor.backoff.failureThreshold")
+      .doc("Number of executor startup failures to trigger Backoff state. " +
+        "Only counts failures within the configured failure interval.")
+      .version("4.2.0")
+      .intConf
+      .checkValue(value => value > 0, "Failure threshold should be a positive integer")
+      .createWithDefault(2)
+
+  val KUBERNETES_ALLOCATION_EXECUTOR_BACKOFF_FAILURE_INTERVAL =
+    ConfigBuilder("spark.kubernetes.allocation.executor.backoff.failureInterval")
+      .doc("Time window for counting executor startup failures. Failures older than " +
+        "this interval are not counted towards the failure threshold.")
+      .version("4.2.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .checkValue(interval => interval > 0, "Failure interval must be a positive time value")
+      .createWithDefaultString("10m")
+
+  val KUBERNETES_ALLOCATION_EXECUTOR_BACKOFF_INITIAL_DELAY =
+    ConfigBuilder("spark.kubernetes.allocation.executor.backoff.initialDelay")
+      .doc("Starting delay for exponential backoff when in Backoff state. " +
+        "The delay doubles with each request made while in Backoff state.")
+      .version("4.2.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .checkValue(delay => delay > 0, "Initial backoff delay must be a positive time value")
+      .createWithDefaultString("30s")
+
+  val KUBERNETES_ALLOCATION_EXECUTOR_BACKOFF_MAX_DELAY =
+    ConfigBuilder("spark.kubernetes.allocation.executor.backoff.maxBackoffDelay")
+      .doc("Maximum backoff delay. The delay will not exceed this value.")
+      .version("4.2.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .checkValue(delay => delay > 0, "Max backoff delay must be a positive time value")
+      .createWithDefaultString("5m")
+
   val KUBERNETES_DRIVER_LABEL_PREFIX = "spark.kubernetes.driver.label."
   val KUBERNETES_DRIVER_ANNOTATION_PREFIX = "spark.kubernetes.driver.annotation."
   val KUBERNETES_DRIVER_SERVICE_LABEL_PREFIX = "spark.kubernetes.driver.service.label."

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/AbstractPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/AbstractPodsAllocator.scala
@@ -19,6 +19,7 @@ package org.apache.spark.scheduler.cluster.k8s
 import io.fabric8.kubernetes.api.model.Pod
 
 import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.metrics.source.Source
 import org.apache.spark.resource.ResourceProfile
 
 
@@ -55,4 +56,14 @@ abstract class AbstractPodsAllocator {
    * Stop hook
    */
   def stop(applicationId: String): Unit
+
+  /**
+   * Called when driver receives RegisterExecutor message from executor
+   */
+  def onRegisterExecutorMsgReceived(executorId: String): Unit = {}
+
+  /**
+   * Metrics sources for this allocator.
+   */
+  def metricsSources: Seq[Source] = Seq.empty
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsBackoffController.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsBackoffController.scala
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.scheduler.cluster.k8s
+
+import scala.collection.mutable
+
+import com.codahale.metrics.MetricRegistry
+
+import org.apache.spark.SparkConf
+import org.apache.spark.deploy.k8s.Config._
+import org.apache.spark.internal.Logging
+import org.apache.spark.metrics.source.Source
+import org.apache.spark.util.Clock
+
+private[spark] object ExecutorPodsBackoffController {
+  sealed trait State
+
+  case class NormalState(
+    // startup failures within the sliding time window (timestamp, executorId)
+    startupFailuresInInterval: mutable.Queue[(Long, Long)] = mutable.Queue.empty) extends State
+
+  case class BackoffState(
+    requestedExecutors: mutable.HashSet[Long] = mutable.HashSet.empty,
+    // time reference for backoff delay calculation - set when entering Backoff
+    // and updated after each pod request
+    var delayReferenceTime: Long) extends State
+}
+
+/**
+ * Applies exponential backoff delays for executor pod requests when pods repeatedly fail to start,
+ * reducing load on the Kubernetes infrastructure (control plane, Istio, etc).
+ *
+ * Operates as a state machine with two states:
+ *  - Normal: No extra delay is introduced. Tracks startup failures in a sliding time window.
+ *    Transitions to Backoff when failure count exceeds threshold.
+ *  - Backoff: Applies exponential backoff delays between requests.
+ *    Transitions back to Normal when an executor requested during Backoff is seen started.
+ *
+ * Only startup failures (executors that never started) are counted for backoff.
+ *
+ * Thread-safe: all public methods are synchronized as they can be called from multiple threads
+ * (ExecutorPodsAllocator and KubernetesClusterSchedulerBackend)
+ */
+private[spark] class ExecutorPodsBackoffController(
+    conf: SparkConf,
+    clock: Clock) extends Logging {
+
+  import ExecutorPodsBackoffController._
+
+  private val failureThreshold =
+    conf.get(KUBERNETES_ALLOCATION_EXECUTOR_BACKOFF_FAILURE_THRESHOLD)
+  private val failureIntervalMs =
+    conf.get(KUBERNETES_ALLOCATION_EXECUTOR_BACKOFF_FAILURE_INTERVAL)
+  private val initialBackoffDelayMs =
+    conf.get(KUBERNETES_ALLOCATION_EXECUTOR_BACKOFF_INITIAL_DELAY)
+  private val maxBackoffDelayMs = conf.get(KUBERNETES_ALLOCATION_EXECUTOR_BACKOFF_MAX_DELAY)
+
+  private var currentState: State = NormalState()
+
+  // executors that were requested to launch but haven't been confirmed as started yet
+  private val executorsAwaitingStartedConfirmation = mutable.HashSet.empty[Long]
+
+  val metricsSource = new ExecutorPodsBackoffControllerSource()
+
+  /**
+   * Record that a pod request is being made.
+   */
+  def recordPodRequest(executorId: Long): Unit = synchronized {
+    logDebug(s"Recording pod request for executor $executorId")
+    executorsAwaitingStartedConfirmation.add(executorId)
+    currentState match {
+      case backoff: BackoffState =>
+        backoff.requestedExecutors.add(executorId)
+        backoff.delayReferenceTime = clock.getTimeMillis()
+      case _ =>
+    }
+  }
+
+  /**
+   * Records a failure - either pod request failure OR pod failure.
+   *
+   * For backoff we count only executors that never started.
+   * Can be called multiple times for the same executor - duplicates are ignored.
+   */
+  def recordFailure(executorId: Long): Unit = synchronized {
+    val currentTime = clock.getTimeMillis()
+
+    // only track startup failures (executors that never started)
+    if (!executorsAwaitingStartedConfirmation.contains(executorId)) {
+      logDebug(s"Ignoring failure for executor $executorId - not awaiting startup confirmation.")
+    } else {
+      logDebug(s"Recording startup failure for executor $executorId")
+      // remove from set since we're processing its failure
+      // ensures we don't count failures for the same executor several times
+      executorsAwaitingStartedConfirmation.remove(executorId)
+      metricsSource.startupFailureCounter.inc()
+
+      currentState match {
+        case normal: NormalState =>
+          // add failure to the sliding time window and remove expired ones
+          val startupFailures = normal.startupFailuresInInterval
+          startupFailures.enqueue((currentTime, executorId))
+          evictExpiredFailures(startupFailures)
+          if (startupFailures.size >= failureThreshold) {
+            logWarning(s"Executor startup failure threshold reached ${startupFailures.size}" +
+              s" failures in ${failureIntervalMs / 1000}s. Transitioning to Backoff state. " +
+              s"Recent failed executors IDs: ${startupFailures.map(_._2).mkString(", ")}")
+            currentState = BackoffState(delayReferenceTime = currentTime)
+            metricsSource.backoffEntryCounter.inc()
+          }
+
+        case backoff: BackoffState =>
+          if (backoff.requestedExecutors.contains(executorId)) {
+            logWarning(s"Executor allocation failed in Backoff state (executor ID: $executorId, " +
+              s"number of requests made in backoff state: ${backoff.requestedExecutors.size})")
+          } else {
+            logDebug(s"Failed executor $executorId was requested before Backoff state.")
+          }
+      }
+    }
+  }
+
+  /**
+   * Records a successful executor startup.
+   * If in Backoff state and this executor was requested during backoff, transitions to Normal.
+   * Can be called multiple times for the same executor - duplicates are ignored.
+   */
+  def recordExecutorStarted(executorId: Long): Unit = synchronized {
+    logDebug(s"Recording executor $executorId as started.")
+    executorsAwaitingStartedConfirmation.remove(executorId)
+
+    // only transition to Normal if this executor was requested during Backoff state.
+    // Success of executors requested before Backoff doesn't prove the issue is resolved.
+    currentState match {
+      case backoff: BackoffState if backoff.requestedExecutors.contains(executorId) =>
+        logInfo(s"Executor $executorId successfully started in Backoff. " +
+          s"Transitioning to Normal state.")
+        currentState = NormalState()
+        metricsSource.backoffExitCounter.inc()
+        executorsAwaitingStartedConfirmation.clear()
+      case _ =>
+    }
+  }
+
+  /**
+   * Record that executor was deleted.
+   */
+  def recordDeleted(executorId: Long): Unit = synchronized {
+    logDebug(s"Recording deleted executor $executorId")
+    // ensure the set is not ever-growing with deleted executors
+    // that were not reported as failed or started
+    executorsAwaitingStartedConfirmation.remove(executorId)
+  }
+
+  /**
+   * Checks if executor request is allowed.
+   * Always allowed in Normal state.
+   * In Backoff state, checks if the backoff delay has passed.
+   */
+  def canRequestNow(): Boolean = synchronized {
+    currentState match {
+      case _: NormalState => true
+      case backoff: BackoffState =>
+        val currentTime = clock.getTimeMillis()
+        val requiredDelay = calculateBackoffDelay(backoff)
+        currentTime >= backoff.delayReferenceTime + requiredDelay
+    }
+  }
+
+  def isBackoffState(): Boolean = synchronized {
+    currentState match {
+      case _: BackoffState => true
+      case _ => false
+    }
+  }
+
+  def isNormalState(): Boolean = synchronized {
+    currentState match {
+      case _: NormalState => true
+      case _ => false
+    }
+  }
+
+  def currentStateDescription(): String = synchronized {
+    currentState match {
+      case normal: NormalState =>
+        s"Normal (recent startup failures: " +
+          s"${evictExpiredFailures(normal.startupFailuresInInterval)})"
+      case backoff: BackoffState =>
+        s"Backoff (attempts in backoff: ${backoff.requestedExecutors.size}, " +
+          s"current delay: ${calculateBackoffDelay(backoff) / 1000}s)"
+    }
+  }
+
+  private[k8s] def calculateBackoffDelay(backoff: BackoffState): Long = {
+    // use BigInt to avoid overflow
+    val delay = BigInt(initialBackoffDelayMs) * BigInt(2).pow(backoff.requestedExecutors.size)
+    delay.min(maxBackoffDelayMs).toLong
+  }
+
+  /**
+   * evicts failures outside the sliding window and returns the count of remaining failures
+   */
+  private def evictExpiredFailures(failuresInInterval: mutable.Queue[(Long, Long)]): Int = {
+    val currentTime = clock.getTimeMillis()
+    while (failuresInInterval.nonEmpty &&
+      currentTime - failuresInInterval.head._1 > failureIntervalMs) {
+      failuresInInterval.dequeue()
+    }
+    failuresInInterval.size
+  }
+
+  // for tests only
+  def startupFailureCountInWindow(): Int = synchronized {
+    currentState match {
+      case normal: NormalState => evictExpiredFailures(normal.startupFailuresInInterval)
+      case _: BackoffState => 0
+    }
+  }
+}
+
+private[spark] class ExecutorPodsBackoffControllerSource extends Source {
+
+  override val sourceName: String = "ExecutorPodsBackoffController"
+  override val metricRegistry: MetricRegistry = new MetricRegistry()
+
+  val startupFailureCounter = metricRegistry.counter(MetricRegistry.name("startupFailureCount"))
+  val backoffEntryCounter = metricRegistry.counter(MetricRegistry.name("backoffEntryCount"))
+  val backoffExitCounter = metricRegistry.counter(MetricRegistry.name("backoffExitCount"))
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsBackoffController.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsBackoffController.scala
@@ -151,7 +151,6 @@ private[spark] class ExecutorPodsBackoffController(
           s"Transitioning to Normal state.")
         currentState = NormalState()
         metricsSource.backoffExitCounter.inc()
-        executorsAwaitingStartedConfirmation.clear()
       case _ =>
     }
   }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsBackoffControllerSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsBackoffControllerSuite.scala
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.scheduler.cluster.k8s
+
+import scala.collection.mutable
+import scala.util.Random
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.deploy.k8s.Config._
+import org.apache.spark.scheduler.cluster.k8s.ExecutorPodsBackoffController._
+import org.apache.spark.util.ManualClock
+
+class ExecutorPodsBackoffControllerSuite extends SparkFunSuite {
+
+  private val FAILURE_THRESHOLD = 2
+  private val FAILURE_INTERVAL_MS = 10 * 60 * 1000L // 10 minutes
+  private val INITIAL_DELAY_MS = 10 * 1000L // 10 seconds
+  private val MAX_DELAY_MS = 2 * 60 * 1000L // 2 minutes
+
+  test("Normal state") {
+    val (controller, _, metrics) = createController()
+
+    assert(controller.isNormalState())
+    assert(!controller.isBackoffState())
+    assert(controller.canRequestNow())
+    assert(controller.startupFailureCountInWindow() == 0)
+    assert(controller.currentStateDescription() == "Normal (recent startup failures: 0)")
+    assert(metrics.startupFailureCounter.getCount == 0)
+    assert(metrics.backoffEntryCounter.getCount == 0)
+    assert(metrics.backoffExitCounter.getCount == 0)
+
+    for (i <- 1 to 10) {
+      assert(controller.canRequestNow())
+      controller.recordPodRequest(i)
+      assert(controller.isNormalState())
+    }
+
+    Random.shuffle(List.range(1, 11)).foreach { i =>
+      controller.recordExecutorStarted(i)
+      assert(controller.isNormalState())
+      assert(controller.canRequestNow())
+    }
+
+    assert(metrics.startupFailureCounter.getCount == 0)
+    assert(metrics.backoffEntryCounter.getCount == 0)
+  }
+
+  test("failure for executor that was seen started is not counted") {
+    val (controller, _, metrics) = createController()
+
+    controller.recordPodRequest(1L)
+    controller.recordPodRequest(2L)
+    controller.recordExecutorStarted(2L)
+    controller.recordExecutorStarted(1L)
+    controller.recordFailure(1L)
+    controller.recordFailure(2L)
+
+    assert(controller.startupFailureCountInWindow() == 0)
+    assert(controller.isNormalState())
+    assert(metrics.startupFailureCounter.getCount == 0)
+  }
+
+  test("duplicate failure for same executor is ignored") {
+    val (controller, _, metrics) = createController()
+
+    controller.recordPodRequest(1L)
+    controller.recordFailure(1L)
+    controller.recordFailure(1L) // duplicate
+
+    assert(controller.isNormalState())
+    assert(controller.startupFailureCountInWindow() == 1)
+    assert(controller.currentStateDescription() == "Normal (recent startup failures: 1)")
+    assert(metrics.startupFailureCounter.getCount == 1)
+  }
+
+  test("failures within sliding window accumulate to trigger Backoff") {
+    val (controller, clock, metrics) = createController()
+
+    for (i <- 1 to FAILURE_THRESHOLD) {
+      controller.recordPodRequest(i)
+    }
+    for (i <- 1 to FAILURE_THRESHOLD) {
+      clock.advance(5000) // increments within window
+      controller.recordFailure(i.toLong)
+    }
+    assert(controller.isBackoffState())
+    assert(controller.currentStateDescription() ==
+      "Backoff (attempts in backoff: 0, current delay: 10s)")
+    assert(metrics.startupFailureCounter.getCount == FAILURE_THRESHOLD)
+    assert(metrics.backoffEntryCounter.getCount == 1)
+  }
+
+  test("failures outside the sliding window are not counted") {
+    val clock = new ManualClock(0L)
+    val conf = new SparkConf()
+      .set(KUBERNETES_ALLOCATION_EXECUTOR_BACKOFF_FAILURE_THRESHOLD, 3)
+      .set(KUBERNETES_ALLOCATION_EXECUTOR_BACKOFF_FAILURE_INTERVAL, 60 * 1000L) // 1 minute
+      .set(KUBERNETES_ALLOCATION_EXECUTOR_BACKOFF_INITIAL_DELAY, INITIAL_DELAY_MS)
+      .set(KUBERNETES_ALLOCATION_EXECUTOR_BACKOFF_MAX_DELAY, MAX_DELAY_MS)
+    val controller = new ExecutorPodsBackoffController(conf, clock)
+
+    // record first failure at t=0
+    controller.recordPodRequest(1L)
+    controller.recordFailure(1L)
+    assert(controller.startupFailureCountInWindow() == 1)
+    assert(controller.isNormalState())
+
+    // record second failure at t=20s (within window)
+    clock.advance(20 * 1000L)
+    controller.recordPodRequest(2L)
+    controller.recordFailure(2L)
+    assert(controller.startupFailureCountInWindow() == 2)
+    assert(controller.isNormalState())
+
+    // advance to t=61s - first failure (at t=0) slides out of window
+    clock.advance(41 * 1000L)
+    assert(controller.startupFailureCountInWindow() == 1)
+    assert(controller.isNormalState())
+
+    // advance to t=81s - second failure (at t=20s) also slides out
+    clock.advance(20 * 1000L)
+    assert(controller.startupFailureCountInWindow() == 0)
+    assert(controller.isNormalState())
+  }
+
+  test("exponential backoff delay capped by MAX_DELAY") {
+    val (controller, clock, _) = createController()
+
+    transitionToBackoff(controller)
+
+    // delays: 10s, 20s, 40s, 80s, 120s (capped), 120s, 120s...
+    // iterate enough times to reach and verify the cap
+    for (i <- 0 until 10) {
+      val expectedDelay = Math.min(INITIAL_DELAY_MS * (1L << i), MAX_DELAY_MS)
+
+      assert(controller.isBackoffState())
+
+      // cannot request before delay is over
+      clock.advance(expectedDelay - 1)
+      assert(!controller.canRequestNow())
+
+      // can request exactly when delay is over
+      clock.advance(1)
+      assert(controller.canRequestNow())
+      controller.recordPodRequest(100 + i)
+
+      // cannot request immediately after
+      assert(!controller.canRequestNow())
+    }
+  }
+
+  test("recordExecutorStarted for executor requested before Backoff does not exit Backoff") {
+    val (controller, _, _) = createController()
+
+    controller.recordPodRequest(1L)
+    for (i <- 2 to 3) {
+      controller.recordPodRequest(i)
+      controller.recordFailure(i)
+    }
+
+    assert(controller.isBackoffState())
+    controller.recordExecutorStarted(1L)
+    assert(controller.isBackoffState())
+  }
+
+  test("recordExecutorStarted for executor requested during Backoff transitions to Normal") {
+    val (controller, clock, metrics) = createController()
+
+    transitionToBackoff(controller)
+    assert(metrics.backoffEntryCounter.getCount == 1)
+    assert(metrics.backoffExitCounter.getCount == 0)
+
+    clock.advance(INITIAL_DELAY_MS + 1)
+    controller.recordPodRequest(100L)
+    controller.recordExecutorStarted(100L)
+
+    assert(controller.isNormalState())
+    assert(controller.startupFailureCountInWindow() == 0)
+    assert(controller.canRequestNow())
+    assert(metrics.backoffEntryCounter.getCount == 1)
+    assert(metrics.backoffExitCounter.getCount == 1)
+  }
+
+  test("multiple Backoff -> Normal transitions") {
+    val (controller, clock, metrics) = createController()
+
+    for (cycle <- 1 to 3) {
+      // enter Backoff
+      for (i <- 1 to FAILURE_THRESHOLD) {
+        controller.recordPodRequest(cycle * 100 + i)
+        controller.recordFailure(cycle * 100 + i)
+      }
+      assert(controller.isBackoffState())
+      assert(metrics.backoffEntryCounter.getCount == cycle)
+
+      // exit Backoff
+      clock.advance(INITIAL_DELAY_MS)
+      val successExecId = cycle * 100 + 99
+      controller.recordPodRequest(successExecId)
+      controller.recordExecutorStarted(successExecId)
+      assert(controller.isNormalState())
+      assert(metrics.backoffExitCounter.getCount == cycle)
+    }
+  }
+
+  test("duplicate recordExecutorStarted calls are handled gracefully") {
+    val (controller, _, _) = createController()
+    controller.recordPodRequest(1)
+    controller.recordExecutorStarted(1)
+    controller.recordExecutorStarted(1) // duplicate
+    assert(controller.isNormalState())
+  }
+
+  test("multiple executors can be tracked simultaneously") {
+    val (controller, _, _) = createController()
+
+    // request multiple executors
+    for (i <- 1 to 10) {
+      controller.recordPodRequest(i.toLong)
+    }
+
+    // fail some, start others
+    for (i <- 1 to 5) {
+      controller.recordFailure(i.toLong)
+    }
+    for (i <- 6 to 10) {
+      controller.recordExecutorStarted(i.toLong)
+    }
+
+    assert(controller.isBackoffState())
+  }
+
+  test("backoff delay calculation doesn't overflow") {
+    val (controller, _, _) = createController()
+
+    // delays: 10s, 20s, 40s, 80s, 120s (capped), 120s, 120s...
+    for (i <- 0 until 2048) {
+      val backoff = BackoffState(
+        requestedExecutors = mutable.HashSet((0 until i).map(_.toLong): _*),
+        delayReferenceTime = 0L)
+      val delay = controller.calculateBackoffDelay(backoff)
+      if (i >= 4) {
+        assert(delay == MAX_DELAY_MS, s"delay should be capped at MAX_DELAY_MS for $i requests")
+      } else {
+        assert(delay > 0 && delay < MAX_DELAY_MS)
+      }
+    }
+  }
+
+  private def createController():
+  (ExecutorPodsBackoffController, ManualClock, ExecutorPodsBackoffControllerSource) = {
+    val clock = new ManualClock(0L)
+    val conf = new SparkConf()
+      .set(KUBERNETES_ALLOCATION_EXECUTOR_BACKOFF_FAILURE_THRESHOLD, FAILURE_THRESHOLD)
+      .set(KUBERNETES_ALLOCATION_EXECUTOR_BACKOFF_FAILURE_INTERVAL, FAILURE_INTERVAL_MS)
+      .set(KUBERNETES_ALLOCATION_EXECUTOR_BACKOFF_INITIAL_DELAY, INITIAL_DELAY_MS)
+      .set(KUBERNETES_ALLOCATION_EXECUTOR_BACKOFF_MAX_DELAY, MAX_DELAY_MS)
+    val controller = new ExecutorPodsBackoffController(conf, clock)
+    (controller, clock, controller.metricsSource)
+  }
+
+  private def transitionToBackoff(controller: ExecutorPodsBackoffController): Unit = {
+    for (i <- 1 to FAILURE_THRESHOLD) {
+      controller.recordPodRequest(i.toLong)
+      controller.recordFailure(i.toLong)
+    }
+    assert(controller.isBackoffState())
+  }
+}


### PR DESCRIPTION
…for executor pod requests when pods repeatedly fail to start

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Introduces exponential backoff delays for executor pod requests when pods repeatedly fail to start. It tracks the following startup failures:
* **API request failures** - Pod creation requests to the Kubernetes API server throw exceptions
* **Pod startup failures** - Pods transition to `PodFailed` status before the executor registers with the driver (indicating the executor never successfully started)
* **Creation timeouts** - Pods do not appear within the timeout period (existing mechanism)

Operates as a state machine with two states:
* **Normal state** - Executor pods are requested without extra delay. Transitions to Backoff when startup failures count in a sliding time window exceeds threshold.
* **Backoff state** - Executor pod requests are throttled with exponentially increasing delays between requests. It immediately transitions back to Normal state when an executor that was requested during the Backoff state successfully starts, indicating the infrastructure issue has resolved.

When backoff is enabled, two new metrics added. Will update `monitoring.md` doc with new source if patch looks good.


### Why are the changes needed?
When executor pods repeatedly fail to start due to Kubernetes infrastructure issues (control plane overload, resource exhaustion, service mesh issues), the current implementation continues requesting pods at full speed, amplifying load on already stressed infrastructure. 

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

**Relationship to ExecutorFailureTracker**:
This backoff mechanism is complementary to the existing `ExecutorFailureTracker`. While `ExecutorFailureTracker` counts all Pod failures (including those that started successfully but failed during task execution) to determine when to abort the application (`spark.executor.maxNumFailures`), the backoff controller specifically tracks startup failures only to throttle allocation requests and protect infrastructure. 

This is especially useful in the following scenarios:
(a) Long-running applications that process heterogeneous workloads, where `spark.executor.maxNumFailures` is set to Int.MAX_VALUE (or another high value). In such cases Spark will make many executor startup attempts before the application is shut down.
(b) Situations involving transient Kubernetes infrastructure issues (e.g with Istio) when the number of executors needs to scale up (e.g., due to dynamic allocation). In these cases it is preferable to wait for the issue to be resolved while continuing to run with the existing executors, rather than shutting down the application.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
When enabled: executor pod allocation is throttled with exponential delays when startup failures exceed the threshold.
Observability changes when enabled:
* New log messages indicating backoff state transitions and current delays
* New metrics.

### How was this patch tested?
1. Unit tests
2. **API request failures** simulated with `kubectl create quota test --hard=cpu=1,memory=1G`
3. **Pod startup failures** simulated with an init container that fails to start.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
Cursor 2.2.9
