### PR TITLE
[SPARK-55054][SS][SQL] Add IDENTIFIED BY support for streaming table-valued functions

### DIFF
--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -429,7 +429,7 @@ streamRelationPrimary
     | STREAM LEFT_PAREN multipartIdentifier RIGHT_PAREN
       optionsClause? identifiedByClause?
       watermarkClause? tableAlias                                      #streamTableName
-    | STREAM functionTable                                             #streamTableValuedFunction
+    | STREAM tableFunctionCallWithTrailingClauses                      #streamTableValuedFunction
     | STREAM LEFT_PAREN tableFunctionCall RIGHT_PAREN
       identifiedByClause? watermarkClause? tableAlias                  #streamTableValuedFunction
     ;
@@ -1071,7 +1071,7 @@ relationPrimary
     | LEFT_PAREN relation RIGHT_PAREN sample?
        watermarkClause? tableAlias                          #aliasedRelation
     | inlineTable                                           #inlineTableDefault2
-    | functionTable                                         #tableValuedFunction
+    | tableFunctionCallWithTrailingClauses                  #tableValuedFunction
     ;
 
 optionsClause
@@ -1121,23 +1121,19 @@ functionTableArgument
     | functionArgument
     ;
 
-// This is only used in relationPrimary where having watermarkClause makes sense. If this becomes
-// referred by other clause, please check wheter watermarkClause makes sense to the clause.
-// If not, consider separate this rule.
-// The identifiedByClause is optional and only valid for streaming TVFs. For non-streaming TVFs,
-// the AST builder will reject it with an error. The clause must come before watermarkClause
-// and tableAlias to avoid ambiguity (since IDENTIFIED is a nonReserved keyword).
-functionTable
-    : tableFunctionCall identifiedByClause? watermarkClause? tableAlias
-    ;
-
-// A table function call without trailing clauses (identifiedByClause, watermarkClause, tableAlias).
-// This is used by stream TVF rules to ensure consistent syntax with stream table names, where
-// the clauses appear OUTSIDE the STREAM() parentheses.
+// A table function call including opening and closing parentheses.
 tableFunctionCall
     : funcName=functionName LEFT_PAREN
       (functionTableArgument (COMMA functionTableArgument)*)?
       RIGHT_PAREN
+    ;
+
+// A table function call with optional trailing clauses for streaming and aliasing.
+// The identifiedByClause is optional and only valid for streaming TVFs. For non-streaming TVFs,
+// the AST builder will reject it with an error. The clause must come before watermarkClause
+// and tableAlias to avoid ambiguity (since IDENTIFIED is a nonReserved keyword).
+tableFunctionCallWithTrailingClauses
+    : tableFunctionCall identifiedByClause? watermarkClause? tableAlias
     ;
 
 tableAlias


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR extends the IDENTIFIED BY syntax to support streaming table-valued functions (TVFs), complementing the existing support for streaming tables.

The changes include:
- Added grammar rules for streaming TVFs with IDENTIFIED BY clause
- Split `functionTable` into `tableFunctionCall` + clauses for consistent syntax
- Added validation that IDENTIFIED BY is only allowed for streaming sources
- Streaming TVFs support two syntaxes:
  1. `STREAM tvf() IDENTIFIED BY name` - clauses inside
  2. `STREAM(tvf()) IDENTIFIED BY name` - clauses outside (consistent with table syntax)
- Added comprehensive test coverage for both syntaxes

### Why are the changes needed?

Streaming TVFs (like range(), read_files() when available) need the ability to be named just like streaming tables. This ensures:
- Consistent source naming across all streaming source types
- Better observability for streaming queries using TVFs
- Proper checkpoint management for TVF-based streams

### Does this PR introduce _any_ user-facing change?

Yes. Users can now use IDENTIFIED BY with streaming TVFs:

```sql
-- Non-parenthesized form
SELECT * FROM STREAM range(100) IDENTIFIED BY my_range_source

-- Parenthesized form (clauses outside for consistency)
SELECT * FROM STREAM(range(100)) IDENTIFIED BY my_range_source

-- With watermark and alias
SELECT * FROM STREAM range(100)
  IDENTIFIED BY my_source
  WATERMARK ts DELAY OF INTERVAL 1 MINUTE
  AS src
```

Using IDENTIFIED BY on non-streaming TVFs produces a clear error:
```
IDENTIFIED BY clause is only supported for streaming sources
```

### How was this patch tested?

- Added comprehensive tests in StreamRelationParserSuite covering:
  - Non-parenthesized form with all clause combinations
  - Parenthesized form with all clause combinations
  - Validation that non-streaming TVFs reject IDENTIFIED BY
- Tests verify correct placement of clauses in both syntaxes
- All existing tests continue to pass

### Was this patch authored or co-authored using generative AI tooling?

No.
