### PR TITLE
[SPARK-54884][CORE][TESTS] Remove private function `totalRunningTasksPerResourceProfile` from `ExecutorAllocationManager`

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -329,12 +329,6 @@ private[spark] class ExecutorAllocationManager(
     }
   }
 
-  // Please do not delete this function, the tests in `ExecutorAllocationManagerSuite`
-  // need to access `listener.totalRunningTasksPerResourceProfile` with `synchronized`.
-  private def totalRunningTasksPerResourceProfile(id: Int): Int = synchronized {
-    listener.totalRunningTasksPerResourceProfile(id)
-  }
-
   /**
    * This is called at a fixed interval to regulate the number of pending executor requests
    * and number of executors running.

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -1924,8 +1924,6 @@ private object ExecutorAllocationManagerSuite extends PrivateMethodTester {
     PrivateMethod[mutable.HashMap[Int, Int]](Symbol("numLocalityAwareTasksPerResourceProfileId"))
   private val _rpIdToHostToLocalTaskCount =
     PrivateMethod[Map[Int, Map[String, Int]]](Symbol("rpIdToHostToLocalTaskCount"))
-  private val _totalRunningTasksPerResourceProfile =
-    PrivateMethod[Int](Symbol("totalRunningTasksPerResourceProfile"))
 
   private val defaultProfile = ResourceProfile.getOrCreateDefaultProfile(new SparkConf)
 
@@ -2022,9 +2020,10 @@ private object ExecutorAllocationManagerSuite extends PrivateMethodTester {
     localMap(defaultProfile.id)
   }
 
-  private def totalRunningTasksPerResourceProfile(manager: ExecutorAllocationManager): Int = {
-    manager invokePrivate _totalRunningTasksPerResourceProfile(defaultProfile.id)
-  }
+  private def totalRunningTasksPerResourceProfile(manager: ExecutorAllocationManager): Int =
+    manager.synchronized {
+      manager.listener.totalRunningTasksPerResourceProfile(defaultProfile.id)
+    }
 
   private def hostToLocalTaskCount(
       manager: ExecutorAllocationManager): Map[String, Int] = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr removes the private function `totalRunningTasksPerResourceProfile` from `ExecutorAllocationManager` and refactors `ExecutorAllocationManagerSuite` so that it no longer relies on this private function, which was solely used for testing purposes.

### Why are the changes needed?
Code cleanup.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions


### Was this patch authored or co-authored using generative AI tooling?
No