### PR TITLE
[SPARK-54870][SQL][FOLLOWUP] Remove dead code and fix typo

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/DataTypeAstBuilder.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/DataTypeAstBuilder.scala
@@ -299,7 +299,6 @@ class DataTypeAstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with DataTypeE
           currentCtx.children.asScala.toSeq match {
             case Seq(_) => StringType
             case Seq(_, ctx: CollateClauseContext) =>
-              val collationNameParts = visitCollateClause(ctx).toArray
               val collationId =
                 CollationFactory.fullyQualifiedNameToId(visitCollateClause(ctx).toArray)
               StringType(collationId)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ApplyDefaultCollation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ApplyDefaultCollation.scala
@@ -130,7 +130,7 @@ object ApplyDefaultCollation extends Rule[LogicalPlan] {
    * which means the system default collation `UTF8_BINARY` will be used and the plan will not be
    * changed.
    * This function applies to DDL commands. An object's default collation is persisted at the moment
-   * of its creation, and altering the schema collation or catalog will not affect existing objects.
+   * of its creation, and altering the schema or catalog collation will not affect existing objects.
    */
   def resolveDefaultCollation(plan: LogicalPlan): LogicalPlan = {
     try {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR:
1. Removes dead code introduced in #53643. The variable `collationNameParts` was assigned but never used in `DataTypeAstBuilder.scala`.
2. Fixes a typo in `ApplyDefaultCollation.scala`: "schema collation or catalog" -> "schema or catalog collation".

### Why are the changes needed?

Code cleanup and typo fix.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Existing tests should pass as this is just dead code removal and typo fix with no behavioral change.

### Was this patch authored or co-authored using generative AI tooling?

cursor 2.3.35