### PR TITLE
[SPARK-54870][FOLLOW-UP][SQL] Add unapply methods to CharType and VarcharType for backward compatible pattern matching

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/types/CharType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/CharType.scala
@@ -62,4 +62,10 @@ object CharType {
 
   def apply(length: Int, collationId: Int): CharType =
     new CharType(length, Some(collationId))
+
+  /**
+   * Extractor for pattern matching that extracts the length.
+   * This maintains backward compatibility with code using `case CharType(length)`.
+   */
+  def unapply(charType: CharType): Option[Int] = Some(charType.length)
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/CharType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/CharType.scala
@@ -64,8 +64,8 @@ object CharType {
     new CharType(length, Some(collationId))
 
   /**
-   * Extractor for pattern matching that extracts the length.
-   * This maintains backward compatibility with code using `case CharType(length)`.
+   * Extractor for pattern matching that extracts the length. This maintains backward
+   * compatibility with code using `case CharType(length)`.
    */
   def unapply(charType: CharType): Option[Int] = Some(charType.length)
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/VarcharType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/VarcharType.scala
@@ -63,8 +63,8 @@ object VarcharType {
     new VarcharType(length, Some(collationId))
 
   /**
-   * Extractor for pattern matching that extracts the length.
-   * This maintains backward compatibility with code using `case VarcharType(length)`.
+   * Extractor for pattern matching that extracts the length. This maintains backward
+   * compatibility with code using `case VarcharType(length)`.
    */
   def unapply(varcharType: VarcharType): Option[Int] = Some(varcharType.length)
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/VarcharType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/VarcharType.scala
@@ -61,4 +61,10 @@ object VarcharType {
 
   def apply(length: Int, collationId: Int): VarcharType =
     new VarcharType(length, Some(collationId))
+
+  /**
+   * Extractor for pattern matching that extracts the length.
+   * This maintains backward compatibility with code using `case VarcharType(length)`.
+   */
+  def unapply(varcharType: VarcharType): Option[Int] = Some(varcharType.length)
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Adds custom `unapply` methods to `CharType` and `VarcharType` companion objects that extract only the `length` field, maintaining backward compatible pattern matching.

### Why are the changes needed?

After adding collation support, the case class signatures changed from one parameter to two:
- `CharType(length: Int)` → `CharType(length: Int, collation: Option[Int])`
- `VarcharType(length: Int)` → `VarcharType(length: Int, collation: Option[Int])`

This broke pattern matching like `case CharType(length) =>` or `case CharType(_) =>` in external projects and applications.

### Does this PR introduce _any_ user-facing change?

No. This restores the previous pattern matching behavior.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No