### PR TITLE
[SPARK-54914] [SQL] Fixing DROP operator in pipe syntax to support qualified column names

### DIFF
--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -1815,7 +1815,7 @@ operatorPipeRightSide
     : selectClause aggregationClause? windowClause?
     | EXTEND extendList=namedExpressionSeq
     | SET operatorPipeSetAssignmentSeq
-    | DROP identifierSeq
+    | DROP multipartIdentifierList
     | AS errorCapturingIdentifier
     // Note that the WINDOW clause is not allowed in the WHERE pipe operator, but we add it here in
     // the grammar simply for purposes of catching this invalid syntax and throwing a specific

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -6659,9 +6659,8 @@ class AstBuilder extends DataTypeAstBuilder
     }.getOrElse(Option(ctx.SET).map { _ =>
       visitOperatorPipeSet(ctx, left)
     }.getOrElse(Option(ctx.DROP).map { _ =>
-      val ids: Seq[Seq[String]] =
-        ctx.multipartIdentifierList().multipartIdentifier.asScala.toSeq.map(
-          _.parts.asScala.map(_.getText).toSeq)
+      val ids: Seq[Seq[String]] = ctx.multipartIdentifierList().multipartIdentifier.asScala
+        .toSeq.map(visitMultipartIdentifier)
       val projectList: Seq[NamedExpression] =
         Seq(UnresolvedStarExceptOrReplace(
           target = None, excepts = ids, replacements = None))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -6659,10 +6659,12 @@ class AstBuilder extends DataTypeAstBuilder
     }.getOrElse(Option(ctx.SET).map { _ =>
       visitOperatorPipeSet(ctx, left)
     }.getOrElse(Option(ctx.DROP).map { _ =>
-      val ids: Seq[String] = visitIdentifierSeq(ctx.identifierSeq())
+      val ids: Seq[Seq[String]] =
+        ctx.multipartIdentifierList().multipartIdentifier.asScala.toSeq.map(
+          _.parts.asScala.map(_.getText).toSeq)
       val projectList: Seq[NamedExpression] =
         Seq(UnresolvedStarExceptOrReplace(
-          target = None, excepts = ids.map(s => Seq(s)), replacements = None))
+          target = None, excepts = ids, replacements = None))
       Project(projectList, left)
     }.getOrElse(Option(ctx.AS).map { _ =>
       SubqueryAlias(ctx.errorCapturingIdentifier().getText, left)

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
@@ -1100,6 +1100,15 @@ Project [x#x, y#x]
 
 
 -- !query
+table st
+|> drop col.i1
+-- !query analysis
+Project [x#x, update_fields(col#x, dropfield(), i1) AS col#x]
++- SubqueryAlias spark_catalog.default.st
+   +- Relation spark_catalog.default.st[x#x,col#x] parquet
+
+
+-- !query
 table t
 |> drop z
 -- !query analysis
@@ -1118,21 +1127,6 @@ org.apache.spark.sql.AnalysisException
     "stopIndex" : 17,
     "fragment" : "table t\n|> drop z"
   } ]
-}
-
-
--- !query
-table st
-|> drop col.i1
--- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
-{
-  "errorClass" : "PARSE_SYNTAX_ERROR",
-  "sqlState" : "42601",
-  "messageParameters" : {
-    "error" : "'.'",
-    "hint" : ""
-  }
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
@@ -1109,6 +1109,46 @@ Project [x#x, named_struct(i2, col#x.i2) AS col#x]
 
 
 -- !query
+table st
+|> drop col.i1, col.i2
+-- !query analysis
+Project [x#x, named_struct() AS col#x]
++- SubqueryAlias spark_catalog.default.st
+   +- Relation spark_catalog.default.st[x#x,col#x] parquet
+
+
+-- !query
+table t
+|> as u
+|> drop u.x
+-- !query analysis
+Project [y#x]
++- SubqueryAlias u
+   +- SubqueryAlias spark_catalog.default.t
+      +- Relation spark_catalog.default.t[x#x,y#x] csv
+
+
+-- !query
+select 1 as x, named_struct('x', 2, 'y', 3) as col
+|> as col
+|> drop col.x
+-- !query analysis
+Project [col#x]
++- SubqueryAlias col
+   +- Project [1 AS x#x, named_struct(x, 2, y, 3) AS col#x]
+      +- OneRowRelation
+
+
+-- !query
+select 1 as x, named_struct('middle', named_struct('inner', 2)) as outer
+|> drop outer.middle.inner
+-- !query analysis
+Project [x#x, named_struct(middle, named_struct()) AS outer#x]
++- Project [1 AS x#x, named_struct(middle, named_struct(inner, 2)) AS outer#x]
+   +- OneRowRelation
+
+
+-- !query
 table t
 |> drop z
 -- !query analysis
@@ -1126,6 +1166,28 @@ org.apache.spark.sql.AnalysisException
     "startIndex" : 1,
     "stopIndex" : 17,
     "fragment" : "table t\n|> drop z"
+  } ]
+}
+
+
+-- !query
+table st
+|> drop col.nonexistent
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "FIELD_NOT_FOUND",
+  "sqlState" : "42704",
+  "messageParameters" : {
+    "fieldName" : "`nonexistent`",
+    "fields" : "`i1`, `i2`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 32,
+    "fragment" : "table st\n|> drop col.nonexistent"
   } ]
 }
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
@@ -1103,7 +1103,7 @@ Project [x#x, y#x]
 table st
 |> drop col.i1
 -- !query analysis
-Project [x#x, update_fields(col#x, dropfield(), i1) AS col#x]
+Project [x#x, named_struct(i2, col#x.i2) AS col#x]
 +- SubqueryAlias spark_catalog.default.st
    +- Relation spark_catalog.default.st[x#x,col#x] parquet
 

--- a/sql/core/src/test/resources/sql-tests/inputs/pipe-operators.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/pipe-operators.sql
@@ -401,6 +401,10 @@ table t
 |> extend 1 as `x.y.z`
 |> drop `x.y.z`;
 
+-- Dropping a struct field using qualified name.
+table st
+|> drop col.i1;
+
 -- DROP operators: negative tests.
 ----------------------------------
 
@@ -408,10 +412,7 @@ table t
 table t
 |> drop z;
 
--- Attempting to drop a struct field.
-table st
-|> drop col.i1;
-
+-- Attempting to drop a column using a backquoted name with dot (looks for a literal column name).
 table st
 |> drop `col.i1`;
 

--- a/sql/core/src/test/resources/sql-tests/inputs/pipe-operators.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/pipe-operators.sql
@@ -405,12 +405,36 @@ table t
 table st
 |> drop col.i1;
 
+-- Dropping multiple struct fields using qualified names.
+table st
+|> drop col.i1, col.i2;
+
+-- Dropping a column using table alias qualified name.
+table t
+|> as u
+|> drop u.x;
+
+-- Dropping a column when the table has a column with the same name as the alias.
+-- This tests the ambiguity: is col.x dropping field x from struct column col,
+-- or dropping column x from table alias col?
+select 1 as x, named_struct('x', 2, 'y', 3) as col
+|> as col
+|> drop col.x;
+
+-- Multi-level nested struct field drop.
+select 1 as x, named_struct('middle', named_struct('inner', 2)) as outer
+|> drop outer.middle.inner;
+
 -- DROP operators: negative tests.
 ----------------------------------
 
 -- Dropping a column that is not present in the input relation.
 table t
 |> drop z;
+
+-- Dropping a non-existent qualified path (struct field that doesn't exist).
+table st
+|> drop col.nonexistent;
 
 -- Attempting to drop a column using a backquoted name with dot (looks for a literal column name).
 table st

--- a/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
@@ -1022,6 +1022,15 @@ struct<x:int,y:string>
 
 
 -- !query
+table st
+|> drop col.i1
+-- !query schema
+struct<x:int,col:struct<i2:int>>
+-- !query output
+1	{"i2":3}
+
+
+-- !query
 table t
 |> drop z
 -- !query schema
@@ -1042,23 +1051,6 @@ org.apache.spark.sql.AnalysisException
     "stopIndex" : 17,
     "fragment" : "table t\n|> drop z"
   } ]
-}
-
-
--- !query
-table st
-|> drop col.i1
--- !query schema
-struct<>
--- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
-{
-  "errorClass" : "PARSE_SYNTAX_ERROR",
-  "sqlState" : "42601",
-  "messageParameters" : {
-    "error" : "'.'",
-    "hint" : ""
-  }
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
@@ -1031,6 +1031,45 @@ struct<x:int,col:struct<i2:int>>
 
 
 -- !query
+table st
+|> drop col.i1, col.i2
+-- !query schema
+struct<x:int,col:struct<>>
+-- !query output
+1	{}
+
+
+-- !query
+table t
+|> as u
+|> drop u.x
+-- !query schema
+struct<y:string>
+-- !query output
+abc
+def
+
+
+-- !query
+select 1 as x, named_struct('x', 2, 'y', 3) as col
+|> as col
+|> drop col.x
+-- !query schema
+struct<col:struct<x:int,y:int>>
+-- !query output
+{"x":2,"y":3}
+
+
+-- !query
+select 1 as x, named_struct('middle', named_struct('inner', 2)) as outer
+|> drop outer.middle.inner
+-- !query schema
+struct<x:int,outer:struct<middle:struct<>>>
+-- !query output
+1	{"middle":{}}
+
+
+-- !query
 table t
 |> drop z
 -- !query schema
@@ -1050,6 +1089,30 @@ org.apache.spark.sql.AnalysisException
     "startIndex" : 1,
     "stopIndex" : 17,
     "fragment" : "table t\n|> drop z"
+  } ]
+}
+
+
+-- !query
+table st
+|> drop col.nonexistent
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "FIELD_NOT_FOUND",
+  "sqlState" : "42704",
+  "messageParameters" : {
+    "fieldName" : "`nonexistent`",
+    "fields" : "`i1`, `i2`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 32,
+    "fragment" : "table st\n|> drop col.nonexistent"
   } ]
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR enables the pipe syntax DROP operator to support qualified column names, allowing users to drop nested struct fields and use table-alias-qualified column references.


### Why are the changes needed?

The DROP operator was inconsistent with other pipe operators (SELECT, WHERE, EXTEND) that already support qualified names. Users could not:
Drop nested struct fields: |> DROP col.field
Drop columns using table alias: |> AS t |> DROP t.column
This limitation reduced the usefulness of pipe syntax when working with nested data structures.

### Does this PR introduce _any_ user-facing change?

Yes. Users can now use qualified column names with the DROP pipe operator.

Before (fails):
```
>>> spark.sql("""
...   CREATE OR REPLACE TEMP VIEW st AS 
...   SELECT 1 as x, named_struct('i1', 2, 'i2', 3) as col
... """)
DataFrame[]

>>> spark.sql("""
...   TABLE st
...   |> DROP col.i1
... """)
```
ParseException: [PARSE_SYNTAX_ERROR] Syntax error at or near '.'

After (works):
```
>>> spark.sql("""
...   CREATE OR REPLACE TEMP VIEW st AS 
...   SELECT 1 as x, named_struct('i1', 2, 'i2', 3) as col
... """)
DataFrame[]

>>> spark.sql("""
...   TABLE st
...   |> DROP col.i1
... """).show()
+---+--------+
|  x|     col|
+---+--------+
|  1|{i2: 3} |
+---+--------+
```

### How was this patch tested?

Test 1:
Updated SQL test cases in pipe-operators.sql with positive test for dropping struct fields using qualified names
Updated expected results in pipe-operators.sql.out and analyzer-results/pipe-operators.sql.out

### Was this patch authored or co-authored using generative AI tooling?
No
