### PR TITLE
[WIP][SPARK-55056][SQL][PYTHON] Fix toPandas() SIGSEGV on nested empty arrays

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow.py
@@ -1853,8 +1853,6 @@ class ArrowTestsMixin:
                     self.assertEqual(t.num_rows, 10000)
                     self.assertEqual(t.column_names, ["id", "str_col", "mod_col"])
 
-
-
     def test_toPandas_double_nested_array_empty_outer(self):
         schema = StructType([StructField("data", ArrayType(ArrayType(StringType())))])
         df = self.spark.createDataFrame([Row(data=[])], schema=schema)
@@ -1882,11 +1880,14 @@ class ArrowTestsMixin:
         self.assertEqual(len(pdf["data"][0]), 0)
 
     def test_toPandas_nested_array_with_map_empty_outer(self):
-        schema = StructType([StructField("data", ArrayType(ArrayType(MapType(StringType(), StringType()))))])
+        schema = StructType(
+            [StructField("data", ArrayType(ArrayType(MapType(StringType(), StringType()))))]
+        )
         df = self.spark.createDataFrame([Row(data=[])], schema=schema)
         pdf = df.toPandas()
         self.assertEqual(len(pdf), 1)
         self.assertEqual(len(pdf["data"][0]), 0)
+
 
 @unittest.skipIf(
     not have_pandas or not have_pyarrow,

--- a/python/pyspark/sql/tests/arrow/test_arrow.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow.py
@@ -1854,6 +1854,40 @@ class ArrowTestsMixin:
                     self.assertEqual(t.column_names, ["id", "str_col", "mod_col"])
 
 
+
+    def test_toPandas_double_nested_array_empty_outer(self):
+        schema = StructType([StructField("data", ArrayType(ArrayType(StringType())))])
+        df = self.spark.createDataFrame([Row(data=[])], schema=schema)
+        pdf = df.toPandas()
+        self.assertEqual(len(pdf), 1)
+        self.assertEqual(len(pdf["data"][0]), 0)
+
+    def test_toPandas_array_of_map_empty_outer(self):
+        schema = StructType([StructField("data", ArrayType(MapType(StringType(), StringType())))])
+        df = self.spark.createDataFrame([Row(data=[])], schema=schema)
+        pdf = df.toPandas()
+        self.assertEqual(len(pdf), 1)
+        self.assertEqual(len(pdf["data"][0]), 0)
+
+    def test_toPandas_triple_nested_array_empty_outer(self):
+        # SPARK-55056: This triggers SIGSEGV without the fix.
+        # When the outer array is empty, the second-level ArrayWriter is never
+        # invoked, so its count stays 0. Arrow format requires ListArray offset
+        # buffer to have N+1 entries even when N=0, but getBufferSizeFor(0)
+        # returns 0 and the buffer is omitted in IPC serialization.
+        schema = StructType([StructField("data", ArrayType(ArrayType(ArrayType(StringType()))))])
+        df = self.spark.createDataFrame([Row(data=[])], schema=schema)
+        pdf = df.toPandas()
+        self.assertEqual(len(pdf), 1)
+        self.assertEqual(len(pdf["data"][0]), 0)
+
+    def test_toPandas_nested_array_with_map_empty_outer(self):
+        schema = StructType([StructField("data", ArrayType(ArrayType(MapType(StringType(), StringType()))))])
+        df = self.spark.createDataFrame([Row(data=[])], schema=schema)
+        pdf = df.toPandas()
+        self.assertEqual(len(pdf), 1)
+        self.assertEqual(len(pdf["data"][0]), 0)
+
 @unittest.skipIf(
     not have_pandas or not have_pyarrow,
     cast(str, pandas_requirement_message or pyarrow_requirement_message),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
@@ -387,6 +387,11 @@ private[arrow] class ArrayWriter(
     val valueVector: ListVector,
     val elementWriter: ArrowFieldWriter) extends ArrowFieldWriter {
 
+  // SPARK-55056: Arrow format requires ListArray offset buffer to have N+1 entries.
+  // Even when N=0, the buffer must contain [0]. Initialize offset buffer at construction
+  // to ensure it exists even if no elements are written.
+  valueVector.getOffsetBuffer.setInt(0, 0)
+
   override def setNull(): Unit = {
   }
 
@@ -402,17 +407,6 @@ private[arrow] class ArrayWriter(
   }
 
   override def finish(): Unit = {
-    // SPARK-55056: Arrow format requires ListArray offset buffer to have N+1 entries.
-    // Even when N=0, the buffer must contain [0]. When the outer array is empty,
-    // nested ArrayWriters are never invoked, so their count stays 0. Then
-    // getBufferSizeFor(0) returns 0, and the offset buffer is omitted in IPC
-    // serialization — violating Arrow spec. Simulate one empty write to ensure
-    // the offset buffer is properly initialized.
-    if (count == 0) {
-      valueVector.startNewValue(0)
-      valueVector.endValue(0, 0)
-      count = 1
-    }
     super.finish()
     elementWriter.finish()
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
@@ -413,6 +413,8 @@ private[arrow] class ArrayWriter(
 
   override def reset(): Unit = {
     super.reset()
+    // Re-initialize offset buffer after reset (see constructor comment)
+    valueVector.getOffsetBuffer.setInt(0, 0)
     elementWriter.reset()
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Initialize the Arrow ListArray offset buffer at `ArrayWriter` construction and after reset to ensure it contains `[0]` even when no elements are written.

### Why are the changes needed?

Arrow format requires ListArray offset buffer to have N+1 entries. Even when N=0, the buffer must contain `[0]`. 

When an outer array is empty, nested `ArrayWriter`s are never invoked, so their count stays 0. Arrow Java's `getBufferSizeFor(0)` returns 0, causing the offset buffer to be omitted in IPC serialization — violating Arrow spec. This causes SIGSEGV when PyArrow tries to read the malformed Arrow data.

The fix directly initializes the offset buffer with `valueVector.getOffsetBuffer.setInt(0, 0)` at construction and after reset, ensuring the buffer exists regardless of whether any elements are written.


### Does this PR introduce _any_ user-facing change?

Yes. `toPandas()` on triple-nested empty arrays no longer crashes.

### How was this patch tested?

- 2 Scala unit tests in `ArrowWriterSuite`
- 4 Python integration tests in `test_arrow.py`

### Was this patch authored or co-authored using generative AI tooling?
No