### PR TITLE
[SPARK-55024][SQL] Use REQUIRES_SINGLE_PART_NAMESPACE error for session catalog namespace validation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/LookupCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/LookupCatalog.scala
@@ -19,7 +19,9 @@ package org.apache.spark.sql.connector.catalog
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
+import org.apache.spark.util.ArrayImplicits._
 
 /**
  * A trait to encapsulate catalog lookup function and helpful extractors.
@@ -107,8 +109,8 @@ private[sql] trait LookupCatalog extends Logging {
 
     def unapply(nameParts: Seq[String]): Option[(CatalogPlugin, Identifier)] = {
       assert(nameParts.nonEmpty)
-      if (nameParts.length == 1) {
-        Some((currentCatalog, Identifier.of(catalogManager.currentNamespace, nameParts.head)))
+      val (catalog, ident) = if (nameParts.length == 1) {
+        (currentCatalog, Identifier.of(catalogManager.currentNamespace, nameParts.head))
       } else if (nameParts.head.equalsIgnoreCase(globalTempDB)) {
         // Conceptually global temp views are in a special reserved catalog. However, the v2 catalog
         // API does not support view yet, and we have to use v1 commands to deal with global temp
@@ -116,15 +118,20 @@ private[sql] trait LookupCatalog extends Logging {
         // in the session catalog. The special namespace has higher priority during name resolution.
         // For example, if the name of a custom catalog is the same with `GLOBAL_TEMP_DATABASE`,
         // this custom catalog can't be accessed.
-        Some((catalogManager.v2SessionCatalog, nameParts.asIdentifier))
+        (catalogManager.v2SessionCatalog, nameParts.asIdentifier)
       } else {
         try {
-          Some((catalogManager.catalog(nameParts.head), nameParts.tail.asIdentifier))
+          (catalogManager.catalog(nameParts.head), nameParts.tail.asIdentifier)
         } catch {
           case _: CatalogNotFoundException =>
-            Some((currentCatalog, nameParts.asIdentifier))
+            (currentCatalog, nameParts.asIdentifier)
         }
       }
+      if (CatalogV2Util.isSessionCatalog(catalog) && ident.namespace().length != 1) {
+        throw QueryCompilationErrors.requiresSinglePartNamespaceError(
+          ident.namespace().toImmutableArraySeq)
+      }
+      Some((catalog, ident))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2FunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2FunctionSuite.scala
@@ -201,8 +201,10 @@ class DataSourceV2FunctionSuite extends DatasourceV2SQLBase {
       exception = intercept[AnalysisException] {
         sql("DROP FUNCTION default.ns1.ns2.fun")
       },
-      condition = "IDENTIFIER_TOO_MANY_NAME_PARTS",
-      parameters = Map("identifier" -> "`default`.`ns1`.`ns2`.`fun`", "limit" -> "2")
+      condition = "REQUIRES_SINGLE_PART_NAMESPACE",
+      parameters = Map(
+        "sessionCatalog" -> "spark_catalog",
+        "namespace" -> "`default`.`ns1`.`ns2`")
     )
   }
 
@@ -230,8 +232,10 @@ class DataSourceV2FunctionSuite extends DatasourceV2SQLBase {
       exception = intercept[AnalysisException] {
         sql("REFRESH FUNCTION default.ns1.ns2.fun")
       },
-      condition = "IDENTIFIER_TOO_MANY_NAME_PARTS",
-      parameters = Map("identifier" -> "`default`.`ns1`.`ns2`.`fun`", "limit" -> "2")
+      condition = "REQUIRES_SINGLE_PART_NAMESPACE",
+      parameters = Map(
+        "sessionCatalog" -> "spark_catalog",
+        "namespace" -> "`default`.`ns1`.`ns2`")
     )
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR improves error consistency by using `REQUIRES_SINGLE_PART_NAMESPACE` instead of `IDENTIFIER_TOO_MANY_NAME_PARTS` when the session catalog is involved. It adds centralized namespace validation in `CatalogAndIdentifier` extractor: when the catalog is session catalog, validate that the namespace has exactly 1 part.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`REQUIRES_SINGLE_PART_NAMESPACE` is more precise for the namespace length error of the session catalog.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, error message change

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
existing tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
cursor 2.3.34