### PR TITLE
[SPARK-55021][CORE][TESTS][FOLLOWUP] Move timezone/locale initialization to constructor in SparkTestSuite

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkTestSuite.scala
@@ -73,23 +73,25 @@ trait SparkTestSuite
     with Logging {
   // scalastyle:on
 
+  // Initialize the logger forcibly to let the logger log timestamp
+  // based on the local time zone depending on environments.
+  // The default time zone will be set to America/Los_Angeles later
+  // so this initialization is necessary here.
+  log
+
+  // Timezone is fixed to America/Los_Angeles for those timezone sensitive tests (timestamp_*)
+  // This must be set at class construction time, not in beforeAll(), because some tests
+  // create timezone-sensitive objects (like Timestamp) during test registration.
+  TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"))
+  // Add Locale setting
+  Locale.setDefault(Locale.US)
+
   protected def enableAutoThreadAudit = true
 
   protected def regenerateGoldenFiles: Boolean =
     System.getenv("SPARK_GENERATE_GOLDEN_FILES") == "1"
 
   protected override def beforeAll(): Unit = {
-    // Initialize the logger forcibly to let the logger log timestamp
-    // based on the local time zone depending on environments.
-    // The default time zone will be set to America/Los_Angeles later
-    // so this initialization is necessary here.
-    log
-
-    // Timezone is fixed to America/Los_Angeles for those timezone sensitive tests (timestamp_*)
-    TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"))
-    // Add Locale setting
-    Locale.setDefault(Locale.US)
-
     System.setProperty(IS_TESTING.key, "true")
     if (enableAutoThreadAudit) {
       doThreadPreAudit()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Move the timezone and locale initialization from `beforeAll()` to the trait's constructor body in `SparkTestSuite`.

### Why are the changes needed?

This is a follow-up fix to #53784 which introduced `SparkTestSuite`.

The original PR moved timezone/locale initialization from the class body to `beforeAll()`. This causes test failures when running tests like `RowJsonSuite` with Maven, because tests that create timezone-sensitive objects (like `java.sql.Timestamp`) during test registration fail - the timezone isn't set until `beforeAll()` runs, which happens after class construction.

For example, in `RowJsonSuite`:
```scala
testJson(
  Timestamp.valueOf("2017-01-06 10:22:03.00"),  // Created during class construction
  TimestampType,
  JString("2017-01-06 10:22:03"))
```

`Timestamp.valueOf()` interprets the string in the current default timezone. If the system timezone is not `America/Los_Angeles`, the Timestamp represents a different instant, causing test failures.

### Does this PR introduce _any_ user-facing change?

No, test-only

### How was this patch tested?

```
build/mvn test -pl sql/catalyst -DwildcardSuites=org.apache.spark.sql.RowJsonSuite
```

### Was this patch authored or co-authored using generative AI tooling?

Yes