### PR TITLE
[SPARK-54856][SQL] Refactor scalar function lookup and resolution

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2102,7 +2102,7 @@ class Analyzer(
             throw QueryCompilationErrors.expectPersistentFuncError(
               nameParts.head, cmd, mismatchHint, u)
           } else {
-            ResolvedNonPersistentFunc(nameParts.head, V1Function(info))
+            ResolvedNonPersistentFunc(nameParts.head, V1Function.metadataOnly(info))
           }
         }.getOrElse {
           val CatalogAndIdentifier(catalog, ident) =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -90,11 +90,16 @@ trait FunctionRegistryBase[T] {
   /* List all of the registered function names. */
   def listFunction(): Seq[FunctionIdentifier]
 
-  /* Get the class of the registered function by specified name. */
-  def lookupFunction(name: FunctionIdentifier): Option[ExpressionInfo]
+  /* Get both ExpressionInfo and FunctionBuilder in a single lookup. */
+  def lookupFunctionEntry(name: FunctionIdentifier): Option[(ExpressionInfo, FunctionBuilder)]
+
+  /* Get the ExpressionInfo of the registered function by specified name. */
+  def lookupFunction(name: FunctionIdentifier): Option[ExpressionInfo] =
+    lookupFunctionEntry(name).map(_._1)
 
   /* Get the builder of the registered function by specified name. */
-  def lookupFunctionBuilder(name: FunctionIdentifier): Option[FunctionBuilder]
+  def lookupFunctionBuilder(name: FunctionIdentifier): Option[FunctionBuilder] =
+    lookupFunctionEntry(name).map(_._2)
 
   /** Drop a function and return whether the function existed. */
   def dropFunction(name: FunctionIdentifier): Boolean
@@ -245,13 +250,9 @@ trait SimpleFunctionRegistryBase[T] extends FunctionRegistryBase[T] with Logging
     functionBuilders.iterator.map(_._1).toList
   }
 
-  override def lookupFunction(name: FunctionIdentifier): Option[ExpressionInfo] = synchronized {
-    functionBuilders.get(normalizeFuncName(name)).map(_._1)
-  }
-
-  override def lookupFunctionBuilder(
-      name: FunctionIdentifier): Option[FunctionBuilder] = synchronized {
-    functionBuilders.get(normalizeFuncName(name)).map(_._2)
+  override def lookupFunctionEntry(
+      name: FunctionIdentifier): Option[(ExpressionInfo, FunctionBuilder)] = synchronized {
+    functionBuilders.get(normalizeFuncName(name))
   }
 
   override def dropFunction(name: FunctionIdentifier): Boolean = synchronized {
@@ -281,11 +282,8 @@ trait EmptyFunctionRegistryBase[T] extends FunctionRegistryBase[T] {
     throw SparkUnsupportedOperationException()
   }
 
-  override def lookupFunction(name: FunctionIdentifier): Option[ExpressionInfo] = {
-    throw SparkUnsupportedOperationException()
-  }
-
-  override def lookupFunctionBuilder(name: FunctionIdentifier): Option[FunctionBuilder] = {
+  override def lookupFunctionEntry(
+      name: FunctionIdentifier): Option[(ExpressionInfo, FunctionBuilder)] = {
     throw SparkUnsupportedOperationException()
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -2201,7 +2201,6 @@ class SessionCatalog(
         val builderFactory: () => FunctionBuilder = () => synchronized {
           // Re-check cache (another thread may have loaded it)
           functionRegistry.lookupFunctionBuilder(qualifiedIdent).getOrElse {
-            loadFunctionResources(funcMetadata.resources)
             if (funcMetadata.isUserDefinedFunction) {
               val udf = UserDefinedFunction.fromCatalogFunction(funcMetadata, parser)
               registerUserDefinedFunction[Expression](
@@ -2210,6 +2209,7 @@ class SessionCatalog(
                 functionRegistry,
                 makeUserDefinedScalarFuncBuilder(udf))
             } else {
+              loadFunctionResources(funcMetadata.resources)
               registerFunction(
                 funcMetadata,
                 overrideIfExists = false,
@@ -2241,7 +2241,6 @@ class SessionCatalog(
         // Hive table functions are not supported
         failFunctionLookup(qualifiedIdent)
       }
-      loadFunctionResources(funcMetadata.resources)
       val udf = UserDefinedFunction.fromCatalogFunction(funcMetadata, parser)
       registerUserDefinedFunction[LogicalPlan](
         udf,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -32,7 +32,6 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.{SparkException, SparkThrowable}
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst._
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
@@ -49,6 +48,7 @@ import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAM
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf.GLOBAL_TEMP_DATABASE
+import org.apache.spark.sql.internal.connector.V1Function
 import org.apache.spark.sql.metricview.util.MetricViewPlanner
 import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType}
 import org.apache.spark.sql.util.{CaseInsensitiveStringMap, PartitioningUtils}
@@ -2153,55 +2153,75 @@ class SessionCatalog(
   }
 
   /**
-   * Look up the `ExpressionInfo` of the given function by name if it's a persistent function.
-   * This supports both scalar and table functions.
+   * Look up a persistent function's ExpressionInfo by name (for DESCRIBE FUNCTION).
+   * This only fetches metadata without loading resources or creating builders.
    */
   def lookupPersistentFunction(name: FunctionIdentifier): ExpressionInfo = {
     val qualifiedIdent = qualifyIdentifier(name)
-    val db = qualifiedIdent.database.get
-    val funcName = qualifiedIdent.funcName
+    // Check if already cached in either registry
     functionRegistry.lookupFunction(qualifiedIdent)
       .orElse(tableFunctionRegistry.lookupFunction(qualifiedIdent))
       .getOrElse {
-        requireDbExists(db)
-        if (externalCatalog.functionExists(db, funcName)) {
-          val metadata = externalCatalog.getFunction(db, funcName)
-          if (metadata.isUserDefinedFunction) {
-            UserDefinedFunction.fromCatalogFunction(metadata, parser).toExpressionInfo
-          } else {
-            makeExprInfoForHiveFunction(metadata.copy(identifier = qualifiedIdent))
-          }
+        val funcMetadata = fetchCatalogFunction(qualifiedIdent)
+        if (funcMetadata.isUserDefinedFunction) {
+          UserDefinedFunction.fromCatalogFunction(funcMetadata, parser).toExpressionInfo
         } else {
-          failFunctionLookup(name)
+          makeExprInfoForHiveFunction(funcMetadata)
         }
       }
   }
 
   /**
-   * Look up a persistent scalar function by name and resolves it to an Expression.
+   * Load a persistent scalar function by name.
+   * Returns V1Function with:
+   * - Eager info (from cache or catalog fetch, no resource loading)
+   * - Lazy builder (resource loading only on first invoke)
+   *
+   * This matches V1 behavior where DESCRIBE doesn't load resources.
    */
-  def resolvePersistentFunction(
-      name: FunctionIdentifier, arguments: Seq[Expression]): Expression = {
-    resolvePersistentFunctionInternal[Expression](
-      name,
-      arguments,
-      functionRegistry,
-      registerHiveFunc = func =>
-        registerFunction(
-          func,
-          overrideIfExists = false,
-          registry = functionRegistry,
-          functionBuilder = makeFunctionBuilder(func)
-        ),
-      registerUserDefinedFunc = function => {
-        val builder = makeUserDefinedScalarFuncBuilder(function)
-        registerUserDefinedFunction[Expression](
-          function = function,
-          overrideIfExists = false,
-          registry = functionRegistry,
-          functionBuilder = builder)
-      }
-    )
+  def loadPersistentScalarFunction(name: FunctionIdentifier): V1Function = {
+    val qualifiedIdent = qualifyIdentifier(name)
+
+    // Check cache first (no synchronization needed for reads)
+    functionRegistry.lookupFunctionEntry(qualifiedIdent) match {
+      case Some((cachedInfo, cachedBuilder)) =>
+        // Already cached - return with eager builder
+        V1Function(cachedInfo, cachedBuilder)
+
+      case None =>
+        // Fetch metadata eagerly (no resource loading yet)
+        val funcMetadata = fetchCatalogFunction(qualifiedIdent)
+        val info = if (funcMetadata.isUserDefinedFunction) {
+          UserDefinedFunction.fromCatalogFunction(funcMetadata, parser).toExpressionInfo
+        } else {
+          makeExprInfoForHiveFunction(funcMetadata)
+        }
+
+        // Builder factory - loads resources only on first invoke()
+        val builderFactory: () => FunctionBuilder = () => synchronized {
+          // Re-check cache (another thread may have loaded it)
+          functionRegistry.lookupFunctionBuilder(qualifiedIdent).getOrElse {
+            loadFunctionResources(funcMetadata.resources)
+            if (funcMetadata.isUserDefinedFunction) {
+              val udf = UserDefinedFunction.fromCatalogFunction(funcMetadata, parser)
+              registerUserDefinedFunction[Expression](
+                udf,
+                overrideIfExists = false,
+                functionRegistry,
+                makeUserDefinedScalarFuncBuilder(udf))
+            } else {
+              registerFunction(
+                funcMetadata,
+                overrideIfExists = false,
+                functionRegistry,
+                makeFunctionBuilder(funcMetadata))
+            }
+            functionRegistry.lookupFunctionBuilder(qualifiedIdent).get
+          }
+        }
+
+        V1Function(info, builderFactory)
+    }
   }
 
   /**
@@ -2209,66 +2229,46 @@ class SessionCatalog(
    */
   def resolvePersistentTableFunction(
       name: FunctionIdentifier,
-      arguments: Seq[Expression]): LogicalPlan = {
-    resolvePersistentFunctionInternal[LogicalPlan](
-      name,
-      arguments,
-      tableFunctionRegistry,
-      // We don't support persistent Hive table functions yet.
-      registerHiveFunc = (func: CatalogFunction) => failFunctionLookup(name),
-      registerUserDefinedFunc = function => {
-        val builder = makeUserDefinedTableFuncBuilder(function)
-        registerUserDefinedFunction[LogicalPlan](
-          function = function,
-          overrideIfExists = false,
-          registry = tableFunctionRegistry,
-          functionBuilder = builder)
+      arguments: Seq[Expression]): LogicalPlan = synchronized {
+    val qualifiedIdent = qualifyIdentifier(name)
+    if (tableFunctionRegistry.functionExists(qualifiedIdent)) {
+      // Already cached
+      tableFunctionRegistry.lookupFunction(qualifiedIdent, arguments)
+    } else {
+      // Load from catalog
+      val funcMetadata = fetchCatalogFunction(qualifiedIdent)
+      if (!funcMetadata.isUserDefinedFunction) {
+        // Hive table functions are not supported
+        failFunctionLookup(qualifiedIdent)
       }
-    )
+      loadFunctionResources(funcMetadata.resources)
+      val udf = UserDefinedFunction.fromCatalogFunction(funcMetadata, parser)
+      registerUserDefinedFunction[LogicalPlan](
+        udf,
+        overrideIfExists = false,
+        tableFunctionRegistry,
+        makeUserDefinedTableFuncBuilder(udf))
+      tableFunctionRegistry.lookupFunction(qualifiedIdent, arguments)
+    }
   }
 
-  private def resolvePersistentFunctionInternal[T](
-      name: FunctionIdentifier,
-      arguments: Seq[Expression],
-      registry: FunctionRegistryBase[T],
-      registerHiveFunc: CatalogFunction => Unit,
-      registerUserDefinedFunc: UserDefinedFunction => Unit): T = {
-    // `synchronized` is used to prevent multiple threads from concurrently resolving the
-    // same function that has not yet been loaded into the function registry. This is needed
-    // because calling `registerFunction` twice with `overrideIfExists = false` can lead to
-    // a FunctionAlreadyExistsException.
-    synchronized {
-      val qualifiedIdent = qualifyIdentifier(name)
-      val db = qualifiedIdent.database.get
-      val funcName = qualifiedIdent.funcName
-      if (registry.functionExists(qualifiedIdent)) {
-        // This function has been already loaded into the function registry.
-        registry.lookupFunction(qualifiedIdent, arguments)
-      } else {
-        // The function has not been loaded to the function registry, which means
-        // that the function is a persistent function (if it actually has been registered
-        // in the metastore). We need to first put the function in the function registry.
-        val catalogFunction = try {
-          externalCatalog.getFunction(db, funcName)
-        } catch {
-          case _: AnalysisException => failFunctionLookup(qualifiedIdent)
-        }
-        // Please note that qualifiedName is provided by the user. However,
-        // catalogFunction.identifier.unquotedString is returned by the underlying
-        // catalog. So, it is possible that qualifiedName is not exactly the same as
-        // catalogFunction.identifier.unquotedString (difference is on case-sensitivity).
-        // At here, we preserve the input from the user.
-        val funcMetadata = catalogFunction.copy(identifier = qualifiedIdent)
-        if (!catalogFunction.isUserDefinedFunction) {
-          loadFunctionResources(catalogFunction.resources)
-          registerHiveFunc(funcMetadata)
-        } else {
-          val function = UserDefinedFunction.fromCatalogFunction(funcMetadata, parser)
-          registerUserDefinedFunc(function)
-        }
-        // Now, we need to create the Expression.
-        registry.lookupFunction(qualifiedIdent, arguments)
-      }
+  /**
+   * Fetch a catalog function from the external catalog.
+   */
+  private def fetchCatalogFunction(qualifiedIdent: FunctionIdentifier): CatalogFunction = {
+    val db = qualifiedIdent.database.get
+    val funcName = qualifiedIdent.funcName
+    requireDbExists(db)
+    try {
+      // Please note that qualifiedIdent is provided by the user. However,
+      // CatalogFunction.identifier is returned by the underlying catalog.
+      // So, it is possible that qualifiedIdent is not exactly the same as
+      // catalogFunction.identifier (difference is on case-sensitivity).
+      // At here, we preserve the input from the user.
+      externalCatalog.getFunction(db, funcName).copy(identifier = qualifiedIdent)
+    } catch {
+      case _: NoSuchPermanentFunctionException | _: NoSuchFunctionException =>
+        failFunctionLookup(qualifiedIdent)
     }
   }
 
@@ -2290,9 +2290,9 @@ class SessionCatalog(
   def lookupFunction(name: FunctionIdentifier, children: Seq[Expression]): Expression = {
     if (name.database.isEmpty) {
       resolveBuiltinOrTempFunction(name.funcName, children)
-        .getOrElse(resolvePersistentFunction(name, children))
+        .getOrElse(loadPersistentScalarFunction(name).invoke(children))
     } else {
-      resolvePersistentFunction(name, children)
+      loadPersistentScalarFunction(name).invoke(children)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -38,7 +38,6 @@ import org.apache.spark.sql.connector.catalog.{CatalogManager, Column, DefaultVa
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryErrorsBase}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.connector.V1Function
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.ArrayImplicits._
@@ -671,7 +670,7 @@ object ResolveDefaultColumns extends QueryErrorsBase
       throw SparkUnsupportedOperationException()
     }
     override def loadFunction(ident: Identifier): UnboundFunction = {
-      V1Function(v1Catalog.lookupPersistentFunction(ident.asFunctionIdentifier))
+      v1Catalog.loadPersistentScalarFunction(ident.asFunctionIdentifier)
     }
     override def functionExists(ident: Identifier): Boolean = {
       v1Catalog.isPersistentFunction(ident.asFunctionIdentifier)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/V1Function.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/V1Function.scala
@@ -17,15 +17,79 @@
 
 package org.apache.spark.sql.internal.connector
 
-import org.apache.spark.SparkUnsupportedOperationException
-import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
+import org.apache.spark.SparkException
+import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionInfo}
 import org.apache.spark.sql.connector.catalog.functions.{BoundFunction, UnboundFunction}
 import org.apache.spark.sql.types.StructType
 
-case class V1Function(info: ExpressionInfo) extends UnboundFunction {
+/**
+ * A wrapper for V1 scalar functions that mirrors the V2 UnboundFunction pattern.
+ *
+ * V1Function has two responsibilities:
+ * 1. Provide ExpressionInfo for DESCRIBE FUNCTION (accessed via `info`)
+ * 2. Provide a function builder for invocation (accessed via `invoke()`)
+ *
+ * The key design is two-phase lazy loading:
+ * - `info` is computed eagerly or from cache (no resource loading)
+ * - `functionBuilder` is computed lazily on first `invoke()` (triggers resource loading)
+ *
+ * This matches V1 behavior where DESCRIBE doesn't load resources but invocation does.
+ */
+class V1Function private (
+    val info: ExpressionInfo,
+    builderFactory: () => FunctionBuilder) extends UnboundFunction {
+
+  /**
+   * Lazy function builder - only computed on first invoke().
+   * For persistent functions, this triggers resource loading.
+   */
+  private lazy val functionBuilder: FunctionBuilder = builderFactory()
+
+  /**
+   * Invoke the function with the given arguments.
+   * This is the V1 equivalent of V2's bind() pattern.
+   * For persistent functions, first invocation triggers resource loading.
+   */
+  def invoke(arguments: Seq[Expression]): Expression = functionBuilder(arguments)
+
+  // UnboundFunction interface
   override def bind(inputType: StructType): BoundFunction = {
-    throw new SparkUnsupportedOperationException("_LEGACY_ERROR_TEMP_3110")
+    // V1 functions don't use the V2 bind() pattern - they use invoke() instead
+    throw SparkException.internalError("V1Function.bind() should not be called")
   }
+
   override def name(): String = info.getName
+
   override def description(): String = info.getUsage
+}
+
+object V1Function {
+  /** A placeholder builder for metadata-only V1Functions that throws on invocation. */
+  private val metadataOnlyBuilder: FunctionBuilder = _ =>
+    throw SparkException.internalError(
+      "Metadata-only V1Function should not be invoked")
+
+  /**
+   * Create a V1Function with eager info and lazy builder.
+   * The builderFactory is called on first invoke().
+   */
+  def apply(info: ExpressionInfo, builderFactory: () => FunctionBuilder): V1Function = {
+    new V1Function(info, builderFactory)
+  }
+
+  /**
+   * Create a V1Function with eager info and builder (for built-in/temp/cached functions).
+   */
+  def apply(info: ExpressionInfo, builder: FunctionBuilder): V1Function = {
+    new V1Function(info, () => builder)
+  }
+
+  /**
+   * Create a metadata-only V1Function (for DESCRIBE FUNCTION).
+   * If invoke() is called, it will throw an error.
+   */
+  def apply(info: ExpressionInfo): V1Function = {
+    new V1Function(info, () => metadataOnlyBuilder)
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/V1Function.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/V1Function.scala
@@ -89,7 +89,7 @@ object V1Function {
    * Create a metadata-only V1Function (for DESCRIBE FUNCTION).
    * If invoke() is called, it will throw an error.
    */
-  def apply(info: ExpressionInfo): V1Function = {
+  def metadataOnly(info: ExpressionInfo): V1Function = {
     new V1Function(info, () => metadataOnlyBuilder)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/LookupFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/LookupFunctionsSuite.scala
@@ -28,7 +28,6 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.connector.catalog.{CatalogManager, FunctionCatalog, Identifier}
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.connector.V1Function
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 class LookupFunctionsSuite extends PlanTest {
@@ -152,7 +151,7 @@ class CustomV2SessionCatalog(v1Catalog: SessionCatalog) extends FunctionCatalog 
   }
 
   override def loadFunction(ident: Identifier): UnboundFunction = {
-    V1Function(v1Catalog.lookupPersistentFunction(ident.asFunctionIdentifier))
+    v1Catalog.loadPersistentScalarFunction(ident.asFunctionIdentifier)
   }
   override def functionExists(ident: Identifier): Boolean = {
     v1Catalog.isPersistentFunction(ident.asFunctionIdentifier)

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -483,8 +483,8 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
         if conf.useV1Command =>
       ShowTablePropertiesCommand(ident, propertyKey, output)
 
-    case DescribeFunction(ResolvedNonPersistentFunc(_, V1Function(info)), extended) =>
-      DescribeFunctionCommand(info, extended)
+    case DescribeFunction(ResolvedNonPersistentFunc(_, v1Func: V1Function), extended) =>
+      DescribeFunctionCommand(v1Func.info, extended)
 
     case DescribeFunction(ResolvedPersistentFunc(catalog, _, func), extended) =>
       if (isSessionCatalog(catalog)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
@@ -35,7 +35,6 @@ import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.datasources.DataSource
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.connector.V1Function
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.ArrayImplicits._
@@ -475,7 +474,7 @@ class V2SessionCatalog(catalog: SessionCatalog)
   }
 
   override def loadFunction(ident: Identifier): UnboundFunction = {
-    V1Function(catalog.lookupPersistentFunction(ident.asFunctionIdentifier))
+    catalog.loadPersistentScalarFunction(ident.asFunctionIdentifier)
   }
 
   override def listFunctions(namespace: Array[String]): Array[Identifier] = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds `loadPersistentScalarFunction` method to `SessionCatalog`, to unify the scalar function lookup and resolution between v1 and v2 catalogs. The key difference between v1 and v2 catalogs about function is:
- v1 catalog provides different APIs for describing function and invoking function to do function lookup: `lookupPersistentFunction` and `resolvePersistentFunction`.
- v2 catalog only has one single lookup API: `loadFunction`. This API returns `UnboundFunction`, for invocation, it needs to enter the second phase and call `UnboundFunction.bind`.

The newly added `loadPersistentScalarFunction` method follows the v2 catalog style and handles function invocation (load resources and create function builder) in a second phase.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Code cleanup, also also avoid redundant function lookup from catalog introduced by https://github.com/apache/spark/pull/53531

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
existing tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
cursor 2.2.44