### PR TITLE
[SPARK-54906][PYTHON][TESTS][FOLLOWUP] Try to use a real module name instead of `__main__`

### DIFF
--- a/python/pyspark/testing/unittestutils.py
+++ b/python/pyspark/testing/unittestutils.py
@@ -19,7 +19,10 @@ import sys
 import unittest
 
 
-def main(module="__main__", output="target/test-reports"):
+def main(module=None, output="target/test-reports"):
+    if module is None:
+        module = _real_module_name()
+
     try:
         import xmlrunner
 
@@ -41,3 +44,12 @@ def main(module="__main__", output="target/test-reports"):
             sys.exit(0)
     else:
         unittest.main(module=module, testRunner=testRunner, verbosity=2)
+
+
+def _real_module_name():
+    mod = sys.modules["__main__"]
+    # When invoked with `-m`, __spec__.name has the real module name.
+    spec = getattr(mod, "__spec__", None)
+    if spec and spec.name:
+        return spec.name
+    return "__main__"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Tries to use a real module name in the test failure report instead of `__main__`.

### Why are the changes needed?

In the test failure report, it uses `__main__` as a module name after apache/spark#53683.

```
======================================================================
FAIL [0.309s]: test_apply_batch_with_type (__main__.FrameApplyFunctionTests.test_apply_batch_with_type)
----------------------------------------------------------------------
```

It should be a real module name as before.

```
======================================================================
FAIL [0.322s]: test_apply_batch_with_type (pyspark.pandas.tests.computation.test_apply_func.FrameApplyFunctionTests.test_apply_batch_with_type)
----------------------------------------------------------------------
```

### Does this PR introduce _any_ user-facing change?

Yes, the test failure report will show a real module name.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

Cursor (gpt-5.2-codex)