### PR TITLE
[SPARK-55110][SQL] Order of application of 3 rules changed to achieve idempotency faster

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -138,10 +138,11 @@ abstract class Optimizer(catalogManager: CatalogManager)
         EliminateAggregateFilter,
         ReorderAssociativeOperator,
         LikeSimplification,
-        BooleanSimplification,
+        // SPARK-55110 : optimal order of application
         SimplifyConditionals,
-        PushFoldableIntoBranches,
         SimplifyBinaryComparison,
+        BooleanSimplification,
+        PushFoldableIntoBranches,
         ReplaceNullWithFalseInPredicate,
         PruneFilters,
         SimplifyCasts,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BinaryComparisonSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BinaryComparisonSimplificationSuite.scala
@@ -41,8 +41,8 @@ class BinaryComparisonSimplificationSuite extends PlanTest {
       Batch("Constant Folding", FixedPoint(50),
         NullPropagation,
         ConstantFolding,
-        BooleanSimplification,
         SimplifyBinaryComparison,
+        BooleanSimplification,
         PruneFilters) :: Nil
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombiningLimitsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombiningLimitsSuite.scala
@@ -37,8 +37,8 @@ class CombiningLimitsSuite extends PlanTest {
       Batch("Constant Folding", FixedPoint(10),
         NullPropagation,
         ConstantFolding,
-        BooleanSimplification,
-        SimplifyConditionals) :: Nil
+        SimplifyConditionals,
+        BooleanSimplification) :: Nil
   }
 
   val testRelation = LocalRelation.fromExternalRows(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PushFoldableIntoBranchesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PushFoldableIntoBranchesSuite.scala
@@ -36,7 +36,7 @@ class PushFoldableIntoBranchesSuite extends PlanTest {
 
   object Optimize extends RuleExecutor[LogicalPlan] {
     val batches = Batch("PushFoldableIntoBranches", FixedPoint(50),
-      BooleanSimplification, ConstantFolding, SimplifyConditionals, PushFoldableIntoBranches) :: Nil
+      SimplifyConditionals, BooleanSimplification, ConstantFolding, PushFoldableIntoBranches) :: Nil
   }
 
   private val relation = LocalRelation($"a".int, $"b".int, $"c".boolean)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceNullWithFalseInPredicateSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceNullWithFalseInPredicateSuite.scala
@@ -36,8 +36,8 @@ class ReplaceNullWithFalseInPredicateSuite extends PlanTest {
       Batch("Replace null literals", FixedPoint(10),
         NullPropagation,
         ConstantFolding,
-        BooleanSimplification,
         SimplifyConditionals,
+        BooleanSimplification,
         ReplaceNullWithFalseInPredicate) :: Nil
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SimplifyConditionalSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SimplifyConditionalSuite.scala
@@ -32,7 +32,7 @@ class SimplifyConditionalSuite extends PlanTest with ExpressionEvalHelper {
 
   object Optimize extends RuleExecutor[LogicalPlan] {
     val batches = Batch("SimplifyConditionals", FixedPoint(50),
-      BooleanSimplification, ConstantFolding, SimplifyConditionals) :: Nil
+      SimplifyConditionals, BooleanSimplification, ConstantFolding) :: Nil
   }
 
   private val relation = LocalRelation($"a".int, $"b".int, $"c".boolean)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
@@ -44,9 +44,9 @@ class ComplexTypesSuite extends PlanTest with ExpressionEvalHelper {
       Batch("Constant Folding", FixedPoint(10),
          NullPropagation,
          ConstantFolding,
-         BooleanSimplification,
          SimplifyConditionals,
          SimplifyBinaryComparison,
+         BooleanSimplification,
          OptimizeUpdateFields,
          SimplifyExtractValueOps) :: Nil
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The order of application of 3 rules is changed from 
```
 BooleanSimplification,
        SimplifyConditionals,
        PushFoldableIntoBranches,
        SimplifyBinaryComparison,
```
to
```
SimplifyConditionals,
        SimplifyBinaryComparison,
        BooleanSimplification,
        PushFoldableIntoBranches,
```

### Why are the changes needed?
This would help achieve idempotency in plan optimization faster, in some cases for eg
`($"a" > 1000 && $"c" =!= false)`
can achieve idempotency in one pass to 
`$"a" > 1000 && $"c"`
with the modified order, as BooleanSimplification rule becomes more efficient due to preprocessing by SimplifyBinaryComparison

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added bugtest


### Was this patch authored or co-authored using generative AI tooling?
No
