### PR TITLE
[SPARK-55170][PYTHON] Extract grouped stream reading pattern from serializers

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -1239,8 +1239,8 @@ class CogroupArrowUDFSerializer(ArrowStreamGroupUDFSerializer):
         """
         Deserialize Cogrouped ArrowRecordBatches and yield as two `pyarrow.RecordBatch`es.
         """
-        for df1_batches, df2_batches in self._load_group_dataframes(stream, num_dfs=2):
-            yield df1_batches, df2_batches
+        for left_batches, right_batches in self._load_group_dataframes(stream, num_dfs=2):
+            yield left_batches, right_batches
 
 
 class CogroupPandasUDFSerializer(ArrowStreamPandasUDFSerializer):
@@ -1251,15 +1251,15 @@ class CogroupPandasUDFSerializer(ArrowStreamPandasUDFSerializer):
         """
         import pyarrow as pa
 
-        for df1_batches, df2_batches in self._load_group_dataframes(stream, num_dfs=2):
+        for left_batches, right_batches in self._load_group_dataframes(stream, num_dfs=2):
             yield (
                 [
                     self.arrow_to_pandas(c, i)
-                    for i, c in enumerate(pa.Table.from_batches(df1_batches).itercolumns())
+                    for i, c in enumerate(pa.Table.from_batches(left_batches).itercolumns())
                 ],
                 [
                     self.arrow_to_pandas(c, i)
-                    for i, c in enumerate(pa.Table.from_batches(df2_batches).itercolumns())
+                    for i, c in enumerate(pa.Table.from_batches(right_batches).itercolumns())
                 ],
             )
 

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -164,12 +164,15 @@ class ArrowStreamSerializer(Serializer):
 
             if dataframes_in_group == num_dfs:
                 if num_dfs == 1:
-                    # Single dataframe: can use lazy iterator (original behavior)
-                    yield (self.load_stream(stream),)
+                    # Single dataframe: can use lazy iterator
+                    yield (ArrowStreamSerializer.load_stream(self, stream),)
                 else:
                     # Multiple dataframes: must eagerly load sequentially
                     # to maintain correct stream position
-                    yield tuple(list(self.load_stream(stream)) for _ in range(num_dfs))
+                    yield tuple(
+                        list(ArrowStreamSerializer.load_stream(self, stream))
+                        for _ in range(num_dfs)
+                    )
             elif dataframes_in_group > 0:
                 raise PySparkValueError(
                     errorClass="INVALID_NUMBER_OF_DATAFRAMES_IN_GROUP",

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -165,7 +165,7 @@ class ArrowStreamSerializer(Serializer):
 
             if dataframes_in_group == num_dfs:
                 yield tuple(self.load_stream(stream) for _ in range(num_dfs))
-            elif dataframes_in_group != 0:
+            elif dataframes_in_group > 0:
                 raise PySparkValueError(
                     errorClass="INVALID_NUMBER_OF_DATAFRAMES_IN_GROUP",
                     messageParameters={"dataframes_in_group": str(dataframes_in_group)},


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR extracts the common grouped stream reading pattern from multiple serializers into a reusable method `_load_group_dataframes` in `ArrowStreamSerializer`.

Multiple serializers previously duplicated the same pattern for reading grouped data from stream:
- `GroupArrowUDFSerializer`
- `ArrowStreamAggArrowUDFSerializer`
- `ArrowStreamAggPandasUDFSerializer`
- `GroupPandasUDFSerializer`
- `CogroupArrowUDFSerializer`
- `CogroupPandasUDFSerializer`

The duplicated pattern was:
```python
dataframes_in_group = None
while dataframes_in_group is None or dataframes_in_group > 0:
    dataframes_in_group = read_int(stream)
    if dataframes_in_group == EXPECTED_COUNT:
        # process group
        yield result
    elif dataframes_in_group != 0:
        raise PySparkValueError(
            errorClass="INVALID_NUMBER_OF_DATAFRAMES_IN_GROUP",
            messageParameters={"dataframes_in_group": str(dataframes_in_group)},
        )
```

This has been extracted into a method in `ArrowStreamSerializer`:
```python
def _load_group_dataframes(self, stream, num_dfs: int = 1):
    """
    Load groups with specified number of dataframes from stream.

    For num_dfs=1, yields a single-element tuple containing a lazy iterator.
    For num_dfs>1 (e.g., cogroup), yields a tuple of eagerly loaded lists.
    """
```

```
Serializer (base)
├── ArrowCollectSerializer
└── ArrowStreamSerializer
    ├── _load_group_dataframes() ← NEW method added here
    │
    ├── ArrowStreamUDFSerializer
    │   ├── ArrowStreamUDTFSerializer
    │   │   └── ArrowStreamArrowUDTFSerializer
    │   ├── ArrowStreamGroupUDFSerializer
    │   │   ├── GroupArrowUDFSerializer          ← uses _load_group_dataframes
    │   │   └── CogroupArrowUDFSerializer        ← uses _load_group_dataframes
    │   └── TransformWithStateInPySparkRowSerializer
    │       └── TransformWithStateInPySparkRowInitStateSerializer
    │
    ├── ArrowStreamPandasSerializer
    │   └── ArrowStreamPandasUDFSerializer
    │       ├── ArrowStreamPandasUDTFSerializer
    │       ├── ArrowStreamAggPandasUDFSerializer   ← uses _load_group_dataframes
    │       ├── GroupPandasUDFSerializer            ← uses _load_group_dataframes
    │       ├── CogroupPandasUDFSerializer          ← uses _load_group_dataframes
    │       ├── ApplyInPandasWithStateSerializer
    │       └── TransformWithStateInPandasSerializer
    │           └── TransformWithStateInPandasInitStateSerializer
    │
    └── ArrowStreamArrowUDFSerializer
        ├── ArrowBatchUDFSerializer
        └── ArrowStreamAggArrowUDFSerializer        ← uses _load_group_dataframes
```

### Why are the changes needed?

This is part of Phase 2: Reduce serializer complexity (SPARK-55159)
1. Reduces code duplication across 6 serializers (~37 lines net reduction)
2. Makes the code easier to maintain and understand

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.