### PR TITLE
[SPARK-55197][PYTHON] Extract `_write_stream_start` helper to deduplicate START_ARROW_STREAM signal logic

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -184,10 +184,9 @@ class ArrowStreamSerializer(Serializer):
         """
         Write START_ARROW_STREAM before the first batch, passing batches through unchanged.
 
-        This marker is required by Pandas UDF serialization protocol to signal the JVM that
-        the Arrow stream is about to begin. It must be sent after the first batch is successfully
-        created, so that if an error occurs during batch creation, the error can be sent back
-        to the JVM before the Arrow stream starts.
+        This marker signals the JVM that the Arrow stream is about to begin. It must be sent
+        after the first batch is successfully created, so that if an error occurs during batch
+        creation, the error can be sent back to the JVM before the Arrow stream starts.
 
         Parameters
         ----------

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -184,6 +184,11 @@ class ArrowStreamSerializer(Serializer):
         """
         Write START_ARROW_STREAM before the first batch, passing batches through unchanged.
 
+        This marker is required by Pandas UDF serialization protocol to signal the JVM that
+        the Arrow stream is about to begin. It must be sent after the first batch is successfully
+        created, so that if an error occurs during batch creation, the error can be sent back
+        to the JVM before the Arrow stream starts.
+
         Parameters
         ----------
         batch_iterator : Iterator[pa.RecordBatch]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR extracts a `_write_stream_start` helper method in `ArrowStreamSerializer` to centralize the `START_ARROW_STREAM` signal writing logic.

### Why are the changes needed?

Multiple Arrow serializers repeated the same pattern for writing `START_ARROW_STREAM`:

```python
should_write_start_length = True
for batch in batches:
    if should_write_start_length:
        write_int(SpecialLengths.START_ARROW_STREAM, stream)
        should_write_start_length = False
    yield batch
```

The new helper centralizes this logic into a single reusable method.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.