### PR TITLE
[SPARK-55075][K8S] Track executor pod creation errors with ExecutorFailureTracker

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/AbstractPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/AbstractPodsAllocator.scala
@@ -36,6 +36,20 @@ import org.apache.spark.resource.ResourceProfile
 @DeveloperApi
 abstract class AbstractPodsAllocator {
   /*
+   * Optional lifecycle manager for tracking executor pod lifecycle events.
+   * Set via setExecutorPodsLifecycleManager for backward compatibility.
+   */
+  protected var executorPodsLifecycleManager: ExecutorPodsLifecycleManager = _
+
+  /*
+   * Set the lifecycle manager for tracking executor pod lifecycle events.
+   * This method is optional and may not exist in custom implementations based on older versions.
+   */
+  def setExecutorPodsLifecycleManager(manager: ExecutorPodsLifecycleManager): Unit = {
+    executorPodsLifecycleManager = manager
+  }
+
+  /*
    * Set the total expected executors for an application
    */
   def setTotalExpectedExecutors(resourceProfileToTotalExecs: Map[ResourceProfile, Int]): Unit

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/AbstractPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/AbstractPodsAllocator.scala
@@ -39,14 +39,14 @@ abstract class AbstractPodsAllocator {
    * Optional lifecycle manager for tracking executor pod lifecycle events.
    * Set via setExecutorPodsLifecycleManager for backward compatibility.
    */
-  protected var executorPodsLifecycleManager: ExecutorPodsLifecycleManager = _
+  protected var executorPodsLifecycleManager: Option[ExecutorPodsLifecycleManager] = None
 
   /*
    * Set the lifecycle manager for tracking executor pod lifecycle events.
    * This method is optional and may not exist in custom implementations based on older versions.
    */
   def setExecutorPodsLifecycleManager(manager: ExecutorPodsLifecycleManager): Unit = {
-    executorPodsLifecycleManager = manager
+    executorPodsLifecycleManager = Some(manager)
   }
 
   /*

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsLifecycleManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsLifecycleManager.scala
@@ -78,10 +78,10 @@ private[spark] class ExecutorPodsLifecycleManager(
   protected[spark] def getNumExecutorsFailed: Int = failureTracker.numFailedExecutors
 
   /**
-   * Register a pod creation failure. This increments the global executor failure count
+   * Register an executor failure. This increments the global executor failure count
    * which is checked against spark.executor.maxNumFailures.
    */
-  protected[spark] def registerPodCreationFailure(): Unit = {
+  protected[spark] def registerExecutorFailure(): Unit = {
     failureTracker.registerExecutorFailure()
   }
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsLifecycleManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsLifecycleManager.scala
@@ -77,6 +77,14 @@ private[spark] class ExecutorPodsLifecycleManager(
 
   protected[spark] def getNumExecutorsFailed: Int = failureTracker.numFailedExecutors
 
+  /**
+   * Register a pod creation failure. This increments the global executor failure count
+   * which is checked against spark.executor.maxNumFailures.
+   */
+  protected[spark] def registerPodCreationFailure(): Unit = {
+    failureTracker.registerExecutorFailure()
+  }
+
   def start(schedulerBackend: KubernetesClusterSchedulerBackend): Unit = {
     val eventProcessingInterval = conf.get(KUBERNETES_EXECUTOR_EVENT_PROCESSING_INTERVAL)
     snapshotsStore.addSubscriber(eventProcessingInterval) { executorPodsSnapshot =>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -194,21 +194,11 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
       new KubernetesExecutorBuilder(),
       kubernetesClient,
       snapshotsStore,
-      new SystemClock())
+      new SystemClock()).asInstanceOf[AbstractPodsAllocator]
 
-    // Try to set the lifecycle manager using reflection for backward compatibility
-    // with custom allocators that may not have this method
+    // Set the lifecycle manager if provided
     lifecycleManager.foreach { manager =>
-      try {
-        val setLifecycleManagerMethod = cls.getMethod(
-          "setExecutorPodsLifecycleManager",
-          classOf[ExecutorPodsLifecycleManager])
-        setLifecycleManagerMethod.invoke(allocatorInstance, manager)
-      } catch {
-        case _: NoSuchMethodException =>
-          logInfo("Allocator does not support setExecutorPodsLifecycleManager method. " +
-            "Pod creation failures will not be tracked.")
-      }
+      allocatorInstance.setExecutorPodsLifecycleManager(manager)
     }
 
     allocatorInstance

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
@@ -1024,9 +1024,9 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     assert(podsAllocatorUnderTest.invokePrivate(counter).get() === 0)
 
     when(pvcResource.create()).thenThrow(new KubernetesClientException("PVC fails to create"))
-    intercept[KubernetesClientException] {
-      podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 1))
-    }
+//    intercept[KubernetesClientException] {
+//      podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 1))
+//    }
     assert(podsAllocatorUnderTest.invokePrivate(counter).get() === 0)
     assert(podsAllocatorUnderTest.invokePrivate(numOutstandingPods).get() == 0)
   }
@@ -1075,7 +1075,7 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     verify(podResource, times(3)).create()
 
     // Verify that registerPodCreationFailure was called 3 times (once per failed executor)
-    verify(lifecycleManager, times(3)).registerPodCreationFailure()
+    verify(lifecycleManager, times(3)).registerExecutorFailure()
 
     // Verify no pods were created since all attempts failed
     assert(podsAllocatorUnderTest.invokePrivate(numOutstandingPods).get() == 0)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
@@ -1024,9 +1024,9 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     assert(podsAllocatorUnderTest.invokePrivate(counter).get() === 0)
 
     when(pvcResource.create()).thenThrow(new KubernetesClientException("PVC fails to create"))
-//    intercept[KubernetesClientException] {
-//      podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 1))
-//    }
+    intercept[KubernetesClientException] {
+      podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 1))
+    }
     assert(podsAllocatorUnderTest.invokePrivate(counter).get() === 0)
     assert(podsAllocatorUnderTest.invokePrivate(numOutstandingPods).get() == 0)
   }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
@@ -1063,7 +1063,7 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
         k8sConf.resourceProfileId.toInt), Seq.empty)
   }
 
-test("Pod creation failures are tracked by ExecutorFailureTracker") {
+  test("SPARK-55075: Pod creation failures are tracked by ExecutorFailureTracker") {
     // Make all pod creation attempts fail
     when(podResource.create()).thenThrow(new KubernetesClientException("Simulated pod" +
       " creation failure"))

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
@@ -112,6 +112,9 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
   @Mock
   private var schedulerBackend: KubernetesClusterSchedulerBackend = _
 
+  @Mock
+  private var lifecycleManager: ExecutorPodsLifecycleManager = _
+
   private var snapshotsStore: DeterministicExecutorPodsSnapshotsStore = _
 
   private var podsAllocatorUnderTest: ExecutorPodsAllocator = _
@@ -142,6 +145,7 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     waitForExecutorPodsClock = new ManualClock(0L)
     podsAllocatorUnderTest = new ExecutorPodsAllocator(
       conf, secMgr, executorBuilder, kubernetesClient, snapshotsStore, waitForExecutorPodsClock)
+    podsAllocatorUnderTest.setExecutorPodsLifecycleManager(lifecycleManager)
     when(schedulerBackend.getExecutorIds()).thenReturn(Seq.empty)
     podsAllocatorUnderTest.start(TEST_SPARK_APP_ID, schedulerBackend)
     when(kubernetesClient.persistentVolumeClaims()).thenReturn(persistentVolumeClaims)
@@ -202,6 +206,7 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     val confWithLowMaxPendingPods = conf.clone.set(KUBERNETES_MAX_PENDING_PODS.key, "3")
     podsAllocatorUnderTest = new ExecutorPodsAllocator(confWithLowMaxPendingPods, secMgr,
       executorBuilder, kubernetesClient, snapshotsStore, waitForExecutorPodsClock)
+    podsAllocatorUnderTest.setExecutorPodsLifecycleManager(lifecycleManager)
     podsAllocatorUnderTest.start(TEST_SPARK_APP_ID, schedulerBackend)
 
     podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 2, rp -> 3))
@@ -268,6 +273,7 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
       .set(KUBERNETES_MAX_PENDING_PODS_PER_RPID.key, "2")
     podsAllocatorUnderTest = new ExecutorPodsAllocator(confWithLowMaxPendingPodsPerRpId, secMgr,
       executorBuilder, kubernetesClient, snapshotsStore, waitForExecutorPodsClock)
+    podsAllocatorUnderTest.setExecutorPodsLifecycleManager(lifecycleManager)
     podsAllocatorUnderTest.start(TEST_SPARK_APP_ID, schedulerBackend)
 
     // Request more than the max per rp for one rp
@@ -321,6 +327,7 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     val confWithAllocationMaximum = conf.clone.set(KUBERNETES_ALLOCATION_MAXIMUM.key, "1")
     podsAllocatorUnderTest = new ExecutorPodsAllocator(confWithAllocationMaximum, secMgr,
       executorBuilder, kubernetesClient, snapshotsStore, waitForExecutorPodsClock)
+    podsAllocatorUnderTest.setExecutorPodsLifecycleManager(lifecycleManager)
     podsAllocatorUnderTest.start(TEST_SPARK_APP_ID, schedulerBackend)
 
     val counter = PrivateMethod[AtomicInteger](Symbol("EXECUTOR_ID_COUNTER"))()
@@ -838,6 +845,7 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     podsAllocatorUnderTest = new ExecutorPodsAllocator(
       confWithPVC, secMgr, executorBuilder,
       kubernetesClient, snapshotsStore, waitForExecutorPodsClock)
+    podsAllocatorUnderTest.setExecutorPodsLifecycleManager(lifecycleManager)
     podsAllocatorUnderTest.start(TEST_SPARK_APP_ID, schedulerBackend)
 
     when(podsWithNamespace
@@ -936,6 +944,7 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     podsAllocatorUnderTest = new ExecutorPodsAllocator(
       confWithPVC, secMgr, executorBuilder,
       kubernetesClient, snapshotsStore, waitForExecutorPodsClock)
+    podsAllocatorUnderTest.setExecutorPodsLifecycleManager(lifecycleManager)
     podsAllocatorUnderTest.start(TEST_SPARK_APP_ID, schedulerBackend)
 
     when(podsWithNamespace
@@ -1005,6 +1014,7 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     podsAllocatorUnderTest = new ExecutorPodsAllocator(
       confWithPVC, secMgr, executorBuilder,
       kubernetesClient, snapshotsStore, waitForExecutorPodsClock)
+    podsAllocatorUnderTest.setExecutorPodsLifecycleManager(lifecycleManager)
     podsAllocatorUnderTest.start(TEST_SPARK_APP_ID, schedulerBackend)
 
     val startTime = Instant.now.toEpochMilli
@@ -1051,5 +1061,23 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
       val k8sConf: KubernetesExecutorConf = invocation.getArgument(0)
       KubernetesExecutorSpec(executorPodWithId(k8sConf.executorId.toInt,
         k8sConf.resourceProfileId.toInt), Seq.empty)
+  }
+
+test("Pod creation failures are tracked by ExecutorFailureTracker") {
+    // Make all pod creation attempts fail
+    when(podResource.create()).thenThrow(new KubernetesClientException("Simulated pod" +
+      " creation failure"))
+
+    // Request 3 executors
+    podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 3))
+
+    // Verify that pod creation was attempted 3 times (once per executor, no retries)
+    verify(podResource, times(3)).create()
+
+    // Verify that registerPodCreationFailure was called 3 times (once per failed executor)
+    verify(lifecycleManager, times(3)).registerPodCreationFailure()
+
+    // Verify no pods were created since all attempts failed
+    assert(podsAllocatorUnderTest.invokePrivate(numOutstandingPods).get() == 0)
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManagerSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManagerSuite.scala
@@ -65,7 +65,7 @@ class KubernetesClusterManagerSuite extends SparkFunSuite with BeforeAndAfter {
     validConfigs.foreach { c =>
       val manager = new KubernetesClusterManager()
       sparkConf.set(KUBERNETES_ALLOCATION_PODS_ALLOCATOR, c)
-      manager.makeExecutorPodsAllocator(sc, kubernetesClient, null, null)
+      manager.makeExecutorPodsAllocator(sc, kubernetesClient, null)
       sparkConf.remove(KUBERNETES_ALLOCATION_PODS_ALLOCATOR)
     }
   }
@@ -96,7 +96,7 @@ class KubernetesClusterManagerSuite extends SparkFunSuite with BeforeAndAfter {
     sparkConf.set("spark.shuffle.service.enabled", "true")
 
     val e = intercept[SparkException] {
-      manager.makeExecutorPodsAllocator(sc, kubernetesClient, null, null)
+      manager.makeExecutorPodsAllocator(sc, kubernetesClient, null)
     }
     assert(e.getMessage.contains(KUBERNETES_EXECUTOR_POD_DELETION_COST.key))
   }
@@ -108,7 +108,7 @@ class KubernetesClusterManagerSuite extends SparkFunSuite with BeforeAndAfter {
     sparkConf.set(KUBERNETES_EXECUTOR_POD_DELETION_COST, 1)
     sparkConf.set("spark.shuffle.service.enabled", "true")
 
-    manager.makeExecutorPodsAllocator(sc, kubernetesClient, null, null)
+    manager.makeExecutorPodsAllocator(sc, kubernetesClient, null)
   }
 
   private def resetDynamicAllocatorConfig(): Unit = {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManagerSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManagerSuite.scala
@@ -65,7 +65,7 @@ class KubernetesClusterManagerSuite extends SparkFunSuite with BeforeAndAfter {
     validConfigs.foreach { c =>
       val manager = new KubernetesClusterManager()
       sparkConf.set(KUBERNETES_ALLOCATION_PODS_ALLOCATOR, c)
-      manager.makeExecutorPodsAllocator(sc, kubernetesClient, null)
+      manager.makeExecutorPodsAllocator(sc, kubernetesClient, null, null)
       sparkConf.remove(KUBERNETES_ALLOCATION_PODS_ALLOCATOR)
     }
   }
@@ -96,7 +96,7 @@ class KubernetesClusterManagerSuite extends SparkFunSuite with BeforeAndAfter {
     sparkConf.set("spark.shuffle.service.enabled", "true")
 
     val e = intercept[SparkException] {
-      manager.makeExecutorPodsAllocator(sc, kubernetesClient, null)
+      manager.makeExecutorPodsAllocator(sc, kubernetesClient, null, null)
     }
     assert(e.getMessage.contains(KUBERNETES_EXECUTOR_POD_DELETION_COST.key))
   }
@@ -108,7 +108,7 @@ class KubernetesClusterManagerSuite extends SparkFunSuite with BeforeAndAfter {
     sparkConf.set(KUBERNETES_EXECUTOR_POD_DELETION_COST, 1)
     sparkConf.set("spark.shuffle.service.enabled", "true")
 
-    manager.makeExecutorPodsAllocator(sc, kubernetesClient, null)
+    manager.makeExecutorPodsAllocator(sc, kubernetesClient, null, null)
   }
 
   private def resetDynamicAllocatorConfig(): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adds tracking of executor pod creation with the ExecutorFailureTracker.

### Why are the changes needed?
If there are unrecoverable pod creation errors then Spark continues to try and create pods instead of failing. An example is where a note book server is constrained to have a maximum number of pods and the user tries to start a notebook with twice the number of executors as the limit. In this case the user gets and 'Unauthorized' message in the logs but Spark will keep on trying to spin up new pods. By tracking pod creation failures we can stop trying after reaching max executor failures.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
New unit tests added

### Was this patch authored or co-authored using generative AI tooling?
Unit tests generated using Claude Code.