### PR TITLE
[SPARK-55005][SQL] Fix CONTINUE HANDLER to continue loop execution after handling exceptions in loop body

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecution.scala
@@ -102,7 +102,12 @@ class SqlScriptingExecution(
 
     currExecPlan match {
       case exec: ConditionalStatementExec =>
-        exec.interrupted = true
+        // Only interrupt if the conditional statement is currently evaluating its condition.
+        // For loop statements, this means we should skip the loop when an exception occurs
+        // during condition evaluation, but NOT when an exception occurs in the loop body.
+        if (exec.isInCondition) {
+          exec.interrupted = true
+        }
       case _ =>
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -585,6 +585,8 @@ class WhileStatementExec(
 
   override def getTreeIterator: Iterator[CompoundStatementExec] = treeIterator
 
+  override protected[scripting] def isInCondition: Boolean = state == WhileState.Condition
+
   override def reset(): Unit = {
     state = WhileState.Condition
     curr = Some(condition)

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -122,6 +122,22 @@ trait ConditionalStatementExec extends NonLeafStatementExec {
    * HANDLER.
    */
   protected[scripting] var interrupted: Boolean = false
+
+  /**
+   * Returns true if the conditional statement is currently evaluating its condition,
+   * false if it's executing its body. This is used by CONTINUE HANDLER to determine
+   * whether to interrupt the conditional statement when an exception occurs.
+   *
+   * For loop statements (WHILE, REPEAT, FOR), this should return true when evaluating
+   * the loop condition and false when executing the loop body. This distinction is
+   * critical because:
+   * - Exception in condition: loop should be skipped (interrupted)
+   * - Exception in body: loop should continue to next iteration (not interrupted)
+   *
+   * For IF/CASE statements, this should return true when evaluating the condition
+   * expression and false when executing any branch body.
+   */
+  protected[scripting] def isInCondition: Boolean
 }
 
 /**
@@ -481,6 +497,8 @@ class IfElseStatementExec(
 
   override def getTreeIterator: Iterator[CompoundStatementExec] = treeIterator
 
+  override protected[scripting] def isInCondition: Boolean = state == IfElseState.Condition
+
   override def reset(): Unit = {
     state = IfElseState.Condition
     curr = Some(conditions.head)
@@ -656,6 +674,8 @@ class SearchedCaseStatementExec(
 
   override def getTreeIterator: Iterator[CompoundStatementExec] = treeIterator
 
+  override protected[scripting] def isInCondition: Boolean = state == CaseState.Condition
+
   override def reset(): Unit = {
     state = CaseState.Condition
     curr = Some(conditions.head)
@@ -795,6 +815,8 @@ class SimpleCaseStatementExec(
 
   override def getTreeIterator: Iterator[CompoundStatementExec] = treeIterator
 
+  override protected[scripting] def isInCondition: Boolean = state == CaseState.Condition
+
   override def reset(): Unit = {
     state = CaseState.Condition
     bodyExec = None
@@ -881,6 +903,8 @@ class RepeatStatementExec(
     }
 
   override def getTreeIterator: Iterator[CompoundStatementExec] = treeIterator
+
+  override protected[scripting] def isInCondition: Boolean = state == RepeatState.Condition
 
   override def reset(): Unit = {
     state = RepeatState.Body
@@ -1217,6 +1241,8 @@ class ForStatementExec(
   }
 
   override def getTreeIterator: Iterator[CompoundStatementExec] = treeIterator
+
+  override protected[scripting] def isInCondition: Boolean = state == ForState.VariableAssignment
 
   override def reset(): Unit = {
     state = ForState.VariableAssignment


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes a critical bug in `CONTINUE HANDLER` execution within loops. When a `CONTINUE HANDLER` handled an exception that occurred inside a loop body, the loop would exit completely instead of continuing to the next iteration.

#### Root cause
The `interruptConditionalStatements` method in `SqlScriptingExecution.scala` was designed to skip conditional statements when exceptions occurred in their condition evaluation (e.g., WHILE 1/0 > 0). However, it didn't distinguish between:
  - Exception in condition → loop should be skipped
  - Exception in body → loop should continue to next iteration

The method unconditionally set `interrupted = true` on all conditional statements, causing loops to exit even when the error occurred during body execution.

#### The fix
The fix was to add `isInCondition: Boolean` method to `ConditionalStatementExec` trait to track whether a conditional statement is currently evaluating its condition or executing its body. It was also needed to implement `isInCondition` for all 6 `ConditionalStatementExec`:
- IfElseStatementExec
- WhileStatementExec
- RepeatStatementExec
- ForStatementExec
- SearchedCaseStatementExec
- SimpleCaseStatementExec

### Why are the changes needed?
This ensures `CONTINUE HANDLER` only interrupts conditional statements when exceptions occur during condition evaluation, allowing loops to continue normally when exceptions occur in their bodies.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added comprehensive test coverage for `CONTINUE HANDLER` across all conditional statement types.  These tests verify that when an exception occurs inside a loop body and is handled by a `CONTINUE HANDLER`, the loop continues to the next iteration rather than exiting.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
