### PR TITLE
[SPARK-55124][PS][CONNECT][TESTS] Move `test_spark_arrow_c_streamer_arrow_consumer` to PS and enable the connect parity test

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -554,7 +554,6 @@ pyspark_sql = Module(
         "pyspark.sql.tests.test_job_cancellation",
         "pyspark.sql.tests.arrow.test_arrow",
         "pyspark.sql.tests.arrow.test_arrow_map",
-        "pyspark.sql.tests.arrow.test_arrow_c_stream",
         "pyspark.sql.tests.arrow.test_arrow_cogrouped_map",
         "pyspark.sql.tests.arrow.test_arrow_grouped_map",
         "pyspark.sql.tests.arrow.test_arrow_python_udf",
@@ -826,6 +825,7 @@ pyspark_pandas = Module(
         "pyspark.pandas.spark.utils",
         "pyspark.pandas.typedef.typehints",
         # unittests
+        "pyspark.pandas.tests.test_arrow_interface",
         "pyspark.pandas.tests.test_categorical",
         "pyspark.pandas.tests.test_config",
         "pyspark.pandas.tests.test_extension",
@@ -1271,6 +1271,7 @@ pyspark_pandas_connect = Module(
         # unittests dedicated for Spark Connect
         "pyspark.pandas.tests.connect.test_connect_plotting",
         # pandas-on-Spark unittests
+        "pyspark.pandas.tests.connect.test_parity_arrow_interface",
         "pyspark.pandas.tests.connect.test_parity_categorical",
         "pyspark.pandas.tests.connect.test_parity_config",
         "pyspark.pandas.tests.connect.test_parity_extension",

--- a/python/pyspark/pandas/tests/connect/test_parity_arrow_interface.py
+++ b/python/pyspark/pandas/tests/connect/test_parity_arrow_interface.py
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.pandas.tests.test_arrow_interface import ArrowInterfaceTestsMixin
+from pyspark.testing.connectutils import ReusedConnectTestCase
+
+
+class ArrowInterfaceParityTests(
+    ArrowInterfaceTestsMixin,
+    ReusedConnectTestCase,
+):
+    pass
+
+
+if __name__ == "__main__":
+    from pyspark.testing import main
+
+    main()

--- a/python/pyspark/pandas/tests/test_arrow_interface.py
+++ b/python/pyspark/pandas/tests/test_arrow_interface.py
@@ -16,27 +16,21 @@
 #
 import ctypes
 import unittest
-import pyspark.pandas as ps
 from pyspark.testing.utils import (
-    have_pandas,
     have_pyarrow,
-    pandas_requirement_message,
     pyarrow_requirement_message,
 )
+from pyspark import pandas as ps
+from pyspark.testing.sqlutils import SQLTestUtils
 
-if have_pandas:
-    import pandas as pd
-
-if have_pyarrow:
-    import pyarrow as pa
+import pandas as pd
 
 
-@unittest.skipIf(
-    not have_pyarrow or not have_pandas,
-    pyarrow_requirement_message or pandas_requirement_message,
-)
-class TestSparkArrowCStreamer(unittest.TestCase):
+@unittest.skipIf(not have_pyarrow, pyarrow_requirement_message)
+class ArrowInterfaceTestsMixin:
     def test_spark_arrow_c_streamer_arrow_consumer(self):
+        import pyarrow as pa
+
         pdf = pd.DataFrame([[1, "a"], [2, "b"], [3, "c"], [4, "d"]], columns=["id", "value"])
         psdf = ps.from_pandas(pdf)
 
@@ -64,6 +58,10 @@ class TestSparkArrowCStreamer(unittest.TestCase):
             schema=schema,
         )
         self.assertEqual(result, expected)
+
+
+class ArrowInterfaceTests(ArrowInterfaceTestsMixin, SQLTestUtils):
+    pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Move `test_spark_arrow_c_streamer_arrow_consumer` to PS and also enable the connect parity test

### Why are the changes needed?
1, The test is based on PS dataframes, so it should be in `pyspark.pandas` instead of `pyspark.sql`;
2, It should also be tested in connect mode;


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no
