### PR TITLE
[SPARK-54921][CORE] Add parentIds in StageData

### DIFF
--- a/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
+++ b/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
@@ -612,6 +612,7 @@ message StageData {
   int64 shuffle_merged_remote_reqs_duration = 62;
   bool is_shuffle_push_enabled = 63;
   int32 shuffle_mergers_count = 64;
+  repeated int64 parent_ids = 65;
 }
 
 message TaskMetrics {

--- a/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
@@ -722,6 +722,7 @@ private[spark] class AppStatusStore(
         details = stage.details,
         schedulingPool = stage.schedulingPool,
         rddIds = stage.rddIds,
+        parentIds = stage.parentIds,
         accumulatorUpdates = stage.accumulatorUpdates,
         tasks = tasks,
         executorSummary = executorSummaries,

--- a/core/src/main/scala/org/apache/spark/status/LiveEntity.scala
+++ b/core/src/main/scala/org/apache/spark/status/LiveEntity.scala
@@ -553,6 +553,7 @@ private class LiveStage(var info: StageInfo) extends LiveEntity {
       schedulingPool = schedulingPool,
 
       rddIds = info.rddInfos.map(_.id),
+      parentIds = info.parentIds,
       accumulatorUpdates = newAccumulatorInfos(info.accumulables.values),
       tasks = None,
       executorSummary = None,

--- a/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
@@ -304,6 +304,7 @@ class StageData private[spark](
     val schedulingPool: String,
 
     val rddIds: collection.Seq[Int],
+    val parentIds: collection.Seq[Int],
     val accumulatorUpdates: collection.Seq[AccumulableInfo],
     val tasks: Option[Map[Long, TaskData]],
     val executorSummary: Option[Map[String, ExecutorStageSummary]],

--- a/core/src/main/scala/org/apache/spark/status/protobuf/StageDataWrapperSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/StageDataWrapperSerializer.scala
@@ -108,6 +108,7 @@ private[protobuf] class StageDataWrapperSerializer extends ProtobufSerDe[StageDa
       stageDataBuilder.setDescription(d)
     }
     stageData.rddIds.foreach(id => stageDataBuilder.addRddIds(id.toLong))
+    stageData.parentIds.foreach(id => stageDataBuilder.addParentIds(id.toLong))
     stageData.accumulatorUpdates.foreach { update =>
       stageDataBuilder.addAccumulatorUpdates(
         AccumulableInfoSerializer.serialize(update))
@@ -470,6 +471,7 @@ private[protobuf] class StageDataWrapperSerializer extends ProtobufSerDe[StageDa
       details = getStringField(binary.hasDetails, () => binary.getDetails),
       schedulingPool = getStringField(binary.hasSchedulingPool, () => binary.getSchedulingPool),
       rddIds = binary.getRddIdsList.asScala.map(_.toInt),
+      parentIds = binary.getParentIdsList.asScala.map(_.toInt),
       accumulatorUpdates = accumulatorUpdates,
       tasks = tasks,
       executorSummary = executorSummary,

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
@@ -298,6 +298,7 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
           schedulingPool = null,
 
           rddIds = Nil,
+          parentIds = Nil,
           accumulatorUpdates = Nil,
           tasks = None,
           executorSummary = None,

--- a/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
@@ -1014,7 +1014,15 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
     testStageDataSerDe(null, null, null)
   }
 
-  private def testStageDataSerDe(name: String, details: String, schedulingPool: String): Unit = {
+  test("Stage Data with empty parentIds") {
+    testStageDataSerDe("name", "test details", "test scheduling pool", parentIds = Seq.empty)
+  }
+
+  private def testStageDataSerDe(
+      name: String,
+      details: String,
+      schedulingPool: String,
+      parentIds: Seq[Int] = Seq(0, 1)): Unit = {
     val accumulatorUpdates = Seq(
       new AccumulableInfo(1L, "duration", Some("update"), "value1"),
       new AccumulableInfo(2L, "duration2", None, "value2")
@@ -1293,6 +1301,7 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
       details = details,
       schedulingPool = schedulingPool,
       rddIds = Seq(1, 2, 3, 4, 5, 6),
+      parentIds = parentIds,
       accumulatorUpdates = accumulatorUpdates,
       tasks = tasks,
       executorSummary = executorSummary,
@@ -1387,6 +1396,7 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
     assert(result.info.schedulingPool == input.info.schedulingPool)
 
     assert(result.info.rddIds == input.info.rddIds)
+    assert(result.info.parentIds == input.info.parentIds)
     checkAnswer(result.info.accumulatorUpdates, input.info.accumulatorUpdates)
 
     assert(result.info.tasks.isDefined == input.info.tasks.isDefined)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added `parentIds: collection.Seq[Int]` field to `StageData` class to track parent stage dependencies. This information was already available in `StageInfo` but not exposed through the public API.

### Why are the changes needed?

The `parentIds` field is necessary for tracking stage dependencies in the Spark UI and other status-related tools. External monitoring systems and UIs can now understand the DAG structure of stages.

### Does this PR introduce any user-facing change?

Yes. The REST API `/api/v1/applications/{appId}/stages` now includes `parentIds` in the response:
```json
{
  "stageId": 5,
  "parentIds": [2, 3],
  ...
}
```

### How was this patch tested?

- Added unit test for `parentIds` serialization/deserialization in `KVStoreProtobufSerializerSuite`
- Added test case for empty `parentIds` (root stages)

### Backward compatibility

- **REST API**: Adding a new field is backward compatible - existing clients will ignore it
- **Protobuf**: New field uses `repeated` which defaults to empty list for old data; old code ignores unknown fields