### PR TITLE
[SPARK-55177][PYTHON] Support keyword arguments for df.groupby(...).agg(...)

### DIFF
--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1162,8 +1162,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     ) -> ParentDataFrame:
         return self.unpivot(ids, values, variableColumnName, valueColumnName)
 
-    def agg(self, *exprs: Union[Column, Dict[str, str]]) -> ParentDataFrame:
-        return self.groupBy().agg(*exprs)  # type: ignore[arg-type]
+    def agg(self, *exprs: Union[Column, Dict[str, str]], **kwargs: str) -> "DataFrame":
+        return self.groupBy().agg(*exprs, **kwargs)  # type: ignore[arg-type]
 
     def observe(
         self,

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1163,7 +1163,7 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         return self.unpivot(ids, values, variableColumnName, valueColumnName)
 
     def agg(self, *exprs: Union[Column, Dict[str, str]], **kwargs: str) -> "DataFrame":
-        return self.groupBy().agg(*exprs, **kwargs)  # type: ignore[arg-type]
+        return self.groupBy().agg(*exprs, **kwargs)
 
     def observe(
         self,

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -258,6 +258,13 @@ class DataFrame(ParentDataFrame):
         return DataFrame(plan.Project(self._plan, sql_expr), session=self._session)
 
     def agg(self, *exprs: Union[Column, Dict[str, str]], **kwargs: str) -> "DataFrame":
+        if kwargs:
+            if exprs:
+                raise PySparkValueError(
+                    "Cannot use both positional arguments and keyword arguments"
+                )
+            exprs = (kwargs,)
+
         if not exprs:
             raise PySparkValueError(
                 errorClass="CANNOT_BE_EMPTY",
@@ -309,9 +316,7 @@ class DataFrame(ParentDataFrame):
         return self._session
 
     def count(self) -> int:
-        table, _ = self.agg(
-            F._invoke_function("count", F.lit(1))
-        )._to_table()  # type: ignore[operator]
+        table, _ = self.agg(F._invoke_function("count", F.lit(1)))._to_table()
         return table[0][0].as_py()
 
     def crossJoin(self, other: ParentDataFrame) -> ParentDataFrame:

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -257,7 +257,7 @@ class DataFrame(ParentDataFrame):
 
         return DataFrame(plan.Project(self._plan, sql_expr), session=self._session)
 
-    def agg(self, *exprs: Union[Column, Dict[str, str]]) -> ParentDataFrame:
+    def agg(self, *exprs: Union[Column, Dict[str, str]], **kwargs: str) -> "DataFrame":
         if not exprs:
             raise PySparkValueError(
                 errorClass="CANNOT_BE_EMPTY",
@@ -271,7 +271,7 @@ class DataFrame(ParentDataFrame):
             # other expressions
             assert all(isinstance(c, Column) for c in exprs), "all exprs should be Expression"
             exprs = cast(Tuple[Column, ...], exprs)
-            return self.groupBy().agg(*exprs)
+            return self.groupBy().agg(*exprs, **kwargs)
 
     def alias(self, alias: str) -> ParentDataFrame:
         res = DataFrame(plan.SubqueryAlias(self._plan, alias), session=self._session)

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -4321,7 +4321,7 @@ class DataFrame:
         ...
 
     @dispatch_df_method
-    def agg(self, *exprs: Union[Column, Dict[str, str]]) -> "DataFrame":
+    def agg(self, *exprs: Union[Column, Dict[str, str]], **kwargs: str) -> "DataFrame":
         """Aggregate on the entire :class:`DataFrame` without groups
         (shorthand for ``df.groupBy().agg()``).
 
@@ -4345,6 +4345,12 @@ class DataFrame:
         >>> from pyspark.sql import functions as sf
         >>> df = spark.createDataFrame([(2, "Alice"), (5, "Bob")], schema=["age", "name"])
         >>> df.agg({"age": "max"}).show()
+        +--------+
+        |max(age)|
+        +--------+
+        |       5|
+        +--------+
+        >>> df.agg(age="max").show()
         +--------+
         |max(age)|
         +--------+

--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -170,7 +170,7 @@ class GroupedData(PandasGroupedOpsMixin):
         +-----+--------+
         |Alice|       2|
         |  Bob|       5|
-        +-----+--------+`
+        +-----+--------+
 
         Group-by name, and calculate the minimum age.
 

--- a/python/pyspark/sql/tests/test_group.py
+++ b/python/pyspark/sql/tests/test_group.py
@@ -59,6 +59,7 @@ class GroupTestsMixin:
         df = self.df
         g = df.groupBy()
         self.assertEqual([99, 100], sorted(g.agg({"key": "max", "value": "count"}).collect()[0]))
+        self.assertEqual([99, 100], sorted(g.agg(key="max", value="count").collect()[0]))
         assertDataFrameEqual([Row(**{"AVG(key#0)": 49.5})], g.mean().collect())
 
         from pyspark.sql import functions


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add support for keyword arguments in `GroupedData.agg()` to allow a more Pythonic syntax for specifying column-to-aggregation-function mappings.

### Why are the changes needed?

Currently, users must use dictionary syntax `agg({"age": "min"})` to specify aggregations. Keyword arguments provide a more intuitive and Pythonic alternative: `agg(age="min", salary="max")`, which is consistent with other Python APIs and reduces verbosity.

### Does this PR introduce _any_ user-facing change?

Yes. Users can now use keyword arguments for aggregations:

Before:
```python
df.groupBy("name").agg({"age": "min", "salary": "max"})
```

After:
```python
df.groupBy("name").agg(age="min", salary="max")
```

### How was this patch tested?

Unittest added.

### Was this patch authored or co-authored using generative AI tooling?

No.