### PR TITLE
[SPARK-55016][SQL] Make SQLConf a direct property of SparkSession to prevent stack overflow

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/SparkSession.scala
@@ -126,7 +126,7 @@ class SparkSession private(
 
   // If there is no active SparkSession, uses the default SQL conf. Otherwise, use the session's.
   SQLConf.setSQLConfGetter(() => {
-    SparkSession.getActiveSession.filterNot(_.sparkContext.isStopped).map(_.sessionState.conf)
+    SparkSession.getActiveSession.filterNot(_.sparkContext.isStopped).map(_.sqlConf)
       .getOrElse(SQLConf.getFallbackConf)
   })
 
@@ -176,6 +176,29 @@ class SparkSession private(
     existingSharedState.getOrElse(new SharedState(sparkContext, initialSessionOptions))
   }
 
+  /**
+   * SQL-specific key-value configurations.
+   *
+   * This is initialized before sessionState to avoid recursive access during sessionState
+   * initialization when SQLConf.get is called.
+   */
+  @transient
+  lazy val sqlConf: SQLConf = {
+    parentSessionState.map { s =>
+      val cloned = s.conf.clone()
+      if (sparkContext.conf.get(StaticSQLConf.SQL_LEGACY_SESSION_INIT_WITH_DEFAULTS)) {
+        SQLConf.mergeSparkConf(cloned, sparkContext.conf)
+      }
+      cloned
+    }.getOrElse {
+      val conf = new SQLConf
+      SQLConf.mergeSparkConf(conf, sharedState.conf)
+      SQLConf.mergeNonStaticSQLConfigs(conf, sparkContext.conf.getAll.toMap)
+      SQLConf.mergeNonStaticSQLConfigs(conf, initialSessionOptions)
+      conf
+    }
+  }
+
   /** @inheritdoc */
   @Unstable
   @transient
@@ -195,7 +218,7 @@ class SparkSession private(
   val sqlContext: SQLContext = new SQLContext(this)
 
   /** @inheritdoc */
-  @transient lazy val conf: RuntimeConfig = new RuntimeConfig(sessionState.conf)
+  @transient lazy val conf: RuntimeConfig = new RuntimeConfig(sqlConf)
 
   /** @inheritdoc */
   def listenerManager: ExecutionListenerManager = sessionState.listenerManager

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/SparkSession.scala
@@ -183,7 +183,7 @@ class SparkSession private(
    * initialization when SQLConf.get is called.
    */
   @transient
-  lazy val sqlConf: SQLConf = {
+  private[sql] lazy val sqlConf: SQLConf = {
     parentSessionState.map { s =>
       val cloned = s.conf.clone()
       if (sparkContext.conf.get(StaticSQLConf.SQL_LEGACY_SESSION_INIT_WITH_DEFAULTS)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -82,25 +82,10 @@ abstract class BaseSessionStateBuilder(
   /**
    * SQL-specific key-value configurations.
    *
-   * These either get cloned from a pre-existing instance or newly created. The conf is merged
-   * with its [[SparkConf]] only when there is no parent session.
+   * Uses the SQLConf from the SparkSession, which is initialized before sessionState
+   * to avoid recursive access during sessionState initialization.
    */
-  protected lazy val conf: SQLConf = {
-    parentState.map { s =>
-      val cloned = s.conf.clone()
-      if (session.sparkContext.conf.get(StaticSQLConf.SQL_LEGACY_SESSION_INIT_WITH_DEFAULTS)) {
-        SQLConf.mergeSparkConf(cloned, session.sparkContext.conf)
-      }
-      cloned
-    }.getOrElse {
-      val conf = new SQLConf
-      SQLConf.mergeSparkConf(conf, session.sharedState.conf)
-      // the later added configs to spark conf shall be respected too
-      SQLConf.mergeNonStaticSQLConfigs(conf, session.sparkContext.conf.getAll.toMap)
-      SQLConf.mergeNonStaticSQLConfigs(conf, session.initialSessionOptions)
-      conf
-    }
-  }
+  protected def conf: SQLConf = session.sqlConf
 
   /**
    * Internal catalog managing functions registered by the user.
@@ -485,35 +470,6 @@ abstract class BaseSessionStateBuilder(
       adaptiveRulesHolder,
       planNormalizationRules,
       () => artifactManager)
-  }
-}
-
-/**
- * Helper class for using SessionStateBuilders during tests.
- */
-private[sql] trait WithTestConf { self: BaseSessionStateBuilder =>
-  def overrideConfs: Map[String, String]
-
-  override protected lazy val conf: SQLConf = {
-    val overrideConfigurations = overrideConfs
-    parentState.map { s =>
-      val cloned = s.conf.clone()
-      if (session.sparkContext.conf.get(StaticSQLConf.SQL_LEGACY_SESSION_INIT_WITH_DEFAULTS)) {
-        SQLConf.mergeSparkConf(conf, session.sparkContext.conf)
-      }
-      cloned
-    }.getOrElse {
-      val conf = new SQLConf {
-        clear()
-        override def clear(): Unit = {
-          super.clear()
-          // Make sure we start with the default test configs even after clear
-          overrideConfigurations.foreach { case (key, value) => setConfString(key, value) }
-        }
-      }
-      SQLConf.mergeSparkConf(conf, session.sparkContext.conf)
-      conf
-    }
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the stack overflow issue that occurs when `SQLConf.get` is called during `sessionState` initialization.

The root cause is a circular dependency: `SQLConf.get` calls `session.sessionState.conf`, but if this happens during `sessionState` initialization itself, it causes infinite recursion.

The fix moves `sqlConf` to be a direct lazy val on `SparkSession`, initialized before `sessionState`. This eliminates the recursion because the confGetter now accesses `session.sqlConf` directly instead of `session.sessionState.conf`.

**Architecture before (problematic):**
```
SparkSession
  └── lazy val sessionState: SessionState
        └── conf: SQLConf  ← created inside SessionStateBuilder

SQLConf.get → confGetter → session.sessionState.conf → RECURSION during init
```

**Architecture after (fixed):**
```
SparkSession
  ├── lazy val sqlConf: SQLConf        ← Initialized FIRST (no dependencies on sessionState)
  └── lazy val sessionState: SessionState
        └── conf → session.sqlConf     ← Same instance, no recursion

SQLConf.get → confGetter → session.sqlConf → NO RECURSION
```

**Changes:**
- Add `sqlConf` lazy val to `SparkSession` before `sessionState`
- Update confGetter to use `session.sqlConf` instead of `session.sessionState.conf`
- Update `RuntimeConfig` to use `sqlConf` directly
- Simplify `BaseSessionStateBuilder.conf` to delegate to `session.sqlConf`
- Remove the old `WithTestConf` trait from builders
- Add new `WithTestConf` trait for test SparkSession subclasses with `newTestConf()` helper
- Update `TestSparkSession` and `TestHiveSparkSession` to use the new pattern

### Why are the changes needed?

To fix the stack overflow when `SQLConf.get` is called during `sessionState` initialization.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests. Ran `ListTablesSuite` to verify basic session functionality works.

### Was this patch authored or co-authored using generative AI tooling?

Yes. cursor 2.3.41