### PR TITLE
[SPARK-54882][PYTHON] Remove legacy PYARROW_IGNORE_TIMEZONE

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -39,9 +39,6 @@ fi
 
 pip install plotly "pandas<2.0.0" "pyspark[sql,ml,mllib,pandas_on_spark,connect]$SPECIFIER$VERSION"
 
-# Set 'PYARROW_IGNORE_TIMEZONE' to suppress warnings from PyArrow.
-echo "export PYARROW_IGNORE_TIMEZONE=1" >> ~/.profile
-
 # Add sbin to PATH to run `start-connect-server.sh`.
 SPARK_HOME=$(python -c "from pyspark.find_spark_home import _find_spark_home; print(_find_spark_home())")
 echo "export PATH=${PATH}:${SPARK_HOME}/sbin" >> ~/.profile

--- a/python/pyspark/pandas/__init__.py
+++ b/python/pyspark/pandas/__init__.py
@@ -39,16 +39,6 @@ except ImportError as e:
     else:
         raise
 
-if "PYARROW_IGNORE_TIMEZONE" not in os.environ:
-    warnings.warn(
-        "'PYARROW_IGNORE_TIMEZONE' environment variable was not set. It is required to "
-        "set this environment variable to '1' in both driver and executor sides if you use "
-        "pyarrow>=2.0.0. "
-        "pandas-on-Spark will set it for you but it does not work if there is a Spark context "
-        "already launched."
-    )
-    os.environ["PYARROW_IGNORE_TIMEZONE"] = "1"
-
 from pyspark.pandas.frame import DataFrame
 from pyspark.pandas.indexes.base import Index
 from pyspark.pandas.indexes.category import CategoricalIndex

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -196,8 +196,6 @@ def run_individual_python_test(target_dir, test_name, pyspark_python, keep_test_
         'SPARK_PREPEND_CLASSES': '1',
         'PYSPARK_PYTHON': which(pyspark_python),
         'PYSPARK_DRIVER_PYTHON': which(pyspark_python),
-        # Preserve legacy nested timezone behavior for pyarrow>=2, remove after SPARK-32285
-        'PYARROW_IGNORE_TIMEZONE': '1',
     })
 
     if "SPARK_CONNECT_TESTING_REMOTE" in os.environ:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Remove legacy PYARROW_IGNORE_TIMEZONE


### Why are the changes needed?
it was added in spark 3.0 for integration with pyarrow 2.0 https://github.com/apache/spark/commit/5e331553726f838f2f14788c135f3497319b4714

seems it is no longer needed for pyspark tests


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
