### PR TITLE
[SPARK-47086][BUILD][CORE][FOLLOWUP] Fix `NoClassFoundError` related to Jetty 12 when building with Maven

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -541,7 +541,7 @@
               <overWriteIfNewer>true</overWriteIfNewer>
               <useSubDirectoryPerType>true</useSubDirectoryPerType>
               <includeArtifactIds>
-                guava,protobuf-java,jetty-io,jetty-ee10-servlet,jetty-ee10-servlets,jetty-http,jetty-ee10-plus,jetty-util,jetty-server,jetty-security,jetty-proxy,jetty-client
+                guava,protobuf-java,jetty-io,jetty-ee10-servlet,jetty-ee10-servlets,jetty-http,jetty-ee10-plus,jetty-util,jetty-server,jetty-security,jetty-proxy,jetty-client,jetty-session
               </includeArtifactIds>
               <silent>true</silent>
             </configuration>
@@ -559,14 +559,15 @@
               <include>org.spark-project.spark:unused</include>
               <include>org.eclipse.jetty:jetty-io</include>
               <include>org.eclipse.jetty:jetty-http</include>
-              <include>org.eclipse.jetty:jetty-proxy</include>
+              <include>org.eclipse.jetty.ee10:jetty-ee10-proxy</include>
               <include>org.eclipse.jetty:jetty-client</include>
-              <include>org.eclipse.jetty:jetty-servlet</include>
-              <include>org.eclipse.jetty:jetty-servlets</include>
-              <include>org.eclipse.jetty:jetty-plus</include>
+              <include>org.eclipse.jetty.ee10:jetty-ee10-servlet</include>
+              <include>org.eclipse.jetty.ee10:jetty-ee10-servlets</include>
+              <include>org.eclipse.jetty.ee10:jetty-ee10-plus</include>
               <include>org.eclipse.jetty:jetty-security</include>
               <include>org.eclipse.jetty:jetty-util</include>
               <include>org.eclipse.jetty:jetty-server</include>
+              <include>org.eclipse.jetty:jetty-session</include>
               <include>com.google.guava:guava</include>
               <include>com.google.guava:failureaccess</include>
               <include>com.google.protobuf:*</include>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes an issue that some tests raise `NoClassFoundError` when building with Maven.
This issue can be reproducible like as follows.

```
$ build/mvn clean install
$ build/mvn -pl assembly clean
$ build/mvn -pl core/sql test

SQLQuerySuite:
*** RUN ABORTED ***
A needed class was not found. This could be due to an error in your runpath. Missing class: [Lorg/sparkproject/jetty/ee10/servlet/ServletContextHandler;
  java.lang.NoClassDefFoundError: [Lorg/sparkproject/jetty/ee10/servlet/ServletContextHandler;
  at org.apache.spark.metrics.MetricsSystem.getServletHandlers(MetricsSystem.scala:91)
  at org.apache.spark.SparkContext.<init>(SparkContext.scala:702)
  at org.apache.spark.SparkContext.<init>(SparkContext.scala:147)
  at org.apache.spark.sql.test.TestSparkSession.<init>(TestSQLContext.scala:30)
  at org.apache.spark.sql.test.SharedSparkSessionBase.createSparkSession(SharedSparkSession.scala:110)
  at org.apache.spark.sql.test.SharedSparkSessionBase.createSparkSession$(SharedSparkSession.scala:108)
  at org.apache.spark.sql.SQLQuerySuite.createSparkSession(SQLQuerySuite.scala:61)
  at org.apache.spark.sql.test.SharedSparkSessionBase.initializeSession(SharedSparkSession.scala:126)
  at org.apache.spark.sql.test.SharedSparkSessionBase.initializeSession$(SharedSparkSession.scala:124)
  at org.apache.spark.sql.SQLQuerySuite.initializeSession(SQLQuerySuite.scala:61)
```

To fix this issue, we need to modify shading rules.

### Why are the changes needed?
To recover CI with Maven.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Confirmed `build/mvn -pl core/sql test` doesn't raise `NoClassDefFoundError`.

### Was this patch authored or co-authored using generative AI tooling?
No.
