### PR TITLE
[SPARK-55237][SQL] Suppress annoying messages when looking up nonexistent DBs

### DIFF
--- a/common/utils-java/src/main/resources/org/apache/spark/log4j2-defaults.properties
+++ b/common/utils-java/src/main/resources/org/apache/spark/log4j2-defaults.properties
@@ -41,12 +41,12 @@ logger.repl2.level = info
 logger.repl.name = org.apache.spark.repl.Main
 logger.repl.level = warn
 
-# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs
-# in SparkSQL with Hive support
+# SPARK-9183, SPARK-55237: Settings to avoid annoying messages when looking up
+# nonexistent DBs/UDFs in spark-sql with Hive support
 logger.metastore.name = org.apache.hadoop.hive.metastore.RetryingHMSHandler
 logger.metastore.level = fatal
-logger.hive_functionregistry.name = org.apache.hadoop.hive.ql.exec.FunctionRegistry
-logger.hive_functionregistry.level = error
+logger.metastore2.name = org.apache.hadoop.hive.metastore.ObjectStore
+logger.metastore2.level = error
 
 # Parquet related logging
 logger.parquet.name = org.apache.parquet.CorruptStatistics

--- a/common/utils-java/src/main/resources/org/apache/spark/log4j2-json-layout.properties
+++ b/common/utils-java/src/main/resources/org/apache/spark/log4j2-json-layout.properties
@@ -41,12 +41,12 @@ logger.repl2.level = info
 logger.repl.name = org.apache.spark.repl.Main
 logger.repl.level = warn
 
-# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs
-# in SparkSQL with Hive support
+# SPARK-9183, SPARK-55237: Settings to avoid annoying messages when looking up
+# nonexistent DBs/UDFs in spark-sql with Hive support
 logger.metastore.name = org.apache.hadoop.hive.metastore.RetryingHMSHandler
 logger.metastore.level = fatal
-logger.hive_functionregistry.name = org.apache.hadoop.hive.ql.exec.FunctionRegistry
-logger.hive_functionregistry.level = error
+logger.metastore2.name = org.apache.hadoop.hive.metastore.ObjectStore
+logger.metastore2.level = error
 
 # Parquet related logging
 logger.parquet.name = org.apache.parquet.CorruptStatistics

--- a/conf/log4j2-json-layout.properties.template
+++ b/conf/log4j2-json-layout.properties.template
@@ -49,8 +49,8 @@ logger.parquet1.level = error
 logger.parquet2.name = parquet
 logger.parquet2.level = error
 
-# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
-logger.RetryingHMSHandler.name = org.apache.hadoop.hive.metastore.RetryingHMSHandler
-logger.RetryingHMSHandler.level = fatal
-logger.FunctionRegistry.name = org.apache.hadoop.hive.ql.exec.FunctionRegistry
-logger.FunctionRegistry.level = error
+# SPARK-9183, SPARK-55237: Settings to avoid annoying messages when looking up nonexistent DBs/UDFs in spark-sql with Hive support
+logger.metastore.name = org.apache.hadoop.hive.metastore.RetryingHMSHandler
+logger.metastore.level = fatal
+logger.metastore2.name = org.apache.hadoop.hive.metastore.ObjectStore
+logger.metastore2.level = error

--- a/conf/log4j2.properties.template
+++ b/conf/log4j2.properties.template
@@ -55,8 +55,8 @@ logger.parquet1.level = error
 logger.parquet2.name = parquet
 logger.parquet2.level = error
 
-# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
-logger.RetryingHMSHandler.name = org.apache.hadoop.hive.metastore.RetryingHMSHandler
-logger.RetryingHMSHandler.level = fatal
-logger.FunctionRegistry.name = org.apache.hadoop.hive.ql.exec.FunctionRegistry
-logger.FunctionRegistry.level = error
+# SPARK-9183, SPARK-55237: Settings to avoid annoying messages when looking up nonexistent DBs/UDFs in spark-sql with Hive support
+logger.metastore.name = org.apache.hadoop.hive.metastore.RetryingHMSHandler
+logger.metastore.level = fatal
+logger.metastore2.name = org.apache.hadoop.hive.metastore.ObjectStore
+logger.metastore2.level = error


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When running `spark-sql` with embedded HMS and default log4j config, I see a lot of noisy logs.
```
spark-sql (default)> create database test_db;
26/01/27 15:56:33 WARN ObjectStore: Failed to get database test_db, returning NoSuchObjectException
26/01/27 15:56:33 WARN ObjectStore: Failed to get database test_db, returning NoSuchObjectException
26/01/27 15:56:33 WARN ObjectStore: Failed to get database test_db, returning NoSuchObjectException
Time taken: 0.87 seconds
spark-sql (default)>
```

This PR modifies the default log4j config files to suppress those logs.

Note, `ObjectStore` will not be called by the Spark driver when using remote HMS (typical deployment of production cases)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Improve UX on `spark-sql` with embedded HMS and default log4j config.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Only affect logs. User would see less noise when running `spark-sql` with embedded HMS and default log4j config.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
before (see above section) vs after
```
spark-sql (default)> create database test_db2;
Time taken: 0.686 seconds
```
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.