### PR TITLE
[SPARK-54843][SQL] Try_to_number expression not working for empty string input

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ToNumberParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ToNumberParser.scala
@@ -496,7 +496,7 @@ class ToNumberParser(numberFormat: String, errorOnFail: Boolean) extends Seriali
       // in the input string, then the input string does not match the format string.
       formatMatchFailure(input, numberFormat)
     } else if (parsedBeforeDecimalPoint.isEmpty && parsedAfterDecimalPoint.isEmpty) {
-      // If no digits were collected (e.g., input was all whitespace), treat as format match failure
+      // If no digits were collected (e.g. input was all whitespace), treat as format match failure.
       formatMatchFailure(input, numberFormat)
     } else {
       parseResultToDecimalValue(negateResult)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ToNumberParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ToNumberParser.scala
@@ -495,6 +495,9 @@ class ToNumberParser(numberFormat: String, errorOnFail: Boolean) extends Seriali
       // If we have consumed all the tokens in the format string, but characters remain unconsumed
       // in the input string, then the input string does not match the format string.
       formatMatchFailure(input, numberFormat)
+    } else if (parsedBeforeDecimalPoint.isEmpty && parsedAfterDecimalPoint.isEmpty) {
+      // If no digits were collected (e.g., input was all whitespace), treat as format match failure
+      formatMatchFailure(input, numberFormat)
     } else {
       parseResultToDecimalValue(negateResult)
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Catching the case in `ToNumberParser` when the input string only consists of whitespace, preventing a failure with an internal error later on when trying to create `BigDecimal`.


### Why are the changes needed?
Without this change passing an empty string (`select try_to_number('', '99')`) would fail with the following exception:
```
JVM stacktrace:
java.lang.NumberFormatException
	at java.base/java.math.BigDecimal.(BigDecimal.java:692)
	at java.base/java.math.BigDecimal.(BigDecimal.java:471)
	at java.base/java.math.BigDecimal.(BigDecimal.java:900)
	at org.apache.spark.sql.catalyst.util.ToNumberParser.parseResultToDecimalValue(ToNumberParser.scala:627)
	at org.apache.spark.sql.catalyst.util.ToNumberParser.parse(ToNumberParser.scala:499)
```

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
New unit tests.

### Was this patch authored or co-authored using generative AI tooling?
No.
