### PR TITLE
[SPARK-43986][SQL][FOLLOWUP] Catch ArrayIndexOutOfBoundsException in Datasketches HLL functions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/datasketchesAggregates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/datasketchesAggregates.scala
@@ -338,7 +338,8 @@ case class HllUnionAgg(
             union.update(sketch)
             Some(union)
           } catch {
-            case _: SketchesArgumentException | _: java.lang.Error =>
+            case _: SketchesArgumentException | _: java.lang.Error
+                 | _: ArrayIndexOutOfBoundsException =>
               throw QueryExecutionErrors.hllInvalidInputSketchBuffer(prettyName)
           }
         case _ =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datasketchesExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datasketchesExpressions.scala
@@ -108,13 +108,15 @@ case class HllUnion(first: Expression, second: Expression, third: Expression)
     val sketch1 = try {
       HllSketch.heapify(Memory.wrap(value1.asInstanceOf[Array[Byte]]))
     } catch {
-      case _: SketchesArgumentException | _: java.lang.Error =>
+      case _: SketchesArgumentException | _: java.lang.Error
+           | _: ArrayIndexOutOfBoundsException =>
         throw QueryExecutionErrors.hllInvalidInputSketchBuffer(prettyName)
     }
     val sketch2 = try {
       HllSketch.heapify(Memory.wrap(value2.asInstanceOf[Array[Byte]]))
     } catch {
-      case _: SketchesArgumentException | _: java.lang.Error =>
+      case _: SketchesArgumentException | _: java.lang.Error
+           | _: ArrayIndexOutOfBoundsException =>
         throw QueryExecutionErrors.hllInvalidInputSketchBuffer(prettyName)
     }
     val allowDifferentLgConfigK = value3.asInstanceOf[Boolean]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datasketchesExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datasketchesExpressions.scala
@@ -56,7 +56,8 @@ case class HllSketchEstimate(child: Expression)
     try {
       Math.round(HllSketch.heapify(Memory.wrap(buffer)).getEstimate)
     } catch {
-      case _: SketchesArgumentException | _: java.lang.Error =>
+      case _: SketchesArgumentException | _: java.lang.Error
+           | _: ArrayIndexOutOfBoundsException =>
         throw QueryExecutionErrors.hllInvalidInputSketchBuffer(prettyName)
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes error handling in `HllUnionAgg` to properly catch `ArrayIndexOutOfBoundsException` and convert it to the user-friendly `HLL_INVALID_INPUT_SKETCH_BUFFER` error.

When an invalid HLL sketch binary is passed to `HllUnionAgg`, the DataSketches library may throw an `ArrayIndexOutOfBoundsException` during parsing. For example, if the `curMode` ordinal in the HLL preamble is set to an invalid value (e.g., 3 when only 0, 1, 2 are valid), `CurMode.fromOrdinal()` throws this exception. Previously, this exception would propagate to the user as an unhelpful `ArrayIndexOutOfBoundsException`. 

The fix adds `ArrayIndexOutOfBoundsException` to the existing catch block that already handles `SketchesArgumentException` and `java.lang.Error`, ensuring all invalid sketch buffer errors are converted to the clear `HLL_INVALID_INPUT_SKETCH_BUFFER` error message.

### Why are the changes needed?

Without this fix, users see a confusing `ArrayIndexOutOfBoundsException` when passing malformed binary data to HLL union functions. This provides a poor user experience as it doesn't indicate what went wrong or how to fix it. The `HLL_INVALID_INPUT_SKETCH_BUFFER` error clearly indicates that the input binary is not a valid HLL sketch.

### Does this PR introduce _any_ user-facing change?

Yes. Users who pass invalid binary data to `hll_union_agg` will now see a clear error message (`HLL_INVALID_INPUT_SKETCH_BUFFER`) instead of an `ArrayIndexOutOfBoundsException`.

### How was this patch tested?

Added a new unit test `"HllUnionAgg throws proper error for invalid binary input causing ArrayIndexOutOfBounds"` in `DatasketchesHllSketchSuite` that:
1. Crafts a byte array with a valid HLL preamble structure but an invalid `curMode` ordinal (3 instead of 0, 1, or 2)
2. Verifies that the exception is NOT an `ArrayIndexOutOfBoundsException`
3. Verifies that the error message contains `HLL_INVALID_INPUT_SKETCH_BUFFER`

### Was this patch authored or co-authored using generative AI tooling?

Yes, `claude-4.5-opus-high` plus manual review and editing.