### PR TITLE
[SPARK-55186][PYTHON] Make ArrowArrayToPandasConversion.convert_legacy able to return pd.DataFrame

### DIFF
--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -1016,8 +1016,11 @@ class ArrowArrayToPandasConversion:
         """
         Parameters
         ----------
-        arr : :class:`pyarrow.Array`
-        spark_type: target spark type, should always be specified
+        arr : :class:`pyarrow.Array`.
+        spark_type: target spark type, should always be specified.
+        timezone : The timezone to convert from. If there is a timestamp type, it's required.
+        struct_in_pandas : How to handle struct type. If there is a struct type, it's required.
+        ndarray_as_list : Whether `np.ndarray` is converted to a list or not.
         df_for_struct: when true, and spark type is a StructType, return a DataFrame.
         """
         import pyarrow as pa

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -1039,10 +1039,12 @@ class ArrowArrayToPandasConversion:
                     struct_in_pandas=struct_in_pandas,
                     ndarray_as_list=ndarray_as_list,
                     df_for_struct=False,  # always False for child fields
-                ).rename(field.name)
+                )
                 for field_arr, field in zip(arr.flatten(), spark_type)
             ]
-            return pd.concat(series, axis=1)
+            pdf = pd.concat(series, axis=1)
+            pdf.columns = spark_type.names
+            return pdf
 
         # If the given column is a date type column, creates a series of datetime.date directly
         # instead of creating datetime64[ns] as intermediate data to avoid overflow caused by

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -1043,7 +1043,7 @@ class ArrowArrayToPandasConversion:
                 for field_arr, field in zip(arr.flatten(), spark_type)
             ]
             pdf = pd.concat(series, axis=1)
-            pdf.columns = spark_type.names
+            pdf.columns = spark_type.names  # type: ignore[assignment]
             return pdf
 
         # If the given column is a date type column, creates a series of datetime.date directly

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -1039,12 +1039,10 @@ class ArrowArrayToPandasConversion:
                     struct_in_pandas=struct_in_pandas,
                     ndarray_as_list=ndarray_as_list,
                     df_for_struct=False,  # always False for child fields
-                )
-                for field_arr, field in enumerate(zip(arr.flatten(), spark_type))
+                ).rename(field.name)
+                for field_arr, field in zip(arr.flatten(), spark_type)
             ]
-            pdf = pd.concat(series, axis=1)
-            pdf.names = spark_type.names
-            return pdf
+            return pd.concat(series, axis=1)
 
         # If the given column is a date type column, creates a series of datetime.date directly
         # instead of creating datetime64[ns] as intermediate data to avoid overflow caused by

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -1005,13 +1005,47 @@ class ArrowArrayToPandasConversion:
     @classmethod
     def convert_legacy(
         cls,
-        arr: "pa.Array",
+        arr: Union["pa.Array", "pa.ChunkedArray"],
         spark_type: DataType,
         *,
         timezone: Optional[str] = None,
         struct_in_pandas: Optional[str] = None,
         ndarray_as_list: bool = False,
-    ) -> "pd.Series":
+        df_for_struct: bool = False,
+    ) -> Union["pd.Series", "pd.DataFrame"]:
+        """
+        Parameters
+        ----------
+        arr : :class:`pyarrow.Array`
+        spark_type: target spark type, should always be specified
+        df_for_struct: when true, and spark type is a StructType, return a DataFrame.
+        """
+        import pyarrow as pa
+        import pandas as pd
+
+        assert isinstance(arr, (pa.Array, pa.ChunkedArray))
+
+        if df_for_struct and isinstance(spark_type, StructType):
+            import pyarrow.types as types
+
+            assert types.is_struct(arr.type)
+            assert len(spark_type.names) == len(arr.type.names), f"{spark_type} {arr.type} "
+
+            series = [
+                cls.convert_legacy(
+                    field_arr,
+                    spark_type=field.dataType,
+                    timezone=timezone,
+                    struct_in_pandas=struct_in_pandas,
+                    ndarray_as_list=ndarray_as_list,
+                    df_for_struct=False,  # always False for child fields
+                )
+                for field_arr, field in enumerate(zip(arr.flatten(), spark_type))
+            ]
+            pdf = pd.concat(series, axis=1)
+            pdf.names = spark_type.names
+            return pdf
+
         # If the given column is a date type column, creates a series of datetime.date directly
         # instead of creating datetime64[ns] as intermediate data to avoid overflow caused by
         # datetime64[ns] type handling.

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -596,7 +596,7 @@ class ArrowStreamPandasUDFSerializer(ArrowStreamPandasSerializer):
     def arrow_to_pandas(self, arrow_column, idx):
         spark_type: DataType
         if self._input_type is not None:
-            spark_type = self._input_type[idx].dtype
+            spark_type = self._input_type[idx].dataType
         else:
             spark_type = from_arrow_type(arrow_column.type)
 

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -594,7 +594,6 @@ class ArrowStreamPandasUDFSerializer(ArrowStreamPandasSerializer):
         self._input_type = input_type
 
     def arrow_to_pandas(self, arrow_column, idx):
-        spark_type: DataType
         if self._input_type is not None:
             spark_type = self._input_type[idx].dataType
         else:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Make ArrowArrayToPandasConversion.convert_legacy able to return pd.DataFrame


### Why are the changes needed?
to replace the `arrow_to_pandas` retuning pd.DataFrame


### Does this PR introduce _any_ user-facing change?
No, refactoring 

### How was this patch tested?
existing tests


### Was this patch authored or co-authored using generative AI tooling?
no