### PR TITLE
[SPARK-53758] Fix EXIT handler not exiting properly if triggered from another EXIT handler

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionContext.scala
@@ -105,6 +105,10 @@ class SqlScriptingExecutionFrame(
   // List of scopes that are currently active.
   private[scripting] val scopes: ListBuffer[SqlScriptingExecutionScope] = ListBuffer.empty
 
+  // Tracks whether a LEAVE statement has been injected into this frame by a handler.
+  // Used to prevent inner handlers from overriding LEAVE statements injected by outer handler.
+  private[scripting] var leaveStatementInjected: Boolean = false
+
   override def hasNext: Boolean = executionPlan.getTreeIterator.hasNext
 
   override def next(): CompoundStatementExec = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
An unexpected behavior happens when an EXIT handler inside of an outer scope gets triggered by an exception inside an EXIT handler thats inside an inner nested scope: instead of leaving the outer scope after finishing all the exception handling, execution only leaves the inner scope.

In the example below, execution returns 3, 2 at the end, but it shouldn't reach that part of the code.

```
BEGIN
  DECLARE VARIABLE flag INT = -1;
  l1: BEGIN
    DECLARE EXIT HANDLER FOR UNRESOLVED_COLUMN.WITHOUT_SUGGESTION
    BEGIN
      SELECT flag;
      SET flag = 2;
    END;
    l2: BEGIN
      DECLARE EXIT HANDLER FOR DIVIDE_BY_ZERO
      BEGIN
        SELECT flag;
        SET flag = 1;
        select X; -- select non existing variable
        SELECT 2;
      END;
      SELECT 5;
      SELECT 1/0; -- divide by zero
      SELECT 6;
    END l2;
    SELECT 3, flag;
  END l1;
END 
```

In this PR I propose a fix for this issue.


### Why are the changes needed?
This change is needed to fix the correctness behavior of the SQL Scripting engine.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
New unit tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
