### PR TITLE
[SPARK-55009][CORE] Remove unnecessary memory copy from the constructor of `LevelDBTypeInfo/RocksDBTypeInfo.Index`

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBTypeInfo.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBTypeInfo.java
@@ -222,14 +222,7 @@ class LevelDBTypeInfo {
     private final Index parent;
 
     private Index(KVIndex self, KVTypeInfo.Accessor accessor, Index parent) {
-      byte[] name = self.value().getBytes(UTF_8);
-      if (parent != null) {
-        byte[] child = new byte[name.length + 1];
-        child[0] = SECONDARY_IDX_PREFIX;
-        System.arraycopy(name, 0, child, 1, name.length);
-      }
-
-      this.name = name;
+      this.name = self.value().getBytes(UTF_8);
       this.isNatural = self.value().equals(KVIndex.NATURAL_INDEX_NAME);
       this.copy = isNatural || self.copy();
       this.accessor = accessor;

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDBTypeInfo.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDBTypeInfo.java
@@ -224,14 +224,7 @@ class RocksDBTypeInfo {
     private final Index parent;
 
     private Index(KVIndex self, KVTypeInfo.Accessor accessor, Index parent) {
-      byte[] name = self.value().getBytes(UTF_8);
-      if (parent != null) {
-        byte[] child = new byte[name.length + 1];
-        child[0] = SECONDARY_IDX_PREFIX;
-        System.arraycopy(name, 0, child, 1, name.length);
-      }
-
-      this.name = name;
+      this.name = self.value().getBytes(UTF_8);
       this.isNatural = self.value().equals(KVIndex.NATURAL_INDEX_NAME);
       this.copy = isNatural || self.copy();
       this.accessor = accessor;


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the constructor of `LevelDBTypeInfo/RocksDBTypeInfo.Index`, when the `parent` is not null, `self.value().getBytes(UTF_8)` is copied into an array named `child`. However, `child` is a local variable and is not used elsewhere, which appears to be an unnecessary operation. Therefore, this pr removes this memory copying process.


### Why are the changes needed?
To eliminate unnecessary memory copying.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions


### Was this patch authored or co-authored using generative AI tooling?
No