### PR TITLE
[SPARK-55113][SQL] `EnsureRequirements` should copy tags

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -679,7 +679,7 @@ case class EnsureRequirements(
       applyPartialClustering: Boolean,
       replicatePartitions: Boolean): SparkPlan = plan match {
     case scan: BatchScanExec =>
-      scan.copy(
+      val newScan = scan.copy(
         spjParams = scan.spjParams.copy(
           commonPartitionValues = Some(values),
           joinKeyPositions = joinKeyPositions,
@@ -688,6 +688,8 @@ case class EnsureRequirements(
           replicatePartitions = replicatePartitions
         )
       )
+      newScan.copyTagsFrom(scan)
+      newScan
     case node =>
       node.mapChildren(child => populateCommonPartitionInfo(
         child, values, joinKeyPositions, reducers, applyPartialClustering, replicatePartitions))
@@ -698,11 +700,13 @@ case class EnsureRequirements(
       plan: SparkPlan,
       joinKeyPositions: Option[Seq[Int]]): SparkPlan = plan match {
     case scan: BatchScanExec =>
-      scan.copy(
+      val newScan = scan.copy(
         spjParams = scan.spjParams.copy(
           joinKeyPositions = joinKeyPositions
         )
       )
+      newScan.copyTagsFrom(scan)
+      newScan
     case node =>
       node.mapChildren(child => populateJoinKeyPositions(
         child, joinKeyPositions))


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is a minor fix of `EnsureRequirements` to make sure copied scan nodes inherit the tags from original ones in SPJ functions.

### Why are the changes needed?
Fix possible bugs.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.
