### PR TITLE
[MINOR][SQL] SQL state code change from XX000 to 42704 for MISSING_ATTRIBUTES

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4479,7 +4479,7 @@
         ]
       }
     },
-    "sqlState" : "XX000"
+    "sqlState" : "42704"
   },
   "MISSING_CATALOG_ABILITY" : {
     "message" : [

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/negative-cases/invalid-correlation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/negative-cases/invalid-correlation.sql.out
@@ -77,7 +77,7 @@ WHERE  t1a IN (SELECT   min(t2a)
 org.apache.spark.sql.catalyst.ExtendedAnalysisException
 {
   "errorClass" : "MISSING_ATTRIBUTES.RESOLVED_ATTRIBUTE_MISSING_FROM_INPUT",
-  "sqlState" : "XX000",
+  "sqlState" : "42704",
   "messageParameters" : {
     "input" : "\"min(t2a)\", \"t2c\"",
     "missingAttributes" : "\"t2b\"",

--- a/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
@@ -72,7 +72,7 @@ struct<>
 org.apache.spark.sql.catalyst.ExtendedAnalysisException
 {
   "errorClass" : "MISSING_ATTRIBUTES.RESOLVED_ATTRIBUTE_MISSING_FROM_INPUT",
-  "sqlState" : "XX000",
+  "sqlState" : "42704",
   "messageParameters" : {
     "input" : "\"min(t2a)\", \"t2c\"",
     "missingAttributes" : "\"t2b\"",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Update SQL state code for MISSING_ATTRIBUTES from XX000 to 42704 since it's not an internal error


### Why are the changes needed?
correct the sql state code


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
existing UT


### Was this patch authored or co-authored using generative AI tooling?
No
