### PR TITLE
[SPARK-55130][BUILD] Upgrade log4j to 2.25.3

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -181,11 +181,11 @@ lapack/3.0.4//lapack-3.0.4.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.16.0//libthrift-0.16.0.jar
-log4j-1.2-api/2.24.3//log4j-1.2-api-2.24.3.jar
-log4j-api/2.24.3//log4j-api-2.24.3.jar
-log4j-core/2.24.3//log4j-core-2.24.3.jar
-log4j-layout-template-json/2.24.3//log4j-layout-template-json-2.24.3.jar
-log4j-slf4j2-impl/2.24.3//log4j-slf4j2-impl-2.24.3.jar
+log4j-1.2-api/2.25.3//log4j-1.2-api-2.25.3.jar
+log4j-api/2.25.3//log4j-api-2.25.3.jar
+log4j-core/2.25.3//log4j-core-2.25.3.jar
+log4j-layout-template-json/2.25.3//log4j-layout-template-json-2.25.3.jar
+log4j-slf4j2-impl/2.25.3//log4j-slf4j2-impl-2.25.3.jar
 lz4-java/1.10.1//lz4-java-1.10.1.jar
 metrics-core/4.2.37//metrics-core-4.2.37.jar
 metrics-graphite/4.2.37//metrics-graphite-4.2.37.jar

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.9</asm.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <log4j.version>2.24.3</log4j.version>
+    <log4j.version>2.25.3</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.4.2</hadoop.version>
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade log4j from  2.24.3 to 2.25.3

### Why are the changes needed?
The new version brings fixes for CVE-2025-68161, the full release notes as follows:
- https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.25.0
- https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.25.1
- https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.25.2
- https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.25.3



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions


### Was this patch authored or co-authored using generative AI tooling?
No