### PR TITLE
[SPARK-54928] Add shuffle migration statistics to MigrationInfo

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -43,6 +43,7 @@ import org.apache.spark.resource.ResourceUtils._
 import org.apache.spark.rpc._
 import org.apache.spark.scheduler.{ExecutorLossMessage, ExecutorLossReason, TaskDescription}
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages._
+import org.apache.spark.storage.MigrationInfo
 import org.apache.spark.util.{ChildFirstURLClassLoader, MutableURLClassLoader, SignalUtils, ThreadUtils, Utils}
 
 private[spark] class CoarseGrainedExecutorBackend(
@@ -357,10 +358,11 @@ private[spark] class CoarseGrainedExecutorBackend(
             if (executor == null || executor.numRunningTasks == 0) {
               if (migrationEnabled) {
                 logInfo("No running tasks, checking migrations")
-                val (migrationTime, allBlocksMigrated) = env.blockManager.lastMigrationInfo()
-                // We can only trust allBlocksMigrated boolean value if there were no tasks running
+                val MigrationInfo(migrationTime, done, _) =
+                  env.blockManager.lastMigrationInfo().get
+                // We can only trust the `done` boolean value if there were no tasks running
                 // since the start of computing it.
-                if (allBlocksMigrated && (migrationTime > lastTaskFinishTime.get())) {
+                if (done && (migrationTime > lastTaskFinishTime.get())) {
                   logInfo("No running tasks, all blocks migrated, stopping.")
                   exitExecutor(0, ExecutorLossMessage.decommissionFinished, notifyDriver = true)
                 } else {

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -2052,8 +2052,8 @@ private[spark] class BlockManager(
    *  Returns the last migration time and a boolean denoting if all the blocks have been migrated.
    *  If there are any tasks running since that time the boolean may be incorrect.
    */
-  private[spark] def lastMigrationInfo(): (Long, Boolean) = {
-    decommissioner.map(_.lastMigrationInfo()).getOrElse((0, false))
+  private[spark] def lastMigrationInfo(): Option[MigrationInfo] = {
+    decommissioner.map(_.lastMigrationInfo())
   }
 
   private[storage] def getMigratableRDDBlocks(): Seq[ReplicateBlock] =


### PR DESCRIPTION
### What changes were proposed in this pull request?
This adds detailed shuffle migration statistics to block manager decommissioning. A new
`MigrationInfo`/`MigrationStat` exposes counts and sizes for discovered, migrated, remaining,
and deleted shuffle blocks, and the executor shutdown path uses the new struct. A unit test
verifies the stats and size accounting.

### Why are the changes needed?
Decommissioning currently exposes only a boolean for “all blocks migrated.” The additional
stats provide visibility into shuffle migration progress and help diagnose slow/failed
migrations.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
`./build/sbt "testOnly org.apache.spark.storage.BlockManagerDecommissionUnitSuite"`
(Note: the suite passed, but the sbt run ended with `sql-api / Antlr4 / antlr4Generate` exit code 1.)

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Codex (GPT-5)
