### PR TITLE
[SPARK-55138][SQL] Fix `convertToMapData` throwing a `NullPointerException`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExprUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExprUtils.scala
@@ -66,7 +66,10 @@ object ExprUtils extends EvalHelper with QueryErrorsBase {
         .acceptsType(m.dataType) =>
       val arrayMap = m.eval().asInstanceOf[ArrayBasedMapData]
       ArrayBasedMapData.toScalaMap(arrayMap).map { case (key, value) =>
-        key.toString -> value.toString
+        if (key == null) {
+          throw QueryExecutionErrors.nullAsMapKeyNotAllowedError()
+        }
+        key.toString -> (if (value == null) "null" else value.toString)
       }
     case m: CreateMap =>
       throw QueryCompilationErrors.keyValueInMapNotStringError(m)

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -365,6 +365,32 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
       Row(Row(1, "haa")) :: Nil)
   }
 
+  test("from_json with NULL in options map values") {
+    val df = Seq("""{"str": "World"}""").toDS()
+    val schema = "str STRING"
+
+    checkAnswer(
+      df.selectExpr(
+        s"from_json(value, '$schema', map('key', 'value', 'mode', NULL))"
+      ),
+      Row(Row("World")) :: Nil
+    )
+  }
+
+  test("from_json with NULL in options map key") {
+    val df = Seq("""{"str": "World"}""").toDS()
+    val schema = "str STRING"
+
+    checkError(
+      exception = intercept[SparkRuntimeException] {
+        df.selectExpr(
+          s"from_json(value, '$schema', map('mode', 'PERMISSIVE', NULL, 'value'))"
+        ).show()
+      },
+      condition = "NULL_MAP_KEY"
+    )
+  }
+
   test("to_json - struct") {
     val df = Seq(Tuple1(Tuple1(1))).toDF("a")
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix `convertToMapData` throwing a `NullPointerException`. If `NULL` is provided as the value of the options parameter in `from_json`, it will throw a `NullPointerException`, because of `value.toString`.


```
val df = Seq("""{"str": "World"}""").toDS()
val schema = "str STRING"
df.selectExpr(s"from_json(value, '$schema', map('key', 'value', 'mode', NULL))
```


### Why are the changes needed?
Bug fix.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
New unit tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
