### PR TITLE
[SPARK-54925][PYTHON][FOLLOWUP] Fix threaddump for run-tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -566,7 +566,7 @@ jobs:
       SKIP_PACKAGING: true
       METASPACE_SIZE: 1g
       BRANCH: ${{ inputs.branch }}
-      PYSPARK_TEST_TIMEOUT: 450
+      PYSPARK_TEST_TIMEOUT: 20
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v4

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -510,6 +510,9 @@ jobs:
     timeout-minutes: 120
     container:
       image: ${{ needs.precondition.outputs.image_pyspark_url_link }}
+      options: >-
+        --cap-add=SYS_PTRACE
+        --security-opt seccomp=unconfined
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -569,7 +569,7 @@ jobs:
       SKIP_PACKAGING: true
       METASPACE_SIZE: 1g
       BRANCH: ${{ inputs.branch }}
-      PYSPARK_TEST_TIMEOUT: 20
+      PYSPARK_TEST_TIMEOUT: 450
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v4

--- a/python/pyspark/threaddump.py
+++ b/python/pyspark/threaddump.py
@@ -31,7 +31,7 @@ def main() -> int:
         from pystack.__main__ import main as pystack_main  # type: ignore
     except ImportError:
         print("pystack and psutil are not installed")
-        return 1
+        return 5
 
     parser = build_parser()
     args = parser.parse_args()

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -219,6 +219,8 @@ class TestRunner:
         )
         if p.returncode == 0:
             LOGGER.error(f"Thread dump:\n{p.stdout.decode('utf-8')}")
+        else:
+            LOGGER.error(f"Failed to get thread dump, exit code {p.returncode}:\n{p.stdout.decode('utf-8')}")
 
 
 def run_individual_python_test(target_dir, test_name, pyspark_python, keep_test_output):

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -211,14 +211,22 @@ class TestRunner:
 
     def thread_dump(self, pid):
         pyspark_python = self.env['PYSPARK_PYTHON']
+        python_path = f"{os.path.join(SPARK_HOME, 'python')}"
+        py4j_path = f"{os.path.join(SPARK_HOME, 'python/lib/py4j-0.10.9.9-src.zip')}"
         p = subprocess.run(
             [pyspark_python, "-m", "pyspark.threaddump", "-p", str(pid)],
-            env={**self.env, "PYTHONPATH": f"{os.path.join(SPARK_HOME, 'python')}:{os.environ.get('PYTHONPATH', '')}"},
+            env={
+                **self.env,
+                "PYTHONPATH": f"{python_path}:{py4j_path}:{os.environ.get('PYTHONPATH', '')}",
+            },
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )
         if p.returncode == 0:
             LOGGER.error(f"Thread dump:\n{p.stdout.decode('utf-8')}")
+        elif p.returncode == 5:
+            # pystack or psutil not installed, that's okay
+            pass
         else:
             LOGGER.error(f"Failed to get thread dump, exit code {p.returncode}:\n{p.stdout.decode('utf-8')}")
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

* Add py4j path in `run-tests.py` so `python -m pyspark.threaddump` can execute
* Enable SYS_PTRACE on docker image so thread dump can work properly
* Changed "missing dependency" return code to 5 so we can easily pick it up (1 is too often used)
* If thread dump failed and not due to missing dependency, print why 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

CI does not thread dump correctly now.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

https://github.com/gaogaotiantian/spark/actions/runs/20841485611/job/59876752869

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No