### PR TITLE
[SPARK-55254][BUILD] Upgrade `analyticsaccelerator-s3` to 1.3.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -8,7 +8,7 @@ aliyun-java-sdk-core/4.5.10//aliyun-java-sdk-core-4.5.10.jar
 aliyun-java-sdk-kms/2.11.0//aliyun-java-sdk-kms-2.11.0.jar
 aliyun-java-sdk-ram/3.1.0//aliyun-java-sdk-ram-3.1.0.jar
 aliyun-sdk-oss/3.13.2//aliyun-sdk-oss-3.13.2.jar
-analyticsaccelerator-s3/1.3.0//analyticsaccelerator-s3-1.3.0.jar
+analyticsaccelerator-s3/1.3.1//analyticsaccelerator-s3-1.3.1.jar
 antlr-runtime/3.5.2//antlr-runtime-3.5.2.jar
 antlr4-runtime/4.13.1//antlr4-runtime-4.13.1.jar
 aopalliance-repackaged/3.0.6//aopalliance-repackaged-3.0.6.jar

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
     <aws.kinesis.producer.version>1.0.6</aws.kinesis.producer.version>
     <!-- Do not use 3.0.0: https://github.com/GoogleCloudDataproc/hadoop-connectors/issues/1114 -->
     <gcs-connector.version>hadoop3-2.2.31</gcs-connector.version>
-    <analyticsaccelerator-s3.version>1.3.0</analyticsaccelerator-s3.version>
+    <analyticsaccelerator-s3.version>1.3.1</analyticsaccelerator-s3.version>
     <!--  org.apache.httpcomponents/httpclient-->
     <commons.httpclient.version>4.5.14</commons.httpclient.version>
     <commons.httpcore.version>4.4.16</commons.httpcore.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `analyticsaccelerator-s3` to 1.3.1 for Apache Spark 4.2.0 in line with Apache Hadoop 3.4.3 (HADOOP-19742).
- https://github.com/apache/hadoop/pull/8093

### Why are the changes needed?

To bring the latest fixes.
- https://github.com/awslabs/analytics-accelerator-s3/releases/tag/v1.3.1
  - https://github.com/awslabs/analytics-accelerator-s3/pull/360
  - https://github.com/awslabs/analytics-accelerator-s3/pull/361
  - https://github.com/awslabs/analytics-accelerator-s3/pull/363
  - https://github.com/awslabs/analytics-accelerator-s3/pull/356
  - https://github.com/awslabs/analytics-accelerator-s3/pull/358

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.