### PR TITLE
[SPARK-55255][BUILD] Upgrade `objenesis` to 3.5

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -235,7 +235,7 @@ netty-transport-native-kqueue/4.2.9.Final/osx-aarch_64/netty-transport-native-kq
 netty-transport-native-kqueue/4.2.9.Final/osx-x86_64/netty-transport-native-kqueue-4.2.9.Final-osx-x86_64.jar
 netty-transport-native-unix-common/4.2.9.Final//netty-transport-native-unix-common-4.2.9.Final.jar
 netty-transport/4.2.9.Final//netty-transport-4.2.9.Final.jar
-objenesis/3.4//objenesis-3.4.jar
+objenesis/3.5//objenesis-3.5.jar
 okhttp/3.12.12//okhttp-3.12.12.jar
 okio/1.17.6//okio-1.17.6.jar
 opencsv/2.3//opencsv-2.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -528,12 +528,12 @@
       </dependency>
       <!--
         SPARK-51806: Kryo 4.0.x depends on objenesis 2.5.1, while Spark currently
-        depends on objenesis 3.4. Here, it is uniformly defined as version 3.4.
+        depends on objenesis 3.5. Here, it is uniformly defined as version 3.5.
         -->
       <dependency>
         <groupId>org.objenesis</groupId>
         <artifactId>objenesis</artifactId>
-        <version>3.4</version>
+        <version>3.5</version>
       </dependency>
       <dependency>
         <groupId>com.github.jnr</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `objenesis` to 3.5.

### Why are the changes needed?

This is the first version which is tested with `Java 25`.

- https://github.com/easymock/objenesis/commit/215ad4bfc2688a472a915bda4b904c711d15c9ad

Here is the full release note.
- https://github.com/easymock/objenesis/releases/tag/3.5

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.