### PR TITLE
[SPARK-54371][SPARK-39959][INFRA][3.5] Pin roxygen2 and pkgdown versions for SparkR doc generation

### DIFF
--- a/dev/create-release/spark-rm/Dockerfile
+++ b/dev/create-release/spark-rm/Dockerfile
@@ -82,10 +82,13 @@ RUN apt-get clean && apt-get update && $APT_INSTALL gnupg ca-certificates && \
   $APT_INSTALL libcurl4-openssl-dev libgit2-dev libssl-dev libxml2-dev && \
   $APT_INSTALL texlive-latex-base texlive texlive-fonts-extra texinfo qpdf texlive-latex-extra && \
   $APT_INSTALL libfontconfig1-dev libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev libwebp-dev && \
-  Rscript -e "install.packages(c('curl', 'xml2', 'httr', 'devtools', 'testthat', 'knitr', 'rmarkdown', 'markdown', 'roxygen2', 'e1071', 'survival'), repos='https://cloud.r-project.org/')" && \
-  Rscript -e "devtools::install_github('jimhester/lintr')" && \
-  Rscript -e "devtools::install_version('pkgdown', version='2.0.1', repos='https://cloud.r-project.org')" && \
+  Rscript -e "install.packages(c('curl', 'xml2', 'httr', 'devtools', 'testthat', 'knitr', 'rmarkdown', 'markdown', 'e1071', 'survival'), repos='https://cloud.r-project.org/')" && \
+  # See more in SPARK-39959, roxygen2 < 7.2.1
+  Rscript -e "devtools::install_version('roxygen2', version='7.2.0', repos='https://cloud.r-project.org')" && \
+  Rscript -e "devtools::install_version('lintr', version='2.0.1', repos='https://cloud.r-project.org')" && \
   Rscript -e "devtools::install_version('preferably', version='0.4', repos='https://cloud.r-project.org')" && \
+  # See more in SPARK-54371, pkgdown should be installed at the end to avoid version upgrade
+  Rscript -e "devtools::install_version('pkgdown', version='2.0.1', repos='https://cloud.r-project.org')" && \
   # Install tools needed to build the documentation.
   $APT_INSTALL ruby2.7 ruby2.7-dev && \
   gem install --no-document $GEM_PKGS


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR backports R package version pinning from master to branch-3.5:

1. Pin `roxygen2` to version 7.2.0 (per SPARK-39959)
2. Pin `lintr` to version 2.0.1 instead of installing from GitHub
3. Install `pkgdown` at the end to prevent version upgrade (per SPARK-54371)

### Why are the changes needed?

The SparkR documentation generated for v3.5.8 differs significantly from v4.2.0-preview1 despite no major API changes. Investigation revealed:

1. **roxygen2 version issue**: The branch-3.5 Dockerfile uses `install.packages('roxygen2')` which installs the latest version from CRAN (7.3.x+), while master pins it to 7.2.0. Different roxygen2 versions generate `.Rd` files differently, affecting the final HTML output.

2. **pkgdown version upgrade**: When `preferably` is installed after `pkgdown`, it can upgrade pkgdown from 2.0.1 to 2.2.0 due to dependency resolution. Installing pkgdown LAST prevents this.

See:
- https://dist.apache.org/repos/dist/release/spark/docs/3.5.8/api/R/reference/
- https://dist.apache.org/repos/dist/release/spark/docs/4.2.0-preview1/api/R/reference/

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This is a backport of fixes already validated on master branch.