### PR TITLE
[SPARK-55065] Avoid making two JDBC API calls

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -73,6 +73,10 @@ object JDBCRDD extends Logging {
     try {
       getQueryOutputSchema(fullQuery, options, dialect, conn)
     } catch {
+      // By checking isObjectNotFoundException before isSyntaxErrorBestEffort, we can reliably
+      // distinguish between the case where the table does not exist and other SQL syntax errors.
+      // This order is important because when a table does not exist, the exception raised can
+      // also match the criteria for isSyntaxErrorBestEffort.
       case e: SQLException if ident.isDefined &&
         dialect.isObjectNotFoundException(e) =>
         throw QueryCompilationErrors.noSuchTableError(catalogName.get, ident.get)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -51,6 +51,9 @@ object JDBCRDD extends Logging {
    * schema.
    *
    * @param options - JDBC options that contains url, table and other information.
+   * @param conn - JDBC connection to use for fetching the schema.
+   * @param ident - Optional table identifier used for error reporting.
+   * @param catalogName - Optional catalog name used for error reporting.
    *
    * @return A StructType giving the table's Catalyst schema.
    * @throws java.sql.SQLException if the table specification is garbage.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -176,7 +176,7 @@ class JDBCTableCatalog extends TableCatalog
         JDBCRDD.resolveTable(optionsWithTableName, conn, Some(ident), Some(name()))
       }
       JDBCTable(ident, schema, optionsWithTableName,
-        additionalMetrics = Map(JDBCRelation.schemaFetchKey -> remoteSchemaFetchMetric))
+        Map(JDBCRelation.schemaFetchKey -> remoteSchemaFetchMetric))
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -152,7 +152,7 @@ class JDBCTableCatalog extends TableCatalog
     }
   }
 
-  def loadTable(ident: Identifier, conn: Connection): Table = {
+  override def loadTable(ident: Identifier): Table = {
     JdbcUtils.withConnection(options) { conn =>
       val optionsWithTableName = new JDBCOptions(
         options.parameters + (JDBCOptions.JDBC_TABLE_NAME -> getTableName(ident)))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -152,31 +152,27 @@ class JDBCTableCatalog extends TableCatalog
     }
   }
 
-  override def loadTable(ident: Identifier): Table = {
-    JdbcUtils.withConnection(options) { conn =>
-      loadTable(ident, conn)
-    }
-  }
-
   def loadTable(ident: Identifier, conn: Connection): Table = {
-    val optionsWithTableName = new JDBCOptions(
-      options.parameters + (JDBCOptions.JDBC_TABLE_NAME -> getTableName(ident)))
-    JdbcUtils.classifyException(
-      condition = "FAILED_JDBC.LOAD_TABLE",
-      messageParameters = Map(
-        "url" -> options.getRedactUrl(),
-        "tableName" -> toSQLId(ident)),
-      dialect,
-      description = s"Failed to load table: $ident",
-      isRuntime = false
-    ) {
-      val remoteSchemaFetchMetric = JdbcUtils
-        .createSchemaFetchMetric(SparkSession.active.sparkContext)
-      val schema = SQLMetrics.withTimingNs(remoteSchemaFetchMetric) {
-        JDBCRDD.resolveTable(optionsWithTableName, conn, Some(ident), Some(name()))
+    JdbcUtils.withConnection(options) { conn =>
+      val optionsWithTableName = new JDBCOptions(
+        options.parameters + (JDBCOptions.JDBC_TABLE_NAME -> getTableName(ident)))
+      JdbcUtils.classifyException(
+        condition = "FAILED_JDBC.LOAD_TABLE",
+        messageParameters = Map(
+          "url" -> options.getRedactUrl(),
+          "tableName" -> toSQLId(ident)),
+        dialect,
+        description = s"Failed to load table: $ident",
+        isRuntime = false
+      ) {
+        val remoteSchemaFetchMetric = JdbcUtils
+          .createSchemaFetchMetric(SparkSession.active.sparkContext)
+        val schema = SQLMetrics.withTimingNs(remoteSchemaFetchMetric) {
+          JDBCRDD.resolveTable(optionsWithTableName, conn, Some(ident), Some(name()))
+        }
+        JDBCTable(ident, schema, optionsWithTableName,
+          Map(JDBCRelation.schemaFetchKey -> remoteSchemaFetchMetric))
       }
-      JDBCTable(ident, schema, optionsWithTableName,
-        Map(JDBCRelation.schemaFetchKey -> remoteSchemaFetchMetric))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -22,9 +22,6 @@ import java.util.Properties
 import scala.jdk.CollectionConverters._
 
 import org.apache.logging.log4j.Level
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito
-import org.mockito.Mockito._
 
 import org.apache.spark.{SparkConf, SparkIllegalArgumentException, SparkRuntimeException}
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
@@ -791,24 +788,5 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       val plan = sql("select * from t1").queryExecution.sparkPlan
       assert(plan.isInstanceOf[InMemoryTableScanExec])
     }
-  }
-
-  test("loadTable execute single query") {
-    val mockConn = mock(classOf[Connection])
-    val mockStatement = mock(classOf[java.sql.PreparedStatement])
-    val mockResultSet = mock(classOf[java.sql.ResultSet])
-    val mockMetaData = mock(classOf[java.sql.ResultSetMetaData])
-
-    when(mockConn.prepareStatement(any[String])).thenReturn(mockStatement)
-    when(mockStatement.executeQuery()).thenReturn(mockResultSet)
-    when(mockResultSet.getMetaData).thenReturn(mockMetaData)
-    when(mockMetaData.getColumnCount).thenReturn(0)
-
-    val ident = Identifier.of(Array("test"), "people")
-    tableCatalog.loadTable(ident, mockConn)
-
-    val invocations = Mockito.mockingDetails(mockStatement).getInvocations
-    val queryCount = invocations.asScala.count(_.getMethod.getName == "executeQuery")
-    assert(queryCount == 1, s"Expected exactly 1 query, but got $queryCount queries")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Instead of explicitly calling `tableExists` in `JDBCTableCatalog.loadTable(...)`, this change now detects whether a table exists by catching `SQLException` from `getQueryOutputSchema` and checking it with the dialect-specific `isObjectNotFoundException` method.

By checking `isObjectNotFoundException` before `isSyntaxErrorBestEffort`, the code can reliably distinguish between the case where table does not exists and other SQL syntax errors. This order is important because when a table does not exist, the exception raised can also match the criteria for `isSyntaxErrorBestEffort`.

### Why are the changes needed?
This change removes the redundant tableExists call, since we can determine whether a table exists based on the error thrown from `getQueryOutputSchema`.

With this change now only makes one JDBC API call instead of two, improving efficiency by eliminating the need for a separate table existence check.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
It was tested using existing and new tests in `JDBCTableCatalogSuite`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.