### PR TITLE
[SPARK-53807][CORE][FOLLOWUP] Fix a race condition issue between `unlock` and `releaseAllLocksForTask` for write lock in `BlockInfoManager`

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockInfoManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockInfoManager.scala
@@ -396,9 +396,9 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
     logTrace(s"Task $taskAttemptId releasing lock for $blockId")
     blockInfo(blockId) { (info, condition) =>
       if (info.writerTask != BlockInfo.NO_WRITER) {
-        info.writerTask = BlockInfo.NO_WRITER
         val blockIds = writeLocksByTask.get(taskAttemptId)
         if (blockIds != null) {
+          info.writerTask = BlockInfo.NO_WRITER
           blockIds.remove(blockId)
         }
       } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes an issue that `unlock` and `releaseAllLocksForTask` for write lock in `BlockInfoManager`.
#52524 tried to fix this issue but it's still remaining.

This issue can be reproduced by inserting `Thread.sleep()` into `BlockInfoManager` like as follows.
```
--- a/core/src/main/scala/org/apache/spark/storage/BlockInfoManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockInfoManager.scala
@@ -397,6 +397,7 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
     blockInfo(blockId) { (info, condition) =>
       if (info.writerTask != BlockInfo.NO_WRITER) {
         info.writerTask = BlockInfo.NO_WRITER
+        Thread.sleep(100)
         val blockIds = writeLocksByTask.get(taskAttemptId)
         if (blockIds != null) {
           blockIds.remove(blockId)
@@ -490,12 +491,14 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
     val blocksWithReleasedLocks = mutable.ArrayBuffer[BlockId]()
 
     val writeLocks = Option(writeLocksByTask.remove(taskAttemptId)).getOrElse(util.Set.of())
+    Thread.sleep(100)
     writeLocks.forEach { blockId =>
       blockInfo(blockId) { (info, condition) =>
         // Check the existence of `blockId` because `unlock` may have already removed it
         // concurrently.
         if (writeLocks.contains(blockId)) {
           blocksWithReleasedLocks += blockId
+          Thread.sleep(100)
           assert(info.writerTask == taskAttemptId)
           info.writerTask = BlockInfo.NO_WRITER
           condition.signalAll()
```

And then, run a test `SPARK-53807 - concurrent unlock and releaseAllLocksForTask for write should not fail` in `BlockInfoManagerSuite`.

```
$ build/sbt 'testOnly org.apache.spark.storage.BlockInfoManagerSuite -- -z "SPARK-53807"'
```

### Why are the changes needed?
To fix a race condition issue.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
`BlockInfoManagerSuite` passes even if inserting `Thread.sleep` as mentioned above.

### Was this patch authored or co-authored using generative AI tooling?
No.
