### PR TITLE
[SPARK-55019][SQL] Allow DROP TABLE to drop VIEW

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2148,6 +2148,13 @@ object SQLConf {
     .enumConf(classOf[Level])
     .createWithDefault(Level.TRACE)
 
+  val DROP_TABLE_VIEW_ENABLED =
+    buildConf("spark.sql.dropTableOnView.enabled")
+      .doc("When true, DROP TABLE command will work on VIEW as well.")
+      .version("4.2.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val CROSS_JOINS_ENABLED = buildConf("spark.sql.crossJoin.enabled")
     .internal()
     .doc("When false, we will throw an error if a query contains a cartesian product without " +
@@ -7526,6 +7533,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
     StorageLevel.fromString(getConf(DEFAULT_CACHE_STORAGE_LEVEL).name())
 
   def dataframeCacheLogLevel: Level = getConf(DATAFRAME_CACHE_LOG_LEVEL)
+
+  def dropTableOnView: Boolean = getConf(DROP_TABLE_VIEW_ENABLED)
 
   def crossJoinEnabled: Boolean = getConf(SQLConf.CROSS_JOINS_ENABLED)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
@@ -329,7 +329,8 @@ class V2SessionCatalog(catalog: SessionCatalog)
   private def dropTableInternal(ident: Identifier, purge: Boolean = false): Boolean = {
     try {
       loadTable(ident) match {
-        case V1Table(v1Table) if v1Table.tableType == CatalogTableType.VIEW =>
+        case V1Table(v1Table) if v1Table.tableType == CatalogTableType.VIEW &&
+            !SQLConf.get.getConf(SQLConf.DROP_TABLE_VIEW_ENABLED) =>
           throw QueryCompilationErrors.wrongCommandForObjectTypeError(
             operation = "DROP TABLE",
             requiredType = s"${CatalogTableType.EXTERNAL.name} or" +

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/sql-udf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/sql-udf.sql.out
@@ -1814,52 +1814,22 @@ DropTable true, false
 -- !query
 DROP TABLE IF EXISTS ts
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "WRONG_COMMAND_FOR_OBJECT_TYPE",
-  "sqlState" : "42809",
-  "messageParameters" : {
-    "alternative" : "DROP VIEW",
-    "foundType" : "VIEW",
-    "objectName" : "spark_catalog.default.ts",
-    "operation" : "DROP TABLE",
-    "requiredType" : "EXTERNAL or MANAGED"
-  }
-}
+DropTable true, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.ts
 
 
 -- !query
 DROP TABLE IF EXISTS tm
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "WRONG_COMMAND_FOR_OBJECT_TYPE",
-  "sqlState" : "42809",
-  "messageParameters" : {
-    "alternative" : "DROP VIEW",
-    "foundType" : "VIEW",
-    "objectName" : "spark_catalog.default.tm",
-    "operation" : "DROP TABLE",
-    "requiredType" : "EXTERNAL or MANAGED"
-  }
-}
+DropTable true, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.tm
 
 
 -- !query
 DROP TABLE IF EXISTS ta
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "WRONG_COMMAND_FOR_OBJECT_TYPE",
-  "sqlState" : "42809",
-  "messageParameters" : {
-    "alternative" : "DROP VIEW",
-    "foundType" : "VIEW",
-    "objectName" : "spark_catalog.default.ta",
-    "operation" : "DROP TABLE",
-    "requiredType" : "EXTERNAL or MANAGED"
-  }
-}
+DropTable true, false
++- ResolvedIdentifier V2SessionCatalog(spark_catalog), default.ta
 
 
 -- !query

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -50,26 +50,6 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
     }
   }
 
-  test("view can be dropped using DROP TABLE") {
-    val viewName = "v"
-    withView(viewName) {
-      sql(s"DROP VIEW IF EXISTS $viewName")
-      // First, create a simple view.
-      sql(s"CREATE VIEW $viewName AS SELECT 1 AS a")
-      checkAnswer(sql(s"SELECT * FROM $viewName"), Row(1))
-      // Then, drop the view using DROP TABLE.
-      sql(s"DROP TABLE $viewName")
-      // Finally, verify that the view is dropped.
-      checkError(
-        exception = intercept[AnalysisException] {
-          sql(s"SELECT * FROM $viewName")
-        },
-        condition = "TABLE_OR_VIEW_NOT_FOUND",
-        parameters = Map("relationName" -> s"`$viewName`"),
-        ExpectedContext(s"$viewName", 14, 13 + viewName.length))
-    }
-  }
-
   test("create a permanent view on a permanent view") {
     withView("jtv1", "jtv2") {
       sql("CREATE VIEW jtv1 AS SELECT * FROM jt WHERE id > 3")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -381,6 +381,26 @@ abstract class SQLViewTestSuite extends QueryTest with SQLTestUtils {
     }
   }
 
+  test("SPARK-55019: view can be dropped using DROP TABLE") {
+    val viewName = "v"
+    withView(viewName) {
+      sql(s"DROP VIEW IF EXISTS $viewName")
+      // First, create a simple view.
+      sql(s"CREATE VIEW $viewName AS SELECT 1 AS a")
+      checkAnswer(sql(s"SELECT * FROM $viewName"), Row(1))
+      // Then, drop the view using DROP TABLE.
+      sql(s"DROP TABLE $viewName")
+      // Finally, verify that the view is dropped.
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql(s"SELECT * FROM $viewName")
+        },
+        condition = "TABLE_OR_VIEW_NOT_FOUND",
+        parameters = Map("relationName" -> s"`$viewName`"),
+        ExpectedContext(s"$viewName", 14, 13 + viewName.length))
+    }
+  }
+
   test("SPARK-34719: view query with duplicated output column names") {
     Seq(true, false).foreach { caseSensitive =>
       withSQLConf(CASE_SENSITIVE.key -> caseSensitive.toString) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -382,11 +382,9 @@ abstract class SQLViewTestSuite extends QueryTest with SQLTestUtils {
   }
 
   test("SPARK-55019: view can be dropped using DROP TABLE") {
-    val viewName = "v"
-    withView(viewName) {
-      sql(s"DROP VIEW IF EXISTS $viewName")
+    withView("v") {
       // First, create a simple view.
-      sql(s"CREATE VIEW $viewName AS SELECT 1 AS a")
+      val viewName = createView("v", "SELECT 1 AS a")
       checkAnswer(sql(s"SELECT * FROM $viewName"), Row(1))
       // Then, drop the view using DROP TABLE.
       sql(s"DROP TABLE $viewName")
@@ -396,7 +394,7 @@ abstract class SQLViewTestSuite extends QueryTest with SQLTestUtils {
           sql(s"SELECT * FROM $viewName")
         },
         condition = "TABLE_OR_VIEW_NOT_FOUND",
-        parameters = Map("relationName" -> s"`$viewName`"),
+        parameters = Map("relationName" -> toSQLId(viewName.split("\\.").toSeq)),
         ExpectedContext(s"$viewName", 14, 13 + viewName.length))
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Modify DROP TABLE command semantics:
`DROP TABLE <view>` **should** work on views.


### Why are the changes needed?

Allow the `DROP TABLE` command to operate on views, to improve usability and convenience for users. Currently in Spark, attempting `DROP TABLE <view>` results in a `WRONG_COMMAND_FOR_OBJECT_TYPE` error even though the intent is unambiguous and the operation is safe. Allowing DROP TABLE to drop views simplifies user code paths by removing the need to special-case view handling in DROP statements.


### Does this PR introduce _any_ user-facing change?
Yes, the `DROP TABLE <view>` will now drop the `VIEW`, instead of returning a `WRONG_COMMAND_FOR_OBJECT_TYPE` error.


### How was this patch tested?
Added appropriate SQL tests to verify the new behaviour.

Also, updated the existing tests to match the proposed spec.


### Was this patch authored or co-authored using generative AI tooling?
No.
