### PR TITLE
Prototype: support eager analysis inside Pipelines query functions

### DIFF
--- a/python/pyspark/pipelines/graph_element_registry.py
+++ b/python/pyspark/pipelines/graph_element_registry.py
@@ -51,6 +51,15 @@ class GraphElementRegistry(ABC):
         :param file_path: The path to the file that the SQL txt came from.
         """
 
+    @abstractmethod
+    def register_signalled_query_functions(self) -> None:
+        """Open up a stream to receive query function execution signals from the server.
+        When a signal is received, execute the corresponding query function and register the
+        result with the server.
+
+        This method should be called after all the flows and datasets have been registered.
+        """
+
 
 _graph_element_registry_context_var: ContextVar[Optional[GraphElementRegistry]] = ContextVar(
     "graph_element_registry_context", default=None

--- a/python/pyspark/pipelines/spark_connect_graph_element_registry.py
+++ b/python/pyspark/pipelines/spark_connect_graph_element_registry.py
@@ -52,6 +52,10 @@ class SparkConnectGraphElementRegistry(GraphElementRegistry):
         self._client_id = str(uuid.uuid4())
         self._query_funcs_by_flow_name: dict[str, QueryFunction] = {}
 
+    @property
+    def dataflow_graph_id(self) -> str:
+        return self._dataflow_graph_id
+
     def register_output(self, output: Output) -> None:
         table_details = None
         sink_details = None

--- a/python/pyspark/pipelines/spark_connect_graph_element_registry.py
+++ b/python/pyspark/pipelines/spark_connect_graph_element_registry.py
@@ -124,9 +124,7 @@ class SparkConnectGraphElementRegistry(GraphElementRegistry):
         try:
             df = self._execute_query_function(flow.name, flow.func)
         except PySparkException as e:
-            print("pizza: exception while executing query function")
             if e.getCondition() == "ATTEMPT_ANALYSIS_IN_PIPELINE_QUERY_FUNCTION":
-                print("pizza: exception is an analysis exception")
                 df = None
             else:
                 raise e
@@ -187,7 +185,6 @@ class SparkConnectGraphElementRegistry(GraphElementRegistry):
 
             signal = result["pipeline_query_function_execution_signal"]
             flow_names = signal.flow_names
-            print("pizza: received signal with flow names: ", flow_names)
             for flow_name in flow_names:
                 func = self._query_funcs_by_flow_name[flow_name]
                 df = self._execute_query_function(flow_name, func)

--- a/python/pyspark/pipelines/tests/python_pipeline_suite_helpers.py
+++ b/python/pyspark/pipelines/tests/python_pipeline_suite_helpers.py
@@ -1,0 +1,24 @@
+from pyspark.sql import SparkSession
+from pyspark import pipelines as dp
+from pyspark.pipelines.spark_connect_graph_element_registry import (
+    SparkConnectGraphElementRegistry,
+)
+from pyspark.pipelines.spark_connect_pipeline import create_dataflow_graph
+
+
+def setup(server_port: str, session_identifier: str) -> tuple[SparkSession, SparkConnectGraphElementRegistry]:
+    spark = SparkSession.builder \
+        .remote(f"sc://localhost:{server_port}") \
+        .config("spark.connect.grpc.channel.timeout", "5s") \
+        .config("spark.custom.identifier", session_identifier) \
+        .create()
+
+    dataflow_graph_id = create_dataflow_graph(
+        spark,
+        default_catalog=None,
+        default_database=None,
+        sql_conf={},
+    )
+
+    registry = SparkConnectGraphElementRegistry(spark, dataflow_graph_id)
+    return spark, registry

--- a/python/pyspark/pipelines/tests/python_pipeline_suite_helpers.py
+++ b/python/pyspark/pipelines/tests/python_pipeline_suite_helpers.py
@@ -4,7 +4,8 @@ from pyspark.pipelines.spark_connect_graph_element_registry import (
     SparkConnectGraphElementRegistry,
 )
 from pyspark.pipelines.spark_connect_pipeline import create_dataflow_graph
-
+from pyspark.pipelines.spark_connect_pipeline import start_run, handle_pipeline_events
+import threading
 
 def setup(server_port: str, session_identifier: str) -> tuple[SparkSession, SparkConnectGraphElementRegistry]:
     spark = SparkSession.builder \
@@ -22,3 +23,23 @@ def setup(server_port: str, session_identifier: str) -> tuple[SparkSession, Spar
 
     registry = SparkConnectGraphElementRegistry(spark, dataflow_graph_id)
     return spark, registry
+
+
+def run_and_handle_signals(
+    spark: SparkSession,
+    registry: SparkConnectGraphElementRegistry,
+    storage_root: str,
+) -> None:
+    result_iter = start_run(
+        spark,
+        dataflow_graph_id=registry.dataflow_graph_id,
+        full_refresh=None,
+        full_refresh_all=False,
+        refresh=None,
+        dry=True,
+        storage=storage_root
+    )
+    thread = threading.Thread(target=handle_pipeline_events, args=(result_iter,), daemon=True)
+    thread.start()
+
+    registry.register_signalled_query_functions()

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/DataflowGraphRegistry.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/DataflowGraphRegistry.scala
@@ -46,28 +46,23 @@ class DataflowGraphRegistry {
     graphId
   }
 
-  /** Retrieves the graph for a given id. */
-  def getDataflowGraph(graphId: String): Option[GraphRegistrationContext] = {
-    Option(dataflowGraphs.get(graphId))
+  /** Returns a Map of dataflow graph IDs to their corresponding GraphRegistrationContext. */
+  def getDataflowGraphs: Map[String, GraphRegistrationContext] = {
+    dataflowGraphs.asScala.toMap
   }
 
   /** Retrieves the graph for a given id, and throws if the id could not be found. */
   def getDataflowGraphOrThrow(dataflowGraphId: String): GraphRegistrationContext =
-    getDataflowGraph(dataflowGraphId).getOrElse {
+    getDataflowGraphs.getOrElse(dataflowGraphId, {
       throw new SparkException(
         errorClass = "DATAFLOW_GRAPH_NOT_FOUND",
         messageParameters = Map("graphId" -> dataflowGraphId),
         cause = null)
-    }
+    })
 
   /** Removes the graph with a given id from the registry. */
   def dropDataflowGraph(graphId: String): Unit = {
     dataflowGraphs.remove(graphId)
-  }
-
-  /** Returns all graphs in the registry. */
-  def getAllDataflowGraphs: Seq[GraphRegistrationContext] = {
-    dataflowGraphs.values().asScala.toSeq
   }
 
   /** Removes all graphs from the registry. */

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
@@ -378,7 +378,7 @@ private[connect] object PipelinesHandler extends Logging {
       }
 
     val relationFlowDetails = flow.getRelationFlowDetails
-    val flowFunction = if (relationFlowDetails.hasRelation()) {
+    val flowFunction = if (relationFlowDetails.hasRelation) {
       FlowAnalysis.createFlowFunctionFromLogicalPlan(
         transformRelationFunc(relationFlowDetails.getRelation))
     } else {
@@ -662,10 +662,12 @@ private[connect] object PipelinesHandler extends Logging {
           session
         )
       case None =>
-        throw new IllegalStateException(
-          s"Pipeline analysis context specifies flow '${pipelineAnalysisContext.getFlowName}' " +
-            s"but no active pipeline execution found for graph '$graphId'"
-        )
+        throw new AnalysisException("ATTEMPT_ANALYSIS_IN_PIPELINE_QUERY_FUNCTION", Map())
+        // TODO
+//        throw new IllegalStateException(
+//          s"Pipeline analysis context specifies flow '${pipelineAnalysisContext.getFlowName}' " +
+//            s"but no active pipeline execution found for graph '$graphId'"
+//        )
     }
   }
 }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
@@ -568,7 +568,7 @@ private[connect] object PipelinesHandler extends Logging {
         val graphAnalysisContext = execution.graphAnalysisContext
 
         try {
-          while (execution.executionStarted) {
+          while (execution.resolvedGraph.isEmpty) {
             val signal = proto.PipelineQueryFunctionExecutionSignal.newBuilder()
 
             while (!graphAnalysisContext.flowClientSignalQueue.isEmpty) {

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
@@ -326,7 +326,6 @@ private[connect] object PipelinesHandler extends Logging {
       flow: proto.PipelineCommand.DefineFlow,
       transformRelationFunc: Relation => LogicalPlan,
       sessionHolder: SessionHolder): TableIdentifier = {
-    logInfo("pizza defining flow")
     if (flow.hasOnce) {
       throw new AnalysisException(
         "DEFINE_FLOW_ONCE_OPTION_NOT_SUPPORTED",
@@ -451,19 +450,11 @@ private[connect] object PipelinesHandler extends Logging {
         cmd.getStorage)
       sessionHolder.cachePipelineExecution(dataflowGraphId, pipelineUpdateContext)
 
-      // scalastyle:off println
-      println(s"INSTRUMENTATION: Starting pipeline execution, dry=${cmd.getDry}")
-      // scalastyle:on println
-
       if (cmd.getDry) {
         pipelineUpdateContext.pipelineExecution.dryRunPipeline()
       } else {
         pipelineUpdateContext.pipelineExecution.runPipeline()
       }
-
-      // scalastyle:off println
-      println(s"INSTRUMENTATION: Pipeline execution completed")
-      // scalastyle:on println
 
       // Rethrow any exceptions that caused the pipeline run to fail so that the exception is
       // propagated back to the SC client / CLI.
@@ -598,10 +589,6 @@ private[connect] object PipelinesHandler extends Logging {
       var signalAttempts = 0
       val maxSignalAttempts = 600
 
-      // scalastyle:off println
-      println(s"INSTRUMENTATION: Starting signal loop")
-      // scalastyle:on println
-
       while (execution.resolvedGraph.isEmpty && signalAttempts < maxSignalAttempts) {
         val signal = proto.PipelineQueryFunctionExecutionSignal.newBuilder()
 
@@ -611,9 +598,6 @@ private[connect] object PipelinesHandler extends Logging {
         }
 
         if (signal.getFlowNamesCount > 0) {
-          // scalastyle:off println
-          println(s"INSTRUMENTATION: Sending signal for ${signal.getFlowNamesCount} flows")
-          // scalastyle:on println
           logInfo(s"Sending execution signal for ${signal.getFlowNamesCount} flows")
 
           val response = ExecutePlanResponse.newBuilder()
@@ -621,22 +605,13 @@ private[connect] object PipelinesHandler extends Logging {
             .build()
 
           responseObserver.onNext(response)
-          // scalastyle:off println
-          println(s"INSTRUMENTATION: Signal sent successfully")
-          // scalastyle:on println
         } else {
-          // scalastyle:off println
-          println(s"INSTRUMENTATION: No signals, attempt $signalAttempts")
           // scalastyle:on println
         }
 
         Thread.sleep(100)
         signalAttempts += 1
       }
-
-      // scalastyle:off println
-      println(s"INSTRUMENTATION: Exited signal loop, attempts=$signalAttempts")
-      // scalastyle:on println
 
       responseObserver.onCompleted()
       streamCompleted = true
@@ -685,9 +660,6 @@ private[connect] object PipelinesHandler extends Logging {
       case Some(pipelineUpdateContext) =>
         // TODO: what if we haven't yet started analysis?
         val graphAnalysisContext = pipelineUpdateContext.pipelineExecution.graphAnalysisContext
-        // scalastyle:off println
-        println(s"INSTRUMENTATION: markFlowPlanRegistered called for flow $flowIdentifier")
-        // scalastyle:on println
         graphAnalysisContext.markFlowPlanRegistered(flowIdentifier)
       case None =>
     }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/pipelines/PipelinesHandler.scala
@@ -326,6 +326,7 @@ private[connect] object PipelinesHandler extends Logging {
       flow: proto.PipelineCommand.DefineFlow,
       transformRelationFunc: Relation => LogicalPlan,
       sessionHolder: SessionHolder): TableIdentifier = {
+    logInfo("pizza defining flow")
     if (flow.hasOnce) {
       throw new AnalysisException(
         "DEFINE_FLOW_ONCE_OPTION_NOT_SUPPORTED",

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -332,6 +332,11 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
     // It is not called under SparkConnectSessionManager.sessionsLock, but it's guaranteed to be
     // called only once, since removing the session from SparkConnectSessionManager.sessionStore is
     // synchronized and guaranteed to happen only once.
+    // scalastyle:off println
+    println(s"INSTRUMENTATION: SessionHolder.close() called for session $sessionId")
+    println(s"INSTRUMENTATION: Called from: ${Thread.currentThread().getStackTrace.take(10).
+      mkString("\n")}")
+    // scalastyle:on println
     if (closedTimeMs.isDefined) {
       throw new IllegalStateException(s"Session $key is already closed.")
     }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -332,11 +332,6 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
     // It is not called under SparkConnectSessionManager.sessionsLock, but it's guaranteed to be
     // called only once, since removing the session from SparkConnectSessionManager.sessionStore is
     // synchronized and guaranteed to happen only once.
-    // scalastyle:off println
-    println(s"INSTRUMENTATION: SessionHolder.close() called for session $sessionId")
-    println(s"INSTRUMENTATION: Called from: ${Thread.currentThread().getStackTrace.take(10).
-      mkString("\n")}")
-    // scalastyle:on println
     if (closedTimeMs.isDefined) {
       throw new IllegalStateException(s"Session $key is already closed.")
     }
@@ -498,7 +493,6 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
   private[connect] def cachePipelineExecution(
       graphId: String,
       pipelineUpdateContext: PipelineUpdateContext): Unit = {
-    print("pizza: caching pipeline execution")
     pipelineExecutions.compute(
       graphId,
       (_, existing) => {

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -140,6 +140,7 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
   // Registry for dataflow graphs specific to this session
   private[connect] lazy val dataflowGraphRegistry = new DataflowGraphRegistry()
 
+
   // Handles Python process clean up for streaming queries. Initialized on first use in a query.
   private[connect] lazy val streamingForeachBatchRunnerCleanerCache =
     new StreamingForeachBatchHelper.CleanerCache(this)

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -493,6 +493,7 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
   private[connect] def cachePipelineExecution(
       graphId: String,
       pipelineUpdateContext: PipelineUpdateContext): Unit = {
+    print("pizza: caching pipeline execution")
     pipelineExecutions.compute(
       graphId,
       (_, existing) => {

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/SparkDeclarativePipelinesServerSuite.scala
@@ -321,7 +321,7 @@ class SparkDeclarativePipelinesServerSuite
             .build()))
 
       // Verify the graph exists in the default session
-      assert(getDefaultSessionHolder.dataflowGraphRegistry.getAllDataflowGraphs.size == 1)
+      assert(getDefaultSessionHolder.dataflowGraphRegistry.getDataflowGraphs.size == 1)
     }
 
     // Create a second session with different user/session ID
@@ -374,8 +374,8 @@ class SparkDeclarativePipelinesServerSuite
         .getIsolatedSession(SessionKey(newSessionUserId, newSessionId), None)
 
       val defaultSessionGraphs =
-        getDefaultSessionHolder.dataflowGraphRegistry.getAllDataflowGraphs
-      val newSessionGraphs = newSessionHolder.dataflowGraphRegistry.getAllDataflowGraphs
+        getDefaultSessionHolder.dataflowGraphRegistry.getDataflowGraphs.values
+      val newSessionGraphs = newSessionHolder.dataflowGraphRegistry.getDataflowGraphs.values
 
       assert(defaultSessionGraphs.size == 1)
       assert(newSessionGraphs.size == 1)
@@ -441,7 +441,7 @@ class SparkDeclarativePipelinesServerSuite
         .getIsolatedSessionIfPresent(SessionKey(testUserId, testSessionId))
         .get
 
-      val graphsBefore = sessionHolder.dataflowGraphRegistry.getAllDataflowGraphs
+      val graphsBefore = sessionHolder.dataflowGraphRegistry.getDataflowGraphs.values
       assert(graphsBefore.size == 1)
 
       // Close the session
@@ -453,7 +453,7 @@ class SparkDeclarativePipelinesServerSuite
 
       assert(sessionAfterClose.isEmpty, "Session should be cleaned up after close")
       // Verify the graph is removed
-      val graphsAfter = sessionHolder.dataflowGraphRegistry.getAllDataflowGraphs
+      val graphsAfter = sessionHolder.dataflowGraphRegistry.getDataflowGraphs.values
       assert(graphsAfter.isEmpty, "Graph should be removed after session close")
     }
   }
@@ -518,7 +518,7 @@ class SparkDeclarativePipelinesServerSuite
 
       // Verify the graph exists
       val sessionHolder = getDefaultSessionHolder
-      val graphsBefore = sessionHolder.dataflowGraphRegistry.getAllDataflowGraphs
+      val graphsBefore = sessionHolder.dataflowGraphRegistry.getDataflowGraphs.values
       assert(graphsBefore.size == 1)
 
       // Drop the graph
@@ -532,7 +532,7 @@ class SparkDeclarativePipelinesServerSuite
             .build()))
 
       // Verify the graph is removed
-      val graphsAfter = sessionHolder.dataflowGraphRegistry.getAllDataflowGraphs
+      val graphsAfter = sessionHolder.dataflowGraphRegistry.getDataflowGraphs.values
       assert(graphsAfter.isEmpty, "Graph should be removed after drop")
     }
   }

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/CoreDataflowNodeProcessor.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/CoreDataflowNodeProcessor.scala
@@ -40,9 +40,6 @@ class CoreDataflowNodeProcessor(rawGraph: DataflowGraph, context: GraphAnalysisC
       context.resolvedInputsByIdentifier
     )
     context.resolvedFlowsQueue.add(resolvedFlow)
-    // scalastyle:off println
-    println(s"INSTRUMENTATION: Adding resolved flow ${flow.identifier} to resolvedFlowsMap")
-    // scalastyle:on println
     context.resolvedFlowsMap.put(flow.identifier, resolvedFlow)
     resolvedFlow
   }

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/CoreDataflowNodeProcessor.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/CoreDataflowNodeProcessor.scala
@@ -40,6 +40,9 @@ class CoreDataflowNodeProcessor(rawGraph: DataflowGraph, context: GraphAnalysisC
       context.resolvedInputsByIdentifier
     )
     context.resolvedFlowsQueue.add(resolvedFlow)
+    // scalastyle:off println
+    println(s"INSTRUMENTATION: Adding resolved flow ${flow.identifier} to resolvedFlowsMap")
+    // scalastyle:on println
     context.resolvedFlowsMap.put(flow.identifier, resolvedFlow)
     resolvedFlow
   }

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DataflowGraph.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DataflowGraph.scala
@@ -228,14 +228,16 @@ case class DataflowGraph(
   def resolved: Boolean =
     flows.forall(f => resolvedFlow.contains(f.identifier))
 
-  def resolve(): DataflowGraph =
+  def resolve(contextOpt: Option[GraphAnalysisContext] = None): DataflowGraph = {
+    val context = contextOpt.getOrElse(new GraphAnalysisContext())
     DataflowGraphTransformer.withDataflowGraphTransformer(this) { transformer =>
       val coreDataflowNodeProcessor =
-        new CoreDataflowNodeProcessor(rawGraph = this)
+        new CoreDataflowNodeProcessor(rawGraph = this, context)
       transformer
-        .transformDownNodes(coreDataflowNodeProcessor.processNode)
+        .transformDownNodes(coreDataflowNodeProcessor.processNode, context)
         .getDataflowGraph
     }
+  }
 }
 
 object DataflowGraph {

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DataflowGraphTransformer.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DataflowGraphTransformer.scala
@@ -122,9 +122,6 @@ class DataflowGraphTransformer(graph: DataflowGraph) extends AutoCloseable {
       transformer: (GraphElement, Seq[GraphElement]) => Seq[GraphElement],
       context: GraphAnalysisContext,
       disableParallelism: Boolean = false): DataflowGraphTransformer = {
-    // scalastyle:off println
-    println("INSTRUMENTATION: transformDownNodes starting")
-    // scalastyle:on println
     val executor = if (disableParallelism) selfExecutor else fixedPoolExecutor
     val batchSize = if (disableParallelism) 1 else parallelism
 
@@ -135,11 +132,6 @@ class DataflowGraphTransformer(graph: DataflowGraph) extends AutoCloseable {
       futures.nonEmpty ||
         context.toBeResolvedFlows.peekFirst() != null ||
         !context.failedUnregisteredFlows.isEmpty) {
-      // scalastyle:off println
-      println("INSTRUMENTATION: transformDownNodes iteration")
-      println(s"INSTRUMENTATION: toBeResolvedFlows.size = ${context.toBeResolvedFlows.size}")
-      println(s"INSTRUMENTATION: failedUnregistered.size = ${context.failedUnregisteredFlows.size}")
-      // scalastyle:on println
       val (done, notDone) = futures.partition(_.isDone)
       // Explicitly call future.get() to propagate exceptions one by one if any
       try {
@@ -167,9 +159,6 @@ class DataflowGraphTransformer(graph: DataflowGraph) extends AutoCloseable {
       }
     }
 
-    // scalastyle:off println
-    println("INSTRUMENTATION: transformDownNodes - exited main while loop")
-    // scalastyle:on println
 
     // Mutate the fail analysis entities
     // A table is failed to analyze if:
@@ -212,8 +201,6 @@ class DataflowGraphTransformer(graph: DataflowGraph) extends AutoCloseable {
     tableMap = computeTableMap()
     viewMap = computeViewMap()
     sinkMap = computeSinkMap()
-    // scalastyle:off println
-    println("pizza: completed transformDownNodes")
     // scalastyle: on
     this
   }
@@ -230,9 +217,6 @@ class DataflowGraphTransformer(graph: DataflowGraph) extends AutoCloseable {
         case e: TransformNodeRetryableException =>
           e.datasetIdentifier match {
             case None =>
-              // scalastyle:off println
-              println(s"INSTRUMENTATION: Adding flow ${e.failedNode.identifier} to unregistered")
-              // scalastyle:on println
               context.failedUnregisteredFlows.put(e.failedNode.identifier, e.failedNode)
             case Some(datasetIdentifier) =>
               context.registerFailedDependentFlow(datasetIdentifier, e.failedNode)
@@ -250,9 +234,6 @@ class DataflowGraphTransformer(graph: DataflowGraph) extends AutoCloseable {
                       (_, toRetryFlows) => {
                         toRetryFlows.foreach { f =>
                           if (context.failedUnregisteredFlows.containsKey(f.identifier)) {
-                            // scalastyle:off println
-                            println(s"INSTRUMENTATION: Adding signal for ${f.identifier}")
-                            // scalastyle:on println
                             context.flowClientSignalQueue.add(f.identifier)
                           } else {
                             context.toBeResolvedFlows.addFirst(f)
@@ -329,9 +310,6 @@ class DataflowGraphTransformer(graph: DataflowGraph) extends AutoCloseable {
                 (_, toRetryFlows) => {
                   toRetryFlows.foreach { f =>
                     if (context.failedUnregisteredFlows.containsKey(f.identifier)) {
-                      // scalastyle:off println
-                      println(s"INSTRUMENTATION: Adding signal for ${f.identifier} (location 2)")
-                      // scalastyle:on println
                       context.flowClientSignalQueue.add(f.identifier)
                     } else {
                       context.toBeResolvedFlows.addFirst(f)

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/Flow.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/Flow.scala
@@ -120,6 +120,23 @@ case class FlowFunctionResult(
   final def resolved: Boolean = failure.isEmpty // don't override this, override failure
 }
 
+object FlowFunctionResult {
+  def fromFlowAnalysisContext(
+      ctx: FlowAnalysisContext,
+      df: Try[DataFrame],
+      confs: Map[String, String]): FlowFunctionResult = {
+    FlowFunctionResult(
+      requestedInputs = ctx.requestedInputs.toSet,
+      batchInputs = ctx.batchInputs.toSet,
+      streamingInputs = ctx.streamingInputs.toSet,
+      usedExternalInputs = ctx.externalInputs.toSet,
+      dataFrame = df,
+      sqlConf = confs,
+      analysisWarnings = ctx.analysisWarnings.toList
+    )
+  }
+}
+
 /** A [[Flow]] whose output schema and dependencies aren't known. */
 case class UnresolvedFlow(
     identifier: TableIdentifier,

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphAnalysisContext.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphAnalysisContext.scala
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.pipelines.graph
+
+import java.util.concurrent.{ConcurrentHashMap, ConcurrentLinkedDeque, ConcurrentLinkedQueue}
+
+import scala.jdk.CollectionConverters.ConcurrentMapHasAsScala
+import scala.util.Failure
+
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.classic.{DataFrame, SparkSession}
+
+class GraphAnalysisContext {
+  val toBeResolvedFlows = new ConcurrentLinkedDeque[Flow]()
+
+  // Map of input identifier to resolved [[Input]].
+  private val resolvedInputsHashMap = new ConcurrentHashMap[TableIdentifier, Input]()
+
+  // Destination identifier to boolean indicating whether the destination has been resolved
+  val resolvedFlowDestinationsMap = new ConcurrentHashMap[TableIdentifier, Boolean]()
+
+  // Map & queue of resolved flows identifiers
+  // queue is there to track the topological order while map is used to store the id -> flow
+  // mapping
+  val resolvedFlowsMap = new ConcurrentHashMap[TableIdentifier, ResolvedFlow]()
+  val resolvedFlowsQueue = new ConcurrentLinkedQueue[ResolvedFlow]()
+
+  // List of resolved tables, sinks and flows
+  val resolvedTables = new ConcurrentLinkedQueue[Table]()
+  val resolvedViews = new ConcurrentLinkedQueue[View]()
+  val resolvedSinks = new ConcurrentLinkedQueue[Sink]()
+
+  // Flows that failed due to the client not yet having registered a plan. Keyed by flow identifier.
+  val failedUnregisteredFlows = new ConcurrentHashMap[TableIdentifier, ResolutionFailedFlow]()
+
+  // Dataset identifier to list of flows that failed resolution due to missing this dataset
+  val failedDependentFlows = new ConcurrentHashMap[TableIdentifier, Seq[ResolutionFailedFlow]]()
+  val failedFlowsQueue = new ConcurrentLinkedQueue[ResolutionFailedFlow]()
+
+  // Queue of flow identifiers that have had their upstream inputs resolved and should have their
+  // flow function retried on the client
+  val flowClientSignalQueue = new ConcurrentLinkedQueue[TableIdentifier]()
+
+  def putResolvedInput(input: Input): Unit = {
+    resolvedInputsHashMap.put(input.identifier, input)
+  }
+
+  def resolvedInputsByIdentifier: Map[TableIdentifier, Input] = resolvedInputsHashMap.asScala.toMap
+
+  def registerFailedDependentFlow(
+      inputDatasetIdentifier: TableIdentifier,
+      failedFlow: ResolutionFailedFlow): Unit = {
+    failedDependentFlows.compute(
+      inputDatasetIdentifier,
+      (_, flows) => {
+        if (flows == null) {
+          Seq(failedFlow)
+        } else {
+          flows :+ failedFlow
+        }
+      }
+    )
+  }
+
+  def markFlowPlanRegistered(flowIdentifier: TableIdentifier): Unit = {
+    val flow = failedUnregisteredFlows.remove(flowIdentifier)
+    // Flow could be null if it failed on the client side and we never tried to execute the flow
+    // function on the server side.
+    if (flow != null) {
+      toBeResolvedFlows.addFirst(flow)
+    }
+  }
+
+  def analyze(
+      flowIdentifier: TableIdentifier,
+      logicalPlan: LogicalPlan,
+      unresolvedGraph: DataflowGraph,
+      session: SparkSession): DataFrame = {
+    val unresolvedFlow = unresolvedGraph.flow(flowIdentifier).asInstanceOf[UnresolvedFlow]
+    val flowAnalysisContext = FlowAnalysisContext(
+      allInputs = unresolvedGraph.inputIdentifiers,
+      availableInputs = resolvedInputsByIdentifier.values.toSeq,
+      queryContext = unresolvedFlow.queryContext,
+      spark = session
+    )
+
+    try {
+      FlowAnalysis.analyze(flowAnalysisContext, plan = logicalPlan)
+    } catch {
+      case e: UnresolvedDatasetException =>
+        val flowFunctionResult =
+          FlowFunctionResult.fromFlowAnalysisContext(flowAnalysisContext, Failure(e), Map.empty)
+
+        val resolutionFailedFlow = new ResolutionFailedFlow(unresolvedFlow, flowFunctionResult)
+        registerFailedDependentFlow(e.identifier, resolutionFailedFlow)
+        throw e
+    }
+  }
+}

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphAnalysisContext.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphAnalysisContext.scala
@@ -78,22 +78,12 @@ class GraphAnalysisContext {
   }
 
   def markFlowPlanRegistered(flowIdentifier: TableIdentifier): Unit = {
-    // scalastyle:off println
-    println(s"INSTRUMENTATION: markFlowPlanRegistered - looking for flow $flowIdentifier")
-    println(s"INSTRUMENTATION: failedUnregisteredFlows size: ${failedUnregisteredFlows.size()}")
-    // scalastyle:on println
     val flow = failedUnregisteredFlows.remove(flowIdentifier)
     // Flow could be null if it failed on the client side and we never tried to execute the flow
     // function on the server side.
     if (flow != null) {
-      // scalastyle:off println
-      println(s"INSTRUMENTATION: Found flow $flowIdentifier, adding to toBeResolvedFlows queue")
-      // scalastyle:on println
       toBeResolvedFlows.addFirst(flow)
     } else {
-      // scalastyle:off println
-      println(s"INSTRUMENTATION: Flow $flowIdentifier not found in failedUnregisteredFlows")
-      // scalastyle:on println
     }
   }
 

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphAnalysisContext.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/GraphAnalysisContext.scala
@@ -78,11 +78,22 @@ class GraphAnalysisContext {
   }
 
   def markFlowPlanRegistered(flowIdentifier: TableIdentifier): Unit = {
+    // scalastyle:off println
+    println(s"INSTRUMENTATION: markFlowPlanRegistered - looking for flow $flowIdentifier")
+    println(s"INSTRUMENTATION: failedUnregisteredFlows size: ${failedUnregisteredFlows.size()}")
+    // scalastyle:on println
     val flow = failedUnregisteredFlows.remove(flowIdentifier)
     // Flow could be null if it failed on the client side and we never tried to execute the flow
     // function on the server side.
     if (flow != null) {
+      // scalastyle:off println
+      println(s"INSTRUMENTATION: Found flow $flowIdentifier, adding to toBeResolvedFlows queue")
+      // scalastyle:on println
       toBeResolvedFlows.addFirst(flow)
+    } else {
+      // scalastyle:off println
+      println(s"INSTRUMENTATION: Flow $flowIdentifier not found in failedUnregisteredFlows")
+      // scalastyle:on println
     }
   }
 

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/PipelineExecution.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/PipelineExecution.scala
@@ -89,13 +89,7 @@ class PipelineExecution(context: PipelineUpdateContext) {
 
   /** Validates that the pipeline graph can be successfully resolved and validates it. */
   def dryRunPipeline(): Unit = synchronized {
-    // scalastyle:off println
-    println("INSTRUMENTATION: dryRunPipeline() starting")
-    // scalastyle:on println
     resolvedGraph = Some(resolveGraph())
-    // scalastyle:off println
-    println("INSTRUMENTATION: dryRunPipeline() - resolveGraph completed")
-    // scalastyle:on println
     context.eventCallback(
       constructTerminationEvent(RunCompletion())
     )
@@ -118,14 +112,8 @@ class PipelineExecution(context: PipelineUpdateContext) {
   }
 
   def resolveGraph(): DataflowGraph = {
-    // scalastyle:off println
-    println("INSTRUMENTATION: resolveGraph() starting")
-    // scalastyle:on println
     try {
       val resolved = context.unresolvedGraph.resolve(Some(graphAnalysisContext)).validate()
-      // scalastyle:off println
-      println("INSTRUMENTATION: resolveGraph() completed successfully")
-      // scalastyle:on println
       resolved
     } catch {
       case e: UnresolvedPipelineException =>

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/PipelineExecution.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/PipelineExecution.scala
@@ -109,7 +109,7 @@ class PipelineExecution(context: PipelineUpdateContext) {
     )
   }
 
-  private def resolveGraph(): DataflowGraph = {
+  def resolveGraph(): DataflowGraph = {
     try {
       context.unresolvedGraph.resolve(Some(graphAnalysisContext)).validate()
     } catch {

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/PipelineExecution.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/PipelineExecution.scala
@@ -89,7 +89,13 @@ class PipelineExecution(context: PipelineUpdateContext) {
 
   /** Validates that the pipeline graph can be successfully resolved and validates it. */
   def dryRunPipeline(): Unit = synchronized {
+    // scalastyle:off println
+    println("INSTRUMENTATION: dryRunPipeline() starting")
+    // scalastyle:on println
     resolvedGraph = Some(resolveGraph())
+    // scalastyle:off println
+    println("INSTRUMENTATION: dryRunPipeline() - resolveGraph completed")
+    // scalastyle:on println
     context.eventCallback(
       constructTerminationEvent(RunCompletion())
     )
@@ -112,8 +118,15 @@ class PipelineExecution(context: PipelineUpdateContext) {
   }
 
   def resolveGraph(): DataflowGraph = {
+    // scalastyle:off println
+    println("INSTRUMENTATION: resolveGraph() starting")
+    // scalastyle:on println
     try {
-      context.unresolvedGraph.resolve(Some(graphAnalysisContext)).validate()
+      val resolved = context.unresolvedGraph.resolve(Some(graphAnalysisContext)).validate()
+      // scalastyle:off println
+      println("INSTRUMENTATION: resolveGraph() completed successfully")
+      // scalastyle:on println
+      resolved
     } catch {
       case e: UnresolvedPipelineException =>
         handleInvalidPipeline(e)

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/PipelineExecution.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/PipelineExecution.scala
@@ -35,7 +35,9 @@ import org.apache.spark.sql.pipelines.logging.{
 class PipelineExecution(context: PipelineUpdateContext) {
 
   /** [Visible for testing] */
-  private[pipelines] var graphExecution: Option[TriggeredGraphExecution] = None
+  @volatile private[pipelines] var graphExecution: Option[TriggeredGraphExecution] = None
+  /** [Visible for testing] */
+  @volatile var resolvedGraph: Option[DataflowGraph] = None
   val graphAnalysisContext = new GraphAnalysisContext()
 
   def executionStarted: Boolean = synchronized { graphExecution.nonEmpty }
@@ -46,12 +48,12 @@ class PipelineExecution(context: PipelineUpdateContext) {
    */
   def startPipeline(): Unit = synchronized {
     // Initialize the graph.
-    val resolvedGraph = resolveGraph()
+    resolvedGraph = Some(resolveGraph())
     if (context.fullRefreshTables.nonEmpty) {
-      State.reset(resolvedGraph, context)
+      State.reset(resolvedGraph.get, context)
     }
 
-    val initializedGraph = DatasetManager.materializeDatasets(resolvedGraph, context)
+    val initializedGraph = DatasetManager.materializeDatasets(resolvedGraph.get, context)
 
     // Execute the graph.
     graphExecution = Some(
@@ -87,7 +89,7 @@ class PipelineExecution(context: PipelineUpdateContext) {
 
   /** Validates that the pipeline graph can be successfully resolved and validates it. */
   def dryRunPipeline(): Unit = synchronized {
-    resolveGraph()
+    resolvedGraph = Some(resolveGraph())
     context.eventCallback(
       constructTerminationEvent(RunCompletion())
     )

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/PipelineExecution.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/PipelineExecution.scala
@@ -36,6 +36,7 @@ class PipelineExecution(context: PipelineUpdateContext) {
 
   /** [Visible for testing] */
   private[pipelines] var graphExecution: Option[TriggeredGraphExecution] = None
+  val graphAnalysisContext = new GraphAnalysisContext()
 
   def executionStarted: Boolean = synchronized { graphExecution.nonEmpty }
 
@@ -110,7 +111,7 @@ class PipelineExecution(context: PipelineUpdateContext) {
 
   private def resolveGraph(): DataflowGraph = {
     try {
-      context.unresolvedGraph.resolve().validate()
+      context.unresolvedGraph.resolve(Some(graphAnalysisContext)).validate()
     } catch {
       case e: UnresolvedPipelineException =>
         handleInvalidPipeline(e)

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/PipelinesErrors.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/PipelinesErrors.scala
@@ -35,6 +35,12 @@ case class UnresolvedDatasetException(identifier: TableIdentifier)
       s"pipeline but could not be resolved."
     )
 
+case class QueryFunctionResultNotAvailableException()
+    extends AnalysisException("Query function result is not yet available.")
+
+case class QueryFunctionTerminalFailureException()
+  extends AnalysisException("Query function failed in a way that further analysis won't fix.")
+
 /**
  * Exception raised when a flow fails to read from a table defined within the pipeline
  *

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/DistributedAnalysisSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/DistributedAnalysisSuite.scala
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.pipelines.graph
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.classic.SparkSession
+import org.apache.spark.sql.pipelines.utils.{PipelineTest, TestGraphRegistrationContext}
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * TODO
+ */
+class DistributedAnalysisSuite extends PipelineTest with SharedSparkSession {
+  case class DummyFlowInfo(
+      destinationTable: String,
+      eagerDeps: Seq[String] = Seq.empty,
+      lazyDeps: Seq[String] = Seq.empty,
+      failsTerminally: Boolean = false
+  ) {
+    val flowName: String = destinationTable.replace("table", "flow")
+
+    def register(registrationContext: TestGraphRegistrationContext): Unit = {
+      val flowFunction = if (eagerDeps.nonEmpty) {
+        FlowAnalysis.createQueryFunctionResultPollingFlowFunction(
+          fullyQualifiedIdentifier(flowName),
+          registrationContext
+        )
+      } else {
+        val plan = if (lazyDeps.nonEmpty) {
+          spark.sessionState.sqlParser
+            .parsePlan(eagerDeps.map(t => s"select * from $t").mkString(" union "))
+        } else {
+          spark.range(4).logicalPlan
+        }
+        FlowAnalysis.createFlowFunctionFromLogicalPlan(plan)
+      }
+      registrationContext.registerFlow(destinationTable, flowName, flowFunction)
+    }
+  }
+
+  class TestDistributedAnalyzer(val dummyFlows: Seq[DummyFlowInfo], val spark: SparkSession) {
+    val registrationContext = new TestGraphRegistrationContext(spark)
+    dummyFlows.foreach { f =>
+      f.register(registrationContext)
+      registrationContext.registerTable(f.destinationTable)
+    }
+    private val dummyFlowsById = dummyFlows.map { f =>
+      (fullyQualifiedIdentifier(f.flowName), f)
+    }.toMap
+
+    val unresolvedGraph: DataflowGraph = registrationContext.toDataflowGraph
+    val analysisContext = new GraphAnalysisContext()
+    unresolvedGraph.flows.foreach(analysisContext.toBeResolvedFlows.add)
+    val transformer = new DataflowGraphTransformer(unresolvedGraph)
+
+    val nodeProcessor = new CoreDataflowNodeProcessor(unresolvedGraph, analysisContext)
+
+    // Signals received by the client, but not yet processed
+    val clientSignalQueue = new mutable.Queue[TableIdentifier]()
+
+    def transformerIteration(): Unit = {
+      Option(analysisContext.toBeResolvedFlows.pollFirst()).foreach { flow =>
+        transformer.transformFlowAndMaybeDestination(
+          flow,
+          nodeProcessor.processNode,
+          analysisContext
+        )
+      }
+    }
+
+    def analyze(flowIdentifier: TableIdentifier, plan: LogicalPlan): Unit = {
+      analysisContext.analyze(flowIdentifier, plan, unresolvedGraph, spark)
+    }
+
+    def registerQueryFunctionResult(
+        flowIdentifier: TableIdentifier,
+        result: QueryFunctionResult): Unit = {
+      registrationContext.registerQueryFunctionResult(flowIdentifier, result)
+      analysisContext.markFlowPlanRegistered(flowIdentifier)
+    }
+
+    def runToCompletion(randomSeed: Integer): Unit = {
+      val r = new scala.util.Random(randomSeed)
+
+      var numIters = 0
+      while (numIters < 200
+        && analysisContext.toBeResolvedFlows.isEmpty
+        && clientSignalQueue.isEmpty
+        && analysisContext.flowClientSignalQueue.isEmpty) {
+        numIters += 1
+
+        r.nextInt(3) match {
+          case 0 => transformerIteration()
+          case 1 => // Simulate the signal-sending RPC thread
+            if (!analysisContext.flowClientSignalQueue.isEmpty) {
+              val flowToRetryId = analysisContext.flowClientSignalQueue.poll()
+              dummyFlowsById(flowToRetryId).eagerDeps.foreach { tableNames =>
+                try {
+                  tableNames.foreach { tableName =>
+                    val plan = spark.sessionState.sqlParser.parsePlan(s"select * from $tableName")
+                    analyze(flowToRetryId, plan)
+                  }
+                  clientSignalQueue.append(flowToRetryId)
+                } catch {
+                  case _: UnresolvedDatasetException =>
+                }
+              }
+            }
+          case 2 => // Simulate the client
+            if (clientSignalQueue.nonEmpty) {
+              val flowId = clientSignalQueue.dequeue()
+              val upstreamTables = dummyFlowsById(flowId).eagerDeps
+              val dummyFlow = dummyFlowsById(flowId)
+              val result = if (dummyFlow.failsTerminally) {
+                QueryFunctionTerminalFailure
+              } else {
+                QueryFunctionSuccess(
+                  spark.sessionState.sqlParser
+                    .parsePlan(s"select * from $upstreamTables")
+                    .logicalPlan
+                )
+              }
+              registerQueryFunctionResult(flowId, result)
+            }
+        }
+
+        assert(
+          analysisContext.toBeResolvedFlows.size +
+          analysisContext.resolvedFlowsMap.size +
+          analysisContext.failedUnregisteredFlows.size +
+          analysisContext.failedDependentFlows.size
+          == unresolvedGraph.flows.size
+        )
+      }
+    }
+  }
+
+  test("single node external .columns") {
+    val externalTableId = fullyQualifiedIdentifier("external")
+    spark.sql(s"CREATE TABLE $externalTableId AS SELECT * FROM RANGE(3)")
+    val dummyFlows = Seq(
+      DummyFlowInfo("table1", eagerDeps = Seq(externalTableId.quotedString))
+    )
+    val testDistributedAnalyzer = new TestDistributedAnalyzer(dummyFlows, spark)
+
+    // transformer processes node, flow function should fail because no relation for node, get
+    // popped back on queue
+    testDistributedAnalyzer.transformerIteration()
+
+    // define query function result
+    testDistributedAnalyzer.registerQueryFunctionResult(
+      fullyQualifiedIdentifier("table1"),
+      QueryFunctionSuccess(spark.range(4).logicalPlan)
+    )
+
+    // transformer processes node again. flow function should succeed.
+    testDistributedAnalyzer.transformerIteration()
+  }
+
+  test("two nodes with second has .columns") {
+    // flow 1 -> table -> flow 2 -> table
+    // flow 2 can't be resolved immediately because it analyzes flow 1
+    val dummyFlows = Seq(
+      DummyFlowInfo("table2", eagerDeps = Seq("table1")),
+      DummyFlowInfo("table1")
+    )
+
+    val testDistributedAnalyzer = new TestDistributedAnalyzer(dummyFlows, spark)
+    val analysisContext = testDistributedAnalyzer.analysisContext
+    val selectFromTable1Plan = spark.sessionState.sqlParser.parsePlan("select * from table1")
+
+    val flow1Id = fullyQualifiedIdentifier("flow1")
+    val table1Id = fullyQualifiedIdentifier("table1")
+    val flow2Id = fullyQualifiedIdentifier("flow2")
+
+    // Attempt to analyze table1 on behalf of flow2. Should fail and record dependency.
+    intercept[UnresolvedDatasetException](
+      testDistributedAnalyzer.analyze(flow2Id, selectFromTable1Plan)
+    )
+    val failedDependentFlows = analysisContext.failedDependentFlows
+    assert(failedDependentFlows.size() == 1)
+    assert(failedDependentFlows.get(table1Id).map(_.identifier).toSet == Set(flow2Id))
+
+    // transformer processes flow2, flow function should fail because no relation for node, get
+    // added to unregistered list
+    testDistributedAnalyzer.transformerIteration()
+    assert(analysisContext.failedUnregisteredFlows.containsKey(flow2Id))
+
+    // transformer processes flow1, flow function should succeed
+    // flow2 shouldn't be added to the queue, because its plan is still unregistered
+    testDistributedAnalyzer.transformerIteration()
+    assert(analysisContext.toBeResolvedFlows.isEmpty)
+    assert(analysisContext.resolvedFlowsMap.containsKey(flow1Id))
+
+    // detects flow1 is resolved, sends signal to retry flow2
+    assert(
+      testDistributedAnalyzer.analysisContext.flowClientSignalQueue.toArray.toSeq == Seq(flow2Id)
+    )
+    testDistributedAnalyzer.analysisContext.flowClientSignalQueue.clear()
+
+    testDistributedAnalyzer.analyze(flow2Id, selectFromTable1Plan)
+
+    // define query function result
+    testDistributedAnalyzer.registerQueryFunctionResult(
+      flow2Id,
+      QueryFunctionSuccess(selectFromTable1Plan)
+    )
+    assert(analysisContext.failedUnregisteredFlows.isEmpty)
+    assert(analysisContext.toBeResolvedFlows.size == 1)
+
+    // transformer processes node again. flow function should succeed.
+    testDistributedAnalyzer.transformerIteration()
+    assert(analysisContext.toBeResolvedFlows.isEmpty)
+    assert(analysisContext.failedUnregisteredFlows.isEmpty)
+    assert(analysisContext.failedDependentFlows.isEmpty)
+    assert(analysisContext.resolvedFlowsMap.size == 2)
+  }
+
+  test("random orderings") {
+    // flow 1 -> table -> flow 2 -> table
+    // flow 2 can't be resolved immediately because it analyzes flow 1
+    val dummyFlows = Seq(
+      DummyFlowInfo("table2", eagerDeps = Seq("table1")),
+      DummyFlowInfo("table1")
+    )
+
+    val testDistributedAnalyzer = new TestDistributedAnalyzer(dummyFlows, spark)
+
+    testDistributedAnalyzer.runToCompletion(4367)
+    assert(testDistributedAnalyzer.analysisContext.failedUnregisteredFlows.isEmpty)
+    assert(testDistributedAnalyzer.analysisContext.failedDependentFlows.isEmpty)
+    assert(testDistributedAnalyzer.analysisContext.resolvedFlowsMap.size == 2)
+  }
+
+  test("query function fails after eager analysis") {
+    val dummyFlows = Seq(
+      DummyFlowInfo("table2", eagerDeps = Seq("table1"), failsTerminally = true),
+      DummyFlowInfo("table1")
+    )
+    val testDistributedAnalyzer = new TestDistributedAnalyzer(dummyFlows, spark)
+    testDistributedAnalyzer.runToCompletion(4367)
+    assert(testDistributedAnalyzer.analysisContext.resolvedFlowsMap.size == 0)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a WIP change that adds support for using functions like `DataFrame.schema` and `DataFrame.columns` inside pipeline query functions.

The change makes graph resolution partially asynchronous.

Many of the data structures that were previously maintained as local variables inside transformDownNodes have been moved to a GraphAnalysisContext object. Moving them into a separate object makes them accessible from Spark Connect RPC handlers that:
- Register query function results
- Poll for query functions to execute
- Analyze within the context of the graph

Were also essentially introducing a new state that flows can be in during resolution, which is “waiting for query function result”.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
