### PR TITLE
[SPARK-54872][SQL] Unify column default value handling between v1 and v2 commands

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/types/Metadata.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/Metadata.scala
@@ -339,6 +339,7 @@ class MetadataBuilder {
 
   private def put(key: String, value: Any): this.type = {
     map.put(key, value)
+    runtimeMap.remove(key)
     this
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statements.scala
@@ -141,6 +141,13 @@ case class QualifiedColType(
   def getV2Default(statement: String): ColumnDefaultValue =
     default.map(_.toV2(statement, colName)).orNull
 
+  /**
+   * Returns true if the default value's type has been coerced to match this column's dataType.
+   */
+  def isDefaultValueTypeCoerced: Boolean = default.forall { d =>
+    ColumnDefinition.isDefaultValueTypeMatched(d.child.dataType, dataType)
+  }
+
   override def children: Seq[Expression] = default.toSeq
 
   override protected def withNewChildrenInternal(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2AlterTableCommands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2AlterTableCommands.scala
@@ -248,7 +248,13 @@ case class AlterColumnSpec(
     copy(column = newColumn, newPosition = newPos, newDefaultExpression = newDefault)
   }
 
-
+  /**
+   * Returns true if the default value's type has been coerced to match the column's dataType.
+   * When newDataType is None, we skip this check as the type will be resolved later.
+   */
+  def isDefaultValueTypeCoerced: Boolean = newDefaultExpression.forall { d =>
+    newDataType.forall(dt => ColumnDefinition.isDefaultValueTypeMatched(d.child.dataType, dt))
+  }
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -40,7 +40,6 @@ import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryErrorsBase}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Utils
 
 /**
@@ -53,52 +52,6 @@ object ResolveDefaultColumns extends QueryErrorsBase
   // Name of attributes representing explicit references to the value stored in the above
   // CURRENT_DEFAULT_COLUMN_METADATA.
   val CURRENT_DEFAULT_COLUMN_NAME = "DEFAULT"
-
-  /**
-   * Finds "current default" expressions in CREATE/REPLACE TABLE columns and constant-folds them.
-   *
-   * The results are stored in the "exists default" metadata of the same columns. For example, in
-   * the event of this statement:
-   *
-   * CREATE TABLE T(a INT, b INT DEFAULT 5 + 5)
-   *
-   * This method constant-folds the "current default" value, stored in the CURRENT_DEFAULT metadata
-   * of the "b" column, to "10", storing the result in the "exists default" value within the
-   * EXISTS_DEFAULT metadata of that same column. Meanwhile the "current default" metadata of this
-   * "b" column retains its original value of "5 + 5".
-   *
-   * The reason for constant-folding the EXISTS_DEFAULT is to make the end-user visible behavior the
-   * same, after executing an ALTER TABLE ADD COLUMNS command with DEFAULT value, as if the system
-   * had performed an exhaustive backfill of the provided value to all previously existing rows in
-   * the table instead. We choose to avoid doing such a backfill because it would be a
-   * time-consuming and costly operation. Instead, we elect to store the EXISTS_DEFAULT in the
-   * column metadata for future reference when querying data out of the data source. In turn, each
-   * data source then takes responsibility to provide the constant-folded value in the
-   * EXISTS_DEFAULT metadata for such columns where the value is not present in storage.
-   *
-   * @param tableSchema   represents the names and types of the columns of the statement to process.
-   * @param statementType name of the statement being processed, such as INSERT; useful for errors.
-   * @return a copy of `tableSchema` with field metadata updated with the constant-folded values.
-   */
-  def constantFoldCurrentDefaultsToExistDefaults(
-      tableSchema: StructType,
-      statementType: String): StructType = {
-    if (SQLConf.get.enableDefaultColumns) {
-      val newFields: Seq[StructField] = tableSchema.fields.map { field =>
-        if (field.metadata.contains(CURRENT_DEFAULT_COLUMN_METADATA_KEY)) {
-          val analyzed: Expression = analyze(field, statementType)
-          val newMetadata: Metadata = new MetadataBuilder().withMetadata(field.metadata)
-            .putString(EXISTS_DEFAULT_COLUMN_METADATA_KEY, analyzed.sql).build()
-          field.copy(metadata = newMetadata)
-        } else {
-          field
-        }
-      }.toImmutableArraySeq
-      StructType(newFields)
-    } else {
-      tableSchema
-    }
-  }
 
   // Fails if the given catalog does not support column default value.
   def validateCatalogForDefaultValue(
@@ -607,24 +560,7 @@ object ResolveDefaultColumns extends QueryErrorsBase
     if (default.containsPattern(PLAN_EXPRESSION)) {
       throw QueryCompilationErrors.defaultValuesMayNotContainSubQueryExpressions(
         statement, colName, default.originalSQL)
-    } else if (default.resolved) {
-      targetTypeOption match {
-        case Some(targetType) =>
-          CharVarcharUtils.replaceCharVarcharWithString(targetType)
-          if (!Cast.canUpCast(default.child.dataType, targetType) &&
-            defaultValueFromWiderTypeLiteral(default.child, targetType, colName).isEmpty) {
-            throw QueryCompilationErrors.defaultValuesDataTypeError(
-              statement, colName, default.originalSQL, targetType, default.child.dataType)
-          }
-        case _ => ()
-      }
-    } else {
-      throw QueryCompilationErrors.defaultValuesUnresolvedExprError(
-        statement, colName, default.originalSQL, null)
     }
-
-    // Our analysis check passes here. We do not further inspect whether the
-    // expression is `foldable` here, as the plan is not optimized yet.
 
     if (default.references.nonEmpty || default.exists(_.isInstanceOf[VariableReference])) {
       // Ideally we should let the rest of `CheckAnalysis` report errors about why the default
@@ -634,6 +570,22 @@ object ResolveDefaultColumns extends QueryErrorsBase
       throw QueryCompilationErrors.defaultValueNotConstantError(
         statement, colName, default.originalSQL)
     }
+
+    if (default.resolved) {
+      targetTypeOption.foreach { targetType =>
+        // Type coercion should have already run before this check, so types should match.
+        if (!ColumnDefinition.isDefaultValueTypeMatched(default.child.dataType, targetType)) {
+          throw QueryCompilationErrors.defaultValuesDataTypeError(
+            statement, colName, default.originalSQL, targetType, default.child.dataType)
+        }
+      }
+    } else {
+      throw QueryCompilationErrors.defaultValuesUnresolvedExprError(
+        statement, colName, default.originalSQL, null)
+    }
+
+    // Our analysis check passes here. We do not further inspect whether the
+    // expression is `foldable` here, as the plan is not optimized yet.
 
     if (!default.deterministic) {
       throw QueryCompilationErrors.defaultValueNonDeterministicError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
@@ -365,7 +365,7 @@ private[sql] object CatalogV2Util {
     }
     validateTableProviderForDefaultValue(
       newSchema, tableProvider, statementType, addNewColumnToExistingTable)
-    constantFoldCurrentDefaultsToExistDefaults(newSchema, statementType)
+    newSchema
   }
 
   private def replace(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -197,16 +197,6 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
           "expectedType" -> "\"BOOLEAN\"",
           "defaultValue" -> "41 + 1",
           "actualType" -> "\"INT\""))
-
-      // Make sure that constant-folding default values does not take place when the feature is
-      // disabled.
-      withSQLConf(SQLConf.ENABLE_DEFAULT_COLUMNS.key -> "false") {
-        val result: StructType = ResolveDefaultColumns.constantFoldCurrentDefaultsToExistDefaults(
-          db1tbl3.schema, "CREATE TABLE")
-        val columnEWithFeatureDisabled: StructField = findField("e", result)
-        // No constant-folding has taken place to the EXISTS_DEFAULT metadata.
-        assert(!columnEWithFeatureDisabled.metadata.contains("EXISTS_DEFAULT"))
-      }
     }
     withSQLConf(SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS.key -> "csv,hive,json,orc,parquet") {
       test

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTableTests.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/AlterTableTests.scala
@@ -394,12 +394,12 @@ trait AlterTableTests extends SharedSparkSession with QueryErrorsBase {
     withSQLConf(SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS.key -> s"$v2Format, ") {
       withTable("t") {
         sql(s"create table t(i boolean) using $v2Format")
-        // The default value fails to analyze.
+        // The default value references a non-existing column, which is not a constant.
         checkError(
           exception = intercept[AnalysisException] {
             sql("alter table t add column s bigint default badvalue")
           },
-          condition = "INVALID_DEFAULT_VALUE.UNRESOLVED_EXPRESSION",
+          condition = "INVALID_DEFAULT_VALUE.NOT_CONSTANT",
           parameters = Map(
             "statement" -> "ALTER TABLE ADD COLUMNS",
             "colName" -> "`s`",
@@ -410,7 +410,7 @@ trait AlterTableTests extends SharedSparkSession with QueryErrorsBase {
           exception = intercept[AnalysisException] {
             sql("alter table t alter column s set default badvalue")
           },
-          condition = "INVALID_DEFAULT_VALUE.UNRESOLVED_EXPRESSION",
+          condition = "INVALID_DEFAULT_VALUE.NOT_CONSTANT",
           parameters = Map(
             "statement" -> "ALTER TABLE ALTER COLUMN",
             "colName" -> "`s`",

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
@@ -1071,7 +1071,7 @@ class DataSourceV2DataFrameSuite
            c1 timestamp,
            current_timestamp TIMESTAMP DEFAULT c1)""")
         },
-        condition = "INVALID_DEFAULT_VALUE.UNRESOLVED_EXPRESSION",
+        condition = "INVALID_DEFAULT_VALUE.NOT_CONSTANT",
         parameters = Map(
           "statement" -> "CREATE TABLE",
           "colName" -> "`current_timestamp`",

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -3682,12 +3682,12 @@ class DataSourceV2SQLSuiteV1Filter
   test("CREATE TABLE with invalid default value") {
     withSQLConf(SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS.key -> s"$v2Format, ") {
       withTable("t") {
-        // The default value fails to analyze.
+        // The default value references a non-existing column, which is not a constant.
         checkError(
           exception = intercept[AnalysisException] {
             sql(s"create table t(s int default badvalue) using $v2Format")
           },
-          condition = "INVALID_DEFAULT_VALUE.UNRESOLVED_EXPRESSION",
+          condition = "INVALID_DEFAULT_VALUE.NOT_CONSTANT",
           parameters = Map(
             "statement" -> "CREATE TABLE",
             "colName" -> "`s`",
@@ -3700,13 +3700,12 @@ class DataSourceV2SQLSuiteV1Filter
     withSQLConf(SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS.key -> s"$v2Format, ") {
       withTable("t") {
         sql(s"create table t(i boolean) using $v2Format")
-
-        // The default value fails to analyze.
+        // The default value references a non-existing column, which is not a constant.
         checkError(
           exception = intercept[AnalysisException] {
             sql(s"replace table t(s int default badvalue) using $v2Format")
           },
-          condition = "INVALID_DEFAULT_VALUE.UNRESOLVED_EXPRESSION",
+          condition = "INVALID_DEFAULT_VALUE.NOT_CONSTANT",
           parameters = Map(
             "statement" -> "REPLACE TABLE",
             "colName" -> "`s`",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR refactors the column default value resolution code for `CRETE TABLE`, `ADD COLUMN`, and `ALTER COLUMN` commands. Now the resolution code is mostly unified between v1 and v2 commands:
- Analyzer will resolve the default value expression.
- For v2 commands, we validate default value in `CheckAnalysis`, and optimizer naturally constant fold the default value expression, which will be used as the EXIST DEFAULT.
- For v1 commands, we convert v2 commands to v1 commands in `ResolveSessionCatalog`. V1 commands use `StructType` so default value expression is invisible to the optimizer.  we have to validate and constant fold the default value expression before we convert to v1 commands.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Code cleanup. Now `CRETE TABLE`, `ADD COLUMN`, and `ALTER COLUMN` commands no longer need a fake analyzer.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
existing test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
cursor 2.2.44