### PR TITLE
[SPARK-55200][K8S][TESTS] Add `RancherDesktopBackend` for K8s integration tests

### DIFF
--- a/resource-managers/kubernetes/integration-tests/README.md
+++ b/resource-managers/kubernetes/integration-tests/README.md
@@ -47,6 +47,12 @@ Uses the local `minikube` cluster, this requires that `minikube` 1.28.0 or great
 at least 4 CPUs and 6GB memory (some users have reported success with as few as 3 CPUs and 4GB memory).  The tests will 
 check if `minikube` is started and abort early if it isn't currently running.
 
+### `rancher-desktop`
+
+[Rancher Desktop](https://github.com/rancher-sandbox/rancher-desktop) is an open-source (Apache 2.0 license)
+project that brings Kubernetes and container management to the desktop. It runs on Windows, macOS and Linux.
+The `rancher-desktop` backend configures the tests to use it.
+
 ### `docker-desktop`
 
 Since July 2018 Docker for Desktop provide an optional Kubernetes cluster that can be enabled as described in this 
@@ -168,7 +174,7 @@ to the wrapper scripts and using the wrapper scripts will simply set these appro
     <td><code>spark.kubernetes.test.deployMode</code></td>
     <td>
       The integration test backend to use.  Acceptable values are <code>minikube</code>, 
-      <code>docker-desktop</code> and <code>cloud</code>.
+      <code>docker-desktop</code>, <code>rancher-desktop</code> and <code>cloud</code>.
     <td><code>minikube</code></td>
   </tr>
   <tr>

--- a/resource-managers/kubernetes/integration-tests/scripts/setup-integration-test-env.sh
+++ b/resource-managers/kubernetes/integration-tests/scripts/setup-integration-test-env.sh
@@ -151,6 +151,13 @@ then
        # build the images directly using the minikube Docker daemon so no need to push
        $SPARK_INPUT_DIR/bin/docker-image-tool.sh -m -r $IMAGE_REPO -t $IMAGE_TAG $JAVA_IMAGE_TAG_BUILD_ARG $LANGUAGE_BINDING_BUILD_ARGS build
        ;;
+
+    rancher-desktop)
+       # Only need to build as this will place it in our local Docker repo which is all
+       # we need for Rancher Desktop to work so no need to also push
+       $SPARK_INPUT_DIR/bin/docker-image-tool.sh -r $IMAGE_REPO -t $IMAGE_TAG $JAVA_IMAGE_TAG_BUILD_ARG $LANGUAGE_BINDING_BUILD_ARGS build
+       ;;
+
     *)
        echo "Unrecognized deploy mode $DEPLOY_MODE" && exit 1
        ;;

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/PVTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/PVTestsSuite.scala
@@ -24,7 +24,7 @@ import org.scalatest.time.{Milliseconds, Span}
 
 import org.apache.spark.deploy.k8s.integrationtest.KubernetesSuite._
 import org.apache.spark.deploy.k8s.integrationtest.TestConstants._
-import org.apache.spark.deploy.k8s.integrationtest.backend.docker.DockerForDesktopBackend
+import org.apache.spark.deploy.k8s.integrationtest.backend.docker.{DockerForDesktopBackend, RancherDesktopBackend}
 import org.apache.spark.deploy.k8s.integrationtest.backend.minikube.MinikubeTestBackend
 
 private[spark] trait PVTestsSuite { k8sSuite: KubernetesSuite =>
@@ -34,6 +34,7 @@ private[spark] trait PVTestsSuite { k8sSuite: KubernetesSuite =>
     val (storageClassName, hostname) = testBackend match {
       case MinikubeTestBackend => ("standard", BACKEND_MINIKUBE)
       case DockerForDesktopBackend => ("hostpath", BACKEND_DOCKER_DESKTOP)
+      case RancherDesktopBackend => ("local-path", "lima-rancher-desktop")
       case _ => ("hostpath", BACKEND_DOCKER_DESKTOP)
     }
     val pvBuilder = new PersistentVolumeBuilder()
@@ -143,7 +144,8 @@ private[spark] trait PVTestsSuite { k8sSuite: KubernetesSuite =>
     }
   }
 
-  ignore("PVs with local hostpath and storageClass on statefulsets", k8sTestTag, pvTestTag) {
+  ignore("PVs with local hostpath and storageClass on statefulsets", k8sTestTag, pvTestTag,
+      commandTestTag) {
     assume(this.getClass.getSimpleName == "KubernetesSuite")
     sparkAppConf
       .set(s"spark.kubernetes.driver.volumes.persistentVolumeClaim.data.mount.path",

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/TestConstants.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/TestConstants.scala
@@ -19,6 +19,7 @@ package org.apache.spark.deploy.k8s.integrationtest
 object TestConstants {
   val BACKEND_MINIKUBE = "minikube"
   val BACKEND_DOCKER_DESKTOP = "docker-desktop"
+  val BACKEND_RANCHER_DESKTOP = "rancher-desktop"
   val BACKEND_CLOUD = "cloud"
 
   val CONFIG_KEY_DEPLOY_MODE = "spark.kubernetes.test.deployMode"

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/VolumeSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/VolumeSuite.scala
@@ -23,6 +23,7 @@ import org.scalatest.concurrent.PatienceConfiguration
 import org.scalatest.time.{Seconds, Span}
 
 import org.apache.spark.deploy.k8s.integrationtest.KubernetesSuite._
+import org.apache.spark.deploy.k8s.integrationtest.backend.docker.RancherDesktopBackend
 import org.apache.spark.deploy.k8s.integrationtest.backend.minikube.MinikubeTestBackend
 
 private[spark] trait VolumeSuite { k8sSuite: KubernetesSuite =>
@@ -102,6 +103,7 @@ private[spark] trait VolumeSuite { k8sSuite: KubernetesSuite =>
   test("A driver-only Spark job with an OnDemand PVC volume", k8sTestTag, commandTestTag) {
     val storageClassName = testBackend match {
       case MinikubeTestBackend => "standard"
+      case RancherDesktopBackend => "local-path"
       case _ => "hostpath"
     }
     val DRIVER_PREFIX = "spark.kubernetes.driver.volumes.persistentVolumeClaim"
@@ -154,6 +156,7 @@ private[spark] trait VolumeSuite { k8sSuite: KubernetesSuite =>
   test("A Spark job with two executors with OnDemand PVC volumes", k8sTestTag, commandTestTag) {
     val storageClassName = testBackend match {
       case MinikubeTestBackend => "standard"
+      case RancherDesktopBackend => "local-path"
       case _ => "hostpath"
     }
     val EXECUTOR_PREFIX = "spark.kubernetes.executor.volumes.persistentVolumeClaim"

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/IntegrationTestBackend.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/IntegrationTestBackend.scala
@@ -22,7 +22,7 @@ import io.fabric8.kubernetes.client.KubernetesClient
 import org.apache.spark.deploy.k8s.integrationtest.ProcessUtils
 import org.apache.spark.deploy.k8s.integrationtest.TestConstants._
 import org.apache.spark.deploy.k8s.integrationtest.backend.cloud.KubeConfigBackend
-import org.apache.spark.deploy.k8s.integrationtest.backend.docker.DockerForDesktopBackend
+import org.apache.spark.deploy.k8s.integrationtest.backend.docker.{DockerForDesktopBackend, RancherDesktopBackend}
 import org.apache.spark.deploy.k8s.integrationtest.backend.minikube.MinikubeTestBackend
 
 private[spark] trait IntegrationTestBackend {
@@ -44,6 +44,7 @@ private[spark] object IntegrationTestBackendFactory {
       case BACKEND_CLOUD =>
         new KubeConfigBackend(System.getProperty(CONFIG_KEY_KUBE_CONFIG_CONTEXT))
       case BACKEND_DOCKER_DESKTOP => DockerForDesktopBackend
+      case BACKEND_RANCHER_DESKTOP => RancherDesktopBackend
       case _ => throw new IllegalArgumentException("Invalid " +
         CONFIG_KEY_DEPLOY_MODE + ": " + deployMode)
     }

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/docker/RancherDesktopBackend.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/docker/RancherDesktopBackend.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.k8s.integrationtest.backend.docker
+
+import org.apache.spark.deploy.k8s.integrationtest.TestConstants
+import org.apache.spark.deploy.k8s.integrationtest.backend.cloud.KubeConfigBackend
+
+private[spark] object RancherDesktopBackend
+  extends KubeConfigBackend(TestConstants.BACKEND_RANCHER_DESKTOP) {
+
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `RancherDesktopBackend` for K8s integration tests in addition to the existing `minikube`, `docker-desktop`, and `cloud`-backend. Like the other backends, this PR doesn't aim to make all test cases passes. In other words, `minikube` (the default backend) is the only test backend for all test coverage.

### Why are the changes needed?

[Rancher Desktop](https://github.com/rancher-sandbox/rancher-desktop) is another open-source (Apache 2.0 license) project that brings Kubernetes and container management to the desktop. It runs on Windows, macOS and Linux. Unlike `Docker Desktop`, this is available freely for all purposes.

It would be great if we can support `Rancher Desktop` as an alternative developer tools.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs and manual tests.

```
$ NO_MANUAL=1 ./dev/make-distribution.sh --pip --tgz -Pkubernetes,hadoop-3,hadoop-cloud,hive
```

```
$ resource-managers/kubernetes/integration-tests/dev/dev-run-integration-tests.sh \
--deploy-mode rancher-desktop --exclude-tags minikube,r,local,command --spark-tgz $PWD/spark-*.tgz
...
VolcanoSuite:
- SPARK-42190: Run SparkPi with local[*]
- Run SparkPi with no resources
- SPARK-53944: Run SparkPi without driver service
- Run SparkPi with no resources & statefulset allocation
- Run SparkPi with a very long application name.
- Use SparkLauncher.NO_RESOURCE
- Run SparkPi with a master URL without a scheme.
- Run SparkPi with an argument.
- Run SparkPi with custom labels, annotations, and environment variables.
- All pods have the same service account by default
- Run extraJVMOptions check on driver
- SPARK-42474: Run extraJVMOptions JVM GC option check - G1GC
- SPARK-42474: Run extraJVMOptions JVM GC option check - Other GC
- SPARK-42769: All executor pods have SPARK_DRIVER_POD_IP env variable
- Verify logging configuration is picked from the provided SPARK_CONF_DIR/log4j2.properties
- Run PySpark on simple pi.py example
- Run PySpark to test a pyfiles example
- Run PySpark with memory customization
- Run PySpark with Spark Connect !!! IGNORED !!!
- Run in client mode.
- Start pod creation from template
- SPARK-38398: Schedule pod creation from template
- PVs with local hostpath storage on statefulsets !!! CANCELED !!!
  "[Volcano]Suite" did not equal "[Kubernetes]Suite" (PVTestsSuite.scala:116)
- Test basic decommissioning
- Test basic decommissioning with shuffle cleanup
- Test decommissioning with dynamic allocation & shuffle cleanups
- Test decommissioning timeouts
- SPARK-37576: Rolling decommissioning
- Run SparkPi with volcano scheduler
- SPARK-38187: Run SparkPi Jobs with minCPU
- SPARK-38187: Run SparkPi Jobs with minMemory
- SPARK-38188: Run SparkPi jobs with 2 queues (only 1 enabled)
- SPARK-38188: Run SparkPi jobs with 2 queues (all enabled)
- SPARK-38423: Run driver job to validate priority order
KubernetesSuite:
- SPARK-42190: Run SparkPi with local[*]
- Run SparkPi with no resources
- SPARK-53944: Run SparkPi without driver service
- Run SparkPi with no resources & statefulset allocation
- Run SparkPi with a very long application name.
- Use SparkLauncher.NO_RESOURCE
- Run SparkPi with a master URL without a scheme.
- Run SparkPi with an argument.
- Run SparkPi with custom labels, annotations, and environment variables.
- All pods have the same service account by default
- Run extraJVMOptions check on driver
- SPARK-42474: Run extraJVMOptions JVM GC option check - G1GC
- SPARK-42474: Run extraJVMOptions JVM GC option check - Other GC
- SPARK-42769: All executor pods have SPARK_DRIVER_POD_IP env variable
- Verify logging configuration is picked from the provided SPARK_CONF_DIR/log4j2.properties
- Run PySpark on simple pi.py example
- Run PySpark to test a pyfiles example
- Run PySpark with memory customization
- Run PySpark with Spark Connect !!! IGNORED !!!
- Run in client mode.
- Start pod creation from template
- SPARK-38398: Schedule pod creation from template
- PVs with local hostpath storage on statefulsets *** FAILED ***
- Test basic decommissioning
- Test basic decommissioning with shuffle cleanup
- Test decommissioning with dynamic allocation & shuffle cleanups
- Test decommissioning timeouts
- SPARK-37576: Rolling decommissioning
YuniKornSuite:
Run completed in 28 minutes, 13 seconds.
Total number of tests run: 59
Suites: completed 4, aborted 0
Tests: succeeded 58, failed 1, canceled 1, ignored 2, pending 0
```

This PR intentionally show the above result including one test case failure which we can simply exclude it by `--exclude-tags pv`. Currently, the above example used `--exclude-tags minikube,r,local,command`. `docker-desktop` and `cloud` backends also have a limited test coverage and needs similar exclusion because some test cases are written for specific backends.

### Was this patch authored or co-authored using generative AI tooling?

No.