### PR TITLE
[MINOR][SQL] Extend Uniform to be TimeZoneAwareExpression

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.trees.{BinaryLike, TernaryLike, UnaryLike}
 import org.apache.spark.sql.catalyst.trees.TreePattern.{EXPRESSION_WITH_RANDOM_SEED, RUNTIME_REPLACEABLE, TreePattern}
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.util.random.XORShiftRandom
 
@@ -286,7 +287,9 @@ case class Uniform(min: Expression, max: Expression, seedExpression: Expression,
     if (Seq(min, max, seedExpression).exists(_.dataType == NullType)) {
       Literal(null)
     } else {
-      def cast(e: Expression, to: DataType): Expression = if (e.dataType == to) e else Cast(e, to)
+      def cast(e: Expression, to: DataType): Expression = {
+        if (e.dataType == to) e else Cast(e, to, Option(SQLConf.get.sessionLocalTimeZone))
+      }
       cast(Add(
         cast(min, DoubleType),
         Multiply(

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
@@ -704,12 +704,6 @@ WithCTE
 
 
 -- !query
-SET spark.sql.legacy.ctePrecedencePolicy=EXCEPTION
--- !query analysis
-SetCommand (spark.sql.legacy.ctePrecedencePolicy,Some(EXCEPTION))
-
-
--- !query
 WITH RECURSIVE r(level, data) AS (
   VALUES (0, 0)
   UNION ALL

--- a/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
@@ -1,5 +1,6 @@
 --SET spark.sql.cteRecursionLevelLimit=25
 --SET spark.sql.cteRecursionRowLimit=50
+--SET spark.sql.analyzer.singlePassResolver.dualRunWithLegacy=true
 
 -- fails due to recursion isn't allowed without RECURSIVE keyword
 WITH r(level) AS (
@@ -248,7 +249,6 @@ WITH
     SELECT * FROM t1
   )
 SELECT * FROM t2;
-SET spark.sql.legacy.ctePrecedencePolicy=EXCEPTION;
 
 -- recursive reference can't be used multiple times in a recursive term
 WITH RECURSIVE r(level, data) AS (

--- a/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
@@ -902,14 +902,6 @@ struct<level:int>
 
 
 -- !query
-SET spark.sql.legacy.ctePrecedencePolicy=EXCEPTION
--- !query schema
-struct<key:string,value:string>
--- !query output
-spark.sql.legacy.ctePrecedencePolicy	EXCEPTION
-
-
--- !query
 WITH RECURSIVE r(level, data) AS (
   VALUES (0, 0)
   UNION ALL


### PR DESCRIPTION
### What changes were proposed in this pull request?

Expanded the `Uniform` to be timeZone aware, so that when they get replaced into `Cast` expressions, the timezone can be used to create a  `Cast` expression that would happen as a result of analysis.

### Why are the changes needed?

Since this `Cast` doesn't need any information about time zones, they are not explicitly needed. However, `ResolveTimeZone` in the analyzer does put the timezone into every cast created before analysis. This causes a problem between the fixed-point and single-pass analyzer, since reanalyzing queries produces different results (single-pass reanalyzes the plan and puts the timezone for the new `Cast`, while the fixed-point considers the `Cast` already resolved and doesn't do anything).


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Single pass analyzer is enabled in dual run mode in the `cte-recursion` golden file (and `ctePrecedencePolicy` isn't set to `EXCEPTION`), so the golden file is being ran on in the singe-pass analyzer. However, since recursive CTEs are still not in single pass, the new analyzer is only invoked in the recursion steps. Without this change, the query 

```
WITH RECURSIVE randoms(val) AS (
    SELECT CAST(UNIFORM(1, 6, 82374) AS INT)
    UNION ALL
    SELECT CAST(UNIFORM(1, 6, 237685) AS INT)
    FROM randoms
)
SELECT val FROM randoms LIMIT 5;
```

fails with plan_mismatch_error (while executing the anchor).


### Was this patch authored or co-authored using generative AI tooling?

No.
