### PR TITLE
[SPARK-55119][SQL] Fix Continue Handler: prevent INTERNAL_ERROR and incorrect conditional statements interruption

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -484,20 +484,22 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
     verifySqlScriptResult(sqlScript, expected = expected)
   }
 
-  test("continue handler - WHILE loop with SIGNAL before IF") {
+  test("continue handler - WHILE loop with zero division before IF") {
     val sqlScript =
       """
         |BEGIN
         |  DECLARE i INT DEFAULT 0;
         |  DECLARE s INT DEFAULT 0;
         |
-        |  DECLARE CONTINUE HANDLER FOR NOT FOUND
+        |  DECLARE CONTINUE HANDLER FOR DIVIDE_BY_ZERO
+        |  BEGIN
         |    SELECT 22;
+        |  END;
         |
         |  WHILE i < 2 DO
         |    SET i = i + 1;
         |
-        |    SIGNAL SQLSTATE '02000';
+        |    SELECT 1/0;
         |
         |    IF 1==1 THEN
         |      SET s = s + 5;
@@ -515,20 +517,22 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
     verifySqlScriptResult(sqlScript, expected = expected)
   }
 
-  test("continue handler - REPEAT loop with SIGNAL before IF") {
+  test("continue handler - REPEAT loop with zero division before IF") {
     val sqlScript =
       """
         |BEGIN
         |  DECLARE i INT DEFAULT 0;
         |  DECLARE s INT DEFAULT 0;
         |
-        |  DECLARE CONTINUE HANDLER FOR NOT FOUND
+        |  DECLARE CONTINUE HANDLER FOR DIVIDE_BY_ZERO
+        |  BEGIN
         |    SELECT 22;
+        |  END;
         |
         |  REPEAT
         |    SET i = i + 1;
         |
-        |    SIGNAL SQLSTATE '02000';
+        |    SELECT 1/0;
         |
         |    IF 1==1 THEN
         |      SET s = s + 5;
@@ -576,18 +580,20 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
     verifySqlScriptResult(sqlScript, expected = expected)
   }
 
-  test("continue handler - FOR loop with signal before IF") {
+  test("continue handler - FOR loop with zero division before IF") {
     val sqlScript =
       """
         |BEGIN
         |  DECLARE s INT DEFAULT 0;
         |
-        |  DECLARE CONTINUE HANDLER FOR NOT FOUND
+        |  DECLARE CONTINUE HANDLER FOR DIVIDE_BY_ZERO
+        |  BEGIN
         |    SELECT 22;
+        |  END;
         |
         |  FOR i AS VALUES (1), (2) DO
         |    SELECT 1;
-        |    SIGNAL SQLSTATE '02000';
+        |    SELECT 1/0;
         |
         |    IF 1==1 THEN
         |      SET s = s + 5;
@@ -607,16 +613,18 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
     verifySqlScriptResult(sqlScript, expected = expected)
   }
 
-  test("continue handler - SIGNAL before FOR loop") {
+  test("continue handler - zero division before FOR loop") {
     val sqlScript =
       """
         |BEGIN
         |  DECLARE s INT DEFAULT 0;
         |
-        |  DECLARE CONTINUE HANDLER FOR NOT FOUND
+        |  DECLARE CONTINUE HANDLER FOR DIVIDE_BY_ZERO
+        |  BEGIN
         |    SELECT 22;
+        |  END;
         |
-        |  SIGNAL SQLSTATE '02000';
+        |  SELECT 1/0;
         |
         |  FOR i AS VALUES (1), (2) DO
         |    SELECT 1;
@@ -637,19 +645,21 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
     verifySqlScriptResult(sqlScript, expected = expected)
   }
 
-  test("continue handler - SIGNAL before simple case") {
+  test("continue handler - zero division before simple case") {
     withTable("t") {
       val commands =
         """
           |BEGIN
-          |  DECLARE CONTINUE HANDLER FOR NOT FOUND
+          |  DECLARE CONTINUE HANDLER FOR DIVIDE_BY_ZERO
+          |  BEGIN
           |    SELECT 22;
+          |  END;
           |
           |  CREATE TABLE t (a INT, b STRING, c DOUBLE) USING parquet;
           |  INSERT INTO t VALUES (1, 'a', 1.0);
           |  INSERT INTO t VALUES (2, 'b', 2.0);
           |
-          |  SIGNAL SQLSTATE '02000';
+          |  SELECT 1/0;
           |  CASE (SELECT COUNT(*) FROM t)
           |   WHEN 1 THEN
           |     SELECT 42;
@@ -668,14 +678,16 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("continue handler - SIGNAL before searched case") {
+  test("continue handler - zero division before searched case") {
     val commands =
       """
         |BEGIN
-        |  DECLARE CONTINUE HANDLER FOR NOT FOUND
+        |  DECLARE CONTINUE HANDLER FOR DIVIDE_BY_ZERO
+        |  BEGIN
         |    SELECT 22;
+        |  END;
         |
-        |  SIGNAL SQLSTATE '02000';
+        |  SELECT 1/0;
         |
         |  CASE
         |    WHEN 1 = (SELECT 2) THEN


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes two issues with `CONTINUE` handler behavior in SQL scripting when exceptions occur in or around conditional statements:

**Issue 1: INTERNAL_ERROR when CONTINUE handler interrupts conditional statement at end of loop body**                                                                           
- When a CONTINUE handler processes an exception in a conditional statement's condition (e.g., `IF (1/0)==1 THEN`), the conditional is interrupted                               
- If the conditional is the last statement in a loop body (WHILE/REPEAT), the loop would call `next()` on an exhausted iterator after the handler completes
- This caused: `INTERNAL_ERROR: No more elements to iterate through in the current SQL compound statement` 

**Fix:** Added `hasNext` checks in WHILE and REPEAT loop iterators before calling `next()` on the body. If the body is exhausted, return `NoOpStatementExec` and transition back to the condition state instead of calling `next()`. 

**Issue 2: Incorrect interruption of conditional statements when exception occurs before them**                                                                                  
- When an exception occurs **before** a conditional statement (e.g., `SIGNAL SQLSTATE '02000'; WHILE ... DO`), the conditional was incorrectly interrupted                        
- This caused the loop statement body to be skipped even though the exception didn't occur during its evaluation                                                             
- The interrupt logic couldn't distinguish between "exception during evaluation" vs "exception before reaching the statement"

**Fix:** Added explicit tracking of when evaluation starts:                                                                                                                      
- `ForStatementExec`: Added `hasStartedQueryEvaluation` flag, set when `cachedQueryResult()` begins evaluating the FOR loop's query                                              
- `SimpleCaseStatementExec`: Added `hasStartedCaseVariableEvaluation` flag, set when `validateCache()` begins evaluating the case variable                                       
- Updated `interruptConditionalStatements()` to check these flags - only interrupt if evaluation was actually attempted

### Why are the changes needed?
Cursor support is dependent on `CONTINUE HANDLER` correct behavior. We needed to fix this to unblock development of cursors support.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added comprehensive test coverage in `SqlScriptingExecutionSuite` that tests both **Issue 1** and **Issue 2**.

### Was this patch authored or co-authored using generative AI tooling?
No.
