### PR TITLE
[SPARK-54987][PYTHON] Change the default value of prefer_timestamp_ntz to True in `from_arrow_type/from_arrow_schema`

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow.py
@@ -783,7 +783,7 @@ class ArrowTestsMixin:
             DateType(),
             TimeType(),
             TimestampType(),
-            # TimestampNTZTydpe(), # from_arrow_type controlled by prefer_timestamp_ntz
+            TimestampNTZType(),
             DayTimeIntervalType(0, 3),
             ArrayType(StringType(), True),
             ArrayType(StringType(), False),


### PR DESCRIPTION

### What changes were proposed in this pull request?
Change the default value of prefer_timestamp_ntz to True in `from_arrow_type/from_arrow_schema`



### Why are the changes needed?
to make the roundtrip `from_arrow_type(to_arrow_type(...))` `from_arrow_schema(to_arrow_schema(...))` work for all datatype with default value


### Does this PR introduce _any_ user-facing change?
no, the two functions are only used internally


### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
No