### PR TITLE
[SPARK-55183][PYTHON] Extract `reorder_columns` transformer from ArrowStreamGroupUDFSerializer

### DIFF
--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -92,11 +92,11 @@ class ArrowBatchTransformer:
         return pa.RecordBatch.from_arrays([struct], ["_0"])
 
     @staticmethod
-    def assign_cols_by_name(
-        batch: "pa.RecordBatch", arrow_type: "pa.StructType"
+    def reorder_columns(
+        batch: "pa.RecordBatch", target_schema: "pa.StructType"
     ) -> "pa.RecordBatch":
         """
-        Reorder a RecordBatch's columns to match the field order of the given schema.
+        Reorder a RecordBatch's columns to match the field order of the target schema.
 
         This is used when UDF results need to be reordered to match the expected
         output schema, selecting columns by name rather than by position.
@@ -105,21 +105,21 @@ class ArrowBatchTransformer:
         ----------
         batch : pa.RecordBatch
             The input batch whose columns may be in a different order.
-        arrow_type : pa.StructType
+        target_schema : pa.StructType
             The target schema defining the expected column order.
 
         Returns
         -------
         pa.RecordBatch
-            A new batch with columns reordered to match arrow_type's field order.
+            A new batch with columns reordered to match target_schema's field order.
 
         Used by: ArrowStreamGroupUDFSerializer.dump_stream
         """
         import pyarrow as pa
 
         return pa.RecordBatch.from_arrays(
-            [batch.column(field.name) for field in arrow_type],
-            names=[field.name for field in arrow_type],
+            [batch.column(field.name) for field in target_schema],
+            names=[field.name for field in target_schema],
         )
 
 

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -346,7 +346,7 @@ class ArrowStreamGroupUDFSerializer(ArrowStreamUDFSerializer):
 
         if self._assign_cols_by_name:
             batch_iter = (
-                (ArrowBatchTransformer.assign_cols_by_name(batch, arrow_type), arrow_type)
+                (ArrowBatchTransformer.reorder_columns(batch, arrow_type), arrow_type)
                 for batch, arrow_type in batch_iter
             )
 

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -336,8 +336,6 @@ class ArrowStreamGroupUDFSerializer(ArrowStreamUDFSerializer):
         self._assign_cols_by_name = assign_cols_by_name
 
     def dump_stream(self, iterator, stream):
-        import pyarrow as pa
-
         # flatten inner list [([pa.RecordBatch], arrow_type)] into [(pa.RecordBatch, arrow_type)]
         # so strip off inner iterator induced by ArrowStreamUDFSerializer.load_stream
         batch_iter = (
@@ -348,13 +346,7 @@ class ArrowStreamGroupUDFSerializer(ArrowStreamUDFSerializer):
 
         if self._assign_cols_by_name:
             batch_iter = (
-                (
-                    pa.RecordBatch.from_arrays(
-                        [batch.column(field.name) for field in arrow_type],
-                        names=[field.name for field in arrow_type],
-                    ),
-                    arrow_type,
-                )
+                (ArrowBatchTransformer.assign_cols_by_name(batch, arrow_type), arrow_type)
                 for batch, arrow_type in batch_iter
             )
 

--- a/python/pyspark/sql/tests/test_conversion.py
+++ b/python/pyspark/sql/tests/test_conversion.py
@@ -161,9 +161,7 @@ class ArrowBatchTransformerTests(unittest.TestCase):
         # With struct column
         struct_type = pa.struct([("a", pa.int64()), ("b", pa.string())])
         struct_array = pa.array([{"a": 1, "b": "x"}, {"a": 2, "b": "y"}], type=struct_type)
-        batch = pa.RecordBatch.from_arrays(
-            [pa.array([10, 20]), struct_array], names=["id", "data"]
-        )
+        batch = pa.RecordBatch.from_arrays([pa.array([10, 20]), struct_array], names=["id", "data"])
         target_schema = pa.struct([("data", struct_type), ("id", pa.int64())])
         reordered = ArrowBatchTransformer.reorder_columns(batch, target_schema)
         self.assertEqual(reordered.schema.names, ["data", "id"])


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR extracts the column reordering logic from `ArrowStreamGroupUDFSerializer.dump_stream` into `ArrowBatchTransformer.reorder_columns`.

**Changes:**

1. **conversion.py**: Add `ArrowBatchTransformer.reorder_columns(batch, target_schema)` - a pure function that reorders a RecordBatch's columns to match the target schema's field order.

2. **serializers.py**: Simplify `ArrowStreamGroupUDFSerializer.dump_stream` to use the new transformer, removing inline pyarrow code.

### Why are the changes needed?

This is part of [SPARK-55159](https://issues.apache.org/jira/browse/SPARK-55159) to improve the composability of Arrow serializers by separating data transformation from serialization.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added `ArrowBatchTransformerTests.test_reorder_columns` covering basic reordering, struct columns, and empty batch handling.

### Was this patch authored or co-authored using generative AI tooling?

No.
