### PR TITLE
[SPARK-50186][CORE] Clarify executor OutOfMemoryError handling docs

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -185,7 +185,7 @@ private[yarn] class ExecutorRunnable(
     // For log4j configuration to reference
     javaOpts += ("-Dspark.yarn.app.container.log.dir=" + ApplicationConstants.LOG_DIR_EXPANSION_VAR)
 
-    YarnSparkHadoopUtil.addOutOfMemoryErrorArgument(javaOpts)
+    YarnSparkHadoopUtil.addOutOfMemoryErrorArgument(javaOpts, sparkConf)
     val commands = prefixEnv ++
       Seq(Environment.JAVA_HOME.$$() + "/bin/java", "-server") ++
       javaOpts ++

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -137,8 +137,17 @@ object YarnSparkHadoopUtil {
    * the behavior of '%' in a .cmd file: it gets interpreted as an incomplete environment
    * variable. Windows .cmd files escape a '%' by '%%'. Thus, the correct way of writing
    * '%%p' in an escaped way is '%%%%p'.
+   *
+   * Optional handling of OutOfMemoryError (OOM) for executor JVMs.
    */
-  private[yarn] def addOutOfMemoryErrorArgument(javaOpts: ListBuffer[String]): Unit = {
+  private[yarn] def addOutOfMemoryErrorArgument(
+                                                 javaOpts: ListBuffer[String],
+                                                 conf: SparkConf): Unit = {
+
+    if (!conf.getBoolean("spark.executor.killOnOutOfMemoryError", false)) {
+      return
+    }
+
     if (!javaOpts.exists(_.contains("-XX:OnOutOfMemoryError"))) {
       if (Utils.isWindows) {
         javaOpts += escapeForShell("-XX:OnOutOfMemoryError=taskkill /F /PID %%%%p")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates documentation/comments related to executor
OutOfMemoryError handling to clarify that JVM termination on OOM
is optional and should be explicitly configured by users.

### Why are the changes needed?

The existing comments assume executors must be killed on OOM,
which can obscure failure reasons. This update aligns the
documentation with the intent discussed in SPARK-50186.

### Does this PR introduce any user-facing change?

No. This is a documentation-only change.

### How was this patch tested?

N/A (comment-only change).
