### PR TITLE
[SPARK-54590][SS] Support Checkpoint V2 for State Rewriter and Repartitioning

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5603,17 +5603,17 @@
           "Ensure that the checkpoint is for a stateful streaming query and the query ran on a Spark version that supports operator metadata (Spark 4.0+)."
         ]
       },
+      "STATE_CHECKPOINT_FORMAT_VERSION_MISMATCH" : {
+        "message" : [
+          "The checkpoint format version in SQLConf does not match the checkpoint version in the commit log.",
+          "Expected version v<expectedVersion>, but found v<actualVersion>.",
+          "Please set '<sqlConfKey>' to <expectedVersion> in your SQLConf before retrying."
+        ]
+      },
       "UNSUPPORTED_STATE_STORE_METADATA_VERSION" : {
         "message" : [
           "Unsupported state store metadata version encountered.",
           "Only StateStoreMetadataV1 and StateStoreMetadataV2 are supported."
-        ]
-      },
-      "CHECKPOINT_VERSION_MISMATCH" : {
-        "message" : [
-          "The checkpoint format version in SQLConf does not match the checkpoint version in the commit log.",
-          "Expected version v<expectedVersion>, but found v<actualVersion>.",
-          "Please set '<sqlConfKey>' to <expectedVersion> in your SQLConf before running StateRewriter."
         ]
       }
     },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5606,7 +5606,7 @@
       "STATE_CHECKPOINT_FORMAT_VERSION_MISMATCH" : {
         "message" : [
           "The checkpoint format version in SQLConf does not match the checkpoint version in the commit log.",
-          "Expected version v<expectedVersion>, but found v<actualVersion>.",
+          "Expected version <expectedVersion>, but found <actualVersion>.",
           "Please set '<sqlConfKey>' to <expectedVersion> in your SQLConf before retrying."
         ]
       },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5608,6 +5608,13 @@
           "Unsupported state store metadata version encountered.",
           "Only StateStoreMetadataV1 and StateStoreMetadataV2 are supported."
         ]
+      },
+      "CHECKPOINT_VERSION_MISMATCH" : {
+        "message" : [
+          "The checkpoint format version in SQLConf does not match the checkpoint version in the commit log.",
+          "Expected version v<expectedVersion>, but found v<actualVersion>.",
+          "Please set '<sqlConfKey>' to <expectedVersion> in your SQLConf before running StateRewriter."
+        ]
       }
     },
     "sqlState" : "55019"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionRunner.scala
@@ -102,7 +102,8 @@ class OfflineStateRepartitionRunner(
         // Commit the repartition batch
         val enableCheckpointId = sparkSession.conf.get(
           SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key).toInt >= 2
-        commitBatch(newBatchId, lastCommittedBatchId, operatorToCkptIds, enableCheckpointId)
+        commitBatch(newBatchId, lastCommittedBatchId,
+          if (enableCheckpointId) Option(operatorToCkptIds) else None)
         newBatchId
       }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -454,7 +454,7 @@ class RocksDB(
         closeDB(ignoreException = false)
         if (loadEmpty) {
           require(stateStoreCkptId.isEmpty,
-            "stateStoeCkptId should be empty when loadEmpty is true")
+            "stateStoreCkptId should be empty when loadEmpty is true")
           loadEmptyStore(version)
           lineageManager.clear()
         } else {
@@ -539,7 +539,7 @@ class RocksDB(
       }
       if (loadEmpty) {
         logInfo(log"Loaded empty store at version ${MDC(LogKeys.VERSION_NUM, version)} " +
-          log"without uniqueId")
+          log"with uniqueId")
       } else {
         logInfo(log"Loaded ${MDC(LogKeys.VERSION_NUM, version)} " +
           log"with uniqueId ${MDC(LogKeys.UUID, stateStoreCkptId)}")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -375,6 +375,8 @@ class RocksDBFileManager(
       createDfsRootDirIfNotExist()
       // Since we cleared the local dir, we should also clear the local file mapping
       rocksDBFileMapping.clear()
+      // Set empty metrics since we're not loading any files from DFS
+      loadCheckpointMetrics = RocksDBFileManagerMetrics.EMPTY_METRICS
       RocksDBCheckpointMetadata(Seq.empty, 0)
     } else {
       // Delete all non-immutable files in local dir, and unzip new ones from DFS commit file

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StatePartitionWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StatePartitionWriter.scala
@@ -145,10 +145,12 @@ class StatePartitionAllColumnFamiliesWriter(
   // - key_bytes, BinaryType
   // - value_bytes, BinaryType
   // - column_family_name, StringType
-  def write(rows: Iterator[InternalRow]): Unit = {
+  // Returns StateStoreCheckpointInfo containing the checkpoint ID after commit
+  def write(rows: Iterator[InternalRow]): StateStoreCheckpointInfo = {
     try {
       rows.foreach(row => writeRow(row))
       stateStore.commit()
+      stateStore.getStateStoreCheckpointInfo()
     } finally {
       if (!stateStore.hasCommitted) {
         stateStore.abort()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StatePartitionWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StatePartitionWriter.scala
@@ -145,7 +145,8 @@ class StatePartitionAllColumnFamiliesWriter(
   // - key_bytes, BinaryType
   // - value_bytes, BinaryType
   // - column_family_name, StringType
-  // Returns StateStoreCheckpointInfo containing the checkpoint ID after commit
+  // Returns StateStoreCheckpointInfo containing the checkpoint ID after commit if
+  // enabled checkpointV2
   def write(rows: Iterator[InternalRow]): StateStoreCheckpointInfo = {
     try {
       rows.foreach(row => writeRow(row))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateRewriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateRewriter.scala
@@ -375,7 +375,9 @@ class StateRewriter(
     val latestCommitLog = commitLog.getLatest()
     assert(latestCommitLog.isDefined)
     if (latestCommitLog.get._2.stateUniqueIds.isDefined) {
-      // hard checkpoint version to 2 if previous commit log has checkpoint id
+      // Hard code checkpoint version to 2 if previous commit log has checkpoint id.
+      // This prevents StateRewriter from crashing in case client forget to set correct
+      // STATE_STORE_CHECKPOINT_FORMAT_VERSION in SQLConf
       sparkSession.conf.set(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key, "2")
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionSuite.scala
@@ -421,9 +421,9 @@ object OfflineStateRepartitionTestUtils {
       serializableConf: SerializableConfiguration,
       batchId: Long
     ): Array[OperatorStateMetadata] = {
-    val repartitionMetadataReader = new StateMetadataPartitionReader(
+    val metadataPartitionReader = new StateMetadataPartitionReader(
       checkpointLocation, serializableConf, batchId)
-    repartitionMetadataReader.allOperatorStateMetadata
+    metadataPartitionReader.allOperatorStateMetadata
   }
 
   private def verifyOperatorMetadata(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -3943,7 +3943,7 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
     }}
   }
 
-  test("SPARK-54420: load with createEmpty creates empty store") {
+  testWithStateStoreCheckpointIds("SPARK-54420: load with createEmpty creates empty store") { _ =>
     val remoteDir = Utils.createTempDir().toString
     new File(remoteDir).delete()
 
@@ -4027,13 +4027,13 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
         version: Long,
         ckptId: Option[String] = None,
         readOnly: Boolean = false,
-        createEmpty: Boolean = false): RocksDB = {
+        loadEmpty: Boolean = false): RocksDB = {
       // When a ckptId is defined, it means the test is explicitly using v2 semantic
       // When it is not, it is possible that implicitly uses it.
       // So still do a versionToUniqueId.get
       ckptId match {
-        case Some(_) => super.load(version, ckptId, readOnly)
-        case None => super.load(version, versionToUniqueId.get(version), readOnly)
+        case Some(_) => super.load(version, ckptId, readOnly, loadEmpty)
+        case None => super.load(version, versionToUniqueId.get(version), readOnly, loadEmpty)
       }
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -3978,6 +3978,7 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
         // load 2 empty store in a row
         db.load(version3, loadEmpty = true)
         db.put("d", "4")
+
         val (version4, checkpointV4) = db.commit()
         assert(db.get("c") === null)
         assert(toStr(db.get("d")) === "4")
@@ -3985,6 +3986,7 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
         lastCheckpointInfo = Option(checkpointV4)
         assert(lastVersion === version3 + 1)
       }
+
       withDB(remoteDir, enableStateStoreCheckpointIds = enableCkptId) { db =>
         db.load(lastVersion, lastCheckpointInfo.map(_.stateStoreCkptId).orNull)
         db.put("e", "5")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -3943,47 +3943,55 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
     }}
   }
 
-  testWithStateStoreCheckpointIds("SPARK-54420: load with createEmpty creates empty store") { _ =>
-    val remoteDir = Utils.createTempDir().toString
-    new File(remoteDir).delete()
+  testWithStateStoreCheckpointIds(
+    "SPARK-54420: load with createEmpty creates empty store") { enableCkptId =>
+      val remoteDir = Utils.createTempDir().toString
+      new File(remoteDir).delete()
 
-    withDB(remoteDir) { db =>
-      // loading batch 0 with loadEmpty = true
-      db.load(0, None, loadEmpty = true)
-      assert(iterator(db).isEmpty)
-      db.put("a", "1")
-      val (version1, _) = db.commit()
-      assert(toStr(db.get("a")) === "1")
+      withDB(remoteDir, enableStateStoreCheckpointIds = enableCkptId) { db =>
+        // loading batch 0 with loadEmpty = true
+        db.load(0, None, loadEmpty = true)
+        assert(iterator(db).isEmpty)
+        db.put("a", "1")
+        val (version1, checkpointInfoV1) = db.commit()
+        assert(toStr(db.get("a")) === "1")
 
-      // check we can load store normally even the previous one loadEmpty = true
-      db.load(version1)
-      db.put("b", "2")
-      val (version2, _) = db.commit()
-      assert(version2 === version1 + 1)
-      assert(toStr(db.get("b")) === "2")
-      assert(toStr(db.get("a")) === "1")
+        // check we can load store normally even the previous one loadEmpty = true
+        db.load(version1, checkpointInfoV1.stateStoreCkptId)
+        db.put("b", "2")
+        val (version2, _) = db.commit()
+        assert(version2 === version1 + 1)
+        assert(toStr(db.get("b")) === "2")
+        assert(toStr(db.get("a")) === "1")
 
-      // load an empty store
-      db.load(version2, loadEmpty = true)
-      db.put("c", "3")
-      val (version3, _) = db.commit()
-      assert(db.get("b") === null)
-      assert(db.get("a") === null)
-      assert(toStr(db.get("c")) === "3")
-      assert(version3 === version2 + 1)
+        // load an empty store
+        db.load(version2, loadEmpty = true)
+        db.put("c", "3")
+        val (version3, _) = db.commit()
+        assert(db.get("b") === null)
+        assert(db.get("a") === null)
+        assert(toStr(db.get("c")) === "3")
+        assert(version3 === version2 + 1)
 
-      // load 2 empty store in a row
-      db.load(version3, loadEmpty = true)
-      db.put("d", "4")
-      val (version4, _) = db.commit()
-      assert(db.get("c") === null)
-      assert(toStr(db.get("d")) === "4")
-      assert(version4 === version3 + 1)
+        // load 2 empty store in a row
+        db.load(version3, loadEmpty = true)
+        db.put("d", "4")
+        val (version4, checkpointInfoV4) = db.commit()
+        assert(db.get("c") === null)
+        assert(toStr(db.get("d")) === "4")
+        assert(version4 === version3 + 1)
 
-      db.load(version4)
-      db.put("e", "5")
-      db.commit()
-      assert(db.iterator().map(toStr).toSet === Set(("d", "4"), ("e", "5")))
+        db.load(version4, checkpointInfoV4.stateStoreCkptId)
+        db.put("e", "5")
+        db.commit()
+        assert(db.iterator().map(toStr).toSet === Set(("d", "4"), ("e", "5")))
+
+        if (enableCkptId) {
+          val ex = intercept[IllegalArgumentException] {
+            db.load(version4, checkpointInfoV4.stateStoreCkptId, loadEmpty = true)
+          }
+          assert(ex.getMessage.contains("stateStoeCkptId should be empty when loadEmpty is true"))
+        }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Support checkpointV2 for repartition writer and StateRewriter by returning the checkpoint Id to caller function after write is done. 
Changes include
- RocksDB loadWithCheckpointId supports loadEmpty
- StatePartitionAllColumnFamiliesWriter return StateStoreCheckpointInfo
- StateRewriter also propagate StateStoreCheckpointInfo back to the RepartitionRunner
- RepartitionRunner stores the checkpointIds in commitLog

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is required in PrPr for repartition project

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
See added unit tests on moth operator with single state store and multiple state stores

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes. Sonnet 4.5