### PR TITLE
[SPARK-55037][CONNECT][SQL] Re-implement Observation Without Using the QueryExecutionListener

### DIFF
--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/SparkSession.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/SparkSession.scala
@@ -747,8 +747,7 @@ class SparkSession private[sql] (
       // All metrics, whether registered or not, will be collected by `SparkResult`.
       val observationOrNull = observationRegistry.remove(metric.getPlanId)
       if (observationOrNull != null) {
-        val metricsRow = SparkResult.transformObservedMetrics(metric)
-        observationOrNull.setMetricsAndNotify(() => metricsRow)
+        observationOrNull.setMetricsAndNotify(SparkResult.transformObservedMetrics(metric))
       }
     }
   }

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/SparkSession.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/SparkSession.scala
@@ -747,7 +747,8 @@ class SparkSession private[sql] (
       // All metrics, whether registered or not, will be collected by `SparkResult`.
       val observationOrNull = observationRegistry.remove(metric.getPlanId)
       if (observationOrNull != null) {
-        observationOrNull.setMetricsAndNotify(SparkResult.transformObservedMetrics(metric))
+        val metricsRow = SparkResult.transformObservedMetrics(metric)
+        observationOrNull.setMetricsAndNotify(() => metricsRow)
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/ObservationManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/ObservationManager.scala
@@ -22,14 +22,12 @@ import org.apache.spark.sql.{Observation, Row}
 import org.apache.spark.sql.catalyst.plans.logical.CollectMetrics
 import org.apache.spark.sql.catalyst.trees.TreePattern
 import org.apache.spark.sql.execution.QueryExecution
-import org.apache.spark.sql.util.QueryExecutionListener
 
 /**
  * This class keeps track of registered Observations that await query completion.
  */
 private[sql] class ObservationManager(session: SparkSession) {
   private val observations = new ConcurrentHashMap[(String, Long), Observation]
-  session.listenerManager.register(Listener)
 
   def register(observation: Observation, ds: Dataset[_]): Unit = {
     if (ds.isStreaming) {
@@ -53,7 +51,7 @@ private[sql] class ObservationManager(session: SparkSession) {
       observation
     })
 
-  private def tryComplete(qe: QueryExecution): Unit = {
+  private[sql] def tryComplete(qe: QueryExecution): Unit = {
     // Use lazy val to defer collecting the observed metrics until it is needed so that tryComplete
     // can finish faster (e.g., when the logical plan doesn't contain CollectMetrics).
     lazy val allMetrics = qe.observedMetrics
@@ -65,17 +63,9 @@ private[sql] class ObservationManager(session: SparkSession) {
           // If the key exists but no metrics were collected, it means for some reason the
           // metrics could not be collected. This can happen e.g., if the CollectMetricsExec
           // was optimized away.
-          observation.setMetricsAndNotify(allMetrics.getOrElse(c.name, Row.empty))
+          observation.setMetricsAndNotify(() => allMetrics.getOrElse(c.name, Row.empty))
         }
       case _ =>
     }
-  }
-
-  private object Listener extends QueryExecutionListener {
-    override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit =
-      tryComplete(qe)
-
-    override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit =
-      tryComplete(qe)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/SparkSession.scala
@@ -884,6 +884,7 @@ class SparkSession private(
       override protected def conf: SQLConf = sessionState.conf
     }
 
+  @transient
   private[sql] lazy val observationManager = new ObservationManager(this)
 
   override private[sql] def isUsable: Boolean = !sparkContext.isStopped

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -239,6 +239,8 @@ object SQLExecution extends Logging {
               event.qe = queryExecution
               event.executionFailure = ex
               sc.listenerBus.post(event)
+
+              sparkSession.observationManager.tryComplete(queryExecution)
             }
           }
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -240,6 +240,8 @@ object SQLExecution extends Logging {
               event.executionFailure = ex
               sc.listenerBus.post(event)
 
+              // Observation.tryComplete is called here to ensure the observation is completed,
+              // but it is not high priority, so it is fine to call it later.
               sparkSession.observationManager.tryComplete(queryExecution)
             }
           }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR proposes the below change:
- **Re-implement Observation without using QueryExecutionListener**: Changed the observation completion mechanism to call ObservationManager.tryComplete() directly from SQLExecution.withNewExecutionId() instead of relying on QueryExecutionListener callbacks.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The previous implementation using QueryExecutionListener had two issues:
- **No guarantees about when observation metrics are delivered**: Because QueryExecutionListener operates asynchronously, there are no guarantees about when observation metrics are delivered. Even after QueryExecution finishes on the main thread, Observation objects may not receive the collected observed metrics from the QueryExecutionListener until the asynchronous observed metrics collection is complete.
- **Delayed metric processing due to listener contention**: The processing of observed metrics in a QueryExecutionListener can be delayed by other slow registered listeners.

The listener contention issue can be reproduced by copying the code below and running it in SparkConnectServerTestSuite using `build/sbt "connect/testOnly *SparkConnectServerTestSuite -- -z SPARK-55037"`:
```scala
test("SPARK-55037: listener contention should not fail observation") {
    withSession { clientSession =>
      // Trigger server session creation by executing a simple query
      clientSession.sql("SELECT 1").collect()

      // Get server-side session to register a slow listener
      val serverSession = getServerSession(clientSession)

      // Register a slow QueryExecutionListener that sleeps during onSuccess
      val slowListener = new QueryExecutionListener {
        override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
          // Simulate slow listener processing. 1000ms is sufficient to hit the timeout
          // in Observation.getRowOrEmpty, since the timeout in Observation.getRowOrEmpty
          // is 100ms in the previous implementation.
          Thread.sleep(1000)
        }

        override def onFailure(
            funcName: String,
            qe: QueryExecution,
            exception: Exception): Unit = {}
      }

      serverSession.listenerManager.register(slowListener)

      // Create a simple observation using the client session
      val observation = new Observation("test_observation")
      val clientDf = clientSession.range(10)
      val observedClientDf = clientDf.observe(
        observation,
        functions.min("id"),
        functions.max("id"),
        functions.sum("id"))

      // Execute the query via client session - this triggers the slow listener on server
      val result = observedClientDf.collect()
      assert(result.length == 10)

      // Verify the observation metrics are available despite the slow listener
      val metrics = observation.get
      assert(metrics.size == 3)
      assert(metrics("min(id)") == 0L)
      assert(metrics("max(id)") == 9L)
      assert(metrics("sum(id)") == 45L)
    }
  }
```

By calling tryComplete() directly from SQLExecution.withNewExecutionId(), we ensure that observation metrics are completed synchronously and deterministically, without being affected by other listeners.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes