### PR TITLE
[SPARK-55251][INFRA] Make `Python Coverage` test with Python 3.12

### DIFF
--- a/.github/workflows/build_coverage.yml
+++ b/.github/workflows/build_coverage.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Python Coverage (master, Python 3.11)"
+name: "Build / Python Coverage (master, Python 3.12)"
 
 on:
   schedule:
@@ -37,8 +37,8 @@ jobs:
       hadoop: hadoop3
       envs: >-
         {
-          "PYSPARK_IMAGE_TO_TEST": "python-311",
-          "PYTHON_TO_TEST": "python3.11",
+          "PYSPARK_IMAGE_TO_TEST": "python-312",
+          "PYTHON_TO_TEST": "python3.12",
           "PYSPARK_CODECOV": "true"
         }
       jobs: >-


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to  make the daily test of `Python Coverage` to be conducted using Python 3.12.

### Why are the changes needed?
`Python Coverage`  should test with Python 3.12


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Monitor after this pr merged.


### Was this patch authored or co-authored using generative AI tooling?
No
