### PR TITLE
[SPARK-55245][PYTHON][PS][TESTS] Fix all timestamp freq usage from M to ME

### DIFF
--- a/python/pyspark/pandas/tests/data_type_ops/test_datetime_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_datetime_ops.py
@@ -178,7 +178,7 @@ class DatetimeOpsTestsMixin:
         self.assertRaises(TypeError, lambda: False | self.psser)
 
     def test_from_to_pandas(self):
-        data = pd.date_range("1994-1-31 10:30:15", periods=3, freq="M")
+        data = pd.date_range("1994-1-31 10:30:15", periods=3, freq="ME")
         pser = pd.Series(data)
         psser = ps.Series(data)
         self.assert_eq(pser, psser._to_pandas())

--- a/python/pyspark/pandas/tests/indexes/test_indexing_adv.py
+++ b/python/pyspark/pandas/tests/indexes/test_indexing_adv.py
@@ -272,7 +272,7 @@ class IndexingAdvMixin:
 
         pdf = pd.DataFrame(
             {"A": np.random.randn(100), "B": np.random.randn(100)},
-            index=pd.date_range("2011-01-01", freq="M", periods=100),
+            index=pd.date_range("2011-01-01", freq="ME", periods=100),
         )
         psdf = ps.from_pandas(pdf)
 

--- a/python/pyspark/pandas/tests/indexes/test_indexing_loc.py
+++ b/python/pyspark/pandas/tests/indexes/test_indexing_loc.py
@@ -223,7 +223,7 @@ class IndexingLocMixin:
 
         pdf = pd.DataFrame(
             {"A": np.random.randn(100), "B": np.random.randn(100)},
-            index=pd.date_range("2011-01-01", freq="M", periods=100),
+            index=pd.date_range("2011-01-01", freq="ME", periods=100),
         )
         psdf = ps.from_pandas(pdf)
         # TODO?: self.assert_eq(pdf.loc['2011-01'], psdf.loc['2011-01'])

--- a/python/pyspark/pandas/tests/plot/test_frame_plot_matplotlib.py
+++ b/python/pyspark/pandas/tests/plot/test_frame_plot_matplotlib.py
@@ -138,7 +138,7 @@ class DataFramePlotMatplotlibTestsMixin:
                 "signups": [5, 5, 6, 12, 14, 13],
                 "visits": [20, 42, 28, 62, 81, 50],
             },
-            index=pd.date_range(start="2018/01/01", end="2018/07/01", freq="M"),
+            index=pd.date_range(start="2018/01/01", end="2018/07/01", freq="ME"),
         )
         psdf = ps.from_pandas(pdf)
         check_area_plot_stacked_false(pdf, psdf)
@@ -164,7 +164,7 @@ class DataFramePlotMatplotlibTestsMixin:
                 "signups": [5, 5, 6, 12, 14, 13],
                 "visits": [20, 42, 28, 62, 81, 50],
             },
-            index=pd.date_range(start="2018/01/01", end="2018/07/01", freq="M"),
+            index=pd.date_range(start="2018/01/01", end="2018/07/01", freq="ME"),
         )
         psdf = ps.from_pandas(pdf)
         check_area_plot_y(pdf, psdf, y="sales")

--- a/python/pyspark/pandas/tests/plot/test_frame_plot_plotly.py
+++ b/python/pyspark/pandas/tests/plot/test_frame_plot_plotly.py
@@ -90,7 +90,7 @@ class DataFramePlotPlotlyTestsMixin:
                 "signups": [5, 5, 6, 12, 14, 13],
                 "visits": [20, 42, 28, 62, 81, 50],
             },
-            index=pd.date_range(start="2018/01/01", end="2018/07/01", freq="M"),
+            index=pd.date_range(start="2018/01/01", end="2018/07/01", freq="ME"),
         )
         psdf = ps.from_pandas(pdf)
         check_area_plot_y(pdf, psdf, y="sales")

--- a/python/pyspark/pandas/tests/plot/test_series_plot_matplotlib.py
+++ b/python/pyspark/pandas/tests/plot/test_series_plot_matplotlib.py
@@ -263,7 +263,7 @@ class SeriesPlotMatplotlibTestsMixin:
                 "signups": [5, 5, 6, 12, 14, 13],
                 "visits": [20, 42, 28, 62, 81, 50],
             },
-            index=pd.date_range(start="2018/01/01", end="2018/07/01", freq="M"),
+            index=pd.date_range(start="2018/01/01", end="2018/07/01", freq="ME"),
         )
         psdf = ps.from_pandas(pdf)
 

--- a/python/pyspark/pandas/tests/plot/test_series_plot_plotly.py
+++ b/python/pyspark/pandas/tests/plot/test_series_plot_plotly.py
@@ -95,7 +95,7 @@ class SeriesPlotPlotlyTestsMixin:
                 "signups": [5, 5, 6, 12, 14, 13],
                 "visits": [20, 42, 28, 62, 81, 50],
             },
-            index=pd.date_range(start="2018/01/01", end="2018/07/01", freq="M"),
+            index=pd.date_range(start="2018/01/01", end="2018/07/01", freq="ME"),
         )
         psdf = ps.from_pandas(pdf)
 

--- a/python/pyspark/pandas/tests/series/test_datetime.py
+++ b/python/pyspark/pandas/tests/series/test_datetime.py
@@ -29,7 +29,7 @@ from pyspark.testing.sqlutils import SQLTestUtils
 class SeriesDateTimeTestsMixin:
     @property
     def pdf1(self):
-        date1 = pd.Series(pd.date_range("2012-1-1 12:45:31", periods=3, freq="M"))
+        date1 = pd.Series(pd.date_range("2012-1-1 12:45:31", periods=3, freq="ME"))
         date2 = pd.Series(pd.date_range("2013-3-11 21:45:00", periods=3, freq="W"))
         return pd.DataFrame(dict(start_date=date1, end_date=date2))
 

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -206,8 +206,8 @@ class NamespaceTestsMixin:
         )
 
         self.assert_eq(
-            ps.date_range(start="1/1/2018", periods=5, freq="M"),
-            pd.date_range(start="1/1/2018", periods=5, freq="M"),
+            ps.date_range(start="1/1/2018", periods=5, freq="ME"),
+            pd.date_range(start="1/1/2018", periods=5, freq="ME"),
         )
 
         self.assert_eq(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Use `ME` instead of `M` for `freq` of `date_range()`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`M` is the wrong usage, it should only be used for periodic timespans. It's not listed as a valid option for `date_range()` anymore - https://pandas.pydata.org/docs/user_guide/timeseries.html#offset-aliases also the code will just report an error.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No, this is a test only change.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Local test did not report an error anymore.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.