### PR TITLE
[SPARK-54985][CORE] Show memory usage when task memory manager can't allocate memory page

### DIFF
--- a/core/src/main/java/org/apache/spark/memory/TaskMemoryManager.java
+++ b/core/src/main/java/org/apache/spark/memory/TaskMemoryManager.java
@@ -401,6 +401,7 @@ public class TaskMemoryManager {
         logger.warn("Failed to allocate a page ({} bytes) for {} times, try again.", e,
             MDC.of(LogKeys.PAGE_SIZE, acquired),
             MDC.of(LogKeys.NUM_RETRY, retryCount));
+        showMemoryUsage();
       } else {
         logger.warn("Failed to allocate a page ({} bytes) for {} times, try again.",
             MDC.of(LogKeys.PAGE_SIZE, acquired),


### PR DESCRIPTION

### What changes were proposed in this pull request?
Show memory usage when task memory manager can't allocate memory page


### Why are the changes needed?
The memory managed by `TaskMemoryManager` may be used by multiple `MemoryConsumers`. When an `OutOfMemoryError (OOM)` occurs in `allocatePage`, displaying memory usage information can help analyze which MemoryConsumers are consuming excessive memory.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
No need test


### Was this patch authored or co-authored using generative AI tooling?
No
