### PR TITLE
[SPARK-55117] [SQL] `EventTimeWatermark` should be resolved when referencing recursive type

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1706,6 +1706,20 @@ class Analyzer(
       case d: DataFrameDropColumns if !d.resolved =>
         resolveDataFrameDropColumns(d)
 
+      case eventTimeWatermark: EventTimeWatermark =>
+        eventTimeWatermark.mapExpressions { expression =>
+          val resolvedExpression = resolveExpressionByPlanChildren(
+            expression,
+            eventTimeWatermark,
+            includeLastResort = true
+          )
+
+          resolvedExpression match {
+            case alias: Alias => alias.toAttribute
+            case other => other
+          }
+        }
+
       case q: LogicalPlan =>
         logTrace(s"Attempting to resolve ${q.simpleString(conf.maxToStringFields)}")
         q.mapExpressions(resolveExpressionByPlanChildren(_, q, includeLastResort = true))

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -5088,6 +5088,18 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
       checkAnswer(sql(query), Row(1, 2))
     }
   }
+
+  test("SPARK-55117: EventTimeWatermark should be resolved when referencing recursive type") {
+    val df1 = sql("SELECT * FROM VALUES(1, named_struct('field', 2)) AS t(col1, col2)")
+      .withWatermark("col2.field", "0 seconds")
+
+    checkAnswer(df1, Row(1, Row(2)))
+
+    val df2 = sql("SELECT * FROM VALUES(1, map('field',2)) AS t(col1, col2)")
+      .withWatermark("col2.field", "0 seconds")
+
+    checkAnswer(df2, Row(1, Map("field" -> 2)))
+  }
 }
 
 case class Foo(bar: Option[String])


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR I propose to transform `EventTimeWatermark.eventTime` to attribute if it is resolved as an `Alias` in `ResolveReferences` (this happens when it references a recursive type).
Before this fix, Dataframe program added as a test failed with an internal error.


### Why are the changes needed?
In order to fix an internal error.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing + added tests.

### Was this patch authored or co-authored using generative AI tooling?
No.