### PR TITLE
[SPARK-55178][K8S][TESTS] Remove `redirectingInput` from `o.a.s.deploy.k8s.integrationtest.Utils.executeCommand`

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
@@ -84,7 +84,6 @@ object Utils extends Logging {
     }
     val listener = new ReadyListener()
     val watch = pod
-      .redirectingInput()
       .writingOutput(out)
       .writingError(System.err)
       .withTTY()
@@ -92,7 +91,6 @@ object Utils extends Logging {
       .exec(cmd.toArray: _*)
     // under load sometimes the stdout isn't connected by the time we try to read from it.
     listener.waitForInputStreamToConnect()
-    System.in.transferTo(watch.getInput)
     listener.waitForClose()
     watch.close()
     out.flush()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `redirectingInput` from `o.a.s.deploy.k8s.integrationtest.Utils.executeCommand`.

### Why are the changes needed?

`executeCommand` doesn't need `redirectingInput` because we collect the result simply from `cat`, `env`, `ls`, and `df` commands without passing any input.

```
$ cd resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/

$ git grep executeCommand
PVTestsSuite.scala:      val contents = Utils.executeCommand("cat", s"$CONTAINER_MOUNT_PATH/$file")
SecretsTestsSuite.scala:      val env = Utils.executeCommand("env")
SecretsTestsSuite.scala:    val files = Utils.executeCommand("ls", s"$SECRET_MOUNT_PATH")
SecretsTestsSuite.scala:      .executeCommand("cat", s"$SECRET_MOUNT_PATH/$ENV_SECRET_KEY_1")
SecretsTestsSuite.scala:      .executeCommand("cat", s"$SECRET_MOUNT_PATH/$ENV_SECRET_KEY_2")
Utils.scala:  def executeCommand(cmd: String*)(
VolumeSuite.scala:      assert(Utils.executeCommand("df", path).contains(expected))
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.