### PR TITLE
[SPARK-55239][CONNECT][YARN] Allow to launch SparkConnectServer in YARN cluster mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -310,6 +310,9 @@ private[spark] class SparkSubmit extends Logging {
         error("Cluster deploy mode is not applicable to Spark SQL shell.")
       case (_, CLUSTER) if isThriftServer(args.mainClass) =>
         error("Cluster deploy mode is not applicable to Spark Thrift server.")
+      case (YARN, CLUSTER) if isConnectServer(args.mainClass) =>
+        logInfo("SparkConnectServer is starting in cluster deploy mode." +
+          "Use `yarn application -kill` command or YARN client API to stop the server.")
       case (_, CLUSTER) if isConnectServer(args.mainClass) =>
         error("Cluster deploy mode is not applicable to Spark Connect server.")
       case _ =>

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -311,10 +311,10 @@ private[spark] class SparkSubmit extends Logging {
       case (_, CLUSTER) if isThriftServer(args.mainClass) =>
         error("Cluster deploy mode is not applicable to Spark Thrift server.")
       case (YARN, CLUSTER) if isConnectServer(args.mainClass) =>
-        logInfo("SparkConnectServer is starting in cluster deploy mode." +
+        logInfo("SparkConnectServer is starting in cluster deploy mode. " +
           "Use `yarn application -kill` command or YARN client API to stop the server.")
       case (_, CLUSTER) if isConnectServer(args.mainClass) =>
-        error("Cluster deploy mode is not applicable to Spark Connect server.")
+        error("Launching Spark Connect server in cluster deploy mode is supported only for YARN")
       case _ =>
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to allow to launch SparkConnectServer in YARN cluster mode.
Thanks to #46182, now we can know the location of SparkConnectServer on a cluster easily.

### Why are the changes needed?
Service providers can utilize their Hadoop cluster for running SparkConnectServer for better resource utilization and high availability.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
I confirmed that SparkConnectServer launched on my Hadoop cluster with `sbin/start-connect-server.sh --master yarn --deploy-mode cluster` and stopped with `yarn application -kill <application id>`.

### Was this patch authored or co-authored using generative AI tooling?
No.
