### PR TITLE
[SPARK-54894][PYTHON] Fix argument passing in `to_arrow_type`

### DIFF
--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -304,7 +304,9 @@ def spark_type_to_pandas_dtype(
             .lower()
             == "true"
         )
-        return np.dtype(to_arrow_type(spark_type, prefers_large_var_types).to_pandas_dtype())
+        return np.dtype(
+            to_arrow_type(spark_type, prefers_large_types=prefers_large_var_types).to_pandas_dtype()
+        )
 
 
 def pandas_on_spark_type(tpe: Union[str, type, Dtype]) -> Tuple[Dtype, types.DataType]:

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -71,6 +71,7 @@ if TYPE_CHECKING:
 
 def to_arrow_type(
     dt: DataType,
+    *,
     error_on_duplicated_field_names_in_struct: bool = False,
     timestamp_utc: bool = True,
     prefers_large_types: bool = False,
@@ -140,9 +141,9 @@ def to_arrow_type(
             "element",
             to_arrow_type(
                 dt.elementType,
-                error_on_duplicated_field_names_in_struct,
-                timestamp_utc,
-                prefers_large_types,
+                error_on_duplicated_field_names_in_struct=error_on_duplicated_field_names_in_struct,
+                timestamp_utc=timestamp_utc,
+                prefers_large_types=prefers_large_types,
             ),
             nullable=dt.containsNull,
         )
@@ -152,9 +153,9 @@ def to_arrow_type(
             "key",
             to_arrow_type(
                 dt.keyType,
-                error_on_duplicated_field_names_in_struct,
-                timestamp_utc,
-                prefers_large_types,
+                error_on_duplicated_field_names_in_struct=error_on_duplicated_field_names_in_struct,
+                timestamp_utc=timestamp_utc,
+                prefers_large_types=prefers_large_types,
             ),
             nullable=False,
         )
@@ -162,9 +163,9 @@ def to_arrow_type(
             "value",
             to_arrow_type(
                 dt.valueType,
-                error_on_duplicated_field_names_in_struct,
-                timestamp_utc,
-                prefers_large_types,
+                error_on_duplicated_field_names_in_struct=error_on_duplicated_field_names_in_struct,
+                timestamp_utc=timestamp_utc,
+                prefers_large_types=prefers_large_types,
             ),
             nullable=dt.valueContainsNull,
         )
@@ -181,9 +182,9 @@ def to_arrow_type(
                 field.name,
                 to_arrow_type(
                     field.dataType,
-                    error_on_duplicated_field_names_in_struct,
-                    timestamp_utc,
-                    prefers_large_types,
+                    error_on_duplicated_field_names_in_struct=error_on_duplicated_field_names_in_struct,
+                    timestamp_utc=timestamp_utc,
+                    prefers_large_types=prefers_large_types,
                 ),
                 nullable=field.nullable,
             )
@@ -195,9 +196,9 @@ def to_arrow_type(
     elif isinstance(dt, UserDefinedType):
         arrow_type = to_arrow_type(
             dt.sqlType(),
-            error_on_duplicated_field_names_in_struct,
-            timestamp_utc,
-            prefers_large_types,
+            error_on_duplicated_field_names_in_struct=error_on_duplicated_field_names_in_struct,
+            timestamp_utc=timestamp_utc,
+            prefers_large_types=prefers_large_types,
         )
     elif type(dt) == VariantType:
         fields = [
@@ -271,9 +272,9 @@ def to_arrow_schema(
             field.name,
             to_arrow_type(
                 field.dataType,
-                error_on_duplicated_field_names_in_struct,
-                timestamp_utc,
-                prefers_large_types,
+                error_on_duplicated_field_names_in_struct=error_on_duplicated_field_names_in_struct,
+                timestamp_utc=timestamp_utc,
+                prefers_large_types=prefers_large_types,
             ),
             nullable=field.nullable,
         )

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -240,6 +240,7 @@ def to_arrow_type(
 
 def to_arrow_schema(
     schema: StructType,
+    *,
     error_on_duplicated_field_names_in_struct: bool = False,
     timestamp_utc: bool = True,
     prefers_large_types: bool = False,

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -655,7 +655,9 @@ def wrap_cogrouped_map_pandas_udf(f, return_type, argspec, runner_conf):
 
         return result
 
-    arrow_return_type = to_arrow_type(return_type, runner_conf.use_large_var_types)
+    arrow_return_type = to_arrow_type(
+        return_type, prefers_large_types=runner_conf.use_large_var_types
+    )
     return lambda kl, vl, kr, vr: [(wrapped(kl, vl, kr, vr), arrow_return_type)]
 
 
@@ -774,7 +776,9 @@ def wrap_grouped_map_arrow_udf(f, return_type, argspec, runner_conf):
 
         yield from result.to_batches()
 
-    arrow_return_type = to_arrow_type(return_type, runner_conf.use_large_var_types)
+    arrow_return_type = to_arrow_type(
+        return_type, prefers_large_types=runner_conf.use_large_var_types
+    )
     return lambda k, v: (wrapped(k, v), arrow_return_type)
 
 
@@ -801,7 +805,9 @@ def wrap_grouped_map_arrow_iter_udf(f, return_type, argspec, runner_conf):
 
         yield from map(verify_element, result)
 
-    arrow_return_type = to_arrow_type(return_type, runner_conf.use_large_var_types)
+    arrow_return_type = to_arrow_type(
+        return_type, prefers_large_types=runner_conf.use_large_var_types
+    )
     return lambda k, v: (wrapped(k, v), arrow_return_type)
 
 
@@ -831,7 +837,9 @@ def wrap_grouped_map_pandas_udf(f, return_type, argspec, runner_conf):
 
         yield result
 
-    arrow_return_type = to_arrow_type(return_type, runner_conf.use_large_var_types)
+    arrow_return_type = to_arrow_type(
+        return_type, prefers_large_types=runner_conf.use_large_var_types
+    )
 
     def flatten_wrapper(k, v):
         # Return Iterator[[(df, arrow_type)]] directly
@@ -866,7 +874,9 @@ def wrap_grouped_map_pandas_iter_udf(f, return_type, argspec, runner_conf):
 
         yield from map(verify_element, result)
 
-    arrow_return_type = to_arrow_type(return_type, runner_conf.use_large_var_types)
+    arrow_return_type = to_arrow_type(
+        return_type, prefers_large_types=runner_conf.use_large_var_types
+    )
 
     def flatten_wrapper(k, v):
         # Return Iterator[[(df, arrow_type)]] directly
@@ -885,7 +895,9 @@ def wrap_grouped_transform_with_state_pandas_udf(f, return_type, runner_conf):
 
         return result_iter
 
-    arrow_return_type = to_arrow_type(return_type, runner_conf.use_large_var_types)
+    arrow_return_type = to_arrow_type(
+        return_type, prefers_large_types=runner_conf.use_large_var_types
+    )
     return lambda p, m, k, v: [(wrapped(p, m, k, v), arrow_return_type)]
 
 
@@ -906,7 +918,9 @@ def wrap_grouped_transform_with_state_pandas_init_state_udf(f, return_type, runn
 
         return result_iter
 
-    arrow_return_type = to_arrow_type(return_type, runner_conf.use_large_var_types)
+    arrow_return_type = to_arrow_type(
+        return_type, prefers_large_types=runner_conf.use_large_var_types
+    )
     return lambda p, m, k, v: [(wrapped(p, m, k, v), arrow_return_type)]
 
 
@@ -919,7 +933,9 @@ def wrap_grouped_transform_with_state_udf(f, return_type, runner_conf):
 
         return result_iter
 
-    arrow_return_type = to_arrow_type(return_type, runner_conf.use_large_var_types)
+    arrow_return_type = to_arrow_type(
+        return_type, prefers_large_types=runner_conf.use_large_var_types
+    )
     return lambda p, m, k, v: [(wrapped(p, m, k, v), arrow_return_type)]
 
 
@@ -939,7 +955,9 @@ def wrap_grouped_transform_with_state_init_state_udf(f, return_type, runner_conf
 
         return result_iter
 
-    arrow_return_type = to_arrow_type(return_type, runner_conf.use_large_var_types)
+    arrow_return_type = to_arrow_type(
+        return_type, prefers_large_types=runner_conf.use_large_var_types
+    )
     return lambda p, m, k, v: [(wrapped(p, m, k, v), arrow_return_type)]
 
 
@@ -1032,7 +1050,9 @@ def wrap_grouped_map_pandas_udf_with_state(f, return_type, runner_conf):
             state,
         )
 
-    arrow_return_type = to_arrow_type(return_type, runner_conf.use_large_var_types)
+    arrow_return_type = to_arrow_type(
+        return_type, prefers_large_types=runner_conf.use_large_var_types
+    )
     return lambda k, v, s: [(wrapped(k, v, s), arrow_return_type)]
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, Fix argument passing in `to_arrow_type`;
2, Force named arguments in `to_arrow_type` and `to_arrow_schema` to avoid such issue in the future


### Why are the changes needed?
It is a long-standing issue that the second arg of `to_arrow_type` is `error_on_duplicated_field_names_in_struct` not `prefers_large_types`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
No
