### PR TITLE
[SPARK-54365][SS] Add Repartition Integration Test for Aggregate, Dedup, FMGWS and SessionWindow Operators

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceTestBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceTestBase.scala
@@ -453,8 +453,6 @@ trait StateDataSourceTestBase extends StreamTest with StateStoreMetricsTest {
    */
   protected def getDedupAndAggregationQuery(
       inputData: MemoryStream[(String, Int)]): DataFrame = {
-    import org.apache.spark.sql.functions._
-
     inputData.toDS()
       .selectExpr("_1 AS key", "_2 AS value")
       .withColumn("eventTime", (unix_timestamp() + $"value").cast("timestamp"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceTestBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceTestBase.scala
@@ -444,6 +444,29 @@ trait StateDataSourceTestBase extends StreamTest with StateStoreMetricsTest {
       StopStream
     )
   }
+
+  /**
+   * Helper function to create a query that combines deduplication and aggregation.
+   * This creates a more complex query with multiple stateful operators:
+   * 1. Deduplicates based on (key, value) pairs
+   * 2. Groups by key and aggregates (count, sum, max)
+   */
+  protected def getDedupAndAggregationQuery(
+      inputData: MemoryStream[(String, Int)]): DataFrame = {
+    import org.apache.spark.sql.functions._
+
+    inputData.toDS()
+      .selectExpr("_1 AS key", "_2 AS value")
+      .withColumn("eventTime", (unix_timestamp() + $"value").cast("timestamp"))
+      .withWatermark("eventTime", "10 seconds")
+      .dropDuplicates("key", "value")  // First stateful operator: dedup
+      .groupBy($"key")  // Second stateful operator: aggregation
+      .agg(
+        count("*").as("count"),
+        sum("value").as("sum"),
+        max("value").as("max")
+      )
+  }
 }
 
 case class Event(sessionId: String, timestamp: Timestamp)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationSuite.scala
@@ -151,7 +151,7 @@ class OfflineStateRepartitionIntegrationSuite
 
   def testWithChangelogConfig(testName: String)(testFun: => Unit): Unit = {
     Seq(true, false).foreach { changelogCheckpointingEnabled =>
-      test(s"$testName - (enableChangelogCheckpointing=$changelogCheckpointingEnabled)") {
+      test(s"$testName - enableChangelogCheckpointing=$changelogCheckpointingEnabled") {
         withSQLConf(
           "spark.sql.streaming.stateStore.rocksdb.changelogCheckpointing.enabled" ->
             changelogCheckpointingEnabled.toString) {
@@ -163,7 +163,7 @@ class OfflineStateRepartitionIntegrationSuite
 
   def testWithStateStoreCheckpointIds(testName: String)(testBody: => Unit): Unit = {
     Seq(1, 2).foreach { ckptVersion =>
-      val newTestName = s"$testName - (enableStateStoreCheckpointIds = ${ckptVersion >= 2})"
+      val newTestName = s"$testName - enableStateStoreCheckpointIds = ${ckptVersion >= 2}"
       withSQLConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key -> ckptVersion.toString) {
         testWithChangelogConfig(newTestName) {
           testBody
@@ -286,7 +286,7 @@ class OfflineStateRepartitionIntegrationSuite
           StartStream(checkpointLocation = checkpointDir),
           AddData(inputData, (1 to 2).flatMap(_ => 10 to 15) ++ (20 to 22): _*),
           CheckNewAnswer(20, 21, 22),
-          assertNumStateRows(total = 13, updated = 3)
+          assertNumStateRows(total = 10, updated = 3)
         )
       }
     )
@@ -334,7 +334,7 @@ class OfflineStateRepartitionIntegrationSuite
           assertNumStateRows(total = 3, updated = 3),
           AddData(inputData, ("a", 4), ("b", 5), ("d", 6)),
           CheckNewAnswer(("d", 6)),
-          assertNumStateRows(total = 4, updated = 1),
+          assertNumStateRows(total = 2, updated = 1),
           StopStream
         )
       },
@@ -344,7 +344,7 @@ class OfflineStateRepartitionIntegrationSuite
           StartStream(checkpointLocation = checkpointDir),
           AddData(inputData, ("a", 5), ("e", 8), ("d", 7)),
           CheckNewAnswer(("a", 5), ("e", 8)),
-          assertNumStateRows(total = 5, updated = 2)
+          assertNumStateRows(total = 3, updated = 2)
         )
       }
     )

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionOperatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionOperatorSuite.scala
@@ -1,0 +1,338 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.streaming.state
+
+import org.apache.spark.sql.{Dataset, Encoder, Row}
+import org.apache.spark.sql.execution.datasources.v2.state.{StateDataSourceTestBase, StateSourceOptions}
+import org.apache.spark.sql.execution.streaming.runtime.{MemoryStream, StreamingQueryCheckpointMetadata}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.streaming.{OutputMode, Trigger}
+import org.apache.spark.sql.streaming.util.StreamManualClock
+
+/**
+ * Integration test suite for OfflineStateRepartitionRunner with simple aggregation operators.
+ * Tests state repartitioning (increase and decrease partitions) and validates:
+ * 1. State data remains identical after repartitioning
+ * 2. Offset and commit logs are updated correctly
+ * 3. Query can resume successfully and compute correctly with repartitioned state
+ */
+class OfflineStateRepartitionOperatorSuite
+  extends StateDataSourceTestBase
+  with AlsoTestWithRocksDBFeatures{
+
+  import testImplicits._
+  import OfflineStateRepartitionTestUtils._
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.conf.set(SQLConf.STATE_STORE_PROVIDER_CLASS.key,
+      classOf[RocksDBStateStoreProvider].getName)
+    spark.conf.set(SQLConf.SHUFFLE_PARTITIONS.key, "2")
+  }
+
+  /**
+   * Captures state data from checkpoint directory using StateStore data source.
+   * Returns sorted rows for deterministic comparison.
+   */
+  private def captureStateData(checkpointDir: String, batchId: Long): Dataset[Row] = {
+    spark.read
+      .format("statestore")
+      .option(StateSourceOptions.PATH, checkpointDir)
+      .option(StateSourceOptions.BATCH_ID, batchId)
+      .load()
+      .selectExpr("key", "value", "partition_id")
+      .orderBy("key")
+  }
+
+  /**
+   * Validates that state data after repartition matches state data before repartition.
+   * Compares key-value pairs, ignoring partition_id which changes during repartitioning.
+   * Also validates partition distribution.
+   */
+  private def validateStateDataAfterRepartition(
+      checkpointDir: String,
+      stateBeforeRepartition: Array[Row],
+      repartitionBatchId: Long): Unit = {
+
+    val stateAfterRepartition = captureStateData(checkpointDir, repartitionBatchId).collect()
+
+    // Validate row count
+    assert(stateBeforeRepartition.length == stateAfterRepartition.length,
+      s"State row count mismatch: before=${stateBeforeRepartition.length}, " +
+        s"after=${stateAfterRepartition.length}")
+
+    // Extract (key, value) pairs, ignoring partition_id (which changes)
+    val beforeByKey = stateBeforeRepartition
+      .map(row => (row.get(0).toString, row.get(1).toString))
+      .sortBy(_._1)
+
+    val afterByKey = stateAfterRepartition
+      .map(row => (row.get(0).toString, row.get(1).toString))
+      .sortBy(_._1)
+
+    // Compare each (key, value) pair
+    beforeByKey.zip(afterByKey).zipWithIndex.foreach {
+      case (((keyBefore, valueBefore), (keyAfter, valueAfter)), idx) =>
+        assert(keyBefore == keyAfter,
+          s"Key mismatch at index $idx: $keyBefore vs $keyAfter")
+        assert(valueBefore == valueAfter,
+          s"Value mismatch at index $idx for key $keyBefore")
+    }
+  }
+
+  /**
+   * Core helper function that encapsulates the complete repartition test workflow:
+   * 1. Run initial query to create state
+   * 2. Capture state before repartition
+   * 3. Run repartition operation
+   * 4. Verify repartition batch and state data
+   * 5. Resume query with new data and verify results
+   *
+   * @param newPartitions The target number of partitions after repartition
+   * @param setupInitialState Callback to set up initial state
+   *                          (receives inputStream, checkpointDir, clock)
+   * @param verifyResumedQuery Callback to verify resumed query
+   *                           (receives inputStream, checkpointDir, clock)
+   * @param useManualClock Whether this test requires a manual clock (for processing time)
+   * @tparam T The type of data in the MemoryStream (requires implicit Encoder)
+   */
+  def testRepartitionWorkflow[T : Encoder](
+      newPartitions: Int,
+      setupInitialState: (MemoryStream[T], String, Option[StreamManualClock]) => Unit,
+      verifyResumedQuery: (MemoryStream[T], String, Option[StreamManualClock]) => Unit,
+      useManualClock: Boolean = false): Unit = {
+    withTempDir { checkpointDir =>
+      val clock = if (useManualClock) Some(new StreamManualClock) else None
+      val inputData = MemoryStream[T]
+
+      // Step 1: Run initial query to create state
+      setupInitialState(inputData, checkpointDir.getAbsolutePath, clock)
+
+      // Step 2: Capture state data before repartition
+      val checkpointMetadata = new StreamingQueryCheckpointMetadata(
+        spark, checkpointDir.getAbsolutePath)
+      val lastBatchId = checkpointMetadata.commitLog.getLatestBatchId().get
+      val stateBeforeRepartition =
+        captureStateData(checkpointDir.getAbsolutePath, lastBatchId)
+
+      // Step 3: Run repartition
+      spark.streamingCheckpointManager.repartition(
+        checkpointDir.getAbsolutePath, newPartitions)
+
+      val repartitionBatchId = lastBatchId + 1
+      val hadoopConf = spark.sessionState.newHadoopConf()
+
+      // Step 4: Verify offset and commit logs are updated correctly
+      verifyRepartitionBatch(
+        repartitionBatchId, checkpointMetadata, hadoopConf,
+        checkpointDir.getAbsolutePath, newPartitions, spark)
+
+      // Step 5: Validate state data matches after repartition
+      validateStateDataAfterRepartition(
+        checkpointDir.getAbsolutePath, stateBeforeRepartition.collect(),
+        repartitionBatchId)
+
+      // Step 6: Resume query with new input and verify
+      withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> newPartitions.toString) {
+        verifyResumedQuery(inputData, checkpointDir.getAbsolutePath, clock)
+      }
+    }
+  }
+
+  /**
+   * Helper function to test with both increase and decrease repartition operations.
+   * This reduces code duplication across different operator tests.
+   *
+   * @param testNamePrefix The prefix for the test name (e.g., "aggregation state v2")
+   * @param testFun The test function that takes newPartitions as parameter
+   */
+  def testWithAllRepartitionOperations(testNamePrefix: String)
+      (testFun: Int => Unit): Unit = {
+    Seq(("increase", 4), ("decrease", 1)).foreach { case (direction, newPartitions) =>
+      testWithStateStoreCheckpointIds(s"Repartition $direction: $testNamePrefix") { _ =>
+        testFun(newPartitions)
+      }
+    }
+  }
+
+  // Test aggregation operator repartitioning
+  Seq(1, 2).foreach { version =>
+    testWithAllRepartitionOperations(s"aggregation state v$version") { newPartitions =>
+      withSQLConf(SQLConf.STREAMING_AGGREGATION_STATE_FORMAT_VERSION.key -> version.toString) {
+        testRepartitionWorkflow[Int](
+          newPartitions = newPartitions,
+          setupInitialState = (inputData, checkpointDir, _) => {
+            val aggregated = getLargeDataStreamingAggregationQuery(inputData)
+            testStream(aggregated, OutputMode.Update)(
+              StartStream(checkpointLocation = checkpointDir),
+              AddData(inputData, 0 until 20: _*),
+              CheckLastBatch(
+                (0, 2, 10, 10, 0), (1, 2, 12, 11, 1), (2, 2, 14, 12, 2), (3, 2, 16, 13, 3),
+                (4, 2, 18, 14, 4), (5, 2, 20, 15, 5), (6, 2, 22, 16, 6), (7, 2, 24, 17, 7),
+                (8, 2, 26, 18, 8), (9, 2, 28, 19, 9)
+              ),
+              AddData(inputData, 20 until 40: _*),
+              CheckLastBatch(
+                (0, 4, 60, 30, 0), (1, 4, 64, 31, 1), (2, 4, 68, 32, 2), (3, 4, 72, 33, 3),
+                (4, 4, 76, 34, 4), (5, 4, 80, 35, 5), (6, 4, 84, 36, 6), (7, 4, 88, 37, 7),
+                (8, 4, 92, 38, 8), (9, 4, 96, 39, 9)
+              ),
+              StopStream
+            )
+          },
+          verifyResumedQuery = (inputData, checkpointDir, _) => {
+            val aggregated = getLargeDataStreamingAggregationQuery(inputData)
+            testStream(aggregated, OutputMode.Update)(
+              StartStream(checkpointLocation = checkpointDir),
+              AddData(inputData, 40 until 50: _*),
+              CheckLastBatch(
+                (0, 5, 100, 40, 0), (1, 5, 105, 41, 1), (2, 5, 110, 42, 2),
+                (3, 5, 115, 43, 3), (4, 5, 120, 44, 4), (5, 5, 125, 45, 5),
+                (6, 5, 130, 46, 6), (7, 5, 135, 47, 7), (8, 5, 140, 48, 8),
+                (9, 5, 145, 49, 9)
+              )
+            )
+          }
+        )
+      }
+    }
+  }
+
+  // Test dedup operator repartitioning
+  testWithAllRepartitionOperations("dedup") { newPartitions =>
+    testRepartitionWorkflow[Int](
+      newPartitions = newPartitions,
+      setupInitialState = (inputData, checkpointDir, _) => {
+        val deduplicated = getDropDuplicatesQuery(inputData)
+        testStream(deduplicated, OutputMode.Append)(
+          StartStream(checkpointLocation = checkpointDir),
+          AddData(inputData, (1 to 5).flatMap(_ => (10 to 15)): _*),
+          CheckAnswer(10 to 15: _*),
+          assertNumStateRows(total = 6, updated = 6),
+          AddData(inputData, (1 to 3).flatMap(_ => (10 to 15)) ++ (16 to 19): _*),
+          CheckNewAnswer(16, 17, 18, 19),
+          assertNumStateRows(total = 10, updated = 4),
+          StopStream
+        )
+      },
+      verifyResumedQuery = (inputData, checkpointDir, _) => {
+        val deduplicated = getDropDuplicatesQuery(inputData)
+        testStream(deduplicated, OutputMode.Append)(
+          StartStream(checkpointLocation = checkpointDir),
+          AddData(inputData, (1 to 2).flatMap(_ => 10 to 15) ++ (20 to 22): _*),
+          CheckNewAnswer(20, 21, 22)
+        )
+      }
+    )
+  }
+
+  // Test session window aggregation repartitioning
+  testWithAllRepartitionOperations("session window aggregation") { newPartitions =>
+    testRepartitionWorkflow[(String, Long)](
+      newPartitions = newPartitions,
+      setupInitialState = (inputData, checkpointDir, _) => {
+        val aggregated = getSessionWindowAggregationQuery(inputData)
+        testStream(aggregated, OutputMode.Complete())(
+          StartStream(checkpointLocation = checkpointDir),
+          AddData(inputData,
+            ("hello world spark streaming", 40L),
+            ("world hello structured streaming", 41L)
+          ),
+          CheckNewAnswer(
+            ("hello", 40, 51, 11, 2), ("world", 40, 51, 11, 2), ("streaming", 40, 51, 11, 2),
+            ("spark", 40, 50, 10, 1), ("structured", 41, 51, 10, 1)
+          ),
+          StopStream
+        )
+      },
+      verifyResumedQuery = (inputData, checkpointDir, _) => {
+        val resumed = getSessionWindowAggregationQuery(inputData)
+        testStream(resumed, OutputMode.Complete())(
+          StartStream(checkpointLocation = checkpointDir),
+          AddData(inputData, ("new session", 100L)),
+          CheckNewAnswer(
+            ("hello", 40, 51, 11, 2), ("world", 40, 51, 11, 2), ("streaming", 40, 51, 11, 2),
+            ("spark", 40, 50, 10, 1), ("structured", 41, 51, 10, 1),
+            ("new", 100, 110, 10, 1), ("session", 100, 110, 10, 1))
+        )
+      }
+    )
+  }
+
+  /**
+   * Helper function to test with both increase and decrease repartition operations.
+   * This reduces code duplication across different operator tests.
+   *
+   * @param testNamePrefix The prefix for the test name (e.g., "aggregation state v2")
+   * @param testFun The test function that takes FLATMAPGROUPSWITHSTATE as parameter
+   */
+  def testFMGWOnAllPartitionOperation(testNamePrefix: String)
+      (testFun: Int => Unit): Unit = {
+    Seq(1, 2).foreach { stateVersion =>
+      if (stateVersion == 1 &&
+        !java.nio.ByteOrder.nativeOrder().equals(java.nio.ByteOrder.LITTLE_ENDIAN)) {
+        // Skip test
+      } else {
+        withSQLConf(
+          SQLConf.FLATMAPGROUPSWITHSTATE_STATE_FORMAT_VERSION.key -> stateVersion.toString) {
+          testWithAllRepartitionOperations(s"$testNamePrefix v$stateVersion") { newPartition =>
+              testFun(newPartition)
+            }
+          }
+      }
+    }
+  }
+
+  // Test flatMapGroupsWithState repartitioning
+  testFMGWOnAllPartitionOperation(s"flatMapGroupsWithState") { newPartitions =>
+    testRepartitionWorkflow[(String, Long)](
+      newPartitions = newPartitions,
+      setupInitialState = (inputData, checkpointDir, clockOpt) => {
+        val clock = clockOpt.get
+        val remapped = getFlatMapGroupsWithStateQuery(inputData)
+        testStream(remapped, OutputMode.Update)(
+          StartStream(Trigger.ProcessingTime("1 second"), triggerClock = clock,
+            checkpointLocation = checkpointDir),
+          AddData(inputData, ("hello world", 1L), ("hello scala", 2L)),
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(
+            ("hello", 2, 1000, false), ("world", 1, 0, false), ("scala", 1, 0, false)
+          ),
+          AddData(inputData, ("hello spark", 3L)),
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(("hello", 3, 2000, false), ("spark", 1, 0, false)),
+          StopStream
+        )
+      },
+      verifyResumedQuery = (inputData, checkpointDir, clockOpt) => {
+        val clock = clockOpt.get
+        val resumed = getFlatMapGroupsWithStateQuery(inputData)
+        testStream(resumed, OutputMode.Update)(
+          StartStream(Trigger.ProcessingTime("1 second"), triggerClock = clock,
+            checkpointLocation = checkpointDir),
+          AddData(inputData, ("hello", 10L), ("new", 11L)),
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(
+            ("hello", 4, 9000, false),
+            ("new", 1, 0, false)
+          )
+        )
+      },
+      useManualClock = true
+    )
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StatePartitionAllColumnFamiliesWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StatePartitionAllColumnFamiliesWriterSuite.scala
@@ -22,7 +22,7 @@ import java.time.Duration
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.execution.datasources.v2.state.{StateDataSourceTestBase, StateSourceOptions, StreamStreamJoinTestUtils}
-import org.apache.spark.sql.execution.streaming.operators.stateful.StatefulOperatorsUtils
+import org.apache.spark.sql.execution.streaming.operators.stateful.{StatefulOperatorsUtils, StreamingAggregationStateManager}
 import org.apache.spark.sql.execution.streaming.operators.stateful.transformwithstate.timers.TimerStateUtils
 import org.apache.spark.sql.execution.streaming.runtime.{MemoryStream, StreamingQueryCheckpointMetadata}
 import org.apache.spark.sql.execution.streaming.utils.StreamingUtils
@@ -801,7 +801,7 @@ class StatePartitionAllColumnFamiliesWriterSuite extends StateDataSourceTestBase
       testRoundTripForAggrStateVersion(2)
     }
 
-    Seq(1, 2).foreach { version =>
+    StreamingAggregationStateManager.supportedVersions.foreach { version =>
       testWithChangelogConfig(s"SPARK-54420: composite key aggregation state ver $version") {
         testCompositeKeyRoundTripForStateVersion(version)
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add Repartition Integration Test for Aggregate, Dedup, FMGWS and SessionWindow Operators, as well as a query that contains multiple operators

The tests verifies that 
- state data is correct after rewrite
- resumed query after repartition loads the correct state data
- verify repartition batch has the correct metadata

The dimensions that this test covers
- increase/decrease partition
- enable/disable changelog checkpoint
- enable/disable checkpoint id
- state version for both Aggregate and FMGWS operators

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We need to create integration test to ensure data correctness for repartitioning on a complete set of operators

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
See added tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes