### PR TITLE
[SPARK-54374][SQL][UI] Enlarge the SVG viewBox attribute of SQL plan visualization initialization

### DIFF
--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -27,7 +27,9 @@ function shouldRenderPlanViz() {
 }
 
 function renderPlanViz() {
-  var svg = planVizContainer().append("svg");
+  var svg = planVizContainer()
+    .append("svg")
+    .attr("viewBox", `${-PlanVizConstants.svgMarginX} ${-PlanVizConstants.svgMarginY} ${window.innerWidth || 1920} 1000`);
   var metadata = d3.select("#plan-viz-metadata");
   var dot = metadata.select(".dot-file").text().trim();
   var graph = svg.append("g");


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to SPARK-54373. Enlarge the SVG viewBox attribute of SQL plan visualization initialization from a 100×100 window to an available width of the window × 1000.

### Why are the changes needed?

Improve the visualization quality while the SQL plan graphics are being painted, consistent with the improvement made to Job DAG in SPARK-54373.

### Does this PR introduce _any_ user-facing change?

No, the final sizes of these SVGs will be adjusted to the actual needs.

### How was this patch tested?

Tested in Chrome DevTools.

### Was this patch authored or co-authored using generative AI tooling?

Yes, GitHub Copilot was used to assist with reviewing SPARK-54373 and applying the same pattern to spark-sql-viz.js.