### PR TITLE
[SPARK-55144][SS] Introduce new state format version for performant stream-stream join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3087,7 +3087,8 @@ object SQLConf {
       .doc("State format version used by streaming join operations in a streaming query. " +
         "State between versions are tend to be incompatible, so state format version shouldn't " +
         "be modified after running. Version 3 uses a single state store with virtual column " +
-        "families instead of four stores and is only supported with RocksDB.")
+        "families instead of four stores and is only supported with RocksDB. NOTE: version " +
+        "1 is DEPRECATED and should not be explicitly set by users.")
       .version("3.0.0")
       .intConf
       .checkValue(v => Set(1, 2, 3).contains(v), "Valid versions are 1, 2, and 3")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3091,6 +3091,8 @@ object SQLConf {
         "1 is DEPRECATED and should not be explicitly set by users.")
       .version("3.0.0")
       .intConf
+      // TODO: [SPARK-55628] Add version 4 once we integrate the state format version 4 into
+      //  stream-stream join operator.
       .checkValue(v => Set(1, 2, 3).contains(v), "Valid versions are 1, 2, and 3")
       .createWithDefault(2)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/StreamingSymmetricHashJoinExec.scala
@@ -789,7 +789,10 @@ case class StreamingSymmetricHashJoinExec(
       joinStateManager.get(key)
     }
 
-    // FIXME: doc!
+    /**
+     * Remove the old state key-value pairs from this joiner's state manager based on the state
+     * watermark predicate, and return the number of removed rows.
+     */
     def removeOldState(): Long = {
       stateWatermarkPredicate match {
         case Some(JoinStateKeyWatermarkPredicate(_, stateWatermark)) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/StreamingSymmetricHashJoinValueRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/StreamingSymmetricHashJoinValueRowConverter.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming.operators.stateful.join
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Literal, UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.execution.streaming.operators.stateful.join.SymmetricHashJoinStateManager.ValueAndMatchPair
+import org.apache.spark.sql.types.BooleanType
+
+/**
+ * Converter between the value row stored in state store and the (actual value, match) pair.
+ */
+trait StreamingSymmetricHashJoinValueRowConverter {
+  /** Defines the schema of the value row (the value side of K-V in state store). */
+  def valueAttributes: Seq[Attribute]
+
+  /**
+   * Convert the value row to (actual value, match) pair.
+   *
+   * NOTE: implementations should ensure the result row is NOT reused during execution, so
+   * that caller can safely read the value in any time.
+   */
+  def convertValue(value: UnsafeRow): ValueAndMatchPair
+
+  /**
+   * Build the value row from (actual value, match) pair. This is expected to be called just
+   * before storing to the state store.
+   *
+   * NOTE: depending on the implementation, the result row "may" be reused during execution
+   * (to avoid initialization of object), so the caller should ensure that the logic doesn't
+   * affect by such behavior. Call copy() against the result row if needed.
+   */
+  def convertToValueRow(value: UnsafeRow, matched: Boolean): UnsafeRow
+}
+
+class StreamingSymmetricHashJoinValueRowConverterFormatV1(
+    inputValueAttributes: Seq[Attribute]) extends StreamingSymmetricHashJoinValueRowConverter {
+  override val valueAttributes: Seq[Attribute] = inputValueAttributes
+
+  override def convertValue(value: UnsafeRow): ValueAndMatchPair = {
+    if (value != null) ValueAndMatchPair(value, false) else null
+  }
+
+  override def convertToValueRow(value: UnsafeRow, matched: Boolean): UnsafeRow = value
+}
+
+class StreamingSymmetricHashJoinValueRowConverterFormatV2(
+    inputValueAttributes: Seq[Attribute]) extends StreamingSymmetricHashJoinValueRowConverter {
+  private val valueWithMatchedExprs = inputValueAttributes :+ Literal(true)
+  private val indexOrdinalInValueWithMatchedRow = inputValueAttributes.size
+
+  private val valueWithMatchedRowGenerator = UnsafeProjection.create(valueWithMatchedExprs,
+    inputValueAttributes)
+
+  override val valueAttributes: Seq[Attribute] = inputValueAttributes :+
+    AttributeReference("matched", BooleanType)()
+
+  // Projection to generate key row from (value + matched) row
+  private val valueRowGenerator = UnsafeProjection.create(
+    inputValueAttributes, valueAttributes)
+
+  override def convertValue(value: UnsafeRow): ValueAndMatchPair = {
+    if (value != null) {
+      ValueAndMatchPair(valueRowGenerator(value).copy(),
+        value.getBoolean(indexOrdinalInValueWithMatchedRow))
+    } else {
+      null
+    }
+  }
+
+  override def convertToValueRow(value: UnsafeRow, matched: Boolean): UnsafeRow = {
+    val row = valueWithMatchedRowGenerator(value)
+    row.setBoolean(indexOrdinalInValueWithMatchedRow, matched)
+    row
+  }
+}
+
+object StreamingSymmetricHashJoinValueRowConverter {
+  def create(
+      inputValueAttributes: Seq[Attribute],
+      stateFormatVersion: Int): StreamingSymmetricHashJoinValueRowConverter = {
+    stateFormatVersion match {
+      case 1 => new StreamingSymmetricHashJoinValueRowConverterFormatV1(inputValueAttributes)
+      case 2 | 3 | 4 =>
+        new StreamingSymmetricHashJoinValueRowConverterFormatV2(inputValueAttributes)
+      case _ => throw new IllegalArgumentException ("Incorrect state format version! " +
+        s"version $stateFormatVersion")
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/StreamingSymmetricHashJoinValueRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/StreamingSymmetricHashJoinValueRowConverter.scala
@@ -42,7 +42,7 @@ trait StreamingSymmetricHashJoinValueRowConverter {
    *
    * NOTE: depending on the implementation, the result row "may" be reused during execution
    * (to avoid initialization of object), so the caller should ensure that the logic doesn't
-   * affect by such behavior. Call copy() against the result row if needed.
+   * get affected by such behavior. Call copy() against the result row if needed.
    */
   def convertToValueRow(value: UnsafeRow, matched: Boolean): UnsafeRow
 }
@@ -57,9 +57,8 @@ class StreamingSymmetricHashJoinValueRowConverterFormatV1(
     inputValueAttributes: Seq[Attribute]) extends StreamingSymmetricHashJoinValueRowConverter {
   override val valueAttributes: Seq[Attribute] = inputValueAttributes
 
-  override def convertValue(value: UnsafeRow): ValueAndMatchPair = {
+  override def convertValue(value: UnsafeRow): ValueAndMatchPair =
     if (value != null) ValueAndMatchPair(value, false) else null
-  }
 
   override def convertToValueRow(value: UnsafeRow, matched: Boolean): UnsafeRow = value
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/SymmetricHashJoinStateManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/SymmetricHashJoinStateManager.scala
@@ -520,8 +520,8 @@ class SymmetricHashJoinStateManagerV4(
         timestamp: Long,
         valuesWithMatched: Seq[(UnsafeRow, Boolean)]): Unit = {
       // copy() is required because convertToValueRow reuses its internal UnsafeProjection output
-      // TODO: StateStore.putList should allow iterator to be passed in, so that we don't need to
-      //   materialize the array and copy the values here.
+      // TODO: [SPARK-55732] StateStore.putList should allow iterator to be passed in, so that we
+      //  don't need to materialize the array and copy the values here.
       val valuesToPut = valuesWithMatched.map { case (value, matched) =>
         valueRowConverter.convertToValueRow(value, matched).copy()
       }.toArray

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/SymmetricHashJoinStateManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/SymmetricHashJoinStateManager.scala
@@ -512,8 +512,11 @@ class SymmetricHashJoinStateManagerV4(
         key: UnsafeRow,
         timestamp: Long,
         valuesWithMatched: Seq[(UnsafeRow, Boolean)]): Unit = {
+      // copy() is required because convertToValueRow reuses its internal UnsafeProjection output
+      // TODO: StateStore.putList should allow iterator to be passed in, so that we don't need to
+      //   materialize the array and copy the values here.
       val valuesToPut = valuesWithMatched.map { case (value, matched) =>
-        valueRowConverter.convertToValueRow(value, matched)
+        valueRowConverter.convertToValueRow(value, matched).copy()
       }.toArray
       stateStore.putList(createKeyRow(key, timestamp), valuesToPut, colFamilyName)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/SymmetricHashJoinStateManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/SymmetricHashJoinStateManager.scala
@@ -271,7 +271,7 @@ class SymmetricHashJoinStateManagerV4(
       generateJoinedRow: InternalRow => JoinedRow,
       predicate: JoinedRow => Boolean,
       excludeRowsAlreadyMatched: Boolean): Iterator[JoinedRow] = {
-    // TODO: [SPARK-55629] We could improve this method to get the scope of timestamp and scan keys
+    // TODO: [SPARK-55147] We could improve this method to get the scope of timestamp and scan keys
     //  more efficiently. For now, we just get all values for the key.
     def getJoinedRowsFromTsAndValues(
         ts: Long,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/SymmetricHashJoinStateManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/SymmetricHashJoinStateManager.scala
@@ -168,6 +168,10 @@ trait SupportsEvictByTimestamp { self: SymmetricHashJoinStateManager =>
  * (timestamp, key) to scan the keys to evict for each watermark. To retrieve the values for a key,
  * we perform prefix scan with the key to get all the (key, timestamp) -> values.
  *
+ * This implementation leverages (virtual) column family, and uses features which are only
+ * available in RocksDB state store provider. Please make sure to set the state store provider to
+ * RocksDBStateStoreProvider.
+ *
  * Refer to the [[KeyWithTsToValuesStore]] and [[TsWithKeyTypeStore]] for more details.
  */
 class SymmetricHashJoinStateManagerV4(
@@ -186,6 +190,9 @@ class SymmetricHashJoinStateManagerV4(
     snapshotOptions: Option[SnapshotOptions] = None,
     joinStoreGenerator: JoinStateManagerStoreGenerator)
   extends SymmetricHashJoinStateManager with SupportsEvictByTimestamp with Logging {
+
+  // TODO: [SPARK-55729] Once the new state manager is integrated to stream-stream join operator,
+  //  we should support state data source to understand the state for state format version v4.
 
   import SymmetricHashJoinStateManager._
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
@@ -669,6 +669,7 @@ object WatermarkSupport {
       val eventTimeColsSet = eventTimeCols.map(_.exprId).toSet
       if (eventTimeColsSet.size > 1) {
         throw new AnalysisException(
+          // TODO: [SPARK-55731] Assign error class for _LEGACY_ERROR_TEMP_3077
           errorClass = "_LEGACY_ERROR_TEMP_3077",
           messageParameters = Map("eventTimeCols" -> eventTimeCols.mkString("(", ",", ")")))
       }
@@ -705,6 +706,7 @@ object WatermarkSupport {
       val eventTimeColsSet = eventTimeCols.map(_._1.exprId).toSet
       if (eventTimeColsSet.size > 1) {
         throw new AnalysisException(
+          // TODO: [SPARK-55731] Assign error class for _LEGACY_ERROR_TEMP_3077
           errorClass = "_LEGACY_ERROR_TEMP_3077",
           messageParameters = Map("eventTimeCols" -> eventTimeCols.mkString("(", ",", ")")))
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
@@ -1838,8 +1838,6 @@ class TimestampAsPrefixKeyStateEncoder(
     useColumnFamilies: Boolean = false)
   extends TimestampKeyStateEncoder(dataEncoder, keySchema) with Logging {
 
-  import TimestampKeyStateEncoder._
-
   override def supportPrefixKeyScan: Boolean = false
 
   override def encodePrefixKey(prefixKey: UnsafeRow): Array[Byte] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
@@ -1838,6 +1838,8 @@ class TimestampAsPrefixKeyStateEncoder(
     useColumnFamilies: Boolean = false)
   extends TimestampKeyStateEncoder(dataEncoder, keySchema) with Logging {
 
+  import TimestampKeyStateEncoder._
+
   override def supportPrefixKeyScan: Boolean = false
 
   override def encodePrefixKey(prefixKey: UnsafeRow): Array[Byte] = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManagerSuite.scala
@@ -17,54 +17,220 @@
 
 package org.apache.spark.sql.execution.streaming.state
 
+import java.io.File
 import java.sql.Timestamp
 import java.util.UUID
 
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.BeforeAndAfter
-import org.scalatest.PrivateMethodTester
 
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.expressions.{Attribute, BoundReference, Expression, GenericInternalRow, LessThanOrEqual, Literal, UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, BoundReference, Expression, GenericInternalRow, LessThanOrEqual, Literal, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.expressions.codegen.GeneratePredicate
 import org.apache.spark.sql.catalyst.plans.logical.EventTimeWatermark
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.execution.metric.SQLMetric
-import org.apache.spark.sql.execution.streaming.operators.stateful.{StatefulOperatorStateInfo, StatefulOperatorsUtils, StatePartitionKeyExtractorFactory}
-import org.apache.spark.sql.execution.streaming.operators.stateful.join.{JoinStateManagerStoreGenerator, SymmetricHashJoinStateManager}
+import org.apache.spark.sql.execution.streaming.operators.stateful.StatefulOperatorStateInfo
+import org.apache.spark.sql.execution.streaming.operators.stateful.join.{JoinStateManagerStoreGenerator, SupportsEvictByCondition, SupportsEvictByTimestamp, SupportsIndexedKeys, SymmetricHashJoinStateManager}
 import org.apache.spark.sql.execution.streaming.operators.stateful.join.StreamingSymmetricHashJoinHelper.LeftSide
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
-class SymmetricHashJoinStateManagerSuite extends StreamTest with BeforeAndAfter
-  with PrivateMethodTester {
-
+abstract class SymmetricHashJoinStateManagerBaseSuite extends StreamTest with BeforeAndAfter {
   before {
     SparkSession.setActiveSession(spark) // set this before force initializing 'joinExec'
     spark.streams.stateStoreCoordinator // initialize the lazy coordinator
   }
 
-  SymmetricHashJoinStateManager.supportedVersions.foreach { version =>
-    test(s"StreamingJoinStateManager V${version} - all operations") {
-      testAllOperations(version)
+  protected def inputValueAttributes: Seq[AttributeReference]
+  protected def inputValueAttributesWithWatermark: AttributeReference
+  protected def joinKeyExpressions: Seq[Expression]
+
+  private def inputValueGen = UnsafeProjection.create(inputValueAttributes.map(_.dataType).toArray)
+  private def joinKeyGen = UnsafeProjection.create(joinKeyExpressions.map(_.dataType).toArray)
+
+  protected def toInputValue(key: Int, value: Int): UnsafeRow = {
+    inputValueGen.apply(new GenericInternalRow(Array[Any](key, value)))
+  }
+
+  protected def toJoinKeyRow(key: Int): UnsafeRow = {
+    joinKeyGen.apply(new GenericInternalRow(Array[Any](false, key, 10.0)))
+  }
+
+  protected def toValueInt(inputValueRow: UnsafeRow): Int = inputValueRow.getInt(1)
+
+  protected def append(key: Int, value: Int)
+                      (implicit manager: SymmetricHashJoinStateManager): Unit = {
+    // we only put matched = false for simplicity - StreamingJoinSuite will test the functionality
+    manager.append(toJoinKeyRow(key), toInputValue(key, value), matched = false)
+  }
+
+  protected def appendAndTest(key: Int, values: Int*)
+                             (implicit manager: SymmetricHashJoinStateManager): Unit = {
+    values.foreach { value => append(key, value)}
+    require(get(key) === values)
+  }
+
+  protected def getNumValues(key: Int)
+                            (implicit manager: SymmetricHashJoinStateManager): Int = {
+    manager.get(toJoinKeyRow(key)).size
+  }
+
+  protected def get(key: Int)(implicit manager: SymmetricHashJoinStateManager): Seq[Int] = {
+    manager.get(toJoinKeyRow(key)).map(toValueInt).toSeq.sorted
+  }
+
+  /** Remove keys (and corresponding values) where `time <= threshold` */
+  protected def removeByKey(threshold: Long)
+                           (implicit manager: SymmetricHashJoinStateManager): Unit = {
+    manager match {
+      case evictByTimestamp: SupportsEvictByTimestamp =>
+        evictByTimestamp.evictByTimestamp(threshold)
+
+      case evictByCondition: SupportsEvictByCondition =>
+        val expr =
+          LessThanOrEqual(
+            BoundReference(
+              1,
+              inputValueAttributesWithWatermark.dataType,
+              inputValueAttributesWithWatermark.nullable),
+            Literal(threshold))
+        evictByCondition.evictByKeyCondition(GeneratePredicate.generate(expr).eval _)
     }
   }
 
-  SymmetricHashJoinStateManager.supportedVersions.foreach { version =>
+  /** Remove values where `time <= threshold` */
+  protected def removeByValue(watermark: Long)
+                             (implicit manager: SymmetricHashJoinStateManager): Unit = {
+    manager match {
+      case evictByTimestamp: SupportsEvictByTimestamp =>
+        evictByTimestamp.evictByTimestamp(watermark)
+
+      case evictByCondition: SupportsEvictByCondition =>
+        val expr = LessThanOrEqual(inputValueAttributesWithWatermark, Literal(watermark))
+        evictByCondition.evictByValueCondition(
+          GeneratePredicate.generate(expr, inputValueAttributes).eval _)
+    }
+  }
+
+  protected def assertNumRows(stateFormatVersion: Int, target: Long)(
+    implicit manager: SymmetricHashJoinStateManager): Unit = {
+    // This suite originally uses HDFSBackStateStoreProvider, which provides instantaneous metrics
+    // for numRows.
+    // But for version 3 with virtual column families, RocksDBStateStoreProvider updates metrics
+    // asynchronously. This means the number of keys obtained from the metrics are very likely
+    // to be outdated right after a put/remove.
+    if (stateFormatVersion <= 2) {
+      assert(manager.metrics.numKeys == target)
+    }
+  }
+
+  protected def withJoinStateManager(
+      inputValueAttribs: Seq[Attribute],
+      joinKeyExprs: Seq[Expression],
+      stateFormatVersion: Int,
+      skipNullsForStreamStreamJoins: Boolean = false,
+      metric: Option[SQLMetric] = None)
+    (f: SymmetricHashJoinStateManager => Unit): Unit = {
+    // HDFS store providers do not support virtual column families
+    val storeProvider = if (stateFormatVersion >= 3) {
+      classOf[RocksDBStateStoreProvider].getName
+    } else {
+      classOf[HDFSBackedStateStoreProvider].getName
+    }
+    withTempDir { file =>
+      withSQLConf(
+        SQLConf.STATE_STORE_SKIP_NULLS_FOR_STREAM_STREAM_JOINS.key ->
+          skipNullsForStreamStreamJoins.toString,
+        SQLConf.STATE_STORE_PROVIDER_CLASS.key -> storeProvider
+      ) {
+        val storeConf = new StateStoreConf(spark.sessionState.conf)
+        val stateInfo = StatefulOperatorStateInfo(
+          file.getAbsolutePath, UUID.randomUUID, 0, 0, 5, None)
+        val manager = SymmetricHashJoinStateManager(
+          LeftSide, inputValueAttribs, joinKeyExprs, Some(stateInfo), storeConf, new Configuration,
+          partitionId = 0, None, None, stateFormatVersion, metric,
+          joinStoreGenerator = new JoinStateManagerStoreGenerator())
+        try {
+          f(manager)
+        } finally {
+          manager.abortIfNeeded()
+        }
+      }
+    }
+    StateStore.stop()
+  }
+
+  protected def withJoinStateManagerWithCheckpointDir(
+      inputValueAttribs: Seq[Attribute],
+      joinKeyExprs: Seq[Expression],
+      stateFormatVersion: Int,
+      checkpointDir: File,
+      storeVersion: Int,
+      changelogCheckpoint: Boolean,
+      skipNullsForStreamStreamJoins: Boolean = false,
+      metric: Option[SQLMetric] = None)
+    (f: SymmetricHashJoinStateManager => Unit): Unit = {
+    // HDFS store providers do not support virtual column families
+    val storeProvider = if (stateFormatVersion >= 3) {
+      classOf[RocksDBStateStoreProvider].getName
+    } else {
+      classOf[HDFSBackedStateStoreProvider].getName
+    }
+    withSQLConf(
+      SQLConf.STATE_STORE_SKIP_NULLS_FOR_STREAM_STREAM_JOINS.key ->
+        skipNullsForStreamStreamJoins.toString,
+      SQLConf.STATE_STORE_PROVIDER_CLASS.key -> storeProvider,
+      "spark.sql.streaming.stateStore.rocksdb.changelogCheckpointing.enabled" ->
+        changelogCheckpoint.toString
+    ) {
+      val storeConf = new StateStoreConf(spark.sessionState.conf)
+      val stateInfo = StatefulOperatorStateInfo(
+        checkpointDir.getAbsolutePath, UUID.randomUUID, 0, storeVersion, 5, None)
+      val manager = SymmetricHashJoinStateManager(
+        LeftSide, inputValueAttribs, joinKeyExprs, Some(stateInfo), storeConf, new Configuration,
+        partitionId = 0, None, None, stateFormatVersion, metric,
+        joinStoreGenerator = new JoinStateManagerStoreGenerator())
+      try {
+        f(manager)
+      } finally {
+        manager.abortIfNeeded()
+      }
+    }
+    StateStore.stop()
+  }
+}
+
+class SymmetricHashJoinStateManagerSuite extends SymmetricHashJoinStateManagerBaseSuite {
+  private val watermarkMetadata = new MetadataBuilder()
+    .putLong(EventTimeWatermark.delayKey, 10).build()
+  private val inputValueSchema = new StructType()
+    .add(StructField("key", IntegerType))
+    .add(StructField("time", IntegerType, metadata = watermarkMetadata))
+
+  override protected val inputValueAttributes = toAttributes(inputValueSchema)
+  override protected val inputValueAttributesWithWatermark = inputValueAttributes(1)
+  override protected val joinKeyExpressions = Seq[Expression](
+    Literal(false), inputValueAttributes(0), Literal(10.0))
+
+  // Below tests are not bound to version 4 as they are specifically for testing null handling
+  private val versionsInTest = Seq(1, 2, 3)
+
+  versionsInTest.foreach { version =>
     test(s"StreamingJoinStateManager V${version} - all operations with nulls") {
       testAllOperationsWithNulls(version)
     }
   }
 
-  SymmetricHashJoinStateManager.supportedVersions.foreach { version =>
+  versionsInTest.foreach { version =>
     test(s"StreamingJoinStateManager V${version} - all operations with nulls in middle") {
       testAllOperationsWithNullsInMiddle(version)
     }
   }
 
-  SymmetricHashJoinStateManager.supportedVersions.foreach { version =>
+  versionsInTest.foreach { version =>
     test(s"SPARK-35689: StreamingJoinStateManager V${version} - " +
         "printable key of keyWithIndexToValue") {
 
@@ -75,83 +241,23 @@ class SymmetricHashJoinStateManagerSuite extends StreamTest with BeforeAndAfter
         Literal(Timestamp.valueOf("2021-6-8 10:25:50")))
       val keyGen = UnsafeProjection.create(keyExprs.map(_.dataType).toArray)
 
-      withJoinStateManager(inputValueAttribs, keyExprs, version) { manager =>
+      withJoinStateManager(inputValueAttributes, keyExprs, version) { manager =>
+        assert(manager.isInstanceOf[SupportsIndexedKeys])
+
         val currentKey = keyGen.apply(new GenericInternalRow(Array[Any](
           false, 10.0, UTF8String.fromString("string"),
           Timestamp.valueOf("2021-6-8 10:25:50").getTime)))
 
-        val projectedRow = manager.getInternalRowOfKeyWithIndex(currentKey)
+        val projectedRow = manager.asInstanceOf[SupportsIndexedKeys]
+          .getInternalRowOfKeyWithIndex(currentKey)
         assert(s"$projectedRow" == "[false,10.0,string,1623173150000]")
       }
     }
   }
 
-  SymmetricHashJoinStateManager.supportedVersions.foreach { version =>
-    test(s"Partition key extraction - SymmetricHashJoinStateManager v$version") {
-      testPartitionKeyExtraction(version)
-    }
-  }
-
-  private def testAllOperations(stateFormatVersion: Int): Unit = {
-    withJoinStateManager(inputValueAttribs, joinKeyExprs, stateFormatVersion) { manager =>
-      implicit val mgr = manager
-
-      assert(get(20) === Seq.empty)     // initially empty
-      append(20, 2)
-      assert(get(20) === Seq(2))        // should first value correctly
-      assertNumRows(stateFormatVersion, 1)
-
-      append(20, 3)
-      assert(get(20) === Seq(2, 3))     // should append new values
-      append(20, 3)
-      assert(get(20) === Seq(2, 3, 3))  // should append another copy if same value added again
-      assertNumRows(stateFormatVersion, 3)
-
-      assert(get(30) === Seq.empty)
-      append(30, 1)
-      assert(get(30) === Seq(1))
-      assert(get(20) === Seq(2, 3, 3))  // add another key-value should not affect existing ones
-      assertNumRows(stateFormatVersion, 4)
-
-      removeByKey(25)
-      assert(get(20) === Seq.empty)
-      assert(get(30) === Seq(1))        // should remove 20, not 30
-      assertNumRows(stateFormatVersion, 1)
-
-      removeByKey(30)
-      assert(get(30) === Seq.empty)     // should remove 30
-      assertNumRows(stateFormatVersion, 0)
-
-      appendAndTest(40, 100, 200, 300)
-      appendAndTest(50, 125)
-      appendAndTest(60, 275)              // prepare for testing removeByValue
-      assertNumRows(stateFormatVersion, 5)
-
-      removeByValue(125)
-      assert(get(40) === Seq(200, 300))
-      assert(get(50) === Seq.empty)
-      assert(get(60) === Seq(275))        // should remove only some values, not all
-      assertNumRows(stateFormatVersion, 3)
-
-      append(40, 50)
-      assert(get(40) === Seq(50, 200, 300))
-      assertNumRows(stateFormatVersion, 4)
-
-      removeByValue(200)
-      assert(get(40) === Seq(300))
-      assert(get(60) === Seq(275))        // should remove only some values, not all
-      assertNumRows(stateFormatVersion, 2)
-
-      removeByValue(300)
-      assert(get(40) === Seq.empty)
-      assert(get(60) === Seq.empty)       // should remove all values now
-      assertNumRows(stateFormatVersion, 0)
-    }
-  }
-
   /* Test removeByValue with nulls simulated by updating numValues on the state manager */
   private def testAllOperationsWithNulls(stateFormatVersion: Int): Unit = {
-    withJoinStateManager(inputValueAttribs, joinKeyExprs, stateFormatVersion) { manager =>
+    withJoinStateManager(inputValueAttributes, joinKeyExpressions, stateFormatVersion) { manager =>
       implicit val mgr = manager
 
       appendAndTest(40, 100, 200, 300)
@@ -189,7 +295,7 @@ class SymmetricHashJoinStateManagerSuite extends StreamTest with BeforeAndAfter
   private def testAllOperationsWithNullsInMiddle(stateFormatVersion: Int): Unit = {
     // Test with skipNullsForStreamStreamJoins set to false which would throw a
     // NullPointerException while iterating and also return null values as part of get
-    withJoinStateManager(inputValueAttribs, joinKeyExprs, stateFormatVersion) { manager =>
+    withJoinStateManager(inputValueAttributes, joinKeyExpressions, stateFormatVersion) { manager =>
       implicit val mgr = manager
 
       val ex = intercept[Exception] {
@@ -214,7 +320,7 @@ class SymmetricHashJoinStateManagerSuite extends StreamTest with BeforeAndAfter
     // Test with skipNullsForStreamStreamJoins set to true which would skip nulls
     // and continue iterating as part of removeByValue as well as get
     val metric = new SQLMetric("sum")
-    withJoinStateManager(inputValueAttribs, joinKeyExprs, stateFormatVersion, true,
+    withJoinStateManager(inputValueAttributes, joinKeyExpressions, stateFormatVersion, true,
         Some(metric)) { manager =>
       implicit val mgr = manager
 
@@ -245,200 +351,299 @@ class SymmetricHashJoinStateManagerSuite extends StreamTest with BeforeAndAfter
     }
   }
 
-  val watermarkMetadata = new MetadataBuilder().putLong(EventTimeWatermark.delayKey, 10).build()
-  val inputValueSchema = new StructType()
+  protected def updateNumValues(key: Int, numValues: Long)
+                               (implicit manager: SymmetricHashJoinStateManager): Unit = {
+    assert(manager.isInstanceOf[SupportsIndexedKeys])
+    manager.asInstanceOf[SupportsIndexedKeys].updateNumValuesTestOnly(toJoinKeyRow(key), numValues)
+  }
+}
+
+class SymmetricHashJoinStateManagerEventTimeInKeySuite
+  extends SymmetricHashJoinStateManagerBaseSuite {
+
+  private val versionsInTest = SymmetricHashJoinStateManager.supportedVersions
+
+  private val watermarkMetadata = new MetadataBuilder()
+    .putLong(EventTimeWatermark.delayKey, 10).build()
+  private val inputValueSchema = new StructType()
     .add(StructField("time", IntegerType, metadata = watermarkMetadata))
-    .add(StructField("value", BooleanType))
-  val inputValueAttribs = toAttributes(inputValueSchema)
-  val inputValueAttribWithWatermark = inputValueAttribs(0)
-  val joinKeyExprs = Seq[Expression](Literal(false), inputValueAttribWithWatermark, Literal(10.0))
+    .add(StructField("value", IntegerType))
 
-  val inputValueGen = UnsafeProjection.create(inputValueAttribs.map(_.dataType).toArray)
-  val joinKeyGen = UnsafeProjection.create(joinKeyExprs.map(_.dataType).toArray)
+  override protected val inputValueAttributes: Seq[AttributeReference] =
+    toAttributes(inputValueSchema)
+  override protected val inputValueAttributesWithWatermark: AttributeReference =
+    inputValueAttributes(0)
+  override protected val joinKeyExpressions: Seq[Expression] = Seq[Expression](
+    Literal(false),
+    inputValueAttributesWithWatermark,
+    Literal(10.0))
 
-
-  def toInputValue(i: Int): UnsafeRow = {
-    inputValueGen.apply(new GenericInternalRow(Array[Any](i, false)))
-  }
-
-  def toJoinKeyRow(i: Int): UnsafeRow = {
-    joinKeyGen.apply(new GenericInternalRow(Array[Any](false, i, 10.0)))
-  }
-
-  def toValueInt(inputValueRow: UnsafeRow): Int = inputValueRow.getInt(0)
-
-  def append(key: Int, value: Int)(implicit manager: SymmetricHashJoinStateManager): Unit = {
-    // we only put matched = false for simplicity - StreamingJoinSuite will test the functionality
-    manager.append(toJoinKeyRow(key), toInputValue(value), matched = false)
-  }
-
-  def appendAndTest(key: Int, values: Int*)
-                   (implicit manager: SymmetricHashJoinStateManager): Unit = {
-    values.foreach { value => append(key, value)}
-    require(get(key) === values)
-  }
-
-  def updateNumValues(key: Int, numValues: Long)
-                     (implicit manager: SymmetricHashJoinStateManager): Unit = {
-    manager.updateNumValuesTestOnly(toJoinKeyRow(key), numValues)
-  }
-
-  def getNumValues(key: Int)
-                  (implicit manager: SymmetricHashJoinStateManager): Int = {
-    manager.get(toJoinKeyRow(key)).size
-  }
-
-  def get(key: Int)(implicit manager: SymmetricHashJoinStateManager): Seq[Int] = {
-    manager.get(toJoinKeyRow(key)).map(toValueInt).toSeq.sorted
-  }
-
-  /** Remove keys (and corresponding values) where `time <= threshold` */
-  def removeByKey(threshold: Long)(implicit manager: SymmetricHashJoinStateManager): Unit = {
-    val expr =
-      LessThanOrEqual(
-        BoundReference(
-          1, inputValueAttribWithWatermark.dataType, inputValueAttribWithWatermark.nullable),
-        Literal(threshold))
-    val iter = manager.removeByKeyCondition(GeneratePredicate.generate(expr).eval _)
-    while (iter.hasNext) iter.next()
-  }
-
-  /** Remove values where `time <= threshold` */
-  def removeByValue(watermark: Long)(implicit manager: SymmetricHashJoinStateManager): Unit = {
-    val expr = LessThanOrEqual(inputValueAttribWithWatermark, Literal(watermark))
-    val iter = manager.removeByValueCondition(
-      GeneratePredicate.generate(expr, inputValueAttribs).eval _)
-    while (iter.hasNext) iter.next()
-  }
-
-  def assertNumRows(stateFormatVersion: Int, target: Long)(
-    implicit manager: SymmetricHashJoinStateManager): Unit = {
-    // This suite originally uses HDFSBackStateStoreProvider, which provides instantaneous metrics
-    // for numRows.
-    // But for version 3 with virtual column families, RocksDBStateStoreProvider updates metrics
-    // asynchronously. This means the number of keys obtained from the metrics are very likely
-    // to be outdated right after a put/remove.
-    if (stateFormatVersion <= 2) {
-      assert(manager.metrics.numKeys == target)
+  versionsInTest.foreach { ver =>
+    test(s"StreamingJoinStateManager V$ver - all operations") {
+      testAllOperations(ver)
     }
   }
 
-  def withJoinStateManager(
-      inputValueAttribs: Seq[Attribute],
-      joinKeyExprs: Seq[Expression],
-      stateFormatVersion: Int,
-      skipNullsForStreamStreamJoins: Boolean = false,
-      metric: Option[SQLMetric] = None)
-      (f: SymmetricHashJoinStateManager => Unit): Unit = {
-    // HDFS store providers do not support virtual column families
-    val storeProvider = if (stateFormatVersion == 3) {
-      classOf[RocksDBStateStoreProvider].getName
-    } else {
-      classOf[HDFSBackedStateStoreProvider].getName
+  versionsInTest.foreach { ver =>
+    test(s"StreamingJoinStateManager V$ver - all operations, with commit and load in between") {
+      testAllOperationsWithCommitAndLoad(ver, changelogCheckpoint = false)
+      testAllOperationsWithCommitAndLoad(ver, changelogCheckpoint = true)
     }
-    withTempDir { file =>
-      withSQLConf(
-        SQLConf.STATE_STORE_SKIP_NULLS_FOR_STREAM_STREAM_JOINS.key ->
-          skipNullsForStreamStreamJoins.toString,
-        SQLConf.STATE_STORE_PROVIDER_CLASS.key -> storeProvider
-      ) {
-        val storeConf = new StateStoreConf(spark.sessionState.conf)
-        val stateInfo = StatefulOperatorStateInfo(
-          file.getAbsolutePath, UUID.randomUUID, 0, 0, 5, None)
-        val manager = SymmetricHashJoinStateManager(
-          LeftSide, inputValueAttribs, joinKeyExprs, Some(stateInfo), storeConf, new Configuration,
-          partitionId = 0, None, None, stateFormatVersion, metric,
-          joinStoreGenerator = new JoinStateManagerStoreGenerator())
-        try {
-          f(manager)
-        } finally {
-          manager.abortIfNeeded()
-        }
-      }
-    }
-    StateStore.stop()
   }
 
-  private def testPartitionKeyExtraction(stateFormatVersion: Int): Unit = {
-    withJoinStateManager(inputValueAttribs, joinKeyExprs, stateFormatVersion) { manager =>
+  private def testAllOperations(stateFormatVersion: Int): Unit = {
+    withJoinStateManager(
+      inputValueAttributes,
+      joinKeyExpressions,
+      stateFormatVersion = stateFormatVersion) { manager =>
       implicit val mgr = manager
 
-      val joinKeySchema = StructType(
-        joinKeyExprs.zipWithIndex.map { case (expr, i) =>
-          StructField(s"field$i", expr.dataType, expr.nullable)
-        })
+      assert(get(20) === Seq.empty)     // initially empty
+      append(20, 2)
+      assert(get(20) === Seq(2))        // should first value correctly
+      assertNumRows(stateFormatVersion, 1)
 
-      // Add some test data
-      append(key = 20, value = 100)
-      append(key = 20, value = 200)
-      append(key = 30, value = 150)
+      append(20, 3)
+      assert(get(20) === Seq(2, 3))     // should append new values
+      append(20, 3)
+      assert(get(20) === Seq(2, 3, 3))  // should append another copy if same value added again
+      assertNumRows(stateFormatVersion, 3)
 
-      Seq(
-        (getKeyToNumValuesStoreAndKeySchema(), SymmetricHashJoinStateManager
-          .getStateStoreName(LeftSide, SymmetricHashJoinStateManager.KeyToNumValuesType),
-          // expect 1 for both key 20 & 30
-          1, 1),
-        (getKeyWithIndexToValueStoreAndKeySchema(), SymmetricHashJoinStateManager
-          .getStateStoreName(LeftSide, SymmetricHashJoinStateManager.KeyWithIndexToValueType),
-          // expect 2 for key 20 & 1 for key 30
-          2, 1)
-      ).foreach { case ((store, keySchema), name, expectedNumKey20, expectedNumKey30) =>
-        val storeName = if (stateFormatVersion == 3) {
-          StateStoreId.DEFAULT_STORE_NAME
-        } else {
-          name
-        }
+      assert(get(30) === Seq.empty)
+      append(30, 1)
+      assert(get(30) === Seq(1))
+      assert(get(20) === Seq(2, 3, 3))  // add another key-value should not affect existing ones
+      assertNumRows(stateFormatVersion, 4)
 
-        val colFamilyName = if (stateFormatVersion == 3) {
-          name
-        } else {
-          StateStore.DEFAULT_COL_FAMILY_NAME
-        }
+      removeByKey(25)
+      assert(get(20) === Seq.empty)
+      assert(get(30) === Seq(1))        // should remove 20, not 30
+      assertNumRows(stateFormatVersion, 1)
 
-        val extractor = StatePartitionKeyExtractorFactory.create(
-          StatefulOperatorsUtils.SYMMETRIC_HASH_JOIN_EXEC_OP_NAME,
-          keySchema,
-          storeName,
-          colFamilyName,
-          stateFormatVersion = Some(stateFormatVersion)
-        )
-
-        assert(extractor.partitionKeySchema === joinKeySchema,
-          "Partition key schema should match the join key schema")
-
-        // Copy both the state key and partition key to avoid UnsafeRow reuse issues
-        val stateKeys = store.iterator(colFamilyName).map(_.key.copy()).toList
-        val partitionKeys = stateKeys.map(extractor.partitionKey(_).copy())
-
-        assert(partitionKeys.length === expectedNumKey20 + expectedNumKey30,
-          "Should have same num partition keys as num state store keys")
-        assert(partitionKeys.count(_ === toJoinKeyRow(20)) === expectedNumKey20,
-          "Should have the expected num partition keys for join key 20")
-        assert(partitionKeys.count(_ === toJoinKeyRow(30)) === expectedNumKey30,
-          "Should have the expected num partition keys for join key 30")
-      }
+      removeByKey(30)
+      assert(get(30) === Seq.empty)     // should remove 30
+      assertNumRows(stateFormatVersion, 0)
     }
   }
 
-  def getKeyToNumValuesStoreAndKeySchema()
-      (implicit manager: SymmetricHashJoinStateManager): (StateStore, StructType) = {
-    val keyToNumValuesHandler = manager.keyToNumValues
-    val keyToNumValuesStoreMethod = PrivateMethod[StateStore](Symbol("stateStore"))
-    val keyToNumValuesStore = keyToNumValuesHandler.invokePrivate(keyToNumValuesStoreMethod())
+  private def testAllOperationsWithCommitAndLoad(
+      stateFormatVersion: Int,
+      changelogCheckpoint: Boolean): Unit = {
+    withTempDir { checkpointDir =>
+      withJoinStateManagerWithCheckpointDir(
+        inputValueAttributes,
+        joinKeyExpressions,
+        stateFormatVersion = stateFormatVersion,
+        checkpointDir,
+        storeVersion = 0,
+        changelogCheckpoint = changelogCheckpoint) { manager =>
 
-    (keyToNumValuesStore, manager.keySchema)
+        implicit val mgr = manager
+
+        assert(get(20) === Seq.empty)     // initially empty
+        append(20, 2)
+        assert(get(20) === Seq(2))        // should first value correctly
+
+        append(20, 3)
+        assert(get(20) === Seq(2, 3))     // should append new values
+        append(20, 3)
+        assert(get(20) === Seq(2, 3, 3))  // should append another copy if same value added again
+
+        mgr.commit()
+      }
+
+      withJoinStateManagerWithCheckpointDir(
+        inputValueAttributes,
+        joinKeyExpressions,
+        stateFormatVersion = stateFormatVersion,
+        checkpointDir,
+        storeVersion = 1,
+        changelogCheckpoint = changelogCheckpoint) { manager =>
+
+        implicit val mgr = manager
+
+        assert(get(30) === Seq.empty)
+        append(30, 1)
+        assert(get(30) === Seq(1))
+        assert(get(20) === Seq(2, 3, 3))  // add another key-value should not affect existing ones
+
+        removeByKey(25)
+        assert(get(20) === Seq.empty)
+        assert(get(30) === Seq(1))        // should remove 20, not 30
+
+        mgr.commit()
+      }
+
+      withJoinStateManagerWithCheckpointDir(
+        inputValueAttributes,
+        joinKeyExpressions,
+        stateFormatVersion = stateFormatVersion,
+        checkpointDir,
+        storeVersion = 2,
+        changelogCheckpoint = changelogCheckpoint) { manager =>
+
+        implicit val mgr = manager
+
+        removeByKey(30)
+        assert(get(30) === Seq.empty)     // should remove 30
+
+        mgr.commit()
+      }
+    }
+  }
+}
+
+class SymmetricHashJoinStateManagerEventTimeInValueSuite
+  extends SymmetricHashJoinStateManagerBaseSuite {
+
+  private val versionsInTest = SymmetricHashJoinStateManager.supportedVersions
+
+  private val watermarkMetadata = new MetadataBuilder()
+    .putLong(EventTimeWatermark.delayKey, 10).build()
+  private val inputValueSchema = new StructType()
+    .add(StructField("key", IntegerType))
+    .add(StructField("time", IntegerType, metadata = watermarkMetadata))
+
+  protected override val inputValueAttributes = toAttributes(inputValueSchema)
+  protected override val inputValueAttributesWithWatermark = inputValueAttributes(1)
+  protected override val joinKeyExpressions = Seq[Expression](
+    Literal(false), inputValueAttributes(0), Literal(10.0))
+
+  versionsInTest.foreach { ver =>
+    test(s"StreamingJoinStateManager V$ver - all operations") {
+      testAllOperations(ver)
+    }
   }
 
-  def getKeyWithIndexToValueStoreAndKeySchema()
-      (implicit manager: SymmetricHashJoinStateManager): (StateStore, StructType) = {
-    val keyWithIndexToValueHandler = manager.keyWithIndexToValue
+  versionsInTest.foreach { ver =>
+    test(s"StreamingJoinStateManager V$ver - all operations, with commit and load in between") {
+      testAllOperationsWithCommitAndLoad(ver, changelogCheckpoint = false)
+      testAllOperationsWithCommitAndLoad(ver, changelogCheckpoint = true)
+    }
+  }
 
-    val keyWithIndexToValueStoreMethod = PrivateMethod[StateStore](Symbol("stateStore"))
-    val keyWithIndexToValueStore =
-      keyWithIndexToValueHandler.invokePrivate(keyWithIndexToValueStoreMethod())
+  private def testAllOperations(stateFormatVersion: Int): Unit = {
+    withJoinStateManager(
+      inputValueAttributes,
+      joinKeyExpressions,
+      stateFormatVersion = stateFormatVersion) { manager =>
+      implicit val mgr = manager
 
-    val keySchemaMethod = PrivateMethod[StructType](Symbol("keyWithIndexSchema"))
-    val keyWithIndexToValueKeySchema = keyWithIndexToValueHandler.invokePrivate(keySchemaMethod())
-    (keyWithIndexToValueStore, keyWithIndexToValueKeySchema)
+      appendAndTest(40, 100, 200, 300)
+      appendAndTest(50, 125)
+      appendAndTest(60, 275)              // prepare for testing removeByValue
+      assertNumRows(stateFormatVersion, 5)
+
+      removeByValue(125)
+      assert(get(40) === Seq(200, 300))
+      assert(get(50) === Seq.empty)
+      assert(get(60) === Seq(275))        // should remove only some values, not all
+      assertNumRows(stateFormatVersion, 3)
+
+      append(40, 50)
+      assert(get(40) === Seq(50, 200, 300))
+      assertNumRows(stateFormatVersion, 4)
+
+      removeByValue(200)
+      assert(get(40) === Seq(300))
+      assert(get(60) === Seq(275))        // should remove only some values, not all
+      assertNumRows(stateFormatVersion, 2)
+
+      removeByValue(300)
+      assert(get(40) === Seq.empty)
+      assert(get(60) === Seq.empty)       // should remove all values now
+      assertNumRows(stateFormatVersion, 0)
+    }
+  }
+
+  private def testAllOperationsWithCommitAndLoad(
+      stateFormatVersion: Int,
+      changelogCheckpoint: Boolean): Unit = {
+    withTempDir { checkpointDir =>
+      withJoinStateManagerWithCheckpointDir(
+        inputValueAttributes,
+        joinKeyExpressions,
+        stateFormatVersion = stateFormatVersion,
+        checkpointDir,
+        storeVersion = 0,
+        changelogCheckpoint = changelogCheckpoint) { manager =>
+
+        implicit val mgr = manager
+
+        appendAndTest(40, 100, 200, 300)
+        appendAndTest(50, 125)
+        appendAndTest(60, 275) // prepare for testing removeByValue
+
+        mgr.commit()
+      }
+
+      withJoinStateManagerWithCheckpointDir(
+        inputValueAttributes,
+        joinKeyExpressions,
+        stateFormatVersion = stateFormatVersion,
+        checkpointDir,
+        storeVersion = 1,
+        changelogCheckpoint = changelogCheckpoint) { manager =>
+
+        implicit val mgr = manager
+
+        removeByValue(125)
+        assert(get(40) === Seq(200, 300))
+        assert(get(50) === Seq.empty)
+        assert(get(60) === Seq(275))        // should remove only some values, not all
+
+        mgr.commit()
+      }
+
+      withJoinStateManagerWithCheckpointDir(
+        inputValueAttributes,
+        joinKeyExpressions,
+        stateFormatVersion = stateFormatVersion,
+        checkpointDir,
+        storeVersion = 2,
+        changelogCheckpoint = changelogCheckpoint) { manager =>
+
+        implicit val mgr = manager
+
+        append(40, 50)
+        assert(get(40) === Seq(50, 200, 300))
+
+        mgr.commit()
+      }
+
+      withJoinStateManagerWithCheckpointDir(
+        inputValueAttributes,
+        joinKeyExpressions,
+        stateFormatVersion = stateFormatVersion,
+        checkpointDir,
+        storeVersion = 3,
+        changelogCheckpoint = changelogCheckpoint) { manager =>
+
+        implicit val mgr = manager
+
+        removeByValue(200)
+        assert(get(40) === Seq(300))
+        assert(get(60) === Seq(275))        // should remove only some values, not all
+
+        mgr.commit()
+      }
+
+      withJoinStateManagerWithCheckpointDir(
+        inputValueAttributes,
+        joinKeyExpressions,
+        stateFormatVersion = stateFormatVersion,
+        checkpointDir,
+        storeVersion = 4,
+        changelogCheckpoint = changelogCheckpoint) { manager =>
+
+        implicit val mgr = manager
+
+        removeByValue(300)
+        assert(get(40) === Seq.empty)
+        assert(get(60) === Seq.empty)       // should remove all values now
+
+        mgr.commit()
+      }
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to implement the new state format for stream-stream join, based on the new state key encoding w.r.t. event time awareness.

The new state format is focused to eliminate the necessity of full scan during eviction & populating unmatched rows. The overhead of eviction should have bound to the actual number of state rows to be evicted (indirectly impacted by the amount of watermark advancement), but we have been doing the full scan with the existing state format, which could take more than 2 seconds in 1,000,000 rows even if there is zero row to be evicted. The overhead of eviction with the new state format would be bound to the actual number of state rows to be evicted, taking around 30ms or even less in 1,000,000 rows when there is zero row to be evicted.

To achieve the above, we make a drastic change of data structure to move out from the logical array, and introduce a secondary index in addition to the main data.

Each side of the join will use two (virtual) column families (total 4 column families), which are following:

* KeyWithTsToValuesStore
  * Primary data store
  * (key, event time) -> values
  * each element in values consists of (value, matched)
* TsWithKeyTypeStore
  * Secondary index for efficient eviction
  * (event time, key) -> empty value (configured as multi-values)
  * numValues is calculated by the number of elements in the value side; new element is added when a new value is added into values in primary data store
    * This is to track the number of deleted rows accurately. It's optional but the metric has been useful so we want to keep it as it is.

As the format of key part implies, KeyWithTsToValuesStore will use `TimestampAsPostfixKeyStateEncoderSpec`, and TsWithKeyTypeStore will use `TimestampAsPrefixKeyStateEncoderSpec`.

The granularity of the timestamp for event time is 1 millisecond, which is in line with the granularity for watermark advancement. This can be a kind of knob controlling the number of the keys vs the number of the values in the key, trading off the granularity of eviction based on watermark advancement vs the size of key space (may impact performance).

There are several follow-ups with this state format implementation, which can be addressed on top of this:

* further optimizations with RocksDB offering: WriteBatch (for batched writes), MGET, etc.
* retrieving matched rows with the "scope" of timestamps (in time-interval join)
  * while the format is ready to support ordered scan of timestamp, this needs another state store API to define the range of keys to scan, which needs some effort
* Do not update the matched flag for non-outer join side.

### Why are the changes needed?

The cost of eviction based on full scan is severe to make the stream-stream join to be lower latency. Also, the logic of maintaining logical array is complicated enough to maintain and the performance characteristic is less predictable given the behavior of deleting the element in random index (placing the value of the last index to the deleted index).

### Does this PR introduce _any_ user-facing change?

No. At this point, this state format is not integrated with the actual stream-stream join operator, and we need to do follow-up work for integration to finally introduce the change to user-facing.

### How was this patch tested?

New UT suites, refactoring the existing suite to test with both time window and time interval cases.

### Was this patch authored or co-authored using generative AI tooling?

No.