### PR TITLE
[SPARK-55013][SS][SQL] Add SQL parser support for streaming source naming infrastructure

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5975,6 +5975,11 @@
       "Streaming query evolution error:"
     ],
     "subClass" : {
+      "SOURCE_NAMING_NOT_SUPPORTED" : {
+        "message" : [
+          "Streaming source naming is not supported. Source name '<name>' was provided but the feature is disabled. Please enable the feature by setting spark.sql.streaming.queryEvolution.enableSourceEvolution to true."
+        ]
+      },
       "UNNAMED_STREAMING_SOURCES_WITH_ENFORCEMENT" : {
         "message" : [
           "All streaming sources must be named when spark.sql.streaming.queryEvolution.enableSourceEvolution is enabled. Unnamed sources found: <sourceInfo>. Use the name() method to assign names to all streaming sources."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -41,6 +41,7 @@ import org.apache.spark.sql.catalyst.expressions.json.PathInstruction.Named
 import org.apache.spark.sql.catalyst.parser.SqlBaseParser._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.streaming.Unassigned
 import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin}
 import org.apache.spark.sql.catalyst.trees.TreePattern.PARAMETER
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
@@ -2461,7 +2462,8 @@ class AstBuilder extends DataTypeAstBuilder
       writePrivileges = Seq.empty,
       isStreaming = true)
 
-    val tableWithWatermark = tableStreamingRelation.optionalMap(ctx.watermarkClause)(withWatermark)
+    val namedStreamingRelation = NamedStreamingRelation(tableStreamingRelation, Unassigned)
+    val tableWithWatermark = namedStreamingRelation.optionalMap(ctx.watermarkClause)(withWatermark)
     mayApplyAliasPlan(ctx.tableAlias, tableWithWatermark)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2408,6 +2408,12 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("sourceInfo" -> sourceInfo))
   }
 
+  def streamingSourceNamingNotSupportedError(name: String): Throwable = {
+    new AnalysisException(
+      errorClass = "STREAMING_QUERY_EVOLUTION_ERROR.SOURCE_NAMING_NOT_SUPPORTED",
+      messageParameters = Map("name" -> name))
+  }
+
   def columnNotFoundInExistingColumnsError(
       columnType: String, columnName: String, validColumnNames: Seq[String]): Throwable = {
     new AnalysisException(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/NameStreamingSourcesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/NameStreamingSourcesSuite.scala
@@ -330,12 +330,12 @@ class NameStreamingSourcesSuite extends AnalysisTest {
       val streamingV2 = createStreamingRelationV2()
       val wrapped = NamedStreamingRelation(streamingV2, UserProvided("my_source"))
 
-      val error = intercept[AnalysisException] {
-        NameStreamingSources.apply(wrapped)
-      }
-      assert(error.getErrorClass ==
-        "STREAMING_QUERY_EVOLUTION_ERROR.SOURCE_NAMING_NOT_SUPPORTED")
-      assert(error.getMessage.contains("my_source"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          NameStreamingSources.apply(wrapped)
+        },
+        condition = "STREAMING_QUERY_EVOLUTION_ERROR.SOURCE_NAMING_NOT_SUPPORTED",
+        parameters = Map("name" -> "my_source"))
     }
   }
 
@@ -346,12 +346,12 @@ class NameStreamingSourcesSuite extends AnalysisTest {
       val streamingV2 = createStreamingRelationV2()
       val wrapped = NamedStreamingRelation(streamingV2, FlowAssigned("flow_source"))
 
-      val error = intercept[AnalysisException] {
-        NameStreamingSources.apply(wrapped)
-      }
-      assert(error.getErrorClass ==
-        "STREAMING_QUERY_EVOLUTION_ERROR.SOURCE_NAMING_NOT_SUPPORTED")
-      assert(error.getMessage.contains("flow_source"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          NameStreamingSources.apply(wrapped)
+        },
+        condition = "STREAMING_QUERY_EVOLUTION_ERROR.SOURCE_NAMING_NOT_SUPPORTED",
+        parameters = Map("name" -> "flow_source"))
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/NameStreamingSourcesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/NameStreamingSourcesSuite.scala
@@ -143,16 +143,18 @@ class NameStreamingSourcesSuite extends AnalysisTest {
   }
 
   test("propagates name to StreamingRelationV2") {
-    val streamingV2 = createStreamingRelationV2()
-    val wrapped = NamedStreamingRelation(streamingV2, UserProvided("my_source"))
+    withSQLConf(SQLConf.ENABLE_STREAMING_SOURCE_EVOLUTION.key -> "true") {
+      val streamingV2 = createStreamingRelationV2()
+      val wrapped = NamedStreamingRelation(streamingV2, UserProvided("my_source"))
 
-    val result = NameStreamingSources.apply(wrapped)
+      val result = NameStreamingSources.apply(wrapped)
 
-    result match {
-      case s: StreamingRelationV2 =>
-        assert(s.sourceIdentifyingName == UserProvided("my_source"))
-      case other =>
-        fail(s"Expected StreamingRelationV2 but got ${other.getClass.getSimpleName}")
+      result match {
+        case s: StreamingRelationV2 =>
+          assert(s.sourceIdentifyingName == UserProvided("my_source"))
+        case other =>
+          fail(s"Expected StreamingRelationV2 but got ${other.getClass.getSimpleName}")
+      }
     }
   }
 
@@ -175,31 +177,35 @@ class NameStreamingSourcesSuite extends AnalysisTest {
   }
 
   test("propagates FlowAssigned name to StreamingRelationV2") {
-    val streamingV2 = createStreamingRelationV2()
-    val wrapped = NamedStreamingRelation(streamingV2, FlowAssigned("flow_source"))
+    withSQLConf(SQLConf.ENABLE_STREAMING_SOURCE_EVOLUTION.key -> "true") {
+      val streamingV2 = createStreamingRelationV2()
+      val wrapped = NamedStreamingRelation(streamingV2, FlowAssigned("flow_source"))
 
-    val result = NameStreamingSources.apply(wrapped)
+      val result = NameStreamingSources.apply(wrapped)
 
-    result match {
-      case s: StreamingRelationV2 =>
-        assert(s.sourceIdentifyingName == FlowAssigned("flow_source"))
-      case other =>
-        fail(s"Expected StreamingRelationV2 but got ${other.getClass.getSimpleName}")
+      result match {
+        case s: StreamingRelationV2 =>
+          assert(s.sourceIdentifyingName == FlowAssigned("flow_source"))
+        case other =>
+          fail(s"Expected StreamingRelationV2 but got ${other.getClass.getSimpleName}")
+      }
     }
   }
 
   test("propagates name through SubqueryAlias") {
-    val streamingV2 = createStreamingRelationV2()
-    val aliased = SubqueryAlias("my_alias", streamingV2)
-    val wrapped = NamedStreamingRelation(aliased, UserProvided("aliased_source"))
+    withSQLConf(SQLConf.ENABLE_STREAMING_SOURCE_EVOLUTION.key -> "true") {
+      val streamingV2 = createStreamingRelationV2()
+      val aliased = SubqueryAlias("my_alias", streamingV2)
+      val wrapped = NamedStreamingRelation(aliased, UserProvided("aliased_source"))
 
-    val result = NameStreamingSources.apply(wrapped)
+      val result = NameStreamingSources.apply(wrapped)
 
-    result match {
-      case SubqueryAlias(_, inner: StreamingRelationV2) =>
-        assert(inner.sourceIdentifyingName == UserProvided("aliased_source"))
-      case other =>
-        fail(s"Expected SubqueryAlias wrapping StreamingRelationV2 but got $other")
+      result match {
+        case SubqueryAlias(_, inner: StreamingRelationV2) =>
+          assert(inner.sourceIdentifyingName == UserProvided("aliased_source"))
+        case other =>
+          fail(s"Expected SubqueryAlias wrapping StreamingRelationV2 but got $other")
+      }
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/StreamRelationParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/StreamRelationParserSuite.scala
@@ -20,8 +20,9 @@ package org.apache.spark.sql.catalyst.parser
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.sql.catalyst.AliasIdentifier
-import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, UnresolvedRelation, UnresolvedStar}
+import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, NamedStreamingRelation, UnresolvedRelation, UnresolvedStar}
 import org.apache.spark.sql.catalyst.plans.logical.{Project, SubqueryAlias}
+import org.apache.spark.sql.catalyst.streaming.Unassigned
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 class StreamRelationParserSuite extends AnalysisTest {
@@ -34,9 +35,12 @@ class StreamRelationParserSuite extends AnalysisTest {
         plan,
         Project(
           projectList = Seq(UnresolvedStar(None)),
-          child = UnresolvedRelation(
-            multipartIdentifier = Seq("t"),
-            isStreaming = true
+          child = NamedStreamingRelation(
+            child = UnresolvedRelation(
+              multipartIdentifier = Seq("t"),
+              isStreaming = true
+            ),
+            sourceIdentifyingName = Unassigned
           )
         )
       )
@@ -58,9 +62,12 @@ class StreamRelationParserSuite extends AnalysisTest {
               name = "a.b.c",
               qualifier = Seq.empty
             ),
-            child = UnresolvedRelation(
-              multipartIdentifier = Seq("t"),
-              isStreaming = true
+            child = NamedStreamingRelation(
+              child = UnresolvedRelation(
+                multipartIdentifier = Seq("t"),
+                isStreaming = true
+              ),
+              sourceIdentifyingName = Unassigned
             )
           )
         )
@@ -82,12 +89,158 @@ class StreamRelationParserSuite extends AnalysisTest {
       parsePlan("SELECT * FROM STREAM table WITH ('key'='value')"),
       Project(
         projectList = Seq(UnresolvedStar(None)),
-        child = UnresolvedRelation(
-          multipartIdentifier = Seq("table"),
-          options = new CaseInsensitiveStringMap(Map("key" -> "value").asJava),
-          isStreaming = true
+        child = NamedStreamingRelation(
+          child = UnresolvedRelation(
+            multipartIdentifier = Seq("table"),
+            options = new CaseInsensitiveStringMap(Map("key" -> "value").asJava),
+            isStreaming = true
+          ),
+          sourceIdentifyingName = Unassigned
         )
       )
     )
+  }
+
+  test("STREAM with options and alias wraps NamedStreamingRelation below SubqueryAlias") {
+    comparePlans(
+      parsePlan("SELECT * FROM STREAM table WITH ('key'='value') AS src"),
+      Project(
+        projectList = Seq(UnresolvedStar(None)),
+        child = SubqueryAlias(
+          identifier = AliasIdentifier(
+            name = "src",
+            qualifier = Seq.empty
+          ),
+          child = NamedStreamingRelation(
+            child = UnresolvedRelation(
+              multipartIdentifier = Seq("table"),
+              options = new CaseInsensitiveStringMap(Map("key" -> "value").asJava),
+              isStreaming = true
+            ),
+            sourceIdentifyingName = Unassigned
+          )
+        )
+      )
+    )
+  }
+
+  test("STREAM with multiple key/value pairs in WITH options") {
+    comparePlans(
+      parsePlan("SELECT * FROM STREAM t WITH ('key1'='value1', 'key2'='value2', 'key3'='value3')"),
+      Project(
+        projectList = Seq(UnresolvedStar(None)),
+        child = NamedStreamingRelation(
+          child = UnresolvedRelation(
+            multipartIdentifier = Seq("t"),
+            options = new CaseInsensitiveStringMap(
+              Map("key1" -> "value1", "key2" -> "value2", "key3" -> "value3").asJava),
+            isStreaming = true
+          ),
+          sourceIdentifyingName = Unassigned
+        )
+      )
+    )
+  }
+
+  test("inner join of two streaming tables") {
+    val plan = parsePlan("SELECT * FROM STREAM t1 JOIN STREAM t2 ON t1.id = t2.id")
+
+    // Verify both streaming sources are wrapped in NamedStreamingRelation
+    val namedStreamingRelations = plan.collect {
+      case n: NamedStreamingRelation => n
+    }
+    assert(namedStreamingRelations.size == 2,
+      "Expected 2 NamedStreamingRelation nodes for join of two streaming tables")
+
+    // Verify both have Unassigned names
+    namedStreamingRelations.foreach { n =>
+      assert(n.sourceIdentifyingName == Unassigned)
+    }
+
+    // Verify the underlying relations are streaming
+    namedStreamingRelations.foreach { n =>
+      n.child match {
+        case u: UnresolvedRelation => assert(u.isStreaming)
+        case _ => fail("Expected UnresolvedRelation as child")
+      }
+    }
+  }
+
+  test("streaming table in CTE (WITH clause)") {
+    val plan = parsePlan(
+      """
+        |WITH streaming_cte AS (SELECT * FROM STREAM source_table)
+        |SELECT * FROM streaming_cte
+      """.stripMargin)
+
+    // CTE definitions are stored in UnresolvedWith.cteRelations, not as children,
+    // so we need to extract them manually
+    val cteRelations = plan match {
+      case w: org.apache.spark.sql.catalyst.plans.logical.UnresolvedWith => w.cteRelations
+      case _ => fail("Expected UnresolvedWith")
+    }
+    assert(cteRelations.size == 1)
+
+    // The CTE definition is wrapped in SubqueryAlias
+    val cteDefinition = cteRelations.head._2
+    val namedStreamingRelations = cteDefinition.collect {
+      case n: NamedStreamingRelation => n
+    }
+    assert(namedStreamingRelations.size == 1,
+      "Expected 1 NamedStreamingRelation node in CTE definition")
+    assert(namedStreamingRelations.head.sourceIdentifyingName == Unassigned)
+  }
+
+  test("lateral join with streaming table") {
+    val plan = parsePlan(
+      "SELECT * FROM STREAM t1 JOIN LATERAL (SELECT * FROM t2 WHERE t2.id = t1.id) sub")
+
+    // Verify the streaming source is wrapped in NamedStreamingRelation
+    val namedStreamingRelations = plan.collect {
+      case n: NamedStreamingRelation => n
+    }
+    assert(namedStreamingRelations.size == 1,
+      "Expected 1 NamedStreamingRelation node for streaming table in lateral join")
+    assert(namedStreamingRelations.head.sourceIdentifyingName == Unassigned)
+
+    // Verify it's a LateralJoin
+    val lateralJoins = plan.collect {
+      case l: org.apache.spark.sql.catalyst.plans.logical.LateralJoin => l
+    }
+    assert(lateralJoins.size == 1, "Expected 1 LateralJoin node")
+  }
+
+  // ===================================
+  // Negative test cases for WITH options syntax
+  // ===================================
+
+  test("Parse Exception: WITH option key without value") {
+    interceptParseException(parsePlan)(
+      "SELECT * FROM STREAM t WITH ('key')"
+    )(None)
+  }
+
+  test("Parse Exception: WITH option using => instead of =") {
+    interceptParseException(parsePlan)(
+      "SELECT * FROM STREAM t WITH ('key'=>'value')"
+    )(None)
+  }
+
+  test("Parse Exception: WITH option key with no value") {
+    interceptParseException(parsePlan)(
+      "SELECT * FROM STREAM t WITH ('key'=)"
+    )(None)
+  }
+
+  test("Parse Exception: WITH option missing quotes around value") {
+    interceptParseException(parsePlan)(
+      "SELECT * FROM STREAM t WITH ('key'=value)"
+    )(None)
+  }
+
+  test("Parse Exception: WITH option empty parentheses") {
+    interceptParseException(parsePlan)(
+      "SELECT * FROM STREAM t WITH ()"
+    )(None)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/StreamRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/StreamRelationSuite.scala
@@ -22,11 +22,12 @@ import java.net.URI
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.sql.catalyst.{AliasIdentifier, TableIdentifier}
-import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, Analyzer, FunctionRegistry, TableFunctionRegistry, TestRelations, UnresolvedRelation, UnresolvedStar}
+import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, Analyzer, FunctionRegistry, NamedStreamingRelation, TableFunctionRegistry, TestRelations, UnresolvedRelation, UnresolvedStar}
 import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, InMemoryCatalog, SessionCatalog}
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser.parsePlan
 import org.apache.spark.sql.catalyst.plans.logical.{Project, SubqueryAlias}
+import org.apache.spark.sql.catalyst.streaming.Unassigned
 import org.apache.spark.sql.execution.datasources.DataSource
 import org.apache.spark.sql.execution.streaming.runtime.StreamingRelation
 import org.apache.spark.sql.test.SharedSparkSession
@@ -88,10 +89,13 @@ class StreamRelationSuite extends SharedSparkSession with AnalysisTest {
             name = "t",
             qualifier = Seq.empty
           ),
-          child = UnresolvedRelation(
-            multipartIdentifier = Seq("table1"),
-            isStreaming = true,
-            options = new CaseInsensitiveStringMap(Map("key" -> "value").asJava)
+          child = NamedStreamingRelation(
+            child = UnresolvedRelation(
+              multipartIdentifier = Seq("table1"),
+              isStreaming = true,
+              options = new CaseInsensitiveStringMap(Map("key" -> "value").asJava)
+            ),
+            sourceIdentifyingName = Unassigned
           )
         )
       )


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds SQL parser support for the streaming source naming infrastructure by:

  1. **Parser Integration**: Wraps streaming table relations in `NamedStreamingRelation` nodes at parse time in `AstBuilder.scala` when parsing SQL `STREAM` syntax (e.g., `SELECT * FROM STREAM table`)

  2. **Analyzer Registration**: Registers the `NameStreamingSources` analyzer rule in `Analyzer.scala` to propagate source identifying names during the analysis phase

  3. **Config Guard**: Gates the feature behind the existing `spark.sql.streaming.queryEvolution.enableSourceEvolution` configuration (off by default):
     - When **enabled**: Propagates names from `NamedStreamingRelation` wrappers to underlying streaming sources (enables source evolution)
     - When **disabled**: Unwraps `NamedStreamingRelation` nodes without propagating names, and throws an error if users explicitly provide source names via the `.name()` API

  4. **Error Handling**: Adds `SOURCE_NAMING_NOT_SUPPORTED` error class to inform users when they attempt to use source naming with the feature disabled

  5. **Testing**: Adds comprehensive unit tests covering parser integration, config-enabled/disabled behavior, and error scenarios

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
 Streaming source naming is critical infrastructure for streaming query evolution (ability to add/remove/reorder sources while maintaining checkpoint state). Currently, source naming only works via the DataFrame API (`.name()` method), but SQL users cannot leverage this functionality.

This PR enables SQL users to use streaming sources that will be compatible with source evolution once the feature is enabled, while ensuring the feature remains safely gated behind the config flag until fully ready.

Without this change, SQL-based streaming queries would not be able to participate in source evolution even when the feature is enabled.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
 Added comprehensive unit tests in:

  1. **NameStreamingSourcesSuite.scala**:
     - 5 new tests for config-disabled behavior (unwrapping, error handling, enforcement skipping)
     - Existing tests validate config-enabled behavior

  2. **StreamRelationParserSuite.scala**:
     - 8 new tests for parser integration (options, aliases, joins, CTEs, lateral joins, error cases)
     - Updated 3 existing tests to expect `NamedStreamingRelation` wrappers

  3. **StreamRelationSuite.scala**:
     - Updated 1 existing test to expect `NamedStreamingRelation` wrapper

  All tests pass with both config enabled and disabled, validating that:
  - Parser correctly wraps streaming relations at parse time
  - Analyzer properly handles wrapped relations based on config
  - Error messages are clear when feature is disabled
  - No regression in existing streaming functionality


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No