### PR TITLE
[SPARK-55158][PYTHON][TESTS] Make the test acknowledge of new string data type

### DIFF
--- a/python/pyspark/pandas/tests/test_typedef.py
+++ b/python/pyspark/pandas/tests/test_typedef.py
@@ -100,7 +100,15 @@ class TypeHintTestsMixin:
 
         expected = StructType([StructField("c0", DoubleType()), StructField("c1", StringType())])
         inferred = infer_return_type(func)
-        self.assertEqual(inferred.dtypes, [np.float64, np.str_])
+        self.assertEqual(
+            inferred.dtypes,
+            [
+                np.float64,
+                np.str_
+                if LooseVersion(pd.__version__) < LooseVersion("3.0.0")
+                else pd.StringDtype(na_value=np.nan),
+            ],
+        )
         self.assertEqual(inferred.spark_type, expected)
 
         def func() -> "pandas.DataFrame[float]":
@@ -123,7 +131,15 @@ class TypeHintTestsMixin:
 
         expected = StructType([StructField("c0", DoubleType()), StructField("c1", StringType())])
         inferred = infer_return_type(func)
-        self.assertEqual(inferred.dtypes, [np.float64, np.str_])
+        self.assertEqual(
+            inferred.dtypes,
+            [
+                np.float64,
+                np.str_
+                if LooseVersion(pd.__version__) < LooseVersion("3.0.0")
+                else pd.StringDtype(na_value=np.nan),
+            ],
+        )
         self.assertEqual(inferred.spark_type, expected)
 
         def func() -> pd.DataFrame[np.float64]:
@@ -174,7 +190,15 @@ class TypeHintTestsMixin:
 
         expected = StructType([StructField("a", DoubleType()), StructField("b", StringType())])
         inferred = infer_return_type(func)
-        self.assertEqual(inferred.dtypes, [np.float64, np.str_])
+        self.assertEqual(
+            inferred.dtypes,
+            [
+                np.float64,
+                np.str_
+                if LooseVersion(pd.__version__) < LooseVersion("3.0.0")
+                else pd.StringDtype(na_value=np.nan),
+            ],
+        )
         self.assertEqual(inferred.spark_type, expected)
 
         def func() -> "pd.DataFrame['a': float, 'b': int]":  # noqa: F821
@@ -329,7 +353,12 @@ class TypeHintTestsMixin:
             float: (np.float64, DoubleType()),
             # string
             np.str_: (np.str_, StringType()),
-            str: (np.str_, StringType()),
+            str: (
+                np.str_
+                if LooseVersion(pd.__version__) < LooseVersion("3.0.0")
+                else pd.StringDtype(na_value=np.nan),
+                StringType(),
+            ),
             # bool
             bool: (np.bool_, BooleanType()),
             # datetime

--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -339,8 +339,10 @@ def pandas_on_spark_type(tpe: Union[str, type, Dtype]) -> Tuple[Dtype, types.Dat
     >>> if using_pandas_3:
     ...     t[0] == pd.StringDtype(na_value=np.nan)
     ... else:
-    ...     t[1] == np.str_
+    ...     t[0] == np.str_
     True
+    >>> t[1]
+    LongType()
     >>> pandas_on_spark_type(datetime.date)
     (dtype('O'), DateType())
     >>> pandas_on_spark_type(datetime.datetime)

--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -342,7 +342,7 @@ def pandas_on_spark_type(tpe: Union[str, type, Dtype]) -> Tuple[Dtype, types.Dat
     ...     t[0] == np.str_
     True
     >>> t[1]
-    LongType()
+    StringType()
     >>> pandas_on_spark_type(datetime.date)
     (dtype('O'), DateType())
     >>> pandas_on_spark_type(datetime.datetime)

--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -339,7 +339,7 @@ def pandas_on_spark_type(tpe: Union[str, type, Dtype]) -> Tuple[Dtype, types.Dat
     >>> if using_pandas_3:
     ...     t[0] == pd.StringDtype(na_value=np.nan)
     ... else:
-    ...     t[1] == dtype('<U')
+    ...     t[1] == np.str_
     True
     >>> pandas_on_spark_type(datetime.date)
     (dtype('O'), DateType())

--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -330,10 +330,17 @@ def pandas_on_spark_type(tpe: Union[str, type, Dtype]) -> Tuple[Dtype, types.Dat
 
     Examples
     --------
+    >>> from pyspark.loose_version import LooseVersion
+    >>> using_pandas_3 = LooseVersion(pd.__version__) >= "3.0.0"
+
     >>> pandas_on_spark_type(int)
     (dtype('int64'), LongType())
-    >>> pandas_on_spark_type(str)
-    (dtype('<U'), StringType())
+    >>> t = pandas_on_spark_type(str)
+    >>> if using_pandas_3:
+    ...     t[0] == pd.StringDtype(na_value=np.nan)
+    ... else:
+    ...     t[1] == dtype('<U')
+    True
     >>> pandas_on_spark_type(datetime.date)
     (dtype('O'), DateType())
     >>> pandas_on_spark_type(datetime.datetime)
@@ -388,6 +395,9 @@ def infer_return_type(f: Callable) -> Union[SeriesType, DataFrameType, ScalarTyp
     The returned type class indicates both dtypes (a pandas only dtype object
     or a numpy dtype object) and its corresponding Spark DataType.
 
+    >>> from pyspark.loose_version import LooseVersion
+    >>> using_pandas_3 = LooseVersion(pd.__version__) >= "3.0.0"
+
     >>> def func() -> int:
     ...    pass
     >>> inferred = infer_return_type(func)
@@ -407,8 +417,13 @@ def infer_return_type(f: Callable) -> Union[SeriesType, DataFrameType, ScalarTyp
     >>> def func() -> ps.DataFrame[float, str]:
     ...    pass
     >>> inferred = infer_return_type(func)
-    >>> inferred.dtypes
-    [dtype('float64'), dtype('<U')]
+    >>> inferred.dtypes[0]
+    dtype('float64')
+    >>> if using_pandas_3:
+    ...     inferred.dtypes[1] == pd.StringDtype(na_value=np.nan)
+    ... else:
+    ...     inferred.dtypes[1] == np.str_
+    True
     >>> inferred.spark_type
     StructType([StructField('c0', DoubleType(), True), StructField('c1', StringType(), True)])
 
@@ -439,8 +454,13 @@ def infer_return_type(f: Callable) -> Union[SeriesType, DataFrameType, ScalarTyp
     >>> def func() -> 'ps.DataFrame[float, str]':
     ...    pass
     >>> inferred = infer_return_type(func)
-    >>> inferred.dtypes
-    [dtype('float64'), dtype('<U')]
+    >>> inferred.dtypes[0]
+    dtype('float64')
+    >>> if using_pandas_3:
+    ...     inferred.dtypes[1] == pd.StringDtype(na_value=np.nan)
+    ... else:
+    ...     inferred.dtypes[1] == np.str_
+    True
     >>> inferred.spark_type
     StructType([StructField('c0', DoubleType(), True), StructField('c1', StringType(), True)])
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

When infer from type hints, `str` should map to the new dedicated string type `pd.StringDtype` instead of `np.str_`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

https://pandas.pydata.org/docs/whatsnew/v3.0.0.html#dedicated-string-data-type-by-default

This is what pandas 3 does.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, the inferred type would be different, but consistent with pandas 3.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Local test passed for pandas 3

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.