### PR TITLE
[SPARK-55073][SQL][PYTHON] Don't capture SparkPlan in EvalPythonUDTFExec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonUDTFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonUDTFExec.scala
@@ -56,7 +56,7 @@ trait EvalPythonUDTFExec extends UnaryExecNode {
 
     // flatten all the arguments
     // Do this outside `mapPartitions()` so we don't serialize and send all of
-    // `this` to the executor. 
+    // `this` to the executor.
     val allInputs = new ArrayBuffer[Expression]
     val dataTypes = new ArrayBuffer[DataType]
     val argMetas = udtf.children.zip(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonUDTFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonUDTFExec.scala
@@ -55,6 +55,8 @@ trait EvalPythonUDTFExec extends UnaryExecNode {
     val inputRDD = child.execute().map(_.copy())
 
     // flatten all the arguments
+    // Do this outside `mapPartitions()` so we don't serialize and send all of
+    // `this` to the executor. 
     val allInputs = new ArrayBuffer[Expression]
     val dataTypes = new ArrayBuffer[DataType]
     val argMetas = udtf.children.zip(


### PR DESCRIPTION
### What changes were proposed in this pull request?
`EvalPythonUDTFExec.execute()` can capture SparkPlan and send it to executors, which can be arbitrarily large.

Move code outside of the task lambda so that it doesn't capture SparkPlan.

### Why are the changes needed?
To reduce overhead of sending tasks to executors and avoid possible OOM on executors.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Rely on existing tests to verify functionality. I did not add new tests because there is no functional difference, just resource overhead.

### Was this patch authored or co-authored using generative AI tooling?
No
