### PR TITLE
[SPARK-54963][PYTHON][CONNECT] Make `createDataFrame` respect `prefer_timestamp_ntz` when `infer_pandas_dict_as_map`

### DIFF
--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -849,7 +849,7 @@ class SparkConversionMixin:
                             StringType(), from_arrow_type(arrow_type, prefer_timestamp_ntz)
                         )
                     else:
-                        spark_type = from_arrow_type(field_type)
+                        spark_type = from_arrow_type(field_type, prefer_timestamp_ntz)
                     struct.add(name, spark_type, nullable=field.nullable)
             else:
                 for name, field in zip(schema, arrow_schema):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `createDataFrame` respect `prefer_timestamp_ntz` when `infer_pandas_dict_as_map`


### Why are the changes needed?
In `createDataFrame`, `prefer_timestamp_ntz` is used in some places but not all places.
It should always respect `prefer_timestamp_ntz`


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
No
