### PR TITLE
[SPARK-54930][PYTHON] Remove redundant _accumulatorRegistry.clear() call in worker.py

### DIFF
--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -3493,7 +3493,6 @@ def main(infile, outfile):
 
         shuffle.MemoryBytesSpilled = 0
         shuffle.DiskBytesSpilled = 0
-        _accumulatorRegistry.clear()
 
         setup_spark_files(infile)
         setup_broadcasts(infile)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove a redundant `_accumulatorRegistry.clear()` call in `worker.py`.

Currently there are two consecutive `clear()` calls with no accumulator-modifying code in between:

```python
shuffle.MemoryBytesSpilled = 0
shuffle.DiskBytesSpilled = 0
_accumulatorRegistry.clear()  # first call

setup_spark_files(infile)
setup_broadcasts(infile)

_accumulatorRegistry.clear()  # second call
```

Neither `setup_spark_files` nor `setup_broadcasts` adds anything to `_accumulatorRegistry`, so the first `clear()` is redundant.

### Why are the changes needed?

This is dead code cleanup. The redundant call was introduced when:
- SPARK-3463 (2014) added the first `clear()` after shuffle initialization
- SPARK-3030 (2014) added the second `clear()` after broadcasts setup
- SPARK-44533 (2023) refactored to extract `setup_spark_files` and `setup_broadcasts`, but preserved both `clear()` calls

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests. This is a simple dead code removal with no functional change.

### Was this patch authored or co-authored using generative AI tooling?
No.
