### PR TITLE
[MINOR][BUILD] Remove undefined -Pscala-2.13 profile from dev scripts

### DIFF
--- a/dev/lint-scala
+++ b/dev/lint-scala
@@ -26,7 +26,6 @@ set -e
 set +e
 # For Spark Connect, we actively enforce scalafmt and check that the produced diff is empty.
 ERRORS=$(./build/mvn \
-    -Pscala-2.13 \
     scalafmt:format \
     -Dscalafmt.skip=false \
     -Dscalafmt.validateOnly=true \

--- a/dev/scalafmt
+++ b/dev/scalafmt
@@ -17,6 +17,5 @@
 # limitations under the License.
 #
 
-VERSION="${@:-2.13}"
-./build/mvn -Pscala-$VERSION scalafmt:format -Dscalafmt.skip=false -Dscalafmt.validateOnly=false
+./build/mvn scalafmt:format -Dscalafmt.skip=false -Dscalafmt.validateOnly=false
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the `-Pscala-2.13` profile specification from two dev scripts:
- `dev/lint-scala`
- `dev/scalafmt`

### Why are the changes needed?

The `-Pscala-2.13` profile is not defined in the project's Maven configuration, making these profile references unnecessary and potentially confusing. The default Scala version configured in `pom.xml` will be used instead, simplifying the build process.

### Changes Made

**dev/lint-scala:**
- Removed `-Pscala-2.13 \` line from the scalafmt validation command

**dev/scalafmt:**
- Removed the `VERSION` parameter logic
- Removed `-Pscala-$VERSION` from the Maven command

### Does this PR introduce any user-facing change?

No. This is an internal build script simplification that doesn't affect end users.

### How was this patch tested?

The changes maintain existing functionality by relying on the default Scala version configured in the project's Maven POM files rather than explicitly specifying an undefined profile.

### Was this patch authored or co-authored using generative AI tooling?

No.