### PR TITLE
[SPARK-55042][WEBUI][BUILD][TESTS] Upgrade Node.js used for UI test to `24.13.0`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1409,7 +1409,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24.11.0
+          node-version: 24.13.0
           cache: 'npm'
           cache-dependency-path: ui-test/package-lock.json
       - run: |


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to upgrade Node.js used for UI test to `24.13.0`.

### Why are the changes needed?
`24.13.0` fixes some high severe security issues.
https://nodejs.org/en/blog/vulnerability/december-2025-security-releases

These CVEs seems little impact on Spark, but it's better to upgrade to it just in case.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
No.