### PR TITLE
[SPARK-55123][SS] Add SequentialUnionOffset for tracking sequential source processing

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/OffsetSeq.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/OffsetSeq.scala
@@ -375,13 +375,11 @@ object OffsetSeqControlBatchInfo {
  * @param activeSourceName The name of the currently active source being processed.
  * @param completedSources Set of source names that have finished processing.
  * @param sourceNames All source names in the order they should be processed.
- * @param version Format version for future compatibility.
  */
 case class SequentialUnionOffset(
     activeSourceName: String,
     completedSources: Set[String],
-    sourceNames: Seq[String],
-    version: Int = 1) extends OffsetV2 {
+    sourceNames: Seq[String]) extends OffsetV2 {
 
   // Validate on construction
   require(sourceNames.nonEmpty, "sourceNames must not be empty")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/OffsetSeq.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/OffsetSeq.scala
@@ -373,22 +373,23 @@ object OffsetSeqControlBatchInfo {
  * and to integrate with the query evolution feature.
  *
  * @param activeSourceName The name of the currently active source being processed.
- * @param completedSources Set of source names that have finished processing.
- * @param sourceNames All source names in the order they should be processed.
+ * @param allSourceNames All source names in the order they should be processed.
+ * @param completedSourceNames Set of source names that have finished processing.
  */
 case class SequentialUnionOffset(
     activeSourceName: String,
-    completedSources: Set[String],
-    sourceNames: Seq[String]) extends OffsetV2 {
+    allSourceNames: Seq[String],
+    completedSourceNames: Set[String]) extends OffsetV2 {
 
   // Validate on construction
-  require(sourceNames.nonEmpty, "sourceNames must not be empty")
-  require(sourceNames.contains(activeSourceName),
-    s"activeSourceName '$activeSourceName' must be in sourceNames: ${sourceNames.mkString(", ")}")
-  require(completedSources.subsetOf(sourceNames.toSet),
-    s"completedSources must be a subset of sourceNames")
-  require(!completedSources.contains(activeSourceName),
-    s"activeSourceName '$activeSourceName' cannot be in completedSources")
+  require(allSourceNames.nonEmpty, "allSourceNames must not be empty")
+  require(allSourceNames.contains(activeSourceName),
+    s"activeSourceName '$activeSourceName' must be in allSourceNames: " +
+      s"${allSourceNames.mkString(", ")}")
+  require(completedSourceNames.subsetOf(allSourceNames.toSet),
+    s"completedSourceNames must be a subset of allSourceNames")
+  require(!completedSourceNames.contains(activeSourceName),
+    s"activeSourceName '$activeSourceName' cannot be in completedSourceNames")
 
   override def json(): String = Serialization.write(this)(SequentialUnionOffset.format)
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/SequentialUnionOffsetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/SequentialUnionOffsetSuite.scala
@@ -26,22 +26,19 @@ class SequentialUnionOffsetSuite extends SparkFunSuite {
     val offset = SequentialUnionOffset(
       activeSourceName = "source2",
       completedSources = Set("source1"),
-      sourceNames = Seq("source1", "source2", "source3"),
-      version = 1
+      sourceNames = Seq("source1", "source2", "source3")
     )
 
     assert(offset.activeSourceName === "source2")
     assert(offset.completedSources === Set("source1"))
     assert(offset.sourceNames === Seq("source1", "source2", "source3"))
-    assert(offset.version === 1)
   }
 
   test("SequentialUnionOffset - JSON serialization and deserialization") {
     val offset = SequentialUnionOffset(
       activeSourceName = "kafka-live",
       completedSources = Set("delta-historical", "delta-backfill"),
-      sourceNames = Seq("delta-historical", "delta-backfill", "kafka-live"),
-      version = 1
+      sourceNames = Seq("delta-historical", "delta-backfill", "kafka-live")
     )
 
     val json = offset.json()
@@ -50,7 +47,6 @@ class SequentialUnionOffsetSuite extends SparkFunSuite {
     assert(deserialized.activeSourceName === offset.activeSourceName)
     assert(deserialized.completedSources === offset.completedSources)
     assert(deserialized.sourceNames === offset.sourceNames)
-    assert(deserialized.version === offset.version)
   }
 
   test("SequentialUnionOffset - JSON roundtrip with special characters") {
@@ -58,8 +54,7 @@ class SequentialUnionOffsetSuite extends SparkFunSuite {
       activeSourceName = "source-with-dashes_and_underscores",
       completedSources = Set("source.with.dots", "source/with/slashes"),
       sourceNames = Seq("source.with.dots", "source/with/slashes",
-        "source-with-dashes_and_underscores"),
-      version = 1
+        "source-with-dashes_and_underscores")
     )
 
     val json = offset.json()
@@ -73,8 +68,7 @@ class SequentialUnionOffsetSuite extends SparkFunSuite {
       SequentialUnionOffset(
         activeSourceName = "source1",
         completedSources = Set.empty,
-        sourceNames = Seq.empty,
-        version = 1
+        sourceNames = Seq.empty
       )
     }
     assert(ex.getMessage.contains("sourceNames must not be empty"))
@@ -85,8 +79,7 @@ class SequentialUnionOffsetSuite extends SparkFunSuite {
       SequentialUnionOffset(
         activeSourceName = "nonexistent",
         completedSources = Set.empty,
-        sourceNames = Seq("source1", "source2"),
-        version = 1
+        sourceNames = Seq("source1", "source2")
       )
     }
     assert(ex.getMessage.contains("activeSourceName"))
@@ -98,8 +91,7 @@ class SequentialUnionOffsetSuite extends SparkFunSuite {
       SequentialUnionOffset(
         activeSourceName = "source2",
         completedSources = Set("source1", "nonexistent"),
-        sourceNames = Seq("source1", "source2", "source3"),
-        version = 1
+        sourceNames = Seq("source1", "source2", "source3")
       )
     }
     assert(ex.getMessage.contains("completedSources must be a subset"))
@@ -110,8 +102,7 @@ class SequentialUnionOffsetSuite extends SparkFunSuite {
       SequentialUnionOffset(
         activeSourceName = "source2",
         completedSources = Set("source1", "source2"),
-        sourceNames = Seq("source1", "source2", "source3"),
-        version = 1
+        sourceNames = Seq("source1", "source2", "source3")
       )
     }
     assert(ex.getMessage.contains("activeSourceName"))
@@ -122,8 +113,7 @@ class SequentialUnionOffsetSuite extends SparkFunSuite {
     val offset = SequentialUnionOffset(
       activeSourceName = "source1",
       completedSources = Set.empty,
-      sourceNames = Seq("source1", "source2", "source3"),
-      version = 1
+      sourceNames = Seq("source1", "source2", "source3")
     )
 
     assert(offset.activeSourceName === "source1")
@@ -134,8 +124,7 @@ class SequentialUnionOffsetSuite extends SparkFunSuite {
     val offset = SequentialUnionOffset(
       activeSourceName = "source2",
       completedSources = Set("source1"),
-      sourceNames = Seq("source1", "source2", "source3"),
-      version = 1
+      sourceNames = Seq("source1", "source2", "source3")
     )
 
     assert(offset.activeSourceName === "source2")
@@ -146,8 +135,7 @@ class SequentialUnionOffsetSuite extends SparkFunSuite {
     val offset = SequentialUnionOffset(
       activeSourceName = "source3",
       completedSources = Set("source1", "source2"),
-      sourceNames = Seq("source1", "source2", "source3"),
-      version = 1
+      sourceNames = Seq("source1", "source2", "source3")
     )
 
     assert(offset.activeSourceName === "source3")
@@ -160,8 +148,7 @@ class SequentialUnionOffsetSuite extends SparkFunSuite {
       activeSourceName = "source5",
       completedSources = Set("source1", "source2", "source3", "source4"),
       sourceNames = Seq("source1", "source2", "source3", "source4", "source5",
-        "source6"),
-      version = 1
+        "source6")
     )
 
     val json = offset.json()
@@ -170,30 +157,5 @@ class SequentialUnionOffsetSuite extends SparkFunSuite {
     assert(deserialized.completedSources.size === 4)
     assert(deserialized.completedSources ===
       Set("source1", "source2", "source3", "source4"))
-  }
-
-  test("SequentialUnionOffset - version field preserved") {
-    val offset1 = SequentialUnionOffset(
-      activeSourceName = "source1",
-      completedSources = Set.empty,
-      sourceNames = Seq("source1", "source2"),
-      version = 1
-    )
-
-    val offset2 = SequentialUnionOffset(
-      activeSourceName = "source1",
-      completedSources = Set.empty,
-      sourceNames = Seq("source1", "source2"),
-      version = 2
-    )
-
-    assert(offset1.version === 1)
-    assert(offset2.version === 2)
-
-    val json1 = offset1.json()
-    val json2 = offset2.json()
-
-    assert(SequentialUnionOffset(json1).version === 1)
-    assert(SequentialUnionOffset(json2).version === 2)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/SequentialUnionOffsetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/SequentialUnionOffsetSuite.scala
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.execution.streaming.checkpointing.SequentialUnionOffset
+
+class SequentialUnionOffsetSuite extends SparkFunSuite {
+
+  test("SequentialUnionOffset - creation and basic properties") {
+    val offset = SequentialUnionOffset(
+      activeSourceName = "source2",
+      completedSources = Set("source1"),
+      sourceNames = Seq("source1", "source2", "source3"),
+      version = 1
+    )
+
+    assert(offset.activeSourceName === "source2")
+    assert(offset.completedSources === Set("source1"))
+    assert(offset.sourceNames === Seq("source1", "source2", "source3"))
+    assert(offset.version === 1)
+  }
+
+  test("SequentialUnionOffset - JSON serialization and deserialization") {
+    val offset = SequentialUnionOffset(
+      activeSourceName = "kafka-live",
+      completedSources = Set("delta-historical", "delta-backfill"),
+      sourceNames = Seq("delta-historical", "delta-backfill", "kafka-live"),
+      version = 1
+    )
+
+    val json = offset.json()
+    val deserialized = SequentialUnionOffset(json)
+
+    assert(deserialized.activeSourceName === offset.activeSourceName)
+    assert(deserialized.completedSources === offset.completedSources)
+    assert(deserialized.sourceNames === offset.sourceNames)
+    assert(deserialized.version === offset.version)
+  }
+
+  test("SequentialUnionOffset - JSON roundtrip with special characters") {
+    val offset = SequentialUnionOffset(
+      activeSourceName = "source-with-dashes_and_underscores",
+      completedSources = Set("source.with.dots", "source/with/slashes"),
+      sourceNames = Seq("source.with.dots", "source/with/slashes",
+        "source-with-dashes_and_underscores"),
+      version = 1
+    )
+
+    val json = offset.json()
+    val deserialized = SequentialUnionOffset(json)
+
+    assert(deserialized === offset)
+  }
+
+  test("SequentialUnionOffset - validation: empty sourceNames") {
+    val ex = intercept[IllegalArgumentException] {
+      SequentialUnionOffset(
+        activeSourceName = "source1",
+        completedSources = Set.empty,
+        sourceNames = Seq.empty,
+        version = 1
+      )
+    }
+    assert(ex.getMessage.contains("sourceNames must not be empty"))
+  }
+
+  test("SequentialUnionOffset - validation: active not in sourceNames") {
+    val ex = intercept[IllegalArgumentException] {
+      SequentialUnionOffset(
+        activeSourceName = "nonexistent",
+        completedSources = Set.empty,
+        sourceNames = Seq("source1", "source2"),
+        version = 1
+      )
+    }
+    assert(ex.getMessage.contains("activeSourceName"))
+    assert(ex.getMessage.contains("must be in sourceNames"))
+  }
+
+  test("SequentialUnionOffset - validation: completedSources not subset") {
+    val ex = intercept[IllegalArgumentException] {
+      SequentialUnionOffset(
+        activeSourceName = "source2",
+        completedSources = Set("source1", "nonexistent"),
+        sourceNames = Seq("source1", "source2", "source3"),
+        version = 1
+      )
+    }
+    assert(ex.getMessage.contains("completedSources must be a subset"))
+  }
+
+  test("SequentialUnionOffset - validation: active in completed") {
+    val ex = intercept[IllegalArgumentException] {
+      SequentialUnionOffset(
+        activeSourceName = "source2",
+        completedSources = Set("source1", "source2"),
+        sourceNames = Seq("source1", "source2", "source3"),
+        version = 1
+      )
+    }
+    assert(ex.getMessage.contains("activeSourceName"))
+    assert(ex.getMessage.contains("cannot be in completedSources"))
+  }
+
+  test("SequentialUnionOffset - initial state (first source active)") {
+    val offset = SequentialUnionOffset(
+      activeSourceName = "source1",
+      completedSources = Set.empty,
+      sourceNames = Seq("source1", "source2", "source3"),
+      version = 1
+    )
+
+    assert(offset.activeSourceName === "source1")
+    assert(offset.completedSources.isEmpty)
+  }
+
+  test("SequentialUnionOffset - middle state (second source active)") {
+    val offset = SequentialUnionOffset(
+      activeSourceName = "source2",
+      completedSources = Set("source1"),
+      sourceNames = Seq("source1", "source2", "source3"),
+      version = 1
+    )
+
+    assert(offset.activeSourceName === "source2")
+    assert(offset.completedSources === Set("source1"))
+  }
+
+  test("SequentialUnionOffset - final source active") {
+    val offset = SequentialUnionOffset(
+      activeSourceName = "source3",
+      completedSources = Set("source1", "source2"),
+      sourceNames = Seq("source1", "source2", "source3"),
+      version = 1
+    )
+
+    assert(offset.activeSourceName === "source3")
+    assert(offset.completedSources === Set("source1", "source2"))
+    assert(offset.completedSources.size === offset.sourceNames.size - 1)
+  }
+
+  test("SequentialUnionOffset - multiple completed sources") {
+    val offset = SequentialUnionOffset(
+      activeSourceName = "source5",
+      completedSources = Set("source1", "source2", "source3", "source4"),
+      sourceNames = Seq("source1", "source2", "source3", "source4", "source5",
+        "source6"),
+      version = 1
+    )
+
+    val json = offset.json()
+    val deserialized = SequentialUnionOffset(json)
+
+    assert(deserialized.completedSources.size === 4)
+    assert(deserialized.completedSources ===
+      Set("source1", "source2", "source3", "source4"))
+  }
+
+  test("SequentialUnionOffset - version field preserved") {
+    val offset1 = SequentialUnionOffset(
+      activeSourceName = "source1",
+      completedSources = Set.empty,
+      sourceNames = Seq("source1", "source2"),
+      version = 1
+    )
+
+    val offset2 = SequentialUnionOffset(
+      activeSourceName = "source1",
+      completedSources = Set.empty,
+      sourceNames = Seq("source1", "source2"),
+      version = 2
+    )
+
+    assert(offset1.version === 1)
+    assert(offset2.version === 2)
+
+    val json1 = offset1.json()
+    val json2 = offset2.json()
+
+    assert(SequentialUnionOffset(json1).version === 1)
+    assert(SequentialUnionOffset(json2).version === 2)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/SequentialUnionOffsetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/SequentialUnionOffsetSuite.scala
@@ -20,41 +20,46 @@ package org.apache.spark.sql.execution.streaming
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.execution.streaming.checkpointing.SequentialUnionOffset
 
+/**
+ * Test suite for [[SequentialUnionOffset]], which tracks the state of sequential source
+ * processing in streaming queries. Tests cover offset creation, JSON serialization/deserialization,
+ * parameter validation, and state transitions through the sequential processing lifecycle.
+ */
 class SequentialUnionOffsetSuite extends SparkFunSuite {
 
   test("SequentialUnionOffset - creation and basic properties") {
     val offset = SequentialUnionOffset(
       activeSourceName = "source2",
-      completedSources = Set("source1"),
-      sourceNames = Seq("source1", "source2", "source3")
+      allSourceNames = Seq("source1", "source2", "source3"),
+      completedSourceNames = Set("source1")
     )
 
     assert(offset.activeSourceName === "source2")
-    assert(offset.completedSources === Set("source1"))
-    assert(offset.sourceNames === Seq("source1", "source2", "source3"))
+    assert(offset.allSourceNames === Seq("source1", "source2", "source3"))
+    assert(offset.completedSourceNames === Set("source1"))
   }
 
   test("SequentialUnionOffset - JSON serialization and deserialization") {
     val offset = SequentialUnionOffset(
       activeSourceName = "kafka-live",
-      completedSources = Set("delta-historical", "delta-backfill"),
-      sourceNames = Seq("delta-historical", "delta-backfill", "kafka-live")
+      allSourceNames = Seq("delta-historical", "delta-backfill", "kafka-live"),
+      completedSourceNames = Set("delta-historical", "delta-backfill")
     )
 
     val json = offset.json()
     val deserialized = SequentialUnionOffset(json)
 
     assert(deserialized.activeSourceName === offset.activeSourceName)
-    assert(deserialized.completedSources === offset.completedSources)
-    assert(deserialized.sourceNames === offset.sourceNames)
+    assert(deserialized.allSourceNames === offset.allSourceNames)
+    assert(deserialized.completedSourceNames === offset.completedSourceNames)
   }
 
   test("SequentialUnionOffset - JSON roundtrip with special characters") {
     val offset = SequentialUnionOffset(
       activeSourceName = "source-with-dashes_and_underscores",
-      completedSources = Set("source.with.dots", "source/with/slashes"),
-      sourceNames = Seq("source.with.dots", "source/with/slashes",
-        "source-with-dashes_and_underscores")
+      allSourceNames = Seq("source.with.dots", "source/with/slashes",
+        "source-with-dashes_and_underscores"),
+      completedSourceNames = Set("source.with.dots", "source/with/slashes")
     )
 
     val json = offset.json()
@@ -67,95 +72,95 @@ class SequentialUnionOffsetSuite extends SparkFunSuite {
     val ex = intercept[IllegalArgumentException] {
       SequentialUnionOffset(
         activeSourceName = "source1",
-        completedSources = Set.empty,
-        sourceNames = Seq.empty
+        allSourceNames = Seq.empty,
+        completedSourceNames = Set.empty
       )
     }
-    assert(ex.getMessage.contains("sourceNames must not be empty"))
+    assert(ex.getMessage.contains("allSourceNames must not be empty"))
   }
 
   test("SequentialUnionOffset - validation: active not in sourceNames") {
     val ex = intercept[IllegalArgumentException] {
       SequentialUnionOffset(
         activeSourceName = "nonexistent",
-        completedSources = Set.empty,
-        sourceNames = Seq("source1", "source2")
+        allSourceNames = Seq("source1", "source2"),
+        completedSourceNames = Set.empty
       )
     }
     assert(ex.getMessage.contains("activeSourceName"))
-    assert(ex.getMessage.contains("must be in sourceNames"))
+    assert(ex.getMessage.contains("must be in allSourceNames"))
   }
 
   test("SequentialUnionOffset - validation: completedSources not subset") {
     val ex = intercept[IllegalArgumentException] {
       SequentialUnionOffset(
         activeSourceName = "source2",
-        completedSources = Set("source1", "nonexistent"),
-        sourceNames = Seq("source1", "source2", "source3")
+        allSourceNames = Seq("source1", "source2", "source3"),
+        completedSourceNames = Set("source1", "nonexistent")
       )
     }
-    assert(ex.getMessage.contains("completedSources must be a subset"))
+    assert(ex.getMessage.contains("completedSourceNames must be a subset"))
   }
 
   test("SequentialUnionOffset - validation: active in completed") {
     val ex = intercept[IllegalArgumentException] {
       SequentialUnionOffset(
         activeSourceName = "source2",
-        completedSources = Set("source1", "source2"),
-        sourceNames = Seq("source1", "source2", "source3")
+        allSourceNames = Seq("source1", "source2", "source3"),
+        completedSourceNames = Set("source1", "source2")
       )
     }
     assert(ex.getMessage.contains("activeSourceName"))
-    assert(ex.getMessage.contains("cannot be in completedSources"))
+    assert(ex.getMessage.contains("cannot be in completedSourceNames"))
   }
 
   test("SequentialUnionOffset - initial state (first source active)") {
     val offset = SequentialUnionOffset(
       activeSourceName = "source1",
-      completedSources = Set.empty,
-      sourceNames = Seq("source1", "source2", "source3")
+      allSourceNames = Seq("source1", "source2", "source3"),
+      completedSourceNames = Set.empty
     )
 
     assert(offset.activeSourceName === "source1")
-    assert(offset.completedSources.isEmpty)
+    assert(offset.completedSourceNames.isEmpty)
   }
 
   test("SequentialUnionOffset - middle state (second source active)") {
     val offset = SequentialUnionOffset(
       activeSourceName = "source2",
-      completedSources = Set("source1"),
-      sourceNames = Seq("source1", "source2", "source3")
+      allSourceNames = Seq("source1", "source2", "source3"),
+      completedSourceNames = Set("source1")
     )
 
     assert(offset.activeSourceName === "source2")
-    assert(offset.completedSources === Set("source1"))
+    assert(offset.completedSourceNames === Set("source1"))
   }
 
   test("SequentialUnionOffset - final source active") {
     val offset = SequentialUnionOffset(
       activeSourceName = "source3",
-      completedSources = Set("source1", "source2"),
-      sourceNames = Seq("source1", "source2", "source3")
+      allSourceNames = Seq("source1", "source2", "source3"),
+      completedSourceNames = Set("source1", "source2")
     )
 
     assert(offset.activeSourceName === "source3")
-    assert(offset.completedSources === Set("source1", "source2"))
-    assert(offset.completedSources.size === offset.sourceNames.size - 1)
+    assert(offset.completedSourceNames === Set("source1", "source2"))
+    assert(offset.completedSourceNames.size === offset.allSourceNames.size - 1)
   }
 
   test("SequentialUnionOffset - multiple completed sources") {
     val offset = SequentialUnionOffset(
       activeSourceName = "source5",
-      completedSources = Set("source1", "source2", "source3", "source4"),
-      sourceNames = Seq("source1", "source2", "source3", "source4", "source5",
-        "source6")
+      allSourceNames = Seq("source1", "source2", "source3", "source4", "source5",
+        "source6"),
+      completedSourceNames = Set("source1", "source2", "source3", "source4")
     )
 
     val json = offset.json()
     val deserialized = SequentialUnionOffset(json)
 
-    assert(deserialized.completedSources.size === 4)
-    assert(deserialized.completedSources ===
+    assert(deserialized.completedSourceNames.size === 4)
+    assert(deserialized.completedSourceNames ===
       Set("source1", "source2", "source3", "source4"))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add SequentialUnionOffset class to support Sequential Union operations in Structured Streaming. This offset type enables tracking the state of sequential source processing in backfill-to-live streaming scenarios.

The implementation includes:
- SequentialUnionOffset case class that extends OffsetV2
- Name-based source tracking (not index-based) for stability across query restarts
- Validation logic to ensure correctness of offset state
- JSON serialization/deserialization support
- Comprehensive test suite

### Why are the changes needed?

Sequential Union is a new streaming operation that processes multiple sources sequentially rather than concurrently, enabling seamless backfill-to-live streaming scenarios. This offset type is needed to track which source is currently active and which sources have completed processing.

### Does this PR introduce _any_ user-facing change?

No. This is infrastructure for an upcoming feature.

### How was this patch tested?

Added SequentialUnionOffsetSuite with comprehensive test coverage:
- Creation and basic properties
- JSON serialization/deserialization
- Validation of invalid states
- Multiple source scenarios
- Special characters in source names

### Was this patch authored or co-authored using generative AI tooling?

No.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
