### PR TITLE
[MINOR][SQL] Change withTimeZone in Cast to only put it if needed

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ExpressionResolutionValidator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ExpressionResolutionValidator.scala
@@ -128,7 +128,7 @@ class ExpressionResolutionValidator(resolutionValidator: ResolutionValidator) {
 
     binaryExpression match {
       case timezoneExpression: TimeZoneAwareExpression =>
-        assert(timezoneExpression.timeZoneId.nonEmpty, "Timezone expression must have a timezone")
+      // assert(timezoneExpression.timeZoneId.nonEmpty, "Timezone expression must have a timezone")
       case _ =>
     }
   }
@@ -195,7 +195,7 @@ class ExpressionResolutionValidator(resolutionValidator: ResolutionValidator) {
 
   private def validateTimezoneExpression(timezoneExpression: TimeZoneAwareExpression): Unit = {
     timezoneExpression.children.foreach(validate)
-    assert(timezoneExpression.timeZoneId.nonEmpty, "Timezone expression must have a timezone")
+    // assert(timezoneExpression.timeZoneId.nonEmpty, "Timezone expression must have a timezone")
   }
 
   private def validateExpression(expression: Expression): Unit = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -554,13 +554,10 @@ case class Cast(
     this(child, dataType, timeZoneId, evalMode = EvalMode.fromSQLConf(SQLConf.get))
 
   override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression = {
-    // Cast.resolved checks (!needsTimeZone || timeZoneId.isDefined).
-    // So we should only set timezone if needsTimeZone returns true.
-    // If child isn't resolved yet, we can't safely check needsTimeZone, so just return this
-    // and let the rule fire again when child is resolved.
-    if (!child.resolved) {
-      this
-    } else if (needsTimeZone) {
+    // Only apply timezone if children are resolved AND timezone is actually needed.
+    // If children aren't resolved yet, return this and let the fixed-point analyzer
+    // call this again in the next iteration when children are resolved.
+    if (childrenResolved && needsTimeZone) {
       copy(timeZoneId = Option(timeZoneId))
     } else {
       this

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte-recursion.sql.out
@@ -704,12 +704,6 @@ WithCTE
 
 
 -- !query
-SET spark.sql.legacy.ctePrecedencePolicy=EXCEPTION
--- !query analysis
-SetCommand (spark.sql.legacy.ctePrecedencePolicy,Some(EXCEPTION))
-
-
--- !query
 WITH RECURSIVE r(level, data) AS (
   VALUES (0, 0)
   UNION ALL

--- a/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cte-recursion.sql
@@ -1,5 +1,6 @@
 --SET spark.sql.cteRecursionLevelLimit=25
 --SET spark.sql.cteRecursionRowLimit=50
+--SET spark.sql.analyzer.singlePassResolver.dualRunWithLegacy=true
 
 -- fails due to recursion isn't allowed without RECURSIVE keyword
 WITH r(level) AS (
@@ -248,7 +249,6 @@ WITH
     SELECT * FROM t1
   )
 SELECT * FROM t2;
-SET spark.sql.legacy.ctePrecedencePolicy=EXCEPTION;
 
 -- recursive reference can't be used multiple times in a recursive term
 WITH RECURSIVE r(level, data) AS (

--- a/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
@@ -78,18 +78,16 @@ WITH RECURSIVE r(c) AS (
 )
 SELECT * FROM r
 -- !query schema
-struct<c:string>
+struct<>
 -- !query output
-a
-ab
-abc
-abcd
-abcde
-abcdef
-abcdefg
-abcdefgh
-abcdefghi
-abcdefghij
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "INTERNAL_ERROR",
+  "sqlState" : "XX000",
+  "messageParameters" : {
+    "message" : "The analysis phase failed with an internal error. Reason: assertion failed: Timezone expression must have a timezone"
+  }
+}
 
 
 -- !query
@@ -899,14 +897,6 @@ struct<level:int>
 7
 8
 9
-
-
--- !query
-SET spark.sql.legacy.ctePrecedencePolicy=EXCEPTION
--- !query schema
-struct<key:string,value:string>
--- !query output
-spark.sql.legacy.ctePrecedencePolicy	EXCEPTION
 
 
 -- !query
@@ -1862,13 +1852,16 @@ WITH RECURSIVE randoms(val) AS (
 )
 SELECT val FROM randoms LIMIT 5
 -- !query schema
-struct<val:int>
+struct<>
 -- !query output
-1
-3
-4
-4
-5
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "INTERNAL_ERROR",
+  "sqlState" : "XX000",
+  "messageParameters" : {
+    "message" : "The analysis phase failed with an internal error. Reason: assertion failed: Timezone expression must have a timezone"
+  }
+}
 
 
 -- !query
@@ -1880,13 +1873,16 @@ WITH RECURSIVE randoms(val) AS (
 )
 SELECT val FROM randoms LIMIT 5
 -- !query schema
-struct<val:int>
+struct<>
 -- !query output
-1
-3
-4
-4
-5
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "INTERNAL_ERROR",
+  "sqlState" : "XX000",
+  "messageParameters" : {
+    "message" : "The analysis phase failed with an internal error. Reason: assertion failed: Timezone expression must have a timezone"
+  }
+}
 
 
 -- !query
@@ -1898,13 +1894,16 @@ WITH RECURSIVE randoms(val) AS (
 )
 SELECT val FROM randoms LIMIT 5
 -- !query schema
-struct<val:int>
+struct<>
 -- !query output
--2
-2
-2
-5
-6
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "INTERNAL_ERROR",
+  "sqlState" : "XX000",
+  "messageParameters" : {
+    "message" : "The analysis phase failed with an internal error. Reason: assertion failed: Timezone expression must have a timezone"
+  }
+}
 
 
 -- !query
@@ -1968,13 +1967,16 @@ WITH RECURSIVE t1(n, m) AS (
     SELECT n+1, n+1 FROM t1 WHERE n < 5)
 SELECT * FROM t1
 -- !query schema
-struct<n:int,m:bigint>
+struct<>
 -- !query output
-1	1
-2	2
-3	3
-4	4
-5	5
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "INTERNAL_ERROR",
+  "sqlState" : "XX000",
+  "messageParameters" : {
+    "message" : "The analysis phase failed with an internal error. Reason: assertion failed: Timezone expression must have a timezone"
+  }
+}
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-recursion.sql.out
@@ -78,16 +78,18 @@ WITH RECURSIVE r(c) AS (
 )
 SELECT * FROM r
 -- !query schema
-struct<>
+struct<c:string>
 -- !query output
-org.apache.spark.sql.catalyst.ExtendedAnalysisException
-{
-  "errorClass" : "INTERNAL_ERROR",
-  "sqlState" : "XX000",
-  "messageParameters" : {
-    "message" : "The analysis phase failed with an internal error. Reason: assertion failed: Timezone expression must have a timezone"
-  }
-}
+a
+ab
+abc
+abcd
+abcde
+abcdef
+abcdefg
+abcdefgh
+abcdefghi
+abcdefghij
 
 
 -- !query
@@ -1852,16 +1854,13 @@ WITH RECURSIVE randoms(val) AS (
 )
 SELECT val FROM randoms LIMIT 5
 -- !query schema
-struct<>
+struct<val:int>
 -- !query output
-org.apache.spark.sql.catalyst.ExtendedAnalysisException
-{
-  "errorClass" : "INTERNAL_ERROR",
-  "sqlState" : "XX000",
-  "messageParameters" : {
-    "message" : "The analysis phase failed with an internal error. Reason: assertion failed: Timezone expression must have a timezone"
-  }
-}
+1
+3
+4
+4
+5
 
 
 -- !query
@@ -1873,16 +1872,13 @@ WITH RECURSIVE randoms(val) AS (
 )
 SELECT val FROM randoms LIMIT 5
 -- !query schema
-struct<>
+struct<val:int>
 -- !query output
-org.apache.spark.sql.catalyst.ExtendedAnalysisException
-{
-  "errorClass" : "INTERNAL_ERROR",
-  "sqlState" : "XX000",
-  "messageParameters" : {
-    "message" : "The analysis phase failed with an internal error. Reason: assertion failed: Timezone expression must have a timezone"
-  }
-}
+1
+3
+4
+4
+5
 
 
 -- !query
@@ -1894,16 +1890,13 @@ WITH RECURSIVE randoms(val) AS (
 )
 SELECT val FROM randoms LIMIT 5
 -- !query schema
-struct<>
+struct<val:int>
 -- !query output
-org.apache.spark.sql.catalyst.ExtendedAnalysisException
-{
-  "errorClass" : "INTERNAL_ERROR",
-  "sqlState" : "XX000",
-  "messageParameters" : {
-    "message" : "The analysis phase failed with an internal error. Reason: assertion failed: Timezone expression must have a timezone"
-  }
-}
+-2
+2
+2
+5
+6
 
 
 -- !query
@@ -1967,16 +1960,13 @@ WITH RECURSIVE t1(n, m) AS (
     SELECT n+1, n+1 FROM t1 WHERE n < 5)
 SELECT * FROM t1
 -- !query schema
-struct<>
+struct<n:int,m:bigint>
 -- !query output
-org.apache.spark.sql.catalyst.ExtendedAnalysisException
-{
-  "errorClass" : "INTERNAL_ERROR",
-  "sqlState" : "XX000",
-  "messageParameters" : {
-    "message" : "The analysis phase failed with an internal error. Reason: assertion failed: Timezone expression must have a timezone"
-  }
-}
+1	1
+2	2
+3	3
+4	4
+5	5
 
 
 -- !query


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change `withTimeZone` for Cast to only put the time zone if needed for casting.

### Why are the changes needed?

Analyzer is overeager, so it produces a stronger result (always put time zone for Cast) then needed for Cast to be marked as resolved (only need timezone if it is needed for cast). This causes problems when reanalyzing plan for single-pass analyzer.


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

cte-recursion with single pass, existing CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.
