### PR TITLE
[SPARK-54920] [SQL] Move grouping analytics extraction logic to a common `GroupingAnalyticsExtractor`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/GroupingAnalyticsExtractor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/GroupingAnalyticsExtractor.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+/**
+ * Extracts and processes grouping expressions from GROUP BY clauses that may contain
+ * grouping analytics operations (GROUPING SETS, ROLLUP, CUBE).
+ *
+ * This object analyzes a sequence of expressions to compute:
+ *  1. The cartesian product of selected group-by expressions from all grouping sets
+ *  2. A distinct list of all group-by expressions used across all grouping sets
+ */
+object GroupingAnalyticsExtractor {
+
+  def apply(expressions: Seq[Expression]): Option[(Seq[Seq[Expression]], Seq[Expression])] = {
+    val groups = expressions.flatMap {
+      case baseGroupingSets: BaseGroupingSets => baseGroupingSets.groupByExprs
+      case other: Expression => other :: Nil
+    }
+
+    val unmergedSelectedGroupByExprs = expressions.map {
+      case baseGroupingSets: BaseGroupingSets => baseGroupingSets.selectedGroupByExprs
+      case other: Expression => Seq(Seq(other))
+    }
+
+    val selectedGroupByExprs = unmergedSelectedGroupByExprs.tail
+      .foldLeft(unmergedSelectedGroupByExprs.head) { (x, y) =>
+        for (a <- x; b <- y) yield a ++ b
+      }
+
+    Some((selectedGroupByExprs, BaseGroupingSets.distinctGroupByExprs(groups)))
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/grouping.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/grouping.scala
@@ -282,19 +282,7 @@ object GroupingAnalytics extends AliasHelper {
       if (!resolved) {
         None
       } else {
-        val groups = exprsNoAlias.flatMap {
-          case gs: BaseGroupingSets => gs.groupByExprs
-          case other: Expression => other :: Nil
-        }
-        val unmergedSelectedGroupByExprs = exprsNoAlias.map {
-          case gs: BaseGroupingSets => gs.selectedGroupByExprs
-          case other: Expression => Seq(Seq(other))
-        }
-        val selectedGroupByExprs = unmergedSelectedGroupByExprs.tail
-          .foldLeft(unmergedSelectedGroupByExprs.head) { (x, y) =>
-            for (a <- x; b <- y) yield a ++ b
-          }
-        Some(selectedGroupByExprs, BaseGroupingSets.distinctGroupByExprs(groups))
+        GroupingAnalyticsExtractor(exprsNoAlias)
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Move grouping analytics extraction logic to a common `GroupingAnalyticsExtractor`.

### Why are the changes needed?
In order to reuse the code in the single-pass resolver implementation of grouping analytics resolution.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.