### PR TITLE
[SPARK-55201][CORE]: Add disableHttpPort to SSLOptions to prevent Jet…

### DIFF
--- a/core/src/test/scala/org/apache/spark/SSLOptionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SSLOptionsSuite.scala
@@ -58,6 +58,7 @@ class SSLOptionsSuite extends SparkFunSuite {
     conf.set("spark.ssl.openSslEnabled", "false")
     conf.set("spark.ssl.enabledAlgorithms", algorithms.mkString(","))
     conf.set("spark.ssl.protocol", "TLSv1.2")
+    conf.set("spark.ssl.disableHttpPort", "true")
 
     val opts = SSLOptions.parse(conf, hadoopConf, "spark.ssl")
 
@@ -82,6 +83,7 @@ class SSLOptionsSuite extends SparkFunSuite {
     assert(opts.keyPassword === Some("password"))
     assert(opts.protocol === Some("TLSv1.2"))
     assert(opts.enabledAlgorithms === algorithms)
+    assert(opts.disableHttpPort === Some(true))
   }
 
   test("test resolving property with defaults specified ") {
@@ -106,6 +108,7 @@ class SSLOptionsSuite extends SparkFunSuite {
     conf.set("spark.ssl.enabledAlgorithms",
       "TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_256_CBC_SHA")
     conf.set("spark.ssl.protocol", "SSLv3")
+    conf.set("spark.ssl.disableHttpPort", "true")
 
     val defaultOpts = SSLOptions.parse(conf, hadoopConf, "spark.ssl", defaults = None)
     val opts = SSLOptions.parse(conf, hadoopConf, "spark.ssl.ui", defaults = Some(defaultOpts))
@@ -133,6 +136,7 @@ class SSLOptionsSuite extends SparkFunSuite {
     assert(opts.protocol === Some("SSLv3"))
     assert(opts.enabledAlgorithms ===
       Set("TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA"))
+    assert(opts.disableHttpPort === Some(true))
   }
 
   test("test whether defaults can be overridden ") {
@@ -161,6 +165,8 @@ class SSLOptionsSuite extends SparkFunSuite {
       "TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_256_CBC_SHA")
     conf.set("spark.ssl.ui.enabledAlgorithms", "ABC, DEF")
     conf.set("spark.ssl.protocol", "SSLv3")
+    conf.set("spark.ssl.disableHttpPort", "false")
+    conf.set("spark.ssl.ui.disableHttpPort", "true")
 
     val defaultOpts = SSLOptions.parse(conf, hadoopConf, "spark.ssl", defaults = None)
     val opts = SSLOptions.parse(conf, hadoopConf, "spark.ssl.ui", defaults = Some(defaultOpts))
@@ -187,6 +193,7 @@ class SSLOptionsSuite extends SparkFunSuite {
     assert(opts.openSslEnabled === true)
     assert(opts.protocol === Some("SSLv3"))
     assert(opts.enabledAlgorithms === Set("ABC", "DEF"))
+    assert(opts.disableHttpPort === Some(true))
   }
 
   test("ensure RPC settings don't get enabled via inheritance ") {

--- a/docs/security.md
+++ b/docs/security.md
@@ -700,6 +700,12 @@ replaced with one of the above namespaces.
     </td>
     <td>rpc</td>
   </tr>
+  <tr>
+    <td><code>${ns}.disableHttpPort</code></td>
+    <td>false</td>
+    <td>When true, Jetty will not bind to the HTTP port.</td>
+    <td>ui,standalone,historyServer</td>
+  </tr>
 </table>
 
 Spark also supports retrieving `${ns}.keyPassword`, `${ns}.keyStorePassword` and `${ns}.trustStorePassword` from


### PR DESCRIPTION
…ty from binding HTTP port

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR introduces a new configuration to allow Spark to skip binding the HTTP port entirely when HTTPS is active for Spark Web UIs (History Server, Master, Worker).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, when SSL/TLS is enabled for Spark Web UIs (History Server, Master, Worker), Spark still binds to an insecure HTTP port to provide redirection. These open ports are flagged as a vulnerability by security scanners.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Users can now use `spark.ssl.[ns].disableHttpPort` to disable the insecure HTTP port. The default behavior remains unchanged.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
I have added Unit tests to `SSLOptionsSuite`, `UISuite` and `HistoryServerSuite`


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes, assisted by Gemini.