### PR TITLE
[SPARK-54844][BUILD] Upgrade maven.version to 3.9.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <java.version>17</java.version>
     <java.minimum.version>17.0.11</java.minimum.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
-    <maven.version>3.9.11</maven.version>
+    <maven.version>3.9.12</maven.version>
     <exec-maven-plugin.version>3.6.1</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.9</asm.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades the Maven version from 3.9.11 to 3.9.12 in the project's root POM file.

### Why are the changes needed?

Witness downloading issue in GHA

### Does this PR introduce _any_ user-facing change?

No. This is a build-only change that does not affect runtime behavior or user-facing features.

### How was this patch tested?

This change only updates the Maven version property in the POM file. The existing CI/CD pipelines will validate the build with the new Maven version.

### Was this patch authored or co-authored using generative AI tooling?

No.