### PR TITLE
[SPARK-54942][PYTHON][TESTS][FOLLOWUP] Fix PyArrow < 21 compatibility for float16 array creation in tests

### DIFF
--- a/python/pyspark/tests/upstream/pyarrow/test_pyarrow_array_cast.py
+++ b/python/pyspark/tests/upstream/pyarrow/test_pyarrow_array_cast.py
@@ -1991,9 +1991,7 @@ class PyArrowNumericalCastTests(unittest.TestCase):
             ],
             "binary": [(_make_float16_array([0.0]), pa.lib.ArrowNotImplementedError)],
             "large_binary": [(_make_float16_array([0.0]), pa.lib.ArrowNotImplementedError)],
-            "fixed_size_binary_16": [
-                (_make_float16_array([0.0]), pa.lib.ArrowNotImplementedError)
-            ],
+            "fixed_size_binary_16": [(_make_float16_array([0.0]), pa.lib.ArrowNotImplementedError)],
             "decimal128": [
                 (_make_float16_array([0.0, 1.0, -1.0, None]), pa.lib.ArrowNotImplementedError),
             ],


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix `test_pyarrow_array_cast.py` to work with PyArrow 18-20 by adding a `_make_float16_array` helper that uses `numpy.float16` for older versions (PyArrow < 21 requires `np.float16` instances, while >= 21 accepts Python floats directly).

### Why are the changes needed?

Tests were failing on PyArrow 18-20 with `ArrowTypeError: Expected np.float16 instance`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually tested on PyArrow 18, 19, 20, 21, 22 - all pass.

### Was this patch authored or co-authored using generative AI tooling?

No.