### PR TITLE
[SPARK-55248][SS] Clean up Jackson deprecated API usage in `streaming.checkpointing.Checksum`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/ChecksumCheckpointFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/ChecksumCheckpointFileManager.scala
@@ -79,7 +79,7 @@ object Checksum {
   /** Used to convert between class and JSON. */
   lazy val mapper = {
     val _mapper = new ObjectMapper with ClassTagExtensions
-    _mapper.setSerializationInclusion(Include.NON_ABSENT)
+    _mapper.setDefaultPropertyInclusion(Include.NON_ABSENT)
     _mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     _mapper.registerModule(DefaultScalaModule)
     _mapper


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to clean up Jackson deprecated API usage in `streaming.checkpointing.Checksum`

### Why are the changes needed?
clean up deprecated API usage


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions


### Was this patch authored or co-authored using generative AI tooling?
No
