### PR TITLE
[SPARK-45846][SQL] optimizeNullAwareAntiJoin should respect autoBroadcastJoinThreshold

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -328,7 +328,8 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
             .getOrElse(createJoinWithoutHint())
         }
 
-      case j @ ExtractSingleColumnNullAwareAntiJoin(leftKeys, rightKeys) =>
+      case j @ ExtractSingleColumnNullAwareAntiJoin(leftKeys, rightKeys)
+          if canBroadcastBySize(j.right, conf) =>
         Seq(joins.BroadcastHashJoinExec(leftKeys, rightKeys, LeftAnti, BuildRight,
           None, planLater(j.left), planLater(j.right), isNullAwareAntiJoin = true))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes an issue where null-aware anti-joins (enabled via `spark.sql.optimizeNullAwareAntiJoin`) were unconditionally using `BroadcastHashJoinExec` without checking if the right side was small enough to broadcast according to `spark.sql.autoBroadcastJoinThreshold`.

### Why are the changes needed?

When `spark.sql.optimizeNullAwareAntiJoin` is enabled, queries using `NOT IN` with a subquery would always attempt to broadcast the right side, even when it exceeded the broadcast threshold. This could lead to OOM errors with large datasets.

### Does this PR introduce any user-facing change?

Yes. When `spark.sql.autoBroadcastJoinThreshold` is set to -1 (or a small value), null-aware anti-joins will now respect this configuration and fall back to `BroadcastNestedLoopJoinExec` instead of attempting to broadcast large tables with `BroadcastHashJoinExec`.

**Join Strategy Selection:**
- **Before fix**: Always uses `BroadcastHashJoinExec` with `isNullAwareAntiJoin=true` (optimized O(M) hash lookup, but risk of OOM)
- **After fix**: 
  - If right side is small enough to broadcast: Uses `BroadcastHashJoinExec` with `isNullAwareAntiJoin=true` (optimized)
  - If broadcast is disabled or right side is too large: Falls back to `BroadcastNestedLoopJoinExec` (slower O(M*N), but avoids OOM)

### How was this patch tested?

Added a new test case "SPARK-45846: optimizeNullAwareAntiJoin should respect autoBroadcastJoinThreshold" in JoinSuite that verifies null-aware anti-joins do not use BroadcastHashJoinExec when broadcast is disabled.