### PR TITLE
[SPARK-54858][INFRA] Fix syntax error in `test_report.yml` and recover GA workflow

### DIFF
--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   test_report:
-    if: ${{ github.event.workflow_run.conclusion not in ['skipped', 'cancelled'] }}
+    if: "!contains(fromJson('[\"skipped\", \"cancelled\"]'), github.event.workflow_run.conclusion)"
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix a syntax error in `test_report.yml` which causes GA workflow failure.

### Why are the changes needed?
To recover GA workflow `test_report`. Recently, that workflow consistently fails.
<img width="1719" height="828" alt="test_report_failure" src="https://github.com/user-attachments/assets/17afed94-963d-42b1-90a1-ad8f015e3740" />
<img width="1370" height="172" alt="test_report_failure_detail" src="https://github.com/user-attachments/assets/799ad6cb-b646-416a-b8aa-0905f3cf987c" />

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
No.