### PR TITLE
[SPARK-55018][PYTHON][TEST] Fix test_convergence by not overflowing the list

### DIFF
--- a/python/pyspark/mllib/tests/test_streaming_algorithms.py
+++ b/python/pyspark/mllib/tests/test_streaming_algorithms.py
@@ -238,7 +238,11 @@ class StreamingLogisticRegressionWithSGDTests(MLLibStreamingTestCase):
         slr = StreamingLogisticRegressionWithSGD(stepSize=0.2, numIterations=25)
         slr.setInitialWeights([0.0])
         slr.trainOn(input_stream)
-        input_stream.foreachRDD(lambda x: models.append(slr.latestModel().weights[0]))
+
+        def update_models(x):
+            if not x.isEmpty():
+                models.append(slr.latestModel().weights[0])
+        input_stream.foreachRDD(update_models)
 
         self.ssc.start()
 

--- a/python/pyspark/mllib/tests/test_streaming_algorithms.py
+++ b/python/pyspark/mllib/tests/test_streaming_algorithms.py
@@ -242,6 +242,7 @@ class StreamingLogisticRegressionWithSGDTests(MLLibStreamingTestCase):
         def update_models(x):
             if not x.isEmpty():
                 models.append(slr.latestModel().weights[0])
+
         input_stream.foreachRDD(update_models)
 
         self.ssc.start()
@@ -251,7 +252,7 @@ class StreamingLogisticRegressionWithSGDTests(MLLibStreamingTestCase):
             return True
 
         # We want all batches to finish for this test.
-        eventually(timeout=120, catch_assertions=True)(condition)()
+        eventually(timeout=120, catch_assertions=True, interval=12.0)(condition)()
 
         t_models = array(models)
         diff = t_models[1:] - t_models[:-1]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Fixed test_convergence by only filling the list if a batch is not empty.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The check below checks that `len(models) == len(input_batches)`, but `input_stream.foreachRDD` will keep sending batches even when it runs through `input_batches`. Which means for every second, we are filling the list with a new element, no matter if we run through the input.

If our condition check missed the exact second where the length of models happen to be 20, the length will become 21 and the condition will never be true.

Actually this would make the check below wrong too - the last two models will be exactly the same so diff check is meaningless.

We should not update `models` if we did not get a real batch.

Increasing interval in `eventually` made this error more frequent.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Locally I set the check interval super high and it still passed

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No