### PR TITLE
[SPARK-54925][PYTHON] Add the capability to dump threads for pyspark

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -77,6 +77,8 @@ graphviz==0.20.3
 flameprof==0.4
 viztracer
 debugpy
+pystack>=1.5.1; python_version!='3.13' and sys_platform=='linux' # no 3.13t wheels
+psutil
 
 # TorchDistributor dependencies
 torch

--- a/dev/spark-test-image/python-311/Dockerfile
+++ b/dev/spark-test-image/python-311/Dockerfile
@@ -68,7 +68,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 
-ARG BASIC_PIP_PKGS="numpy pyarrow>=22.0.0 six==1.16.0 pandas==2.3.3 scipy plotly<6.0.0 mlflow>=2.8.1 coverage matplotlib openpyxl memory-profiler>=0.61.0 scikit-learn>=1.3.2"
+ARG BASIC_PIP_PKGS="numpy pyarrow>=22.0.0 six==1.16.0 pandas==2.3.3 scipy plotly<6.0.0 mlflow>=2.8.1 coverage matplotlib openpyxl memory-profiler>=0.61.0 scikit-learn>=1.3.2 pystack psutil"
 # Python deps for Spark Connect
 ARG CONNECT_PIP_PKGS="grpcio==1.76.0 grpcio-status==1.76.0 protobuf==6.33.0 googleapis-common-protos==1.71.0 zstandard==0.25.0 graphviz==0.20.3"
 

--- a/python/pyspark/threaddump.py
+++ b/python/pyspark/threaddump.py
@@ -27,8 +27,8 @@ def build_parser():
 
 def main():
     try:
-        import pystack
         import psutil
+        from pystack.__main__ import main as pystack_main
     except ImportError:
         print("pystack and psutil are not installed")
         return 1
@@ -47,13 +47,11 @@ def main():
         return 2
 
     for pid in pids:
-        from pystack.__main__ import main as pystack_main
-
         sys.argv = ["pystack", "remote", str(pid)]
         try:
             print(f"Dumping threads for process {pid}")
             pystack_main()
-        except Exception as e:
+        except Exception:
             # We might tried to dump a process that is not a Python process
             pass
 

--- a/python/pyspark/threaddump.py
+++ b/python/pyspark/threaddump.py
@@ -19,16 +19,16 @@ import argparse
 import sys
 
 
-def build_parser():
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Dump threads of a process and its children")
     parser.add_argument("-p", "--pid", type=int, required=True, help="The PID to dump")
     return parser
 
 
-def main():
+def main() -> int:
     try:
         import psutil
-        from pystack.__main__ import main as pystack_main
+        from pystack.__main__ import main as pystack_main  # type: ignore
     except ImportError:
         print("pystack and psutil are not installed")
         return 1

--- a/python/pyspark/threaddump.py
+++ b/python/pyspark/threaddump.py
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+import sys
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(description="Dump threads of a process and its children")
+    parser.add_argument("-p", "--pid", type=int, required=True, help="The PID to dump")
+    return parser
+
+
+def main():
+    try:
+        import pystack
+        import psutil
+    except ImportError:
+        print("pystack and psutil are not installed")
+        return 1
+
+    parser = build_parser()
+    args = parser.parse_args()
+
+    try:
+        pids = [args.pid] + [
+            child.pid
+            for child in psutil.Process(args.pid).children(recursive=True)
+            if "python" in child.exe()
+        ]
+    except Exception as e:
+        print(f"Error getting children of process {args.pid}: {e}")
+        return 2
+
+    for pid in pids:
+        from pystack.__main__ import main as pystack_main
+
+        sys.argv = ["pystack", "remote", str(pid)]
+        try:
+            print(f"Dumping threads for process {pid}")
+            pystack_main()
+        except Exception as e:
+            # We might tried to dump a process that is not a Python process
+            pass
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add an optional capability to dump thread info of *all* pyspark processes. It is intentionally hidden now because it's not fully polished. It can be used as `python -m pyspark.threaddump -p <pid>`. It requires `pystack` and `psutil`. Without these libraries the command will fail.

For now it was only used when test hangs. The result would be like:

```
Thread dump:
Dumping threads for process 1904
Traceback for thread 2175 (python3.12) [] (most recent call last):
    (Python) File "/usr/lib/python3.12/threading.py", line 1032, in _bootstrap
        self._bootstrap_inner()
    (Python) File "/usr/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
        self.run()
    (Python) File "/usr/lib/python3.12/threading.py", line 1012, in run
        self._target(*self._args, **self._kwargs)
    (Python) File "/usr/lib/python3.12/socketserver.py", line 240, in serve_forever
        self._handle_request_noblock()
    (Python) File "/usr/lib/python3.12/socketserver.py", line 318, in _handle_request_noblock
        self.process_request(request, client_address)
    (Python) File "/usr/lib/python3.12/socketserver.py", line 349, in process_request
        self.finish_request(request, client_address)
    (Python) File "/usr/lib/python3.12/socketserver.py", line 362, in finish_request
        self.RequestHandlerClass(request, client_address, self)
    (Python) File "/usr/lib/python3.12/socketserver.py", line 766, in __init__
        self.handle()
    (Python) File "/workspaces/spark/python/pyspark/accumulators.py", line 327, in handle
        poll(accum_updates)
    (Python) File "/workspaces/spark/python/pyspark/accumulators.py", line 281, in poll
        for fd, event in poller.poll(1000):

Traceback for thread 2034 (python3.12) [] (most recent call last):
    (Python) File "/usr/lib/python3.12/threading.py", line 1032, in _bootstrap
        self._bootstrap_inner()
    (Python) File "/usr/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
        self.run()
    (Python) File "/workspaces/spark/python/lib/py4j-0.10.9.9-src.zip/py4j/clientserver.py", line 58, in run

Traceback for thread 1904 (python3.12) [] (most recent call last):
    (Python) File "<frozen runpy>", line 198, in _run_module_as_main
    (Python) File "<frozen runpy>", line 88, in _run_code
    (Python) File "/workspaces/spark/python/pyspark/sql/tests/test_udf.py", line 1790, in <module>
        unittest.main(testRunner=testRunner, verbosity=2)
    (Python) File "/workspaces/spark/python/pyspark/testing/__init__.py", line 30, in unittest_main
        res = _unittest_main(*args, **kwargs)
    (Python) File "/usr/lib/python3.12/unittest/main.py", line 105, in __init__
        self.runTests()
    (Python) File "/usr/lib/python3.12/unittest/main.py", line 281, in runTests
        self.result = testRunner.run(self.test)
    (Python) File "/usr/local/lib/python3.12/dist-packages/xmlrunner/runner.py", line 67, in run
        test(result)
    (Python) File "/usr/lib/python3.12/unittest/suite.py", line 84, in __call__
        return self.run(*args, **kwds)
    (Python) File "/usr/lib/python3.12/unittest/suite.py", line 122, in run
        test(result)
    (Python) File "/usr/lib/python3.12/unittest/suite.py", line 84, in __call__
        return self.run(*args, **kwds)
    (Python) File "/usr/lib/python3.12/unittest/suite.py", line 122, in run
        test(result)
    (Python) File "/usr/lib/python3.12/unittest/case.py", line 690, in __call__
        return self.run(*args, **kwds)
    (Python) File "/usr/lib/python3.12/unittest/case.py", line 634, in run
        self._callTestMethod(testMethod)
    (Python) File "/usr/lib/python3.12/unittest/case.py", line 589, in _callTestMethod
        if method() is not None:
    (Python) File "/workspaces/spark/python/pyspark/sql/tests/test_udf.py", line 212, in test_chained_udf
        [row] = self.spark.sql("SELECT double_int(double_int(1) + 1)").collect()
    (Python) File "/workspaces/spark/python/pyspark/sql/classic/dataframe.py", line 469, in collect
        sock_info = self._jdf.collectToPython()
    (Python) File "/workspaces/spark/python/lib/py4j-0.10.9.9-src.zip/py4j/java_gateway.py", line 1361, in __call__
    (Python) File "/workspaces/spark/python/lib/py4j-0.10.9.9-src.zip/py4j/java_gateway.py", line 1038, in send_command
    (Python) File "/workspaces/spark/python/lib/py4j-0.10.9.9-src.zip/py4j/clientserver.py", line 535, in send_command
    (Python) File "/usr/lib/python3.12/socket.py", line 720, in readinto
        return self._sock.recv_into(b)

Dumping threads for process 2191
Traceback for thread 2191 (python3.12) [] (most recent call last):
    (Python) File "<frozen runpy>", line 198, in _run_module_as_main
    (Python) File "<frozen runpy>", line 88, in _run_code
    (Python) File "/workspaces/spark/python/lib/pyspark.zip/pyspark/daemon.py", line 287, in <module>
    (Python) File "/workspaces/spark/python/lib/pyspark.zip/pyspark/daemon.py", line 180, in manager

Dumping threads for process 2198
Traceback for thread 2198 (python3.12) [] (most recent call last):
    (Python) File "<frozen runpy>", line 198, in _run_module_as_main
    (Python) File "<frozen runpy>", line 88, in _run_code
    (Python) File "/workspaces/spark/python/lib/pyspark.zip/pyspark/daemon.py", line 287, in <module>
    (Python) File "/workspaces/spark/python/lib/pyspark.zip/pyspark/daemon.py", line 259, in manager
    (Python) File "/workspaces/spark/python/lib/pyspark.zip/pyspark/daemon.py", line 88, in worker
    (Python) File "/workspaces/spark/python/lib/pyspark.zip/pyspark/util.py", line 981, in wrapper
    (Python) File "/workspaces/spark/python/lib/pyspark.zip/pyspark/worker.py", line 3439, in main
    (Python) File "/workspaces/spark/python/lib/pyspark.zip/pyspark/serializers.py", line 583, in read_int

Dumping threads for process 2257
Traceback for thread 2257 (python3.12) [] (most recent call last):
    (Python) File "<frozen runpy>", line 198, in _run_module_as_main
    (Python) File "<frozen runpy>", line 88, in _run_code
    (Python) File "/workspaces/spark/python/lib/pyspark.zip/pyspark/daemon.py", line 287, in <module>
    (Python) File "/workspaces/spark/python/lib/pyspark.zip/pyspark/daemon.py", line 259, in manager
    (Python) File "/workspaces/spark/python/lib/pyspark.zip/pyspark/daemon.py", line 88, in worker
    (Python) File "/workspaces/spark/python/lib/pyspark.zip/pyspark/util.py", line 981, in wrapper
    (Python) File "/workspaces/spark/python/lib/pyspark.zip/pyspark/worker.py", line 3439, in main
    (Python) File "/workspaces/spark/python/lib/pyspark.zip/pyspark/serializers.py", line 583, in read_int
```

Notice that it has not only the driver process, but also daemon and worker process. The plan is to incorporate this into our existing debug framework so `threaddump` button will return both JVM executor threads and python worker threads.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We need insights into python worker/daemon.

We have some thread dump capability in our test, but that's not stable. `SIGTERM` sometimes is hooked and `faulthandler` can't work properly. Also it can't dump the subprocesses.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, but it's hidden for now. A new command entry is introduced.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Locally it works.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.