### PR TITLE
[SPARK-54957][PYTHON][TEST] Remove the unnecessary sleep in streaming tests

### DIFF
--- a/python/pyspark/sql/tests/connect/streaming/test_parity_listener.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_listener.py
@@ -202,10 +202,14 @@ class StreamingListenerParityTests(StreamingListenerTestsMixin, ReusedConnectTes
 
             q.stop()
             # need to wait a while before QueryTerminatedEvent reaches client
-            time.sleep(5)
-            self.assertTrue(len(listener_good.start) > 0)
-            self.assertTrue(len(listener_good.progress) > 0)
-            self.assertTrue(len(listener_good.terminated) > 0)
+
+            @eventually(timeout=5, catch_assertions=True)
+            def check_listner():
+                self.assertTrue(len(listener_good.start) > 0)
+                self.assertTrue(len(listener_good.progress) > 0)
+                self.assertTrue(len(listener_good.terminated) > 0)
+
+            check_listner()
         finally:
             for listener in self.spark.streams._sqlb._listener_bus:
                 self.spark.streams.removeListener(listener)
@@ -245,26 +249,27 @@ class StreamingListenerParityTests(StreamingListenerTestsMixin, ReusedConnectTes
                 q.stop()
                 self.assertFalse(q.isActive)
 
-                time.sleep(
-                    60
-                )  # Sleep to make sure listener_terminated_events is written successfully
+                events = {
+                    "start_event": None,
+                    "progress_event": None,
+                    "terminated_event": None,
+                }
 
-                start_event = pyspark.cloudpickle.loads(
-                    self.spark.read.table("listener_start_events").collect()[0][0]
-                )
+                @eventually(timeout=60, catch_assertions=True)
+                def load_event(event_name, table_name):
+                    table = self.spark.read.table(table_name).collect()
+                    if len(table) == 0:
+                        return False
+                    events[event_name] = pyspark.cloudpickle.loads(table[0][0])
+                    return True
+                    
+                load_event("start_event", "listener_start_events")
+                load_event("progress_event", "listener_progress_events")
+                load_event("terminated_event", "listener_terminated_events")
 
-                progress_event = pyspark.cloudpickle.loads(
-                    self.spark.read.table("listener_progress_events").collect()[0][0]
-                )
-
-                terminated_event = pyspark.cloudpickle.loads(
-                    self.spark.read.table("listener_terminated_events").collect()[0][0]
-                )
-
-                self.check_start_event(start_event)
-                self.check_progress_event(progress_event, is_stateful=True)
-                self.check_terminated_event(terminated_event)
-
+                self.check_start_event(events["start_event"])
+                self.check_progress_event(events["progress_event"], is_stateful=True)
+                self.check_terminated_event(events["terminated_event"])
         finally:
             self.spark.streams.removeListener(test_listener)
             # Remove again to verify this won't throw any error

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_listener.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_listener.py
@@ -262,7 +262,7 @@ class StreamingListenerParityTests(StreamingListenerTestsMixin, ReusedConnectTes
                         return False
                     events[event_name] = pyspark.cloudpickle.loads(table[0][0])
                     return True
-                    
+
                 load_event("start_event", "listener_start_events")
                 load_event("progress_event", "listener_progress_events")
                 load_event("terminated_event", "listener_terminated_events")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Instead of do a fixed time wait, we try to poll results until it meets the requirement.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We are wasting time on this test. `time.sleep(60)` is totally unnecessary. I still have trouble with the other `time.sleep(30)` which just try to wait to see if the server crashes without traffic - but at least that has an explanation.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

My local setup has some issues with this specific test so I'll have to wait for the CI result.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No