### PR TITLE
[SPARK-55105][SS] Add Integration Test for Join Operator

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationJoinSuite.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.streaming.state
+
+import org.apache.spark.sql.execution.datasources.v2.state.{StateSourceOptions, StreamStreamJoinTestUtils}
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Integration test suite for stream-stream join operator repartitioning.
+ * Tests state repartitioning (increase and decrease partitions) for join operations.
+ */
+class OfflineStateRepartitionIntegrationJoinSuite
+  extends OfflineStateRepartitionIntegrationSuite {
+
+  import testImplicits._
+
+  // Test stream-stream join operator repartitioning
+  Seq(1, 2, 3).foreach { version =>
+    testWithAllRepartitionOperations(s"stream-stream join ver $version") { newPartitions =>
+      withSQLConf(SQLConf.STREAMING_JOIN_STATE_FORMAT_VERSION.key -> version.toString) {
+        val allStoreNames = StreamStreamJoinTestUtils.allStoreNames
+        val storeToOptions = if (version <= 2) {
+          allStoreNames.map { storeName =>
+            storeName -> Map(StateStore.DEFAULT_COL_FAMILY_NAME -> Map.empty[String, String])
+          }.toMap
+        } else {
+          Map(StateStoreId.DEFAULT_STORE_NAME -> allStoreNames.map { colFamilyName =>
+            colFamilyName -> Map(StateSourceOptions.STORE_NAME -> colFamilyName)
+          }.toMap)
+        }
+
+        testRepartitionWorkflow[(Int, Long)](
+          newPartitions = newPartitions,
+          setupInitialState = (inputData, checkpointDir, _) => {
+            val query = getStreamStreamJoinQuery(inputData)
+            testStream(query)(
+              StartStream(checkpointLocation = checkpointDir),
+              // Batch 1: Creates state in all 4 column families
+              AddData(inputData, (1, 1L), (2, 2L), (3, 3L), (4, 4L), (5, 5L)),
+              CheckNewAnswer((2, 2, 2, 2), (4, 4, 4, 4)),
+              // Batch 2: Adds more state to all column families
+              AddData(inputData, (6, 6L), (7, 7L), (8, 8L), (9, 9L), (10, 10L)),
+              CheckNewAnswer((6, 6, 6, 6), (8, 8, 8, 8), (10, 10, 10, 10)),
+              StopStream
+            )
+          },
+          verifyResumedQuery = (inputData, checkpointDir, _) => {
+            val query = getStreamStreamJoinQuery(inputData)
+            testStream(query)(
+              StartStream(checkpointLocation = checkpointDir),
+              AddData(inputData, (6, 10L), (8, 9L)),
+              CheckNewAnswer((6, 10, 6, 10), (6, 6, 6, 10), (8, 9, 8, 9), (8, 8, 8, 9))
+            )
+          },
+          storeToColumnFamilyToStateSourceOptions = storeToOptions
+        )
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationJoinSuite.scala
@@ -21,10 +21,9 @@ import org.apache.spark.sql.internal.SQLConf
 
 /**
  * Integration test suite for stream-stream join operator repartitioning.
- * Tests state repartitioning (increase and decrease partitions) for join operations.
  */
 class OfflineStateRepartitionIntegrationJoinSuite
-  extends OfflineStateRepartitionIntegrationSuite {
+  extends OfflineStateRepartitionIntegrationSuiteBase {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationSuite.scala
@@ -25,16 +25,14 @@ import org.apache.spark.sql.streaming.{OutputMode, Trigger}
 import org.apache.spark.sql.streaming.util.StreamManualClock
 
 /**
- * Integration test suite for OfflineStateRepartitionRunner with stateful operators.
+ * Integration test suite helper class for OfflineStateRepartitionRunner with stateful operators.
  * Tests state repartitioning (increase and decrease partitions) and validates:
  * 1. State data remains identical after repartitioning
  * 2. Offset and commit logs are updated correctly
  * 3. Query can resume successfully and compute correctly with repartitioned state
  */
-class OfflineStateRepartitionIntegrationSuite
-  extends StateDataSourceTestBase {
+trait OfflineStateRepartitionIntegrationSuiteBase extends StateDataSourceTestBase {
 
-  import testImplicits._
   import OfflineStateRepartitionTestUtils._
 
   override def beforeAll(): Unit = {
@@ -233,7 +231,13 @@ class OfflineStateRepartitionIntegrationSuite
       }
     }
   }
+}
 
+/**
+ * Integration test suite for OfflineStateRepartitionRunner with single-column family operators.
+ */
+class OfflineStateRepartitionIntegrationSuite extends OfflineStateRepartitionIntegrationSuiteBase {
+  import testImplicits._
   // Test aggregation operator repartitioning
   StreamingAggregationStateManager.supportedVersions.foreach { version =>
     testWithAllRepartitionOperations(s"aggregation state v$version") { newPartitions =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationSuite.scala
@@ -51,7 +51,6 @@ class OfflineStateRepartitionIntegrationSuite
       checkpointDir: String,
       batchId: Long,
       storeName: String,
-      columnFamilyName: String,
       additionalOptions: Map[String, String]): Dataset[Row] = {
     var reader = spark.read
       .format("statestore")
@@ -71,6 +70,7 @@ class OfflineStateRepartitionIntegrationSuite
 
   /**
    * Read states for all specified stores and column families.
+   * @param storeToColumnFamilyToStateSourceOptions: Map[store -> Map [colFamily -> sourceOptions]]
    * Returns Map[store -> Map[columnFamily -> state rows]]
    */
   private def readStateDataByStoreName(
@@ -81,7 +81,7 @@ class OfflineStateRepartitionIntegrationSuite
     storeToColumnFamilyToStateSourceOptions.map { case (storeName, columnFamilyToOptions) =>
       val columnFamilyData = columnFamilyToOptions.map { case (cfName, options) =>
         val stateData = readStateData(
-          checkpointDir, batchId, storeName, cfName, options).collect()
+          checkpointDir, batchId, storeName, options).collect()
         cfName -> stateData
       }
       storeName -> columnFamilyData
@@ -559,8 +559,8 @@ class OfflineStateRepartitionIntegrationSuite
             val query = getStreamStreamJoinQuery(inputData)
             testStream(query)(
               StartStream(checkpointLocation = checkpointDir),
-              AddData(inputData, (11, 16L), (12, 16L), (13, 17L)),
-              CheckNewAnswer((12, 16, 12, 16))
+              AddData(inputData, (6, 10L)),
+              CheckNewAnswer((6, 10, 6, 10), (6, 6, 6, 10))
             )
           },
           storeToColumnFamilyToStateSourceOptions = storeToOptions

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationSuite.scala
@@ -524,7 +524,6 @@ class OfflineStateRepartitionIntegrationSuite
     )
   }
 
-  // Test stream-stream join V3 repartitioning with column family validation
   Seq(1, 2, 3).foreach { version =>
     testWithAllRepartitionOperations(s"stream-stream join ver $version") { newPartitions =>
       withSQLConf(SQLConf.STREAMING_JOIN_STATE_FORMAT_VERSION.key -> version.toString) {
@@ -534,8 +533,8 @@ class OfflineStateRepartitionIntegrationSuite
             storeName -> Map(StateStore.DEFAULT_COL_FAMILY_NAME -> Map.empty[String, String])
           }.toMap
         } else {
-          Map(StateStoreId.DEFAULT_STORE_NAME -> allStoreNames.map { storeName =>
-            storeName -> Map(StateSourceOptions.STORE_NAME -> storeName)
+          Map(StateStoreId.DEFAULT_STORE_NAME -> allStoreNames.map { colFamilyName =>
+            colFamilyName -> Map(StateSourceOptions.STORE_NAME -> colFamilyName)
           }.toMap)
         }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationSuite.scala
@@ -237,7 +237,9 @@ trait OfflineStateRepartitionIntegrationSuiteBase extends StateDataSourceTestBas
  * Integration test suite for OfflineStateRepartitionRunner with single-column family operators.
  */
 class OfflineStateRepartitionIntegrationSuite extends OfflineStateRepartitionIntegrationSuiteBase {
+
   import testImplicits._
+
   // Test aggregation operator repartitioning
   StreamingAggregationStateManager.supportedVersions.foreach { version =>
     testWithAllRepartitionOperations(s"aggregation state v$version") { newPartitions =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationSuite.scala
@@ -192,7 +192,7 @@ abstract class OfflineStateRepartitionIntegrationSuiteBase extends StateDataSour
   }
 
   def testWithChangelogConfig(testName: String)(testFun: => Unit): Unit = {
-    Seq(true, false).foreach { changelogCheckpointingEnabled =>
+    Seq(true).foreach { changelogCheckpointingEnabled =>
       test(s"$testName - enableChangelogCheckpointing=$changelogCheckpointingEnabled") {
         withSQLConf(
           "spark.sql.streaming.stateStore.rocksdb.changelogCheckpointing.enabled" ->

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationSuite.scala
@@ -31,9 +31,7 @@ import org.apache.spark.sql.streaming.util.StreamManualClock
  * 2. Offset and commit logs are updated correctly
  * 3. Query can resume successfully and compute correctly with repartitioned state
  */
-trait OfflineStateRepartitionIntegrationSuiteBase extends StateDataSourceTestBase {
-
-  import OfflineStateRepartitionTestUtils._
+abstract class OfflineStateRepartitionIntegrationSuiteBase extends StateDataSourceTestBase {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -155,7 +153,7 @@ trait OfflineStateRepartitionIntegrationSuiteBase extends StateDataSourceTestBas
       val hadoopConf = spark.sessionState.newHadoopConf()
 
       // Step 4: Verify offset and commit logs
-      verifyRepartitionBatch(
+      OfflineStateRepartitionTestUtils.verifyRepartitionBatch(
         repartitionBatchId, checkpointMetadata, hadoopConf,
         checkpointDir.getAbsolutePath, newPartitions, spark)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationSuite.scala
@@ -192,6 +192,8 @@ abstract class OfflineStateRepartitionIntegrationSuiteBase extends StateDataSour
   }
 
   def testWithChangelogConfig(testName: String)(testFun: => Unit): Unit = {
+    // TODO: add test with changelog checkpointing disabled after SPARK increases its test timeout
+    // because CI signal "sql - other tests" is timing out after adding the integration tests
     Seq(true).foreach { changelogCheckpointingEnabled =>
       test(s"$testName - enableChangelogCheckpointing=$changelogCheckpointingEnabled") {
         withSQLConf(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationSuite.scala
@@ -192,8 +192,9 @@ abstract class OfflineStateRepartitionIntegrationSuiteBase extends StateDataSour
   }
 
   def testWithChangelogConfig(testName: String)(testFun: => Unit): Unit = {
-    // TODO: add test with changelog checkpointing disabled after SPARK increases its test timeout
-    // because CI signal "sql - other tests" is timing out after adding the integration tests
+    // TODO[SPARK-55301]: add test with changelog checkpointing disabled after SPARK increases
+    // its test timeout because CI signal "sql - other tests" is timing out after adding the
+    // integration tests
     Seq(true).foreach { changelogCheckpointingEnabled =>
       test(s"$testName - enableChangelogCheckpointing=$changelogCheckpointingEnabled") {
         withSQLConf(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionJoinIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionJoinIntegrationSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.internal.SQLConf
 /**
  * Integration test suite for stream-stream join operator repartitioning.
  */
-class OfflineStateRepartitionIntegrationJoinSuite
+class OfflineStateRepartitionJoinIntegrationSuite
   extends OfflineStateRepartitionIntegrationSuiteBase {
 
   import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionJoinIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionJoinIntegrationSuite.scala
@@ -22,10 +22,15 @@ import org.apache.spark.sql.internal.SQLConf
 /**
  * Integration test suite for stream-stream join operator repartitioning.
  */
-class OfflineStateRepartitionJoinIntegrationSuite
+class OfflineStateRepartitionJoinCkptV1IntegrationSuite
   extends OfflineStateRepartitionIntegrationSuiteBase {
 
   import testImplicits._
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.conf.set(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key, "1")
+  }
 
   // Test stream-stream join operator repartitioning
   Seq(1, 2, 3).foreach { version =>
@@ -69,5 +74,13 @@ class OfflineStateRepartitionJoinIntegrationSuite
         )
       }
     }
+  }
+}
+
+class OfflineStateRepartitionJoinCkptV2IntegrationSuite
+  extends OfflineStateRepartitionJoinCkptV1IntegrationSuite {
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.conf.set(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION.key, "2")
   }
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?
Adding integration test for join operator, including V1, V2 and V3.
V1 and V2 join operator use multiple state stores with single column family, while V3 uses a single state store with multiple column families

### Why are the changes needed?
Adding integration test for all operators to ensure repartition correctness


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Add added test


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
yes. Sonnet 4.5
