### PR TITLE
[MINOR][INFRA] Add GitHub copilot instructions/agents/prompts/skills to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,10 @@ sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/gen/
 tpcds-sf-1/
 tpcds-sf-1-text/
 tpcds-kit/
+
+# For GitHub Copilot
+.github/copilot-instructions.md
+.github/agents/
+.github/instructions/
+.github/prompts/
+.github/skills/


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds GitHub Copilot-related directories to `.gitignore`:
- `.github/copilot-instructions.md`
- `.github/agents/`
- `.github/instructions/`
- `.github/prompts/`
- `.github/skills/`

### Why are the changes needed?

GitHub Copilot allows users to customize its behavior through instruction files, prompts, agents, and skills stored in the `.github` directory. These files are typically user-specific or workspace-specific configurations and should not be committed to the repository.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

N/A - gitignore changes only

### Was this patch authored or co-authored using generative AI tooling?

No