### PR TITLE
[SPARK-54956][CORE] Unify the indeterminate shuffle retry solution

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1906,7 +1906,7 @@ private[spark] class DAGScheduler(
     } else {
       collectSucceedingStages(mapStage).filterNot(_ == mapStage)
     }
-    val stagesCanRollback = filterAndAbortUnrollbackableStages(mapStage, stagesToRollback)
+    val stagesCanRollback = filterAndAbortUnrollbackableStages(stagesToRollback)
     // stages which cannot be rolled back were aborted which leads to removing the
     // the dependant job(s) from the active jobs set, there could be no active jobs
     // left depending on the indeterminate stage and hence no need to roll back any stages.
@@ -2514,12 +2514,11 @@ private[spark] class DAGScheduler(
   /**
    * Abort stages where roll back is requested but cannot be completed.
    *
-   * @param sms the shuffle map stage with indeterminate output
    * @param stagesToRollback stages to roll back
    * @return Shuffle map stages which need and can be rolled back
    */
   private def filterAndAbortUnrollbackableStages(
-      sms: ShuffleMapStage, stagesToRollback: HashSet[Stage]): HashSet[Stage] = {
+      stagesToRollback: HashSet[Stage]): HashSet[Stage] = {
 
     def generateErrorMessage(stage: Stage): String = {
       "A shuffle map stage with indeterminate output was failed and retried. " +

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1567,13 +1567,10 @@ private[spark] class DAGScheduler(
         if (sms.isStaticallyIndeterminate &&
             !sms.shuffleDep.checksumMismatchFullRetryEnabled &&
             sms.getNextAttemptId > 0) {
-          // For indeterminate stages being retried, we need to prepare both this stage and its
-          // succeeding stages for a fresh start. The `rollbackCurrentStage = true` parameter
-          // ensures this stage is included in the cleanup process to:
-          // 1. Clear its shuffle outputs from previous attempts
-          // 2. Mark old task results to be ignored
-          // 3. Create a new shuffle merge state
-          // This ensures a full retry.
+          // The `rollbackCurrentStage = true` parameter ensures the current submitting stage
+          // is included in the cleanup for a fresh start: clearing its shuffle outputs, marking
+          // old task results to be ignored, and creating a new shuffle merge state for the
+          // upcoming retry.
           rollbackSucceedingStages(sms, rollbackCurrentStage = true)
           if (!stageIdToStage.contains(stage.id)) {
             logInfo(log"All jobs depending on the indeterminate stage " +

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1555,28 +1555,23 @@ private[spark] class DAGScheduler(
   private def submitMissingTasks(stage: Stage, jobId: Int): Unit = {
     logDebug("submitMissingTasks(" + stage + ")")
 
-    // Before find missing partition, do the intermediate state clean work first.
-    // The operation here can make sure for the partially completed intermediate stage,
-    // `findMissingPartitions()` returns all partitions every time.
+    // For statically indeterminate stages being retried, we trigger rollback BEFORE task
+    // submission. This is more efficient than deferring to task completion because:
+    // 1. It avoids submitting a partial stage that would need to be cancelled
+    // 2. It ensures findMissingPartitions() returns ALL partitions for the retry
+    //
+    // For runtime detection (checksum mismatch), we must defer to task completion because
+    // we don't know the stage is indeterminate until we see the checksum differ.
     stage match {
       case sms: ShuffleMapStage if !sms.isAvailable =>
-        if (!sms.shuffleDep.checksumMismatchFullRetryEnabled && stage.isIndeterminate) {
-          // already executed at least once
-          if (sms.getNextAttemptId > 0) {
-            // While we previously validated possible rollbacks during the handling of a FetchFailure,
-            // where we were fetching from an indeterminate source map stages, this later check
-            // covers additional cases like recalculating an indeterminate stage after an executor
-            // loss. Moreover, because this check occurs later in the process, if a result stage task
-            // has successfully completed, we can detect this and abort the job, as rolling back a
-            // result stage is not possible.
-            rollbackSucceedingStages(sms, rollbackCurrentStage = true)
-            // stages which cannot be rolled back were aborted which leads to removing the
-            // the dependant job(s) and stages. If current stage is not needed anymore, return.
-            if (!stageIdToStage.contains(stage.id)) {
-              logInfo(log"All jobs depending on the indeterminate stage " +
-                log"(${MDC(STAGE_ID, stage.id)}) were aborted so this stage is not needed anymore.")
-              return
-            }
+        if (sms.isStaticallyIndeterminate &&
+            !sms.shuffleDep.checksumMismatchFullRetryEnabled &&
+            sms.getNextAttemptId > 0) {
+          rollbackSucceedingStages(sms, rollbackCurrentStage = true)
+          if (!stageIdToStage.contains(stage.id)) {
+            logInfo(log"All jobs depending on the indeterminate stage " +
+              log"(${MDC(STAGE_ID, stage.id)}) were aborted so this stage is not needed anymore.")
+            return
           }
         }
       case _ =>
@@ -1875,7 +1870,9 @@ private[spark] class DAGScheduler(
         if (shuffleStage.isAvailable) {
           computedTotalSize
         } else {
-          if (shuffleStage.isIndeterminate) {
+          // For indeterminate stages, don't use partial merge results as the stage output
+          // may change on retry
+          if (shuffleStage.isStaticallyIndeterminate) {
             0L
           } else {
             computedTotalSize
@@ -2093,19 +2090,11 @@ private[spark] class DAGScheduler(
         // tasks complete, they still count and we can mark the corresponding partitions as
         // finished if the stage is determinate. Here we notify the task scheduler to skip running
         // tasks for the same partition to save resource.
-        def stageWithChecksumMismatchFullRetryEnabled(stage: Stage): Boolean = {
-          stage match {
-            case s: ShuffleMapStage => s.shuffleDep.checksumMismatchFullRetryEnabled
-            case _ => stage.parents.exists(stageWithChecksumMismatchFullRetryEnabled)
-          }
-        }
 
-        // Ignore task completion for old attempt of indeterminate stage
-        val ignoreOldTaskAttempts = if (stageWithChecksumMismatchFullRetryEnabled(stage)) {
+        // Ignore task completion for old attempt of stages with nondeterministic output.
+        // This is tracked via maxAttemptIdToIgnore which is set when a stage is rolled back.
+        val ignoreOldTaskAttempts =
           stage.maxAttemptIdToIgnore.exists(_ >= task.stageAttemptId)
-        } else {
-          stage.isIndeterminate && task.stageAttemptId < stage.latestInfo.attemptNumber()
-        }
 
         if (!ignoreOldTaskAttempts && task.stageAttemptId < stage.latestInfo.attemptNumber()) {
           taskScheduler.notifyPartitionCompletion(stageId, task.partitionId)
@@ -2186,18 +2175,16 @@ private[spark] class DAGScheduler(
                   shuffleStage.shuffleDep.shuffleId, smt.partitionId, status)
                 if (isChecksumMismatched) {
                   shuffleStage.isChecksumMismatched = isChecksumMismatched
-                  // There could be multiple checksum mismatches detected for a single stage attempt.
-                  // We check for stage abortion once and only once when we first detect checksum
-                  // mismatch for each stage attempt. For example, assume that we have
-                  // stage1 -> stage2, and we encounter checksum mismatch during the retry of stage1.
-                  // In this case, we need to call abortUnrollbackableStages() for the succeeding
-                  // stages. Assume that when stage2 is retried, some tasks finish and some tasks
-                  // failed again with FetchFailed. In case that we encounter checksum mismatch again
-                  // during the retry of stage1, we need to call abortUnrollbackableStages() again.
-                  if (shuffleStage.maxChecksumMismatchedId < smt.stageAttemptId) {
-                    shuffleStage.maxChecksumMismatchedId = smt.stageAttemptId
-                    if (shuffleStage.shuffleDep.checksumMismatchFullRetryEnabled
-                      && shuffleStage.isStageIndeterminate) {
+                  // Runtime detection of nondeterministic output via checksum mismatch.
+                  // This is the trigger point for runtime detection - we only know the stage
+                  // is indeterminate when we see different checksums from different attempts.
+                  //
+                  // Note: Static detection (isStaticallyIndeterminate) is triggered earlier
+                  // in FetchFailed handler and submitMissingTasks for efficiency.
+                  if (shuffleStage.shuffleDep.checksumMismatchFullRetryEnabled
+                      && shuffleStage.isRuntimeIndeterminate) {
+                    if (shuffleStage.maxChecksumMismatchedId < smt.stageAttemptId) {
+                      shuffleStage.maxChecksumMismatchedId = smt.stageAttemptId
                       rollbackSucceedingStages(shuffleStage)
                     }
                   }
@@ -2319,14 +2306,15 @@ private[spark] class DAGScheduler(
             failedStages += failedStage
             failedStages += mapStage
             if (noResubmitEnqueued) {
-              // If the map stage is INDETERMINATE, which means the map tasks may return
-              // different result when re-try, we need to re-try all the tasks of the failed
-              // stage and its succeeding stages, because the input data will be changed after the
-              // map tasks are re-tried.
-              // Note that, if map stage is UNORDERED, we are fine. The shuffle partitioner is
-              // guaranteed to be determinate, so the input data of the reducers will not change
-              // even if the map tasks are re-tried.
-              if (mapStage.isIndeterminate && !mapStage.shuffleDep.checksumMismatchFullRetryEnabled) {
+              // For statically indeterminate stages, trigger rollback early (here and in
+              // submitMissingTasks) rather than deferring to task completion. This is more
+              // efficient because it clears shuffle outputs before the retry is submitted,
+              // ensuring findMissingPartitions() returns all partitions.
+              //
+              // For runtime detection (checksum mismatch), rollback is triggered at task
+              // completion when the mismatch is discovered.
+              if (mapStage.isStaticallyIndeterminate &&
+                  !mapStage.shuffleDep.checksumMismatchFullRetryEnabled) {
                 rollbackSucceedingStages(mapStage, rollbackCurrentStage = true)
               }
 
@@ -2827,11 +2815,11 @@ private[spark] class DAGScheduler(
       if (stage.pendingPartitions.isEmpty)
         if (runningStages.contains(stage)) {
           processShuffleMapStageCompletion(stage)
-        } else if (stage.isIndeterminate) {
+        } else if (stage.isStaticallyIndeterminate) {
           // There are 2 possibilities here - stage is either cancelled or it will be resubmitted.
-          // If this is an indeterminate stage which is cancelled, we unregister all its merge
-          // results here just to free up some memory. If the indeterminate stage is resubmitted,
-          // merge results are cleared again when the newer attempt is submitted.
+          // If this is a statically indeterminate stage which is cancelled, we unregister all its
+          // merge results here just to free up some memory. If the indeterminate stage is
+          // resubmitted, merge results are cleared again when the newer attempt is submitted.
           mapOutputTracker.unregisterAllMergeResult(stage.shuffleDep.shuffleId)
           // For determinate stages, which have completed merge finalization, we don't need to
           // unregister merge results - since the stage retry, or any other stage computing the

--- a/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
@@ -21,7 +21,7 @@ import scala.collection.mutable.HashSet
 
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.internal.Logging
-import org.apache.spark.rdd.{DeterministicLevel, RDD}
+import org.apache.spark.rdd.RDD
 import org.apache.spark.util.CallSite
 
 /**
@@ -155,18 +155,4 @@ private[scheduler] abstract class Stage(
 
   /** Returns the sequence of partition ids that are missing (i.e. needs to be computed). */
   def findMissingPartitions(): Seq[Int]
-
-  def isIndeterminate: Boolean = {
-    rdd.outputDeterministicLevel == DeterministicLevel.INDETERMINATE
-  }
-
-  // Returns true if any parents of this stage are indeterminate.
-  def isParentIndeterminate: Boolean = {
-    parents.exists(_.isStageIndeterminate)
-  }
-
-  // Returns true if the stage itself is indeterminate.
-  def isStageIndeterminate: Boolean = {
-    !rdd.isReliablyCheckpointed && isChecksumMismatched
-  }
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -3275,8 +3275,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
   test("SPARK-25341: abort stage while using old fetch protocol") {
     conf.set(config.SHUFFLE_USE_OLD_FETCH_PROTOCOL.key, "true")
     // Construct the scenario of indeterminate stage fetch failed.
-    constructChecksumMismatchStageFetchFailed(
-      checksumMismatchFullRetryEnabled = false)
+    constructIndeterminateStageFetchFailed()
     // The job should fail because Spark can't rollback the shuffle map stage while
     // using old protocol.
     assert(failure != null && failure.getMessage.contains(
@@ -3289,10 +3288,10 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     // Check status for all failedStages
     val failedStages = scheduler.failedStages.toSeq
     assert(failedStages.map(_.id) == Seq(1, 2))
-    // Shuffle blocks of "hostC" is lost, so first task of the `shuffleMapRdd2` needs to retry.
+    // Shuffle blocks of "hostC" is lost, rollback to do a fully-retry.
     assert(failedStages.collect {
       case stage: ShuffleMapStage if stage.shuffleDep.shuffleId == shuffleId2 => stage
-    }.head.findMissingPartitions() == Seq(0))
+    }.head.findMissingPartitions() == Seq(0, 1))
     // The result stage is still waiting for its 2 tasks to complete
     assert(failedStages.collect {
       case stage: ResultStage => stage
@@ -3314,7 +3313,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     // First shuffle map stage resubmitted and reran all tasks.
     assert(taskSets(4).stageId == 0)
     assert(taskSets(4).stageAttemptId == 1)
-    assert(taskSets(4).tasks.length == 1)
+    assert(taskSets(4).tasks.length == 2)
 
     // Finish all stage.
     completeShuffleMapStageSuccessfully(0, 1, 2)
@@ -3471,8 +3470,8 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     scheduler.resubmitFailedStages()
 
     // Check all indeterminate stage roll back.
-    checkAndCompleteRetryStage(3, 0, shuffleId1, numTasks = 1)
-    checkAndCompleteRetryStage(4, 1, shuffleId2, numTasks = 1)
+    checkAndCompleteRetryStage(3, 0, shuffleId1)
+    checkAndCompleteRetryStage(4, 1, shuffleId2)
     checkAndCompleteRetryStage(5, 2, shuffleId3)
 
     // Result stage success, all job ended.
@@ -3483,14 +3482,13 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
   }
 
   // Construct the scenario of stages with checksum mismatches and FetchFailed.
-  private def constructChecksumMismatchStageFetchFailed(
-      checksumMismatchFullRetryEnabled: Boolean = true): (Int, Int) = {
-    val shuffleMapRdd1 = new MyRDD(sc, 2, Nil, indeterminate = true)
+  private def constructChecksumMismatchStageFetchFailed(): (Int, Int) = {
+    val shuffleMapRdd1 = new MyRDD(sc, 2, Nil)
 
     val shuffleDep1 = new ShuffleDependency(
       shuffleMapRdd1,
       new HashPartitioner(2),
-      _checksumMismatchFullRetryEnabled = checksumMismatchFullRetryEnabled
+      _checksumMismatchFullRetryEnabled = true
     )
     val shuffleId1 = shuffleDep1.shuffleId
     val shuffleMapRdd2 = new MyRDD(sc, 2, List(shuffleDep1), tracker = mapOutputTracker)
@@ -3498,7 +3496,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     val shuffleDep2 = new ShuffleDependency(
       shuffleMapRdd2,
       new HashPartitioner(2),
-      _checksumMismatchFullRetryEnabled = checksumMismatchFullRetryEnabled
+      _checksumMismatchFullRetryEnabled = true
     )
     val shuffleId2 = shuffleDep2.shuffleId
     val finalRdd = new MyRDD(sc, 2, List(shuffleDep2), tracker = mapOutputTracker)
@@ -4634,7 +4632,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     // Check status for all failedStages
     val failedStages = scheduler.failedStages.toSeq
     assert(failedStages.map(_.id) == Seq(1, 2))
-    // Shuffle blocks of "hostC" is lost, so first task of the `shuffleMapRdd2` needs to retry.
+    // Shuffle blocks of "hostC" is lost, rollback to do a fully-retry.
     assert(failedStages.collect {
       case stage: ShuffleMapStage if stage.shuffleDep.shuffleId == shuffleId2 => stage
     }.head.findMissingPartitions() == Seq(0, 1))
@@ -4645,7 +4643,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     // shuffleMergeId for indeterminate stages would start from 1
     assert(failedStages.collect {
       case stage: ShuffleMapStage => stage.shuffleDep.shuffleMergeId
-    }.forall(x => x == 2))
+    }.forall(x => x == 1))
     scheduler.resubmitFailedStages()
 
     // The first task of the `shuffleMapRdd2` failed with fetch failure
@@ -4656,10 +4654,11 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
 
     val newFailedStages = scheduler.failedStages.toSeq
     assert(newFailedStages.map(_.id) == Seq(0, 1))
-    // shuffleMergeId for indeterminate failed stages should be 2
-    assert(failedStages.collect {
-      case stage: ShuffleMapStage => stage.shuffleDep.shuffleMergeId
-    }.forall(x => x == 2))
+    // shuffleMergeId for indeterminate failed stages should be increased
+    assert(newFailedStages.filter(_.id == 0)
+      .exists(_.asInstanceOf[ShuffleMapStage].shuffleDep.shuffleMergeId == 1))
+    assert(newFailedStages.filter(_.id == 1)
+      .exists(_.asInstanceOf[ShuffleMapStage].shuffleDep.shuffleMergeId == 2))
     scheduler.resubmitFailedStages()
 
     // First shuffle map stage resubmitted and reran all tasks.
@@ -4670,16 +4669,16 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     // Finish all stage.
     completeShuffleMapStageSuccessfully(0, 1, 2)
     assert(mapOutputTracker.findMissingPartitions(shuffleId1) === Some(Seq.empty))
-    // shuffleMergeId should be 2 for the attempt number 1 for stage 0
+    // shuffleMergeId should be 1 for the attempt number 1 for stage 0
     assert(mapOutputTracker.shuffleStatuses.get(shuffleId1).forall(
-      _.mergeStatuses.forall(x => x.shuffleMergeId == 2)))
+      _.mergeStatuses.forall(x => x.shuffleMergeId == 1)))
     assert(mapOutputTracker.getNumAvailableMergeResults(shuffleId1) == 2)
 
     completeShuffleMapStageSuccessfully(1, 2, 2, Seq("hostC", "hostD"))
     assert(mapOutputTracker.findMissingPartitions(shuffleId2) === Some(Seq.empty))
     // shuffleMergeId should be 2 for the attempt number 2 for stage 1
     assert(mapOutputTracker.shuffleStatuses.get(shuffleId2).forall(
-      _.mergeStatuses.forall(x => x.shuffleMergeId == 3)))
+      _.mergeStatuses.forall(x => x.shuffleMergeId == 2)))
     assert(mapOutputTracker.getNumAvailableMergeResults(shuffleId2) == 2)
 
     complete(taskSets(6), Seq((Success, 11), (Success, 12)))
@@ -5117,7 +5116,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
         (Success, makeMapStatus("host" + idx, parts))
     }.toSeq)
 
-    assert(shuffleStage1.shuffleDep.shuffleMergeId == 2)
+    assert(shuffleStage1.shuffleDep.shuffleMergeId == 1)
     assert(shuffleStage1.shuffleDep.isShuffleMergeFinalizedMarked)
     val newMergerLocs =
       scheduler.stageIdToStage(0).asInstanceOf[ShuffleMapStage].shuffleDep.getMergerLocs

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -4944,7 +4944,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     }
 
     val shuffleIndeterminateStage = scheduler.stageIdToStage(3).asInstanceOf[ShuffleMapStage]
-    assert(shuffleIndeterminateStage.isIndeterminate)
+    assert(shuffleIndeterminateStage.isStaticallyIndeterminate)
     scheduler.handleShuffleMergeFinalized(shuffleIndeterminateStage, 2)
     assert(shuffleIndeterminateStage.shuffleDep.shuffleMergeEnabled)
     assert(!shuffleIndeterminateStage.shuffleDep.isShuffleMergeFinalizedMarked)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Unify the approach to handle indeterminate shuffle retry.

Currently we have two mechanism to detect indeterminate shuffle retry, shuffle checksum mismatch detection and stage's indeterminate attribute. For either way, once indeterminate shuffle retry is detected, we should ensure all the succeeding stages will do a fully retry.

The PR proposes to unify the approach to the new approach we added with shuffle checksum mismatch detection which can cover more cases.

### Why are the changes needed?
Align the approach to handle indeterminate shuffle retry to cover more scenarios and reduce the code maintenance effort.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UTs

### Was this patch authored or co-authored using generative AI tooling?
No
