### PR TITLE
[SPARK-55058][SS] Throw error on inconsistent checkpoint metadata

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5942,6 +5942,12 @@
     ],
     "sqlState" : "42601"
   },
+  "STREAMING_CHECKPOINT_MISSING_METADATA_FILE" : {
+    "message" : [
+      "Checkpoint location <checkpointLocation> is in an inconsistent state: the metadata file is missing but offset and/or commit logs contain data. Please restore the metadata file or create a new checkpoint directory."
+    ],
+    "sqlState" : "42K03"
+  },
   "STREAMING_OUTPUT_MODE" : {
     "message" : [
       "Invalid streaming output mode: <outputMode>."
@@ -6055,12 +6061,6 @@
       "Stateful operators in current batch: [<OpsInCurBatchSeq>].",
       "This typically occurs when state files have been deleted or the streaming query was previously run without stateful operators but restarted with stateful operators.",
       "Please remove the stateful operators, use a new checkpoint location, or restore the missing state files."
-    ],
-    "sqlState" : "42K03"
-  },
-  "MISSING_METADATA_FILE" : {
-    "message" : [
-      "Checkpoint location <checkpointLocation> is in an inconsistent state: the metadata file is missing but offset and/or commit logs contain data. Please restore the metadata file or create a new checkpoint directory."
     ],
     "sqlState" : "42K03"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -6058,6 +6058,12 @@
     ],
     "sqlState" : "42K03"
   },
+  "STREAMING_CHECKPOINT_METADATA_MISSING" : {
+    "message" : [
+      "Checkpoint location <checkpointLocation> is in an inconsistent state: the metadata file is missing but offset and/or commit logs contain data. Please restore the metadata file or create a new checkpoint directory."
+    ],
+    "sqlState" : "42K03"
+  },
   "STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA" : {
     "message" : [
       "Streaming stateful operator name does not match with the operator in state metadata. This likely to happen when user adds/removes/changes stateful operator of existing streaming query.",

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -6058,7 +6058,7 @@
     ],
     "sqlState" : "42K03"
   },
-  "STREAMING_CHECKPOINT_METADATA_MISSING" : {
+  "MISSING_METADATA_FILE" : {
     "message" : [
       "Checkpoint location <checkpointLocation> is in an inconsistent state: the metadata file is missing but offset and/or commit logs contain data. Please restore the metadata file or create a new checkpoint directory."
     ],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2953,6 +2953,19 @@ object SQLConf {
         "repartitioning to be complete before restarting the query.")
       .version("4.2.0")
       .booleanConf
+      .createWithDefault(false)
+
+  val STREAMING_CHECKPOINT_VERIFY_METADATA_EXISTS =
+    buildConf("spark.sql.streaming.checkpoint.verifyMetadataExists.enabled")
+      .internal()
+      .doc("When true, validates that the checkpoint metadata file exists when offset " +
+        "or commit logs contain data. This prevents generating a new query ID when " +
+        "checkpoint data already exists, which would cause data duplication in " +
+        "exactly-once sinks like DeltaSink.")
+      .version("4.2.0")
+      .owner("streaming-engine")
+      .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .booleanConf
       .createWithDefault(true)
 
   val STATE_STORE_COMPRESSION_CODEC =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2961,7 +2961,7 @@ object SQLConf {
       .doc("When true, validates that the checkpoint metadata file exists when offset " +
         "or commit logs contain data. This prevents generating a new query ID when " +
         "checkpoint data already exists, which would cause data duplication in " +
-        "exactly-once sinks like DeltaSink.")
+        "exactly-once sinks.")
       .version("4.2.0")
       .booleanConf
       .createWithDefault(true)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2963,8 +2963,6 @@ object SQLConf {
         "checkpoint data already exists, which would cause data duplication in " +
         "exactly-once sinks like DeltaSink.")
       .version("4.2.0")
-      .owner("streaming-engine")
-      .withBindingPolicy(ConfigBindingPolicy.SESSION)
       .booleanConf
       .createWithDefault(true)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2953,7 +2953,7 @@ object SQLConf {
         "repartitioning to be complete before restarting the query.")
       .version("4.2.0")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val STREAMING_CHECKPOINT_VERIFY_METADATA_EXISTS =
     buildConf("spark.sql.streaming.checkpoint.verifyMetadataExists.enabled")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingErrors.scala
@@ -52,4 +52,11 @@ object StreamingErrors {
       )
     )
   }
+
+  def missingMetadataFile(checkpointLocation: String): Throwable = {
+    new SparkRuntimeException(
+      errorClass = "STREAMING_CHECKPOINT_METADATA_MISSING",
+      messageParameters = Map("checkpointLocation" -> checkpointLocation)
+    )
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingErrors.scala
@@ -55,7 +55,7 @@ object StreamingErrors {
 
   def missingMetadataFile(checkpointLocation: String): Throwable = {
     new SparkRuntimeException(
-      errorClass = "STREAMING_CHECKPOINT_METADATA_MISSING",
+      errorClass = "MISSING_METADATA_FILE",
       messageParameters = Map("checkpointLocation" -> checkpointLocation)
     )
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingErrors.scala
@@ -55,7 +55,7 @@ object StreamingErrors {
 
   def missingMetadataFile(checkpointLocation: String): Throwable = {
     new SparkRuntimeException(
-      errorClass = "MISSING_METADATA_FILE",
+      errorClass = "STREAMING_CHECKPOINT_MISSING_METADATA_FILE",
       messageParameters = Map("checkpointLocation" -> checkpointLocation)
     )
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamingQueryCheckpointMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamingQueryCheckpointMetadata.scala
@@ -21,8 +21,8 @@ import java.util.UUID
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.execution.streaming.checkpointing.{CommitLog, OffsetSeqLog}
 import org.apache.spark.sql.execution.streaming.StreamingErrors
+import org.apache.spark.sql.execution.streaming.checkpointing.{CommitLog, OffsetSeqLog}
 import org.apache.spark.sql.internal.SQLConf
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamingQueryCheckpointMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamingQueryCheckpointMetadata.scala
@@ -22,6 +22,8 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.streaming.checkpointing.{CommitLog, OffsetSeqLog}
+import org.apache.spark.sql.execution.streaming.StreamingErrors
+import org.apache.spark.sql.internal.SQLConf
 
 /**
  * An interface for accessing the checkpoint metadata associated with a streaming query.
@@ -52,6 +54,18 @@ class StreamingQueryCheckpointMetadata(sparkSession: SparkSession, resolvedCheck
     val metadataPath = new Path(checkpointFile(StreamingCheckpointConstants.DIR_NAME_METADATA))
     val hadoopConf = sparkSession.sessionState.newHadoopConf()
     StreamMetadata.read(metadataPath, hadoopConf).getOrElse {
+      // Before creating a new metadata file with a new query ID, validate that the checkpoint
+      // is not in an inconsistent state where the metadata file is missing but offset/commit
+      // logs have data. This prevents data duplication when using exactly-once sinks
+      // (e.g. DeltaSink) which rely on the query ID for deduplication.
+      if (sparkSession.conf.get(SQLConf.STREAMING_CHECKPOINT_VERIFY_METADATA_EXISTS)) {
+        val hasOffsetData = offsetLog.getLatestBatchId().isDefined
+        val hasCommitData = commitLog.getLatestBatchId().isDefined
+        if (hasOffsetData || hasCommitData) {
+          throw StreamingErrors
+            .missingMetadataFile(resolvedCheckpointRoot)
+        }
+      }
       val newMetadata = new StreamMetadata(UUID.randomUUID.toString)
       StreamMetadata.write(newMetadata, metadataPath, hadoopConf)
       newMetadata

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamingQueryCheckpointMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamingQueryCheckpointMetadata.scala
@@ -57,7 +57,7 @@ class StreamingQueryCheckpointMetadata(sparkSession: SparkSession, resolvedCheck
       // Before creating a new metadata file with a new query ID, validate that the checkpoint
       // is not in an inconsistent state where the metadata file is missing but offset/commit
       // logs have data. This prevents data duplication when using exactly-once sinks
-      // (e.g. DeltaSink) which rely on the query ID for deduplication.
+      // which rely on the query ID for deduplication.
       if (sparkSession.conf.get(SQLConf.STREAMING_CHECKPOINT_VERIFY_METADATA_EXISTS)) {
         val hasOffsetData = offsetLog.getLatestBatchId().isDefined
         val hasCommitData = commitLog.getLatestBatchId().isDefined

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/StreamingQueryCheckpointMetadataSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/StreamingQueryCheckpointMetadataSuite.scala
@@ -22,13 +22,14 @@ import java.util.UUID
 
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.SparkException
+import org.apache.spark.SparkRuntimeException
 import org.apache.spark.sql.execution.streaming.checkpointing.{CommitLog, CommitMetadata, OffsetSeq, OffsetSeqLog}
 import org.apache.spark.sql.execution.streaming.runtime.{MemoryStream, StreamingQueryCheckpointMetadata}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.streaming.StreamTest
+import org.apache.spark.sql.streaming.{OutputMode, StreamTest}
 
 class StreamingQueryCheckpointMetadataSuite extends StreamTest {
+  import testImplicits._
 
   test("valid case: new checkpoint with no metadata and no logs") {
     withTempDir { dir =>
@@ -84,12 +85,12 @@ class StreamingQueryCheckpointMetadataSuite extends StreamTest {
 
       // Try to create a new checkpoint metadata - should throw error
       val checkpointMetadata2 = new StreamingQueryCheckpointMetadata(spark, checkpointRoot)
-      val exception = intercept[SparkException] {
+      val exception = intercept[SparkRuntimeException] {
         checkpointMetadata2.streamMetadata
       }
       checkError(
         exception = exception,
-        condition = "STREAMING_CHECKPOINT_METADATA_ERROR.MISSING_METADATA_FILE",
+        condition = "MISSING_METADATA_FILE",
         parameters = Map("checkpointLocation" -> checkpointRoot)
       )
     }
@@ -114,12 +115,12 @@ class StreamingQueryCheckpointMetadataSuite extends StreamTest {
 
       // Try to create a new checkpoint metadata - should throw error
       val checkpointMetadata2 = new StreamingQueryCheckpointMetadata(spark, checkpointRoot)
-      val exception = intercept[SparkException] {
+      val exception = intercept[SparkRuntimeException] {
         checkpointMetadata2.streamMetadata
       }
       checkError(
         exception = exception,
-        condition = "STREAMING_CHECKPOINT_METADATA_ERROR.MISSING_METADATA_FILE",
+        condition = "MISSING_METADATA_FILE",
         parameters = Map("checkpointLocation" -> checkpointRoot)
       )
     }
@@ -148,12 +149,12 @@ class StreamingQueryCheckpointMetadataSuite extends StreamTest {
 
       // Try to create a new checkpoint metadata - should throw error
       val checkpointMetadata2 = new StreamingQueryCheckpointMetadata(spark, checkpointRoot)
-      val exception = intercept[SparkException] {
+      val exception = intercept[SparkRuntimeException] {
         checkpointMetadata2.streamMetadata
       }
       checkError(
         exception = exception,
-        condition = "STREAMING_CHECKPOINT_METADATA_ERROR.MISSING_METADATA_FILE",
+        condition = "MISSING_METADATA_FILE",
         parameters = Map("checkpointLocation" -> checkpointRoot)
       )
     }
@@ -199,12 +200,12 @@ class StreamingQueryCheckpointMetadataSuite extends StreamTest {
 
       // Should throw error because validation is enabled
       val checkpointMetadata2 = new StreamingQueryCheckpointMetadata(spark, checkpointRoot)
-      val exception = intercept[SparkException] {
+      val exception = intercept[SparkRuntimeException] {
         checkpointMetadata2.streamMetadata
       }
       checkError(
         exception = exception,
-        condition = "STREAMING_CHECKPOINT_METADATA_ERROR.MISSING_METADATA_FILE",
+        condition = "MISSING_METADATA_FILE",
         parameters = Map("checkpointLocation" -> checkpointRoot)
       )
     }
@@ -271,7 +272,7 @@ class StreamingQueryCheckpointMetadataSuite extends StreamTest {
           assert(!fs.exists(metadataPath), "Metadata file should be deleted")
 
           // Attempt to restart the query - should fail with validation error
-          val exception = intercept[SparkException] {
+          val exception = intercept[SparkRuntimeException] {
             inputData.toDF()
               .writeStream
               .format("parquet")
@@ -284,7 +285,7 @@ class StreamingQueryCheckpointMetadataSuite extends StreamTest {
           val qualifiedPath = fs.makeQualified(new Path(checkpointDir.getAbsolutePath))
           checkError(
             exception = exception,
-            condition = "STREAMING_CHECKPOINT_METADATA_ERROR.MISSING_METADATA_FILE",
+            condition = "MISSING_METADATA_FILE",
             parameters = Map("checkpointLocation" -> qualifiedPath.toString)
           )
         } finally {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/StreamingQueryCheckpointMetadataSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/StreamingQueryCheckpointMetadataSuite.scala
@@ -24,12 +24,11 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.execution.streaming.checkpointing.{CommitLog, CommitMetadata, OffsetSeq, OffsetSeqLog}
-import org.apache.spark.sql.execution.streaming.runtime.{AlsoTestWithPipelinedExecution, StreamingQueryCheckpointMetadata}
+import org.apache.spark.sql.execution.streaming.runtime.{MemoryStream, StreamingQueryCheckpointMetadata}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.streaming.{OutputMode, StreamTest}
+import org.apache.spark.sql.streaming.StreamTest
 
-class StreamingQueryCheckpointMetadataSuite extends StreamTest
-  with AlsoTestWithPipelinedExecution {
+class StreamingQueryCheckpointMetadataSuite extends StreamTest {
 
   test("valid case: new checkpoint with no metadata and no logs") {
     withTempDir { dir =>
@@ -240,8 +239,6 @@ class StreamingQueryCheckpointMetadataSuite extends StreamTest
   }
 
   test("e2e: streaming query fails to restart when checkpoint metadata is corrupted") {
-    import testImplicits._
-
     withTempDir { checkpointDir =>
       withTempDir { outputDir =>
         val inputData = MemoryStream[Int]
@@ -300,8 +297,6 @@ class StreamingQueryCheckpointMetadataSuite extends StreamTest
   }
 
   test("e2e: streaming query restarts successfully when flag is disabled") {
-    import testImplicits._
-
     withSQLConf(SQLConf.STREAMING_CHECKPOINT_VERIFY_METADATA_EXISTS.key -> "false") {
       withTempDir { checkpointDir =>
         withTempDir { outputDir =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/StreamingQueryCheckpointMetadataSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/StreamingQueryCheckpointMetadataSuite.scala
@@ -1,0 +1,352 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming
+
+import java.io.File
+import java.util.UUID
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.execution.streaming.checkpointing.{CommitLog, CommitMetadata, OffsetSeq, OffsetSeqLog}
+import org.apache.spark.sql.execution.streaming.runtime.{AlsoTestWithPipelinedExecution, StreamingQueryCheckpointMetadata}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.streaming.{OutputMode, StreamTest}
+
+class StreamingQueryCheckpointMetadataSuite extends StreamTest
+  with AlsoTestWithPipelinedExecution {
+
+  test("valid case: new checkpoint with no metadata and no logs") {
+    withTempDir { dir =>
+      val checkpointRoot = dir.getAbsolutePath
+      val checkpointMetadata = new StreamingQueryCheckpointMetadata(spark, checkpointRoot)
+
+      // Accessing streamMetadata should succeed and create a new UUID
+      val metadata = checkpointMetadata.streamMetadata
+      assert(metadata != null)
+      assert(metadata.id != null)
+      assert(UUID.fromString(metadata.id) != null) // Should be a valid UUID
+    }
+  }
+
+  test("valid case: existing checkpoint with metadata and logs") {
+    withTempDir { dir =>
+      val checkpointRoot = dir.getAbsolutePath
+
+      // Create metadata file first
+      val checkpointMetadata1 = new StreamingQueryCheckpointMetadata(spark, checkpointRoot)
+      val metadata1 = checkpointMetadata1.streamMetadata
+      val originalId = metadata1.id
+
+      // Add some offset data
+      checkpointMetadata1.offsetLog.add(0, OffsetSeq.fill(None))
+
+      // Add some commit data
+      checkpointMetadata1.commitLog.add(0, CommitMetadata())
+
+      // Re-read checkpoint - should succeed and return the same ID
+      val checkpointMetadata2 = new StreamingQueryCheckpointMetadata(spark, checkpointRoot)
+      val metadata2 = checkpointMetadata2.streamMetadata
+      assert(metadata2.id === originalId)
+    }
+  }
+
+  test("invalid case: missing metadata with non-empty offset log") {
+    withTempDir { dir =>
+      val checkpointRoot = dir.getAbsolutePath
+
+      // Create checkpoint with metadata first
+      val checkpointMetadata1 = new StreamingQueryCheckpointMetadata(spark, checkpointRoot)
+      checkpointMetadata1.streamMetadata // Initialize metadata
+
+      // Add offset data
+      checkpointMetadata1.offsetLog.add(0, OffsetSeq.fill(None))
+      checkpointMetadata1.offsetLog.add(1, OffsetSeq.fill(None))
+
+      // Delete the metadata file
+      val metadataPath = new Path(new Path(checkpointRoot), "metadata")
+      val fs = metadataPath.getFileSystem(spark.sessionState.newHadoopConf())
+      fs.delete(metadataPath, false)
+
+      // Try to create a new checkpoint metadata - should throw error
+      val checkpointMetadata2 = new StreamingQueryCheckpointMetadata(spark, checkpointRoot)
+      val exception = intercept[SparkException] {
+        checkpointMetadata2.streamMetadata
+      }
+      checkError(
+        exception = exception,
+        condition = "STREAMING_CHECKPOINT_METADATA_ERROR.MISSING_METADATA_FILE",
+        parameters = Map("checkpointLocation" -> checkpointRoot)
+      )
+    }
+  }
+
+  test("invalid case: missing metadata with non-empty commit log") {
+    withTempDir { dir =>
+      val checkpointRoot = dir.getAbsolutePath
+
+      // Create checkpoint with metadata first
+      val checkpointMetadata1 = new StreamingQueryCheckpointMetadata(spark, checkpointRoot)
+      checkpointMetadata1.streamMetadata // Initialize metadata
+
+      // Add commit data
+      checkpointMetadata1.commitLog.add(0, CommitMetadata())
+      checkpointMetadata1.commitLog.add(1, CommitMetadata())
+
+      // Delete the metadata file
+      val metadataPath = new Path(new Path(checkpointRoot), "metadata")
+      val fs = metadataPath.getFileSystem(spark.sessionState.newHadoopConf())
+      fs.delete(metadataPath, false)
+
+      // Try to create a new checkpoint metadata - should throw error
+      val checkpointMetadata2 = new StreamingQueryCheckpointMetadata(spark, checkpointRoot)
+      val exception = intercept[SparkException] {
+        checkpointMetadata2.streamMetadata
+      }
+      checkError(
+        exception = exception,
+        condition = "STREAMING_CHECKPOINT_METADATA_ERROR.MISSING_METADATA_FILE",
+        parameters = Map("checkpointLocation" -> checkpointRoot)
+      )
+    }
+  }
+
+  test("invalid case: missing metadata with both offset and commit logs non-empty") {
+    withTempDir { dir =>
+      val checkpointRoot = dir.getAbsolutePath
+
+      // Create checkpoint with metadata first
+      val checkpointMetadata1 = new StreamingQueryCheckpointMetadata(spark, checkpointRoot)
+      checkpointMetadata1.streamMetadata // Initialize metadata
+
+      // Add offset data
+      checkpointMetadata1.offsetLog.add(0, OffsetSeq.fill(None))
+      checkpointMetadata1.offsetLog.add(1, OffsetSeq.fill(None))
+
+      // Add commit data
+      checkpointMetadata1.commitLog.add(0, CommitMetadata())
+      checkpointMetadata1.commitLog.add(1, CommitMetadata())
+
+      // Delete the metadata file
+      val metadataPath = new Path(new Path(checkpointRoot), "metadata")
+      val fs = metadataPath.getFileSystem(spark.sessionState.newHadoopConf())
+      fs.delete(metadataPath, false)
+
+      // Try to create a new checkpoint metadata - should throw error
+      val checkpointMetadata2 = new StreamingQueryCheckpointMetadata(spark, checkpointRoot)
+      val exception = intercept[SparkException] {
+        checkpointMetadata2.streamMetadata
+      }
+      checkError(
+        exception = exception,
+        condition = "STREAMING_CHECKPOINT_METADATA_ERROR.MISSING_METADATA_FILE",
+        parameters = Map("checkpointLocation" -> checkpointRoot)
+      )
+    }
+  }
+
+  test("valid case: missing metadata with empty logs should succeed") {
+    withTempDir { dir =>
+      val checkpointRoot = dir.getAbsolutePath
+
+      // Create checkpoint directories but don't add any data
+      val offsetLog = new OffsetSeqLog(spark, new File(dir, "offsets").toString)
+      val commitLog = new CommitLog(spark, new File(dir, "commits").toString)
+
+      // Verify logs are empty
+      assert(offsetLog.getLatestBatchId().isEmpty)
+      assert(commitLog.getLatestBatchId().isEmpty)
+
+      // Try to create checkpoint metadata - should succeed
+      val checkpointMetadata = new StreamingQueryCheckpointMetadata(spark, checkpointRoot)
+      val metadata = checkpointMetadata.streamMetadata
+      assert(metadata != null)
+      assert(metadata.id != null)
+      assert(UUID.fromString(metadata.id) != null) // Should be a valid UUID
+    }
+  }
+
+  test("feature flag: validation is performed when flag is enabled (default)") {
+    // Verify flag is enabled by default
+    assert(spark.conf.get(SQLConf.STREAMING_CHECKPOINT_VERIFY_METADATA_EXISTS) === true)
+
+    withTempDir { dir =>
+      val checkpointRoot = dir.getAbsolutePath
+
+      // Create checkpoint with metadata and logs
+      val checkpointMetadata1 = new StreamingQueryCheckpointMetadata(spark, checkpointRoot)
+      checkpointMetadata1.streamMetadata
+      checkpointMetadata1.offsetLog.add(0, OffsetSeq.fill(None))
+
+      // Delete metadata file
+      val metadataPath = new Path(new Path(checkpointRoot), "metadata")
+      val fs = metadataPath.getFileSystem(spark.sessionState.newHadoopConf())
+      fs.delete(metadataPath, false)
+
+      // Should throw error because validation is enabled
+      val checkpointMetadata2 = new StreamingQueryCheckpointMetadata(spark, checkpointRoot)
+      val exception = intercept[SparkException] {
+        checkpointMetadata2.streamMetadata
+      }
+      checkError(
+        exception = exception,
+        condition = "STREAMING_CHECKPOINT_METADATA_ERROR.MISSING_METADATA_FILE",
+        parameters = Map("checkpointLocation" -> checkpointRoot)
+      )
+    }
+  }
+
+  test("feature flag: validation is skipped when flag is disabled") {
+    withSQLConf(SQLConf.STREAMING_CHECKPOINT_VERIFY_METADATA_EXISTS.key -> "false") {
+      // Verify flag is disabled
+      assert(spark.conf.get(SQLConf.STREAMING_CHECKPOINT_VERIFY_METADATA_EXISTS) === false)
+
+      withTempDir { dir =>
+        val checkpointRoot = dir.getAbsolutePath
+
+        // Create checkpoint with metadata and logs
+        val checkpointMetadata1 = new StreamingQueryCheckpointMetadata(spark, checkpointRoot)
+        checkpointMetadata1.streamMetadata
+        checkpointMetadata1.offsetLog.add(0, OffsetSeq.fill(None))
+
+        // Delete metadata file
+        val metadataPath = new Path(new Path(checkpointRoot), "metadata")
+        val fs = metadataPath.getFileSystem(spark.sessionState.newHadoopConf())
+        fs.delete(metadataPath, false)
+
+        // Should succeed and create new metadata with new UUID (validation is skipped)
+        val checkpointMetadata2 = new StreamingQueryCheckpointMetadata(spark, checkpointRoot)
+        val metadata = checkpointMetadata2.streamMetadata
+        assert(metadata != null)
+        assert(metadata.id != null)
+        assert(UUID.fromString(metadata.id) != null)
+      }
+    }
+  }
+
+  test("e2e: streaming query fails to restart when checkpoint metadata is corrupted") {
+    import testImplicits._
+
+    withTempDir { checkpointDir =>
+      withTempDir { outputDir =>
+        val inputData = MemoryStream[Int]
+        var query = inputData.toDF()
+          .writeStream
+          .format("parquet")
+          .option("checkpointLocation", checkpointDir.getAbsolutePath)
+          .outputMode(OutputMode.Append())
+          .start(outputDir.getAbsolutePath)
+
+        try {
+          // Add data and process batches
+          inputData.addData(1, 2, 3)
+          query.processAllAvailable()
+
+          inputData.addData(4, 5, 6)
+          query.processAllAvailable()
+
+          // Verify checkpoint files exist
+          val metadataPath = new Path(new Path(checkpointDir.getAbsolutePath), "metadata")
+          val fs = metadataPath.getFileSystem(spark.sessionState.newHadoopConf())
+          assert(fs.exists(metadataPath), "Metadata file should exist")
+
+          // Stop the query
+          query.stop()
+          query = null
+
+          // Simulate corrupted checkpoint by deleting only the metadata file
+          fs.delete(metadataPath, false)
+          assert(!fs.exists(metadataPath), "Metadata file should be deleted")
+
+          // Attempt to restart the query - should fail with validation error
+          val exception = intercept[SparkException] {
+            inputData.toDF()
+              .writeStream
+              .format("parquet")
+              .option("checkpointLocation", checkpointDir.getAbsolutePath)
+              .outputMode(OutputMode.Append())
+              .start(outputDir.getAbsolutePath)
+          }
+
+          // Verify the error is our checkpoint consistency error
+          val qualifiedPath = fs.makeQualified(new Path(checkpointDir.getAbsolutePath))
+          checkError(
+            exception = exception,
+            condition = "STREAMING_CHECKPOINT_METADATA_ERROR.MISSING_METADATA_FILE",
+            parameters = Map("checkpointLocation" -> qualifiedPath.toString)
+          )
+        } finally {
+          if (query != null && query.isActive) {
+            query.stop()
+          }
+        }
+      }
+    }
+  }
+
+  test("e2e: streaming query restarts successfully when flag is disabled") {
+    import testImplicits._
+
+    withSQLConf(SQLConf.STREAMING_CHECKPOINT_VERIFY_METADATA_EXISTS.key -> "false") {
+      withTempDir { checkpointDir =>
+        withTempDir { outputDir =>
+          val inputData = MemoryStream[Int]
+          var query = inputData.toDF()
+            .writeStream
+            .format("parquet")
+            .option("checkpointLocation", checkpointDir.getAbsolutePath)
+            .outputMode(OutputMode.Append())
+            .start(outputDir.getAbsolutePath)
+
+          try {
+            // Add data and process batches
+            inputData.addData(1, 2, 3)
+            query.processAllAvailable()
+
+            // Stop the query
+            query.stop()
+            query = null
+
+            // Simulate corrupted checkpoint by deleting only the metadata file
+            val metadataPath = new Path(new Path(checkpointDir.getAbsolutePath), "metadata")
+            val fs = metadataPath.getFileSystem(spark.sessionState.newHadoopConf())
+            fs.delete(metadataPath, false)
+
+            // Restart the query - should succeed because validation is disabled
+            query = inputData.toDF()
+              .writeStream
+              .format("parquet")
+              .option("checkpointLocation", checkpointDir.getAbsolutePath)
+              .outputMode(OutputMode.Append())
+              .start(outputDir.getAbsolutePath)
+
+            // Query should be active and can process more data
+            assert(query.isActive, "Query should be active after restart")
+
+            inputData.addData(7, 8, 9)
+            query.processAllAvailable()
+          } finally {
+            if (query != null && query.isActive) {
+              query.stop()
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/StreamingQueryCheckpointMetadataSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/StreamingQueryCheckpointMetadataSuite.scala
@@ -90,7 +90,7 @@ class StreamingQueryCheckpointMetadataSuite extends StreamTest {
       }
       checkError(
         exception = exception,
-        condition = "MISSING_METADATA_FILE",
+        condition = "STREAMING_CHECKPOINT_MISSING_METADATA_FILE",
         parameters = Map("checkpointLocation" -> checkpointRoot)
       )
     }
@@ -120,7 +120,7 @@ class StreamingQueryCheckpointMetadataSuite extends StreamTest {
       }
       checkError(
         exception = exception,
-        condition = "MISSING_METADATA_FILE",
+        condition = "STREAMING_CHECKPOINT_MISSING_METADATA_FILE",
         parameters = Map("checkpointLocation" -> checkpointRoot)
       )
     }
@@ -154,7 +154,7 @@ class StreamingQueryCheckpointMetadataSuite extends StreamTest {
       }
       checkError(
         exception = exception,
-        condition = "MISSING_METADATA_FILE",
+        condition = "STREAMING_CHECKPOINT_MISSING_METADATA_FILE",
         parameters = Map("checkpointLocation" -> checkpointRoot)
       )
     }
@@ -205,7 +205,7 @@ class StreamingQueryCheckpointMetadataSuite extends StreamTest {
       }
       checkError(
         exception = exception,
-        condition = "MISSING_METADATA_FILE",
+        condition = "STREAMING_CHECKPOINT_MISSING_METADATA_FILE",
         parameters = Map("checkpointLocation" -> checkpointRoot)
       )
     }
@@ -285,7 +285,7 @@ class StreamingQueryCheckpointMetadataSuite extends StreamTest {
           val qualifiedPath = fs.makeQualified(new Path(checkpointDir.getAbsolutePath))
           checkError(
             exception = exception,
-            condition = "MISSING_METADATA_FILE",
+            condition = "STREAMING_CHECKPOINT_MISSING_METADATA_FILE",
             parameters = Map("checkpointLocation" -> qualifiedPath.toString)
           )
         } finally {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR will add validation when accessing the checkpoint to detect this inconsistent state and throw an error before the query can start with a new query ID.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When a streaming checkpoint directory has non-empty offset and commit logs but is missing the metadata file (containing the streaming query ID), the query will generate a new UUID on restart. This breaks the deduplication mechanism of exactly-once sinks like which relies on the streaming query ID to skip already-processed batches, leading to data duplication.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. There is a new error condition MISSING_METADATA_FILE that occurs when a streaming checkpoint directory has non-empty offset and commit logs but is missing the metadata file.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Unit tests and integration tests are added.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Used to assist in writing test suite.
Generated-by: Claude Sonnet 4.5
