### PR TITLE
[SPARK-55115][INFRA] Use master branch's Dockerfile for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,13 @@ jobs:
         with:
           repository: apache/spark
           ref: "${{ inputs.branch }}"
+      - name: Use master branch's Dockerfile for release
+        # The release Docker image should always use master's Dockerfile which is actively maintained.
+        # Old branch Dockerfiles may have broken dependencies (expired GPG keys, outdated base images, etc.)
+        run: |
+          git fetch origin master --depth=1
+          git checkout origin/master -- dev/create-release/spark-rm/
+          echo "Using master branch's Dockerfile for building release image"
       - name: Free up disk space
         run: |
           if [ -f ./dev/free_disk_space ]; then


### PR DESCRIPTION
### What changes were proposed in this pull request?

Modified the release GitHub Actions workflow to always use master branch's Dockerfile when building the release Docker image, instead of using the Dockerfile from the release branch.

### Why are the changes needed?

Old branch Dockerfiles can become unmaintainable over time due to:
- Expired GPG keys (e.g., Node.js 12 repository keys)
- Outdated base images with broken package dependencies
- Package version conflicts with aging OS versions (e.g., Ubuntu 20.04)

The master branch's Dockerfile is actively maintained and uses modern base images (Ubuntu 22.04), making release builds more reliable.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested locally by building the release Docker image using master's Dockerfile and generating SparkR documentation for branch-3.5.

### Was this patch authored or co-authored using generative AI tooling?

Yes. cursor 2.3.41

---
_This PR was created with [GitHub MCP](http://go/mcps)._