### PR TITLE
[SPARK-54992][PYTHON] Replace cast with a runtime check for make_timestamp

### DIFF
--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -3987,6 +3987,15 @@ def time_to_micros(col: "ColumnOrName") -> Column:
 time_to_micros.__doc__ = pysparkfuncs.time_to_micros.__doc__
 
 
+def _ensure_column_or_str(arg: Optional[Any]) -> ColumnOrName:
+    if not isinstance(arg, (Column, str)):
+        raise PySparkTypeError(
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "arg", "arg_type": type(arg).__name__},
+        )
+    return arg
+
+
 @overload
 def make_timestamp(
     years: "ColumnOrName",
@@ -4044,23 +4053,23 @@ def make_timestamp(
         if timezone is not None:
             return _invoke_function_over_columns(
                 "make_timestamp",
-                cast("ColumnOrName", years),
-                cast("ColumnOrName", months),
-                cast("ColumnOrName", days),
-                cast("ColumnOrName", hours),
-                cast("ColumnOrName", mins),
-                cast("ColumnOrName", secs),
-                cast("ColumnOrName", timezone),
+                _ensure_column_or_str(years),
+                _ensure_column_or_str(months),
+                _ensure_column_or_str(days),
+                _ensure_column_or_str(hours),
+                _ensure_column_or_str(mins),
+                _ensure_column_or_str(secs),
+                _ensure_column_or_str(timezone),
             )
         else:
             return _invoke_function_over_columns(
                 "make_timestamp",
-                cast("ColumnOrName", years),
-                cast("ColumnOrName", months),
-                cast("ColumnOrName", days),
-                cast("ColumnOrName", hours),
-                cast("ColumnOrName", mins),
-                cast("ColumnOrName", secs),
+                _ensure_column_or_str(years),
+                _ensure_column_or_str(months),
+                _ensure_column_or_str(days),
+                _ensure_column_or_str(hours),
+                _ensure_column_or_str(mins),
+                _ensure_column_or_str(secs),
             )
     else:
         if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
@@ -4071,13 +4080,13 @@ def make_timestamp(
         if timezone is not None:
             return _invoke_function_over_columns(
                 "make_timestamp",
-                cast("ColumnOrName", date),
-                cast("ColumnOrName", time),
-                cast("ColumnOrName", timezone),
+                _ensure_column_or_str(date),
+                _ensure_column_or_str(time),
+                _ensure_column_or_str(timezone),
             )
         else:
             return _invoke_function_over_columns(
-                "make_timestamp", cast("ColumnOrName", date), cast("ColumnOrName", time)
+                "make_timestamp", _ensure_column_or_str(date), _ensure_column_or_str(time)
             )
 
 
@@ -4138,26 +4147,27 @@ def try_make_timestamp(
                 errorClass="CANNOT_SET_TOGETHER",
                 messageParameters={"arg_list": "years|months|days|hours|mins|secs and date|time"},
             )
+
         if timezone is not None:
             return _invoke_function_over_columns(
                 "try_make_timestamp",
-                cast("ColumnOrName", years),
-                cast("ColumnOrName", months),
-                cast("ColumnOrName", days),
-                cast("ColumnOrName", hours),
-                cast("ColumnOrName", mins),
-                cast("ColumnOrName", secs),
-                cast("ColumnOrName", timezone),
+                _ensure_column_or_str(years),
+                _ensure_column_or_str(months),
+                _ensure_column_or_str(days),
+                _ensure_column_or_str(hours),
+                _ensure_column_or_str(mins),
+                _ensure_column_or_str(secs),
+                _ensure_column_or_str(timezone),
             )
         else:
             return _invoke_function_over_columns(
                 "try_make_timestamp",
-                cast("ColumnOrName", years),
-                cast("ColumnOrName", months),
-                cast("ColumnOrName", days),
-                cast("ColumnOrName", hours),
-                cast("ColumnOrName", mins),
-                cast("ColumnOrName", secs),
+                _ensure_column_or_str(years),
+                _ensure_column_or_str(months),
+                _ensure_column_or_str(days),
+                _ensure_column_or_str(hours),
+                _ensure_column_or_str(mins),
+                _ensure_column_or_str(secs),
             )
     else:
         if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
@@ -4168,14 +4178,12 @@ def try_make_timestamp(
         if timezone is not None:
             return _invoke_function_over_columns(
                 "try_make_timestamp",
-                cast("ColumnOrName", date),
-                cast("ColumnOrName", time),
-                cast("ColumnOrName", timezone),
+                _ensure_column_or_str(date),
+                _ensure_column_or_str(time),
+                _ensure_column_or_str(timezone),
             )
         else:
-            return _invoke_function_over_columns(
-                "try_make_timestamp", cast("ColumnOrName", date), cast("ColumnOrName", time)
-            )
+            return _invoke_function_over_columns("try_make_timestamp", _ensure_column_or_str(date), _ensure_column_or_str(time))
 
 
 try_make_timestamp.__doc__ = pysparkfuncs.try_make_timestamp.__doc__
@@ -4264,12 +4272,12 @@ def make_timestamp_ntz(
             )
         return _invoke_function_over_columns(
             "make_timestamp_ntz",
-            cast("ColumnOrName", years),
-            cast("ColumnOrName", months),
-            cast("ColumnOrName", days),
-            cast("ColumnOrName", hours),
-            cast("ColumnOrName", mins),
-            cast("ColumnOrName", secs),
+            _ensure_column_or_str(years),
+            _ensure_column_or_str(months),
+            _ensure_column_or_str(days),
+            _ensure_column_or_str(hours),
+            _ensure_column_or_str(mins),
+            _ensure_column_or_str(secs),
         )
     else:
         if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
@@ -4278,7 +4286,7 @@ def make_timestamp_ntz(
                 messageParameters={"arg_list": "years|months|days|hours|mins|secs and date|time"},
             )
         return _invoke_function_over_columns(
-            "make_timestamp_ntz", cast("ColumnOrName", date), cast("ColumnOrName", time)
+            "make_timestamp_ntz", _ensure_column_or_str(date), _ensure_column_or_str(time)
         )
 
 
@@ -4324,12 +4332,12 @@ def try_make_timestamp_ntz(
             )
         return _invoke_function_over_columns(
             "try_make_timestamp_ntz",
-            cast("ColumnOrName", years),
-            cast("ColumnOrName", months),
-            cast("ColumnOrName", days),
-            cast("ColumnOrName", hours),
-            cast("ColumnOrName", mins),
-            cast("ColumnOrName", secs),
+            _ensure_column_or_str(years),
+            _ensure_column_or_str(months),
+            _ensure_column_or_str(days),
+            _ensure_column_or_str(hours),
+            _ensure_column_or_str(mins),
+            _ensure_column_or_str(secs),
         )
     else:
         if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
@@ -4338,7 +4346,7 @@ def try_make_timestamp_ntz(
                 messageParameters={"arg_list": "years|months|days|hours|mins|secs and date|time"},
             )
         return _invoke_function_over_columns(
-            "try_make_timestamp_ntz", cast("ColumnOrName", date), cast("ColumnOrName", time)
+            "try_make_timestamp_ntz", _ensure_column_or_str(date), _ensure_column_or_str(time)
         )
 
 

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -4183,7 +4183,9 @@ def try_make_timestamp(
                 _ensure_column_or_name(timezone),
             )
         else:
-            return _invoke_function_over_columns("try_make_timestamp", _ensure_column_or_name(date), _ensure_column_or_name(time))
+            return _invoke_function_over_columns(
+                "try_make_timestamp", _ensure_column_or_name(date), _ensure_column_or_name(time)
+            )
 
 
 try_make_timestamp.__doc__ = pysparkfuncs.try_make_timestamp.__doc__

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -3987,7 +3987,7 @@ def time_to_micros(col: "ColumnOrName") -> Column:
 time_to_micros.__doc__ = pysparkfuncs.time_to_micros.__doc__
 
 
-def _ensure_column_or_name(arg: Optional[Any]) -> ColumnOrName:
+def _ensure_column_or_name(arg: Optional[Any]) -> "ColumnOrName":
     if not isinstance(arg, (Column, str)):
         raise PySparkTypeError(
             errorClass="NOT_COLUMN_OR_STR",

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -3987,7 +3987,7 @@ def time_to_micros(col: "ColumnOrName") -> Column:
 time_to_micros.__doc__ = pysparkfuncs.time_to_micros.__doc__
 
 
-def _ensure_column_or_str(arg: Optional[Any]) -> ColumnOrName:
+def _ensure_column_or_name(arg: Optional[Any]) -> ColumnOrName:
     if not isinstance(arg, (Column, str)):
         raise PySparkTypeError(
             errorClass="NOT_COLUMN_OR_STR",
@@ -4053,23 +4053,23 @@ def make_timestamp(
         if timezone is not None:
             return _invoke_function_over_columns(
                 "make_timestamp",
-                _ensure_column_or_str(years),
-                _ensure_column_or_str(months),
-                _ensure_column_or_str(days),
-                _ensure_column_or_str(hours),
-                _ensure_column_or_str(mins),
-                _ensure_column_or_str(secs),
-                _ensure_column_or_str(timezone),
+                _ensure_column_or_name(years),
+                _ensure_column_or_name(months),
+                _ensure_column_or_name(days),
+                _ensure_column_or_name(hours),
+                _ensure_column_or_name(mins),
+                _ensure_column_or_name(secs),
+                _ensure_column_or_name(timezone),
             )
         else:
             return _invoke_function_over_columns(
                 "make_timestamp",
-                _ensure_column_or_str(years),
-                _ensure_column_or_str(months),
-                _ensure_column_or_str(days),
-                _ensure_column_or_str(hours),
-                _ensure_column_or_str(mins),
-                _ensure_column_or_str(secs),
+                _ensure_column_or_name(years),
+                _ensure_column_or_name(months),
+                _ensure_column_or_name(days),
+                _ensure_column_or_name(hours),
+                _ensure_column_or_name(mins),
+                _ensure_column_or_name(secs),
             )
     else:
         if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
@@ -4080,13 +4080,13 @@ def make_timestamp(
         if timezone is not None:
             return _invoke_function_over_columns(
                 "make_timestamp",
-                _ensure_column_or_str(date),
-                _ensure_column_or_str(time),
-                _ensure_column_or_str(timezone),
+                _ensure_column_or_name(date),
+                _ensure_column_or_name(time),
+                _ensure_column_or_name(timezone),
             )
         else:
             return _invoke_function_over_columns(
-                "make_timestamp", _ensure_column_or_str(date), _ensure_column_or_str(time)
+                "make_timestamp", _ensure_column_or_name(date), _ensure_column_or_name(time)
             )
 
 
@@ -4151,23 +4151,23 @@ def try_make_timestamp(
         if timezone is not None:
             return _invoke_function_over_columns(
                 "try_make_timestamp",
-                _ensure_column_or_str(years),
-                _ensure_column_or_str(months),
-                _ensure_column_or_str(days),
-                _ensure_column_or_str(hours),
-                _ensure_column_or_str(mins),
-                _ensure_column_or_str(secs),
-                _ensure_column_or_str(timezone),
+                _ensure_column_or_name(years),
+                _ensure_column_or_name(months),
+                _ensure_column_or_name(days),
+                _ensure_column_or_name(hours),
+                _ensure_column_or_name(mins),
+                _ensure_column_or_name(secs),
+                _ensure_column_or_name(timezone),
             )
         else:
             return _invoke_function_over_columns(
                 "try_make_timestamp",
-                _ensure_column_or_str(years),
-                _ensure_column_or_str(months),
-                _ensure_column_or_str(days),
-                _ensure_column_or_str(hours),
-                _ensure_column_or_str(mins),
-                _ensure_column_or_str(secs),
+                _ensure_column_or_name(years),
+                _ensure_column_or_name(months),
+                _ensure_column_or_name(days),
+                _ensure_column_or_name(hours),
+                _ensure_column_or_name(mins),
+                _ensure_column_or_name(secs),
             )
     else:
         if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
@@ -4178,12 +4178,12 @@ def try_make_timestamp(
         if timezone is not None:
             return _invoke_function_over_columns(
                 "try_make_timestamp",
-                _ensure_column_or_str(date),
-                _ensure_column_or_str(time),
-                _ensure_column_or_str(timezone),
+                _ensure_column_or_name(date),
+                _ensure_column_or_name(time),
+                _ensure_column_or_name(timezone),
             )
         else:
-            return _invoke_function_over_columns("try_make_timestamp", _ensure_column_or_str(date), _ensure_column_or_str(time))
+            return _invoke_function_over_columns("try_make_timestamp", _ensure_column_or_name(date), _ensure_column_or_name(time))
 
 
 try_make_timestamp.__doc__ = pysparkfuncs.try_make_timestamp.__doc__
@@ -4272,12 +4272,12 @@ def make_timestamp_ntz(
             )
         return _invoke_function_over_columns(
             "make_timestamp_ntz",
-            _ensure_column_or_str(years),
-            _ensure_column_or_str(months),
-            _ensure_column_or_str(days),
-            _ensure_column_or_str(hours),
-            _ensure_column_or_str(mins),
-            _ensure_column_or_str(secs),
+            _ensure_column_or_name(years),
+            _ensure_column_or_name(months),
+            _ensure_column_or_name(days),
+            _ensure_column_or_name(hours),
+            _ensure_column_or_name(mins),
+            _ensure_column_or_name(secs),
         )
     else:
         if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
@@ -4286,7 +4286,7 @@ def make_timestamp_ntz(
                 messageParameters={"arg_list": "years|months|days|hours|mins|secs and date|time"},
             )
         return _invoke_function_over_columns(
-            "make_timestamp_ntz", _ensure_column_or_str(date), _ensure_column_or_str(time)
+            "make_timestamp_ntz", _ensure_column_or_name(date), _ensure_column_or_name(time)
         )
 
 
@@ -4332,12 +4332,12 @@ def try_make_timestamp_ntz(
             )
         return _invoke_function_over_columns(
             "try_make_timestamp_ntz",
-            _ensure_column_or_str(years),
-            _ensure_column_or_str(months),
-            _ensure_column_or_str(days),
-            _ensure_column_or_str(hours),
-            _ensure_column_or_str(mins),
-            _ensure_column_or_str(secs),
+            _ensure_column_or_name(years),
+            _ensure_column_or_name(months),
+            _ensure_column_or_name(days),
+            _ensure_column_or_name(hours),
+            _ensure_column_or_name(mins),
+            _ensure_column_or_name(secs),
         )
     else:
         if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
@@ -4346,7 +4346,7 @@ def try_make_timestamp_ntz(
                 messageParameters={"arg_list": "years|months|days|hours|mins|secs and date|time"},
             )
         return _invoke_function_over_columns(
-            "try_make_timestamp_ntz", _ensure_column_or_str(date), _ensure_column_or_str(time)
+            "try_make_timestamp_ntz", _ensure_column_or_name(date), _ensure_column_or_name(time)
         )
 
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -25064,7 +25064,7 @@ def time_to_micros(col: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("time_to_micros", col)
 
 
-def _ensure_column_or_str(arg: Optional[Any]) -> ColumnOrName:
+def _ensure_column_or_name(arg: Optional[Any]) -> ColumnOrName:
     if not isinstance(arg, (Column, str)):
         raise PySparkTypeError(
             errorClass="NOT_COLUMN_OR_STR",
@@ -25266,23 +25266,23 @@ def make_timestamp(
         if timezone is not None:
             return _invoke_function_over_columns(
                 "make_timestamp",
-                _ensure_column_or_str(years),
-                _ensure_column_or_str(months),
-                _ensure_column_or_str(days),
-                _ensure_column_or_str(hours),
-                _ensure_column_or_str(mins),
-                _ensure_column_or_str(secs),
-                _ensure_column_or_str(timezone),
+                _ensure_column_or_name(years),
+                _ensure_column_or_name(months),
+                _ensure_column_or_name(days),
+                _ensure_column_or_name(hours),
+                _ensure_column_or_name(mins),
+                _ensure_column_or_name(secs),
+                _ensure_column_or_name(timezone),
             )
         else:
             return _invoke_function_over_columns(
                 "make_timestamp",
-                _ensure_column_or_str(years),
-                _ensure_column_or_str(months),
-                _ensure_column_or_str(days),
-                _ensure_column_or_str(hours),
-                _ensure_column_or_str(mins),
-                _ensure_column_or_str(secs),
+                _ensure_column_or_name(years),
+                _ensure_column_or_name(months),
+                _ensure_column_or_name(days),
+                _ensure_column_or_name(hours),
+                _ensure_column_or_name(mins),
+                _ensure_column_or_name(secs),
             )
     else:
         if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
@@ -25293,13 +25293,13 @@ def make_timestamp(
         if timezone is not None:
             return _invoke_function_over_columns(
                 "make_timestamp",
-                _ensure_column_or_str(date),
-                _ensure_column_or_str(time),
-                _ensure_column_or_str(timezone),
+                _ensure_column_or_name(date),
+                _ensure_column_or_name(time),
+                _ensure_column_or_name(timezone),
             )
         else:
             return _invoke_function_over_columns(
-                "make_timestamp", _ensure_column_or_str(date), _ensure_column_or_str(time)
+                "make_timestamp", _ensure_column_or_name(date), _ensure_column_or_name(time)
             )
 
 
@@ -25509,23 +25509,23 @@ def try_make_timestamp(
         if timezone is not None:
             return _invoke_function_over_columns(
                 "try_make_timestamp",
-                _ensure_column_or_str(years),
-                _ensure_column_or_str(months),
-                _ensure_column_or_str(days),
-                _ensure_column_or_str(hours),
-                _ensure_column_or_str(mins),
-                _ensure_column_or_str(secs),
-                _ensure_column_or_str(timezone),
+                _ensure_column_or_name(years),
+                _ensure_column_or_name(months),
+                _ensure_column_or_name(days),
+                _ensure_column_or_name(hours),
+                _ensure_column_or_name(mins),
+                _ensure_column_or_name(secs),
+                _ensure_column_or_name(timezone),
             )
         else:
             return _invoke_function_over_columns(
                 "try_make_timestamp",
-                _ensure_column_or_str(years),
-                _ensure_column_or_str(months),
-                _ensure_column_or_str(days),
-                _ensure_column_or_str(hours),
-                _ensure_column_or_str(mins),
-                _ensure_column_or_str(secs),
+                _ensure_column_or_name(years),
+                _ensure_column_or_name(months),
+                _ensure_column_or_name(days),
+                _ensure_column_or_name(hours),
+                _ensure_column_or_name(mins),
+                _ensure_column_or_name(secs),
             )
     else:
         if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
@@ -25536,13 +25536,13 @@ def try_make_timestamp(
         if timezone is not None:
             return _invoke_function_over_columns(
                 "try_make_timestamp",
-                _ensure_column_or_str(date),
-                _ensure_column_or_str(time),
-                _ensure_column_or_str(timezone),
+                _ensure_column_or_name(date),
+                _ensure_column_or_name(time),
+                _ensure_column_or_name(timezone),
             )
         else:
             return _invoke_function_over_columns(
-                "try_make_timestamp", _ensure_column_or_str(date), _ensure_column_or_str(time)
+                "try_make_timestamp", _ensure_column_or_name(date), _ensure_column_or_name(time)
             )
 
 
@@ -25893,12 +25893,12 @@ def make_timestamp_ntz(
             )
         return _invoke_function_over_columns(
             "make_timestamp_ntz",
-            _ensure_column_or_str(years),
-            _ensure_column_or_str(months),
-            _ensure_column_or_str(days),
-            _ensure_column_or_str(hours),
-            _ensure_column_or_str(mins),
-            _ensure_column_or_str(secs),
+            _ensure_column_or_name(years),
+            _ensure_column_or_name(months),
+            _ensure_column_or_name(days),
+            _ensure_column_or_name(hours),
+            _ensure_column_or_name(mins),
+            _ensure_column_or_name(secs),
         )
     else:
         if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
@@ -25907,7 +25907,7 @@ def make_timestamp_ntz(
                 messageParameters={"arg_list": "years|months|days|hours|mins|secs and date|time"},
             )
         return _invoke_function_over_columns(
-            "make_timestamp_ntz", _ensure_column_or_str(date), _ensure_column_or_str(time)
+            "make_timestamp_ntz", _ensure_column_or_name(date), _ensure_column_or_name(time)
         )
 
 
@@ -26049,12 +26049,12 @@ def try_make_timestamp_ntz(
             )
         return _invoke_function_over_columns(
             "try_make_timestamp_ntz",
-            _ensure_column_or_str(years),
-            _ensure_column_or_str(months),
-            _ensure_column_or_str(days),
-            _ensure_column_or_str(hours),
-            _ensure_column_or_str(mins),
-            _ensure_column_or_str(secs),
+            _ensure_column_or_name(years),
+            _ensure_column_or_name(months),
+            _ensure_column_or_name(days),
+            _ensure_column_or_name(hours),
+            _ensure_column_or_name(mins),
+            _ensure_column_or_name(secs),
         )
     else:
         if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
@@ -26063,7 +26063,7 @@ def try_make_timestamp_ntz(
                 messageParameters={"arg_list": "years|months|days|hours|mins|secs and date|time"},
             )
         return _invoke_function_over_columns(
-            "try_make_timestamp_ntz", _ensure_column_or_str(date), _ensure_column_or_str(time)
+            "try_make_timestamp_ntz", _ensure_column_or_name(date), _ensure_column_or_name(time)
         )
 
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -25064,7 +25064,7 @@ def time_to_micros(col: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("time_to_micros", col)
 
 
-def _ensure_column_or_name(arg: Optional[Any]) -> ColumnOrName:
+def _ensure_column_or_name(arg: Optional[Any]) -> "ColumnOrName":
     if not isinstance(arg, (Column, str)):
         raise PySparkTypeError(
             errorClass="NOT_COLUMN_OR_STR",

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -25064,6 +25064,15 @@ def time_to_micros(col: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("time_to_micros", col)
 
 
+def _ensure_column_or_str(arg: Optional[Any]) -> ColumnOrName:
+    if not isinstance(arg, (Column, str)):
+        raise PySparkTypeError(
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "arg", "arg_type": type(arg).__name__},
+        )
+    return arg
+
+
 @overload
 def make_timestamp(
     years: "ColumnOrName",
@@ -25257,23 +25266,23 @@ def make_timestamp(
         if timezone is not None:
             return _invoke_function_over_columns(
                 "make_timestamp",
-                cast("ColumnOrName", years),
-                cast("ColumnOrName", months),
-                cast("ColumnOrName", days),
-                cast("ColumnOrName", hours),
-                cast("ColumnOrName", mins),
-                cast("ColumnOrName", secs),
-                cast("ColumnOrName", timezone),
+                _ensure_column_or_str(years),
+                _ensure_column_or_str(months),
+                _ensure_column_or_str(days),
+                _ensure_column_or_str(hours),
+                _ensure_column_or_str(mins),
+                _ensure_column_or_str(secs),
+                _ensure_column_or_str(timezone),
             )
         else:
             return _invoke_function_over_columns(
                 "make_timestamp",
-                cast("ColumnOrName", years),
-                cast("ColumnOrName", months),
-                cast("ColumnOrName", days),
-                cast("ColumnOrName", hours),
-                cast("ColumnOrName", mins),
-                cast("ColumnOrName", secs),
+                _ensure_column_or_str(years),
+                _ensure_column_or_str(months),
+                _ensure_column_or_str(days),
+                _ensure_column_or_str(hours),
+                _ensure_column_or_str(mins),
+                _ensure_column_or_str(secs),
             )
     else:
         if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
@@ -25284,13 +25293,13 @@ def make_timestamp(
         if timezone is not None:
             return _invoke_function_over_columns(
                 "make_timestamp",
-                cast("ColumnOrName", date),
-                cast("ColumnOrName", time),
-                cast("ColumnOrName", timezone),
+                _ensure_column_or_str(date),
+                _ensure_column_or_str(time),
+                _ensure_column_or_str(timezone),
             )
         else:
             return _invoke_function_over_columns(
-                "make_timestamp", cast("ColumnOrName", date), cast("ColumnOrName", time)
+                "make_timestamp", _ensure_column_or_str(date), _ensure_column_or_str(time)
             )
 
 
@@ -25500,23 +25509,23 @@ def try_make_timestamp(
         if timezone is not None:
             return _invoke_function_over_columns(
                 "try_make_timestamp",
-                cast("ColumnOrName", years),
-                cast("ColumnOrName", months),
-                cast("ColumnOrName", days),
-                cast("ColumnOrName", hours),
-                cast("ColumnOrName", mins),
-                cast("ColumnOrName", secs),
-                cast("ColumnOrName", timezone),
+                _ensure_column_or_str(years),
+                _ensure_column_or_str(months),
+                _ensure_column_or_str(days),
+                _ensure_column_or_str(hours),
+                _ensure_column_or_str(mins),
+                _ensure_column_or_str(secs),
+                _ensure_column_or_str(timezone),
             )
         else:
             return _invoke_function_over_columns(
                 "try_make_timestamp",
-                cast("ColumnOrName", years),
-                cast("ColumnOrName", months),
-                cast("ColumnOrName", days),
-                cast("ColumnOrName", hours),
-                cast("ColumnOrName", mins),
-                cast("ColumnOrName", secs),
+                _ensure_column_or_str(years),
+                _ensure_column_or_str(months),
+                _ensure_column_or_str(days),
+                _ensure_column_or_str(hours),
+                _ensure_column_or_str(mins),
+                _ensure_column_or_str(secs),
             )
     else:
         if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
@@ -25527,13 +25536,13 @@ def try_make_timestamp(
         if timezone is not None:
             return _invoke_function_over_columns(
                 "try_make_timestamp",
-                cast("ColumnOrName", date),
-                cast("ColumnOrName", time),
-                cast("ColumnOrName", timezone),
+                _ensure_column_or_str(date),
+                _ensure_column_or_str(time),
+                _ensure_column_or_str(timezone),
             )
         else:
             return _invoke_function_over_columns(
-                "try_make_timestamp", cast("ColumnOrName", date), cast("ColumnOrName", time)
+                "try_make_timestamp", _ensure_column_or_str(date), _ensure_column_or_str(time)
             )
 
 
@@ -25884,12 +25893,12 @@ def make_timestamp_ntz(
             )
         return _invoke_function_over_columns(
             "make_timestamp_ntz",
-            cast("ColumnOrName", years),
-            cast("ColumnOrName", months),
-            cast("ColumnOrName", days),
-            cast("ColumnOrName", hours),
-            cast("ColumnOrName", mins),
-            cast("ColumnOrName", secs),
+            _ensure_column_or_str(years),
+            _ensure_column_or_str(months),
+            _ensure_column_or_str(days),
+            _ensure_column_or_str(hours),
+            _ensure_column_or_str(mins),
+            _ensure_column_or_str(secs),
         )
     else:
         if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
@@ -25898,7 +25907,7 @@ def make_timestamp_ntz(
                 messageParameters={"arg_list": "years|months|days|hours|mins|secs and date|time"},
             )
         return _invoke_function_over_columns(
-            "make_timestamp_ntz", cast("ColumnOrName", date), cast("ColumnOrName", time)
+            "make_timestamp_ntz", _ensure_column_or_str(date), _ensure_column_or_str(time)
         )
 
 
@@ -26040,12 +26049,12 @@ def try_make_timestamp_ntz(
             )
         return _invoke_function_over_columns(
             "try_make_timestamp_ntz",
-            cast("ColumnOrName", years),
-            cast("ColumnOrName", months),
-            cast("ColumnOrName", days),
-            cast("ColumnOrName", hours),
-            cast("ColumnOrName", mins),
-            cast("ColumnOrName", secs),
+            _ensure_column_or_str(years),
+            _ensure_column_or_str(months),
+            _ensure_column_or_str(days),
+            _ensure_column_or_str(hours),
+            _ensure_column_or_str(mins),
+            _ensure_column_or_str(secs),
         )
     else:
         if any(arg is not None for arg in [years, months, days, hours, mins, secs]):
@@ -26054,7 +26063,7 @@ def try_make_timestamp_ntz(
                 messageParameters={"arg_list": "years|months|days|hours|mins|secs and date|time"},
             )
         return _invoke_function_over_columns(
-            "try_make_timestamp_ntz", cast("ColumnOrName", date), cast("ColumnOrName", time)
+            "try_make_timestamp_ntz", _ensure_column_or_str(date), _ensure_column_or_str(time)
         )
 
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Replaced all `cast(ColumnOrName, arg)` with `_ensure_column_or_name()`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`cast` will raise a mypy error when the `cast ` is unnecessary. For example, if we already checked that `year is not None`, `cast(ColumnOrName, year)` will be an error in latest mypy - because it not needed.

There are some alternatives to fix this

1. Only `cast` the variables that need the cast. This would make the code ugly and we need to keep track of the variables that are checked.
2. Add some ignores to the complaining lines - similar issue.
3. Have a inline check that non of the variables are `None`. If we want to do this, we can't do it in a loop, because mypy does not recognize that. We had to do something like `if month is None or date is None or day is None or ...` 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

latest version mypy does not complain anymore. Rest is on CI

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.