### PR TITLE
[SPARK-55265][INFRA] Increase timeout to 150 mins in GitHub Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -235,7 +235,7 @@ jobs:
     needs: precondition
     if: fromJson(needs.precondition.outputs.required).build == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 150
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Increases timeout to 150 mins in GitHub Actions.

### Why are the changes needed?

Some jobs started to fail 
https://github.com/apache/spark/actions/runs/21453237849/job/61787264414. It seems legitimate. We should probably think about splitting more but should probably increase to unblock other PRs for now.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Not tested.

### Was this patch authored or co-authored using generative AI tooling?

No.