### PR TITLE
[SPARK-55103][CORE][TESTS] Fix a flaky test in `RpcIntegrationSuite`

### DIFF
--- a/common/network-common/src/test/java/org/apache/spark/network/RpcIntegrationSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/RpcIntegrationSuite.java
@@ -367,7 +367,7 @@ public class RpcIntegrationSuite {
         "Connection reset",
         "java.nio.channels.ClosedChannelException",
         "io.netty.channel.StacklessClosedChannelException",
-        "java.io.IOException: Broken pipe"
+        "Broken pipe"
     );
     Set<String> containsAndClosed = new HashSet<>(Set.of(expectedError));
     containsAndClosed.addAll(possibleClosedErrors);


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix a flaky test in `RpcIntegrationSuite`.
Recently, `sendRpcWithStreamFailures` occasionally fails.
https://github.com/apache/spark/actions/runs/21073107447/job/60608256322
```
[error] Test org.apache.spark.network.RpcIntegrationSuite.sendRpcWithStreamFailures failed: org.opentest4j.AssertionFailedError: Got a non-empty set [Failed to send RPC RPC 4622017872898699852 to localhost/127.0.0.1:41507: io.netty.channel.unix.Errors$NativeIoException: send(..) failed with error(-32): Broken pipe] ==> expected: <true> but was: <false>, took 0.018s
[error]     at org.apache.spark.network.RpcIntegrationSuite.assertErrorAndClosed(RpcIntegrationSuite.java:377)
[error]     at org.apache.spark.network.RpcIntegrationSuite.sendRpcWithStreamFailures(RpcIntegrationSuite.java:332)
[info] Test org.apache.spark.network.RpcIntegrationSuite#sendRpcWithStreamOneAtATime() started
[info] Test org.apache.spark.network.RpcIntegrationSuite#sendSuccessAndFailure() started
[info] Test run finished: 1 failed, 0 ignored, 10 total, 0.195s
```

The root cause seems that one of the expected error message is [java.io.IOException Broken pipe](https://github.com/apache/spark/blob/edc7c96741c4382f79956f7ff5b9077e45f92014/common/network-common/src/test/java/org/apache/spark/network/RpcIntegrationSuite.java#L370) but the actual error message is ` io.netty.channel.unix.Errors$NativeIoException: send(..) failed with error(-32): Broken pipe`.

Actually, the old Netty threw `IOException` directly but newer Netty wraps `IOException` in `NativeIOException`.
https://github.com/netty/netty/blob/5272df455afcd1cfae3e1156d6ac958a69fca32a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Errors.java#L87

### Why are the changes needed?
For test stability.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Self code review. Let's see this issue no longer occurs on CI.

### Was this patch authored or co-authored using generative AI tooling?
No.
