### PR TITLE
[SPARK-55044][SQL] Keep the metadata in toArrowSchema/fromArrowSchema

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/ArrowUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/ArrowUtilsSuite.scala
@@ -105,6 +105,55 @@ class ArrowUtilsSuite extends SparkFunSuite {
       new StructType().add("i", IntegerType).add("arr", ArrayType(IntegerType))))
   }
 
+  test("metadata") {
+    roundtrip(new StructType()
+      .add("i", IntegerType, true, Metadata.empty)
+      .add("j", LongType, true,
+        new MetadataBuilder()
+          .putLong("a", Long.MaxValue).putString("city", "beijing").build())
+    )
+
+    roundtrip(new StructType()
+      .add("v", VariantType, true,
+        new MetadataBuilder()
+          .putDouble("a", 1.234).putBoolean("is_geo?", false).build())
+      .add("i", GeometryType("ANY"), false,
+        new MetadataBuilder()
+          .putLongArray("list", Array(1, 2, 3)).putString("is_geo?", "true").build())
+      .add("i", GeographyType("ANY"), false,
+        new MetadataBuilder()
+          .putStringArray("list", Array("x", "y")).putString("is_geo?", "true").build())
+    )
+
+    roundtrip(new StructType()
+      .add("arr", ArrayType(IntegerType), false,
+        new MetadataBuilder()
+          .putBoolean("is_array?", true).putString("old_name", "old_arr").build())
+      .add("map", MapType(LongType, StringType), false,
+        new MetadataBuilder()
+          .putBoolean("is_array?", false).putString("old_name", "old_map").build())
+      .add("struct",
+        new StructType()
+          .add("s", IntegerType, true,
+            new MetadataBuilder()
+              .putDouble("pi", 3.14)
+              .putString("what type", "struct").build()),
+        false,
+        new MetadataBuilder()
+          .putBoolean("is_array?", false).putString("old_name", "old_map").build())
+      .add("3_dim_array",
+        ArrayType(ArrayType(ArrayType(new StructType()
+          .add("i", IntegerType, true,
+            new MetadataBuilder().putLong("v", 1).putString("type", "data point").build())
+          .add("c", StringType, false,
+            new MetadataBuilder()
+              .putLong("v", 1).putString("city", "singapore").build())))),
+        true,
+        new MetadataBuilder()
+          .putBoolean("is_nested_array?", true).putString("dims", "x-y-z").build())
+    )
+  }
+
   test("struct with duplicated field names") {
 
     def check(dt: DataType, expected: DataType): Unit = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/util/ArrowUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/util/ArrowUtilsSuite.scala
@@ -105,7 +105,7 @@ class ArrowUtilsSuite extends SparkFunSuite {
       new StructType().add("i", IntegerType).add("arr", ArrayType(IntegerType))))
   }
 
-  test("metadata") {
+  test("metadata should be kept after roundtrip") {
     roundtrip(new StructType()
       .add("i", IntegerType, true, Metadata.empty)
       .add("j", LongType, true,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Keep the metadata in toArrowSchema/fromArrowSchema

### Why are the changes needed?
To make the metadata still available after roundtrip `fromArrowSchema(toArrowSchema(schema))`

This will be used to store the original fields name when the field names are duplicated.

### Does this PR introduce _any_ user-facing change?
No, internal utils improvement


### How was this patch tested?
added tests


### Was this patch authored or co-authored using generative AI tooling?
no
