### PR TITLE
[SPARK-55052][SQL] Add AQEShuffleRead properties to Physical Plan Tree

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEShuffleReadExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEShuffleReadExec.scala
@@ -278,4 +278,14 @@ case class AQEShuffleReadExec private(
 
   override protected def withNewChildInternal(newChild: SparkPlan): AQEShuffleReadExec =
     copy(child = newChild)
+
+  override def simpleStringWithNodeId(): String = {
+    val args = stringArgs.mkString(", ")
+    if (args.nonEmpty) {
+      super.simpleStringWithNodeId() + ", " + args
+    } else {
+      super.simpleStringWithNodeId()
+    }
+  }
+
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -967,7 +967,7 @@ class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuit
         checkKeywordsExistsInExplain(
           df = df,
           mode = ExplainMode.fromString("FORMATTED"),
-          keywords = getExpectedFinalPlanWithCoalescedAndSkewedAQEShuffleRead)
+          keywords = "AQEShuffleRead (6), coalesced", "AQEShuffleRead (13), coalesced and skewed")
       }
     }
   }
@@ -991,54 +991,10 @@ class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuit
       checkKeywordsExistsInExplain(
         df = joinedDF,
         mode = ExplainMode.fromString("FORMATTED"),
-        keywords = getExpectedFinalPlanWithLocalAQEShuffleRead)
+        keywords = "AQEShuffleRead (6), local", "AQEShuffleRead (9), local")
     }
   }
 
-  private def getExpectedFinalPlanWithCoalescedAndSkewedAQEShuffleRead: String = {
-    """== Physical Plan ==
-      |AdaptiveSparkPlan (24)
-      |+- == Final Plan ==
-      |   ResultQueryStage (17)
-      |   +- * Project (16)
-      |      +- * SortMergeJoin(skew=true) Inner (15)
-      |         :- * Sort (7)
-      |         :  +- AQEShuffleRead (6), coalesced
-      |         :     +- ShuffleQueryStage (5), Statistics(sizeInBytes=15.6 KiB, rowCount=1.00E+3)
-      |         :        +- Exchange (4)
-      |         :           +- * Project (3)
-      |         :              +- * Filter (2)
-      |         :                 +- * Range (1)
-      |         +- * Sort (14)
-      |            +- AQEShuffleRead (13), coalesced and skewed
-      |               +- ShuffleQueryStage (12), Statistics(sizeInBytes=3.1 KiB, rowCount=200)
-      |                  +- Exchange (11)
-      |                     +- * Project (10)
-      |                        +- * Filter (9)
-      |                           +- * Range (8)
-      |""".stripMargin
-  }
-
-  private def getExpectedFinalPlanWithLocalAQEShuffleRead: String = {
-    """== Physical Plan ==
-      |AdaptiveSparkPlan (24)
-      |+- == Final Plan ==
-      |   ResultQueryStage (14)
-      |   +- * Project (13)
-      |      +- * BroadcastHashJoin LeftOuter BuildRight (12)
-      |         :- AQEShuffleRead (6), local
-      |         :  +- ShuffleQueryStage (5), Statistics(sizeInBytes=0.0 B, rowCount=0)
-      |         :     +- Exchange (4)
-      |         :        +- * Project (3)
-      |         :           +- * Filter (2)
-      |         :              +- * Range (1)
-      |         +- BroadcastQueryStage (11), Statistics(sizeInBytes=0.0 B, rowCount=0)
-      |            +- BroadcastExchange (10)
-      |               +- AQEShuffleRead (9), local
-      |                  +- ShuffleQueryStage (8), Statistics(sizeInBytes=0.0 B, rowCount=0)
-      |                     +- ReusedExchange (7)
-      |""".stripMargin
-  }
 }
 
 case class ExplainSingleData(id: Int)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
`AQEShuffleRead` can have `local` / `coalesced` / `skewed` / `coalesced and skewed` properties when reading shuffle files. When Physical Plan Tree is complex, it is hard to track this info by correlating with AQEShuffleRead details such as which AQEShuffleRead has local read or skewed partition info etc. For example, following skewed SortMergeJoin case, this helps to understand which SMJ leg has AQEShuffleRead with skew. This addition aims to access this kind of use-cases at physical plan tree level. Plan Tree details section per AQEShuffleRead node also shows these properties but when query plan tree is too complex (e.g: composed by 1000+ physical nodes), it is hard to correlate this information with AQEShuffleRead details.

**Current Physical Plan Tree:**
```
== Physical Plan ==
AdaptiveSparkPlan (24)
+- == Final Plan ==
   ResultQueryStage (17), Statistics(sizeInBytes=8.0 EiB)
   +- * Project (16)
      +- * SortMergeJoin(skew=true) Inner (15)
         :- * Sort (7)
         :  +- AQEShuffleRead (6)
         :     +- ShuffleQueryStage (5), Statistics(sizeInBytes=15.6 KiB, rowCount=1.00E+3)
         :        +- Exchange (4)
         :           +- * Project (3)
         :              +- * Filter (2)
         :                 +- * Range (1)
         +- * Sort (14)
            +- AQEShuffleRead (13)
               +- ShuffleQueryStage (12), Statistics(sizeInBytes=3.1 KiB, rowCount=200)
                  +- Exchange (11)
                     +- * Project (10)
                        +- * Filter (9)
                           +- * Range (8)
```

**New Physical Plan Tree:**
```
== Physical Plan ==
AdaptiveSparkPlan (24)
+- == Final Plan ==
   ResultQueryStage (17), Statistics(sizeInBytes=8.0 EiB)
   +- * Project (16)
      +- * SortMergeJoin(skew=true) Inner (15)
         :- * Sort (7)
         :  +- AQEShuffleRead (6), coalesced
         :     +- ShuffleQueryStage (5), Statistics(sizeInBytes=15.6 KiB, rowCount=1.00E+3)
         :        +- Exchange (4)
         :           +- * Project (3)
         :              +- * Filter (2)
         :                 +- * Range (1)
         +- * Sort (14)
            +- AQEShuffleRead (13), coalesced and skewed
               +- ShuffleQueryStage (12), Statistics(sizeInBytes=3.1 KiB, rowCount=200)
                  +- Exchange (11)
                     +- * Project (10)
                        +- * Filter (9)
                           +- * Range (8)
```


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When physical plan tree is complex (e.g: composed by 1000+ physical nodes), it is hard to correlate this information with `AQEShuffleRead` details.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, when the user investigates the physical plan, new AQEShuffleRead properties will be seen at Physical Plan Tree.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added a new UT

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
