### PR TITLE
[DNM][SPARK-54934][CORE] Make UnsafeInMemorySorter free memory thread-safety

### DIFF
--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeInMemorySorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeInMemorySorter.java
@@ -177,7 +177,8 @@ public final class UnsafeInMemorySorter {
         // Set the array to null instead of allocating a new array. Allocating an array could have
         // triggered another spill and this method already is called from UnsafeExternalSorter when
         // spilling. Attempting to allocate while spilling is dangerous, as we could be holding onto
-        // a large partially complete allocation, which may prevent other memory from being allocated.
+        // a large partially complete allocation, which may prevent other memory from being
+        // allocated.
         // Instead we will allocate the new array when it is necessary.
         array = null;
         usableCapacity = 0;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Make UnsafeInMemorySorter free memory thread-safety

### Why are the changes needed?

I encountered a `SparkOutOfMemoryError`. Logs indicate that memory is held by `UnsafeExternalSorter`, but `UnsafeExternalSorter` is supposed to trigger spilling and release memory. `UnsafeInMemorySorter.freeMemory` is not thread-safe, while `UnsafeExternalSorter.spill` may be called concurrently by multiple threads, which could lead to a memory leak. Related logs:
```
26/01/05 23:04:53 INFO UnsafeExternalSorter: Thread 152 spilling sort data of 2.1 GiB to disk (0  time so far)
...
26/01/05 23:05:10 INFO UnsafeExternalSorter: Thread 152 spilling sort data of 303.0 KiB to disk (0  time so far)
26/01/05 23:05:10 INFO TaskMemoryManager: Memory used in task 172030
26/01/05 23:05:10 INFO TaskMemoryManager: Acquired by org.apache.spark.util.collection.unsafe.sort.UnsafeExternalSorter@72075707: 303.0 KiB
26/01/05 23:05:10 INFO TaskMemoryManager: Acquired by org.apache.spark.util.collection.unsafe.sort.UnsafeExternalSorter@3e02e759: 2.1 GiB
26/01/05 23:05:10 INFO TaskMemoryManager: 0 bytes of memory were used by task 172030 but are not associated with specific consumers
26/01/05 23:05:10 INFO TaskMemoryManager: 2214902769 bytes of memory are used for execution and 87455554 bytes of memory are used for storage
26/01/05 23:05:10 ERROR Executor: Exception in task 5038.0 in stage 185.0 (TID 172030)
org.apache.spark.memory.SparkOutOfMemoryError: [UNABLE_TO_ACQUIRE_MEMORY] Unable to acquire 16384 bytes of memory, got 0.
	at org.apache.spark.errors.SparkCoreErrors$.outOfMemoryError(SparkCoreErrors.scala:467)
	at org.apache.spark.errors.SparkCoreErrors.outOfMemoryError(SparkCoreErrors.scala)
	at org.apache.spark.memory.MemoryConsumer.throwOom(MemoryConsumer.java:157)
	at org.apache.spark.memory.MemoryConsumer.allocateArray(MemoryConsumer.java:98)
	at org.apache.spark.util.collection.unsafe.sort.UnsafeExternalSorter.growPointerArrayIfNecessary(UnsafeExternalSorter.java:384)
	at org.apache.spark.util.collection.unsafe.sort.UnsafeExternalSorter.allocateMemoryForRecordIfNecessary(UnsafeExternalSorter.java:467)
	at org.apache.spark.util.collection.unsafe.sort.UnsafeExternalSorter.insertRecord(UnsafeExternalSorter.java:487)
	at org.apache.spark.sql.execution.ExternalAppendOnlyUnsafeRowArray.$anonfun$add$2(ExternalAppendOnlyUnsafeRowArray.scala:149)
	at org.apache.spark.sql.execution.ExternalAppendOnlyUnsafeRowArray.$anonfun$add$2$adapted(ExternalAppendOnlyUnsafeRowArray.scala:143)
	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
```

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

add unit test

### Was this patch authored or co-authored using generative AI tooling?

No