### PR TITLE
[SPARK-54870][SQL] Collation support for char/varchar and CTAS/RTAS

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
@@ -1248,6 +1248,13 @@ public final class CollationFactory {
   }
 
   /**
+   * Returns the collation ID for the given fully qualified name.
+   */
+  public static int fullyQualifiedNameToId(String[] collationName) throws SparkException {
+    return collationNameToId(resolveFullyQualifiedName(collationName));
+  }
+
+  /**
    * Returns the collation ID for the given collation name.
    */
   public static int collationNameToId(String collationName) throws SparkException {

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -42,6 +42,18 @@ object MimaExcludes {
     // [SPARK-51261][ML][CONNECT] Introduce model size estimation to control ml cache
     ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.ml.linalg.Vector.getSizeInBytes"),
 
+    // CharType and VarcharType signature change (added collation parameter)
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.types.CharType.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.types.CharType.compose"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.types.CharType.copy"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.types.CharType.this"),
+    ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.sql.types.CharType$"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.types.VarcharType.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.types.VarcharType.compose"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.types.VarcharType.copy"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.types.VarcharType.this"),
+    ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.sql.types.VarcharType$"),
+
     // [SPARK-52221][SQL] Refactor SqlScriptingLocalVariableManager into more generic context manager
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.scripting.SqlScriptingExecution.withLocalVariableManager"),
 

--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -1407,8 +1407,8 @@ collateClause
 
 nonTrivialPrimitiveType
     : STRING collateClause?
-    | (CHARACTER | CHAR) (LEFT_PAREN length=integerValue RIGHT_PAREN)?
-    | VARCHAR (LEFT_PAREN length=integerValue RIGHT_PAREN)?
+    | (CHARACTER | CHAR) (LEFT_PAREN length=integerValue RIGHT_PAREN)? collateClause?
+    | VARCHAR (LEFT_PAREN length=integerValue RIGHT_PAREN)? collateClause?
     | (DECIMAL | DEC | NUMERIC)
         (LEFT_PAREN precision=integerValue (COMMA scale=integerValue)? RIGHT_PAREN)?
     | INTERVAL

--- a/sql/api/src/main/java/org/apache/spark/sql/types/DataTypes.java
+++ b/sql/api/src/main/java/org/apache/spark/sql/types/DataTypes.java
@@ -302,7 +302,7 @@ public class DataTypes {
    * @since 4.0.0
    */
   public static CharType createCharType(int length) {
-    return new CharType(length);
+    return CharType$.MODULE$.apply(length);
   }
 
   /**
@@ -311,6 +311,6 @@ public class DataTypes {
    * @since 4.0.0
    */
   public static VarcharType createVarcharType(int length) {
-    return new VarcharType(length);
+    return VarcharType$.MODULE$.apply(length);
   }
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/encoders/RowEncoder.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/encoders/RowEncoder.scala
@@ -81,10 +81,10 @@ object RowEncoder extends DataTypeErrorsBase {
       case DoubleType => BoxedDoubleEncoder
       case dt: DecimalType => JavaDecimalEncoder(dt, lenientSerialization = true)
       case BinaryType => BinaryEncoder
-      case CharType(length) if SqlApiConf.get.preserveCharVarcharTypeInfo =>
-        CharEncoder(length)
-      case VarcharType(length) if SqlApiConf.get.preserveCharVarcharTypeInfo =>
-        VarcharEncoder(length)
+      case c: CharType if SqlApiConf.get.preserveCharVarcharTypeInfo =>
+        CharEncoder(c.length)
+      case v: VarcharType if SqlApiConf.get.preserveCharVarcharTypeInfo =>
+        VarcharEncoder(v.length)
       case s: StringType if StringHelper.isPlainString(s) => StringEncoder
       case TimestampType if SqlApiConf.get.datetimeJava8ApiEnabled => InstantEncoder(lenient)
       case TimestampType => TimestampEncoder(lenient)

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/DataTypeAstBuilder.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/DataTypeAstBuilder.scala
@@ -300,39 +300,38 @@ class DataTypeAstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with DataTypeE
             case Seq(_) => StringType
             case Seq(_, ctx: CollateClauseContext) =>
               val collationNameParts = visitCollateClause(ctx).toArray
-              val collationId = CollationFactory.fullyQualifiedNameToId(
-                visitCollateClause(ctx).toArray
-              )
+              val collationId =
+                CollationFactory.fullyQualifiedNameToId(visitCollateClause(ctx).toArray)
               StringType(collationId)
           }
         case CHARACTER | CHAR =>
           (Option(currentCtx.length), Option(currentCtx.collateClause)) match {
             case (None, _) =>
               throw QueryParsingErrors.charVarcharTypeMissingLengthError(
-                currentCtx.start.getText, ctx)
+                currentCtx.start.getText,
+                ctx)
 
             case (Some(length), None) =>
               CharType(length.getText.toInt)
 
             case (Some(length), Some(collate)) =>
-              val collationId = CollationFactory.fullyQualifiedNameToId(
-                visitCollateClause(collate).toArray
-              )
+              val collationId =
+                CollationFactory.fullyQualifiedNameToId(visitCollateClause(collate).toArray)
               CharType(length.getText.toInt, collationId)
           }
         case VARCHAR =>
           (Option(currentCtx.length), Option(currentCtx.collateClause)) match {
             case (None, _) =>
               throw QueryParsingErrors.charVarcharTypeMissingLengthError(
-                currentCtx.start.getText, ctx)
+                currentCtx.start.getText,
+                ctx)
 
             case (Some(length), None) =>
               VarcharType(length.getText.toInt)
 
             case (Some(length), Some(collate)) =>
-              val collationId = CollationFactory.fullyQualifiedNameToId(
-                visitCollateClause(collate).toArray
-              )
+              val collationId =
+                CollationFactory.fullyQualifiedNameToId(visitCollateClause(collate).toArray)
               VarcharType(length.getText.toInt, collationId)
           }
         case DECIMAL | DEC | NUMERIC =>

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/DataTypeAstBuilder.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/DataTypeAstBuilder.scala
@@ -300,18 +300,41 @@ class DataTypeAstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with DataTypeE
             case Seq(_) => StringType
             case Seq(_, ctx: CollateClauseContext) =>
               val collationNameParts = visitCollateClause(ctx).toArray
-              val collationId = CollationFactory.collationNameToId(
-                CollationFactory.resolveFullyQualifiedName(collationNameParts))
+              val collationId = CollationFactory.fullyQualifiedNameToId(
+                visitCollateClause(ctx).toArray
+              )
               StringType(collationId)
           }
         case CHARACTER | CHAR =>
-          if (currentCtx.length == null) {
-            throw QueryParsingErrors.charVarcharTypeMissingLengthError(typeCtx.getText, ctx)
-          } else CharType(currentCtx.length.getText.toInt)
+          (Option(currentCtx.length), Option(currentCtx.collateClause)) match {
+            case (None, _) =>
+              throw QueryParsingErrors.charVarcharTypeMissingLengthError(
+                currentCtx.start.getText, ctx)
+
+            case (Some(length), None) =>
+              CharType(length.getText.toInt)
+
+            case (Some(length), Some(collate)) =>
+              val collationId = CollationFactory.fullyQualifiedNameToId(
+                visitCollateClause(collate).toArray
+              )
+              CharType(length.getText.toInt, collationId)
+          }
         case VARCHAR =>
-          if (currentCtx.length == null) {
-            throw QueryParsingErrors.charVarcharTypeMissingLengthError(typeCtx.getText, ctx)
-          } else VarcharType(currentCtx.length.getText.toInt)
+          (Option(currentCtx.length), Option(currentCtx.collateClause)) match {
+            case (None, _) =>
+              throw QueryParsingErrors.charVarcharTypeMissingLengthError(
+                currentCtx.start.getText, ctx)
+
+            case (Some(length), None) =>
+              VarcharType(length.getText.toInt)
+
+            case (Some(length), Some(collate)) =>
+              val collationId = CollationFactory.fullyQualifiedNameToId(
+                visitCollateClause(collate).toArray
+              )
+              VarcharType(length.getText.toInt, collationId)
+          }
         case DECIMAL | DEC | NUMERIC =>
           if (currentCtx.precision == null) {
             DecimalType.USER_DEFAULT

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkCharVarcharUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkCharVarcharUtils.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.catalyst.util
 
 import org.apache.spark.sql.errors.DataTypeErrors
 import org.apache.spark.sql.internal.SqlApiConf
-import org.apache.spark.sql.types.{ArrayType, CharType, DataType, MapType, StringType, StructType, VarcharType}
+import org.apache.spark.sql.types.{ArrayType, CharType, DataType, MapType, StructType, VarcharType}
 
 trait SparkCharVarcharUtils {
 
@@ -54,7 +54,8 @@ trait SparkCharVarcharUtils {
       StructType(fields.map { field =>
         field.copy(dataType = replaceCharVarcharWithString(field.dataType))
       })
-    case CharType(_) | VarcharType(_) if !SqlApiConf.get.preserveCharVarcharTypeInfo => StringType
+    case c: CharType if !SqlApiConf.get.preserveCharVarcharTypeInfo => c.toStringType
+    case v: VarcharType if !SqlApiConf.get.preserveCharVarcharTypeInfo => v.toStringType
     case _ => dt
   }
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/CharType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/CharType.scala
@@ -17,19 +17,47 @@
 
 package org.apache.spark.sql.types
 
-import org.json4s.JsonAST.{JString, JValue}
-
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.catalyst.util.CollationFactory
 
+/**
+ * A data type representing fixed-length character strings with a specified length.
+ *
+ * @param length The fixed length of the char string (must be non-negative)
+ * @param collation Optional collation ID for string comparison and sorting. If None,
+ *   uses UTF8_BINARY_COLLATION_ID. The reason for using an `Option` is to be able to see in
+ *   the analyzer whether the collation was explicitly specified or not.
+ */
 @Experimental
-case class CharType(length: Int)
-    extends StringType(CollationFactory.UTF8_BINARY_COLLATION_ID, FixedLength(length)) {
+case class CharType private[sql] (length: Int, collation: Option[Int])
+    extends StringType(
+      collation.getOrElse(CollationFactory.UTF8_BINARY_COLLATION_ID),
+      FixedLength(length)) {
   require(length >= 0, "The length of char type cannot be negative.")
 
   override def defaultSize: Int = length
-  override def typeName: String = s"char($length)"
-  override def jsonValue: JValue = JString(typeName)
-  override def toString: String = s"CharType($length)"
+  override def typeName: String =
+    if (isUTF8BinaryCollation) s"char($length)"
+    else s"char($length) collate $collationName"
+  override def toString: String =
+    if (isUTF8BinaryCollation) s"CharType($length)"
+    else s"CharType($length, $collationName)"
   private[spark] override def asNullable: CharType = this
+
+  def toStringType: StringType = {
+    if (collation.isEmpty) StringType
+    else StringType(collationId)
+  }
+}
+
+object CharType {
+  def apply(length: Int): CharType = new CharType(length, None)
+
+  def apply(length: Int, collationName: String): CharType = {
+    val collationId = CollationFactory.collationNameToId(collationName)
+    new CharType(length, Some(collationId))
+  }
+
+  def apply(length: Int, collationId: Int): CharType =
+    new CharType(length, Some(collationId))
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/CharType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/CharType.scala
@@ -23,10 +23,12 @@ import org.apache.spark.sql.catalyst.util.CollationFactory
 /**
  * A data type representing fixed-length character strings with a specified length.
  *
- * @param length The fixed length of the char string (must be non-negative)
- * @param collation Optional collation ID for string comparison and sorting. If None,
- *   uses UTF8_BINARY_COLLATION_ID. The reason for using an `Option` is to be able to see in
- *   the analyzer whether the collation was explicitly specified or not.
+ * @param length
+ *   The fixed length of the char string (must be non-negative)
+ * @param collation
+ *   Optional collation ID for string comparison and sorting. If None, uses
+ *   UTF8_BINARY_COLLATION_ID. The reason for using an `Option` is to be able to see in the
+ *   analyzer whether the collation was explicitly specified or not.
  */
 @Experimental
 case class CharType private[sql] (length: Int, collation: Option[Int])

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StringType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StringType.scala
@@ -177,8 +177,8 @@ case object StringHelper extends PartialOrdering[StringConstraint] {
   }
 
   def removeCollation(s: StringType): StringType = s match {
-    case CharType(length) => CharType(length)
-    case VarcharType(length) => VarcharType(length)
+    case c: CharType => CharType(c.length)
+    case v: VarcharType => VarcharType(v.length)
     case _: StringType => StringType
   }
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/VarcharType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/VarcharType.scala
@@ -16,19 +16,47 @@
  */
 package org.apache.spark.sql.types
 
-import org.json4s.JsonAST.{JString, JValue}
-
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.catalyst.util.CollationFactory
 
+/**
+ * A data type representing variable-length character strings with a specified maximum length.
+ *
+ * @param length The maximum length of the varchar string (must be non-negative)
+ * @param collation Optional collation ID for string comparison and sorting. If None,
+ *   uses UTF8_BINARY_COLLATION_ID. The reason for using an `Option` is to be able to see in
+ *   the analyzer whether the collation was explicitly specified or not.
+ */
 @Experimental
-case class VarcharType(length: Int)
-    extends StringType(CollationFactory.UTF8_BINARY_COLLATION_ID, MaxLength(length)) {
+case class VarcharType private[sql] (length: Int, collation: Option[Int])
+    extends StringType(
+      collation.getOrElse(CollationFactory.UTF8_BINARY_COLLATION_ID),
+      MaxLength(length)) {
   require(length >= 0, "The length of varchar type cannot be negative.")
 
   override def defaultSize: Int = length
-  override def typeName: String = s"varchar($length)"
-  override def jsonValue: JValue = JString(typeName)
-  override def toString: String = s"VarcharType($length)"
+  override def typeName: String =
+    if (isUTF8BinaryCollation) s"varchar($length)"
+    else s"varchar($length) collate $collationName"
+  override def toString: String =
+    if (isUTF8BinaryCollation) s"VarcharType($length)"
+    else s"VarcharType($length, $collationName)"
   private[spark] override def asNullable: VarcharType = this
+
+  def toStringType: StringType = {
+    if (collation.isEmpty) StringType
+    else StringType(collationId)
+  }
+}
+
+object VarcharType {
+  def apply(length: Int): VarcharType = new VarcharType(length, None)
+
+  def apply(length: Int, collationName: String): VarcharType = {
+    val collationId = CollationFactory.collationNameToId(collationName)
+    new VarcharType(length, Some(collationId))
+  }
+
+  def apply(length: Int, collationId: Int): VarcharType =
+    new VarcharType(length, Some(collationId))
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/VarcharType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/VarcharType.scala
@@ -22,10 +22,12 @@ import org.apache.spark.sql.catalyst.util.CollationFactory
 /**
  * A data type representing variable-length character strings with a specified maximum length.
  *
- * @param length The maximum length of the varchar string (must be non-negative)
- * @param collation Optional collation ID for string comparison and sorting. If None,
- *   uses UTF8_BINARY_COLLATION_ID. The reason for using an `Option` is to be able to see in
- *   the analyzer whether the collation was explicitly specified or not.
+ * @param length
+ *   The maximum length of the varchar string (must be non-negative)
+ * @param collation
+ *   Optional collation ID for string comparison and sorting. If None, uses
+ *   UTF8_BINARY_COLLATION_ID. The reason for using an `Option` is to be able to see in the
+ *   analyzer whether the collation was explicitly specified or not.
  */
 @Experimental
 case class VarcharType private[sql] (length: Int, collation: Option[Int])

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
@@ -67,8 +67,8 @@ object CatalystTypeConverters {
       case arrayType: ArrayType => ArrayConverter(arrayType.elementType)
       case mapType: MapType => MapConverter(mapType.keyType, mapType.valueType)
       case structType: StructType => StructConverter(structType)
-      case CharType(length) => new CharConverter(length)
-      case VarcharType(length) => new VarcharConverter(length)
+      case c: CharType => new CharConverter(c.length)
+      case v: VarcharType => new VarcharConverter(v.length)
       case _: StringType => StringConverter
       case g: GeographyType =>
         new GeographyConverter(g)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -474,7 +474,7 @@ class Analyzer(
       ResolveAliases ::
       ResolveSubquery ::
       ResolveSubqueryColumnAliases ::
-      ApplyDefaultCollationToStringType ::
+      ApplyDefaultCollation ::
       ResolveWindowOrder ::
       ResolveWindowFrame ::
       ResolveNaturalAndUsingJoin ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ApplyDefaultCollation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ApplyDefaultCollation.scala
@@ -21,30 +21,46 @@ import scala.util.control.NonFatal
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.expressions.{Cast, DefaultStringProducingExpression, Expression, Literal, SubqueryExpression}
-import org.apache.spark.sql.catalyst.plans.logical.{AddColumns, AlterColumns, AlterColumnSpec, AlterViewAs, ColumnDefinition, CreateTable, CreateTempView, CreateView, LogicalPlan, QualifiedColType, ReplaceColumns, ReplaceTable, TableSpec, V2CreateTablePlan}
+import org.apache.spark.sql.catalyst.plans.logical.{AddColumns, AlterColumns, AlterColumnSpec, AlterViewAs, ColumnDefinition, CreateTable, CreateTableAsSelect, CreateTempView, CreateView, LogicalPlan, QualifiedColType, ReplaceColumns, ReplaceTable, ReplaceTableAsSelect, TableSpec, V2CreateTablePlan}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.CurrentOrigin
+import org.apache.spark.sql.catalyst.types.DataTypeUtils.{areSameBaseType, isDefaultStringCharOrVarcharType, replaceDefaultStringCharAndVarcharTypes}
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.catalog.{SupportsNamespaces, TableCatalog}
-import org.apache.spark.sql.connector.catalog.SupportsNamespaces.PROP_COLLATION
-import org.apache.spark.sql.types.{CharType, DataType, StringType, VarcharType}
+import org.apache.spark.sql.types.{DataType, StringHelper, StringType}
 
 /**
- * Resolves string types in logical plans by assigning them the appropriate collation. The
- * collation is inherited from the relevant object in the hierarchy (e.g., table/view -> schema ->
- * catalog). This rule is primarily applied to DDL commands, but it can also be triggered in other
- * scenarios. For example, when querying a view, its query is re-resolved each time, and that query
- * can take various forms.
+ * Resolves string/char/varchar types in logical plans by assigning them the appropriate collation.
+ * The collation is inherited from the relevant object in the hierarchy (e.g., table/view ->
+ * schema). This rule is primarily applied to DDL commands, but it can also be triggered
+ * in other scenarios. For example, when querying a view, its query is re-resolved each time, and
+ * that query can take various forms.
  */
-object ApplyDefaultCollationToStringType extends Rule[LogicalPlan] {
+object ApplyDefaultCollation extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = {
     val preprocessedPlan = resolveDefaultCollation(pruneRedundantAlterColumnTypes(plan))
 
     fetchDefaultCollation(preprocessedPlan) match {
       case Some(collation) =>
-        transform(preprocessedPlan, StringType(collation))
+        transform(preprocessedPlan, collation)
       case None => preprocessedPlan
     }
+  }
+
+  /**
+   * Returns true if any of the given expressions needs resolution, i.e., if it contains
+   * a default string/char/varchar type to which a collation can be applied.
+   */
+  def needsResolution(expressions: Seq[Expression]): Boolean = {
+    expressions.exists(needsResolution)
+  }
+
+  /**
+   * Returns true if the given expression needs resolution, i.e., if it contains a default
+   * string/char/varchar type to which a collation can be applied.
+   */
+  def needsResolution(expression: Expression): Boolean = {
+    transformExpression.isDefinedAt(expression)
   }
 
   /** Returns the default collation that should be applied to the plan
@@ -55,18 +71,23 @@ object ApplyDefaultCollationToStringType extends Rule[LogicalPlan] {
       case CreateTable(_: ResolvedIdentifier, _, _, tableSpec: TableSpec, _) =>
         tableSpec.collation
 
+      case CreateTableAsSelect(_: ResolvedIdentifier, _, _, tableSpec: TableSpec, _, _, _) =>
+        tableSpec.collation
+
+      case ReplaceTableAsSelect(_: ResolvedIdentifier, _, _, tableSpec: TableSpec, _, _, _) =>
+        tableSpec.collation
+
       // CreateView also handles CREATE OR REPLACE VIEW
-      // Unlike for tables, CreateView also handles CREATE OR REPLACE VIEW
       case createView: CreateView =>
         createView.collation
+
+      case ReplaceTable(_: ResolvedIdentifier, _, _, tableSpec: TableSpec, _) =>
+        tableSpec.collation
 
       // Temporary views are created via CreateViewCommand, which we can't import here.
       // Instead, we use the CreateTempView trait to access the collation.
       case createTempView: CreateTempView =>
         createTempView.collation
-
-      case ReplaceTable(_: ResolvedIdentifier, _, _, tableSpec: TableSpec, _) =>
-        tableSpec.collation
 
       // In `transform` we handle these 3 ALTER TABLE commands.
       case cmd: AddColumns => getCollationFromTableProps(cmd.table)
@@ -93,7 +114,7 @@ object ApplyDefaultCollationToStringType extends Rule[LogicalPlan] {
   private def getCollationFromTableProps(t: LogicalPlan): Option[String] = {
     t match {
       case resolvedTbl: ResolvedTable
-          if resolvedTbl.table.properties.containsKey(TableCatalog.PROP_COLLATION) =>
+         if resolvedTbl.table.properties.containsKey(TableCatalog.PROP_COLLATION) =>
         Some(resolvedTbl.table.properties.get(TableCatalog.PROP_COLLATION))
       case _ => None
     }
@@ -103,13 +124,12 @@ object ApplyDefaultCollationToStringType extends Rule[LogicalPlan] {
    * Determines the default collation for an object in the following order:
    * 1. Use the object's explicitly defined default collation, if available.
    * 2. Otherwise, use the default collation defined by the object's schema.
-   * 3. If not defined in the schema, use the default collation from the object's catalog.
    *
    * If none of these collations are specified, None will be persisted as the default collation,
    * which means the system default collation `UTF8_BINARY` will be used and the plan will not be
    * changed.
    * This function applies to DDL commands. An object's default collation is persisted at the moment
-   * of its creation, and altering the schema or catalog collation will not affect existing objects.
+   * of its creation, and altering the schema collation will not affect existing objects.
    */
   def resolveDefaultCollation(plan: LogicalPlan): LogicalPlan = {
     try {
@@ -118,6 +138,18 @@ object ApplyDefaultCollationToStringType extends Rule[LogicalPlan] {
         catalog: SupportsNamespaces, identifier), _, _, tableSpec: TableSpec, _)
           if tableSpec.collation.isEmpty =>
           createTable.copy(tableSpec = tableSpec.copy(
+            collation = getCollationFromSchemaMetadata(catalog, identifier.namespace())))
+
+        case createTableAsSelect@CreateTableAsSelect(ResolvedIdentifier(
+        catalog: SupportsNamespaces, identifier), _, _, tableSpec: TableSpec, _, _, _)
+          if tableSpec.collation.isEmpty =>
+          createTableAsSelect.copy(tableSpec = tableSpec.copy(
+            collation = getCollationFromSchemaMetadata(catalog, identifier.namespace())))
+
+        case replaceTableAsSelect@ReplaceTableAsSelect(ResolvedIdentifier(
+        catalog: SupportsNamespaces, identifier), _, _, tableSpec: TableSpec, _, _, _)
+          if tableSpec.collation.isEmpty =>
+          replaceTableAsSelect.copy(tableSpec = tableSpec.copy(
             collation = getCollationFromSchemaMetadata(catalog, identifier.namespace())))
 
         case replaceTable@ReplaceTable(ResolvedIdentifier(
@@ -129,8 +161,12 @@ object ApplyDefaultCollationToStringType extends Rule[LogicalPlan] {
         case createView@CreateView(ResolvedIdentifier(
         catalog: SupportsNamespaces, identifier), _, _, _, _, _, _, _, _, _)
           if createView.collation.isEmpty =>
-          createView.copy(
-            collation = getCollationFromSchemaMetadata(catalog, identifier.namespace()))
+          val newCreateView = CurrentOrigin.withOrigin(createView.origin) {
+            createView.copy(
+              collation = getCollationFromSchemaMetadata(catalog, identifier.namespace()))
+          }
+          newCreateView.copyTagsFrom(createView)
+          newCreateView
 
         // We match against ResolvedPersistentView because temporary views don't have a
         // schema/catalog.
@@ -140,7 +176,12 @@ object ApplyDefaultCollationToStringType extends Rule[LogicalPlan] {
           val newResolvedPersistentView = resolvedPersistentView.copy(
             metadata = resolvedPersistentView.metadata.copy(
               collation = getCollationFromSchemaMetadata(catalog, identifier.namespace())))
-          alterViewAs.copy(child = newResolvedPersistentView)
+          val newAlterViewAs = CurrentOrigin.withOrigin(alterViewAs.origin) {
+            alterViewAs.copy(child = newResolvedPersistentView)
+          }
+          newAlterViewAs.copyTagsFrom(alterViewAs)
+          newAlterViewAs
+
         case other =>
           other
       }
@@ -151,38 +192,38 @@ object ApplyDefaultCollationToStringType extends Rule[LogicalPlan] {
   }
 
   /**
-   Retrieves the schema's default collation from the metadata of the given catalog and schema
-   name. Returns None if the default collation is not specified for the schema.
+   * Retrieves the schema's default collation from the metadata of the given catalog and schema
+   * name. Returns None if the default collation is not specified for the schema.
    */
   private def getCollationFromSchemaMetadata(
       catalog: SupportsNamespaces, schemaName: Array[String]): Option[String] = {
     val metadata = catalog.loadNamespaceMetadata(schemaName)
-    Option(metadata.get(PROP_COLLATION))
+    Option(metadata.get(TableCatalog.PROP_COLLATION))
   }
 
   private def isCreateOrAlterPlan(plan: LogicalPlan): Boolean = plan match {
     // For CREATE TABLE, only v2 CREATE TABLE command is supported.
-    // Also, table DEFAULT COLLATION cannot be specified through CREATE TABLE AS SELECT command.
     case _: V2CreateTablePlan | _: ReplaceTable | _: CreateView | _: AlterViewAs |
          _: CreateTempView => true
     case _ => false
   }
 
-  private def transform(plan: LogicalPlan, newType: StringType): LogicalPlan = {
+  private def transform(plan: LogicalPlan, collation: String): LogicalPlan = {
     plan resolveOperators {
       case p if isCreateOrAlterPlan(p) || AnalysisContext.get.collation.isDefined =>
-        transformPlan(p, newType)
+        transformPlan(p, collation)
 
-      case addCols@AddColumns(_: ResolvedTable, _) =>
-        addCols.copy(columnsToAdd = replaceColumnTypes(addCols.columnsToAdd, newType))
+      case addCols: AddColumns =>
+        addCols.copy(columnsToAdd = replaceColumnTypes(addCols.columnsToAdd, collation))
 
-      case replaceCols@ReplaceColumns(_: ResolvedTable, _) =>
-        replaceCols.copy(columnsToAdd = replaceColumnTypes(replaceCols.columnsToAdd, newType))
+      case replaceCols: ReplaceColumns =>
+        replaceCols.copy(columnsToAdd = replaceColumnTypes(replaceCols.columnsToAdd, collation))
 
       case a @ AlterColumns(ResolvedTable(_, _, _, _), specs: Seq[AlterColumnSpec]) =>
         val newSpecs = specs.map {
           case spec if shouldApplyDefaultCollationToAlterColumn(spec) =>
-            spec.copy(newDataType = Some(replaceDefaultStringType(spec.newDataType.get, newType)))
+            spec.copy(newDataType =
+              Some(replaceDefaultStringCharAndVarcharTypes(spec.newDataType.get, collation)))
           case col => col
         }
         a.copy(specs = newSpecs)
@@ -190,8 +231,9 @@ object ApplyDefaultCollationToStringType extends Rule[LogicalPlan] {
   }
 
   /**
-   * The column type should not be changed if the original column type is [[StringType]] and the new
-   * type is the default [[StringType]] (i.e., [[StringType]] without an explicit collation).
+   * The column type should not be changed if the original column type is [[StringType]],
+   * [[CharType]], or [[VarcharType]], and the new type is the default instance of the same type
+   * (i.e., [[StringType]], [[CharType]], or [[VarcharType]] without an explicit collation).
    *
    * Query Example:
    * {{{
@@ -204,8 +246,7 @@ object ApplyDefaultCollationToStringType extends Rule[LogicalPlan] {
       case alterColumns@AlterColumns(
       ResolvedTable(_, _, _, _), specs: Seq[AlterColumnSpec]) =>
         val resolvedSpecs = specs.map { spec =>
-          if (spec.newDataType.isDefined && isStringTypeColumn(spec.column) &&
-            isDefaultStringType(spec.newDataType.get)) {
+          if (isAlterColumnNOP(spec)) {
             spec.copy(newDataType = None)
           } else {
             spec
@@ -221,26 +262,33 @@ object ApplyDefaultCollationToStringType extends Rule[LogicalPlan] {
     }
   }
 
+  private def isAlterColumnNOP(spec: AlterColumnSpec): Boolean = {
+    val colType = getFieldType(spec.column)
+    spec.newDataType.isDefined &&
+      colType.isInstanceOf[StringType] &&
+      isDefaultStringCharOrVarcharType(spec.newDataType.get) &&
+      StringHelper.removeCollation(colType.asInstanceOf[StringType]) ==
+        StringHelper.removeCollation(spec.newDataType.get.asInstanceOf[StringType])
+  }
+
   private def shouldApplyDefaultCollationToAlterColumn(
       alterColumnSpec: AlterColumnSpec): Boolean = {
+    val colType = getFieldType(alterColumnSpec.column)
     alterColumnSpec.newDataType.isDefined &&
-      // Applies the default collation only if the original column's type is not StringType.
-      !isStringTypeColumn(alterColumnSpec.column) &&
-      hasDefaultStringType(alterColumnSpec.newDataType.get)
+      isDefaultStringCharOrVarcharType(alterColumnSpec.newDataType.get) && (
+        !colType.isInstanceOf[StringType] ||
+        !areSameBaseType(colType.asInstanceOf[StringType],
+          alterColumnSpec.newDataType.get.asInstanceOf[StringType])
+      )
   }
 
   /**
-   * Checks whether the field's [[DataType]] is [[StringType]].
+   * Return field's type.
    */
-  private def isStringTypeColumn(fieldName: FieldName): Boolean = {
+  private def getFieldType(fieldName: FieldName): DataType = {
     fieldName match {
       case ResolvedFieldName(_, field) =>
-        CharVarcharUtils.getRawType(field.metadata).getOrElse(field.dataType) match {
-          case _: CharType => false
-          case _: VarcharType => false
-          case _: StringType => true
-          case _ => false
-        }
+        CharVarcharUtils.getRawType(field.metadata).getOrElse(field.dataType)
       case UnresolvedFieldName(name) =>
         throw SparkException.internalError(s"Unexpected UnresolvedFieldName: $name")
     }
@@ -250,36 +298,39 @@ object ApplyDefaultCollationToStringType extends Rule[LogicalPlan] {
    * Transforms the given plan, by transforming all expressions in its operators to use the given
    * new type instead of the default string type.
    */
-  private def transformPlan(plan: LogicalPlan, newType: StringType): LogicalPlan = {
-    val transformedPlan = plan resolveExpressionsUp { expression =>
+  private def transformPlan(plan: LogicalPlan, collation: String): LogicalPlan = {
+    val transformedPlan = plan resolveExpressionsUp { case expression =>
       transformExpression
-        .andThen(_.apply(newType))
+        .andThen(_.apply(collation))
         .applyOrElse(expression, identity[Expression])
     }
 
-    castDefaultStringExpressions(transformedPlan, newType)
+    castDefaultStringExpressions(transformedPlan, StringType(collation))
   }
 
   /**
-   * Transforms the given expression, by changing all default string types to the given new type.
+   * Transforms the given expression, by changing all default string/char/varchar types with
+   * collated types.
    */
-  private def transformExpression: PartialFunction[Expression, StringType => Expression] = {
-    case columnDef: ColumnDefinition if hasDefaultStringType(columnDef.dataType) =>
-      newType => columnDef.copy(dataType = replaceDefaultStringType(columnDef.dataType, newType))
+  private def transformExpression: PartialFunction[Expression, String => Expression] = {
+    case columnDef: ColumnDefinition if hasDefaultStringCharOrVarcharType(columnDef.dataType) =>
+      collation => columnDef.copy(dataType =
+        replaceDefaultStringCharAndVarcharTypes(columnDef.dataType, collation))
 
-    case cast: Cast if hasDefaultStringType(cast.dataType) &&
+    case cast: Cast if hasDefaultStringCharOrVarcharType(cast.dataType) &&
       cast.containsTag(Cast.USER_SPECIFIED_CAST) =>
-      newType => cast.copy(dataType = replaceDefaultStringType(cast.dataType, newType))
+      collation => cast.copy(dataType =
+        replaceDefaultStringCharAndVarcharTypes(cast.dataType, collation))
 
-    case Literal(value, dt) if hasDefaultStringType(dt) =>
-      newType => Literal(value, replaceDefaultStringType(dt, newType))
+    case Literal(value, dt) if hasDefaultStringCharOrVarcharType(dt) =>
+      collation => Literal(value, replaceDefaultStringCharAndVarcharTypes(dt, collation))
 
     case subquery: SubqueryExpression =>
       val plan = subquery.plan
-      newType =>
-        val newPlan = plan resolveExpressionsUp { expression =>
+      collation =>
+        val newPlan = plan resolveExpressionsUp { case expression =>
           transformExpression
-            .andThen(_.apply(newType))
+            .andThen(_.apply(collation))
             .applyOrElse(expression, identity[Expression])
         }
         subquery.withNewPlan(newPlan)
@@ -304,40 +355,20 @@ object ApplyDefaultCollationToStringType extends Rule[LogicalPlan] {
         other.withNewChildren(other.children.map(inner))
     }
 
-    plan resolveOperators { operator =>
+    plan resolveOperators { case operator =>
       operator.mapExpressions(inner)
     }
   }
 
-  private def hasDefaultStringType(dataType: DataType): Boolean =
-    dataType.existsRecursively(isDefaultStringType)
-
-  private def isDefaultStringType(dataType: DataType): Boolean = {
-    // STRING (without explicit collation) is considered default string type.
-    // STRING COLLATE <collation_name> (with explicit collation) is not considered
-    // default string type even when explicit collation is UTF8_BINARY (default collation).
-    dataType match {
-      // should only return true for StringType object and not for StringType("UTF8_BINARY")
-      case st: StringType => st.eq(StringType)
-      case _ => false
-    }
-  }
-
-  private def replaceDefaultStringType(dataType: DataType, newType: StringType): DataType = {
-    // Should replace STRING with the new type.
-    // Should not replace STRING COLLATE UTF8_BINARY, as that is explicit collation.
-    dataType.transformRecursively {
-      case currentType: StringType if isDefaultStringType(currentType) =>
-        newType
-    }
-  }
+  private def hasDefaultStringCharOrVarcharType(dataType: DataType): Boolean =
+    dataType.existsRecursively(isDefaultStringCharOrVarcharType)
 
   private def replaceColumnTypes(
       colTypes: Seq[QualifiedColType],
-      newType: StringType): Seq[QualifiedColType] = {
+      collation: String): Seq[QualifiedColType] = {
     colTypes.map {
-      case colWithDefault if hasDefaultStringType(colWithDefault.dataType) =>
-        val replaced = replaceDefaultStringType(colWithDefault.dataType, newType)
+      case colWithDefault if hasDefaultStringCharOrVarcharType(colWithDefault.dataType) =>
+        val replaced = replaceDefaultStringCharAndVarcharTypes(colWithDefault.dataType, collation)
         colWithDefault.copy(dataType = replaced)
 
       case col => col

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ApplyDefaultCollation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ApplyDefaultCollation.scala
@@ -114,7 +114,7 @@ object ApplyDefaultCollation extends Rule[LogicalPlan] {
   private def getCollationFromTableProps(t: LogicalPlan): Option[String] = {
     t match {
       case resolvedTbl: ResolvedTable
-         if resolvedTbl.table.properties.containsKey(TableCatalog.PROP_COLLATION) =>
+          if resolvedTbl.table.properties.containsKey(TableCatalog.PROP_COLLATION) =>
         Some(resolvedTbl.table.properties.get(TableCatalog.PROP_COLLATION))
       case _ => None
     }
@@ -124,12 +124,13 @@ object ApplyDefaultCollation extends Rule[LogicalPlan] {
    * Determines the default collation for an object in the following order:
    * 1. Use the object's explicitly defined default collation, if available.
    * 2. Otherwise, use the default collation defined by the object's schema.
+   * 3. If not defined in the schema, use the default collation from the object's catalog.
    *
    * If none of these collations are specified, None will be persisted as the default collation,
    * which means the system default collation `UTF8_BINARY` will be used and the plan will not be
    * changed.
    * This function applies to DDL commands. An object's default collation is persisted at the moment
-   * of its creation, and altering the schema collation will not affect existing objects.
+   * of its creation, and altering the schema collation or catalog will not affect existing objects.
    */
   def resolveDefaultCollation(plan: LogicalPlan): LogicalPlan = {
     try {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -1071,9 +1071,9 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
 
               // We don't need to handle nested types here which shall fail before.
               def canAlterColumnType(from: DataType, to: DataType): Boolean = (from, to) match {
-                case (CharType(l1), CharType(l2)) => l1 == l2
-                case (CharType(l1), VarcharType(l2)) => l1 <= l2
-                case (VarcharType(l1), VarcharType(l2)) => l1 <= l2
+                case (c1: CharType, c2: CharType) => c1.length == c2.length
+                case (c: CharType, v: VarcharType) => c.length <= v.length
+                case (v1: VarcharType, v2: VarcharType) => v1.length <= v2.length
                 case _ => Cast.canUpCast(from, to)
               }
               if (!canAlterColumnType(field.dataType, newDataType)) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationRulesRunner.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationRulesRunner.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 object CollationRulesRunner {
   def apply(plan: LogicalPlan): LogicalPlan = {
     Seq(
-      ApplyDefaultCollationToStringType,
+      ApplyDefaultCollation,
       CollationTypeCasts
     ).foldLeft(plan) { case (plan, rule) => rule(plan) }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -169,7 +169,7 @@ object Literal {
       case _: DayTimeIntervalType if v.isInstanceOf[Duration] =>
         Literal(CatalystTypeConverters.createToCatalystConverter(dataType)(v), dataType)
       case _: ObjectType => Literal(v, dataType)
-      case CharType(_) | VarcharType(_) if SQLConf.get.preserveCharVarcharTypeInfo =>
+      case _: CharType | _: VarcharType if SQLConf.get.preserveCharVarcharTypeInfo =>
         Literal(CatalystTypeConverters.createToCatalystConverter(dataType)(v), dataType)
       case _ => Literal(CatalystTypeConverters.convertToCatalyst(v), dataType)
     }
@@ -202,11 +202,11 @@ object Literal {
     case t: TimeType => create(0L, t)
     case it: DayTimeIntervalType => create(0L, it)
     case it: YearMonthIntervalType => create(0, it)
-    case CharType(length) =>
-      create(CharVarcharCodegenUtils.charTypeWriteSideCheck(UTF8String.fromString(""), length),
+    case c: CharType =>
+      create(CharVarcharCodegenUtils.charTypeWriteSideCheck(UTF8String.fromString(""), c.length),
         dataType)
-    case VarcharType(length) =>
-      create(CharVarcharCodegenUtils.varcharTypeWriteSideCheck(UTF8String.fromString(""), length),
+    case v: VarcharType =>
+      create(CharVarcharCodegenUtils.varcharTypeWriteSideCheck(UTF8String.fromString(""), v.length),
         dataType)
     case st: StringType => Literal(UTF8String.fromString(""), st)
     case BinaryType => Literal("".getBytes(StandardCharsets.UTF_8))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala
@@ -349,7 +349,7 @@ case object VariantGet {
    */
   def checkDataType(dataType: DataType, allowStructsAndMaps: Boolean = true): Boolean =
     dataType match {
-    case CharType(_) | VarcharType(_) => false
+    case _: CharType | _: VarcharType => false
     case _: NumericType | BooleanType | _: StringType | BinaryType | _: DatetimeType |
         VariantType =>
       true

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -1673,7 +1673,7 @@ case class CreateView(
 }
 
 /**
- * Used to apply ApplyDefaultCollationToStringType to CreateViewCommand
+ * Used to apply ApplyDefaultCollation to CreateViewCommand
  */
 trait CreateTempView {
   val collation: Option[String]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/DataTypeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/DataTypeUtils.scala
@@ -282,5 +282,50 @@ object DataTypeUtils {
       }
     }
   }
+
+  /**
+   * Returns true if the two StringTypes have the same base type, i.e., both are [[CharType]],
+   * both are [[VarcharType]], or both are plain [[StringType]].
+   */
+  def areSameBaseType(s1: StringType, s2: StringType): Boolean = {
+    (s1.constraint, s2.constraint) match {
+      case (NoConstraint, NoConstraint) => true
+      case (FixedLength(_), FixedLength(_)) => true
+      case (MaxLength(_), MaxLength(_)) => true
+      case _ => false
+    }
+  }
+
+  /**
+   * Replace STRING/CHAR/VARCHAR (including nested ones) without explicit collation with the new
+   * type with the given collation.
+   */
+  def replaceDefaultStringCharAndVarcharTypes(
+      dataType: DataType, collation: String): DataType = {
+    // Should replace STRING/CHAR(10)/VARCHAR(10) with the new type.
+    // Should not replace STRING COLLATE UTF8_BINARY/CHAR(10) COLLATE UTF8_BINARY/
+    // VARCHAR(10) COLLATE UTF8_BINARY, as that is explicit collation.
+    dataType.transformRecursively {
+      case currentType: CharType if isDefaultStringCharOrVarcharType(currentType) =>
+        CharType(currentType.length, collation)
+      case currentType: VarcharType if isDefaultStringCharOrVarcharType(currentType) =>
+        VarcharType(currentType.length, collation)
+      case currentType: StringType if isDefaultStringCharOrVarcharType(currentType) =>
+        StringType(collation)
+    }
+  }
+
+  /**
+   * Returns true if the given data type is STRING/CHAR/VARCHAR without explicit collation.
+   * Even `STRING COLLATE UTF8_BINARY` is considered as with explicit collation.
+   */
+  def isDefaultStringCharOrVarcharType(dataType: DataType): Boolean = {
+    dataType match {
+      case charType: CharType => charType.collation.isEmpty
+      case varcharType: VarcharType => varcharType.collation.isEmpty
+      case st: StringType => st.eq(StringType)
+      case _ => false
+    }
+  }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/PhysicalDataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/PhysicalDataType.scala
@@ -40,8 +40,8 @@ object PhysicalDataType {
     case ShortType => PhysicalShortType
     case IntegerType => PhysicalIntegerType
     case LongType => PhysicalLongType
-    case VarcharType(_) => PhysicalStringType(StringType.collationId)
-    case CharType(_) => PhysicalStringType(StringType.collationId)
+    case v: VarcharType => PhysicalStringType(v.collationId)
+    case c: CharType => PhysicalStringType(c.collationId)
     case s: StringType => PhysicalStringType(s.collationId)
     case FloatType => PhysicalFloatType
     case DoubleType => PhysicalDoubleType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/PartitioningUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/PartitioningUtils.scala
@@ -80,17 +80,17 @@ private[sql] object PartitioningUtils {
 
       val normalizedVal =
         if (SQLConf.get.charVarcharAsString) value else normalizedFiled.dataType match {
-          case CharType(len) if value != null && value != DEFAULT_PARTITION_NAME =>
+          case c: CharType if value != null && value != DEFAULT_PARTITION_NAME =>
             val v = value match {
-              case Some(str: String) => Some(charTypeWriteSideCheck(str, len))
-              case str: String => charTypeWriteSideCheck(str, len)
+              case Some(str: String) => Some(charTypeWriteSideCheck(str, c.length))
+              case str: String => charTypeWriteSideCheck(str, c.length)
               case other => other
             }
             v.asInstanceOf[T]
-          case VarcharType(len) if value != null && value != DEFAULT_PARTITION_NAME =>
+          case vc: VarcharType if value != null && value != DEFAULT_PARTITION_NAME =>
             val v = value match {
-              case Some(str: String) => Some(varcharTypeWriteSideCheck(str, len))
-              case str: String => varcharTypeWriteSideCheck(str, len)
+              case Some(str: String) => Some(varcharTypeWriteSideCheck(str, vc.length))
+              case str: String => varcharTypeWriteSideCheck(str, vc.length)
               case other => other
             }
             v.asInstanceOf[T]

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/DataTypeProtoConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/DataTypeProtoConverter.scala
@@ -200,16 +200,16 @@ object DataTypeProtoConverter {
             proto.DataType.Decimal.newBuilder().setPrecision(precision).setScale(scale).build())
           .build()
 
-      case CharType(length) =>
+      case c: CharType =>
         proto.DataType
           .newBuilder()
-          .setChar(proto.DataType.Char.newBuilder().setLength(length).build())
+          .setChar(proto.DataType.Char.newBuilder().setLength(c.length).build())
           .build()
 
-      case VarcharType(length) =>
+      case v: VarcharType =>
         proto.DataType
           .newBuilder()
-          .setVarChar(proto.DataType.VarChar.newBuilder().setLength(length).build())
+          .setVarChar(proto.DataType.VarChar.newBuilder().setLength(v.length).build())
           .build()
 
       // StringType must be matched after CharType and VarcharType

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzeColumnCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzeColumnCommand.scala
@@ -142,7 +142,7 @@ case class AnalyzeColumnCommand(
     case DoubleType | FloatType => true
     case BooleanType => true
     case _: DatetimeType => true
-    case CharType(_) | VarcharType(_) => false
+    case _: CharType | _: VarcharType => false
     case BinaryType | _: StringType => true
     case _ => false
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -156,8 +156,8 @@ object JdbcUtils extends Logging with SQLConfHelper {
       case BooleanType => Option(JdbcType("BIT(1)", java.sql.Types.BIT))
       case StringType => Option(JdbcType("TEXT", java.sql.Types.CLOB))
       case BinaryType => Option(JdbcType("BLOB", java.sql.Types.BLOB))
-      case CharType(n) => Option(JdbcType(s"CHAR($n)", java.sql.Types.CHAR))
-      case VarcharType(n) => Option(JdbcType(s"VARCHAR($n)", java.sql.Types.VARCHAR))
+      case c: CharType => Option(JdbcType(s"CHAR(${c.length})", java.sql.Types.CHAR))
+      case v: VarcharType => Option(JdbcType(s"VARCHAR(${v.length})", java.sql.Types.VARCHAR))
       case TimestampType => Option(JdbcType("TIMESTAMP", java.sql.Types.TIMESTAMP))
       // This is a common case of timestamp without time zone. Most of the databases either only
       // support TIMESTAMP type or use TIMESTAMP as an alias for TIMESTAMP WITHOUT TIME ZONE.

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -174,7 +174,7 @@ private case class OracleDialect() extends JdbcDialect with SQLConfHelper with N
     case ByteType => Some(JdbcType("NUMBER(3)", java.sql.Types.SMALLINT))
     case ShortType => Some(JdbcType("NUMBER(5)", java.sql.Types.SMALLINT))
     case StringType => Some(JdbcType("VARCHAR2(255)", java.sql.Types.VARCHAR))
-    case VarcharType(n) => Some(JdbcType(s"VARCHAR2($n)", java.sql.Types.VARCHAR))
+    case v: VarcharType => Some(JdbcType(s"VARCHAR2(${v.length})", java.sql.Types.VARCHAR))
     case TimestampType if !conf.legacyOracleTimestampMappingEnabled =>
       Some(JdbcType("TIMESTAMP WITH LOCAL TIME ZONE", TIMESTAMP_LTZ))
     case _ => None

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -190,9 +190,9 @@ trait CreatableRelationProvider {
       case MapType(k, v, _) => supportsDataType(k) && supportsDataType(v)
       case StructType(fields) => fields.forall(f => supportsDataType(f.dataType))
       case udt: UserDefinedType[_] => supportsDataType(udt.sqlType)
-      case BinaryType | BooleanType | ByteType | CharType(_) | DateType | _ : DecimalType |
+      case BinaryType | BooleanType | ByteType | _: CharType | DateType | _: DecimalType |
            DoubleType | FloatType | IntegerType | LongType | NullType | ObjectType(_) | ShortType |
-           _: StringType | TimestampNTZType | TimestampType | VarcharType(_) => true
+           _: StringType | TimestampNTZType | TimestampType | _: VarcharType => true
       case _ => false
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -46,16 +46,16 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
     val dataType = CatalystSqlParser.parseDataType(dt)
     checkColType(df.schema(1), dataType)
     dataType match {
-      case CharType(len) =>
+      case c: CharType =>
         // char value will be padded if (<= len) or trimmed if (> len)
         val fixLenStr = if (insertVal != null) {
-          insertVal.take(len).padTo(len, " ").mkString
+          insertVal.take(c.length).padTo(c.length, " ").mkString
         } else null
         checkAnswer(df, Row("1", fixLenStr))
-      case VarcharType(len) =>
+      case v: VarcharType =>
         // varchar value will be remained if (<= len) or trimmed if (> len)
         val varLenStrWithUpperBound = if (insertVal != null) {
-          insertVal.take(len)
+          insertVal.take(v.length)
         } else null
         checkAnswer(df, Row("1", varLenStrWithUpperBound))
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/GenTPCDSData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GenTPCDSData.scala
@@ -163,7 +163,7 @@ class TPCDSTables(spark: SparkSession, dsdgenDir: String, scaleFactor: Int)
         val columns = schema.fields.map { f =>
           val c = f.dataType match {
             // Needs right-padding for char types
-            case CharType(n) => rpad(Column(f.name), n, " ")
+            case c: CharType => rpad(Column(f.name), c.length, " ")
             // Don't need a cast for varchar types
             case _: VarcharType => col(f.name)
             case _ => col(f.name).cast(f.dataType)

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
@@ -84,7 +84,7 @@ abstract class DefaultCollationTestSuite extends QueryTest with SharedSparkSessi
 
   // This is used for tests that don't depend on explicitly specifying the data type
   // (these tests still test the string type), or ones that are not applicable to char/varchar
-  // types. E.g., UDFs don't support char/varchar as input parameters/return types.
+  // types.
   protected def stringTestNames: Seq[String] = Seq(
     "default string producing expressions in CTAS definition",
     "ctas with complex types",

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
@@ -23,15 +23,23 @@ import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.logical.Project
 import org.apache.spark.sql.catalyst.util.CollationFactory
 import org.apache.spark.sql.connector.DatasourceV2SQLBase
+import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.StringType
+import org.apache.spark.sql.types.{StringType, StructType}
 
 abstract class DefaultCollationTestSuite extends QueryTest with SharedSparkSession {
+
+  protected def resetCatalog: Boolean = false
 
   override def beforeEach(): Unit = {
     super.beforeEach()
     spark.conf.set(SQLConf.SCHEMA_LEVEL_COLLATIONS_ENABLED, true)
+
+    if (resetCatalog) {
+      sql(s"CREATE NAMESPACE IF NOT EXISTS $testCatalog.$DEFAULT_DATABASE")
+      sql(s"USE $testCatalog.$DEFAULT_DATABASE")
+    }
   }
 
   override def afterEach(): Unit = {
@@ -46,29 +54,48 @@ abstract class DefaultCollationTestSuite extends QueryTest with SharedSparkSessi
     "version()", "space(5)", "randstr(5, 123)"
   )
 
-  def dataSource: String = "parquet"
+  protected val charVarcharLength: Int = 10
+
+  def testCatalog: String = SESSION_CATALOG_NAME
   def testSchema: String = "test_schema"
-  def testTable: String = "test_tbl"
+  def testTable1: String = "test_tbl1"
+  def testTable2: String = "test_tbl2"
   def testView: String = "test_view"
   protected val fullyQualifiedPrefix = s"${CollationFactory.CATALOG}.${CollationFactory.SCHEMA}."
 
-  protected val schemaAndObjectCollationPairs =
+  protected def schemaAndObjectCollationPairs: Seq[(String, Option[String])] =
     Seq(
       // (schemaDefaultCollation, objectDefaultCollation)
       ("UTF8_BINARY", None),
       ("UTF8_LCASE", None),
       ("UNICODE", None),
-      ("DE", None),
+      ("de", None),
       ("UTF8_BINARY", Some("UTF8_BINARY")),
       ("UTF8_BINARY", Some("UTF8_LCASE")),
-      ("UTF8_BINARY", Some("DE")),
+      ("UTF8_BINARY", Some("de")),
       ("UTF8_LCASE", Some("UTF8_BINARY")),
       ("UTF8_LCASE", Some("UTF8_LCASE")),
-      ("UTF8_LCASE", Some("DE")),
-      ("DE", Some("UTF8_BINARY")),
-      ("DE", Some("UTF8_LCASE")),
-      ("DE", Some("DE"))
+      ("UTF8_LCASE", Some("de")),
+      ("de", Some("UTF8_BINARY")),
+      ("de", Some("UTF8_LCASE")),
+      ("de", Some("de"))
     )
+
+
+  // This is used for tests that don't depend on explicitly specifying the data type
+  // (these tests still test the string type), or ones that are not applicable to char/varchar
+  // types. E.g., UDFs don't support char/varchar as input parameters/return types.
+  protected def stringTestNames: Seq[String] = Seq(
+    "default string producing expressions in CTAS definition",
+    "ctas with complex types",
+    "ctas with union",
+    "inline table in CTAS",
+    "subsequent analyzer iterations correctly resolve default string types",
+    "CREATE TABLE AS SELECT with inline table and DEFAULT COLLATION",
+    "CREATE OR REPLACE TABLE AS SELECT with inline table and DEFAULT COLLATION",
+    "CREATE  VIEW with inline table and DEFAULT COLLATION",
+    "CREATE OR REPLACE VIEW with inline table and DEFAULT COLLATION"
+  )
 
   def assertTableColumnCollation(
       table: String,
@@ -87,136 +114,264 @@ abstract class DefaultCollationTestSuite extends QueryTest with SharedSparkSessi
 
   // region DDL tests
 
-  test("create/alter table") {
-    withTable(testTable) {
+  testDataType("create/alter table") { dataType =>
+    withTable(testTable1) {
       // create table with implicit collation
-      sql(s"CREATE TABLE $testTable (c1 STRING) USING $dataSource")
-      assertTableColumnCollation(testTable, "c1", "UTF8_BINARY")
+      sql(s"CREATE TABLE $testTable1 (c1 $dataType)")
+      assertTableColumnCollation(testTable1, "c1", "UTF8_BINARY")
 
       // alter table add column with implicit collation
-      sql(s"ALTER TABLE $testTable ADD COLUMN c2 STRING")
-      assertTableColumnCollation(testTable, "c2", "UTF8_BINARY")
+      sql(s"ALTER TABLE $testTable1 ADD COLUMN c2 $dataType")
+      assertTableColumnCollation(testTable1, "c2", "UTF8_BINARY")
 
-      sql(s"ALTER TABLE $testTable ALTER COLUMN c2 TYPE STRING COLLATE UNICODE")
-      assertTableColumnCollation(testTable, "c2", "UNICODE")
+      sql(s"ALTER TABLE $testTable1 ALTER COLUMN c2 TYPE $dataType COLLATE UNICODE")
+      assertTableColumnCollation(testTable1, "c2", "UNICODE")
 
-      // When using ALTER TABLE ALTER COLUMN TYPE, the column should inherit the table's collation
-      // only if it wasn't a string column before. If the column was already a string, and we're
-      // just changing its type to string (without explicit collation) again, keep the original
-      // collation.
-      sql(s"ALTER TABLE $testTable ALTER COLUMN c2 TYPE STRING")
-      assertTableColumnCollation(testTable, "c2", "UNICODE")
+      sql(s"ALTER TABLE $testTable1 ALTER COLUMN c2 TYPE $dataType")
+      assertTableColumnCollation(testTable1, "c2", "UNICODE")
     }
   }
 
-  test("create table with explicit collation") {
-    withTable(testTable) {
-      sql(s"CREATE TABLE $testTable (c1 STRING COLLATE UTF8_LCASE) USING $dataSource")
-      assertTableColumnCollation(testTable, "c1", "UTF8_LCASE")
+  testDataType("create table with explicit collation") { dataType =>
+    withTable(testTable1) {
+      sql(s"CREATE TABLE $testTable1 (c1 $dataType COLLATE UTF8_LCASE)")
+      assertTableColumnCollation(testTable1, "c1", "UTF8_LCASE")
     }
 
-    withTable(testTable) {
-      sql(s"CREATE TABLE $testTable (c1 STRING COLLATE UNICODE) USING $dataSource")
-      assertTableColumnCollation(testTable, "c1", "UNICODE")
+    withTable(testTable1) {
+      sql(s"CREATE TABLE $testTable1 (c1 $dataType COLLATE UNICODE)")
+      assertTableColumnCollation(testTable1, "c1", "UNICODE")
     }
   }
 
-  test("create/alter table with table level collation") {
-    withTable(testTable) {
+  testDataType("create/alter table with table level collation") { dataType =>
+    withTable(testTable1) {
       // create table with default table level collation and explicit collation for some columns
-      sql(s"CREATE TABLE $testTable " +
-        s"(c1 STRING, c2 STRING COLLATE SR, c3 STRING COLLATE UTF8_BINARY, c4 STRING, id INT) " +
-        s"USING $dataSource DEFAULT COLLATION UTF8_LCASE")
-      assertTableColumnCollation(testTable, "c1", "UTF8_LCASE")
-      assertTableColumnCollation(testTable, "c2", "SR")
-      assertTableColumnCollation(testTable, "c3", "UTF8_BINARY")
-      assertTableColumnCollation(testTable, "c4", "UTF8_LCASE")
+      sql(s"CREATE TABLE $testTable1 (c1 $dataType, c2 $dataType COLLATE SR," +
+        s" c3 $dataType COLLATE UTF8_BINARY, c4 $dataType, id INT) " +
+        s"DEFAULT COLLATION UTF8_LCASE")
+      sql(s"INSERT INTO TABLE $testTable1 VALUES " +
+        s"('a', 'b', 'c', 'd', 1), ('A', 'B', 'C', 'D', 2)")
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable1 WHERE c1 = 'a'"), Row(2))
+
+      assertTableColumnCollation(testTable1, "c1", "UTF8_LCASE")
+      assertTableColumnCollation(testTable1, "c2", "SR")
+      assertTableColumnCollation(testTable1, "c3", "UTF8_BINARY")
+      assertTableColumnCollation(testTable1, "c4", "UTF8_LCASE")
 
       // alter table add column
-      sql(s"ALTER TABLE $testTable ADD COLUMN c5 STRING")
-      assertTableColumnCollation(testTable, "c5", "UTF8_LCASE")
+      sql(s"ALTER TABLE $testTable1 ADD COLUMN c5 $dataType")
+      assertTableColumnCollation(testTable1, "c5", "UTF8_LCASE")
 
       // alter table default collation should not affect existing columns
-      sql(s"ALTER TABLE $testTable DEFAULT COLLATION UNICODE")
-      assertTableColumnCollation(testTable, "c1", "UTF8_LCASE")
-      assertTableColumnCollation(testTable, "c2", "SR")
-      assertTableColumnCollation(testTable, "c3", "UTF8_BINARY")
-      assertTableColumnCollation(testTable, "c4", "UTF8_LCASE")
-      assertTableColumnCollation(testTable, "c5", "UTF8_LCASE")
+      sql(s"ALTER TABLE $testTable1 DEFAULT COLLATION UNICODE")
+      assertTableColumnCollation(testTable1, "c1", "UTF8_LCASE")
+      assertTableColumnCollation(testTable1, "c2", "SR")
+      assertTableColumnCollation(testTable1, "c3", "UTF8_BINARY")
+      assertTableColumnCollation(testTable1, "c4", "UTF8_LCASE")
+      assertTableColumnCollation(testTable1, "c5", "UTF8_LCASE")
 
       // alter table add column, where the new column should pick up new collation
-      sql(s"ALTER TABLE $testTable ADD COLUMN c6 STRING")
-      assertTableColumnCollation(testTable, "c6", "UNICODE")
+      sql(s"ALTER TABLE $testTable1 ADD COLUMN c6 $dataType")
+      assertTableColumnCollation(testTable1, "c6", "UNICODE")
 
       // alter table alter column with explicit collation change
-      sql(s"ALTER TABLE $testTable ALTER COLUMN c1 TYPE STRING COLLATE UNICODE_CI")
-      assertTableColumnCollation(testTable, "c1", "UNICODE_CI")
+      sql(s"ALTER TABLE $testTable1 ALTER COLUMN c1 TYPE $dataType COLLATE UNICODE_CI")
+      assertTableColumnCollation(testTable1, "c1", "UNICODE_CI")
 
-      // When using ALTER TABLE ALTER COLUMN TYPE, the column should inherit the table's collation
-      // only if it wasn't a string column before. If the column was already a string, and we're
-      // just changing its type to string (without explicit collation) again, keep the original
-      // collation.
-      sql(s"ALTER TABLE $testTable ALTER COLUMN c1 TYPE STRING")
-      assertTableColumnCollation(testTable, "c1", "UNICODE_CI")
+      // When using ALTER TABLE ALTER COLUMN TYPE, the column should inherit the table's
+      // collation only if its base type changes (e.g., CharType -> StringType, StringType ->
+      // VarcharType, etc.). If the type remains the same (e.g., CharType -> CharType), the
+      // collation should not be inherited.
+      sql(s"ALTER TABLE $testTable1 ALTER COLUMN c1 TYPE $dataType")
+      assertTableColumnCollation(testTable1, "c1", "UNICODE_CI")
 
       // alter table add columns with explicit collation, check collation for each column
-      sql(s"ALTER TABLE $testTable ADD COLUMN c7 STRING COLLATE SR_CI_AI")
-      sql(s"ALTER TABLE $testTable ADD COLUMN c8 STRING COLLATE UTF8_BINARY")
-      assertTableColumnCollation(testTable, "c7", "SR_CI_AI")
-      assertTableColumnCollation(testTable, "c8", "UTF8_BINARY")
+      sql(s"ALTER TABLE $testTable1 ADD COLUMN c7 $dataType COLLATE SR_CI_AI")
+      sql(s"ALTER TABLE $testTable1 ADD COLUMN c8 $dataType COLLATE UTF8_BINARY")
+      assertTableColumnCollation(testTable1, "c7", "SR_CI_AI")
+      assertTableColumnCollation(testTable1, "c8", "UTF8_BINARY")
 
-      // When using ALTER TABLE ALTER COLUMN TYPE, the column should inherit the table's collation
-      // only if it wasn't a string column before. If the column was already a string, and we're
-      // just changing its type to string (without explicit collation) again, keep the original
-      // collation.
-      sql(s"ALTER TABLE $testTable ALTER COLUMN c8 TYPE STRING")
-      assertTableColumnCollation(testTable, "c8", "UTF8_BINARY")
+      // When using ALTER TABLE ALTER COLUMN TYPE, the column should inherit the table's
+      // collation only if its base type changes (e.g., CharType -> StringType, StringType ->
+      // VarcharType, etc.). If the type remains the same (e.g., CharType -> CharType), the
+      // collation should not be inherited.
+      sql(s"ALTER TABLE $testTable1 ALTER COLUMN c8 TYPE $dataType")
 
-      assertTableColumnCollation(testTable, "c1", "UNICODE_CI")
-      assertTableColumnCollation(testTable, "c2", "SR")
-      assertTableColumnCollation(testTable, "c3", "UTF8_BINARY")
-      assertTableColumnCollation(testTable, "c4", "UTF8_LCASE")
-      assertTableColumnCollation(testTable, "c5", "UTF8_LCASE")
-      assertTableColumnCollation(testTable, "c6", "UNICODE")
-      assertTableColumnCollation(testTable, "c7", "SR_CI_AI")
-      assertTableColumnCollation(testTable, "c8", "UTF8_BINARY")
+      assertTableColumnCollation(testTable1, "c1", "UNICODE_CI")
+      assertTableColumnCollation(testTable1, "c2", "SR")
+      assertTableColumnCollation(testTable1, "c3", "UTF8_BINARY")
+      assertTableColumnCollation(testTable1, "c4", "UTF8_LCASE")
+      assertTableColumnCollation(testTable1, "c5", "UTF8_LCASE")
+      assertTableColumnCollation(testTable1, "c6", "UNICODE")
+      assertTableColumnCollation(testTable1, "c7", "SR_CI_AI")
+      assertTableColumnCollation(testTable1, "c8", "UTF8_BINARY")
     }
   }
 
-  test("Alter table alter column type with default collation") {
-    // When using ALTER TABLE ALTER COLUMN TYPE, the column should inherit the table's collation
-    // only if it wasn't a string column before. If the column was already a string, and we're
-    // just changing its type to string (without explicit collation) again, keep the original
-    // collation.
-    withTable(testTable) {
-      sql(s"CREATE TABLE $testTable (c1 STRING, c2 STRING COLLATE UTF8_LCASE, c3 STRING)" +
-        s" DEFAULT COLLATION UTF8_LCASE")
-      sql(s"ALTER TABLE $testTable ALTER COLUMN c1 TYPE STRING")
-      sql(s"ALTER TABLE $testTable ALTER COLUMN c2 TYPE STRING")
-      sql(s"ALTER TABLE $testTable ALTER COLUMN c3 TYPE STRING COLLATE UNICODE")
+  testDataType("Alter table alter column type with default collation") { dataType =>
+    // When using ALTER TABLE ALTER COLUMN TYPE, the column should inherit the table's
+    // collation only if its base type changes (e.g., CharType -> StringType, StringType ->
+    // VarcharType, etc.). If the type remains the same (e.g., CharType -> CharType), the
+    // collation should not be inherited.
+    withTable(testTable1) {
+      sql(s"CREATE TABLE $testTable1 (c1 $dataType, c2 $dataType COLLATE UTF8_LCASE, " +
+        s"c3 $dataType) DEFAULT COLLATION UTF8_LCASE")
+      sql(s"ALTER TABLE $testTable1 ALTER COLUMN c1 TYPE $dataType")
+      sql(s"ALTER TABLE $testTable1 ALTER COLUMN c2 TYPE $dataType")
+      sql(s"ALTER TABLE $testTable1 ALTER COLUMN c3 TYPE $dataType COLLATE UNICODE")
 
-      assertTableColumnCollation(testTable, "c1", "UTF8_LCASE")
-      assertTableColumnCollation(testTable, "c2", "UTF8_LCASE")
-      assertTableColumnCollation(testTable, "c3", "UNICODE")
+      assertTableColumnCollation(testTable1, "c1", "UTF8_LCASE")
+      assertTableColumnCollation(testTable1, "c2", "UTF8_LCASE")
+      assertTableColumnCollation(testTable1, "c3", "UNICODE")
     }
   }
 
+  testString("default string producing expressions in CTAS definition") { _ =>
+    Seq(
+      // tableDefaultCollation
+      "UTF8_BINARY",
+      "UTF8_LCASE",
+      "UNICODE",
+      "DE"
+    ).foreach { tableDefaultCollation =>
+      testCTASWithDefaultStringProducingExpressions(
+        tableDefaultCollation = Some(tableDefaultCollation))
+    }
+  }
+
+  testDataType(
+    "default string producing expressions in CTAS definition - nested in expr tree") { dataType =>
+    withTable(testTable1) {
+      sql(
+        s"""
+           |CREATE TABLE $testTable1
+           |DEFAULT COLLATION UNICODE AS SELECT
+           |SUBSTRING(current_database(), 1, 1) AS c1,
+           |SUBSTRING(SUBSTRING(current_database(), 1, 2), 1, 1) AS c2,
+           |SUBSTRING(current_database()::$dataType, 1, 1) AS c3,
+           |SUBSTRING(CAST(current_database() AS $dataType COLLATE UTF8_BINARY), 1, 1) AS c4
+           |""".stripMargin)
+
+      assertTableColumnCollation(testTable1, "c1", "UNICODE")
+      assertTableColumnCollation(testTable1, "c2", "UNICODE")
+      assertTableColumnCollation(testTable1, "c3", "UNICODE")
+      assertTableColumnCollation(testTable1, "c4", "UTF8_BINARY")
+    }
+  }
+
+  testDataType("CTAS with DEFAULT COLLATION") { dataType =>
+    withTable(testTable1) {
+      sql(
+        s"""CREATE TABLE $testTable1 DEFAULT COLLATION UTF8_LCASE
+           | as SELECT 'a' as c1
+           |""".stripMargin)
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable1 WHERE c1 = 'A'"), Seq(Row(1)))
+    }
+    withTable(testTable1) {
+      sql(s"CREATE TABLE $testTable1 (c1 $dataType COLLATE UTF8_LCASE)")
+      sql(s"INSERT INTO $testTable1 VALUES ('a'), ('A')")
+      withTable(testTable2) {
+        // scalastyle:off
+        sql(
+          s"""CREATE TABLE $testTable2 DEFAULT COLLATION SR_AI_CI
+             | AS SELECT c1 FROM $testTable1
+             | WHERE 'ć' = 'č'
+             |""".stripMargin)
+        // scalastyle:on
+        checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable2"), Seq(Row(2)))
+        checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable2 WHERE c1 = 'A'"), Seq(Row(2)))
+      }
+    }
+    // TODO: Fix the following test for char data type
+    if (dataType != s"CHAR($charVarcharLength)") {
+      withTable(testTable1) {
+        sql(s"CREATE TABLE $testTable1 (c1 $dataType COLLATE UTF8_LCASE)")
+        // scalastyle:off
+        sql(s"INSERT INTO $testTable1 VALUES ('ć'), ('č')")
+        // scalastyle:on
+        withTable(testTable2) {
+          sql(
+            s"""CREATE TABLE $testTable2 DEFAULT COLLATION UNICODE
+               | AS SELECT CAST(c1 AS $dataType COLLATE SR_AI) FROM $testTable1
+               |""".stripMargin)
+          val prefix = "SYSTEM.BUILTIN"
+          checkAnswer(sql(s"SELECT DISTINCT COLLATION(c1) FROM $testTable2"), Row(s"$prefix.sr_AI"))
+          checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable2 WHERE c1 = 'c'"), Row(2))
+        }
+      }
+    }
+    withTable(testTable1) {
+      sql(
+        s"""CREATE TABLE $testTable1 DEFAULT COLLATION UTF8_LCASE
+           | AS SELECT 'a' AS c1,
+           | (SELECT (SELECT CASE 'a' = 'A' WHEN TRUE THEN 'a' ELSE 'b' END)
+           |  WHERE (SELECT 'b' WHERE 'c' = 'C') = 'B') AS c2
+           |""".stripMargin)
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable1 WHERE c1 = 'A'"), Seq(Row(1)))
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable1 WHERE c2 = 'a'"), Seq(Row(1)))
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable1 WHERE c2 = 'b'"), Seq(Row(0)))
+    }
+  }
+
+  testString(s"CREATE TABLE AS SELECT with inline table and DEFAULT COLLATION") { _ =>
+    withTable(testTable1) {
+      sql(
+        s"""CREATE TABLE $testTable1 DEFAULT COLLATION UTF8_LCASE AS
+           | SELECT *
+           | FROM VALUES ('a', 'a' COLLATE UNICODE), ('b', 'b' COLLATE UNICODE),
+           |  ('c', 'c' COLLATE UNICODE) AS T(c1, c2)
+           | WHERE c1 = 'A'
+           |""".stripMargin)
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable1"), Seq(Row(1)))
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable1 WHERE c1 = 'A'"), Seq(Row(1)))
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable1 WHERE c1 = 'B'"), Seq(Row(0)))
+      checkAnswer(sql(s"SELECT DISTINCT COLLATION(c1) FROM $testTable1"),
+        Row(s"${fullyQualifiedPrefix}UTF8_LCASE"))
+      checkAnswer(sql(s"SELECT DISTINCT COLLATION(c2) FROM $testTable1"),
+        Row(s"${fullyQualifiedPrefix}UNICODE"))
+    }
+  }
+
+  // Table with schema level collation tests
   schemaAndObjectCollationPairs.foreach {
     case (schemaDefaultCollation, tableDefaultCollation) =>
-      test(
+      testDataType(
         s"""CREATE table with schema level collation
           | (schema default collation = $schemaDefaultCollation,
-          | table default collation = $tableDefaultCollation)""".stripMargin) {
+          | table default collation = $tableDefaultCollation)""".stripMargin) { dataType =>
         testCreateTableWithSchemaLevelCollation(
-          schemaDefaultCollation, tableDefaultCollation)
+          dataType, schemaDefaultCollation, tableDefaultCollation)
       }
 
-      test(
+      testDataType(
         s"""ALTER table with schema level collation
           | (schema default collation = $schemaDefaultCollation,
-          | table default collation = $tableDefaultCollation)""".stripMargin) {
+          | table default collation = $tableDefaultCollation)""".stripMargin) { dataType =>
         testAlterTableWithSchemaLevelCollation(
-         schemaDefaultCollation, tableDefaultCollation)
+          dataType, schemaDefaultCollation, tableDefaultCollation)
+      }
+
+      testDataType(
+        s"""CTAS with schema level collation
+           | (schema default collation = $schemaDefaultCollation,
+           | table default collation = $tableDefaultCollation)""".stripMargin) { dataType =>
+        testCTASWithSchemaLevelCollation(
+          dataType, schemaDefaultCollation, tableDefaultCollation)
+      }
+
+      testString(
+        s"""CTAS with default string producing expressions
+           | (schema default collation = $schemaDefaultCollation,
+           | table default collation = $tableDefaultCollation)""".stripMargin) {
+          _ =>
+        withDatabase(testSchema) {
+          sql(s"CREATE SCHEMA $testSchema DEFAULT COLLATION $schemaDefaultCollation")
+          sql(s"USE $testSchema")
+
+          testCTASWithDefaultStringProducingExpressions(
+            Some(schemaDefaultCollation), tableDefaultCollation)
+        }
       }
   }
 
@@ -240,15 +395,15 @@ abstract class DefaultCollationTestSuite extends QueryTest with SharedSparkSessi
           ""
         }
 
-      test(
+      testDataType(
         s"""ALTER schema default collation (old schema default collation = $schemaOldCollation,
-          | new schema default collation = $schemaNewCollation)""".stripMargin) {
+           | new schema default collation = $schemaNewCollation)""".stripMargin) { dataType =>
         withDatabase(testSchema) {
           sql(s"CREATE SCHEMA $testSchema $schemaOldCollationDefaultClause")
           sql(s"USE $testSchema")
 
-          withTable(testTable) {
-            sql(s"CREATE TABLE $testTable (c1 STRING, c2 STRING COLLATE SR_AI)")
+          withTable(testTable1) {
+            sql(s"CREATE TABLE $testTable1 (c1 $dataType, c2 $dataType COLLATE SR_AI)")
             val tableDefaultCollation =
               if (schemaOldCollation.isDefined) {
                 schemaOldCollation.get
@@ -260,156 +415,157 @@ abstract class DefaultCollationTestSuite extends QueryTest with SharedSparkSessi
             sql(s"ALTER SCHEMA $testSchema DEFAULT COLLATION $schemaNewCollation")
 
             // Altering schema default collation should not affect existing objects.
-            addAndAlterColumns(c2Collation = "SR_AI", tableDefaultCollation = tableDefaultCollation)
+            addAndAlterColumns(
+              dataType, tableDefaultCollation = tableDefaultCollation, c2Collation = "sr_AI")
           }
 
-          withTable(testTable) {
-            sql(s"CREATE TABLE $testTable " +
-              s"(c1 STRING, c2 STRING COLLATE SR_AI, c3 STRING COLLATE UTF8_BINARY)")
-            assertTableColumnCollation(testTable, "c1", schemaNewCollation)
-            assertTableColumnCollation(testTable, "c2", "SR_AI")
-            assertTableColumnCollation(testTable, "c3", "UTF8_BINARY")
+          withTable(testTable1) {
+            sql(s"CREATE TABLE $testTable1 " +
+              s"(c1 $dataType, c2 $dataType COLLATE SR_AI, c3 $dataType COLLATE UTF8_BINARY)")
+            assertTableColumnCollation(testTable1, "c1", schemaNewCollation)
+            assertTableColumnCollation(testTable1, "c2", "SR_AI")
+            assertTableColumnCollation(testTable1, "c3", "UTF8_BINARY")
           }
         }
       }
   }
 
-  test("create table as select") {
+  testDataType("create table as select") { dataType =>
     // literals in select do not pick up session collation
-    withTable(testTable) {
+    withTable(testTable1) {
       sql(s"""
-           |CREATE TABLE $testTable USING $dataSource AS SELECT
+           |CREATE TABLE $testTable1 AS SELECT
            |  'a' AS c1,
            |  'a' || 'a' AS c2,
            |  SUBSTRING('a', 1, 1) AS c3,
            |  SUBSTRING(SUBSTRING('ab', 1, 1), 1, 1) AS c4,
            |  'a' = 'A' AS truthy
            |""".stripMargin)
-      assertTableColumnCollation(testTable, "c1", "UTF8_BINARY")
-      assertTableColumnCollation(testTable, "c2", "UTF8_BINARY")
-      assertTableColumnCollation(testTable, "c3", "UTF8_BINARY")
-      assertTableColumnCollation(testTable, "c4", "UTF8_BINARY")
+      assertTableColumnCollation(testTable1, "c1", "UTF8_BINARY")
+      assertTableColumnCollation(testTable1, "c2", "UTF8_BINARY")
+      assertTableColumnCollation(testTable1, "c3", "UTF8_BINARY")
+      assertTableColumnCollation(testTable1, "c4", "UTF8_BINARY")
 
-      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable WHERE truthy"), Seq(Row(0)))
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable1 WHERE truthy"), Seq(Row(0)))
     }
 
     // literals in inline table do not pick up session collation
-    withTable(testTable) {
+    withTable(testTable1) {
       sql(s"""
-           |CREATE TABLE $testTable USING $dataSource AS
+           |CREATE TABLE $testTable1 AS
            |SELECT c1, c1 = 'A' as c2 FROM VALUES ('a'), ('A') AS vals(c1)
            |""".stripMargin)
-      assertTableColumnCollation(testTable, "c1", "UTF8_BINARY")
-      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable WHERE c2"), Seq(Row(1)))
+      assertTableColumnCollation(testTable1, "c1", "UTF8_BINARY")
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable1 WHERE c2"), Seq(Row(1)))
     }
 
     // cast in select does not pick up session collation
-    withTable(testTable) {
-      sql(s"CREATE TABLE $testTable USING $dataSource AS SELECT cast('a' AS STRING) AS c1")
-      assertTableColumnCollation(testTable, "c1", "UTF8_BINARY")
+    withTable(testTable1) {
+      sql(s"CREATE TABLE $testTable1 AS SELECT cast('a' AS $dataType) AS c1")
+      assertTableColumnCollation(testTable1, "c1", "UTF8_BINARY")
     }
   }
 
-  test("ctas with complex types") {
-    withTable(testTable) {
+  testString("ctas with complex types") { _ =>
+    withTable(testTable1) {
       sql(s"""
-           |CREATE TABLE $testTable USING $dataSource AS
+           |CREATE TABLE $testTable1 AS
            |SELECT
            |  struct('a') AS c1,
            |  map('a', 'b') AS c2,
            |  array('a') AS c3
            |""".stripMargin)
 
-      checkAnswer(sql(s"SELECT COLLATION(c1.col1) FROM $testTable"),
+      checkAnswer(sql(s"SELECT COLLATION(c1.col1) FROM $testTable1"),
         Seq(Row(fullyQualifiedPrefix + "UTF8_BINARY")))
-      checkAnswer(sql(s"SELECT COLLATION(c2['a']) FROM $testTable"),
+      checkAnswer(sql(s"SELECT COLLATION(c2['a']) FROM $testTable1"),
         Seq(Row(fullyQualifiedPrefix + "UTF8_BINARY")))
-      checkAnswer(sql(s"SELECT COLLATION(c3[0]) FROM $testTable"),
+      checkAnswer(sql(s"SELECT COLLATION(c3[0]) FROM $testTable1"),
         Seq(Row(fullyQualifiedPrefix + "UTF8_BINARY")))
     }
   }
 
-  test("ctas with union") {
-    withTable(testTable) {
+  testString("ctas with union") { _ =>
+    withTable(testTable1) {
       sql(s"""
-           |CREATE TABLE $testTable USING $dataSource AS
+           |CREATE TABLE $testTable1 AS
            |SELECT 'a' = 'A' AS c1
            |UNION
            |SELECT 'b' = 'B' AS c1
            |""".stripMargin)
 
-      checkAnswer(sql(s"SELECT * FROM $testTable"), Seq(Row(false)))
+      checkAnswer(sql(s"SELECT * FROM $testTable1"), Seq(Row(false)))
     }
 
-    withTable(testTable) {
+    withTable(testTable1) {
       sql(s"""
-           |CREATE TABLE $testTable USING $dataSource AS
+           |CREATE TABLE $testTable1 AS
            |SELECT 'a' = 'A' AS c1
            |UNION ALL
            |SELECT 'b' = 'B' AS c1
            |""".stripMargin)
 
-      checkAnswer(sql(s"SELECT * FROM $testTable"), Seq(Row(false), Row(false)))
+      checkAnswer(sql(s"SELECT * FROM $testTable1"), Seq(Row(false), Row(false)))
     }
   }
 
-  test("add column") {
-    withTable(testTable) {
-      sql(s"CREATE TABLE $testTable (c1 STRING COLLATE UTF8_LCASE) USING $dataSource")
-      assertTableColumnCollation(testTable, "c1", "UTF8_LCASE")
+  testDataType("add column") { dataType =>
+    withTable(testTable1) {
+      sql(s"CREATE TABLE $testTable1 (c1 $dataType COLLATE UTF8_LCASE)")
+      assertTableColumnCollation(testTable1, "c1", "UTF8_LCASE")
 
-      sql(s"ALTER TABLE $testTable ADD COLUMN c2 STRING")
-      assertTableColumnCollation(testTable, "c2", "UTF8_BINARY")
+      sql(s"ALTER TABLE $testTable1 ADD COLUMN c2 $dataType")
+      assertTableColumnCollation(testTable1, "c2", "UTF8_BINARY")
 
-      sql(s"ALTER TABLE $testTable ADD COLUMN c3 STRING COLLATE UNICODE")
-      assertTableColumnCollation(testTable, "c3", "UNICODE")
+      sql(s"ALTER TABLE $testTable1 ADD COLUMN c3 $dataType COLLATE UNICODE")
+      assertTableColumnCollation(testTable1, "c3", "UNICODE")
     }
   }
 
-  test("inline table in CTAS") {
-    withTable(testTable) {
+  testString("inline table in CTAS") { _ =>
+    withTable(testTable1) {
       sql(s"""
-           |CREATE TABLE $testTable
-           |USING $dataSource
+           |CREATE TABLE $testTable1
            |AS SELECT *
            |FROM (VALUES ('a', 'a' = 'A'))
            |AS inline_table(c1, c2);
            |""".stripMargin)
 
-      assertTableColumnCollation(testTable, "c1", "UTF8_BINARY")
-      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable WHERE c2"), Seq(Row(0)))
+      assertTableColumnCollation(testTable1, "c1", "UTF8_BINARY")
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable1 WHERE c2"), Seq(Row(0)))
     }
   }
 
-  test("subsequent analyzer iterations correctly resolve default string types") {
+  testString("subsequent analyzer iterations correctly resolve default string types") { _ =>
     // since concat coercion happens after resolving default types this test
     // makes sure that we are correctly resolving the default string types
     // in subsequent analyzer iterations
-    withTable(testTable) {
+    withTable(testTable1) {
       sql(s"""
-           |CREATE TABLE $testTable
-           |USING $dataSource AS
+           |CREATE TABLE $testTable1
+           |AS
            |SELECT CONCAT(X'68656C6C6F', 'world') AS c1
            |""".stripMargin)
 
-      checkAnswer(sql(s"SELECT c1 FROM $testTable"), Seq(Row("helloworld")))
+      checkAnswer(sql(s"SELECT c1 FROM $testTable1"), Seq(Row("helloworld")))
     }
 
     // ELT is similar
-    withTable(testTable) {
+    withTable(testTable1) {
       sql(s"""
-             |CREATE TABLE $testTable
-             |USING $dataSource AS
+             |CREATE TABLE $testTable1
+             |AS
              |SELECT ELT(1, X'68656C6C6F', 'world') AS c1
              |""".stripMargin)
 
-      checkAnswer(sql(s"SELECT c1 FROM $testTable"), Seq(Row("hello")))
+      checkAnswer(sql(s"SELECT c1 FROM $testTable1"), Seq(Row("hello")))
     }
   }
 
   // endregion
 
   protected def testCreateTableWithSchemaLevelCollation(
+      dataType: String,
       schemaDefaultCollation: String,
       tableDefaultCollation: Option[String] = None,
       replaceTable: Boolean = false): Unit = {
@@ -424,19 +580,21 @@ abstract class DefaultCollationTestSuite extends QueryTest with SharedSparkSessi
     withDatabase(testSchema) {
       sql(s"CREATE SCHEMA $testSchema DEFAULT COLLATION $schemaDefaultCollation")
       sql(s"USE $testSchema")
-      withTable(testTable) {
-        sql(s"CREATE $replace TABLE $testTable " +
-          s"(c1 STRING, c2 STRING COLLATE SR_AI, c3 STRING COLLATE UTF8_BINARY) " +
+      withTable(testTable1) {
+        sql(s"CREATE $replace TABLE $testTable1 " +
+          s"(c1 $dataType, c2 $dataType COLLATE SR_AI, c3 $dataType COLLATE UTF8_BINARY) " +
           s"$tableDefaultCollationClause")
-        assertTableColumnCollation(testTable, "c1", resolvedDefaultCollation)
-        assertTableColumnCollation(testTable, "c2", "SR_AI")
-        assertTableColumnCollation(testTable, "c3", "UTF8_BINARY")
+        assertTableColumnCollation(testTable1, "c1", resolvedDefaultCollation)
+        assertTableColumnCollation(testTable1, "c2", "SR_AI")
+        assertTableColumnCollation(testTable1, "c3", "UTF8_BINARY")
       }
     }
   }
 
   def testAlterTableWithSchemaLevelCollation(
-      schemaDefaultCollation: String, tableDefaultCollation: Option[String] = None): Unit = {
+      dataType: String,
+      schemaDefaultCollation: String,
+      tableDefaultCollation: Option[String] = None): Unit = {
     val (tableDefaultCollationClause, resolvedDefaultCollation) =
       if (tableDefaultCollation.isDefined) {
         (s"DEFAULT COLLATION ${tableDefaultCollation.get}", tableDefaultCollation.get)
@@ -448,37 +606,143 @@ abstract class DefaultCollationTestSuite extends QueryTest with SharedSparkSessi
       sql(s"CREATE SCHEMA $testSchema DEFAULT COLLATION $schemaDefaultCollation")
       sql(s"USE $testSchema")
 
-      withTable(testTable) {
-        sql(s"CREATE TABLE $testTable (c1 STRING, c2 STRING COLLATE SR_AI) " +
+      withTable(testTable1) {
+        sql(s"CREATE TABLE $testTable1 (c1 $dataType, c2 $dataType COLLATE SR_AI) " +
           s"$tableDefaultCollationClause")
 
-        addAndAlterColumns(c2Collation = "SR_AI", tableDefaultCollation = resolvedDefaultCollation)
+        addAndAlterColumns(
+          dataType, tableDefaultCollation = resolvedDefaultCollation, c2Collation = "sr_AI")
       }
     }
   }
 
-  private def addAndAlterColumns(c2Collation: String, tableDefaultCollation: String): Unit = {
+  private def addAndAlterColumns(
+      dataType: String, tableDefaultCollation: String, c2Collation: String): Unit = {
     // ADD COLUMN
-    sql(s"ALTER TABLE $testTable ADD COLUMN c3 STRING")
-    sql(s"ALTER TABLE $testTable ADD COLUMN c4 STRING COLLATE SR_AI")
-    sql(s"ALTER TABLE $testTable ADD COLUMN c5 STRING COLLATE UTF8_BINARY")
-    assertTableColumnCollation(testTable, "c3", tableDefaultCollation)
-    assertTableColumnCollation(testTable, "c4", "SR_AI")
-    assertTableColumnCollation(testTable, "c5", "UTF8_BINARY")
+    sql(s"ALTER TABLE $testTable1 ADD COLUMN c3 $dataType")
+    sql(s"ALTER TABLE $testTable1 ADD COLUMN c4 $dataType COLLATE SR_AI")
+    sql(s"ALTER TABLE $testTable1 ADD COLUMN c5 $dataType COLLATE UTF8_BINARY")
+    assertTableColumnCollation(testTable1, "c3", tableDefaultCollation)
+    assertTableColumnCollation(testTable1, "c4", "SR_AI")
+    assertTableColumnCollation(testTable1, "c5", "UTF8_BINARY")
 
     // ALTER COLUMN
-    sql(s"ALTER TABLE $testTable ALTER COLUMN c1 TYPE STRING COLLATE UNICODE")
-    sql(s"ALTER TABLE $testTable ALTER COLUMN c2 TYPE STRING")
-    sql(s"ALTER TABLE $testTable ALTER COLUMN c3 TYPE STRING COLLATE UTF8_BINARY")
-    assertTableColumnCollation(testTable, "c1", "UNICODE")
-    assertTableColumnCollation(testTable, "c2", c2Collation)
-    assertTableColumnCollation(testTable, "c3", "UTF8_BINARY")
+    sql(s"ALTER TABLE $testTable1 ALTER COLUMN c1 TYPE $dataType COLLATE UNICODE")
+    sql(s"ALTER TABLE $testTable1 ALTER COLUMN c2 TYPE $dataType")
+    sql(s"ALTER TABLE $testTable1 ALTER COLUMN c3 TYPE $dataType COLLATE UTF8_BINARY")
+    assertTableColumnCollation(testTable1, "c1", "UNICODE")
+    assertTableColumnCollation(testTable1, "c2", c2Collation)
+    assertTableColumnCollation(testTable1, "c3", "UTF8_BINARY")
+  }
+
+  protected def testCTASWithSchemaLevelCollation(
+      dataType: String,
+      schemaDefaultCollation: String,
+      tableDefaultCollation: Option[String] = None,
+      replaceTable: Boolean = false): Unit = {
+    val (tableDefaultCollationClause, resolvedDefaultCollation) =
+      if (tableDefaultCollation.isDefined) {
+        (s"DEFAULT COLLATION ${tableDefaultCollation.get}", tableDefaultCollation.get)
+      } else {
+        ("", schemaDefaultCollation)
+      }
+    val replace = if (replaceTable) "OR REPLACE" else ""
+
+    withDatabase(testSchema) {
+      sql(s"CREATE SCHEMA $testSchema DEFAULT COLLATION $schemaDefaultCollation")
+      sql(s"USE $testSchema")
+
+      withTable(testTable1) {
+        sql(s"CREATE $replace TABLE $testTable1 $tableDefaultCollationClause AS SELECT 'a' AS c1")
+
+        assertTableColumnCollation(testTable1, "c1", resolvedDefaultCollation)
+      }
+
+      withTable(testTable1) {
+        sql(s"CREATE TABLE $testTable1 (c1 $dataType COLLATE UTF8_BINARY, " +
+          s"c2 $dataType COLLATE UTF8_LCASE, c3 $dataType COLLATE UNICODE)")
+        sql(s"INSERT INTO $testTable1 VALUES ('a', 'b', 'c'), ('A', 'D', 'C')")
+
+        withTable(testTable2) {
+          // scalastyle:off
+          sql(s"CREATE $replace TABLE $testTable2 $tableDefaultCollationClause AS " +
+            s"SELECT *, 'd' AS c4  FROM $testTable1 WHERE c2 = 'B'  AND 'ć' != 'č'")
+          // scalastyle:on
+
+          checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable2"), Row(1))
+
+          assertTableColumnCollation(testTable2, "c1", "UTF8_BINARY")
+          assertTableColumnCollation(testTable2, "c2", "UTF8_LCASE")
+          assertTableColumnCollation(testTable2, "c3", "UNICODE")
+          assertTableColumnCollation(testTable2, "c4", resolvedDefaultCollation)
+
+          // ALTER SCHEMA DEFAULT COLLATION does not affect the collation of existing objects
+          sql(s"ALTER SCHEMA $testSchema DEFAULT COLLATION EN")
+
+          checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable2"), Row(1))
+
+          assertTableColumnCollation(testTable2, "c1", "UTF8_BINARY")
+          assertTableColumnCollation(testTable2, "c2", "UTF8_LCASE")
+          assertTableColumnCollation(testTable2, "c3", "UNICODE")
+          assertTableColumnCollation(testTable2, "c4", resolvedDefaultCollation)
+        }
+      }
+    }
+  }
+
+  private def testCTASWithDefaultStringProducingExpressions(
+      schemaDefaultCollation: Option[String] = None,
+      tableDefaultCollation: Option[String] = None): Unit = {
+    val (tableDefaultCollationClause, resolvedDefaultCollation) =
+      if (tableDefaultCollation.isDefined) {
+        (s"DEFAULT COLLATION ${tableDefaultCollation.get}", tableDefaultCollation.get)
+      } else if (schemaDefaultCollation.isDefined) {
+        ("", schemaDefaultCollation.get)
+      } else {
+        ("", "UTF8_BINARY")
+      }
+
+    withTable(testTable1) {
+      val columns = defaultStringProducingExpressions.zipWithIndex.map {
+        case (expr, index) => s"$expr AS c${index + 1}"
+      }.mkString(", ")
+
+      sql(
+        s"""
+           |CREATE TABLE $testTable1
+           |$tableDefaultCollationClause
+           |AS SELECT $columns
+           |""".stripMargin)
+
+      (1 to defaultStringProducingExpressions.length).foreach { index =>
+        assertTableColumnCollation(testTable1, s"c$index", resolvedDefaultCollation)
+      }
+    }
+  }
+
+  protected def testDataType(testName: String)(testFn: String => Unit): Unit
+
+  // This method is used to test tests that don't depend on explicitly specifying the data type
+  // (these tests still test the string type), or ones that are not applicable to char/varchar
+  // types. E.g., UDFs don't support char/varchar as input parameters/return types.
+  protected def testString(testName: String)(testFn: String => Unit): Unit = {
+    test(s"$testName [STRING]") {
+      testFn("STRING")
+    }
   }
 }
 
-class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
+abstract class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
 
-  test("Check AttributeReference dataType from View with default collation") {
+  protected def stringTestNamesV1: Seq[String] = Seq(
+    "Check AttributeReference dataType from View with default collation",
+    "CTAS with DEFAULT COLLATION and VIEW",
+    "default string producing expressions in view definition",
+    "View with UTF8_LCASE default collation from schema level"
+  )
+
+    testString("Check AttributeReference dataType from View with default collation") {
+      _ =>
     withView(testView) {
       sql(s"CREATE VIEW $testView DEFAULT COLLATION UTF8_LCASE AS SELECT 'a' AS c1")
 
@@ -493,13 +757,35 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
     }
   }
 
-  test("create/alter view created from a table") {
-    withTable(testTable) {
-      sql(s"CREATE TABLE $testTable (c1 STRING, c2 STRING COLLATE UNICODE_CI) USING $dataSource")
-      sql(s"INSERT INTO $testTable VALUES ('a', 'a'), ('A', 'A')")
+  testString("CTAS with DEFAULT COLLATION and VIEW") { _ =>
+    val prefix = "SYSTEM.BUILTIN"
+    withView(testView) {
+      sql(s"CREATE VIEW $testView DEFAULT COLLATION UNICODE AS SELECT 'a' AS c1")
+
+      withTable(testTable1) {
+        sql(s"CREATE TABLE $testTable1 DEFAULT COLLATION UTF8_LCASE AS " +
+          s"SELECT c1, 'b' AS c2 FROM $testView WHERE c1 != 'A' AND 'b' = 'B'")
+
+        val expected = Seq(
+          Row(s"$prefix.UNICODE", s"$prefix.UTF8_LCASE")
+        )
+        val expectedSchema = new StructType()
+          .add("collation(c1)", StringType)
+          .add("collation(c2)", StringType)
+        checkAnswer(sql(s"SELECT COLLATION(c1), COLLATION(c2) FROM $testTable1"),
+          spark.createDataFrame(spark.sparkContext.parallelize(expected), expectedSchema))
+        checkAnswer(sql(s"SELECT * FROM $testTable1"), Row("a", "b"))
+      }
+    }
+  }
+
+  testDataType("create/alter view created from a table") { dataType =>
+    withTable(testTable1) {
+      sql(s"CREATE TABLE $testTable1 (c1 $dataType, c2 $dataType COLLATE UNICODE_CI)")
+      sql(s"INSERT INTO $testTable1 VALUES ('a', 'a'), ('A', 'A')")
 
       withView(testView) {
-        sql(s"CREATE VIEW $testView AS SELECT * FROM $testTable")
+        sql(s"CREATE VIEW $testView AS SELECT * FROM $testTable1")
 
         assertTableColumnCollation(testView, "c1", "UTF8_BINARY")
         assertTableColumnCollation(testView, "c2", "UNICODE_CI")
@@ -514,35 +800,41 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
           sql(s"SELECT COUNT(*) FROM $testView WHERE c1 = substring('A', 0, 1)"),
           Row(1))
 
-        // literal with explicit collation wins
-        checkAnswer(
-          sql(s"SELECT COUNT(*) FROM $testView WHERE c1 = 'A' collate UNICODE_CI"),
-          Row(2))
+        // TODO: Fix the following check for char data type
+        if (dataType != s"CHAR($charVarcharLength)") {
+          // literal with explicit collation wins
+          checkAnswer(
+            sql(s"SELECT COUNT(*) FROM $testView WHERE c1 = 'A' collate UNICODE_CI"),
+            Row(2))
+        }
 
         // two implicit collations -> errors out
         assertThrowsIndeterminateCollation(sql(s"SELECT c1 = c2 FROM $testView"))
 
-        sql(s"ALTER VIEW $testView AS SELECT c1 COLLATE UNICODE_CI AS c1, c2 FROM $testTable")
+        sql(s"ALTER VIEW $testView AS SELECT c1 COLLATE UNICODE_CI AS c1, c2 FROM $testTable1")
         assertTableColumnCollation(testView, "c1", "UNICODE_CI")
         assertTableColumnCollation(testView, "c2", "UNICODE_CI")
         checkAnswer(
           sql(s"SELECT DISTINCT COLLATION(c1), COLLATION('a') FROM $testView"),
           Row(fullyQualifiedPrefix + "UNICODE_CI", fullyQualifiedPrefix + "UTF8_BINARY"))
 
-        // after alter both rows should be returned
-        checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c1 = 'A'"), Row(2))
+        // TODO: Fix the following check for char data type
+        if (dataType != s"CHAR($charVarcharLength)") {
+          // after alter both rows should be returned
+          checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c1 = 'A'"), Row(2))
+        }
       }
     }
   }
 
-  test("join view with table") {
+  testDataType("join view with table") { dataType =>
     val viewTableName = "view_table"
     val joinTableName = "join_table"
     val sessionCollation = "sr"
 
     withTable(viewTableName, joinTableName) {
-      sql(s"CREATE TABLE $viewTableName (c1 STRING COLLATE UNICODE_CI) USING $dataSource")
-      sql(s"CREATE TABLE $joinTableName (c1 STRING COLLATE UTF8_LCASE) USING $dataSource")
+      sql(s"CREATE TABLE $viewTableName (c1 $dataType COLLATE UNICODE_CI)")
+      sql(s"CREATE TABLE $joinTableName (c1 $dataType COLLATE UTF8_LCASE)")
       sql(s"INSERT INTO $viewTableName VALUES ('a')")
       sql(s"INSERT INTO $joinTableName VALUES ('A')")
 
@@ -563,14 +855,14 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
     }
   }
 
-  test("view has utf8 binary collation by default") {
-    withView(testTable) {
-      sql(s"CREATE VIEW $testTable AS SELECT current_database() AS db")
-      assertTableColumnCollation(testTable, "db", "UTF8_BINARY")
+  testDataType("view has utf8 binary collation by default") { dataType =>
+    withView(testTable1) {
+      sql(s"CREATE VIEW $testTable1 AS SELECT current_database() AS db")
+      assertTableColumnCollation(testTable1, "db", "UTF8_BINARY")
     }
   }
 
-  test("default string producing expressions in view definition") {
+  testString("default string producing expressions in view definition") { _ =>
     Seq(
       // viewDefaultCollation
       "UTF8_BINARY",
@@ -583,63 +875,214 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
     }
   }
 
-  test("default string producing expressions in view definition - nested in expr tree") {
-    withView(testTable) {
+  testDataType(
+    "default string producing expressions in view definition - nested in expr tree") { dataType =>
+    withView(testTable1) {
       sql(
         s"""
-           |CREATE view $testTable
+           |CREATE view $testTable1
            |DEFAULT COLLATION UNICODE AS SELECT
            |SUBSTRING(current_database(), 1, 1) AS c1,
            |SUBSTRING(SUBSTRING(current_database(), 1, 2), 1, 1) AS c2,
-           |SUBSTRING(current_database()::STRING, 1, 1) AS c3,
-           |SUBSTRING(CAST(current_database() AS STRING COLLATE UTF8_BINARY), 1, 1) AS c4
+           |SUBSTRING(current_database()::$dataType, 1, 1) AS c3,
+           |SUBSTRING(CAST(current_database() AS $dataType COLLATE UTF8_BINARY), 1, 1) AS c4
            |""".stripMargin)
 
-      assertTableColumnCollation(testTable, "c1", "UNICODE")
-      assertTableColumnCollation(testTable, "c2", "UNICODE")
-      assertTableColumnCollation(testTable, "c3", "UNICODE")
-      assertTableColumnCollation(testTable, "c4", "UTF8_BINARY")
+      assertTableColumnCollation(testTable1, "c1", "UNICODE")
+      assertTableColumnCollation(testTable1, "c2", "UNICODE")
+      assertTableColumnCollation(testTable1, "c3", "UNICODE")
+      assertTableColumnCollation(testTable1, "c4", "UTF8_BINARY")
+    }
+  }
+
+  testDataType("CREATE OR REPLACE VIEW with DEFAULT COLLATION") { dataType =>
+    withTable(testTable1) {
+      sql(s"CREATE TABLE $testTable1 (c1 $dataType, c2 $dataType COLLATE UTF8_LCASE)")
+      sql(s"INSERT INTO $testTable1 VALUES ('a', 'a'), ('A', 'A'), ('b', 'b')")
+      withView(testView) {
+        // scalastyle:off
+        sql(
+          s"""CREATE OR REPLACE VIEW $testView
+             | DEFAULT COLLATION sr_ci_ai
+             | AS SELECT *, 'ć' AS c3 FROM $testTable1
+             |""".stripMargin)
+        val prefix = "SYSTEM.BUILTIN"
+        checkAnswer(sql(s"SELECT DISTINCT COLLATION(c1) FROM $testView"), Row(s"$prefix.UTF8_BINARY"))
+        checkAnswer(sql(s"SELECT DISTINCT COLLATION(c2) FROM $testView"), Row(s"$prefix.UTF8_LCASE"))
+        checkAnswer(sql(s"SELECT DISTINCT COLLATION(c3) FROM $testView"), Row(s"$prefix.sr_CI_AI"))
+        checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c1 = 'A'"), Row(1))
+        checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c2 = 'a'"), Row(2))
+        checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c3 = 'Č'"), Row(3))
+        // scalastyle:on
+      }
+    }
+    withView(testView) {
+      // scalastyle:off
+      sql(
+        s"""CREATE OR REPLACE VIEW $testView
+          | (c1)
+          | DEFAULT COLLATION sr_ai
+          | AS SELECT 'Ć' as c1 WHERE 'Ć' = 'C'
+          |""".stripMargin)
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c1 = 'Č'"), Row(1))
+      // scalastyle:on
+    }
+  }
+
+  testDataType("CREATE VIEW with DEFAULT COLLATION") { dataType =>
+    withView(testView) {
+      sql(
+        s"""CREATE VIEW $testView DEFAULT COLLATION UTF8_LCASE
+          | as SELECT 'a' as c1
+          |""".stripMargin)
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c1 = 'A'"), Seq(Row(1)))
+    }
+    withTable(testTable1) {
+      sql(s"CREATE TABLE $testTable1 (c1 $dataType COLLATE UTF8_LCASE)")
+      sql(s"INSERT INTO $testTable1 VALUES ('a'), ('A')")
+      withView(testView) {
+        withSQLConf() {
+          // scalastyle:off
+          sql(
+            s"""CREATE VIEW $testView DEFAULT COLLATION SR_AI_CI
+              | AS SELECT c1 FROM $testTable1
+              | WHERE 'ć' = 'č'
+              |""".stripMargin)
+          // scalastyle:on
+          checkAnswer(sql(s"SELECT COUNT(*) FROM $testView"), Seq(Row(2)))
+          checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c1 = 'A'"), Seq(Row(2)))
+        }
+      }
+    }
+    // TODO: Fix the following test for char data type
+    if (dataType != s"CHAR($charVarcharLength)") {
+      withTable(testTable1) {
+        sql(s"CREATE TABLE $testTable1 (c1 $dataType COLLATE UTF8_LCASE)")
+        // scalastyle:off
+        sql(s"INSERT INTO $testTable1 VALUES ('ć'), ('č')")
+        // scalastyle:on
+        withView(testView) {
+          sql(
+            s"""CREATE VIEW $testView DEFAULT COLLATION UNICODE
+              | AS SELECT CAST(c1 AS $dataType COLLATE SR_AI) FROM $testTable1
+              |""".stripMargin)
+          val prefix = "SYSTEM.BUILTIN"
+          checkAnswer(sql(s"SELECT DISTINCT COLLATION(c1) FROM $testView"), Row(s"$prefix.sr_AI"))
+          checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c1 = 'c'"), Row(2))
+        }
+      }
+    }
+    withView(testView) {
+      sql(
+        s"""CREATE VIEW $testView DEFAULT COLLATION UTF8_LCASE
+          | AS SELECT 'a' AS c1,
+          | (SELECT (SELECT CASE 'a' = 'A' WHEN TRUE THEN 'a' ELSE 'b' END)
+          |  WHERE (SELECT 'b' WHERE 'c' = 'C') = 'B') AS c2
+          |""".stripMargin)
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c1 = 'A'"), Seq(Row(1)))
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c2 = 'a'"), Seq(Row(1)))
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c2 = 'b'"), Seq(Row(0)))
+    }
+  }
+
+  Seq("", "OR REPLACE").foreach { replace =>
+    testString(s"CREATE $replace VIEW with inline table and DEFAULT COLLATION") { _ =>
+      withView(testView) {
+        sql(
+          s"""CREATE $replace VIEW $testView DEFAULT COLLATION UTF8_LCASE AS
+             | SELECT *
+             | FROM VALUES ('a', 'a' COLLATE UNICODE), ('b', 'b' COLLATE UNICODE),
+             |  ('c', 'c' COLLATE UNICODE) AS T(c1, c2)
+             | WHERE c1 = 'A'
+             |""".stripMargin)
+        checkAnswer(sql(s"SELECT COUNT(*) FROM $testView"), Seq(Row(1)))
+        checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c1 = 'A'"), Seq(Row(1)))
+        checkAnswer(sql(s"SELECT COUNT(*) FROM $testView WHERE c1 = 'B'"), Seq(Row(0)))
+        checkAnswer(sql(s"SELECT DISTINCT COLLATION(c1) FROM $testView"),
+          Row(s"${fullyQualifiedPrefix}UTF8_LCASE"))
+        checkAnswer(sql(s"SELECT DISTINCT COLLATION(c2) FROM $testView"),
+          Row(s"${fullyQualifiedPrefix}UNICODE"))
+      }
+    }
+  }
+
+  testDataType("ALTER VIEW check default collation") { dataType =>
+    Seq("", "TEMPORARY").foreach { temporary =>
+      withView(testView) {
+        sql(s"CREATE $temporary VIEW $testView DEFAULT COLLATION UTF8_LCASE AS SELECT 1")
+        sql(s"ALTER VIEW $testView AS SELECT 'a' AS c1, 'b' AS c2")
+        val prefix = "SYSTEM.BUILTIN"
+        checkAnswer(sql(s"SELECT COLLATION(c1) FROM $testView"),
+          Row(s"$prefix.UTF8_LCASE"))
+        checkAnswer(sql(s"SELECT COLLATION(c2) FROM $testView"),
+          Row(s"$prefix.UTF8_LCASE"))
+        sql(s"ALTER VIEW $testView AS SELECT 'c' AS c3 WHERE 'a' = 'A'")
+        checkAnswer(sql(s"SELECT COLLATION(c3) FROM $testView"),
+          Row(s"$prefix.UTF8_LCASE"))
+      }
+      withTable(testTable1) {
+        sql(s"CREATE TABLE $testTable1 (c1 $dataType COLLATE UTF8_LCASE, c2 $dataType, c3 INT)")
+        sql(s"INSERT INTO $testTable1 VALUES ('a', 'b', 1)")
+        withView(testView) {
+          sql(s"CREATE $temporary VIEW $testView DEFAULT COLLATION sr_AI_CI AS SELECT 'a' AS c1")
+          // scalastyle:off
+          sql(
+            s"""ALTER VIEW $testView AS
+              | SELECT *, 'c' AS c4,
+              | (SELECT (SELECT CASE 'š' = 'S' WHEN TRUE THEN 'd' ELSE 'b' END)) AS c5
+              | FROM $testTable1
+              | WHERE c1 = 'A' AND 'ć' = 'Č'""".stripMargin)
+          // scalastyle:on
+          val prefix = "SYSTEM.BUILTIN"
+          checkAnswer(sql(s"SELECT COLLATION(c4) FROM $testView"),
+            Row(s"$prefix.sr_CI_AI"))
+          checkAnswer(sql(s"SELECT COLLATION(c5) FROM $testView"),
+            Row(s"$prefix.sr_CI_AI"))
+          checkAnswer(sql(s"SELECT c5 FROM $testView"), Row("d"))
+        }
+      }
     }
   }
 
   // View with schema level collation tests
   schemaAndObjectCollationPairs.foreach {
     case (schemaDefaultCollation, viewDefaultCollation) =>
-      test(
+      testDataType(
         s"""CREATE VIEW with schema level collation
           | (schema default collation = $schemaDefaultCollation,
-          | view default collation = $viewDefaultCollation)""".stripMargin) {
+          | view default collation = $viewDefaultCollation)""".stripMargin) { dataType =>
         testCreateViewWithSchemaLevelCollation(
-          schemaDefaultCollation, viewDefaultCollation)
+          dataType, schemaDefaultCollation, viewDefaultCollation)
       }
 
-      test(
+      testDataType(
         s"""CREATE OR REPLACE VIEW with schema level collation
           | (schema default collation = $schemaDefaultCollation,
-          | view default collation = $viewDefaultCollation)""".stripMargin) {
+          | view default collation = $viewDefaultCollation)""".stripMargin) { dataType =>
         testCreateViewWithSchemaLevelCollation(
-          schemaDefaultCollation, viewDefaultCollation, replaceView = true)
+          dataType, schemaDefaultCollation, viewDefaultCollation, replaceView = true)
       }
 
-      test(
+      testDataType(
         s"""ALTER VIEW with schema level collation
           | (schema default collation = $schemaDefaultCollation,
-          | view default collation = $viewDefaultCollation)""".stripMargin) {
-        testAlterViewWithSchemaLevelCollation(schemaDefaultCollation, viewDefaultCollation)
+          | view default collation = $viewDefaultCollation)""".stripMargin) { dataType =>
+        testAlterViewWithSchemaLevelCollation(
+          dataType, schemaDefaultCollation, viewDefaultCollation)
       }
 
-      test(
+      testDataType(
         s"""ALTER VIEW after ALTER SCHEMA DEFAULT COLLATION
           | (original schema default collation = $schemaDefaultCollation,
-          | view default collation = $viewDefaultCollation)""".stripMargin) {
+          | view default collation = $viewDefaultCollation)""".stripMargin) { dataType =>
         testAlterViewWithSchemaLevelCollation(
-          schemaDefaultCollation, viewDefaultCollation, alterSchemaCollation = true)
+          dataType, schemaDefaultCollation, viewDefaultCollation, alterSchemaCollation = true)
       }
 
-      test(
+      testString(
         s"""View with default string producing expressions and schema level collation
           | (schema default collation = $schemaDefaultCollation,
-          | view default collation = $viewDefaultCollation)""".stripMargin) {
+          | view default collation = $viewDefaultCollation)""".stripMargin) { _ =>
         withDatabase(testSchema) {
           sql(s"CREATE SCHEMA $testSchema DEFAULT COLLATION $schemaDefaultCollation")
           sql(s"USE $testSchema")
@@ -650,7 +1093,7 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
       }
   }
 
-  test("View with UTF8_LCASE default collation from schema level") {
+  testString("View with UTF8_LCASE default collation from schema level") { _ =>
     withDatabase(testSchema) {
       sql(s"CREATE SCHEMA $testSchema DEFAULT COLLATION UTF8_LCASE")
       sql(s"USE $testSchema")
@@ -665,6 +1108,7 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
   }
 
   private def testCreateViewWithSchemaLevelCollation(
+      dataType: String,
       schemaDefaultCollation: String,
       viewDefaultCollation: Option[String] = None,
       replaceView: Boolean = false): Unit = {
@@ -686,15 +1130,15 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
         assertTableColumnCollation(testView, "c1", resolvedDefaultCollation)
       }
 
-      withTable(testTable) {
-        sql(s"CREATE TABLE $testTable (c1 STRING COLLATE UTF8_BINARY, " +
-          s"c2 STRING COLLATE UTF8_LCASE, c3 STRING COLLATE UNICODE)")
-        sql(s"INSERT INTO $testTable VALUES ('a', 'b', 'c'), ('A', 'D', 'C')")
+      withTable(testTable1) {
+        sql(s"CREATE TABLE $testTable1 (c1 $dataType COLLATE UTF8_BINARY, " +
+          s"c2 $dataType COLLATE UTF8_LCASE, c3 $dataType COLLATE UNICODE)")
+        sql(s"INSERT INTO $testTable1 VALUES ('a', 'b', 'c'), ('A', 'D', 'C')")
 
         withView(testView) {
           // scalastyle:off
           sql(s"CREATE $replace VIEW $testView $viewDefaultCollationClause AS " +
-            s"SELECT *, 'd' AS c4  FROM $testTable WHERE c2 = 'B'  AND 'ć' != 'č'")
+            s"SELECT *, 'd' AS c4  FROM $testTable1 WHERE c2 = 'B'  AND 'ć' != 'č'")
           // scalastyle:on
 
           checkAnswer(sql(s"SELECT COUNT(*) FROM $testView"), Row(1))
@@ -709,6 +1153,7 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
   }
 
   private def testAlterViewWithSchemaLevelCollation(
+      dataType: String,
       schemaDefaultCollation: String,
       viewDefaultCollation: Option[String] = None,
       alterSchemaCollation: Boolean = false): Unit = {
@@ -725,10 +1170,10 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
 
       withView(testView) {
         sql(s"CREATE VIEW $testView $viewDefaultCollationClause AS SELECT 'a' AS c1")
-        withTable(testTable) {
-          sql(s"CREATE TABLE $testTable (c1 STRING COLLATE UTF8_BINARY, " +
-            s"c2 STRING COLLATE UTF8_LCASE, c3 STRING COLLATE UNICODE)")
-          sql(s"INSERT INTO $testTable VALUES ('a', 'b', 'c'), ('A', 'D', 'C')")
+        withTable(testTable1) {
+          sql(s"CREATE TABLE $testTable1 (c1 $dataType COLLATE UTF8_BINARY, " +
+            s"c2 $dataType COLLATE UTF8_LCASE, c3 $dataType COLLATE UNICODE)")
+          sql(s"INSERT INTO $testTable1 VALUES ('a', 'b', 'c'), ('A', 'D', 'C')")
 
           if (alterSchemaCollation) {
             // ALTER SCHEMA DEFAULT COLLATION shouldn't change View's default collation
@@ -737,7 +1182,7 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
 
           // scalastyle:off
           sql(s"ALTER VIEW $testView " +
-            s"AS SELECT *, 'd' AS c4 FROM $testTable WHERE c2 = 'B' AND 'ć' != 'č'")
+            s"AS SELECT *, 'd' AS c4 FROM $testTable1 WHERE c2 = 'B' AND 'ć' != 'č'")
           // scalastyle:on
 
           checkAnswer(sql(s"SELECT COUNT(*) FROM $testView"), Row(1))
@@ -782,93 +1227,130 @@ class DefaultCollationTestSuiteV1 extends DefaultCollationTestSuite {
   }
 }
 
-class DefaultCollationTestSuiteV2 extends DefaultCollationTestSuite with DatasourceV2SQLBase {
-  override def testSchema: String = s"testcat.${super.testSchema}"
+abstract class DefaultCollationTestSuiteV2
+    extends DefaultCollationTestSuite with DatasourceV2SQLBase {
+  override def testCatalog: String = "testcat"
+  override def testSchema: String = s"$testCatalog.${super.testSchema}"
 
-  override def beforeEach(): Unit = {
-    super.beforeEach()
-    sql("USE testcat")
-    sql(s"CREATE SCHEMA IF NOT EXISTS $DEFAULT_DATABASE")
-    sql(s"USE testcat.$DEFAULT_DATABASE")
-  }
+  override def resetCatalog: Boolean = true
 
-  test("inline table in RTAS") {
-    withTable(testTable) {
-      sql(s"CREATE TABLE $testTable (c1 STRING, c2 BOOLEAN) USING $dataSource")
+  testDataType("inline table in RTAS") { dataType =>
+    withTable(testTable1) {
+      sql(s"CREATE TABLE $testTable1 (c1 $dataType, c2 BOOLEAN)")
       sql(s"""
-           |REPLACE TABLE $testTable
-           |USING $dataSource
-           |AS SELECT *
-           |FROM (VALUES ('a', 'a' = 'A'))
-           |AS inline_table(c1, c2);
-           |""".stripMargin)
+            |REPLACE TABLE $testTable1
+            |AS SELECT *
+            |FROM (VALUES ('a', 'a' = 'A'))
+            |AS inline_table(c1, c2);
+            |""".stripMargin)
 
-      assertTableColumnCollation(testTable, "c1", "UTF8_BINARY")
-      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable WHERE c2"), Seq(Row(0)))
+      assertTableColumnCollation(testTable1, "c1", "UTF8_BINARY")
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable1 WHERE c2"), Seq(Row(0)))
     }
   }
 
-  test("CREATE OR REPLACE TABLE with DEFAULT COLLATION") {
-    withTable(testTable) {
+  testDataType("CREATE OR REPLACE TABLE with DEFAULT COLLATION") { dataType =>
+    withTable(testTable1) {
       sql(
-        s"""CREATE OR REPLACE TABLE $testTable
-           | (c1 STRING, c2 STRING COLLATE UTF8_LCASE)
+        s"""CREATE OR REPLACE TABLE $testTable1
+           | (c1 $dataType, c2 $dataType COLLATE UTF8_LCASE)
            | DEFAULT COLLATION sr_ai
            |""".stripMargin)
       // scalastyle:off
-      sql(s"INSERT INTO $testTable VALUES ('Ć', 'a'), ('Č', 'A'), ('C', 'b')")
-      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable WHERE c1 = 'Ć'"), Row(3))
+      sql(s"INSERT INTO $testTable1 VALUES ('Ć', 'a'), ('Č', 'A'), ('C', 'b')")
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable1 WHERE c1 = 'Ć'"), Row(3))
       // scalastyle:on
-      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable WHERE c2 = 'a'"), Row(2))
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable1 WHERE c2 = 'a'"), Row(2))
       val prefix = "SYSTEM.BUILTIN"
-      checkAnswer(sql(s"SELECT DISTINCT COLLATION(c1) FROM $testTable"), Row(s"$prefix.sr_AI"))
-      checkAnswer(sql(s"SELECT DISTINCT COLLATION(c2) FROM $testTable"), Row(s"$prefix.UTF8_LCASE"))
+      checkAnswer(sql(s"SELECT DISTINCT COLLATION(c1) FROM $testTable1"), Row(s"$prefix.sr_AI"))
+      checkAnswer(sql(s"SELECT DISTINCT COLLATION(c2) FROM $testTable1"),
+        Row(s"$prefix.UTF8_LCASE"))
+    }
+  }
+
+  testDataType("CREATE OR REPLACE TABLE AS SELECT with DEFAULT COLLATION") { dataType =>
+    withTable(testTable1) {
+      sql(s"CREATE TABLE $testTable1 (c1 $dataType, c2 $dataType COLLATE UTF8_LCASE)")
+      sql(s"INSERT INTO $testTable1 VALUES ('a', 'a'), ('A', 'A'), ('b', 'b')")
+      withTable(testTable2) {
+        // scalastyle:off
+        sql(
+          s"""CREATE OR REPLACE TABLE $testTable2
+             | DEFAULT COLLATION sr_ci_ai
+             | AS SELECT *, 'ć' AS c3 FROM $testTable1
+             |""".stripMargin)
+        val prefix = "SYSTEM.BUILTIN"
+        checkAnswer(sql(s"SELECT DISTINCT COLLATION(c1) FROM $testTable2"), Row(s"$prefix.UTF8_BINARY"))
+        checkAnswer(sql(s"SELECT DISTINCT COLLATION(c2) FROM $testTable2"), Row(s"$prefix.UTF8_LCASE"))
+        checkAnswer(sql(s"SELECT DISTINCT COLLATION(c3) FROM $testTable2"), Row(s"$prefix.sr_CI_AI"))
+        checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable2 WHERE c1 = 'A'"), Row(1))
+        checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable2 WHERE c2 = 'a'"), Row(2))
+        checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable2 WHERE c3 = 'Č'"), Row(3))
+        // scalastyle:on
+      }
+    }
+    withTable(testTable1) {
+      // scalastyle:off
+      sql(
+        s"""CREATE OR REPLACE TABLE $testTable1
+           | DEFAULT COLLATION sr_ai
+           | AS SELECT 'Ć' as c1 WHERE 'Ć' = 'C'
+           |""".stripMargin)
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable1 WHERE c1 = 'Č'"), Row(1))
+      // scalastyle:on
+    }
+  }
+
+  testString(s"CREATE OR REPLACE TABLE AS SELECT with inline table and DEFAULT COLLATION") { _ =>
+    withTable(testTable1) {
+      sql(
+        s"""CREATE OR REPLACE TABLE $testTable1 DEFAULT COLLATION UTF8_LCASE AS
+           | SELECT *
+           | FROM VALUES ('a', 'a' COLLATE UNICODE), ('b', 'b' COLLATE UNICODE),
+           |  ('c', 'c' COLLATE UNICODE) AS T(c1, c2)
+           | WHERE c1 = 'A'
+           |""".stripMargin)
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable1"), Seq(Row(1)))
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable1 WHERE c1 = 'A'"), Seq(Row(1)))
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $testTable1 WHERE c1 = 'B'"), Seq(Row(0)))
+      checkAnswer(sql(s"SELECT DISTINCT COLLATION(c1) FROM $testTable1"),
+        Row(s"${fullyQualifiedPrefix}UTF8_LCASE"))
+      checkAnswer(sql(s"SELECT DISTINCT COLLATION(c2) FROM $testTable1"),
+        Row(s"${fullyQualifiedPrefix}UNICODE"))
     }
   }
 
   schemaAndObjectCollationPairs.foreach {
     case (schemaDefaultCollation, tableDefaultCollation) =>
-      test(
+      testDataType(
         s"""CREATE OR REPLACE table with schema level collation
           | (schema default collation = $schemaDefaultCollation,
-          | table default collation = $tableDefaultCollation)""".stripMargin) {
+          | table default collation = $tableDefaultCollation)""".stripMargin) { dataType =>
         testCreateTableWithSchemaLevelCollation(
-          schemaDefaultCollation, tableDefaultCollation, replaceTable = true)
+          dataType, schemaDefaultCollation, tableDefaultCollation, replaceTable = true)
       }
 
-      test(
+      testDataType(
+        s"""CREATE OR REPLACE TABLE AS SELECT with schema level collation
+          | (schema default collation = $schemaDefaultCollation,
+          | table default collation = $tableDefaultCollation)""".stripMargin) { dataType =>
+        testCTASWithSchemaLevelCollation(
+          dataType, schemaDefaultCollation, tableDefaultCollation, replaceTable = true)
+      }
+
+      testDataType(
         s"""REPLACE COLUMNS with schema level collation
           | (schema default collation = $schemaDefaultCollation,
-          | table default collation = $tableDefaultCollation""".stripMargin) {
+          | table default collation = $tableDefaultCollation)""".stripMargin) { dataType =>
         testReplaceColumns(
-          schemaDefaultCollation, tableDefaultCollation)
+          dataType, schemaDefaultCollation, tableDefaultCollation)
       }
-  }
-
-  test("alter char/varchar column to string type") {
-    withTable(testTable) {
-      sql(s"CREATE TABLE $testTable (c1 VARCHAR(10), c2 CHAR(10)) " +
-        s"DEFAULT COLLATION UTF8_LCASE")
-
-      sql(s"ALTER TABLE $testTable ALTER COLUMN c1 TYPE STRING")
-      sql(s"ALTER TABLE $testTable ALTER COLUMN c2 TYPE STRING")
-      assertTableColumnCollation(testTable, "c1", "UTF8_LCASE")
-      assertTableColumnCollation(testTable, "c2", "UTF8_LCASE")
-    }
-
-    withTable(testTable) {
-      sql(s"CREATE TABLE $testTable (c1 VARCHAR(10), c2 CHAR(10)) " +
-        s"DEFAULT COLLATION UTF8_LCASE")
-
-      sql(s"ALTER TABLE $testTable ALTER COLUMN c1 TYPE STRING COLLATE UNICODE")
-      sql(s"ALTER TABLE $testTable ALTER COLUMN c2 TYPE STRING COLLATE UNICODE")
-      assertTableColumnCollation(testTable, "c1", "UNICODE")
-      assertTableColumnCollation(testTable, "c2", "UNICODE")
-    }
   }
 
   private def testReplaceColumns(
-      schemaDefaultCollation: String, tableDefaultCollation: Option[String] = None): Unit = {
+      dataType: String,
+      schemaDefaultCollation: String,
+      tableDefaultCollation: Option[String] = None): Unit = {
     val (tableDefaultCollationClause, resolvedDefaultCollation) =
       if (tableDefaultCollation.isDefined) {
         (s"DEFAULT COLLATION ${tableDefaultCollation.get}", tableDefaultCollation.get)
@@ -880,16 +1362,83 @@ class DefaultCollationTestSuiteV2 extends DefaultCollationTestSuite with Datasou
       sql(s"CREATE SCHEMA $testSchema DEFAULT COLLATION $schemaDefaultCollation")
       sql(s"USE $testSchema")
 
-      withTable(testTable) {
-        sql(s"CREATE TABLE $testTable (c1 STRING, c2 STRING COLLATE SR_AI) " +
+      withTable(testTable1) {
+        sql(s"CREATE TABLE $testTable1 (c1 $dataType, c2 $dataType COLLATE SR_AI) " +
           s"$tableDefaultCollationClause")
 
-        sql(s"ALTER TABLE $testTable REPLACE COLUMNS " +
-          "(c1 STRING COLLATE UNICODE, c2 STRING, c3 STRING COLLATE UTF8_BINARY)")
-        assertTableColumnCollation(testTable, "c1", "UNICODE")
-        assertTableColumnCollation(testTable, "c2", resolvedDefaultCollation)
-        assertTableColumnCollation(testTable, "c3", "UTF8_BINARY")
+        sql(s"ALTER TABLE $testTable1 REPLACE COLUMNS " +
+          s"(c1 $dataType COLLATE UNICODE, c2 $dataType, c3 $dataType COLLATE UTF8_BINARY)")
+        assertTableColumnCollation(testTable1, "c1", "UNICODE")
+        assertTableColumnCollation(testTable1, "c2", resolvedDefaultCollation)
+        assertTableColumnCollation(testTable1, "c3", "UTF8_BINARY")
       }
+    }
+  }
+}
+
+class DefaultCollationStringTestSuiteV1 extends DefaultCollationTestSuiteV1 {
+  override protected def testDataType(testName: String)(testFn: String => Unit): Unit = {
+    test(s"$testName [STRING]") {
+      testFn("STRING")
+    }
+  }
+}
+
+class DefaultCollationStringTestSuiteV2 extends DefaultCollationTestSuiteV2 {
+  override protected def testDataType(testName: String)(testFn: String => Unit): Unit = {
+    test(s"$testName [STRING]") {
+      testFn("STRING")
+    }
+  }
+
+  // We have this test for STRING type only, since we don't support altering STRING to CHAR/VARCHAR.
+  test("alter char/varchar column to string type") {
+    withTable(testTable1) {
+      sql(s"CREATE TABLE $testTable1 (c1 VARCHAR(10), c2 CHAR(10)) " +
+        s"DEFAULT COLLATION UTF8_LCASE")
+
+      sql(s"ALTER TABLE $testTable1 ALTER COLUMN c1 TYPE STRING")
+      sql(s"ALTER TABLE $testTable1 ALTER COLUMN c2 TYPE STRING")
+      assertTableColumnCollation(testTable1, "c1", "UTF8_LCASE")
+      assertTableColumnCollation(testTable1, "c2", "UTF8_LCASE")
+    }
+
+    withTable(testTable1) {
+      sql(s"CREATE TABLE $testTable1 (c1 VARCHAR(10), c2 CHAR(10)) " +
+        s"DEFAULT COLLATION UTF8_LCASE")
+
+      sql(s"ALTER TABLE $testTable1 ALTER COLUMN c1 TYPE STRING COLLATE UNICODE")
+      sql(s"ALTER TABLE $testTable1 ALTER COLUMN c2 TYPE STRING COLLATE UNICODE")
+      assertTableColumnCollation(testTable1, "c1", "UNICODE")
+      assertTableColumnCollation(testTable1, "c2", "UNICODE")
+    }
+  }
+}
+
+class DefaultCollationCharVarcharTestSuiteV1 extends DefaultCollationTestSuiteV1 {
+  override protected def excluded: Seq[String] =
+    super.excluded ++ stringTestNames ++ stringTestNamesV1
+
+  override protected def testDataType(testName: String)(testFn: String => Unit): Unit = {
+    test(s"$testName [CHAR($charVarcharLength)]") {
+      testFn(s"CHAR($charVarcharLength)")
+    }
+    test(s"$testName [VARCHAR($charVarcharLength)]") {
+      testFn(s"VARCHAR($charVarcharLength)")
+    }
+  }
+}
+
+class DefaultCollationCharVarcharTestSuiteV2 extends DefaultCollationTestSuiteV2 {
+  override protected def excluded: Seq[String] =
+    super.excluded ++ stringTestNames
+
+  override protected def testDataType(testName: String)(testFn: String => Unit): Unit = {
+    test(s"$testName [CHAR($charVarcharLength)]") {
+      testFn(s"CHAR($charVarcharLength)")
+    }
+    test(s"$testName [VARCHAR($charVarcharLength)]") {
+      testFn(s"VARCHAR($charVarcharLength)")
     }
   }
 }

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkGetColumnsOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkGetColumnsOperation.scala
@@ -135,7 +135,7 @@ private[hive] class SparkGetColumnsOperation(
     case dt @ (BooleanType | _: NumericType | DateType | TimestampType | TimestampNTZType |
                CalendarIntervalType | NullType | _: AnsiIntervalType) =>
       Some(dt.defaultSize)
-    case CharType(n) => Some(n)
+    case c: CharType => Some(c.length)
     case StructType(fields) =>
       val sizeArr = fields.map(f => getColumnSize(f.dataType))
       if (sizeArr.contains(None)) {
@@ -178,8 +178,8 @@ private[hive] class SparkGetColumnsOperation(
     case FloatType => java.sql.Types.FLOAT
     case DoubleType => java.sql.Types.DOUBLE
     case _: DecimalType => java.sql.Types.DECIMAL
-    case VarcharType(_) => java.sql.Types.VARCHAR
-    case CharType(_) => java.sql.Types.CHAR
+    case _: VarcharType => java.sql.Types.VARCHAR
+    case _: CharType => java.sql.Types.CHAR
     case _: StringType => java.sql.Types.VARCHAR
     case BinaryType => java.sql.Types.BINARY
     case DateType => java.sql.Types.DATE


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR extends the string collation feature to support char/varchar data type and CTAS/RTAS commands.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
new feature

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, now users can specify collation for char/varchar data type, and CTAS/RTAS will inherit default collation from the relevant object.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
cursor 2.2.44