### PR TITLE
[SPARK-49110][SQL] Fix reading metadata columns for tables with CHAR columns

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ApplyCharTypePaddingHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ApplyCharTypePaddingHelper.scala
@@ -28,7 +28,6 @@ import org.apache.spark.sql.catalyst.expressions.{
   OuterReference
 }
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
-import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.catalyst.trees.TreePattern.{BINARY_COMPARISON, IN}
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils.createStringRPad
@@ -40,7 +39,6 @@ import org.apache.spark.unsafe.types.UTF8String
  * package in order to make the methods accessible to single-pass [[Resolver]].
  */
 object ApplyCharTypePaddingHelper {
-  val READ_SIDE_PADDING_PROJECT_TAG = TreeNodeTag[Unit]("read_side_padding_project")
 
   object AttrOrOuterRef {
     def unapply(e: Expression): Option[Attribute] = e match {
@@ -63,7 +61,6 @@ object ApplyCharTypePaddingHelper {
       relation -> Nil
     } else {
       val newPlan = Project(projectList, cleanedRelation())
-      newPlan.setTagValue(ApplyCharTypePaddingHelper.READ_SIDE_PADDING_PROJECT_TAG, ())
       newPlan -> relation.output.zip(newPlan.output)
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ApplyCharTypePaddingHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ApplyCharTypePaddingHelper.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.expressions.{
   OuterReference
 }
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.catalyst.trees.TreePattern.{BINARY_COMPARISON, IN}
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils.createStringRPad
@@ -39,6 +40,7 @@ import org.apache.spark.unsafe.types.UTF8String
  * package in order to make the methods accessible to single-pass [[Resolver]].
  */
 object ApplyCharTypePaddingHelper {
+  val READ_SIDE_PADDING_PROJECT_TAG = TreeNodeTag[Unit]("read_side_padding_project")
 
   object AttrOrOuterRef {
     def unapply(e: Expression): Option[Attribute] = e match {
@@ -61,6 +63,7 @@ object ApplyCharTypePaddingHelper {
       relation -> Nil
     } else {
       val newPlan = Project(projectList, cleanedRelation())
+      newPlan.setTagValue(ApplyCharTypePaddingHelper.READ_SIDE_PADDING_PROJECT_TAG, ())
       newPlan -> relation.output.zip(newPlan.output)
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -6026,6 +6026,14 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val READ_SIDE_CHAR_PADDING_AFTER_SUBQUERY_ALIAS =
+    buildConf("spark.sql.readSideCharPadding.afterSubqueryAlias")
+      .doc("When true, Spark applies the project used for string padding when reading CHAR " +
+        "columns fields, after the SubqueryAlias instead of before it.")
+      .version("4.2.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val LEGACY_NO_CHAR_PADDING_IN_PREDICATE = buildConf("spark.sql.legacy.noCharPaddingInPredicate")
     .internal()
     .doc("When true, Spark will not apply char type padding for CHAR type columns in string " +
@@ -7894,6 +7902,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def preserveCharVarcharTypeInfo: Boolean = getConf(SQLConf.PRESERVE_CHAR_VARCHAR_TYPE_INFO)
 
   def readSideCharPadding: Boolean = getConf(SQLConf.READ_SIDE_CHAR_PADDING)
+
+  def readSideCharPaddingAfterAlias: Boolean =
+    getConf(SQLConf.READ_SIDE_CHAR_PADDING_AFTER_SUBQUERY_ALIAS)
 
   def cliPrintHeader: Boolean = getConf(SQLConf.CLI_PRINT_HEADER)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -7903,9 +7903,6 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def readSideCharPadding: Boolean = getConf(SQLConf.READ_SIDE_CHAR_PADDING)
 
-  def readSideCharPaddingAfterAlias: Boolean =
-    getConf(SQLConf.READ_SIDE_CHAR_PADDING_AFTER_SUBQUERY_ALIAS)
-
   def cliPrintHeader: Boolean = getConf(SQLConf.CLI_PRINT_HEADER)
 
   def legacyIntervalEnabled: Boolean = getConf(LEGACY_INTERVAL_ENABLED)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
@@ -60,6 +60,8 @@ object ApplyCharTypePadding extends Rule[LogicalPlan] {
         case SubqueryAlias(identifier, project: Project)
             if readSideCharPaddingAfterSubqueryAlias && project.getTagValue(
               ApplyCharTypePaddingHelper.READ_SIDE_PADDING_PROJECT_TAG).isDefined =>
+          // Move the padding projection to after the subquery alias to still allow metadata
+          // columns to be accessed.
           project.copy(child = SubqueryAlias(identifier, project.child)) -> Nil
       }
       ApplyCharTypePaddingHelper.paddingForStringComparison(newPlan, padCharCol = false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.internal.SQLConf
  */
 object ApplyCharTypePadding extends Rule[LogicalPlan] {
   private def readSideCharPaddingAfterSubqueryAlias =
-    conf.getConf(SQLConf.READ_SIDE_CHAR_PADDING_AFTER_SUBQUERY_ALIAS) =
+    conf.getConf(SQLConf.READ_SIDE_CHAR_PADDING_AFTER_SUBQUERY_ALIAS)
 
   override def apply(plan: LogicalPlan): LogicalPlan = {
     if (conf.charVarcharAsString) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources
 
 import org.apache.spark.sql.catalyst.analysis.ApplyCharTypePaddingHelper
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, SubqueryAlias}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, SubqueryAlias}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
@@ -44,7 +44,36 @@ object ApplyCharTypePadding extends Rule[LogicalPlan] {
     }
 
     if (conf.readSideCharPadding) {
-      val newPlan = plan.resolveOperatorsUpWithNewOutput {
+      // Two-pass approach when readSideCharPaddingAfterSubqueryAlias is enabled:
+      // - First pass: match SubqueryAlias with data source scan, add padding Project AFTER
+      //   SubqueryAlias to preserve metadata column access
+      // - Second pass: match data source scan alone (for cases like spark.read.format(...).load())
+      // For idempotence, readSidePadding clears char type metadata in output attributes,
+      // so the second pass does nothing if the first pass already matched.
+      val afterFirstPass = if (readSideCharPaddingAfterSubqueryAlias) {
+        // First pass: match SubqueryAlias with data source scan
+        plan.resolveOperatorsUpWithNewOutput {
+          case s @ SubqueryAlias(identifier, r: LogicalRelation) =>
+            ApplyCharTypePaddingHelper.readSidePadding(s, () =>
+              SubqueryAlias(identifier,
+                r.copy(output = r.output.map(CharVarcharUtils.cleanAttrMetadata))))
+          case s @ SubqueryAlias(identifier, r: DataSourceV2Relation) =>
+            ApplyCharTypePaddingHelper.readSidePadding(s, () =>
+              SubqueryAlias(identifier,
+                r.copy(output = r.output.map(CharVarcharUtils.cleanAttrMetadata))))
+          case s @ SubqueryAlias(identifier, r: HiveTableRelation) =>
+            val cleanedDataCols = r.dataCols.map(CharVarcharUtils.cleanAttrMetadata)
+            val cleanedPartCols = r.partitionCols.map(CharVarcharUtils.cleanAttrMetadata)
+            ApplyCharTypePaddingHelper.readSidePadding(s, () =>
+              SubqueryAlias(identifier,
+                r.copy(dataCols = cleanedDataCols, partitionCols = cleanedPartCols)))
+        }
+      } else {
+        plan
+      }
+      // Second pass: match data source scan alone (char type already cleared if first pass
+      // matched, so this does nothing for those cases)
+      val newPlan = afterFirstPass.resolveOperatorsUpWithNewOutput {
         case r: LogicalRelation =>
           ApplyCharTypePaddingHelper.readSidePadding(r, () =>
             r.copy(output = r.output.map(CharVarcharUtils.cleanAttrMetadata)))
@@ -57,12 +86,6 @@ object ApplyCharTypePadding extends Rule[LogicalPlan] {
             val cleanedPartCols = r.partitionCols.map(CharVarcharUtils.cleanAttrMetadata)
             r.copy(dataCols = cleanedDataCols, partitionCols = cleanedPartCols)
           })
-        case SubqueryAlias(identifier, project: Project)
-            if readSideCharPaddingAfterSubqueryAlias && project.getTagValue(
-              ApplyCharTypePaddingHelper.READ_SIDE_PADDING_PROJECT_TAG).isDefined =>
-          // Move the padding projection to after the subquery alias to still allow metadata
-          // columns to be accessed.
-          project.copy(child = SubqueryAlias(identifier, project.child)) -> Nil
       }
       ApplyCharTypePaddingHelper.paddingForStringComparison(newPlan, padCharCol = false)
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ApplyCharTypePadding.scala
@@ -35,6 +35,8 @@ import org.apache.spark.sql.internal.SQLConf
  * right-pad the shorter one to the longer length.
  */
 object ApplyCharTypePadding extends Rule[LogicalPlan] {
+  private def readSideCharPaddingAfterSubqueryAlias =
+    conf.getConf(SQLConf.READ_SIDE_CHAR_PADDING_AFTER_SUBQUERY_ALIAS) =
 
   override def apply(plan: LogicalPlan): LogicalPlan = {
     if (conf.charVarcharAsString) {
@@ -56,7 +58,7 @@ object ApplyCharTypePadding extends Rule[LogicalPlan] {
             r.copy(dataCols = cleanedDataCols, partitionCols = cleanedPartCols)
           })
         case SubqueryAlias(identifier, project: Project)
-            if conf.readSideCharPaddingAfterAlias && project.getTagValue(
+            if readSideCharPaddingAfterSubqueryAlias && project.getTagValue(
               ApplyCharTypePaddingHelper.READ_SIDE_PADDING_PROJECT_TAG).isDefined =>
           project.copy(child = SubqueryAlias(identifier, project.child)) -> Nil
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/MetadataColumnSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/MetadataColumnSuite.scala
@@ -364,9 +364,12 @@ class MetadataColumnSuite extends DatasourceV2SQLBase {
         sql(s"CREATE TABLE $tbl (id bigint, data char(1)) PARTITIONED BY (bucket(4, id), id)")
         sql(s"INSERT INTO $tbl VALUES (1, 'a'), (2, 'b'), (3, 'c')")
         val sqlQuery = sql(s"SELECT id, data, index, _partition FROM $tbl")
+        val sqlQueryWithAlias = sql(s"SELECT t.id, t.data, t.index, t._partition FROM $tbl t")
         val dfQuery = spark.table(tbl).select("id", "data", "index", "_partition")
+        val dfQueryWithAlias = spark.table(tbl).as("t")
+          .select("t.id", "t.data", "t.index", "t._partition")
 
-        Seq(sqlQuery, dfQuery).foreach { query =>
+        Seq(sqlQuery, sqlQueryWithAlias, dfQuery, dfQueryWithAlias).foreach { query =>
           checkAnswer(
             query, Seq(Row(1, "a", 0, "3/1"), Row(2, "b", 0, "0/2"), Row(3, "c", 0, "1/3")))
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR modifies `SubqueryAlias` to propagate the metadata output of its child if the is a `Project` injected by `ApplyCharTypePadding`.

### Why are the changes needed?

This is needed because with these changes it is not possible to read metadata columns when reading a table with a CHAR column when read-side padding is enabled. In the case the plan is `SubqueryAlias(Project(LeafNode)))`, so without this patch the metadata output is not propagated.

### Does this PR introduce _any_ user-facing change?

Yes, there will be more cases in which the metadata columns can be accessed, and users will no longer get an exception in these cases.

### How was this patch tested?

Added a case to `MetadataColumnSuite`.

### Was this patch authored or co-authored using generative AI tooling?

No
