### PR TITLE
[SPARK-55252][CORE] Improve `HttpSecurityFilter` to add `Content-Security-Policy` header

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/HttpSecurityFilter.scala
+++ b/core/src/main/scala/org/apache/spark/ui/HttpSecurityFilter.scala
@@ -48,6 +48,7 @@ private class HttpSecurityFilter(
     val hreq = req.asInstanceOf[HttpServletRequest]
     val hres = res.asInstanceOf[HttpServletResponse]
     hres.setHeader("Cache-Control", "no-cache, no-store, must-revalidate")
+    hres.setHeader("Content-Security-Policy", "default-src 'self'")
 
     val requestUser = hreq.getRemoteUser()
 

--- a/core/src/test/scala/org/apache/spark/ui/HttpSecurityFilterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/HttpSecurityFilterSuite.scala
@@ -130,6 +130,7 @@ class HttpSecurityFilterSuite extends SparkFunSuite {
     filter.doFilter(req, res, chain)
 
     Map(
+      "Content-Security-Policy" -> "default-src 'self'",
       "X-Frame-Options" -> "ALLOW-FROM example.com",
       "X-XSS-Protection" -> "xssProtection",
       "X-Content-Type-Options" -> "nosniff",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `HttpSecurityFilter` to add `Content-Security-Policy` header.

### Why are the changes needed?

To improve Apache Spark's security by setting `Content-Security-Policy: default-src 'self'` acting as a safety net by restricting all content sources to the current domain by default. It prevents the loading of malicious scripts from untrusted external sites.
- [Content Security Policy Level 3: `default-src`](https://www.w3.org/TR/CSP3/#directive-default-src)

### Does this PR introduce _any_ user-facing change?

No because Apache Spark binary distribution provides all required resources as built-in.

### How was this patch tested?

Pass the CIs with the revised test case.

### Was this patch authored or co-authored using generative AI tooling?

No.