### PR TITLE
[SPARK-53991][SQL][TEST][FOLLOW-UP] Improve KLL quantile errors by removing internal details

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4291,7 +4291,7 @@
     ],
     "sqlState" : "22000"
   },
-  "KLL_SKETCH_INVALID_INPUT" : {
+  "KLL_INVALID_INPUT_SKETCH_BUFFER" : {
     "message" : [
       "Invalid call to <function>; only valid KLL sketch buffers are supported as inputs (such as those produced by the `kll_sketch_agg` function)."
     ],

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4285,15 +4285,15 @@
     ],
     "sqlState" : "42K0E"
   },
-  "KLL_SKETCH_INCOMPATIBLE_MERGE" : {
-    "message" : [
-      "For function <functionName>, cannot merge KLL sketches: <reason>"
-    ],
-    "sqlState" : "22000"
-  },
   "KLL_INVALID_INPUT_SKETCH_BUFFER" : {
     "message" : [
       "Invalid call to <function>; only valid KLL sketch buffers are supported as inputs (such as those produced by the `kll_sketch_agg` function)."
+    ],
+    "sqlState" : "22000"
+  },
+  "KLL_SKETCH_INCOMPATIBLE_MERGE" : {
+    "message" : [
+      "For function <functionName>, cannot merge KLL sketches: <reason>"
     ],
     "sqlState" : "22000"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4291,15 +4291,9 @@
     ],
     "sqlState" : "22000"
   },
-  "KLL_SKETCH_INCOMPATIBLE_MERGE" : {
-    "message" : [
-      "For function <functionName>, cannot merge KLL sketches: <reason>"
-    ],
-    "sqlState" : "22000"
-  },
   "KLL_SKETCH_INVALID_QUANTILE_RANGE" : {
     "message" : [
-      "For function <functionName>, the quantile value must be between 0.0 and 1.0 (inclusive), but got <quantile>."
+      "For function <functionName>, the quantile value must be between 0.0 and 1.0 (inclusive)."
     ],
     "sqlState" : "22003"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4293,7 +4293,7 @@
   },
   "KLL_SKETCH_INVALID_INPUT" : {
     "message" : [
-      "For function <functionName>, invalid KLL sketch binary data: <reason>"
+      "Invalid call to <function>; only valid KLL sketch buffers are supported as inputs (such as those produced by the `kll_sketch_agg` function)."
     ],
     "sqlState" : "22000"
   },

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -26991,7 +26991,7 @@ def kll_sketch_to_string_bigint(col: "ColumnOrName") -> Column:
     >>> df = spark.createDataFrame([1,2,3,4,5], "INT")
     >>> sketch_df = df.agg(sf.kll_sketch_agg_bigint("value").alias("sketch"))
     >>> result = sketch_df.select(sf.kll_sketch_to_string_bigint("sketch")).first()[0]
-    >>> "Kll" in result and "N" in result
+    >>> "kll" in result.lower()
     True
     """
     fn = "kll_sketch_to_string_bigint"
@@ -27021,7 +27021,7 @@ def kll_sketch_to_string_float(col: "ColumnOrName") -> Column:
     >>> df = spark.createDataFrame([1.0,2.0,3.0,4.0,5.0], "FLOAT")
     >>> sketch_df = df.agg(sf.kll_sketch_agg_float("value").alias("sketch"))
     >>> result = sketch_df.select(sf.kll_sketch_to_string_float("sketch")).first()[0]
-    >>> "Kll" in result and "N" in result
+    >>> "kll" in result.lower()
     True
     """
     fn = "kll_sketch_to_string_float"
@@ -27051,7 +27051,7 @@ def kll_sketch_to_string_double(col: "ColumnOrName") -> Column:
     >>> df = spark.createDataFrame([1.0,2.0,3.0,4.0,5.0], "DOUBLE")
     >>> sketch_df = df.agg(sf.kll_sketch_agg_double("value").alias("sketch"))
     >>> result = sketch_df.select(sf.kll_sketch_to_string_double("sketch")).first()[0]
-    >>> "Kll" in result and "N" in result
+    >>> "kll" in result.lower()
     True
     """
     fn = "kll_sketch_to_string_double"

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -2151,7 +2151,7 @@ class FunctionsTestsMixin:
         result = sketch_df.select(F.kll_sketch_to_string_bigint("sketch")).first()[0]
         self.assertIsNotNone(result)
         self.assertIsInstance(result, str)
-        self.assertIn("Kll", result)
+        self.assertIn("kll", result.lower())
 
     def test_kll_sketch_get_n_bigint(self):
         """Test kll_sketch_get_n_bigint function"""
@@ -2212,7 +2212,7 @@ class FunctionsTestsMixin:
 
         # Test to_string
         string_result = sketch_df.select(F.kll_sketch_to_string_float("sketch")).first()[0]
-        self.assertIn("Kll", string_result)
+        self.assertIn("kll", string_result.lower())
 
         # Test get_n
         n = sketch_df.select(F.kll_sketch_get_n_float("sketch")).first()[0]
@@ -2240,7 +2240,7 @@ class FunctionsTestsMixin:
 
         # Test to_string
         string_result = sketch_df.select(F.kll_sketch_to_string_double("sketch")).first()[0]
-        self.assertIn("Kll", string_result)
+        self.assertIn("kll", string_result.lower())
 
         # Test get_n
         n = sketch_df.select(F.kll_sketch_get_n_double("sketch")).first()[0]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/kllAggregates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/kllAggregates.scala
@@ -168,7 +168,7 @@ case class KllSketchAggBigint(
       KllLongsSketch.heapify(Memory.wrap(buffer))
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllSketchInvalidInputError(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
     }
   } else {
     this.createAggregationBuffer()
@@ -304,7 +304,7 @@ case class KllSketchAggFloat(
       KllFloatsSketch.heapify(Memory.wrap(buffer))
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllSketchInvalidInputError(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
     }
   } else {
     this.createAggregationBuffer()
@@ -442,7 +442,7 @@ case class KllSketchAggDouble(
       KllDoublesSketch.heapify(Memory.wrap(buffer))
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllSketchInvalidInputError(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
     }
   } else {
     this.createAggregationBuffer()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/kllAggregates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/kllAggregates.scala
@@ -151,8 +151,8 @@ case class KllSketchAggBigint(
       updateBuffer.merge(input)
       updateBuffer
     } catch {
-      case e: Exception =>
-        throw QueryExecutionErrors.kllSketchIncompatibleMergeError(prettyName, e.getMessage)
+      case _: Exception =>
+        throw QueryExecutionErrors.kllSketchInvalidSketchBufferError(prettyName)
     }
   }
 
@@ -167,7 +167,7 @@ case class KllSketchAggBigint(
     try {
       KllLongsSketch.heapify(Memory.wrap(buffer))
     } catch {
-      case e: Exception =>
+      case _: Exception =>
         throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   } else {
@@ -287,8 +287,8 @@ case class KllSketchAggFloat(
       updateBuffer.merge(input)
       updateBuffer
     } catch {
-      case e: Exception =>
-        throw QueryExecutionErrors.kllSketchIncompatibleMergeError(prettyName, e.getMessage)
+      case _: Exception =>
+        throw QueryExecutionErrors.kllSketchInvalidSketchBufferError(prettyName)
     }
   }
 
@@ -303,7 +303,7 @@ case class KllSketchAggFloat(
     try {
       KllFloatsSketch.heapify(Memory.wrap(buffer))
     } catch {
-      case e: Exception =>
+      case _: Exception =>
         throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   } else {
@@ -425,8 +425,8 @@ case class KllSketchAggDouble(
       updateBuffer.merge(input)
       updateBuffer
     } catch {
-      case e: Exception =>
-        throw QueryExecutionErrors.kllSketchIncompatibleMergeError(prettyName, e.getMessage)
+      case _: Exception =>
+        throw QueryExecutionErrors.kllSketchInvalidSketchBufferError(prettyName)
     }
   }
 
@@ -441,7 +441,7 @@ case class KllSketchAggDouble(
     try {
       KllDoublesSketch.heapify(Memory.wrap(buffer))
     } catch {
-      case e: Exception =>
+      case _: Exception =>
         throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/kllAggregates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/kllAggregates.scala
@@ -152,7 +152,7 @@ case class KllSketchAggBigint(
       updateBuffer
     } catch {
       case _: Exception =>
-        throw QueryExecutionErrors.kllSketchInvalidSketchBufferError(prettyName)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
 
@@ -288,7 +288,7 @@ case class KllSketchAggFloat(
       updateBuffer
     } catch {
       case _: Exception =>
-        throw QueryExecutionErrors.kllSketchInvalidSketchBufferError(prettyName)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
 
@@ -426,7 +426,7 @@ case class KllSketchAggDouble(
       updateBuffer
     } catch {
       case _: Exception =>
-        throw QueryExecutionErrors.kllSketchInvalidSketchBufferError(prettyName)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/kllAggregates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/kllAggregates.scala
@@ -168,7 +168,7 @@ case class KllSketchAggBigint(
       KllLongsSketch.heapify(Memory.wrap(buffer))
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   } else {
     this.createAggregationBuffer()
@@ -304,7 +304,7 @@ case class KllSketchAggFloat(
       KllFloatsSketch.heapify(Memory.wrap(buffer))
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   } else {
     this.createAggregationBuffer()
@@ -442,7 +442,7 @@ case class KllSketchAggDouble(
       KllDoublesSketch.heapify(Memory.wrap(buffer))
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   } else {
     this.createAggregationBuffer()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/kllExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/kllExpressions.scala
@@ -51,7 +51,7 @@ case class KllSketchToStringBigint(child: Expression) extends KllSketchToStringB
       UTF8String.fromString(sketch.toString())
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
 }
@@ -79,7 +79,7 @@ case class KllSketchToStringFloat(child: Expression) extends KllSketchToStringBa
       UTF8String.fromString(sketch.toString())
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
 }
@@ -107,7 +107,7 @@ case class KllSketchToStringDouble(child: Expression) extends KllSketchToStringB
       UTF8String.fromString(sketch.toString())
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
 }
@@ -145,7 +145,7 @@ case class KllSketchGetNBigint(child: Expression) extends KllSketchGetNBase {
       sketch.getN()
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
 }
@@ -173,7 +173,7 @@ case class KllSketchGetNFloat(child: Expression) extends KllSketchGetNBase {
       sketch.getN()
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
 }
@@ -201,7 +201,7 @@ case class KllSketchGetNDouble(child: Expression) extends KllSketchGetNBase {
       sketch.getN()
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
 }
@@ -458,10 +458,10 @@ abstract class KllSketchGetQuantileBase
         if (e.getMessage.contains("normalized rank")) {
           throw QueryExecutionErrors.kllSketchInvalidQuantileRangeError(prettyName, rankForError)
         } else {
-          throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
+          throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
         }
       case e: Exception =>
-        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
 
@@ -618,7 +618,7 @@ abstract class KllSketchGetRankBase
       operation
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/kllExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/kllExpressions.scala
@@ -242,7 +242,7 @@ case class KllSketchMergeBigint(left: Expression, right: Expression) extends Kll
       leftSketch.toByteArray
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllSketchIncompatibleMergeError(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllSketchInvalidSketchBufferError(prettyName)
     }
   }
 }
@@ -273,7 +273,7 @@ case class KllSketchMergeFloat(left: Expression, right: Expression) extends KllS
       leftSketch.toByteArray
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllSketchIncompatibleMergeError(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllSketchInvalidSketchBufferError(prettyName)
     }
   }
 }
@@ -304,7 +304,7 @@ case class KllSketchMergeDouble(left: Expression, right: Expression) extends Kll
       leftSketch.toByteArray
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllSketchIncompatibleMergeError(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllSketchInvalidSketchBufferError(prettyName)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/kllExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/kllExpressions.scala
@@ -50,7 +50,7 @@ case class KllSketchToStringBigint(child: Expression) extends KllSketchToStringB
       val sketch = KllLongsSketch.heapify(Memory.wrap(buffer))
       UTF8String.fromString(sketch.toString())
     } catch {
-      case e: Exception =>
+      case _: Exception =>
         throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
@@ -78,7 +78,7 @@ case class KllSketchToStringFloat(child: Expression) extends KllSketchToStringBa
       val sketch = KllFloatsSketch.heapify(Memory.wrap(buffer))
       UTF8String.fromString(sketch.toString())
     } catch {
-      case e: Exception =>
+      case _: Exception =>
         throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
@@ -106,7 +106,7 @@ case class KllSketchToStringDouble(child: Expression) extends KllSketchToStringB
       val sketch = KllDoublesSketch.heapify(Memory.wrap(buffer))
       UTF8String.fromString(sketch.toString())
     } catch {
-      case e: Exception =>
+      case _: Exception =>
         throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
@@ -144,7 +144,7 @@ case class KllSketchGetNBigint(child: Expression) extends KllSketchGetNBase {
       val sketch = KllLongsSketch.heapify(Memory.wrap(buffer))
       sketch.getN()
     } catch {
-      case e: Exception =>
+      case _: Exception =>
         throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
@@ -172,7 +172,7 @@ case class KllSketchGetNFloat(child: Expression) extends KllSketchGetNBase {
       val sketch = KllFloatsSketch.heapify(Memory.wrap(buffer))
       sketch.getN()
     } catch {
-      case e: Exception =>
+      case _: Exception =>
         throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
@@ -200,7 +200,7 @@ case class KllSketchGetNDouble(child: Expression) extends KllSketchGetNBase {
       val sketch = KllDoublesSketch.heapify(Memory.wrap(buffer))
       sketch.getN()
     } catch {
-      case e: Exception =>
+      case _: Exception =>
         throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
@@ -241,7 +241,7 @@ case class KllSketchMergeBigint(left: Expression, right: Expression) extends Kll
       leftSketch.merge(rightSketch)
       leftSketch.toByteArray
     } catch {
-      case e: Exception =>
+      case _: Exception =>
         throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
@@ -272,7 +272,7 @@ case class KllSketchMergeFloat(left: Expression, right: Expression) extends KllS
       leftSketch.merge(rightSketch)
       leftSketch.toByteArray
     } catch {
-      case e: Exception =>
+      case _: Exception =>
         throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
@@ -303,7 +303,7 @@ case class KllSketchMergeDouble(left: Expression, right: Expression) extends Kll
       leftSketch.merge(rightSketch)
       leftSketch.toByteArray
     } catch {
-      case e: Exception =>
+      case _: Exception =>
         throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
@@ -460,7 +460,7 @@ abstract class KllSketchGetQuantileBase
         } else {
           throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
         }
-      case e: Exception =>
+      case _: Exception =>
         throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
@@ -617,7 +617,7 @@ abstract class KllSketchGetRankBase
     try {
       operation
     } catch {
-      case e: Exception =>
+      case _: Exception =>
         throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/kllExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/kllExpressions.scala
@@ -456,7 +456,7 @@ abstract class KllSketchGetQuantileBase
     } catch {
       case e: org.apache.datasketches.common.SketchesArgumentException =>
         if (e.getMessage.contains("normalized rank")) {
-          throw QueryExecutionErrors.kllSketchInvalidQuantileRangeError(prettyName, rankForError)
+          throw QueryExecutionErrors.kllSketchInvalidQuantileRangeError(prettyName)
         } else {
           throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/kllExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/kllExpressions.scala
@@ -51,7 +51,7 @@ case class KllSketchToStringBigint(child: Expression) extends KllSketchToStringB
       UTF8String.fromString(sketch.toString())
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllSketchInvalidInputError(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
     }
   }
 }
@@ -79,7 +79,7 @@ case class KllSketchToStringFloat(child: Expression) extends KllSketchToStringBa
       UTF8String.fromString(sketch.toString())
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllSketchInvalidInputError(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
     }
   }
 }
@@ -107,7 +107,7 @@ case class KllSketchToStringDouble(child: Expression) extends KllSketchToStringB
       UTF8String.fromString(sketch.toString())
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllSketchInvalidInputError(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
     }
   }
 }
@@ -145,7 +145,7 @@ case class KllSketchGetNBigint(child: Expression) extends KllSketchGetNBase {
       sketch.getN()
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllSketchInvalidInputError(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
     }
   }
 }
@@ -173,7 +173,7 @@ case class KllSketchGetNFloat(child: Expression) extends KllSketchGetNBase {
       sketch.getN()
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllSketchInvalidInputError(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
     }
   }
 }
@@ -201,7 +201,7 @@ case class KllSketchGetNDouble(child: Expression) extends KllSketchGetNBase {
       sketch.getN()
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllSketchInvalidInputError(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
     }
   }
 }
@@ -458,10 +458,10 @@ abstract class KllSketchGetQuantileBase
         if (e.getMessage.contains("normalized rank")) {
           throw QueryExecutionErrors.kllSketchInvalidQuantileRangeError(prettyName, rankForError)
         } else {
-          throw QueryExecutionErrors.kllSketchInvalidInputError(prettyName, e.getMessage)
+          throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
         }
       case e: Exception =>
-        throw QueryExecutionErrors.kllSketchInvalidInputError(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
     }
   }
 
@@ -618,7 +618,7 @@ abstract class KllSketchGetRankBase
       operation
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllSketchInvalidInputError(prettyName, e.getMessage)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName, e.getMessage)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/kllExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/kllExpressions.scala
@@ -242,7 +242,7 @@ case class KllSketchMergeBigint(left: Expression, right: Expression) extends Kll
       leftSketch.toByteArray
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllSketchInvalidSketchBufferError(prettyName)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
 }
@@ -273,7 +273,7 @@ case class KllSketchMergeFloat(left: Expression, right: Expression) extends KllS
       leftSketch.toByteArray
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllSketchInvalidSketchBufferError(prettyName)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
 }
@@ -304,7 +304,7 @@ case class KllSketchMergeDouble(left: Expression, right: Expression) extends Kll
       leftSketch.toByteArray
     } catch {
       case e: Exception =>
-        throw QueryExecutionErrors.kllSketchInvalidSketchBufferError(prettyName)
+        throw QueryExecutionErrors.kllInvalidInputSketchBuffer(prettyName)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -3199,13 +3199,6 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
         "functionName" -> toSQLId(function)))
   }
 
-  def kllSketchInvalidSketchBufferError(function: String): Throwable = {
-    new SparkRuntimeException(
-      errorClass = "KLL_INVALID_INPUT_SKETCH_BUFFER",
-      messageParameters = Map(
-        "functionName" -> toSQLId(function)))
-  }
-
   def kllSketchKMustBeConstantError(function: String): Throwable = {
     new SparkRuntimeException(
       errorClass = "KLL_SKETCH_K_MUST_BE_CONSTANT",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -3199,12 +3199,11 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
         "functionName" -> toSQLId(function)))
   }
 
-  def kllSketchIncompatibleMergeError(function: String, reason: String): Throwable = {
+  def kllSketchInvalidSketchBufferError(function: String): Throwable = {
     new SparkRuntimeException(
-      errorClass = "KLL_SKETCH_INCOMPATIBLE_MERGE",
+      errorClass = "KLL_INVALID_INPUT_SKETCH_BUFFER",
       messageParameters = Map(
-        "functionName" -> toSQLId(function),
-        "reason" -> reason))
+        "functionName" -> toSQLId(function)))
   }
 
   def kllSketchKMustBeConstantError(function: String): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2822,7 +2822,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
 
   def kllInvalidInputSketchBuffer(function: String, reason: String = ""): Throwable = {
     new SparkRuntimeException(
-      errorClass = "KLL_SKETCH_INVALID_INPUT",
+      errorClass = "KLL_INVALID_INPUT_SKETCH_BUFFER",
       messageParameters = Map(
         "function" -> toSQLId(function)))
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2820,12 +2820,11 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
         "function" -> toSQLId(function)))
   }
 
-  def kllInvalidInputSketchBuffer(function: String, reason: String): Throwable = {
+  def kllInvalidInputSketchBuffer(function: String, reason: String = ""): Throwable = {
     new SparkRuntimeException(
       errorClass = "KLL_SKETCH_INVALID_INPUT",
       messageParameters = Map(
-        "functionName" -> toSQLId(function),
-        "reason" -> reason))
+        "function" -> toSQLId(function)))
   }
 
   def hllUnionDifferentLgK(left: Int, right: Int, function: String): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -3192,12 +3192,11 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       messageParameters = Map("function" -> toSQLId(function)))
   }
 
-  def kllSketchInvalidQuantileRangeError(function: String, quantile: Double): Throwable = {
+  def kllSketchInvalidQuantileRangeError(function: String): Throwable = {
     new SparkRuntimeException(
       errorClass = "KLL_SKETCH_INVALID_QUANTILE_RANGE",
       messageParameters = Map(
-        "functionName" -> toSQLId(function),
-        "quantile" -> toSQLValue(quantile, DoubleType)))
+        "functionName" -> toSQLId(function)))
   }
 
   def kllSketchIncompatibleMergeError(function: String, reason: String): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2820,6 +2820,14 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
         "function" -> toSQLId(function)))
   }
 
+  def kllInvalidInputSketchBuffer(function: String, reason: String): Throwable = {
+    new SparkRuntimeException(
+      errorClass = "KLL_SKETCH_INVALID_INPUT",
+      messageParameters = Map(
+        "functionName" -> toSQLId(function),
+        "reason" -> reason))
+  }
+
   def hllUnionDifferentLgK(left: Int, right: Int, function: String): Throwable = {
     new SparkRuntimeException(
       errorClass = "HLL_UNION_DIFFERENT_LG_K",
@@ -3191,14 +3199,6 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       messageParameters = Map(
         "functionName" -> toSQLId(function),
         "quantile" -> toSQLValue(quantile, DoubleType)))
-  }
-
-  def kllSketchInvalidInputError(function: String, reason: String): Throwable = {
-    new SparkRuntimeException(
-      errorClass = "KLL_SKETCH_INVALID_INPUT",
-      messageParameters = Map(
-        "functionName" -> toSQLId(function),
-        "reason" -> reason))
   }
 
   def kllSketchIncompatibleMergeError(function: String, reason: String): Throwable = {

--- a/sql/core/src/test/resources/sql-tests/results/kllquantiles.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/kllquantiles.sql.out
@@ -909,12 +909,12 @@ FROM (
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkException
+org.apache.spark.SparkRuntimeException
 {
-  "errorClass" : "INTERNAL_ERROR",
-  "sqlState" : "XX000",
+  "errorClass" : "KLL_INVALID_INPUT_SKETCH_BUFFER",
+  "sqlState" : "22000",
   "messageParameters" : {
-    "message" : "Undefined error message parameter for error class: 'KLL_INVALID_INPUT_SKETCH_BUFFER', MessageTemplate: Invalid call to <function>; only valid KLL sketch buffers are supported as inputs (such as those produced by the `kll_sketch_agg` function)., Parameters: Map(functionName -> `kll_sketch_merge_bigint`)"
+    "function" : "`kll_sketch_merge_bigint`"
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/kllquantiles.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/kllquantiles.sql.out
@@ -892,12 +892,12 @@ FROM (
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkException
+org.apache.spark.SparkRuntimeException
 {
-  "errorClass" : "INTERNAL_ERROR",
-  "sqlState" : "XX000",
+  "errorClass" : "KLL_SKETCH_INVALID_INPUT",
+  "sqlState" : "22000",
   "messageParameters" : {
-    "message" : "Undefined error message parameter for error class: 'KLL_SKETCH_INVALID_INPUT', MessageTemplate: Invalid call to <function>; only valid KLL sketch buffers are supported as inputs (such as those produced by the `kll_sketch_agg` function)., Parameters: Map(functionName -> `kll_sketch_get_rank_bigint`, reason -> reqOffset: 40, reqLength: 56, (reqOff + reqLen): 96, allocSize: 60)"
+    "function" : "`kll_sketch_get_rank_bigint`"
   }
 }
 
@@ -928,12 +928,12 @@ SELECT kll_sketch_get_quantile_bigint(CAST('not_a_sketch' AS BINARY), 0.5) AS in
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkException
+org.apache.spark.SparkRuntimeException
 {
-  "errorClass" : "INTERNAL_ERROR",
-  "sqlState" : "XX000",
+  "errorClass" : "KLL_SKETCH_INVALID_INPUT",
+  "sqlState" : "22000",
   "messageParameters" : {
-    "message" : "Undefined error message parameter for error class: 'KLL_SKETCH_INVALID_INPUT', MessageTemplate: Invalid call to <function>; only valid KLL sketch buffers are supported as inputs (such as those produced by the `kll_sketch_agg` function)., Parameters: Map(functionName -> `kll_sketch_get_quantile_bigint`, reason -> Error combination of PreInts and SerVer: PreInts: 110, SerVer: 111)"
+    "function" : "`kll_sketch_get_quantile_bigint`"
   }
 }
 
@@ -1094,12 +1094,12 @@ SELECT kll_sketch_get_n_bigint(X'deadbeef') AS invalid_binary_bigint
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkException
+org.apache.spark.SparkRuntimeException
 {
-  "errorClass" : "INTERNAL_ERROR",
-  "sqlState" : "XX000",
+  "errorClass" : "KLL_SKETCH_INVALID_INPUT",
+  "sqlState" : "22000",
   "messageParameters" : {
-    "message" : "Undefined error message parameter for error class: 'KLL_SKETCH_INVALID_INPUT', MessageTemplate: Invalid call to <function>; only valid KLL sketch buffers are supported as inputs (such as those produced by the `kll_sketch_agg` function)., Parameters: Map(functionName -> `kll_sketch_get_n_bigint`, reason -> A sketch memory image must be at least 8 bytes. 4)"
+    "function" : "`kll_sketch_get_n_bigint`"
   }
 }
 
@@ -1109,12 +1109,12 @@ SELECT kll_sketch_get_n_float(X'cafebabe') AS invalid_binary_float
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkException
+org.apache.spark.SparkRuntimeException
 {
-  "errorClass" : "INTERNAL_ERROR",
-  "sqlState" : "XX000",
+  "errorClass" : "KLL_SKETCH_INVALID_INPUT",
+  "sqlState" : "22000",
   "messageParameters" : {
-    "message" : "Undefined error message parameter for error class: 'KLL_SKETCH_INVALID_INPUT', MessageTemplate: Invalid call to <function>; only valid KLL sketch buffers are supported as inputs (such as those produced by the `kll_sketch_agg` function)., Parameters: Map(functionName -> `kll_sketch_get_n_float`, reason -> A sketch memory image must be at least 8 bytes. 4)"
+    "function" : "`kll_sketch_get_n_float`"
   }
 }
 
@@ -1124,12 +1124,12 @@ SELECT kll_sketch_get_n_double(X'12345678') AS invalid_binary_double
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkException
+org.apache.spark.SparkRuntimeException
 {
-  "errorClass" : "INTERNAL_ERROR",
-  "sqlState" : "XX000",
+  "errorClass" : "KLL_SKETCH_INVALID_INPUT",
+  "sqlState" : "22000",
   "messageParameters" : {
-    "message" : "Undefined error message parameter for error class: 'KLL_SKETCH_INVALID_INPUT', MessageTemplate: Invalid call to <function>; only valid KLL sketch buffers are supported as inputs (such as those produced by the `kll_sketch_agg` function)., Parameters: Map(functionName -> `kll_sketch_get_n_double`, reason -> A sketch memory image must be at least 8 bytes. 4)"
+    "function" : "`kll_sketch_get_n_double`"
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/kllquantiles.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/kllquantiles.sql.out
@@ -832,13 +832,12 @@ FROM (
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkRuntimeException
+org.apache.spark.SparkException
 {
-  "errorClass" : "KLL_SKETCH_INVALID_QUANTILE_RANGE",
-  "sqlState" : "22003",
+  "errorClass" : "INTERNAL_ERROR",
+  "sqlState" : "XX000",
   "messageParameters" : {
-    "functionName" : "`kll_sketch_get_quantile_bigint`",
-    "quantile" : "-0.5D"
+    "message" : "Undefined error message parameter for error class: 'KLL_SKETCH_INVALID_QUANTILE_RANGE', MessageTemplate: For function <functionName>, the quantile value must be between 0.0 and 1.0 (inclusive), but got <quantile>., Parameters: Map(functionName -> `kll_sketch_get_quantile_bigint`)"
   }
 }
 
@@ -852,13 +851,12 @@ FROM (
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkRuntimeException
+org.apache.spark.SparkException
 {
-  "errorClass" : "KLL_SKETCH_INVALID_QUANTILE_RANGE",
-  "sqlState" : "22003",
+  "errorClass" : "INTERNAL_ERROR",
+  "sqlState" : "XX000",
   "messageParameters" : {
-    "functionName" : "`kll_sketch_get_quantile_bigint`",
-    "quantile" : "1.5D"
+    "message" : "Undefined error message parameter for error class: 'KLL_SKETCH_INVALID_QUANTILE_RANGE', MessageTemplate: For function <functionName>, the quantile value must be between 0.0 and 1.0 (inclusive), but got <quantile>., Parameters: Map(functionName -> `kll_sketch_get_quantile_bigint`)"
   }
 }
 
@@ -872,13 +870,12 @@ FROM (
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkRuntimeException
+org.apache.spark.SparkException
 {
-  "errorClass" : "KLL_SKETCH_INVALID_QUANTILE_RANGE",
-  "sqlState" : "22003",
+  "errorClass" : "INTERNAL_ERROR",
+  "sqlState" : "XX000",
   "messageParameters" : {
-    "functionName" : "`kll_sketch_get_quantile_float`",
-    "quantile" : "-0.1D"
+    "message" : "Undefined error message parameter for error class: 'KLL_SKETCH_INVALID_QUANTILE_RANGE', MessageTemplate: For function <functionName>, the quantile value must be between 0.0 and 1.0 (inclusive), but got <quantile>., Parameters: Map(functionName -> `kll_sketch_get_quantile_float`)"
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/kllquantiles.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/kllquantiles.sql.out
@@ -914,7 +914,7 @@ org.apache.spark.SparkException
   "errorClass" : "INTERNAL_ERROR",
   "sqlState" : "XX000",
   "messageParameters" : {
-    "message" : "Cannot find main error class 'KLL_SKETCH_INCOMPATIBLE_MERGE'"
+    "message" : "Undefined error message parameter for error class: 'KLL_INVALID_INPUT_SKETCH_BUFFER', MessageTemplate: Invalid call to <function>; only valid KLL sketch buffers are supported as inputs (such as those produced by the `kll_sketch_agg` function)., Parameters: Map(functionName -> `kll_sketch_merge_bigint`)"
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/kllquantiles.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/kllquantiles.sql.out
@@ -894,7 +894,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkRuntimeException
 {
-  "errorClass" : "KLL_SKETCH_INVALID_INPUT",
+  "errorClass" : "KLL_INVALID_INPUT_SKETCH_BUFFER",
   "sqlState" : "22000",
   "messageParameters" : {
     "function" : "`kll_sketch_get_rank_bigint`"
@@ -930,7 +930,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkRuntimeException
 {
-  "errorClass" : "KLL_SKETCH_INVALID_INPUT",
+  "errorClass" : "KLL_INVALID_INPUT_SKETCH_BUFFER",
   "sqlState" : "22000",
   "messageParameters" : {
     "function" : "`kll_sketch_get_quantile_bigint`"
@@ -1096,7 +1096,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkRuntimeException
 {
-  "errorClass" : "KLL_SKETCH_INVALID_INPUT",
+  "errorClass" : "KLL_INVALID_INPUT_SKETCH_BUFFER",
   "sqlState" : "22000",
   "messageParameters" : {
     "function" : "`kll_sketch_get_n_bigint`"
@@ -1111,7 +1111,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkRuntimeException
 {
-  "errorClass" : "KLL_SKETCH_INVALID_INPUT",
+  "errorClass" : "KLL_INVALID_INPUT_SKETCH_BUFFER",
   "sqlState" : "22000",
   "messageParameters" : {
     "function" : "`kll_sketch_get_n_float`"
@@ -1126,7 +1126,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkRuntimeException
 {
-  "errorClass" : "KLL_SKETCH_INVALID_INPUT",
+  "errorClass" : "KLL_INVALID_INPUT_SKETCH_BUFFER",
   "sqlState" : "22000",
   "messageParameters" : {
     "function" : "`kll_sketch_get_n_double`"

--- a/sql/core/src/test/resources/sql-tests/results/kllquantiles.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/kllquantiles.sql.out
@@ -832,12 +832,12 @@ FROM (
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkException
+org.apache.spark.SparkRuntimeException
 {
-  "errorClass" : "INTERNAL_ERROR",
-  "sqlState" : "XX000",
+  "errorClass" : "KLL_SKETCH_INVALID_QUANTILE_RANGE",
+  "sqlState" : "22003",
   "messageParameters" : {
-    "message" : "Undefined error message parameter for error class: 'KLL_SKETCH_INVALID_QUANTILE_RANGE', MessageTemplate: For function <functionName>, the quantile value must be between 0.0 and 1.0 (inclusive), but got <quantile>., Parameters: Map(functionName -> `kll_sketch_get_quantile_bigint`)"
+    "functionName" : "`kll_sketch_get_quantile_bigint`"
   }
 }
 
@@ -851,12 +851,12 @@ FROM (
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkException
+org.apache.spark.SparkRuntimeException
 {
-  "errorClass" : "INTERNAL_ERROR",
-  "sqlState" : "XX000",
+  "errorClass" : "KLL_SKETCH_INVALID_QUANTILE_RANGE",
+  "sqlState" : "22003",
   "messageParameters" : {
-    "message" : "Undefined error message parameter for error class: 'KLL_SKETCH_INVALID_QUANTILE_RANGE', MessageTemplate: For function <functionName>, the quantile value must be between 0.0 and 1.0 (inclusive), but got <quantile>., Parameters: Map(functionName -> `kll_sketch_get_quantile_bigint`)"
+    "functionName" : "`kll_sketch_get_quantile_bigint`"
   }
 }
 
@@ -870,12 +870,12 @@ FROM (
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkException
+org.apache.spark.SparkRuntimeException
 {
-  "errorClass" : "INTERNAL_ERROR",
-  "sqlState" : "XX000",
+  "errorClass" : "KLL_SKETCH_INVALID_QUANTILE_RANGE",
+  "sqlState" : "22003",
   "messageParameters" : {
-    "message" : "Undefined error message parameter for error class: 'KLL_SKETCH_INVALID_QUANTILE_RANGE', MessageTemplate: For function <functionName>, the quantile value must be between 0.0 and 1.0 (inclusive), but got <quantile>., Parameters: Map(functionName -> `kll_sketch_get_quantile_float`)"
+    "functionName" : "`kll_sketch_get_quantile_float`"
   }
 }
 
@@ -909,13 +909,12 @@ FROM (
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkRuntimeException
+org.apache.spark.SparkException
 {
-  "errorClass" : "KLL_SKETCH_INCOMPATIBLE_MERGE",
-  "sqlState" : "22000",
+  "errorClass" : "INTERNAL_ERROR",
+  "sqlState" : "XX000",
   "messageParameters" : {
-    "functionName" : "`kll_sketch_merge_bigint`",
-    "reason" : "reqOffset: 40, reqLength: 56, (reqOff + reqLen): 96, allocSize: 60"
+    "message" : "Cannot find main error class 'KLL_SKETCH_INCOMPATIBLE_MERGE'"
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/kllquantiles.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/kllquantiles.sql.out
@@ -892,13 +892,12 @@ FROM (
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkRuntimeException
+org.apache.spark.SparkException
 {
-  "errorClass" : "KLL_SKETCH_INVALID_INPUT",
-  "sqlState" : "22000",
+  "errorClass" : "INTERNAL_ERROR",
+  "sqlState" : "XX000",
   "messageParameters" : {
-    "functionName" : "`kll_sketch_get_rank_bigint`",
-    "reason" : "reqOffset: 40, reqLength: 56, (reqOff + reqLen): 96, allocSize: 60"
+    "message" : "Undefined error message parameter for error class: 'KLL_SKETCH_INVALID_INPUT', MessageTemplate: Invalid call to <function>; only valid KLL sketch buffers are supported as inputs (such as those produced by the `kll_sketch_agg` function)., Parameters: Map(functionName -> `kll_sketch_get_rank_bigint`, reason -> reqOffset: 40, reqLength: 56, (reqOff + reqLen): 96, allocSize: 60)"
   }
 }
 
@@ -929,13 +928,12 @@ SELECT kll_sketch_get_quantile_bigint(CAST('not_a_sketch' AS BINARY), 0.5) AS in
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkRuntimeException
+org.apache.spark.SparkException
 {
-  "errorClass" : "KLL_SKETCH_INVALID_INPUT",
-  "sqlState" : "22000",
+  "errorClass" : "INTERNAL_ERROR",
+  "sqlState" : "XX000",
   "messageParameters" : {
-    "functionName" : "`kll_sketch_get_quantile_bigint`",
-    "reason" : "Error combination of PreInts and SerVer: PreInts: 110, SerVer: 111"
+    "message" : "Undefined error message parameter for error class: 'KLL_SKETCH_INVALID_INPUT', MessageTemplate: Invalid call to <function>; only valid KLL sketch buffers are supported as inputs (such as those produced by the `kll_sketch_agg` function)., Parameters: Map(functionName -> `kll_sketch_get_quantile_bigint`, reason -> Error combination of PreInts and SerVer: PreInts: 110, SerVer: 111)"
   }
 }
 
@@ -1096,13 +1094,12 @@ SELECT kll_sketch_get_n_bigint(X'deadbeef') AS invalid_binary_bigint
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkRuntimeException
+org.apache.spark.SparkException
 {
-  "errorClass" : "KLL_SKETCH_INVALID_INPUT",
-  "sqlState" : "22000",
+  "errorClass" : "INTERNAL_ERROR",
+  "sqlState" : "XX000",
   "messageParameters" : {
-    "functionName" : "`kll_sketch_get_n_bigint`",
-    "reason" : "A sketch memory image must be at least 8 bytes. 4"
+    "message" : "Undefined error message parameter for error class: 'KLL_SKETCH_INVALID_INPUT', MessageTemplate: Invalid call to <function>; only valid KLL sketch buffers are supported as inputs (such as those produced by the `kll_sketch_agg` function)., Parameters: Map(functionName -> `kll_sketch_get_n_bigint`, reason -> A sketch memory image must be at least 8 bytes. 4)"
   }
 }
 
@@ -1112,13 +1109,12 @@ SELECT kll_sketch_get_n_float(X'cafebabe') AS invalid_binary_float
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkRuntimeException
+org.apache.spark.SparkException
 {
-  "errorClass" : "KLL_SKETCH_INVALID_INPUT",
-  "sqlState" : "22000",
+  "errorClass" : "INTERNAL_ERROR",
+  "sqlState" : "XX000",
   "messageParameters" : {
-    "functionName" : "`kll_sketch_get_n_float`",
-    "reason" : "A sketch memory image must be at least 8 bytes. 4"
+    "message" : "Undefined error message parameter for error class: 'KLL_SKETCH_INVALID_INPUT', MessageTemplate: Invalid call to <function>; only valid KLL sketch buffers are supported as inputs (such as those produced by the `kll_sketch_agg` function)., Parameters: Map(functionName -> `kll_sketch_get_n_float`, reason -> A sketch memory image must be at least 8 bytes. 4)"
   }
 }
 
@@ -1128,13 +1124,12 @@ SELECT kll_sketch_get_n_double(X'12345678') AS invalid_binary_double
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkRuntimeException
+org.apache.spark.SparkException
 {
-  "errorClass" : "KLL_SKETCH_INVALID_INPUT",
-  "sqlState" : "22000",
+  "errorClass" : "INTERNAL_ERROR",
+  "sqlState" : "XX000",
   "messageParameters" : {
-    "functionName" : "`kll_sketch_get_n_double`",
-    "reason" : "A sketch memory image must be at least 8 bytes. 4"
+    "message" : "Undefined error message parameter for error class: 'KLL_SKETCH_INVALID_INPUT', MessageTemplate: Invalid call to <function>; only valid KLL sketch buffers are supported as inputs (such as those produced by the `kll_sketch_agg` function)., Parameters: Map(functionName -> `kll_sketch_get_n_double`, reason -> A sketch memory image must be at least 8 bytes. 4)"
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR improves error messages from the new KLL quantile sketch functions added in https://github.com/apache/spark/pull/52800.

### Why are the changes needed?

The previous error messages reported internal DataSketches library state which was not meaningful for end users of the SQL/DF functions in Apache Spark.

### Does this PR introduce _any_ user-facing change?

Yes, error messages are improved. For example, before this change, we observed the following:

```
SELECT kll_sketch_get_rank_bigint(agg, 5) AS wrong_type
FROM (
    SELECT kll_sketch_agg_float(col1) AS agg
    FROM t_float_1_5_through_7_11
)

> For function `kll_sketch_get_rank_bigint`, invalid KLL sketch binary data: reqOffset: 40, reqLength: 56, (reqOff + reqLen): 96, allocSize: 60"
```

Now the error message becomes:

```
> "Invalid call to `kll_sketch_get_rank_bigint`; only valid KLL sketch buffers are supported as inputs (such as those produced by the `kll_sketch_agg` function)."
```

### How was this patch tested?

This PR updates golden file test coverage to show the improved error messages.

### Was this patch authored or co-authored using generative AI tooling?

No.