### PR TITLE
[SPARK-54852][SQL] `NOT IN` subquery returns incorrect results with a collated table

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CollationKey.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CollationKey.scala
@@ -18,10 +18,11 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
-import org.apache.spark.sql.catalyst.util.CollationFactory
+import org.apache.spark.sql.catalyst.util.{CollationFactory, UnsafeRowUtils}
 import org.apache.spark.sql.internal.types.StringTypeWithCollation
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.util.ArrayImplicits.SparkArrayOps
 
 case class CollationKey(expr: Expression) extends UnaryExpression with ExpectsInputTypes {
   override def inputTypes: Seq[AbstractDataType] =
@@ -45,4 +46,62 @@ case class CollationKey(expr: Expression) extends UnaryExpression with ExpectsIn
   }
 
   override def child: Expression = expr
+}
+
+object CollationKey {
+  /**
+   * Recursively process the expression in order to recursively replace non-binary collated strings
+   * with their associated collation key.
+   */
+  def injectCollationKey(expr: Expression): Expression = {
+    injectCollationKey(expr, expr.dataType)
+  }
+
+  private def injectCollationKey(expr: Expression, dt: DataType): Expression = {
+    dt match {
+      // For binary stable expressions, no special handling is needed.
+      case _ if UnsafeRowUtils.isBinaryStable(dt) =>
+        expr
+
+      // Inject CollationKey for non-binary collated strings.
+      case _: StringType =>
+        CollationKey(expr)
+
+      // Recursively process struct fields for non-binary structs.
+      case StructType(fields) =>
+        val transformed = fields.zipWithIndex.map { case (f, i) =>
+          val originalField = GetStructField(expr, i, Some(f.name))
+          val injected = injectCollationKey(originalField, f.dataType)
+          (f, injected, injected.fastEquals(originalField))
+        }
+        val anyChanged = transformed.exists { case (_, _, same) => !same }
+        if (!anyChanged) {
+          expr
+        } else {
+          val struct = CreateNamedStruct(
+            transformed.flatMap { case (f, injected, _) =>
+              Seq(Literal(f.name), injected)
+            }.toImmutableArraySeq)
+          if (expr.nullable) {
+            If(IsNull(expr), Literal(null, struct.dataType), struct)
+          } else {
+            struct
+          }
+        }
+
+      // Recursively process array elements for non-binary arrays.
+      case ArrayType(et, containsNull) =>
+        val param: NamedExpression = NamedLambdaVariable("a", et, containsNull)
+        val funcBody: Expression = injectCollationKey(param, et)
+        if (!funcBody.fastEquals(param)) {
+          ArrayTransform(expr, LambdaFunction(funcBody, Seq(param)))
+        } else {
+          expr
+        }
+
+      // Joins are not supported on maps, so there's no special handling for MapType.
+      case _ =>
+        expr
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastJoinSuite.scala
@@ -397,8 +397,8 @@ abstract class BroadcastJoinSuiteBase extends QueryTest with SQLTestUtils
     }
   }
 
-  private val bh = BroadcastHashJoinExec.toString
-  private val bl = BroadcastNestedLoopJoinExec.toString
+  private val bh = classOf[BroadcastHashJoinExec].getSimpleName
+  private val bl = classOf[BroadcastNestedLoopJoinExec].getSimpleName
 
   private def assertJoinBuildSide(sqlStr: String, joinMethod: String, buildSide: BuildSide): Any = {
     val executedPlan = stripAQEPlan(sql(sqlStr).queryExecution.executedPlan)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
```
create or replace table t1 (c1 string collate utf8_lcase_rtrim);
create or replace table t2 (c1 string collate utf8_lcase_rtrim);
insert into t1 values ('a');
insert into t2 values ('A ');

select * from t1 where c1 not in (select * from t2);
-- should return no data, but it returns one row
```

When performing a hash join on collated columns, we first wrap the column with `CollationKey` during analysis. This is because the hash of `CollationKey` is collation-aware. The problem with this query is that there is no join during the analysis phase (we have `NOT IN`), and the join is added during the optimization phase. As a result, the join operates on raw columns, which are not collation-aware.

This PR fixes the issue by rewriting the join keys in `HashJoin` trait.


### Why are the changes needed?
Bug fix.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
New tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
