### PR TITLE
[SPARK-55047][CONNECT] Add client-side limit for local relation size

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4357,6 +4357,12 @@
     ],
     "sqlState" : "42601"
   },
+  "LOCAL_RELATION_SIZE_LIMIT_EXCEEDED" : {
+    "message" : [
+      "Local relation size (<actualSize> bytes) exceeds the limit (<sizeLimit> bytes)."
+    ],
+    "sqlState" : "54000"
+  },
   "LOCATION_ALREADY_EXISTS" : {
     "message" : [
       "Cannot name the managed table as <identifier>, as its associated location <location> already exists. Please pick a different table name, or remove the existing location first."

--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -551,6 +551,12 @@
       "<arg1> and <arg2> should be of the same length, got <arg1_length> and <arg2_length>."
     ]
   },
+  "LOCAL_RELATION_SIZE_LIMIT_EXCEEDED": {
+    "message": [
+      "Local relation size (<actualSize> bytes) exceeds the limit (<sizeLimit> bytes)."
+    ],
+    "sqlState": "54000"
+  },
   "MALFORMED_GEOGRAPHY": {
     "message": [
       "Geography binary is malformed. Please check the data source is valid."

--- a/python/pyspark/sql/tests/connect/arrow/test_parity_arrow.py
+++ b/python/pyspark/sql/tests/connect/arrow/test_parity_arrow.py
@@ -28,9 +28,9 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
     def thisSetUpClass(cls):
         super().thisSetUpClass()
 
-        # set the local relations size limit to 100MB for
+        # set the local relations size limit to 80MB for
         # test_large_local_relation_size_limit_exceeded
-        cls.spark.conf.set("spark.sql.session.localRelationSizeLimit", str(100 * 1024 * 1024))
+        cls.spark.conf.set("spark.sql.session.localRelationSizeLimit", str(80 * 1024 * 1024))
 
     @unittest.skip("Spark Connect does not support fallback.")
     def test_createDataFrame_fallback_disabled(self):
@@ -106,7 +106,7 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
         data = [(i, str_value) for i in range(row_count)]
 
         with self.assertRaisesRegex(
-            AnalysisException, f"LOCAL_RELATION_SIZE_LIMIT_EXCEEDED.*{100 * 1024 * 1024}"
+            AnalysisException, f"LOCAL_RELATION_SIZE_LIMIT_EXCEEDED.*{80 * 1024 * 1024}"
         ):
             df = self.spark.createDataFrame(data, ["col1", "col2"])
             df.count()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -6248,6 +6248,16 @@ object SQLConf {
       .checkValue(_ >= 0, "The threshold of cached local relations must not be negative")
       .createWithDefault(1024 * 1024)
 
+  val LOCAL_RELATION_SIZE_LIMIT =
+    buildConf("spark.sql.session.localRelationSizeLimit")
+      .internal()
+      .doc("Limit on how large ChunkedCachedLocalRelation.data can be in bytes." +
+        "If the limit is exceeded, an exception is thrown.")
+      .version("4.1.0")
+      .longConf
+      .checkValue(_ > 0, "The local relation size in bytes must be positive")
+      .createWithDefault(3L * 1024 * 1024 * 1024)
+
   val LOCAL_RELATION_CHUNK_SIZE_ROWS =
     buildConf(SqlApiConfHelper.LOCAL_RELATION_CHUNK_SIZE_ROWS_KEY)
       .doc("The chunk size in number of rows when splitting ChunkedCachedLocalRelation.data " +
@@ -6280,15 +6290,6 @@ object SQLConf {
       .version("4.1.0")
       .bytesConf(ByteUnit.BYTE)
       .createWithDefaultString("2000MB")
-
-  val LOCAL_RELATION_SIZE_LIMIT =
-    buildConf("spark.sql.session.localRelationSizeLimit")
-      .internal()
-      .doc("Limit on how large ChunkedCachedLocalRelation.data can be in bytes." +
-        "If the limit is exceeded, an exception is thrown.")
-      .version("4.1.0")
-      .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("3GB")
 
   val LOCAL_RELATION_BATCH_OF_CHUNKS_SIZE_BYTES =
     buildConf(SqlApiConfHelper.LOCAL_RELATION_BATCH_OF_CHUNKS_SIZE_BYTES_KEY)

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/SparkSessionE2ESuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/SparkSessionE2ESuite.scala
@@ -479,12 +479,13 @@ class SparkSessionE2ESuite extends ConnectFunSuite with RemoteSparkSession {
 
   test("large local relation size limit exceeded") {
     // Set a low limit so we don't need to create a huge dataset
-    val originalLimit = spark.conf.get("spark.sql.session.localRelationSizeLimit")
+    val conf_key = "spark.sql.session.localRelationSizeLimit"
+    val originalLimit = spark.conf.get(conf_key)
     try {
-      val newLimit = (100 * 1024 * 1024).toString
-      spark.conf.set("spark.sql.session.localRelationSizeLimit", newLimit)
+      val newLimit = (50 * 1024 * 1024).toString
+      spark.conf.set(conf_key, newLimit)
       val rowSize = 1000
-      val rowCount = 128 * 1000
+      val rowCount = 64 * 1000
       val suffix = "abcdef"
       val str = scala.util.Random.alphanumeric.take(rowSize).mkString + suffix
       val data = Seq.tabulate(rowCount)(i => (i, str))
@@ -496,7 +497,7 @@ class SparkSessionE2ESuite extends ConnectFunSuite with RemoteSparkSession {
       assert(e.getMessage.contains("LOCAL_RELATION_SIZE_LIMIT_EXCEEDED"))
       assert(e.getMessage.contains(newLimit))
     } finally {
-      spark.conf.set("spark.sql.session.localRelationSizeLimit", originalLimit)
+      spark.conf.set(conf_key, originalLimit)
     }
   }
 }

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/SparkSession.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/SparkSession.scala
@@ -45,7 +45,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{CONFIG, PATH}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql
-import org.apache.spark.sql.{Column, Encoder, ExperimentalMethods, Observation, Row, SparkSessionBuilder, SparkSessionCompanion, SparkSessionExtensions}
+import org.apache.spark.sql.{AnalysisException, Column, Encoder, ExperimentalMethods, Observation, Row, SparkSessionBuilder, SparkSessionCompanion, SparkSessionExtensions}
 import org.apache.spark.sql.catalyst.{JavaTypeInference, ScalaReflection}
 import org.apache.spark.sql.catalyst.encoders.{AgnosticEncoder, RowEncoder}
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders.{agnosticEncoderFor, BoxedLongEncoder, UnboundRowEncoder}
@@ -122,6 +122,7 @@ class SparkSession private[sql] (
         val maxChunkSizeBytes = conf.get(SqlApiConf.LOCAL_RELATION_CHUNK_SIZE_BYTES_KEY).toInt
         val maxBatchOfChunksSize =
           conf.get(SqlApiConf.LOCAL_RELATION_BATCH_OF_CHUNKS_SIZE_BYTES_KEY).toLong
+        val localRelationSizeLimit = conf.get("spark.sql.session.localRelationSizeLimit").toLong
 
         // Serialize with chunking support
         val it = ArrowSerializer.serialize(
@@ -149,6 +150,14 @@ class SparkSession private[sql] (
             val chunkSize = chunk.length
             totalChunks += 1
             totalSize += chunkSize
+
+            if (totalSize > localRelationSizeLimit) {
+              throw new AnalysisException(
+                errorClass = "LOCAL_RELATION_SIZE_LIMIT_EXCEEDED",
+                messageParameters = Map(
+                  "actualSize" -> totalSize.toString,
+                  "sizeLimit" -> localRelationSizeLimit.toString))
+            }
 
             // Check if adding this chunk would exceed batch size
             if (currentBatchSize + chunkSize > maxBatchOfChunksSize) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Currently, local relation sizes are limited using `spark.sql.session.localRelationSizeLimit` conf (set to 3GB by default).
This limit is only checked on the server. The client can upload arbitrary large relations, e.g. 100 GB, as artifacts, the server will store them, try to materialize the local relation on the driver and only then throw an error if the relation exceeds the limit.

This is bad for several reasons:
- The driver will need to store arbitrary amount of data and can run out of memory or disk space causing driver failure.
- The client wastes a lot of time uploading the data to the server only to fail later. This is bad UX.

This PR adds a check on the client side. If the client sees that the local relation it serializes exceeds the limit, it will throw an AnalysisException with error class LOCAL_RELATION_SIZE_LIMIT_EXCEEDED and sql state 54000 (program limit exceeded)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Improve driver stability when using large local relations in Spark Connect.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

New integration tests for Scala and Python clients.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No