### PR TITLE
[PYTHON] Add missing docstrings to worker utility functions

### DIFF
--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -202,6 +202,24 @@ class RunnerConf:
 
 
 def report_times(outfile, boot, init, finish):
+    """
+    Report timing data to the output file.
+
+    Parameters
+    ----------
+    outfile : file-like object
+        The output file to write timing data to.
+    boot : float
+        Boot time in seconds.
+    init : float
+        Initialization time in seconds.
+    finish : float
+        Finish time in seconds.
+
+    Notes
+    -----
+    Times are converted to milliseconds (multiplied by 1000) before writing.
+    """
     write_int(SpecialLengths.TIMING_DATA, outfile)
     write_long(int(1000 * boot), outfile)
     write_long(int(1000 * init), outfile)
@@ -1302,6 +1320,28 @@ def wrap_bounded_window_agg_arrow_udf(f, args_offsets, kwargs_offsets, return_ty
 
 
 def wrap_kwargs_support(f, args_offsets, kwargs_offsets):
+    """
+    Wrap a function to support keyword arguments from positional arguments.
+
+    This function creates a wrapper that converts positional arguments into
+    keyword arguments based on the provided offsets.
+
+    Parameters
+    ----------
+    f : callable
+        The function to wrap.
+    args_offsets : list
+        List of offsets for positional arguments.
+    kwargs_offsets : dict
+        Dictionary mapping keyword argument names to their offsets.
+
+    Returns
+    -------
+    tuple
+        A tuple containing:
+        - The wrapped function (or original function if no kwargs)
+        - Combined list of argument offsets (args + kwargs offsets)
+    """
     if len(kwargs_offsets):
         keys = list(kwargs_offsets.keys())
 
@@ -1322,6 +1362,24 @@ def wrap_kwargs_support(f, args_offsets, kwargs_offsets):
 
 
 def _is_iter_based(eval_type: int) -> bool:
+    """
+    Check if the evaluation type is iterator-based.
+
+    Parameters
+    ----------
+    eval_type : int
+        The Python evaluation type constant.
+
+    Returns
+    -------
+    bool
+        True if the evaluation type is iterator-based, False otherwise.
+
+    Notes
+    -----
+    Iterator-based UDFs process data in batches using iterators rather than
+    processing all data at once.
+    """
     return eval_type in (
         PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF,
         PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF,


### PR DESCRIPTION
Add comprehensive docstrings to report_times, wrap_kwargs_support, and _is_iter_based functions in pyspark/worker.py to improve code documentation and maintainability. The docstrings follow the NumPy style used throughout the PySpark codebase.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
