### PR TITLE
[SPARK-55036][PYTHON] Add `ArrowTimestampConversion` for arrow timezone handling

### DIFF
--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -876,18 +876,16 @@ class ArrowTimestampeConversion:
         Convert Arrow timezone-aware timestamps to timezone-naive in the specified timezone.
         This function works on Arrow Arrays, and it recurses to convert nested types.
         This function is dedicated for Pandas UDF execution.
-        Arrow UDF (@arrow_udf/mapInArrow/etc) doesn't need this conversion and preserve
-        the original timezone.
 
         Differences from _create_converter_to_pandas + _check_series_convert_timestamps_local_tz:
-        1, respect the timezone field in pyarrow timestamp type, pa.timestamp("us", tz="Asia/Tokyo");
+        1, respect the timezone field in pyarrow timestamp type;
         2, do not use local time at any time;
-        3, support nested types;
+        3, handle nested types in a consistent way;
 
         Differences from _check_arrow_array_timestamps_localize:
-        1, do not handle timezone-naive timestamp;
-        2, do not support unit coercion which won't happen in UDF execution;
-        3, respect the timezone field in pyarrow timestamp type, pa.timestamp("us", tz="Asia/Tokyo");
+        1, respect the timezone field in pyarrow timestamp type,
+        2, do not handle timezone-naive timestamp;
+        3, do not support unit coercion which won't happen in UDF execution;
 
         Parameters
         ----------
@@ -896,6 +894,11 @@ class ArrowTimestampeConversion:
         Returns
         -------
         :class:`pyarrow.Array`
+
+        Notes
+        -----
+        Arrow UDF (@arrow_udf/mapInArrow/etc) always preserve the original timezone, and thus
+        doesn't need this conversion.
         """
         import pyarrow as pa
         import pyarrow.types as types

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -847,7 +847,7 @@ class ArrowTableToRowsConversion:
                 return [_create_row(fields, tuple())] * table.num_rows
 
 
-class ArrowTimeStampeConversion:
+class ArrowTimestampeConversion:
     @staticmethod
     def _need_localization(at: "pa.DataType") -> bool:
         import pyarrow.types as types
@@ -860,13 +860,13 @@ class ArrowTimeStampeConversion:
             or types.is_fixed_size_list(at)
             or types.is_dictionary(at)
         ):
-            return ArrowTimeStampeConversion._need_localization(at.value_type)
+            return ArrowTimestampeConversion._need_localization(at.value_type)
         elif types.is_map(at):
-            return ArrowTimeStampeConversion._need_localization(
+            return ArrowTimestampeConversion._need_localization(
                 at.key_type
-            ) or ArrowTimeStampeConversion._need_localization(at.item_type)
+            ) or ArrowTimestampeConversion._need_localization(at.item_type)
         elif types.is_struct(at):
-            return any(ArrowTimeStampeConversion._need_localization(field.type) for field in at)
+            return any(ArrowTimestampeConversion._need_localization(field.type) for field in at)
         else:
             return False
 
@@ -903,7 +903,7 @@ class ArrowTimeStampeConversion:
 
         at = a.type
 
-        if not ArrowTimeStampeConversion._need_localization(at):
+        if not ArrowTimestampeConversion._need_localization(at):
             return a
 
         if types.is_timestamp(at) and at.tz is not None:
@@ -921,32 +921,32 @@ class ArrowTimeStampeConversion:
         elif types.is_list(a.type):
             return pa.ListArray.from_arrays(
                 offsets=a.offsets,
-                values=ArrowTimeStampeConversion.localize_tz(a.values),
+                values=ArrowTimestampeConversion.localize_tz(a.values),
             )
         elif types.is_large_list(a.type):
             return pa.LargeListType.from_arrays(
                 offsets=a.offsets,
-                values=ArrowTimeStampeConversion.localize_tz(a.values),
+                values=ArrowTimestampeConversion.localize_tz(a.values),
             )
         elif types.is_fixed_size_list(at):
             return pa.FixedSizeListArray.from_arrays(
-                values=ArrowTimeStampeConversion.localize_tz(a.values),
+                values=ArrowTimestampeConversion.localize_tz(a.values),
             )
         elif types.is_dictionary(a.type):
             return pa.DictionaryArray.from_arrays(
                 indices=a.indices,
-                dictionary=ArrowTimeStampeConversion.localize_tz(a.dictionary),
+                dictionary=ArrowTimestampeConversion.localize_tz(a.dictionary),
             )
         elif types.is_map(at):
             return pa.MapArray.from_arrays(
                 offsets=a.offsets,
-                keys=ArrowTimeStampeConversion.localize_tz(a.keys),
-                items=ArrowTimeStampeConversion.localize_tz(a.items),
+                keys=ArrowTimestampeConversion.localize_tz(a.keys),
+                items=ArrowTimestampeConversion.localize_tz(a.items),
             )
         elif types.is_struct(a.type):
             return pa.StructArray.from_arrays(
                 arrays=[
-                    ArrowTimeStampeConversion.localize_tz(a.field(i)) for i in range(len(a.type))
+                    ArrowTimestampeConversion.localize_tz(a.field(i)) for i in range(len(a.type))
                 ],
                 names=a.type.names,
             )

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -880,12 +880,14 @@ class ArrowTimestampeConversion:
         Differences from _create_converter_to_pandas + _check_series_convert_timestamps_local_tz:
         1, respect the timezone field in pyarrow timestamp type;
         2, do not use local time at any time;
-        3, handle nested types in a consistent way;
+        3, handle nested types in a consistent way. (_create_converter_to_pandas handles
+        simple timestamp series with session timezone, but handles nested series with
+        datetime.timezone.utc)
 
         Differences from _check_arrow_array_timestamps_localize:
-        1, respect the timezone field in pyarrow timestamp type,
+        1, respect the timezone field in pyarrow timestamp type;
         2, do not handle timezone-naive timestamp;
-        3, do not support unit coercion which won't happen in UDF execution;
+        3, do not support unit coercion which won't happen in UDF execution.
 
         Parameters
         ----------

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -862,9 +862,10 @@ class ArrowTimestampeConversion:
         ):
             return ArrowTimestampeConversion._need_localization(at.value_type)
         elif types.is_map(at):
-            return ArrowTimestampeConversion._need_localization(
-                at.key_type
-            ) or ArrowTimestampeConversion._need_localization(at.item_type)
+            return any(
+                ArrowTimestampeConversion._need_localization(dt)
+                for dt in [at.key_type, at.item_type]
+            )
         elif types.is_struct(at):
             return any(ArrowTimestampeConversion._need_localization(field.type) for field in at)
         else:

--- a/python/pyspark/sql/tests/test_conversion.py
+++ b/python/pyspark/sql/tests/test_conversion.py
@@ -14,15 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import unittest
 import datetime
+import unittest
 from zoneinfo import ZoneInfo
 
 from pyspark.errors import PySparkValueError
 from pyspark.sql.conversion import (
     ArrowTableToRowsConversion,
     LocalDataToArrowConversion,
-    ArrowTimestampeConversion,
+    ArrowTimestampConversion,
 )
 from pyspark.sql.types import (
     ArrayType,
@@ -224,7 +224,7 @@ class ConversionTests(unittest.TestCase):
             pa.StructArray.from_arrays([pa.array([1, 2]), pa.array(["x", "y"])], names=["a", "b"]),
             pa.array([{1: None, 2: "x"}], type=pa.map_(pa.int32(), pa.string())),
         ]:
-            output = ArrowTimestampeConversion.localize_tz(arr)
+            output = ArrowTimestampConversion.localize_tz(arr)
             self.assertTrue(output is arr, f"MUST not generate a new array {output.tolist()}")
 
         # timestampe types
@@ -292,7 +292,7 @@ class ConversionTests(unittest.TestCase):
                 ),
             ),  # map<int, array<ts-ltz>>
         ]:
-            output = ArrowTimestampeConversion.localize_tz(arr)
+            output = ArrowTimestampConversion.localize_tz(arr)
             self.assertEqual(output, expected, f"{output.tolist()} != {expected.tolist()}")
 
 

--- a/python/pyspark/sql/tests/test_conversion.py
+++ b/python/pyspark/sql/tests/test_conversion.py
@@ -22,7 +22,7 @@ from pyspark.errors import PySparkValueError
 from pyspark.sql.conversion import (
     ArrowTableToRowsConversion,
     LocalDataToArrowConversion,
-    ArrowTimeStampeConversion,
+    ArrowTimestampeConversion,
 )
 from pyspark.sql.types import (
     ArrayType,
@@ -224,7 +224,7 @@ class ConversionTests(unittest.TestCase):
             pa.StructArray.from_arrays([pa.array([1, 2]), pa.array(["x", "y"])], names=["a", "b"]),
             pa.array([{1: None, 2: "x"}], type=pa.map_(pa.int32(), pa.string())),
         ]:
-            output = ArrowTimeStampeConversion.localize_tz(arr)
+            output = ArrowTimestampeConversion.localize_tz(arr)
             self.assertTrue(output is arr, f"MUST not generate a new array {output.tolist()}")
 
         # timestampe types
@@ -292,7 +292,7 @@ class ConversionTests(unittest.TestCase):
                 ),
             ),  # map<int, array<ts-ltz>>
         ]:
-            output = ArrowTimeStampeConversion.localize_tz(arr)
+            output = ArrowTimestampeConversion.localize_tz(arr)
             self.assertEqual(output, expected, f"{output.tolist()} != {expected.tolist()}")
 
 

--- a/python/pyspark/sql/tests/test_conversion.py
+++ b/python/pyspark/sql/tests/test_conversion.py
@@ -15,11 +15,14 @@
 # limitations under the License.
 #
 import unittest
+import datetime
+from zoneinfo import ZoneInfo
 
 from pyspark.errors import PySparkValueError
 from pyspark.sql.conversion import (
     ArrowTableToRowsConversion,
     LocalDataToArrowConversion,
+    ArrowTimeStampeConversion,
 )
 from pyspark.sql.types import (
     ArrayType,
@@ -200,6 +203,97 @@ class ConversionTests(unittest.TestCase):
             schema = StructType([StructField("x", row_schema)])
             with self.assertRaises(PySparkValueError):
                 LocalDataToArrowConversion.convert([(value,)], schema, use_large_var_types=False)
+
+    def test_arrow_array_localize_tz(self):
+        import pyarrow as pa
+
+        tz1 = ZoneInfo("Asia/Singapore")
+        tz2 = ZoneInfo("America/Los_Angeles")
+        tz3 = ZoneInfo("UTC")
+
+        ts0 = datetime.datetime(2026, 1, 5, 15, 0, 1)
+        ts1 = datetime.datetime(2026, 1, 5, 15, 0, 1, tzinfo=tz1)
+        ts2 = datetime.datetime(2026, 1, 5, 15, 0, 1, tzinfo=tz2)
+        ts3 = datetime.datetime(2026, 1, 5, 15, 0, 1, tzinfo=tz3)
+
+        # non-timestampe types
+        for arr in [
+            pa.array([1, 2]),
+            pa.array([["x", "y"]]),
+            pa.array([[[3.0, 4.0]]]),
+            pa.StructArray.from_arrays([pa.array([1, 2]), pa.array(["x", "y"])], names=["a", "b"]),
+            pa.array([{1: None, 2: "x"}], type=pa.map_(pa.int32(), pa.string())),
+        ]:
+            output = ArrowTimeStampeConversion.localize_tz(arr)
+            self.assertTrue(output is arr, f"MUST not generate a new array {output.tolist()}")
+
+        # timestampe types
+        for arr, expected in [
+            (pa.array([ts0, None]), pa.array([ts0, None])),  # ts-ntz
+            (pa.array([ts1, None]), pa.array([ts0, None])),  # ts-ltz
+            (pa.array([[ts2, None]]), pa.array([[ts0, None]])),  # array<ts-ltz>
+            (pa.array([[[ts3, None]]]), pa.array([[[ts0, None]]])),  # array<array<ts-ltz>>
+            (
+                pa.StructArray.from_arrays(
+                    [pa.array([1, 2]), pa.array([ts0, None]), pa.array([ts1, None])],
+                    names=["a", "b", "c"],
+                ),
+                pa.StructArray.from_arrays(
+                    [pa.array([1, 2]), pa.array([ts0, None]), pa.array([ts0, None])],
+                    names=["a", "b", "c"],
+                ),
+            ),  # struct<int, ts-ntz, ts-ltz>
+            (
+                pa.StructArray.from_arrays(
+                    [pa.array([1, 2]), pa.array([[ts2], [None]])], names=["a", "b"]
+                ),
+                pa.StructArray.from_arrays(
+                    [pa.array([1, 2]), pa.array([[ts0], [None]])], names=["a", "b"]
+                ),
+            ),  # struct<int, array<ts-ltz>>
+            (
+                pa.StructArray.from_arrays(
+                    [
+                        pa.array([ts2, None]),
+                        pa.StructArray.from_arrays(
+                            [pa.array(["a", "b"]), pa.array([[ts3], [None]])], names=["x", "y"]
+                        ),
+                    ],
+                    names=["a", "b"],
+                ),
+                pa.StructArray.from_arrays(
+                    [
+                        pa.array([ts0, None]),
+                        pa.StructArray.from_arrays(
+                            [pa.array(["a", "b"]), pa.array([[ts0], [None]])], names=["x", "y"]
+                        ),
+                    ],
+                    names=["a", "b"],
+                ),
+            ),  # struct<ts-ltz, struct<str, array<ts-ltz>>>
+            (
+                pa.array(
+                    [{1: None, 2: ts1}],
+                    type=pa.map_(pa.int32(), pa.timestamp("us", tz=tz1)),
+                ),
+                pa.array(
+                    [{1: None, 2: ts0}],
+                    type=pa.map_(pa.int32(), pa.timestamp("us")),
+                ),
+            ),  # map<int, ts-ltz>
+            (
+                pa.array(
+                    [{1: [None], 2: [ts2, None]}],
+                    type=pa.map_(pa.int32(), pa.list_(pa.timestamp("us", tz=tz2))),
+                ),
+                pa.array(
+                    [{1: [None], 2: [ts0, None]}],
+                    type=pa.map_(pa.int32(), pa.list_(pa.timestamp("us"))),
+                ),
+            ),  # map<int, array<ts-ltz>>
+        ]:
+            output = ArrowTimeStampeConversion.localize_tz(arr)
+            self.assertEqual(output, expected, f"{output.tolist()} != {expected.tolist()}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add `ArrowTimeStampConversion` for arrow timezone handling


### Why are the changes needed?
revisit existing timezone handling in pandas udf, introduce a new pure pyarrow one for complex datatypes, will try to use it to replace existing one in the future


### Does this PR introduce _any_ user-facing change?
no, this PR just adds a new utils


### How was this patch tested?
added tests


### Was this patch authored or co-authored using generative AI tooling?
no