### PR TITLE
[SPARK-55029][SS] Propagate streaming source identifying name through resolution pipeline

### DIFF
--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -125,7 +125,7 @@ abstract class KafkaSourceTest extends StreamTest with SharedSparkSession with K
 
       val sources: Seq[SparkDataStream] = {
         query.get.logicalPlan.collect {
-          case StreamingExecutionRelation(source: KafkaSource, _, _) => source
+          case StreamingExecutionRelation(source: KafkaSource, _, _, _) => source
           case r: StreamingDataSourceV2ScanRelation
             if r.stream.isInstanceOf[KafkaMicroBatchStream] ||
               r.stream.isInstanceOf[KafkaContinuousStream] =>
@@ -1615,7 +1615,7 @@ abstract class KafkaMicroBatchV1SourceSuite extends KafkaMicroBatchSourceSuiteBa
       makeSureGetOffsetCalled,
       AssertOnQuery { query =>
         query.logicalPlan.collectFirst {
-          case StreamingExecutionRelation(_: KafkaSource, _, _) => true
+          case StreamingExecutionRelation(_: KafkaSource, _, _, _) => true
         }.nonEmpty
       }
     )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/NameStreamingSources.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/NameStreamingSources.scala
@@ -127,8 +127,10 @@ object NameStreamingSources extends Rule[LogicalPlan] {
     } else {
       // Feature disabled - unwrap NamedStreamingRelation nodes without propagating names.
       // Error if any source has an explicitly assigned name since the feature is disabled.
+      // Only unwrap when child is resolved - this allows FindDataSourceTable to resolve
+      // UnresolvedCatalogRelation to StreamingRelation before we unwrap.
       plan.resolveOperatorsWithPruning(_.containsPattern(NAMED_STREAMING_RELATION)) {
-        case NamedStreamingRelation(child, Unassigned) =>
+        case NamedStreamingRelation(child, Unassigned) if child.resolved =>
           child
         case NamedStreamingRelation(_, UserProvided(name)) =>
           throw QueryCompilationErrors.streamingSourceNamingNotSupportedError(name)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -41,6 +41,7 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable.VIEW_STORING_ANALYZED_
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, Cast, ExprId, Literal}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils
+import org.apache.spark.sql.catalyst.streaming.StreamingSourceIdentifyingName
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.connector.catalog.CatalogManager
@@ -442,7 +443,9 @@ case class CatalogTable(
     tracksPartitionsInCatalog: Boolean = false,
     schemaPreservesCase: Boolean = true,
     ignoredProperties: Map[String, String] = Map.empty,
-    viewOriginalText: Option[String] = None) extends MetadataMapSupport {
+    viewOriginalText: Option[String] = None,
+    streamingSourceIdentifyingName: Option[StreamingSourceIdentifyingName] = None)
+  extends MetadataMapSupport {
 
   import CatalogTable._
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamingRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamingRelation.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.analysis.MultiInstanceRelation
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.catalyst.plans.logical.{ExposesMetadataColumns, LeafNode, LogicalPlan, Statistics}
+import org.apache.spark.sql.catalyst.streaming.{StreamingSourceIdentifyingName, Unassigned}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.connector.read.streaming.SparkDataStream
 import org.apache.spark.sql.errors.QueryExecutionErrors
@@ -34,8 +35,13 @@ import org.apache.spark.sql.sources.SupportsStreamSourceMetadataColumns
 
 object StreamingRelation {
   def apply(dataSource: DataSource): StreamingRelation = {
+    // Extract source identifying name from CatalogTable for stable checkpoints
+    val sourceIdentifyingName = dataSource.catalogTable
+      .flatMap(_.streamingSourceIdentifyingName)
+      .getOrElse(Unassigned)
     StreamingRelation(
-      dataSource, dataSource.sourceInfo.name, toAttributes(dataSource.sourceInfo.schema))
+      dataSource, dataSource.sourceInfo.name, toAttributes(dataSource.sourceInfo.schema),
+      sourceIdentifyingName)
   }
 }
 
@@ -46,10 +52,19 @@ object StreamingRelation {
  * It should be used to create [[Source]] and converted to [[StreamingExecutionRelation]] when
  * passing to [[StreamExecution]] to run a query.
  */
-case class StreamingRelation(dataSource: DataSource, sourceName: String, output: Seq[Attribute])
+case class StreamingRelation(
+    dataSource: DataSource,
+    sourceName: String,
+    output: Seq[Attribute],
+    sourceIdentifyingName: StreamingSourceIdentifyingName = Unassigned)
   extends LeafNode with MultiInstanceRelation with ExposesMetadataColumns {
   override def isStreaming: Boolean = true
   override def toString: String = sourceName
+
+  // Provide a concise representation for plan comparison output
+  override def simpleString(maxFields: Int): String = {
+    s"StreamingRelation $sourceName, ${output.mkString("[", ", ", "]")}, $sourceIdentifyingName"
+  }
 
   // There's no sensible value here. On the execution path, this relation will be
   // swapped out with microbatches. But some dataframe operations (in particular explain) do lead
@@ -88,7 +103,9 @@ case class StreamingRelation(dataSource: DataSource, sourceName: String, output:
 case class StreamingExecutionRelation(
     source: SparkDataStream,
     output: Seq[Attribute],
-    catalogTable: Option[CatalogTable])(session: SparkSession)
+    catalogTable: Option[CatalogTable],
+    sourceIdentifyingName: StreamingSourceIdentifyingName = Unassigned)
+    (session: SparkSession)
   extends LeafNode with MultiInstanceRelation {
 
   override def otherCopyArgs: Seq[AnyRef] = session :: Nil

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/StreamRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/StreamRelationSuite.scala
@@ -130,6 +130,9 @@ class StreamRelationSuite extends SharedSparkSession with AnalysisTest {
     val catalogTable = spark.sessionState.catalog.getTableMetadata(
       TableIdentifier("t")
     )
+    // During streaming resolution, the CatalogTable gets streamingSourceIdentifyingName set
+    val catalogTableWithSourceName = catalogTable.copy(
+      streamingSourceIdentifyingName = Some(Unassigned))
     val idAttr = AttributeReference(name = "id", dataType = IntegerType)()
 
     val expectedAnalyzedPlan = Project(
@@ -145,7 +148,7 @@ class StreamRelationSuite extends SharedSparkSession with AnalysisTest {
               "path" -> catalogTable.location.toString
             ),
             userSpecifiedSchema = Option(catalogTable.schema),
-            catalogTable = Option(catalogTable)
+            catalogTable = Option(catalogTableWithSourceName)
           ),
           sourceName = s"FileSource[${catalogTable.location.toString}]",
           output = Seq(idAttr)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -190,7 +190,7 @@ abstract class FileStreamSourceTest
   protected def getSourceFromFileStream(df: DataFrame): FileStreamSource = {
     val checkpointLocation = Utils.createTempDir(namePrefix = "streaming.metadata").getCanonicalPath
     df.queryExecution.analyzed
-      .collect { case StreamingRelation(dataSource, _, _) =>
+      .collect { case StreamingRelation(dataSource, _, _, _) =>
         // There is only one source in our tests so just set sourceId to 0
         dataSource.createSource(s"$checkpointLocation/sources/0").asInstanceOf[FileStreamSource]
       }.head
@@ -198,7 +198,7 @@ abstract class FileStreamSourceTest
 
   protected def getSourcesFromStreamingQuery(query: StreamExecution): Seq[FileStreamSource] = {
     query.logicalPlan.collect {
-      case StreamingExecutionRelation(source, _, _) if source.isInstanceOf[FileStreamSource] =>
+      case StreamingExecutionRelation(source, _, _, _) if source.isInstanceOf[FileStreamSource] =>
         source.asInstanceOf[FileStreamSource]
     }
   }
@@ -251,7 +251,7 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
         reader.load()
       }
     df.queryExecution.analyzed
-      .collect { case s @ StreamingRelation(dataSource, _, _) => s.schema }.head
+      .collect { case s @ StreamingRelation(dataSource, _, _, _) => s.schema }.head
   }
 
   override def beforeAll(): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSourceIdentifyingNameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSourceIdentifyingNameSuite.scala
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.streaming
+
+import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias
+import org.apache.spark.sql.catalyst.streaming.Unassigned
+import org.apache.spark.sql.execution.streaming.runtime.StreamingRelation
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Tests for streaming source identifying name propagation through the resolution pipeline.
+ * These tests verify that sourceIdentifyingName is correctly propagated from CatalogTable
+ * through DataSource to StreamingRelation during streaming table resolution.
+ */
+class StreamingSourceIdentifyingNameSuite extends SharedSparkSession {
+
+  test("STREAM table resolution propagates sourceIdentifyingName through pipeline") {
+    withTable("stream_name_test") {
+      sql("CREATE TABLE stream_name_test (id INT) USING PARQUET")
+
+      val analyzedPlan = sql("SELECT * FROM STREAM stream_name_test").queryExecution.analyzed
+
+      val streamingRelation = analyzedPlan.collectFirst {
+        case sr: StreamingRelation => sr
+      }
+
+      assert(streamingRelation.isDefined, "Expected StreamingRelation in analyzed plan")
+      assert(streamingRelation.get.sourceIdentifyingName == Unassigned,
+        s"Expected Unassigned but got ${streamingRelation.get.sourceIdentifyingName}")
+
+      // Verify the CatalogTable in DataSource has the name set
+      val catalogTable = streamingRelation.get.dataSource.catalogTable
+      assert(catalogTable.isDefined, "Expected CatalogTable in DataSource")
+      assert(catalogTable.get.streamingSourceIdentifyingName == Some(Unassigned),
+        s"Expected Some(Unassigned) but got ${catalogTable.get.streamingSourceIdentifyingName}")
+    }
+  }
+
+  test("STREAM with qualified name propagates sourceIdentifyingName through SubqueryAlias") {
+    // When querying a table with a qualified name (e.g., spark_catalog.default.t),
+    // the catalog lookup creates a SubqueryAlias wrapper.
+    withTable("stream_alias_test") {
+      sql("CREATE TABLE stream_alias_test (id INT, data STRING) USING PARQUET")
+
+      // Query using fully qualified name to ensure SubqueryAlias is created
+      val analyzedPlan = sql(
+        "SELECT * FROM STREAM spark_catalog.default.stream_alias_test"
+      ).queryExecution.analyzed
+
+      val streamingRelation = analyzedPlan.collectFirst {
+        case sr: StreamingRelation => sr
+      }
+
+      assert(streamingRelation.isDefined, "Expected StreamingRelation in analyzed plan")
+      assert(streamingRelation.get.sourceIdentifyingName == Unassigned,
+        s"Expected Unassigned but got ${streamingRelation.get.sourceIdentifyingName}")
+
+      // Verify the plan has SubqueryAlias wrapping StreamingRelation
+      val hasSubqueryAlias = analyzedPlan.collect {
+        case SubqueryAlias(_, _: StreamingRelation) => true
+      }.nonEmpty
+      assert(hasSubqueryAlias, "Expected SubqueryAlias wrapping StreamingRelation")
+    }
+  }
+
+  test("readStream.table() API resolves streaming table correctly") {
+    // This tests the fallback case in FindDataSourceTable for streaming
+    // UnresolvedCatalogRelation that is NOT wrapped in NamedStreamingRelation.
+    withTable("api_stream_test") {
+      sql("CREATE TABLE api_stream_test (id INT) USING PARQUET")
+
+      val df = spark.readStream.table("api_stream_test")
+      val analyzedPlan = df.queryExecution.analyzed
+
+      val streamingRelation = analyzedPlan.collectFirst {
+        case sr: StreamingRelation => sr
+      }
+
+      assert(streamingRelation.isDefined, "Expected StreamingRelation in analyzed plan")
+      assert(streamingRelation.get.sourceIdentifyingName == Unassigned,
+        s"Expected Unassigned but got ${streamingRelation.get.sourceIdentifyingName}")
+    }
+  }
+
+  test("batch table query still resolves correctly (regression test)") {
+    // Verify that the !isStreaming guard in FindDataSourceTable
+    // doesn't break normal batch table resolution.
+    withTable("batch_test") {
+      sql("CREATE TABLE batch_test (id INT, value STRING) USING PARQUET")
+      sql("INSERT INTO batch_test VALUES (1, 'a'), (2, 'b')")
+
+      val result = sql("SELECT * FROM batch_test").collect()
+      assert(result.length == 2, s"Expected 2 rows but got ${result.length}")
+
+      val analyzedPlan = sql("SELECT * FROM batch_test").queryExecution.analyzed
+      val hasStreamingRelation = analyzedPlan.collect {
+        case _: StreamingRelation => true
+      }.nonEmpty
+      assert(!hasStreamingRelation, "Batch query should not contain StreamingRelation")
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This change enables streaming source identifying name propagation from CatalogTable through DataSource to StreamingRelation during table resolution.
Key changes:
- Add streamingSourceIdentifyingName field to CatalogTable
- Update NameStreamingSources to only unwrap when child is resolved
- Extend getStreamingRelation to accept and propagate sourceIdentifyingName
- Handle NamedStreamingRelation wrapping UnresolvedCatalogRelation/SubqueryAlias
- Add sourceIdentifyingName to StreamingRelation and StreamingExecutionRelation
- Add tests for streaming table resolution with source naming
- Update existing test expectations to include sourceIdentifyingName


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This infrastructure is needed for stable checkpoint locations and source evolution.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No