### PR TITLE
[SPARK-55202] Fix UNEXPECTED_USE_OF_PARAMETER_MARKER when using param…

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
@@ -29,6 +29,7 @@ import org.apache.spark.SparkThrowable
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.COMMAND
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.parser.NamedParameterContext
 import org.apache.spark.sql.catalyst.plans.logical.CommandResult
 import org.apache.spark.sql.execution.{QueryExecution, QueryExecutionException, SQLExecution}
 import org.apache.spark.sql.execution.HiveResult.hiveResultString
@@ -67,7 +68,12 @@ private[hive] class SparkSQLDriver(val sparkSession: SparkSession = SparkSQLEnv.
       }
       sparkSession.sparkContext.setJobDescription(substitutorCommand)
 
-      val logicalPlan = sparkSession.sessionState.sqlParser.parsePlan(substitutorCommand)
+      // Parse with an empty parameter context to enable pre-parsing phase that scans for
+      // parameter markers. If any parameter markers (:name or ?) are found in the SQL,
+      // the pre-parser will throw UNBOUND_SQL_PARAMETER with proper position information.
+      val emptyParamContext = NamedParameterContext(Map.empty)
+      val logicalPlan = sparkSession.sessionState.sqlParser.parsePlanWithParameters(
+        substitutorCommand, emptyParamContext)
       val conf = sparkSession.sessionState.conf
 
       val shuffleCleanupMode =

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -877,4 +877,3 @@ class CliSuite extends SparkFunSuite {
     )
   }
 }
-

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -863,4 +863,18 @@ class CliSuite extends SparkFunSuite {
       extraArgs = "--conf" :: s"spark.plugins=${classOf[RedirectConsolePlugin].getName}" :: Nil)(
       "SELECT 1;" -> "1")
   }
+
+  test("unbound parameter markers in CLI are detected and reported") {
+    // Test that parameter markers without parameters are properly detected in spark-sql CLI
+    // and throw UNBOUND_SQL_PARAMETER error instead of internal errors.
+    // This guards against regression where SparkSQLDriver wasn't using pre-parser.
+    runCliWithin(
+      2.minute,
+      errorResponses = Seq("UNBOUND_SQL_PARAMETER"))(
+      "SELECT :param;" -> "param",
+      "SELECT 'hello' :parm;" -> "parm",
+      "SELECT ?;" -> ""
+    )
+  }
 }
+


### PR DESCRIPTION
…eter marke in spark-sql

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Ensure pre-parser for parameter markers is called by spark-sql CLI

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Without invoking the pre-parser, the presence of a parameter marker results in an internal error (UNEXPECTED_USE_OF_PARAMETER_MARKER).
By calling the pre-parser, this case is correctly detected and reported as UNBOUND_PARAMETER_MARKER, which is the expected behavior.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New test added to CLI suite

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Clause Sonnet