### PR TITLE
[SPARK-54866][SQL][FOLLOWUP] Fix DROP FUNCTION IF EXISTS to not fail when namespace doesn't exist

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -1552,7 +1552,13 @@ class SessionCatalog(
     val qualifiedIdent = qualifyIdentifier(name)
     val db = qualifiedIdent.database.get
     val funcName = qualifiedIdent.funcName
-    requireDbExists(db)
+    if (!databaseExists(db)) {
+      if (ignoreIfNotExists) {
+        return
+      } else {
+        throw new NoSuchNamespaceException(Seq(CatalogManager.SESSION_CATALOG_NAME, db))
+      }
+    }
     if (functionExists(qualifiedIdent)) {
       if (functionRegistry.functionExists(qualifiedIdent)) {
         // If we have loaded this function into the FunctionRegistry,

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2FunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2FunctionSuite.scala
@@ -208,6 +208,11 @@ class DataSourceV2FunctionSuite extends DatasourceV2SQLBase {
     )
   }
 
+  test("DROP FUNCTION IF EXISTS in non-existing namespace should not fail") {
+    // This should not throw any exception - the namespace doesn't exist but IF EXISTS is specified
+    sql("DROP FUNCTION IF EXISTS non_existing_db.non_existing_func")
+  }
+
   test("CREATE FUNCTION: only support session catalog") {
     val e = intercept[AnalysisException] {
       sql("CREATE FUNCTION testcat.ns1.ns2.fun as 'f'")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes a regression introduced by SPARK-54866 (PR #53638) where `DROP FUNCTION IF EXISTS` would fail when the namespace doesn't exist.

Previously, when dropping a function in a non-existing namespace with `IF EXISTS`, the `UnresolvedFunctionName` would remain unchanged because `CatalogV2Util.loadFunction` returns None. Later, the drop function command was converted to `NoopCommand`, which gracefully handles the case.

After PR #53638, the drop function command directly calls `SessionCatalog.dropFunction`, which calls `requireDbExists` and throws an exception when the namespace doesn't exist, even with `IF EXISTS` specified.

### Why are the changes needed?

To fix a regression where `DROP FUNCTION IF EXISTS` fails on non-existing namespace instead of gracefully doing nothing.

### Does this PR introduce _any_ user-facing change?

Yes, it fixes a regression. `DROP FUNCTION IF EXISTS db.func` no longer throws an error when `db` doesn't exist.

### How was this patch tested?

Added a new test in `DataSourceV2FunctionSuite`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: cursor 2.3.35