### PR TITLE
[SPARK-54877][UI] Make display stacktrace on UI error page configurable

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/UI.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/UI.scala
@@ -271,4 +271,10 @@ private[spark] object UI {
     .version("4.0.0")
     .timeConf(TimeUnit.MILLISECONDS)
     .createWithDefaultString("30s")
+
+  val UI_SHOW_ERROR_STACKS = ConfigBuilder("spark.ui.showErrorStacks")
+    .doc("Whether to display stack traces in the UI error pages.")
+    .version("4.2.0")
+    .booleanConf
+    .createWithDefault(true)
 }

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -265,7 +265,7 @@ private[spark] object JettyUtils extends Logging {
     val server = new Server(pool)
 
     val errorHandler = new ErrorHandler()
-    errorHandler.setShowStacks(true)
+    errorHandler.setShowStacks(conf.get(UI_SHOW_ERROR_STACKS))
     errorHandler.setServer(server)
     server.addBean(errorHandler)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds a new configuration `spark.ui.showErrorStacks` to allow user to disable displaying stacktrace on UI error page.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To avoid exposing much internal info of the service for security purposes. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, the default value of the newly added configuration does not change the existing behavior.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Manually tested, modified AllJobsPage.scala to simulate an internal error.

Run with `--conf spark.ui.showErrorStacks=true` (default behavior)

<img width="894" height="756" alt="image" src="https://github.com/user-attachments/assets/cb2e77ef-175a-43b0-bab2-1cb9e294be27" />


Run with `--conf spark.ui.showErrorStacks=false`

<img width="885" height="206" alt="image" src="https://github.com/user-attachments/assets/50d53286-eb11-466e-8c80-52a88a1806e1" />


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.