### PR TITLE
[SPARK-45414][SQL][TESTS] Add regression tests for XML mixed type serialization

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/parsers/StaxXmlGeneratorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/parsers/StaxXmlGeneratorSuite.scala
@@ -33,7 +33,8 @@ case class KnownData(
     stringDatum: String,
     timeDatum: String,
     timestampDatum: Timestamp,
-    nullDatum: Null)
+    nullDatum: Null
+)
 
 final class StaxXmlGeneratorSuite extends SharedSparkSession {
   test("write/read roundtrip") {
@@ -49,11 +50,10 @@ final class StaxXmlGeneratorSuite extends SharedSparkSession {
         longDatum = 1520828868,
         stringDatum = "test,breakdelimiter",
         timeDatum = "12:34:56",
-        timestampDatum = Timestamp.from(
-          ZonedDateTime.of(2017, 12, 20, 21, 46, 54, 0, ZoneId.of("UTC")).toInstant),
+        timestampDatum = Timestamp.from(ZonedDateTime.of(2017, 12, 20, 21, 46, 54, 0,
+          ZoneId.of("UTC")).toInstant),
         nullDatum = null),
-      KnownData(
-        booleanDatum = false,
+      KnownData(booleanDatum = false,
         dateDatum = Date.valueOf("2016-12-19"),
         decimalDatum = Decimal(12.345, 10, 3),
         doubleDatum = 21.2121,
@@ -61,9 +61,10 @@ final class StaxXmlGeneratorSuite extends SharedSparkSession {
         longDatum = 1520828123,
         stringDatum = "breakdelimiter,test",
         timeDatum = "23:45:16",
-        timestampDatum = Timestamp.from(
-          ZonedDateTime.of(2017, 12, 29, 17, 21, 49, 0, ZoneId.of("America/New_York")).toInstant),
-        nullDatum = null))
+        timestampDatum = Timestamp.from(ZonedDateTime.of(2017, 12, 29, 17, 21, 49, 0,
+          ZoneId.of("America/New_York")).toInstant),
+        nullDatum = null)
+    )
 
     val df = dataset.toDF().orderBy("booleanDatum")
     val targetFile =

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/parsers/StaxXmlGeneratorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/parsers/StaxXmlGeneratorSuite.scala
@@ -75,7 +75,8 @@ final class StaxXmlGeneratorSuite extends SharedSparkSession {
     assert(df.collect().toSeq === newDf.collect().toSeq)
   }
 
-  // SPARK-45414: Test for string tag content misplacement with mixed column types
+  // SPARK-45414: Test for string tag content misplacement issue (found in spark-xml library)
+  // with mixed column types
   test("SPARK-45414: write mixed types with string columns between and after nested types") {
     import org.apache.spark.sql.Row
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/parsers/StaxXmlGeneratorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/parsers/StaxXmlGeneratorSuite.scala
@@ -33,8 +33,7 @@ case class KnownData(
     stringDatum: String,
     timeDatum: String,
     timestampDatum: Timestamp,
-    nullDatum: Null
-)
+    nullDatum: Null)
 
 final class StaxXmlGeneratorSuite extends SharedSparkSession {
   test("write/read roundtrip") {
@@ -50,10 +49,11 @@ final class StaxXmlGeneratorSuite extends SharedSparkSession {
         longDatum = 1520828868,
         stringDatum = "test,breakdelimiter",
         timeDatum = "12:34:56",
-        timestampDatum = Timestamp.from(ZonedDateTime.of(2017, 12, 20, 21, 46, 54, 0,
-          ZoneId.of("UTC")).toInstant),
+        timestampDatum = Timestamp.from(
+          ZonedDateTime.of(2017, 12, 20, 21, 46, 54, 0, ZoneId.of("UTC")).toInstant),
         nullDatum = null),
-      KnownData(booleanDatum = false,
+      KnownData(
+        booleanDatum = false,
         dateDatum = Date.valueOf("2016-12-19"),
         decimalDatum = Decimal(12.345, 10, 3),
         doubleDatum = 21.2121,
@@ -61,10 +61,9 @@ final class StaxXmlGeneratorSuite extends SharedSparkSession {
         longDatum = 1520828123,
         stringDatum = "breakdelimiter,test",
         timeDatum = "23:45:16",
-        timestampDatum = Timestamp.from(ZonedDateTime.of(2017, 12, 29, 17, 21, 49, 0,
-          ZoneId.of("America/New_York")).toInstant),
-        nullDatum = null)
-    )
+        timestampDatum = Timestamp.from(
+          ZonedDateTime.of(2017, 12, 29, 17, 21, 49, 0, ZoneId.of("America/New_York")).toInstant),
+        nullDatum = null))
 
     val df = dataset.toDF().orderBy("booleanDatum")
     val targetFile =
@@ -73,6 +72,111 @@ final class StaxXmlGeneratorSuite extends SharedSparkSession {
     val newDf =
       spark.read.option("rowTag", "ROW").schema(df.schema).xml(targetFile).orderBy("booleanDatum")
     assert(df.collect().toSeq === newDf.collect().toSeq)
+  }
+
+  // SPARK-45414: Test for string tag content misplacement with mixed column types
+  test("SPARK-45414: write mixed types with string columns between and after nested types") {
+    import org.apache.spark.sql.Row
+
+    // Create a schema with mixed types: struct, array, and string columns
+    // This reproduces the scenario from SPARK-45414 where string content gets misplaced
+    val schema = StructType(
+      Seq(
+        StructField("id", IntegerType, nullable = false),
+        StructField(
+          "metadata",
+          StructType(Seq(StructField("version", StringType), StructField("timestamp", LongType))),
+          nullable = true),
+        StructField("description", StringType, nullable = true), // String between nested types
+        StructField("tags", ArrayType(StringType), nullable = true),
+        StructField("color", StringType, nullable = true), // String at the end
+        StructField("numbers", ArrayType(IntegerType), nullable = true)))
+
+    val data = Seq(
+      Row(1, Row("v1.0", 1000L), "MyDescription", Array("tag1", "tag2"), "Red", Array(1, 2, 3)),
+      Row(2, Row("v2.0", 2000L), "AnotherDescription", Array("tag3"), "Blue", Array(4, 5)))
+
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+
+    // Write to XML
+    val targetFile =
+      Files.createTempDirectory("StaxXmlGeneratorSuite").resolve("mixed-types.xml").toString
+    df.write.option("rowTag", "item").xml(targetFile)
+
+    // Read back and verify the content is in correct XML tags
+    val readDf = spark.read.option("rowTag", "item").schema(schema).xml(targetFile)
+    val results = readDf.collect()
+
+    // Verify structure is preserved
+    assert(results.length === 2)
+
+    // Verify first row - ensure no data misplacement
+    assert(results(0).getAs[Int]("id") === 1)
+    val metadata1 = results(0).getAs[Row]("metadata")
+    assert(metadata1.getAs[String]("version") === "v1.0")
+    assert(metadata1.getAs[Long]("timestamp") === 1000L)
+    // Critical: ensure "MyDescription" is in description field, not in tags or color
+    assert(results(0).getAs[String]("description") === "MyDescription")
+    assert(results(0).getAs[Seq[String]]("tags") === Seq("tag1", "tag2"))
+    // Critical: ensure "Red" is in color field, not misplaced
+    assert(results(0).getAs[String]("color") === "Red")
+    assert(results(0).getAs[Seq[Int]]("numbers") === Seq(1, 2, 3))
+
+    // Verify second row
+    assert(results(1).getAs[Int]("id") === 2)
+    val metadata2 = results(1).getAs[Row]("metadata")
+    assert(metadata2.getAs[String]("version") === "v2.0")
+    assert(metadata2.getAs[Long]("timestamp") === 2000L)
+    assert(results(1).getAs[String]("description") === "AnotherDescription")
+    assert(results(1).getAs[Seq[String]]("tags") === Seq("tag3"))
+    assert(results(1).getAs[String]("color") === "Blue")
+    assert(results(1).getAs[Seq[Int]]("numbers") === Seq(4, 5))
+  }
+
+  // SPARK-45414: Test with attributes mixed with elements
+  test("SPARK-45414: write mixed types with attributes and string elements") {
+    import org.apache.spark.sql.Row
+
+    // Schema with attributes (using _ prefix) and string elements
+    val schema = StructType(
+      Seq(
+        StructField("_id", IntegerType, nullable = false), // attribute
+        StructField(
+          "nested",
+          StructType(
+            Seq(
+              StructField("_attr1", StringType), // attribute
+              StructField("value", StringType))),
+          nullable = true),
+        StructField("description", StringType, nullable = true), // element
+        StructField("items", ArrayType(IntegerType), nullable = true),
+        StructField("name", StringType, nullable = true) // element at end
+      ))
+
+    val data = Seq(Row(100, Row("attrValue", "nestedValue"), "DescText", Array(1, 2), "ItemName"))
+
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+
+    val targetFile =
+      Files.createTempDirectory("StaxXmlGeneratorSuite").resolve("mixed-attrs.xml").toString
+    df.write.option("rowTag", "record").option("attributePrefix", "_").xml(targetFile)
+
+    val readDf = spark.read
+      .option("rowTag", "record")
+      .option("attributePrefix", "_")
+      .schema(schema)
+      .xml(targetFile)
+    val results = readDf.collect()
+
+    assert(results.length === 1)
+    assert(results(0).getAs[Int]("_id") === 100)
+    val nested = results(0).getAs[Row]("nested")
+    assert(nested.getAs[String]("_attr1") === "attrValue")
+    assert(nested.getAs[String]("value") === "nestedValue")
+    // Critical: ensure string elements are not misplaced
+    assert(results(0).getAs[String]("description") === "DescText")
+    assert(results(0).getAs[Seq[Int]]("items") === Seq(1, 2))
+    assert(results(0).getAs[String]("name") === "ItemName")
   }
 
 }


### PR DESCRIPTION
This adds two regression tests for SPARK-45414 to prevent reintroduction of the bug where string tag content was misplaced when writing XML with mixed column types (structs, arrays, and strings).

Tests verify:
- String columns between and after nested types write correctly
- Attributes mixed with string elements serialize properly

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add two regression tests for SPARK-45414 to prevent reintroduction of the bug where string tag content could be misplaced when writing XML with mixed column types.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
SPARK-45414 reported a bug in the spark-xml library where string content was misplaced when writing structs with mixed types. While this bug was fixed during spark-xml integration into Spark core, there were no tests ensuring this specific scenario remains correct. These tests provide coverage for the bug scenario.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No, this only adds test coverage.
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
The new tests were run successfully:
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
Yes, co-authored with Claude Sonnet 4.5.

Generated-by: Claude Sonnet 4.5

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
