### PR TITLE
[SPARK-49110][SQL] Simplify SubqueryAlias.metadataOutput to always propagate metadata columns

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -281,6 +281,17 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val SUBQUERY_ALIAS_ALWAYS_PROPAGATE_METADATA_COLUMNS =
+    buildConf("spark.sql.analyzer.subqueryAliasAlwaysPropagateMetadataColumns")
+      .internal()
+      .version("4.1.0")
+      .doc(
+        "When true, SubqueryAlias always propagates metadata columns from its child. " +
+        "When false, SubqueryAlias only propagates metadata columns if the child is a " +
+        "LeafNode or another SubqueryAlias (legacy behavior).")
+      .booleanConf
+      .createWithDefault(true)
+
   val BLOCK_CREATE_TEMP_TABLE_USING_PROVIDER =
     buildConf("spark.sql.legacy.blockCreateTempTableUsingProvider")
       .doc("If enabled, we fail legacy CREATE TEMPORARY TABLE ... USING provider during parsing.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -284,7 +284,7 @@ object SQLConf {
   val SUBQUERY_ALIAS_ALWAYS_PROPAGATE_METADATA_COLUMNS =
     buildConf("spark.sql.analyzer.subqueryAliasAlwaysPropagateMetadataColumns")
       .internal()
-      .version("4.1.0")
+      .version("4.2.0")
       .doc(
         "When true, SubqueryAlias always propagates metadata columns from its child. " +
         "When false, SubqueryAlias only propagates metadata columns if the child is a " +


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR simplifies `SubqueryAlias.metadataOutput` to always propagate metadata columns from its child, rather than only propagating when the child is a `LeafNode` or another `SubqueryAlias`.

The previous implementation was introduced in SPARK-40149 as a workaround to forbid queries like `SELECT m FROM (SELECT a FROM t)` while still allowing DataFrame API chaining. However, this created an inconsistency since `SubqueryAlias` should conceptually just rename/qualify columns, not filter which ones are accessible.

With this change:
- `SubqueryAlias` always propagates `metadataOutput` (with qualifier applied)
- The `qualifiedAccessOnly` filter is preserved to handle natural join metadata columns
- Queries like `SELECT m FROM (SELECT a FROM t) AS alias` now work, consistent with how `Project` already propagates metadata columns

### Why are the changes needed?

1. **Consistency**: `SubqueryAlias` is a rename operation and should not selectively block metadata column propagation
2. **Simpler code**: Removes the special-case logic checking for `LeafNode`/`SubqueryAlias` children
3. **Better error messages**: When metadata columns from both sides of a join have the same name, users now get an "ambiguous reference" error rather than "column not found"

### Does this PR introduce _any_ user-facing change?

Yes, queries that previously failed with "column not found" when accessing metadata columns through a subquery alias will now succeed (if unambiguous) or fail with "ambiguous reference" (if multiple columns have the same name).

### How was this patch tested?

Updated existing tests and added new test for ambiguous metadata columns after join with SubqueryAlias.

### Was this patch authored or co-authored using generative AI tooling?

Yes.