### PR TITLE
[SPARK-54910][SS] Add sourceIdentifyingName parameter to StreamingRelationV2

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/streaming/StreamingSourceIdentifyingName.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/streaming/StreamingSourceIdentifyingName.scala
@@ -17,6 +17,22 @@
 
 package org.apache.spark.sql.catalyst.streaming
 
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+/**
+ * A trait for logical plans that have a streaming source identifying name.
+ *
+ * This trait provides a common interface for both V1 (StreamingRelation) and V2
+ * (StreamingRelationV2) streaming sources, allowing analyzer rules in sql/catalyst
+ * to uniformly handle source naming without module boundary issues.
+ *
+ * The self-type constraint ensures this trait can only be mixed into LogicalPlan subclasses.
+ */
+trait HasStreamingSourceIdentifyingName { self: LogicalPlan =>
+  def sourceIdentifyingName: StreamingSourceIdentifyingName
+  def withSourceIdentifyingName(name: StreamingSourceIdentifyingName): LogicalPlan
+}
+
 /**
  * Represents the identifying name state for a streaming source during query analysis.
  *

--- a/sql/connect/common/src/test/resources/query-tests/explain-results/streaming_table_API_with_options.explain
+++ b/sql/connect/common/src/test/resources/query-tests/explain-results/streaming_table_API_with_options.explain
@@ -1,2 +1,2 @@
 ~SubqueryAlias primary.tempdb.myStreamingTable
-+- ~StreamingRelationV2 primary.tempdb.myStreamingTable, org.apache.spark.sql.connector.catalog.InMemoryTable, [p1=v1, p2=v2], [id#0L], org.apache.spark.sql.connector.catalog.InMemoryCatalog, tempdb.myStreamingTable
++- ~StreamingRelationV2 primary.tempdb.myStreamingTable, org.apache.spark.sql.connector.catalog.InMemoryTable, [p1=v1, p2=v2], [id#0L], org.apache.spark.sql.connector.catalog.InMemoryCatalog, tempdb.myStreamingTable, name=<Unassigned>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -331,7 +331,8 @@ class FindDataSourceTable(sparkSession: SparkSession) extends Rule[LogicalPlan] 
       result
 
     case s @ StreamingRelationV2(
-        _, _, table, extraOptions, _, _, _, Some(UnresolvedCatalogRelation(tableMeta, _, true))) =>
+        _, _, table, extraOptions, _, _, _,
+        Some(UnresolvedCatalogRelation(tableMeta, _, true)), _) =>
       import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Implicits._
       val v1Relation = getStreamingRelation(tableMeta, extraOptions)
       if (table.isInstanceOf[SupportsRead]

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
@@ -79,7 +79,7 @@ class ContinuousExecution(
     import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Implicits._
     val _logicalPlan = analyzedPlan.transform {
       case s @ StreamingRelationV2(ds, sourceName, table: SupportsRead, options, output,
-        catalog, identifier, _) =>
+        catalog, identifier, _, _) =>
         val dsStr = if (ds.nonEmpty) s"[${ds.get}]" else ""
         if (!table.supports(TableCapability.CONTINUOUS_READ)) {
           throw QueryExecutionErrors.continuousProcessingUnsupportedByDataSourceError(sourceName)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -198,7 +198,7 @@ class MicroBatchExecution(
         })
 
       case s @ StreamingRelationV2(src, srcName, table: SupportsRead, options, output,
-        catalog, identifier, v1) =>
+        catalog, identifier, v1, _) =>
         val dsStr = if (src.nonEmpty) s"[${src.get}]" else ""
         val v2Disabled = disabledSources.contains(src.getOrElse(None).getClass.getCanonicalName)
         if (!v2Disabled && table.supports(TableCapability.MICRO_BATCH_READ)) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds the `sourceIdentifyingName` parameter to `StreamingRelationV2` and introduces the `HasStreamingSourceIdentifyingName` trait to provide a uniform interface for streaming source naming.

Key changes:
- Added `HasStreamingSourceIdentifyingName` trait in `StreamingSourceIdentifyingName.scala`
- Added `sourceIdentifyingName` parameter to `StreamingRelationV2` case class with default value `Unassigned`
- Implemented `withSourceIdentifyingName` method to support name propagation
- Updated all pattern matches for `StreamingRelationV2` in sql/core to account for new parameter
- Updated explain test golden file to include the new parameter in output

## Why are the changes needed?

This change lays the groundwork for streaming source evolution by enabling sources to have stable identifying names. The parameter will be used by analyzer rules to assign and propagate names from DataFrame API calls, allowing sources to maintain their checkpoint state even when sources are added, removed, or reordered in a query.

## Does this PR introduce _any_ user-facing change?

No. The parameter is added with a default value (`Unassigned`) that maintains backward compatibility. No user-facing APIs are modified.

## How was this patch tested?

- Updated ProtoToPlan explain test to verify the parameter appears correctly in explain output
- Verified pattern matches compile correctly with the new parameter
- All existing tests pass with the new parameter

## Was this patch authored or co-authored using generative AI tooling?

No.
