### PR TITLE
[SPARK-54910][SS] Add streamingSourceIdentifyingName field to CatalogTable

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -41,6 +41,7 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable.VIEW_STORING_ANALYZED_
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, Cast, ExprId, Literal}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils
+import org.apache.spark.sql.catalyst.streaming.StreamingSourceIdentifyingName
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.connector.catalog.CatalogManager
@@ -442,7 +443,9 @@ case class CatalogTable(
     tracksPartitionsInCatalog: Boolean = false,
     schemaPreservesCase: Boolean = true,
     ignoredProperties: Map[String, String] = Map.empty,
-    viewOriginalText: Option[String] = None) extends MetadataMapSupport {
+    viewOriginalText: Option[String] = None,
+    streamingSourceIdentifyingName: Option[StreamingSourceIdentifyingName] = None)
+  extends MetadataMapSupport {
 
   import CatalogTable._
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a `streamingSourceIdentifyingName` field to `CatalogTable` to support tracking streaming source identifying names through the catalog layer.

Changes:
1. Added import for `StreamingSourceIdentifyingName`
2. Added `streamingSourceIdentifyingName: Option[StreamingSourceIdentifyingName] = None` field to the `CatalogTable` case class

The field stores the identifying name for a streaming source, which will be used by streaming queries to track source names through the `NameStreamingSources` analyzer rule. The field is `None` for non-streaming tables.

### Why are the changes needed?

This is part of the streaming source identification infrastructure introduced in SPARK-54867. To properly track streaming source names through query analysis, we need to persist the source identifying name in the catalog metadata.

This enables:
- Stable source identification for checkpoint location management
- Consistent source names for schema evolution and offset tracking
- Integration with flow systems (e.g., SDP) that require per-source metadata

### Does this PR introduce _any_ user-facing change?

No. This is an internal field used by the streaming infrastructure.

### How was this patch tested?

- Verified compilation of the catalyst module succeeds
- The change leverages Scala's case class automatic generation of `copy`, `equals`, and `hashCode` methods, which automatically includes the new field

### Was this patch authored or co-authored using generative AI tooling?

No.