### PR TITLE
[WIP][SPARK-55221][PYTHON] Add `to_arrow` transformer and remove `_create_struct_array`

### DIFF
--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -205,9 +205,7 @@ class PandasBatchTransformer:
             # Convert to Arrow array
             try:
                 try:
-                    arr = pa.Array.from_pandas(
-                        series, mask=mask, type=arrow_type, safe=safecheck
-                    )
+                    arr = pa.Array.from_pandas(series, mask=mask, type=arrow_type, safe=safecheck)
                 except pa.lib.ArrowInvalid:
                     if arrow_cast:
                         arr = pa.Array.from_pandas(series, mask=mask).cast(

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -123,9 +123,7 @@ class PandasBatchTransformer:
         return pd.concat(series_list, axis=1)
 
     @staticmethod
-    def reorder_columns(
-        df: "pd.DataFrame", schema: "pa.StructType"
-    ) -> "pd.DataFrame":
+    def reorder_columns(df: "pd.DataFrame", schema: "pa.StructType") -> "pd.DataFrame":
         """
         Reorder a DataFrame's columns to match the schema field order by name.
 

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -140,6 +140,7 @@ class PandasBatchTransformer:
         safecheck: bool = True,
         arrow_cast: bool = False,
         assign_cols_by_name: bool = False,
+        int_to_decimal_coercion_enabled: bool = False,
     ) -> "pa.RecordBatch":
         """
         Convert a pandas DataFrame to an Arrow RecordBatch.
@@ -158,6 +159,8 @@ class PandasBatchTransformer:
             Whether to allow Arrow casting on type mismatch (default False)
         assign_cols_by_name : bool
             Whether to reorder columns by name to match schema (default False)
+        int_to_decimal_coercion_enabled : bool
+            Whether to enable int to decimal coercion (default False)
 
         Returns
         -------
@@ -189,6 +192,7 @@ class PandasBatchTransformer:
                     spark_type,
                     timezone=timezone,
                     error_on_duplicated_field_names=False,
+                    int_to_decimal_coercion_enabled=int_to_decimal_coercion_enabled,
                 )
                 series = conv(series)
 

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -1831,27 +1831,27 @@ class TransformWithStateInPandasInitStateSerializer(TransformWithStateInPandasSe
                     self._update_batch_size_stats(batch)
 
                     flatten_state_table = flatten_columns(batch, "inputData")
-                    data_pandas = [
+                    input_data_series = [
                         self.arrow_to_pandas(c, i)
                         for i, c in enumerate(flatten_state_table.itercolumns())
                     ]
 
                     flatten_init_table = flatten_columns(batch, "initState")
-                    init_data_pandas = [
+                    init_state_series = [
                         self.arrow_to_pandas(c, i)
                         for i, c in enumerate(flatten_init_table.itercolumns())
                     ]
 
-                    assert not (bool(init_data_pandas) and bool(data_pandas))
+                    assert not (bool(init_state_series) and bool(input_data_series))
 
-                    if bool(data_pandas):
-                        for row in PandasBatchTransformer.wrap_series(data_pandas).itertuples(
+                    if bool(input_data_series):
+                        for row in PandasBatchTransformer.wrap_series(input_data_series).itertuples(
                             index=False
                         ):
                             batch_key = tuple(row[s] for s in self.key_offsets)
                             yield (batch_key, row, None)
-                    elif bool(init_data_pandas):
-                        for row in PandasBatchTransformer.wrap_series(init_data_pandas).itertuples(
+                    elif bool(init_state_series):
+                        for row in PandasBatchTransformer.wrap_series(init_state_series).itertuples(
                             index=False
                         ):
                             batch_key = tuple(row[s] for s in self.init_key_offsets)

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -662,6 +662,7 @@ class ArrowStreamPandasUDFSerializer(ArrowStreamPandasSerializer):
                                 safecheck=self._safecheck,
                                 arrow_cast=self._arrow_cast,
                                 assign_cols_by_name=self._assign_cols_by_name,
+                                int_to_decimal_coercion_enabled=self._int_to_decimal_coercion_enabled,
                             )
                         ).column(0)
                     )
@@ -951,6 +952,7 @@ class ArrowStreamPandasUDTFSerializer(ArrowStreamPandasUDFSerializer):
                             safecheck=self._safecheck,
                             arrow_cast=self._arrow_cast,
                             assign_cols_by_name=self._assign_cols_by_name,
+                            int_to_decimal_coercion_enabled=self._int_to_decimal_coercion_enabled,
                         )
                     ).column(0)
                 )

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -1845,11 +1845,15 @@ class TransformWithStateInPandasInitStateSerializer(TransformWithStateInPandasSe
                     assert not (bool(init_data_pandas) and bool(data_pandas))
 
                     if bool(data_pandas):
-                        for row in PandasBatchTransformer.wrap_series(data_pandas).itertuples(index=False):
+                        for row in PandasBatchTransformer.wrap_series(data_pandas).itertuples(
+                            index=False
+                        ):
                             batch_key = tuple(row[s] for s in self.key_offsets)
                             yield (batch_key, row, None)
                     elif bool(init_data_pandas):
-                        for row in PandasBatchTransformer.wrap_series(init_data_pandas).itertuples(index=False):
+                        for row in PandasBatchTransformer.wrap_series(init_data_pandas).itertuples(
+                            index=False
+                        ):
                             batch_key = tuple(row[s] for s in self.init_key_offsets)
                             yield (batch_key, None, row)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `PandasBatchTransformer.to_arrow` transformer method that converts a pandas DataFrame to an Arrow RecordBatch.

Replace `_create_struct_array` with transformer composition:
```python
ArrowBatchTransformer.wrap_struct(
    PandasBatchTransformer.to_arrow(df, schema, ...)
).column(0)
```

### Why are the changes needed?

Part of [SPARK-55159](https://issues.apache.org/jira/browse/SPARK-55159).

`_create_struct_array` mixed two transformations: pandas→arrow conversion and wrapping into struct. By extracting `to_arrow` as a standalone transformer, we can compose it with existing `ArrowBatchTransformer.wrap_struct`, following the single-responsibility principle.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Unit tests for `to_arrow` transformer
- Existing pandas UDF tests

### Was this patch authored or co-authored using generative AI tooling?

No.
