### PR TITLE
[MINOR] Raise exception if no active Spark context

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -39,7 +39,7 @@ from typing import (
     ValuesView,
 )
 
-from pyspark.errors import PySparkTypeError, PySparkValueError
+from pyspark.errors import PySparkException, PySparkTypeError, PySparkValueError
 from pyspark.errors.utils import _with_origin
 from pyspark.sql.column import Column
 from pyspark.sql.types import (
@@ -107,7 +107,8 @@ def _invoke_function(name: str, *args: Any) -> Column:
     """
     from pyspark import SparkContext
 
-    assert SparkContext._active_spark_context is not None
+    if SparkContext._active_spark_context is None:
+        raise PySparkException("No active Spark context.")
     jf = _get_jvm_function(name, SparkContext._active_spark_context)
     return Column(jf(*args))
 


### PR DESCRIPTION
Replace generic `AssertionError` with pyspark-specific `PySparkException` for missing Spark context.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Raise a pyspark-specific error when trying to use a `pyspark` function without an active Spark context.

### Why are the changes needed?

The current error message is a generic Python `AssertionError`.

### Does this PR introduce _any_ user-facing change?

A better pyspark-specific error when trying to use a `pyspark` function without an active Spark context.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?

No.
