### PR TITLE
[SPARK-55140][PYTHON][PS] Do not map builtin functions to numpy version for pandas 3

### DIFF
--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -1955,7 +1955,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
             psdf, self._groupkeys, agg_columns
         )
 
-        if LooseVersion(pd.__version__) < LooseVersion("3.0.0"):
+        if LooseVersion(pd.__version__) < "3.0.0":
             from pandas.core.common import is_builtin_func  # type: ignore[import-untyped]
             f = is_builtin_func(func)
         else:

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -45,7 +45,6 @@ import warnings
 
 import pandas as pd
 from pandas.api.types import is_number, is_hashable, is_list_like
-from pandas.core.common import _builtin_table  # type: ignore[import-untyped]
 
 from pyspark.sql import Column, DataFrame as SparkDataFrame, Window, functions as F
 from pyspark.sql.internal import InternalFunction as SF
@@ -59,6 +58,7 @@ from pyspark.sql.types import (
     StringType,
 )
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
+from pyspark.loose_version import LooseVersion
 from pyspark.pandas._typing import Axis, FrameLike, Label, Name
 from pyspark.pandas.typedef import infer_return_type, DataFrameType, ScalarType, SeriesType
 from pyspark.pandas.frame import DataFrame
@@ -1955,12 +1955,16 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
             psdf, self._groupkeys, agg_columns
         )
 
+        if LooseVersion(pd.__version__) < LooseVersion("3.0.0"):
+            from pandas.core.common import is_builtin_func  # type: ignore[import-untyped]
+            f = is_builtin_func(func)
+        else:
+            f = func
+
         if is_series_groupby:
             name = psdf.columns[-1]
-            pandas_apply = _builtin_table.get(func, func)
+            pandas_apply = f
         else:
-            f = _builtin_table.get(func, func)
-
             def pandas_apply(pdf: pd.DataFrame, *a: Any, **k: Any) -> Any:
                 return f(pdf.drop(groupkey_names, axis=1), *a, **k)
 

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -1956,7 +1956,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         )
 
         if LooseVersion(pd.__version__) < "3.0.0":
-            from pandas.core.common import is_builtin_func  # type: ignore[import-untyped]
+            from pandas.core.common import is_builtin_func
 
             f = is_builtin_func(func)
         else:
@@ -2189,7 +2189,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
 
         else:
             if LooseVersion(pd.__version__) < "3.0.0":
-                from pandas.core.common import is_builtin_func  # type: ignore[import-untyped]
+                from pandas.core.common import is_builtin_func
 
                 f = is_builtin_func(func)
             else:

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -1957,6 +1957,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
 
         if LooseVersion(pd.__version__) < "3.0.0":
             from pandas.core.common import is_builtin_func  # type: ignore[import-untyped]
+
             f = is_builtin_func(func)
         else:
             f = func
@@ -1965,6 +1966,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
             name = psdf.columns[-1]
             pandas_apply = f
         else:
+
             def pandas_apply(pdf: pd.DataFrame, *a: Any, **k: Any) -> Any:
                 return f(pdf.drop(groupkey_names, axis=1), *a, **k)
 
@@ -2186,7 +2188,12 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
                 return pd.DataFrame(pdf.groupby(groupkey_names)[pdf.columns[-1]].filter(func))  # type: ignore[arg-type]
 
         else:
-            f = _builtin_table.get(func, func)
+            if LooseVersion(pd.__version__) < "3.0.0":
+                from pandas.core.common import is_builtin_func  # type: ignore[import-untyped]
+
+                f = is_builtin_func(func)
+            else:
+                f = func
 
             def wrapped_func(pdf: pd.DataFrame) -> pd.DataFrame:
                 return f(pdf.drop(groupkey_names, axis=1))

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -1956,7 +1956,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         )
 
         if LooseVersion(pd.__version__) < "3.0.0":
-            from pandas.core.common import is_builtin_func
+            from pandas.core.common import is_builtin_func  # type: ignore[import-untyped]
 
             f = is_builtin_func(func)
         else:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

* We do not map builtin functions to numpy version for pandas 3
* Used `is_builtin_func` in pandas 2 to replace the even more private `_builtin_table`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Pandas 3 decided to not map the builtin functions for groupby anymore - https://github.com/pandas-dev/pandas/issues/53425 and we should match the behavior. Also the private API we were using was removed completely.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, the behavior for groupby apply will be slightly different if users are using pandas 3.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Locally at least the import error is fixed. CI is pinned at 2.x so it should pass.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No