### PR TITLE
[DRAFT][SQL][PYTHON][CONNECT] Enable xxhash64 with seed parameter

### DIFF
--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -4450,8 +4450,11 @@ def hash(*cols: "ColumnOrName") -> Column:
 hash.__doc__ = pysparkfuncs.hash.__doc__
 
 
-def xxhash64(*cols: "ColumnOrName") -> Column:
-    return _invoke_function_over_columns("xxhash64", *cols)
+def xxhash64(*cols: "ColumnOrName", seed: Optional[int] = None) -> Column:
+    if seed is None:
+        return _invoke_function_over_columns("xxhash64", *cols)
+    else:
+        return _invoke_function("xxhash64_with_seed", lit(seed), *[_to_col(c) for c in cols])
 
 
 xxhash64.__doc__ = pysparkfuncs.xxhash64.__doc__

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3900,6 +3900,23 @@ object functions {
   def xxhash64(cols: Column*): Column = Column.fn("xxhash64", cols: _*)
 
   /**
+   * Calculates the hash code of given columns using the 64-bit variant of the xxHash algorithm,
+   * and returns the result as a long column.
+   *
+   * @param seed
+   *   the seed value for the hash function.
+   * @param cols
+   *   the columns to hash.
+   * @return
+   *   a long column containing the hash value.
+   *
+   * @group hash_funcs
+   * @since 4.0.0
+   */
+  def xxhash64(seed: Long, cols: Column*): Column =
+    Column.internalFn("xxhash64_with_seed", (lit(seed) +: cols): _*)
+
+  /**
    * Returns null if the condition is true, and throws an exception otherwise.
    *
    * @group misc_funcs

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -794,7 +794,8 @@ object FunctionRegistry {
     expression[Md5]("md5"),
     expression[Uuid]("uuid"),
     expression[Murmur3Hash]("hash"),
-    expression[XxHash64]("xxhash64"),
+    ("xxhash64", (FunctionRegistryBase.expressionInfo[XxHash64]("xxhash64", Some("3.0.0")),
+      (expressions: Seq[Expression]) => XxHash64ExpressionBuilder.build("xxhash64", expressions))),
     expression[Sha1]("sha", true),
     expression[Sha1]("sha1"),
     expression[Sha2]("sha2"),
@@ -998,6 +999,7 @@ object FunctionRegistry {
   registerInternalExpression[NullIndex]("null_index")
   registerInternalExpression[CastTimestampNTZToLong]("timestamp_ntz_to_long")
   registerInternalExpression[ArrayBinarySearch]("array_binary_search")
+  registerInternalExpression[XxHash64WithSeed]("xxhash64_with_seed")
 
   private def makeExprInfoForVirtualOperator(name: String, usage: String): ExpressionInfo = {
     new ExpressionInfo(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
DRAFT.


### Why are the changes needed?
DRAFT.


### Does this PR introduce _any_ user-facing change?
Yes, the `xxhash64` function can now take an optional `seed` parameter (instead of always using 42 as seed value).


### How was this patch tested?
Added new tests to confirm the desired behaviour.


### Was this patch authored or co-authored using generative AI tooling?
Yes.
