### PR TITLE
[SPARK-54830][SQL][BUILD][FOLLOWUP] Add  comments to remind that the SQL module should use the same `-Xmx` setting in both Maven and SBT tests

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1324,6 +1324,7 @@ object SQL {
   lazy val settings = Seq(
     // SPARK-54830: avoid AdaptiveQueryExecSuite OOM, since computing order independent shuffle checksum needs more
     // memory for test case introduced by SPARK-48037 which set shuffle partition to 16777216
+    // It needs to be consistent with the configuration of the `scalatest-maven-plugin` in `sql/core/pom.xml`.
     (Test / javaOptions) += "-Xmx6g",
     // Setting version for the protobuf compiler. This has to be propagated to every sub-project
     // even if the project is not using it.

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -344,6 +344,7 @@
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
         <configuration>
+          <!-- SPARK-54830: Increase `-Xmx` to 6g to prevent OOM during testing, ensuring consistency with the SQL module configuration in `SparkBuild.scala`.-->
           <argLine>-ea -Xmx6g -Xss4m -XX:ReservedCodeCacheSize=${CodeCacheSize} ${extraJavaTestArgs} -Dio.netty.tryReflectionSetAccessible=true</argLine>
         </configuration>
       </plugin>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr incorporates suggestions from https://github.com/apache/spark/pull/53847#discussion_r2703643610 by adding comments to remind that the SQL module should utilize the same `-Xmx` setting in both Maven and SBT tests.


### Why are the changes needed?
Add necessary comments.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions

### Was this patch authored or co-authored using generative AI tooling?
No