### PR TITLE
[SPARK-55196][K8S][TESTS] Add `commandTestTag` to K8s Integration Test

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -642,6 +642,7 @@ class KubernetesSuite extends SparkFunSuite
 private[spark] object KubernetesSuite {
   val k8sTestTag = Tag("k8s")
   val localTestTag = Tag("local")
+  val commandTestTag = Tag("command")
   val pvTestTag = Tag("pv")
   val schedulingTestTag = Tag("schedule")
   val decomTestTag = Tag("decom")

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/PVTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/PVTestsSuite.scala
@@ -178,7 +178,7 @@ private[spark] trait PVTestsSuite { k8sSuite: KubernetesSuite =>
     }
   }
 
-  test("PVs with local storage", k8sTestTag, pvTestTag) {
+  test("PVs with local storage", k8sTestTag, pvTestTag, commandTestTag) {
     assume(this.getClass.getSimpleName == "KubernetesSuite")
     sparkAppConf
       .set(s"spark.kubernetes.driver.volumes.persistentVolumeClaim.data.mount.path",

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SecretsTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SecretsTestsSuite.scala
@@ -57,7 +57,7 @@ private[spark] trait SecretsTestsSuite { k8sSuite: KubernetesSuite =>
       .delete()
   }
 
-  test("Run SparkPi with env and mount secrets.", k8sTestTag) {
+  test("Run SparkPi with env and mount secrets.", k8sTestTag, commandTestTag) {
     createTestSecret()
     sparkAppConf
       .set(s"spark.kubernetes.driver.secrets.$ENV_SECRET_NAME", SECRET_MOUNT_PATH)

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/VolumeSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/VolumeSuite.scala
@@ -36,7 +36,7 @@ private[spark] trait VolumeSuite { k8sSuite: KubernetesSuite =>
     }
   }
 
-  test("A driver-only Spark job with a tmpfs-backed localDir volume", k8sTestTag) {
+  test("A driver-only Spark job with a tmpfs-backed localDir volume", k8sTestTag, commandTestTag) {
     sparkAppConf
       .set("spark.kubernetes.driver.master", "local[10]")
       .set("spark.kubernetes.local.dirs.tmpfs", "true")
@@ -57,7 +57,8 @@ private[spark] trait VolumeSuite { k8sSuite: KubernetesSuite =>
       executorPatience = IGNORE)
   }
 
-  test("A driver-only Spark job with a tmpfs-backed emptyDir data volume", k8sTestTag) {
+  test("A driver-only Spark job with a tmpfs-backed emptyDir data volume", k8sTestTag,
+      commandTestTag) {
     sparkAppConf
       .set("spark.kubernetes.driver.master", "local[10]")
       .set("spark.kubernetes.driver.volumes.emptyDir.data.mount.path", "/data")
@@ -78,7 +79,7 @@ private[spark] trait VolumeSuite { k8sSuite: KubernetesSuite =>
       executorPatience = IGNORE)
   }
 
-  test("A driver-only Spark job with a disk-backed emptyDir volume", k8sTestTag) {
+  test("A driver-only Spark job with a disk-backed emptyDir volume", k8sTestTag, commandTestTag) {
     sparkAppConf
       .set("spark.kubernetes.driver.master", "local[10]")
       .set("spark.kubernetes.driver.volumes.emptyDir.data.mount.path", "/data")
@@ -98,7 +99,7 @@ private[spark] trait VolumeSuite { k8sSuite: KubernetesSuite =>
       executorPatience = IGNORE)
   }
 
-  test("A driver-only Spark job with an OnDemand PVC volume", k8sTestTag) {
+  test("A driver-only Spark job with an OnDemand PVC volume", k8sTestTag, commandTestTag) {
     val storageClassName = testBackend match {
       case MinikubeTestBackend => "standard"
       case _ => "hostpath"
@@ -126,7 +127,7 @@ private[spark] trait VolumeSuite { k8sSuite: KubernetesSuite =>
       executorPatience = IGNORE)
   }
 
-  test("A Spark job with tmpfs-backed localDir volumes", k8sTestTag) {
+  test("A Spark job with tmpfs-backed localDir volumes", k8sTestTag, commandTestTag) {
     sparkAppConf
       .set("spark.kubernetes.local.dirs.tmpfs", "true")
     runSparkApplicationAndVerifyCompletion(
@@ -150,7 +151,7 @@ private[spark] trait VolumeSuite { k8sSuite: KubernetesSuite =>
       isJVM = true)
   }
 
-  test("A Spark job with two executors with OnDemand PVC volumes", k8sTestTag) {
+  test("A Spark job with two executors with OnDemand PVC volumes", k8sTestTag, commandTestTag) {
     val storageClassName = testBackend match {
       case MinikubeTestBackend => "standard"
       case _ => "hostpath"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a new test tag, `commandTestTag`, to K8s Integration Test.

### Why are the changes needed?

`o.a.s.deploy.k8s.integrationtest.Utils.executeCommand` requires a live pod access like `cat`, `env`, `ls`, and `df` commands . We had better distinguish this kind of test group.

```
$ cd resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/

$ git grep executeCommand
PVTestsSuite.scala:      val contents = Utils.executeCommand("cat", s"$CONTAINER_MOUNT_PATH/$file")
SecretsTestsSuite.scala:      val env = Utils.executeCommand("env")
SecretsTestsSuite.scala:    val files = Utils.executeCommand("ls", s"$SECRET_MOUNT_PATH")
SecretsTestsSuite.scala:      .executeCommand("cat", s"$SECRET_MOUNT_PATH/$ENV_SECRET_KEY_1")
SecretsTestsSuite.scala:      .executeCommand("cat", s"$SECRET_MOUNT_PATH/$ENV_SECRET_KEY_2")
Utils.scala:  def executeCommand(cmd: String*)(
VolumeSuite.scala:      assert(Utils.executeCommand("df", path).contains(expected))
```

### Does this PR introduce _any_ user-facing change?

No, this is a test-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.