### PR TITLE
[SPARK-54820][PYTHON][4.0][4.1] Make pandas_on_spark_type compatible with numpy 2.4.0

### DIFF
--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -342,7 +342,7 @@ def pandas_on_spark_type(tpe: Union[str, type, Dtype]) -> Tuple[Dtype, types.Dat
     try:
         dtype = pandas_dtype(tpe)
         spark_type = as_spark_type(dtype)
-    except TypeError:
+    except (TypeError, ValueError):
         spark_type = as_spark_type(tpe)
         dtype = spark_type_to_pandas_dtype(spark_type)
     return dtype, spark_type


### PR DESCRIPTION
backport https://github.com/apache/spark/pull/53580 to 4.0 and 4.1,
to restore https://github.com/apache/spark/actions/runs/20493084511/job/58888601618