### PR TITLE
[SPARK-55032][PYTHON] Refactor profilers in workers.py

### DIFF
--- a/python/pyspark/sql/profiler.py
+++ b/python/pyspark/sql/profiler.py
@@ -83,7 +83,7 @@ class WorkerPerfProfiler:
     """
 
     def __init__(self, accumulator: Accumulator["ProfileResults"], result_id: int) -> None:
-        self.accumulator = accumulator
+        self._accumulator = accumulator
         self._profiler = cProfile.Profile()
         self._result_id = result_id
 
@@ -97,7 +97,7 @@ class WorkerPerfProfiler:
         st = pstats.Stats(self._profiler)
         st.stream = None  # make it picklable
         st.strip_dirs()
-        self.accumulator.add({self._result_id: (st, None)})
+        self._accumulator.add({self._result_id: (st, None)})
 
     def __enter__(self) -> "WorkerPerfProfiler":
         self.start()
@@ -123,7 +123,7 @@ class WorkerMemoryProfiler:
     ) -> None:
         from pyspark.profiler import UDFLineProfilerV2
 
-        self.accumulator = accumulator
+        self._accumulator = accumulator
         self._profiler = UDFLineProfilerV2()
         self._profiler.add_function(func)
         self._result_id = result_id
@@ -139,7 +139,7 @@ class WorkerMemoryProfiler:
             filename: list(line_iterator)
             for filename, line_iterator in self._profiler.code_map.items()
         }
-        self.accumulator.add({self._result_id: (None, codemap_dict)})
+        self._accumulator.add({self._result_id: (None, codemap_dict)})
 
     def __enter__(self) -> "WorkerMemoryProfiler":
         self.start()

--- a/python/pyspark/sql/profiler.py
+++ b/python/pyspark/sql/profiler.py
@@ -16,9 +16,11 @@
 #
 from abc import ABC, abstractmethod
 from io import StringIO
+import cProfile
 import os
 import pstats
 from threading import RLock
+from types import TracebackType
 from typing import Any, Callable, Dict, Literal, Optional, Tuple, Union, TYPE_CHECKING, overload
 import warnings
 
@@ -73,6 +75,84 @@ class _ProfileResultsParam(AccumulatorParam[Optional["ProfileResults"]]):
 
 
 ProfileResultsParam = _ProfileResultsParam()
+
+
+class WorkerPerfProfiler:
+    """
+    PerfProfiler is a profiler for performance profiling.
+    """
+
+    def __init__(self, accumulator: Accumulator["ProfileResults"], result_id: int) -> None:
+        self.accumulator = accumulator
+        self._profiler = cProfile.Profile()
+        self._result_id = result_id
+
+    def start(self) -> None:
+        self._profiler.enable()
+
+    def stop(self) -> None:
+        self._profiler.disable()
+
+    def save(self) -> None:
+        st = pstats.Stats(self._profiler)
+        st.stream = None  # make it picklable
+        st.strip_dirs()
+        self.accumulator.add({self._result_id: (st, None)})
+
+    def __enter__(self) -> "WorkerPerfProfiler":
+        self.start()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        self.stop()
+        self.save()
+
+
+class WorkerMemoryProfiler:
+    """
+    MemoryProfiler is a profiler for memory profiling.
+    """
+
+    def __init__(
+        self, accumulator: Accumulator["ProfileResults"], result_id: int, func: Callable
+    ) -> None:
+        from pyspark.profiler import UDFLineProfilerV2
+
+        self.accumulator = accumulator
+        self._profiler = UDFLineProfilerV2()
+        self._profiler.add_function(func)
+        self._result_id = result_id
+
+    def start(self) -> None:
+        self._profiler.enable_by_count()
+
+    def stop(self) -> None:
+        self._profiler.disable_by_count()
+
+    def save(self) -> None:
+        codemap_dict = {
+            filename: list(line_iterator)
+            for filename, line_iterator in self._profiler.code_map.items()
+        }
+        self.accumulator.add({self._result_id: (None, codemap_dict)})
+
+    def __enter__(self) -> "WorkerMemoryProfiler":
+        self.start()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        self.stop()
+        self.save()
 
 
 class ProfilerCollector(ABC):

--- a/python/pyspark/sql/profiler.py
+++ b/python/pyspark/sql/profiler.py
@@ -94,8 +94,9 @@ class WorkerPerfProfiler:
         self._profiler.disable()
 
     def save(self) -> None:
-        st = pstats.Stats(self._profiler)
-        st.stream = None  # make it picklable
+        st = pstats.Stats(self._profiler, stream=None)
+        # make it picklable
+        st.stream = None  # type: ignore[attr-defined]
         st.strip_dirs()
         self._accumulator.add({self._result_id: (st, None)})
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -1331,10 +1331,7 @@ def _is_iter_based(eval_type: int) -> bool:
 
 
 def wrap_perf_profiler(f, eval_type, result_id):
-    import cProfile
-    import pstats
-
-    from pyspark.sql.profiler import ProfileResultsParam
+    from pyspark.sql.profiler import ProfileResultsParam, WorkerPerfProfiler
 
     accumulator = _deserialize_accumulator(
         SpecialAccumulatorIds.SQL_UDF_PROFIER, None, ProfileResultsParam
@@ -1344,40 +1341,26 @@ def wrap_perf_profiler(f, eval_type, result_id):
 
         def profiling_func(*args, **kwargs):
             iterator = iter(f(*args, **kwargs))
-            pr = cProfile.Profile()
             while True:
                 try:
-                    with pr:
+                    with WorkerPerfProfiler(accumulator, result_id):
                         item = next(iterator)
                     yield item
                 except StopIteration:
                     break
 
-            st = pstats.Stats(pr)
-            st.stream = None  # make it picklable
-            st.strip_dirs()
-
-            accumulator.add({result_id: (st, None)})
-
     else:
 
         def profiling_func(*args, **kwargs):
-            with cProfile.Profile() as pr:
+            with WorkerPerfProfiler(accumulator, result_id):
                 ret = f(*args, **kwargs)
-            st = pstats.Stats(pr)
-            st.stream = None  # make it picklable
-            st.strip_dirs()
-
-            accumulator.add({result_id: (st, None)})
-
             return ret
 
     return profiling_func
 
 
 def wrap_memory_profiler(f, eval_type, result_id):
-    from pyspark.sql.profiler import ProfileResultsParam
-    from pyspark.profiler import UDFLineProfilerV2
+    from pyspark.sql.profiler import ProfileResultsParam, WorkerMemoryProfiler
 
     if not has_memory_profiler:
         return f
@@ -1389,39 +1372,21 @@ def wrap_memory_profiler(f, eval_type, result_id):
     if _is_iter_based(eval_type):
 
         def profiling_func(*args, **kwargs):
-            profiler = UDFLineProfilerV2()
-            profiler.add_function(f)
-
             iterator = iter(f(*args, **kwargs))
 
             while True:
                 try:
-                    with profiler:
+                    with WorkerMemoryProfiler(accumulator, result_id, f):
                         item = next(iterator)
                     yield item
                 except StopIteration:
                     break
 
-            codemap_dict = {
-                filename: list(line_iterator)
-                for filename, line_iterator in profiler.code_map.items()
-            }
-            accumulator.add({result_id: (None, codemap_dict)})
-
     else:
 
         def profiling_func(*args, **kwargs):
-            profiler = UDFLineProfilerV2()
-            profiler.add_function(f)
-
-            with profiler:
+            with WorkerMemoryProfiler(accumulator, result_id, f):
                 ret = f(*args, **kwargs)
-
-            codemap_dict = {
-                filename: list(line_iterator)
-                for filename, line_iterator in profiler.code_map.items()
-            }
-            accumulator.add({result_id: (None, codemap_dict)})
             return ret
 
     return profiling_func


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Refactored the perf and memory profiler in workers.py so adding profiler only requires a single line of code. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This makes it easier for the code to be reused in other workers like data source.

In the future, if we need to replace the backend of perf/memory profiler, it would also be easier.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

`test_udf_profilers` passed locally.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No