### PR TITLE
[SPARK-54864][SQL] Add rCTE nodes to NormalizePlan

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/NormalizePlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/NormalizePlan.scala
@@ -205,8 +205,14 @@ object NormalizePlan extends PredicateHelper {
         })
       case cteRelationDef: CTERelationDef =>
         cteIdNormalizer.normalizeDef(cteRelationDef)
+      case unionLoop: UnionLoop =>
+        cteIdNormalizer.normalizeUnionLoop(
+          unionLoop.copy(outputAttrIds = Seq.fill(unionLoop.outputAttrIds.size)(ExprId(0)))
+        )
       case cteRelationRef: CTERelationRef =>
         cteIdNormalizer.normalizeRef(cteRelationRef)
+      case unionLoopRef: UnionLoopRef =>
+        cteIdNormalizer.normalizeUnionLoopRef(unionLoopRef)
       case normalizeableRelation: NormalizeableRelation =>
         normalizeableRelation.normalize()
     }
@@ -247,8 +253,12 @@ class CteIdNormalizer {
 
   def normalizeDef(cteRelationDef: CTERelationDef): CTERelationDef = {
     try {
-      oldToNewIdMapping.put(cteRelationDef.id, cteIdCounter)
-      cteRelationDef.copy(id = cteIdCounter)
+      if (oldToNewIdMapping.containsKey(cteRelationDef)) {
+        cteRelationDef.copy(id = oldToNewIdMapping.get(cteRelationDef.id))
+      } else {
+        oldToNewIdMapping.put(cteRelationDef.id, cteIdCounter)
+        cteRelationDef.copy(id = cteIdCounter)
+      }
     } finally {
       cteIdCounter += 1
     }
@@ -259,6 +269,23 @@ class CteIdNormalizer {
       cteRelationRef.copy(cteId = oldToNewIdMapping.get(cteRelationRef.cteId))
     } else {
       cteRelationRef
+    }
+  }
+
+  def normalizeUnionLoop(unionLoop: UnionLoop): UnionLoop = {
+    if (oldToNewIdMapping.containsKey(unionLoop.id)) {
+      unionLoop.copy(id = oldToNewIdMapping.get(unionLoop.id))
+    } else {
+      unionLoop
+    }
+  }
+
+  def normalizeUnionLoopRef(unionLoopRef: UnionLoopRef): UnionLoopRef = {
+    try {
+      oldToNewIdMapping.put(unionLoopRef.loopId, cteIdCounter)
+      unionLoopRef.copy(loopId = cteIdCounter)
+    } finally {
+      cteIdCounter += 1
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
@@ -269,7 +269,7 @@ class NormalizePlanSuite extends SparkFunSuite with SQLConfHelper {
         recursion = UnionLoopRef(loopId = 200L, output = Seq(col2), accumulated = false),
         outputAttrIds = Seq(ExprId(1), ExprId(2))
       ),
-      id = 100L
+      id = 200L
     )
 
     // Before normalization, plans are different

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/NormalizePlanSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{CTERelationDef, LocalRelation, LogicalPlan, UnionLoop, UnionLoopRef}
 import org.apache.spark.sql.types.BooleanType
 
 class NormalizePlanSuite extends SparkFunSuite with SQLConfHelper {
@@ -192,6 +192,91 @@ class NormalizePlanSuite extends SparkFunSuite with SQLConfHelper {
 
     assert(baselinePlan != testPlan)
     assert(NormalizePlan(baselinePlan) == NormalizePlan(testPlan))
+  }
+
+  test("Normalize UnionLoopRef IDs") {
+    val col1 = $"col1".int
+    val col2 = col1.newInstance()
+
+    // Create two UnionLoopRefs with different loopIds
+    val baselineLoopRef = UnionLoopRef(
+      loopId = 100L,
+      output = Seq(col2),
+      accumulated = false
+    )
+
+    val testLoopRef = UnionLoopRef(
+      loopId = 200L,
+      output = Seq(col2),
+      accumulated = false
+    )
+
+    // Before normalization, plans are different
+    assert(baselineLoopRef != testLoopRef)
+
+    // After normalization, they should be equal (loopIds normalized)
+    assert(NormalizePlan(baselineLoopRef) == NormalizePlan(testLoopRef))
+  }
+
+  test("Normalize UnionLoop IDs and outputAttrIds and UnionLoopRefIds") {
+    val col1 = $"col1".int
+    val col2 = col1.newInstance()
+    val anchor = LocalRelation(col1)
+
+    // Create two UnionLoops with different IDs and different outputAttrIds
+    val unionLoop1 = UnionLoop(
+      id = 100L,
+      anchor = anchor,
+      recursion = UnionLoopRef(loopId = 100L, output = Seq(col2), accumulated = false),
+      outputAttrIds = Seq(ExprId(1), ExprId(2))
+    )
+
+    val unionLoop2 = UnionLoop(
+      id = 200L,
+      anchor = anchor,
+      recursion = UnionLoopRef(loopId = 200L, output = Seq(col2), accumulated = false),
+      outputAttrIds = Seq(ExprId(1), ExprId(2))
+    )
+
+    // Before normalization, plans are different
+    assert(unionLoop1 != unionLoop2)
+
+    // After normalization, they should be equal (IDs normalized, outputAttrIds zeroed)
+    assert(NormalizePlan(unionLoop1) == NormalizePlan(unionLoop2))
+  }
+
+  test("Normalize rCTEs") {
+    val col1 = $"col1".int
+    val col2 = col1.newInstance()
+    val anchor = LocalRelation(col1)
+
+    // Create two full recursive CTEs - CTERelationDef with a UnionLoop and UnionLoopRef with the
+    // same id
+    val recursiveCTE1 = CTERelationDef(
+      child = UnionLoop(
+        id = 100L,
+        anchor = anchor,
+        recursion = UnionLoopRef(loopId = 100L, output = Seq(col2), accumulated = false),
+        outputAttrIds = Seq(ExprId(1), ExprId(2))
+      ),
+      id = 100L
+    )
+
+    val recursiveCTE2 = CTERelationDef(
+      child = UnionLoop(
+        id = 200L,
+        anchor = anchor,
+        recursion = UnionLoopRef(loopId = 200L, output = Seq(col2), accumulated = false),
+        outputAttrIds = Seq(ExprId(1), ExprId(2))
+      ),
+      id = 100L
+    )
+
+    // Before normalization, plans are different
+    assert(recursiveCTE1 != recursiveCTE2)
+
+    // After normalization, they should be equal
+    assert(NormalizePlan(recursiveCTE1) == NormalizePlan(recursiveCTE2))
   }
 
   private def setTimezoneForAllExpression(plan: LogicalPlan): LogicalPlan = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace `CteIdNormalizer` in `NormalizePlan` with an application of the rule `NormalizeCteIds`. 

### Why are the changes needed?

To add testing for recursive CTEs for single pass analyzer.
Reduce code duplication.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New test in `NormalizePlanSuite`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Sonnet 4.5 via Cursor AI - Original draft of the tests.
