### PR TITLE
[SPARK-55034][PYTHON][TESTS] Test `test_arrow_udf_output_timestamps_ltz` without timezone conversion to UTC

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_udf_scalar.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf_scalar.py
@@ -379,10 +379,10 @@ class ScalarArrowUDFTestsMixin:
                     int(mi[i].as_py()),
                     int(s[i].as_py()),
                     tzinfo=ZoneInfo(tz),
-                ).astimezone(datetime.timezone.utc)
+                )
                 for i in range(len(y))
             ]
-            return pa.array(dates, pa.timestamp("us", "UTC"))
+            return pa.array(dates)
 
         result = df.select(build_ts("y", "m", "d", "h", "mi", "s").alias("ts"))
         self.assertEqual(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Test `test_arrow_udf_output_timestamps_ltz` without timezone conversion to UTC


### Why are the changes needed?
this conversion is counter-intuitive, and after https://github.com/apache/spark/pull/53660, it is no longer needed


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no