### PR TITLE
[SPARK-55233][BUILD] Upgrade ASM to 9.9.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -288,7 +288,7 @@ vertx-web-common/4.5.24//vertx-web-common-4.5.24.jar
 volcano-client/7.5.2//volcano-client-7.5.2.jar
 volcano-model/7.5.2//volcano-model-7.5.2.jar
 wildfly-openssl/2.2.5.Final//wildfly-openssl-2.2.5.Final.jar
-xbean-asm9-shaded/4.28//xbean-asm9-shaded-4.28.jar
+xbean-asm9-shaded/4.30//xbean-asm9-shaded-4.30.jar
 xmlschema-core/2.3.1//xmlschema-core-2.3.1.jar
 xz/1.10//xz-1.10.jar
 zjsonpatch/7.5.2//zjsonpatch-7.5.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <maven.version>3.9.12</maven.version>
     <exec-maven-plugin.version>3.6.1</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
-    <asm.version>9.9</asm.version>
+    <asm.version>9.9.1</asm.version>
     <slf4j.version>2.0.17</slf4j.version>
     <log4j.version>2.25.3</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
@@ -547,7 +547,7 @@
       <dependency>
         <groupId>org.apache.xbean</groupId>
         <artifactId>xbean-asm9-shaded</artifactId>
-        <version>4.28</version>
+        <version>4.30</version>
       </dependency>
 
       <!-- Shaded deps marked as provided. These are promoted to compile scope

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -33,9 +33,9 @@ addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")
 
-libraryDependencies += "org.ow2.asm"  % "asm" % "9.9"
+libraryDependencies += "org.ow2.asm"  % "asm" % "9.9.1"
 
-libraryDependencies += "org.ow2.asm"  % "asm-commons" % "9.9"
+libraryDependencies += "org.ow2.asm"  % "asm-commons" % "9.9.1"
 
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.3")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `ASM` to 9.9.1 for Apache Spark 4.2.0.

### Why are the changes needed?

Release Note: [2025-12-06: ASM 9.9.1 (tag ASM_9_9)](https://asm.ow2.io/versions.html)
- 318036: OutOfMemoryError when reading invalid class
- 318037: Version ranges too wide on Import-Package

XBean 4.30 is announced Today.
- [[ANNOUNCE] Apache Geronimo XBean 4.30 released](https://lists.apache.org/thread/w6clm5s9tx2lwq418zrjlbfzdl1755ch)
- https://github.com/apache/geronimo-xbean/releases/tag/xbean-4.30
- https://repo1.maven.org/maven2/org/apache/xbean/xbean-asm9-shaded/4.30/

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No