### PR TITLE
[MINOR][DOCS][SS][PYTHON] Fix streaming query listener documentation and update return type docstrings

### DIFF
--- a/docs/streaming/apis-on-dataframes-and-datasets.md
+++ b/docs/streaming/apis-on-dataframes-and-datasets.md
@@ -3116,17 +3116,17 @@ There are multiple ways to monitor active streaming queries. You can either push
 You can directly get the current status and metrics of an active query using
 `streamingQuery.lastProgress()` and `streamingQuery.status()`.
 `lastProgress()` returns a `StreamingQueryProgress` object
-in [Scala](/api/scala/org/apache/spark/sql/streaming/StreamingQueryProgress.html)
-and [Java](/api/java/org/apache/spark/sql/streaming/StreamingQueryProgress.html)
-and a dictionary with the same fields in Python. It has all the information about
+in [Scala](/docs/latest/api/scala/org/apache/spark/sql/streaming/StreamingQueryProgress.html),
+[Java](/docs/latest/api/java/org/apache/spark/sql/streaming/StreamingQueryProgress.html)
+and [Python](/docs/latest/api/python/reference/pyspark.ss/api/pyspark.sql.streaming.StreamingQuery.lastProgress.html). It has all the information about
 the progress made in the last trigger of the stream - what data was processed,
 what were the processing rates, latencies, etc. There is also
 `streamingQuery.recentProgress` which returns an array of last few progresses.
 
 In addition, `streamingQuery.status()` returns a `StreamingQueryStatus` object
-in [Scala](/api/scala/org/apache/spark/sql/streaming/StreamingQueryStatus.html)
-and [Java](/api/java/org/apache/spark/sql/streaming/StreamingQueryStatus.html)
-and a dictionary with the same fields in Python. It gives information about
+in [Scala](/docs/latest/api/scala/org/apache/spark/sql/streaming/StreamingQueryStatus.html),
+[Java](/docs/latest/api/java/org/apache/spark/sql/streaming/StreamingQueryStatus.html)
+and [Python](/docs/latest/api/python/reference/pyspark.ss/api/pyspark.sql.streaming.StreamingQuery.status.html). It gives information about
 what the query is immediately doing - is a trigger active, is data being processed, etc.
 
 Here are a few examples.

--- a/python/pyspark/sql/streaming/query.py
+++ b/python/pyspark/sql/streaming/query.py
@@ -265,10 +265,13 @@ class StreamingQuery:
         .. versionchanged:: 3.5.0
             Supports Spark Connect.
 
+        .. versionchanged:: 4.0.0
+            Returns a :class:`StreamingQueryStatus` instead of a dict.
+
         Returns
         -------
         list
-            List of dict which is the most recent :class:`StreamingQueryProgress` updates
+            List of :class:`StreamingQueryProgress` which is the most recent :class:`StreamingQueryProgress` updates
             for this query.
 
         Examples
@@ -299,9 +302,12 @@ class StreamingQuery:
         .. versionchanged:: 3.5.0
             Supports Spark Connect.
 
+        .. versionchanged:: 4.0.0
+            Returns a list of :class:`StreamingQueryProgress` instead of a dict.
+
         Returns
         -------
-        dict, optional
+        :class:`StreamingQueryProgress`, optional
             The most recent :class:`StreamingQueryProgress` update of this streaming query or
             None if there were no progress updates.
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR makes two related documentation improvements for Structured Streaming query monitoring APIs:

1. Fixed [broken API documentation links](https://spark.apache.org/docs/latest/streaming/apis-on-dataframes-and-datasets.html#reading-metrics-interactively) in docs/streaming/apis-on-dataframes-and-datasets.md:
2. Updated PySpark docstrings in python/pyspark/sql/streaming/query.py that was initially changed in [this PR](https://github.com/apache/spark/pull/47470).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  3. If you fix a bug, you can clarify why it is a bug.
-->

- The existing documentation links were broken and did not resolve correctly to the API documentation pages
- Python was incorrectly documented as returning dictionaries when the return types changed to proper typed objects (StreamingQueryProgress and StreamingQueryStatus) in Spark 4.0.0

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No. This is a documentation-only change.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Documentation

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
