### PR TITLE
[SPARK-54972][SQL] Improve NOT IN subqueries with non-nullable columns

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -264,6 +264,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
       CheckCartesianProducts),
     Batch("RewriteSubquery", Once,
       RewritePredicateSubquery,
+      NullPropagation,
       PushPredicateThroughJoin,
       LimitPushDown,
       ColumnPruning,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Run `NullPropagation` after NOT IN subquery rewrite.

### Why are the changes needed?

NOT IN subqueries like `SELECT * FROM t1 WHERE c NOT IN (SELECT c FROM t2)` are rewritten as left anti join `t1.c = t2.c` with additional `OR IsNull(t1.c = t2.c)` conditions which prevents equi join implementations to be used so those joins end up as `BroadcastNestedLoopJoin`. When we know the columns can't be null, we can either drop those additional conditions during subquery rewrite or call `NullPropagation` after the rewrite to simplify them to `false`. This PR contains the latter.

Please note that https://github.com/apache/spark/pull/29104 already optmized the single column NOT IN subqueries from `BroadcastNestedLoopJoin` to "null aware" `BroadcastHashJoin` very well, but when the columns are not nullable we can optimize multi column cases as well and the join don't need to be "null aware".

### Does this PR introduce _any_ user-facing change?

Yes, performance improvement.

### How was this patch tested?

A new UTs was added and some exsisting tests were adjusted to keep their validity.

### Was this patch authored or co-authored using generative AI tooling?

No.