### PR TITLE
[SPARK-54868][PYTHON][INFRA][FOLLOW-UP] Also enable `faulthandler` in classic tests

### DIFF
--- a/python/pyspark/testing/sqlutils.py
+++ b/python/pyspark/testing/sqlutils.py
@@ -209,6 +209,7 @@ class ReusedSQLTestCase(ReusedPySparkTestCase, SQLTestUtils, PySparkErrorTestUti
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
         cls._legacy_sc = cls.sc
         cls.spark = SparkSession(cls.sc)
         cls.tempdir = tempfile.NamedTemporaryFile(delete=False)
@@ -218,9 +219,11 @@ class ReusedSQLTestCase(ReusedPySparkTestCase, SQLTestUtils, PySparkErrorTestUti
 
     @classmethod
     def tearDownClass(cls):
-        super().tearDownClass()
-        cls.spark.stop()
-        shutil.rmtree(cls.tempdir.name, ignore_errors=True)
+        try:
+            cls.spark.stop()
+            shutil.rmtree(cls.tempdir.name, ignore_errors=True)
+        finally:
+            super().tearDownClass()
 
     def tearDown(self):
         try:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Also enable `faulthandler` in classic tests, by introducing a base class `PySparkBaseTestCase`


### Why are the changes needed?
`faulthandler` was only enabled in `ReusedConnectTestCase` for spark connect,

after this change `faulthandler` will be enabled in most classic tests (There are still some tests directly use `unittest.TestCase`, we can change them when they hit hanging issues)


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
ci and manually check with 
```
PYSPARK_TEST_TIMEOUT=10 python/run-tests -k --python-executables python3 --testnames 'pyspark.tests.test_util'
```


### Was this patch authored or co-authored using generative AI tooling?
no
