### PR TITLE
[SPARK-55053][PYTHON] Refactor data source/udtf analysis workers so they have a unified entry

### DIFF
--- a/python/pyspark/sql/worker/data_source_pushdown_filters.py
+++ b/python/pyspark/sql/worker/data_source_pushdown_filters.py
@@ -18,16 +18,14 @@
 import base64
 import json
 import os
-import sys
 import typing
 from dataclasses import dataclass, field
 from typing import IO, Type, Union
 
-from pyspark.accumulators import _accumulatorRegistry
 from pyspark.errors import PySparkAssertionError, PySparkValueError
 from pyspark.errors.exceptions.base import PySparkNotImplementedError
 from pyspark.logger.worker_io import capture_outputs
-from pyspark.serializers import SpecialLengths, UTF8Deserializer, read_int, read_bool, write_int
+from pyspark.serializers import UTF8Deserializer, read_int, read_bool, write_int
 from pyspark.sql.datasource import (
     DataSource,
     DataSourceReader,
@@ -48,20 +46,11 @@ from pyspark.sql.datasource import (
 )
 from pyspark.sql.types import StructType, VariantVal, _parse_datatype_json_string
 from pyspark.sql.worker.plan_data_source_read import write_read_func_and_partitions
-from pyspark.util import (
-    handle_worker_exception,
-    local_connect_and_auth,
-    with_faulthandler,
-    start_faulthandler_periodic_traceback,
-)
+from pyspark.sql.worker.utils import worker_run
+from pyspark.util import local_connect_and_auth
 from pyspark.worker_util import (
-    check_python_version,
     pickleSer,
     read_command,
-    send_accumulator_updates,
-    setup_broadcasts,
-    setup_memory_limits,
-    setup_spark_files,
 )
 
 utf8_deserializer = UTF8Deserializer()
@@ -123,8 +112,7 @@ def deserializeFilter(jsonDict: dict) -> Filter:
     return filter
 
 
-@with_faulthandler
-def main(infile: IO, outfile: IO) -> None:
+def _main(infile: IO, outfile: IO) -> None:
     """
     Main method for planning a data source read with filter pushdown.
 
@@ -145,126 +133,96 @@ def main(infile: IO, outfile: IO) -> None:
     on the reader and determines which filters are supported. The indices of the supported
     filters are sent back to the JVM, along with the list of partitions and the read function.
     """
-    try:
-        check_python_version(infile)
+    # Receive the data source instance.
+    data_source = read_command(pickleSer, infile)
+    if not isinstance(data_source, DataSource):
+        raise PySparkAssertionError(
+            errorClass="DATA_SOURCE_TYPE_MISMATCH",
+            messageParameters={
+                "expected": "a Python data source instance of type 'DataSource'",
+                "actual": f"'{type(data_source).__name__}'",
+            },
+        )
 
-        start_faulthandler_periodic_traceback()
+    # Receive the data source output schema.
+    schema_json = utf8_deserializer.loads(infile)
+    schema = _parse_datatype_json_string(schema_json)
+    if not isinstance(schema, StructType):
+        raise PySparkAssertionError(
+            errorClass="DATA_SOURCE_TYPE_MISMATCH",
+            messageParameters={
+                "expected": "an output schema of type 'StructType'",
+                "actual": f"'{type(schema).__name__}'",
+            },
+        )
 
-        memory_limit_mb = int(os.environ.get("PYSPARK_PLANNER_MEMORY_MB", "-1"))
-        setup_memory_limits(memory_limit_mb)
-
-        setup_spark_files(infile)
-        setup_broadcasts(infile)
-
-        _accumulatorRegistry.clear()
-
-        # ----------------------------------------------------------------------
-        # Start of worker logic
-        # ----------------------------------------------------------------------
-
-        # Receive the data source instance.
-        data_source = read_command(pickleSer, infile)
-        if not isinstance(data_source, DataSource):
+    with capture_outputs():
+        # Get the reader.
+        reader = data_source.reader(schema=schema)
+        # Validate the reader.
+        if not isinstance(reader, DataSourceReader):
             raise PySparkAssertionError(
                 errorClass="DATA_SOURCE_TYPE_MISMATCH",
                 messageParameters={
-                    "expected": "a Python data source instance of type 'DataSource'",
-                    "actual": f"'{type(data_source).__name__}'",
+                    "expected": "an instance of DataSourceReader",
+                    "actual": f"'{type(reader).__name__}'",
                 },
             )
 
-        # Receive the data source output schema.
-        schema_json = utf8_deserializer.loads(infile)
-        schema = _parse_datatype_json_string(schema_json)
-        if not isinstance(schema, StructType):
-            raise PySparkAssertionError(
-                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+        # Receive the pushdown filters.
+        json_str = utf8_deserializer.loads(infile)
+        filter_dicts = json.loads(json_str)
+        filters = [FilterRef(deserializeFilter(f)) for f in filter_dicts]
+
+        # Push down the filters and get the indices of the unsupported filters.
+        unsupported_filters = set(
+            FilterRef(f) for f in reader.pushFilters([ref.filter for ref in filters])
+        )
+        supported_filter_indices = []
+        for i, filter in enumerate(filters):
+            if filter in unsupported_filters:
+                unsupported_filters.remove(filter)
+            else:
+                supported_filter_indices.append(i)
+
+        # If it returned any filters that are not in the original filters, raise an error.
+        if len(unsupported_filters) > 0:
+            raise PySparkValueError(
+                errorClass="DATA_SOURCE_EXTRANEOUS_FILTERS",
                 messageParameters={
-                    "expected": "an output schema of type 'StructType'",
-                    "actual": f"'{type(schema).__name__}'",
+                    "type": type(reader).__name__,
+                    "input": str(list(filters)),
+                    "extraneous": str(list(unsupported_filters)),
                 },
             )
 
-        with capture_outputs():
-            # Get the reader.
-            reader = data_source.reader(schema=schema)
-            # Validate the reader.
-            if not isinstance(reader, DataSourceReader):
-                raise PySparkAssertionError(
-                    errorClass="DATA_SOURCE_TYPE_MISMATCH",
-                    messageParameters={
-                        "expected": "an instance of DataSourceReader",
-                        "actual": f"'{type(reader).__name__}'",
-                    },
-                )
+        # Receive the max arrow batch size.
+        max_arrow_batch_size = read_int(infile)
+        assert max_arrow_batch_size > 0, (
+            "The maximum arrow batch size should be greater than 0, but got "
+            f"'{max_arrow_batch_size}'"
+        )
+        binary_as_bytes = read_bool(infile)
 
-            # Receive the pushdown filters.
-            json_str = utf8_deserializer.loads(infile)
-            filter_dicts = json.loads(json_str)
-            filters = [FilterRef(deserializeFilter(f)) for f in filter_dicts]
+        # Return the read function and partitions. Doing this in the same worker
+        # as filter pushdown helps reduce the number of Python worker calls.
+        write_read_func_and_partitions(
+            outfile,
+            reader=reader,
+            data_source=data_source,
+            schema=schema,
+            max_arrow_batch_size=max_arrow_batch_size,
+            binary_as_bytes=binary_as_bytes,
+        )
 
-            # Push down the filters and get the indices of the unsupported filters.
-            unsupported_filters = set(
-                FilterRef(f) for f in reader.pushFilters([ref.filter for ref in filters])
-            )
-            supported_filter_indices = []
-            for i, filter in enumerate(filters):
-                if filter in unsupported_filters:
-                    unsupported_filters.remove(filter)
-                else:
-                    supported_filter_indices.append(i)
+    # Return the supported filter indices.
+    write_int(len(supported_filter_indices), outfile)
+    for index in supported_filter_indices:
+        write_int(index, outfile)
 
-            # If it returned any filters that are not in the original filters, raise an error.
-            if len(unsupported_filters) > 0:
-                raise PySparkValueError(
-                    errorClass="DATA_SOURCE_EXTRANEOUS_FILTERS",
-                    messageParameters={
-                        "type": type(reader).__name__,
-                        "input": str(list(filters)),
-                        "extraneous": str(list(unsupported_filters)),
-                    },
-                )
 
-            # Receive the max arrow batch size.
-            max_arrow_batch_size = read_int(infile)
-            assert max_arrow_batch_size > 0, (
-                "The maximum arrow batch size should be greater than 0, but got "
-                f"'{max_arrow_batch_size}'"
-            )
-            binary_as_bytes = read_bool(infile)
-
-            # Return the read function and partitions. Doing this in the same worker
-            # as filter pushdown helps reduce the number of Python worker calls.
-            write_read_func_and_partitions(
-                outfile,
-                reader=reader,
-                data_source=data_source,
-                schema=schema,
-                max_arrow_batch_size=max_arrow_batch_size,
-                binary_as_bytes=binary_as_bytes,
-            )
-
-        # Return the supported filter indices.
-        write_int(len(supported_filter_indices), outfile)
-        for index in supported_filter_indices:
-            write_int(index, outfile)
-
-        # ----------------------------------------------------------------------
-        # End of worker logic
-        # ----------------------------------------------------------------------
-    except BaseException as e:
-        handle_worker_exception(e, outfile)
-        sys.exit(-1)
-
-    send_accumulator_updates(outfile)
-
-    # check end of stream
-    if read_int(infile) == SpecialLengths.END_OF_STREAM:
-        write_int(SpecialLengths.END_OF_STREAM, outfile)
-    else:
-        # write a different value to tell JVM to not reuse this worker
-        write_int(SpecialLengths.END_OF_DATA_SECTION, outfile)
-        sys.exit(-1)
+def main(infile: IO, outfile: IO) -> None:
+    worker_run(_main, infile, outfile)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/worker/lookup_data_sources.py
+++ b/python/pyspark/sql/worker/lookup_data_sources.py
@@ -17,35 +17,19 @@
 from importlib import import_module
 from pkgutil import iter_modules
 import os
-import sys
 from typing import IO
 
-from pyspark.accumulators import _accumulatorRegistry
 from pyspark.serializers import (
-    read_int,
     write_int,
     write_with_length,
-    SpecialLengths,
 )
 from pyspark.sql.datasource import DataSource
-from pyspark.util import (
-    handle_worker_exception,
-    local_connect_and_auth,
-    with_faulthandler,
-    start_faulthandler_periodic_traceback,
-)
-from pyspark.worker_util import (
-    check_python_version,
-    pickleSer,
-    send_accumulator_updates,
-    setup_broadcasts,
-    setup_memory_limits,
-    setup_spark_files,
-)
+from pyspark.sql.worker.utils import worker_run
+from pyspark.util import local_connect_and_auth
+from pyspark.worker_util import pickleSer
 
 
-@with_faulthandler
-def main(infile: IO, outfile: IO) -> None:
+def _main(infile: IO, outfile: IO) -> None:
     """
     Main method for looking up the available Python Data Sources in Python path.
 
@@ -56,46 +40,23 @@ def main(infile: IO, outfile: IO) -> None:
     This is responsible for searching the available Python Data Sources so they can be
     statically registered automatically.
     """
-    try:
-        check_python_version(infile)
+    infos = {}
+    for info in iter_modules():
+        if info.name.startswith("pyspark_"):
+            mod = import_module(info.name)
+            if hasattr(mod, "DefaultSource") and issubclass(mod.DefaultSource, DataSource):
+                infos[mod.DefaultSource.name()] = mod.DefaultSource
 
-        start_faulthandler_periodic_traceback()
+    # Writes name -> pickled data source to JVM side to be registered
+    # as a Data Source.
+    write_int(len(infos), outfile)
+    for name, dataSource in infos.items():
+        write_with_length(name.encode("utf-8"), outfile)
+        pickleSer._write_with_length(dataSource, outfile)
 
-        memory_limit_mb = int(os.environ.get("PYSPARK_PLANNER_MEMORY_MB", "-1"))
-        setup_memory_limits(memory_limit_mb)
 
-        setup_spark_files(infile)
-        setup_broadcasts(infile)
-
-        _accumulatorRegistry.clear()
-
-        infos = {}
-        for info in iter_modules():
-            if info.name.startswith("pyspark_"):
-                mod = import_module(info.name)
-                if hasattr(mod, "DefaultSource") and issubclass(mod.DefaultSource, DataSource):
-                    infos[mod.DefaultSource.name()] = mod.DefaultSource
-
-        # Writes name -> pickled data source to JVM side to be registered
-        # as a Data Source.
-        write_int(len(infos), outfile)
-        for name, dataSource in infos.items():
-            write_with_length(name.encode("utf-8"), outfile)
-            pickleSer._write_with_length(dataSource, outfile)
-
-    except BaseException as e:
-        handle_worker_exception(e, outfile)
-        sys.exit(-1)
-
-    send_accumulator_updates(outfile)
-
-    # check end of stream
-    if read_int(infile) == SpecialLengths.END_OF_STREAM:
-        write_int(SpecialLengths.END_OF_STREAM, outfile)
-    else:
-        # write a different value to tell JVM to not reuse this worker
-        write_int(SpecialLengths.END_OF_DATA_SECTION, outfile)
-        sys.exit(-1)
+def main(infile: IO, outfile: IO) -> None:
+    worker_run(_main, infile, outfile)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/worker/utils.py
+++ b/python/pyspark/sql/worker/utils.py
@@ -28,6 +28,7 @@ from pyspark.serializers import (
 from pyspark.util import (
     start_faulthandler_periodic_traceback,
     handle_worker_exception,
+    with_faulthandler,
 )
 from pyspark.worker_util import (
     check_python_version,
@@ -35,7 +36,6 @@ from pyspark.worker_util import (
     setup_memory_limits,
     setup_spark_files,
     setup_broadcasts,
-    with_faulthandler,
 )
 
 

--- a/python/pyspark/sql/worker/utils.py
+++ b/python/pyspark/sql/worker/utils.py
@@ -1,0 +1,70 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import sys
+from typing import Callable, IO
+
+from pyspark.accumulators import _accumulatorRegistry
+from pyspark.serializers import (
+    read_int,
+    write_int,
+    SpecialLengths,
+)
+from pyspark.util import (
+    start_faulthandler_periodic_traceback,
+    handle_worker_exception,
+)
+from pyspark.worker_util import (
+    check_python_version,
+    send_accumulator_updates,
+    setup_memory_limits,
+    setup_spark_files,
+    setup_broadcasts,
+    with_faulthandler,
+)
+
+
+@with_faulthandler
+def worker_run(main: Callable, infile: IO, outfile: IO) -> None:
+    try:
+        check_python_version(infile)
+
+        start_faulthandler_periodic_traceback()
+
+        memory_limit_mb = int(os.environ.get("PYSPARK_PLANNER_MEMORY_MB", "-1"))
+        setup_memory_limits(memory_limit_mb)
+
+        setup_spark_files(infile)
+        setup_broadcasts(infile)
+
+        _accumulatorRegistry.clear()
+
+        main(infile, outfile)
+    except BaseException as e:
+        handle_worker_exception(e, outfile)
+        sys.exit(-1)
+
+    send_accumulator_updates(outfile)
+
+    # check end of stream
+    if read_int(infile) == SpecialLengths.END_OF_STREAM:
+        write_int(SpecialLengths.END_OF_STREAM, outfile)
+    else:
+        # write a different value to tell JVM to not reuse this worker
+        write_int(SpecialLengths.END_OF_DATA_SECTION, outfile)
+        sys.exit(-1)

--- a/python/pyspark/sql/worker/write_into_data_source.py
+++ b/python/pyspark/sql/worker/write_into_data_source.py
@@ -16,10 +16,8 @@
 #
 import inspect
 import os
-import sys
 from typing import IO, Iterable, Iterator
 
-from pyspark.accumulators import _accumulatorRegistry
 from pyspark.sql.conversion import ArrowTableToRowsConversion
 from pyspark.errors import PySparkAssertionError, PySparkRuntimeError, PySparkTypeError
 from pyspark.logger.worker_io import capture_outputs
@@ -27,7 +25,6 @@ from pyspark.serializers import (
     read_bool,
     read_int,
     write_int,
-    SpecialLengths,
 )
 from pyspark.sql import Row
 from pyspark.sql.datasource import (
@@ -45,26 +42,18 @@ from pyspark.sql.types import (
     BinaryType,
     _create_row,
 )
+from pyspark.sql.worker.utils import worker_run
 from pyspark.util import (
-    handle_worker_exception,
     local_connect_and_auth,
-    with_faulthandler,
-    start_faulthandler_periodic_traceback,
 )
 from pyspark.worker_util import (
-    check_python_version,
     read_command,
     pickleSer,
-    send_accumulator_updates,
-    setup_broadcasts,
-    setup_memory_limits,
-    setup_spark_files,
     utf8_deserializer,
 )
 
 
-@with_faulthandler
-def main(infile: IO, outfile: IO) -> None:
+def _main(infile: IO, outfile: IO) -> None:
     """
     Main method for saving into a Python data source.
 
@@ -83,194 +72,172 @@ def main(infile: IO, outfile: IO) -> None:
     instance and send a function using the writer instance that can be used
     in mapInPandas/mapInArrow back to the JVM.
     """
-    try:
-        check_python_version(infile)
 
-        start_faulthandler_periodic_traceback()
+    # Receive the data source class.
+    data_source_cls = read_command(pickleSer, infile)
+    if not (isinstance(data_source_cls, type) and issubclass(data_source_cls, DataSource)):
+        raise PySparkAssertionError(
+            errorClass="DATA_SOURCE_TYPE_MISMATCH",
+            messageParameters={
+                "expected": "a subclass of DataSource",
+                "actual": f"'{type(data_source_cls).__name__}'",
+            },
+        )
 
-        memory_limit_mb = int(os.environ.get("PYSPARK_PLANNER_MEMORY_MB", "-1"))
-        setup_memory_limits(memory_limit_mb)
+    # Check the name method is a class method.
+    if not inspect.ismethod(data_source_cls.name):
+        raise PySparkTypeError(
+            errorClass="DATA_SOURCE_TYPE_MISMATCH",
+            messageParameters={
+                "expected": "'name()' method to be a classmethod",
+                "actual": f"'{type(data_source_cls.name).__name__}'",
+            },
+        )
 
-        setup_spark_files(infile)
-        setup_broadcasts(infile)
+    # Receive the provider name.
+    provider = utf8_deserializer.loads(infile)
 
-        _accumulatorRegistry.clear()
-
-        # Receive the data source class.
-        data_source_cls = read_command(pickleSer, infile)
-        if not (isinstance(data_source_cls, type) and issubclass(data_source_cls, DataSource)):
+    with capture_outputs():
+        # Check if the provider name matches the data source's name.
+        name = data_source_cls.name()
+        if provider.lower() != name.lower():
             raise PySparkAssertionError(
                 errorClass="DATA_SOURCE_TYPE_MISMATCH",
                 messageParameters={
-                    "expected": "a subclass of DataSource",
+                    "expected": f"provider with name {name}",
+                    "actual": f"'{provider}'",
+                },
+            )
+
+        # Receive the input schema
+        schema = _parse_datatype_json_string(utf8_deserializer.loads(infile))
+        if not isinstance(schema, StructType):
+            raise PySparkAssertionError(
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
+                    "expected": "the schema to be a 'StructType'",
                     "actual": f"'{type(data_source_cls).__name__}'",
                 },
             )
 
-        # Check the name method is a class method.
-        if not inspect.ismethod(data_source_cls.name):
-            raise PySparkTypeError(
+        # Receive the return type
+        return_type = _parse_datatype_json_string(utf8_deserializer.loads(infile))
+        if not isinstance(return_type, StructType):
+            raise PySparkAssertionError(
                 errorClass="DATA_SOURCE_TYPE_MISMATCH",
                 messageParameters={
-                    "expected": "'name()' method to be a classmethod",
-                    "actual": f"'{type(data_source_cls.name).__name__}'",
+                    "expected": "a return type of type 'StructType'",
+                    "actual": f"'{type(return_type).__name__}'",
                 },
             )
+        assert len(return_type) == 1 and isinstance(return_type[0].dataType, BinaryType), (
+            "The output schema of Python data source write should contain only one column "
+            f"of type 'BinaryType', but got '{return_type}'"
+        )
+        return_col_name = return_type[0].name
 
-        # Receive the provider name.
-        provider = utf8_deserializer.loads(infile)
+        # Receive the options.
+        options = CaseInsensitiveDict()
+        num_options = read_int(infile)
+        for _ in range(num_options):
+            key = utf8_deserializer.loads(infile)
+            value = utf8_deserializer.loads(infile)
+            options[key] = value
 
-        with capture_outputs():
-            # Check if the provider name matches the data source's name.
-            name = data_source_cls.name()
-            if provider.lower() != name.lower():
+        # Receive the `overwrite` flag.
+        overwrite = read_bool(infile)
+
+        is_streaming = read_bool(infile)
+        binary_as_bytes = read_bool(infile)
+
+        # Instantiate a data source.
+        data_source = data_source_cls(options=options)  # type: ignore
+
+        if is_streaming:
+            # Instantiate the streaming data source writer.
+            writer = data_source.streamWriter(schema, overwrite)
+            if not isinstance(writer, (DataSourceStreamWriter, DataSourceStreamArrowWriter)):
                 raise PySparkAssertionError(
-                    errorClass="DATA_SOURCE_TYPE_MISMATCH",
-                    messageParameters={
-                        "expected": f"provider with name {name}",
-                        "actual": f"'{provider}'",
-                    },
-                )
-
-            # Receive the input schema
-            schema = _parse_datatype_json_string(utf8_deserializer.loads(infile))
-            if not isinstance(schema, StructType):
-                raise PySparkAssertionError(
-                    errorClass="DATA_SOURCE_TYPE_MISMATCH",
-                    messageParameters={
-                        "expected": "the schema to be a 'StructType'",
-                        "actual": f"'{type(data_source_cls).__name__}'",
-                    },
-                )
-
-            # Receive the return type
-            return_type = _parse_datatype_json_string(utf8_deserializer.loads(infile))
-            if not isinstance(return_type, StructType):
-                raise PySparkAssertionError(
-                    errorClass="DATA_SOURCE_TYPE_MISMATCH",
-                    messageParameters={
-                        "expected": "a return type of type 'StructType'",
-                        "actual": f"'{type(return_type).__name__}'",
-                    },
-                )
-            assert len(return_type) == 1 and isinstance(return_type[0].dataType, BinaryType), (
-                "The output schema of Python data source write should contain only one column "
-                f"of type 'BinaryType', but got '{return_type}'"
-            )
-            return_col_name = return_type[0].name
-
-            # Receive the options.
-            options = CaseInsensitiveDict()
-            num_options = read_int(infile)
-            for _ in range(num_options):
-                key = utf8_deserializer.loads(infile)
-                value = utf8_deserializer.loads(infile)
-                options[key] = value
-
-            # Receive the `overwrite` flag.
-            overwrite = read_bool(infile)
-
-            is_streaming = read_bool(infile)
-            binary_as_bytes = read_bool(infile)
-
-            # Instantiate a data source.
-            data_source = data_source_cls(options=options)  # type: ignore
-
-            if is_streaming:
-                # Instantiate the streaming data source writer.
-                writer = data_source.streamWriter(schema, overwrite)
-                if not isinstance(writer, (DataSourceStreamWriter, DataSourceStreamArrowWriter)):
-                    raise PySparkAssertionError(
-                        errorClass="DATA_SOURCE_TYPE_MISMATCH",
-                        messageParameters={
-                            "expected": (
-                                "an instance of DataSourceStreamWriter or "
-                                "DataSourceStreamArrowWriter"
-                            ),
-                            "actual": f"'{type(writer).__name__}'",
-                        },
-                    )
-            else:
-                # Instantiate the data source writer.
-
-                writer = data_source.writer(schema, overwrite)  # type: ignore[assignment]
-                if not isinstance(writer, DataSourceWriter):
-                    raise PySparkAssertionError(
-                        errorClass="DATA_SOURCE_TYPE_MISMATCH",
-                        messageParameters={
-                            "expected": "an instance of DataSourceWriter",
-                            "actual": f"'{type(writer).__name__}'",
-                        },
-                    )
-
-        # Create a function that can be used in mapInArrow.
-        import pyarrow as pa
-
-        converters = [
-            ArrowTableToRowsConversion._create_converter(
-                f.dataType, none_on_identity=False, binary_as_bytes=binary_as_bytes
-            )
-            for f in schema.fields
-        ]
-        fields = schema.fieldNames()
-
-        def data_source_write_func(iterator: Iterable[pa.RecordBatch]) -> Iterable[pa.RecordBatch]:
-            def batch_to_rows() -> Iterator[Row]:
-                for batch in iterator:
-                    columns = [column.to_pylist() for column in batch.columns]
-                    for row in range(0, batch.num_rows):
-                        values = [
-                            converters[col](columns[col][row])  # type: ignore[misc]
-                            for col in range(batch.num_columns)
-                        ]
-                        yield _create_row(fields=fields, values=values)
-
-            if isinstance(writer, DataSourceArrowWriter):
-                res = writer.write(iterator)
-            elif isinstance(writer, DataSourceStreamArrowWriter):
-                res = writer.write(iterator)  # type: ignore[arg-type]
-            else:
-                res = writer.write(batch_to_rows())
-
-            # Check the commit message has the right type.
-            if not isinstance(res, WriterCommitMessage):
-                raise PySparkRuntimeError(
                     errorClass="DATA_SOURCE_TYPE_MISMATCH",
                     messageParameters={
                         "expected": (
-                            "'WriterCommitMessage' as the return type of " "the `write` method"
+                            "an instance of DataSourceStreamWriter or "
+                            "DataSourceStreamArrowWriter"
                         ),
-                        "actual": type(res).__name__,
+                        "actual": f"'{type(writer).__name__}'",
+                    },
+                )
+        else:
+            # Instantiate the data source writer.
+
+            writer = data_source.writer(schema, overwrite)  # type: ignore[assignment]
+            if not isinstance(writer, DataSourceWriter):
+                raise PySparkAssertionError(
+                    errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                    messageParameters={
+                        "expected": "an instance of DataSourceWriter",
+                        "actual": f"'{type(writer).__name__}'",
                     },
                 )
 
-            # Serialize the commit message and return it.
-            pickled = pickleSer.dumps(res)
+    # Create a function that can be used in mapInArrow.
+    import pyarrow as pa
 
-            # Return the commit message.
-            messages = pa.array([pickled])
-            yield pa.record_batch([messages], names=[return_col_name])
+    converters = [
+        ArrowTableToRowsConversion._create_converter(
+            f.dataType, none_on_identity=False, binary_as_bytes=binary_as_bytes
+        )
+        for f in schema.fields
+    ]
+    fields = schema.fieldNames()
 
-        # Return the pickled write UDF.
-        command = (data_source_write_func, return_type)
-        pickleSer._write_with_length(command, outfile)
+    def data_source_write_func(iterator: Iterable[pa.RecordBatch]) -> Iterable[pa.RecordBatch]:
+        def batch_to_rows() -> Iterator[Row]:
+            for batch in iterator:
+                columns = [column.to_pylist() for column in batch.columns]
+                for row in range(0, batch.num_rows):
+                    values = [
+                        converters[col](columns[col][row])  # type: ignore[misc]
+                        for col in range(batch.num_columns)
+                    ]
+                    yield _create_row(fields=fields, values=values)
 
-        # Return the picked writer.
-        pickleSer._write_with_length(writer, outfile)
+        if isinstance(writer, DataSourceArrowWriter):
+            res = writer.write(iterator)
+        elif isinstance(writer, DataSourceStreamArrowWriter):
+            res = writer.write(iterator)  # type: ignore[arg-type]
+        else:
+            res = writer.write(batch_to_rows())
 
-    except BaseException as e:
-        handle_worker_exception(e, outfile)
-        sys.exit(-1)
+        # Check the commit message has the right type.
+        if not isinstance(res, WriterCommitMessage):
+            raise PySparkRuntimeError(
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
+                    "expected": (
+                        "'WriterCommitMessage' as the return type of " "the `write` method"
+                    ),
+                    "actual": type(res).__name__,
+                },
+            )
 
-    send_accumulator_updates(outfile)
+        # Serialize the commit message and return it.
+        pickled = pickleSer.dumps(res)
 
-    # check end of stream
-    if read_int(infile) == SpecialLengths.END_OF_STREAM:
-        write_int(SpecialLengths.END_OF_STREAM, outfile)
-    else:
-        # write a different value to tell JVM to not reuse this worker
-        write_int(SpecialLengths.END_OF_DATA_SECTION, outfile)
-        sys.exit(-1)
+        # Return the commit message.
+        messages = pa.array([pickled])
+        yield pa.record_batch([messages], names=[return_col_name])
+
+    # Return the pickled write UDF.
+    command = (data_source_write_func, return_type)
+    pickleSer._write_with_length(command, outfile)
+
+    # Return the picked writer.
+    pickleSer._write_with_length(writer, outfile)
+
+
+def main(infile: IO, outfile: IO) -> None:
+    worker_run(_main, infile, outfile)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

* A new `util.py` file is added in `pyspark.sql.worker` to handle the common logic for all planner workers.
* All the worker modules in that folder, including data source and udtf analysis modules, are using this unified entry.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

* Reduce duplicated code. We have the same worker communication logic in all files and when we need to change it, we have to change all.
* Make it easier for future instrumentation like data source profiler

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

test_datasource passed locally

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Yes, cursor (claude-4.5-opus-high)