### PR TITLE
[SPARK-54916][K8S][BUILD] Enable `volcano` profile by default

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -265,6 +265,8 @@ io.fabric8:kubernetes-model-rbac
 io.fabric8:kubernetes-model-resource
 io.fabric8:kubernetes-model-scheduling
 io.fabric8:kubernetes-model-storageclass
+io.fabric8:volcano-client
+io.fabric8:volcano-model
 io.fabric8:zjsonpatch
 io.github.java-diff-utils:java-diff-utils
 io.jsonwebtoken:jjwt-api

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -285,6 +285,8 @@ vertx-auth-common/4.5.14//vertx-auth-common-4.5.14.jar
 vertx-core/4.5.14//vertx-core-4.5.14.jar
 vertx-web-client/4.5.14//vertx-web-client-4.5.14.jar
 vertx-web-common/4.5.14//vertx-web-common-4.5.14.jar
+volcano-client/7.4.0//volcano-client-7.4.0.jar
+volcano-model/7.4.0//volcano-model-7.4.0.jar
 wildfly-openssl/2.2.5.Final//wildfly-openssl-2.2.5.Final.jar
 xbean-asm9-shaded/4.28//xbean-asm9-shaded-4.28.jar
 xmlschema-core/2.3.1//xmlschema-core-2.3.1.jar

--- a/resource-managers/kubernetes/core/pom.xml
+++ b/resource-managers/kubernetes/core/pom.xml
@@ -34,6 +34,9 @@
   <profiles>
     <profile>
       <id>volcano</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <dependencies>
         <dependency>
           <groupId>io.fabric8</groupId>

--- a/resource-managers/kubernetes/integration-tests/pom.xml
+++ b/resource-managers/kubernetes/integration-tests/pom.xml
@@ -197,6 +197,9 @@
   <profiles>
     <profile>
       <id>volcano</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <dependencies>
         <dependency>
           <groupId>io.fabric8</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `volcano` profile by default for Apache Spark 4.2.0.

### Why are the changes needed?

`Volcano` scheduler has been supported experimentally since Apache Spark 3.3.0 and stably since 3.4.0.
- #35422
- #40152

This helps volcano users.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs and manually build.

```
$ dev/make-distribution.sh -Pkubernetes

$ jar tvf dist/jars/spark-kubernetes_2.13-4.2.0-SNAPSHOT.jar | grep Volcano
  1059 Sat Mar 15 11:45:26 KST 2025 org/apache/spark/deploy/k8s/features/VolcanoFeatureStep$.class
 19891 Sat Mar 15 11:45:26 KST 2025 org/apache/spark/deploy/k8s/features/VolcanoFeatureStep.class

$ ls -al dist/jars/volcano-*
-rw-r--r--@ 1 dongjoon  staff   10108 Jan  6 20:51 dist/jars/volcano-client-7.4.0.jar
-rw-r--r--@ 1 dongjoon  staff  547522 Jan  6 20:51 dist/jars/volcano-model-7.4.0.jar
```

### Was this patch authored or co-authored using generative AI tooling?

No.