### PR TITLE
[SPARK-54943][PYTHON][TESTS] Add test coverage for pa.Array.cast with safe=False

### DIFF
--- a/python/pyspark/tests/upstream/pyarrow/test_pyarrow_array_cast.py
+++ b/python/pyspark/tests/upstream/pyarrow/test_pyarrow_array_cast.py
@@ -330,7 +330,10 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 case_id = f"{source_type_name}->{tgt_type_name}[{i}]"
 
                 # Test both safe=True and safe=False
-                for safe_mode, expected in [(True, expected_safe_true), (False, expected_safe_false)]:
+                for safe_mode, expected in [
+                    (True, expected_safe_true),
+                    (False, expected_safe_false),
+                ]:
                     mode_str = "safe=True" if safe_mode else "safe=False"
                     case_id_with_mode = f"{case_id} ({mode_str})"
 
@@ -432,14 +435,30 @@ class PyArrowNumericalCastTests(unittest.TestCase):
             "uint32": [
                 (pa.array([0, 1, 127, None], pa.int8()), pa.array([0, 1, 127, None], pa.uint32())),
                 # Negative values overflow: safe=True raises, safe=False wraps
-                (pa.array([-1], pa.int8()), pa.lib.ArrowInvalid, pa.array([4294967295], pa.uint32())),
-                (pa.array([-128], pa.int8()), pa.lib.ArrowInvalid, pa.array([4294967168], pa.uint32())),
+                (
+                    pa.array([-1], pa.int8()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([4294967295], pa.uint32()),
+                ),
+                (
+                    pa.array([-128], pa.int8()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([4294967168], pa.uint32()),
+                ),
             ],
             "uint64": [
                 (pa.array([0, 1, 127, None], pa.int8()), pa.array([0, 1, 127, None], pa.uint64())),
                 # Negative values overflow: safe=True raises, safe=False wraps
-                (pa.array([-1], pa.int8()), pa.lib.ArrowInvalid, pa.array([18446744073709551615], pa.uint64())),
-                (pa.array([-128], pa.int8()), pa.lib.ArrowInvalid, pa.array([18446744073709551488], pa.uint64())),
+                (
+                    pa.array([-1], pa.int8()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([18446744073709551615], pa.uint64()),
+                ),
+                (
+                    pa.array([-128], pa.int8()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([18446744073709551488], pa.uint64()),
+                ),
             ],
             # int8 -> floats
             "float16": [
@@ -599,7 +618,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 ),
                 # Negative overflow: safe=True raises, safe=False wraps
                 (pa.array([-1], pa.int16()), pa.lib.ArrowInvalid, pa.array([65535], pa.uint16())),
-                (pa.array([-32768], pa.int16()), pa.lib.ArrowInvalid, pa.array([32768], pa.uint16())),
+                (
+                    pa.array([-32768], pa.int16()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([32768], pa.uint16()),
+                ),
             ],
             "uint32": [
                 (
@@ -607,8 +630,16 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, 32767, None], pa.uint32()),
                 ),
                 # Negative overflow: safe=True raises, safe=False wraps
-                (pa.array([-1], pa.int16()), pa.lib.ArrowInvalid, pa.array([4294967295], pa.uint32())),
-                (pa.array([-32768], pa.int16()), pa.lib.ArrowInvalid, pa.array([4294934528], pa.uint32())),
+                (
+                    pa.array([-1], pa.int16()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([4294967295], pa.uint32()),
+                ),
+                (
+                    pa.array([-32768], pa.int16()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([4294934528], pa.uint32()),
+                ),
             ],
             "uint64": [
                 (
@@ -616,8 +647,16 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, 32767, None], pa.uint64()),
                 ),
                 # Negative overflow: safe=True raises, safe=False wraps
-                (pa.array([-1], pa.int16()), pa.lib.ArrowInvalid, pa.array([18446744073709551615], pa.uint64())),
-                (pa.array([-32768], pa.int16()), pa.lib.ArrowInvalid, pa.array([18446744073709518848], pa.uint64())),
+                (
+                    pa.array([-1], pa.int16()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([18446744073709551615], pa.uint64()),
+                ),
+                (
+                    pa.array([-32768], pa.int16()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([18446744073709518848], pa.uint64()),
+                ),
             ],
             # int16 -> floats
             "float16": [
@@ -752,7 +791,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 ),
                 # Overflow: safe=True raises, safe=False wraps
                 (pa.array([128], pa.int32()), pa.lib.ArrowInvalid, pa.array([-128], pa.int8())),
-                (pa.array([2147483647], pa.int32()), pa.lib.ArrowInvalid, pa.array([-1], pa.int8())),
+                (
+                    pa.array([2147483647], pa.int32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-1], pa.int8()),
+                ),
             ],
             "int16": [
                 (
@@ -760,8 +803,16 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, -1, 32767, -32768, None], pa.int16()),
                 ),
                 # Overflow: safe=True raises, safe=False wraps
-                (pa.array([32768], pa.int32()), pa.lib.ArrowInvalid, pa.array([-32768], pa.int16())),
-                (pa.array([-32769], pa.int32()), pa.lib.ArrowInvalid, pa.array([32767], pa.int16())),
+                (
+                    pa.array([32768], pa.int32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-32768], pa.int16()),
+                ),
+                (
+                    pa.array([-32769], pa.int32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([32767], pa.int16()),
+                ),
             ],
             "int32": [
                 (pa.array([0, 1, -1, None], pa.int32()), pa.array([0, 1, -1, None], pa.int32())),
@@ -800,8 +851,16 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, 2147483647, None], pa.uint32()),
                 ),
                 # Negative overflow: safe=True raises, safe=False wraps
-                (pa.array([-1], pa.int32()), pa.lib.ArrowInvalid, pa.array([4294967295], pa.uint32())),
-                (pa.array([-2147483648], pa.int32()), pa.lib.ArrowInvalid, pa.array([2147483648], pa.uint32())),
+                (
+                    pa.array([-1], pa.int32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([4294967295], pa.uint32()),
+                ),
+                (
+                    pa.array([-2147483648], pa.int32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([2147483648], pa.uint32()),
+                ),
             ],
             "uint64": [
                 (
@@ -809,8 +868,16 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, 2147483647, None], pa.uint64()),
                 ),
                 # Negative overflow: safe=True raises, safe=False wraps
-                (pa.array([-1], pa.int32()), pa.lib.ArrowInvalid, pa.array([18446744073709551615], pa.uint64())),
-                (pa.array([-2147483648], pa.int32()), pa.lib.ArrowInvalid, pa.array([18446744071562067968], pa.uint64())),
+                (
+                    pa.array([-1], pa.int32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([18446744073709551615], pa.uint64()),
+                ),
+                (
+                    pa.array([-2147483648], pa.int32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([18446744071562067968], pa.uint64()),
+                ),
             ],
             "float16": [
                 (
@@ -819,7 +886,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 ),
                 (pa.array([2048], pa.int32()), _make_float16_array([2048.0])),
                 # Large int overflows to inf with safe=False
-                (pa.array([2147483647], pa.int32()), pa.lib.ArrowInvalid, _make_float16_array([float('inf')])),
+                (
+                    pa.array([2147483647], pa.int32()),
+                    pa.lib.ArrowInvalid,
+                    _make_float16_array([float("inf")]),
+                ),
             ],
             "float32": [
                 (
@@ -828,7 +899,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 ),
                 (pa.array([16777216], pa.int32()), pa.array([16777216.0], pa.float32())),
                 # Large int loses precision with safe=False
-                (pa.array([2147483647], pa.int32()), pa.lib.ArrowInvalid, pa.array([2147483648.0], pa.float32())),
+                (
+                    pa.array([2147483647], pa.int32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([2147483648.0], pa.float32()),
+                ),
             ],
             "float64": [
                 (
@@ -968,7 +1043,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 ),
                 # Overflow: safe=True raises, safe=False wraps
                 (pa.array([128], pa.int64()), pa.lib.ArrowInvalid, pa.array([-128], pa.int8())),
-                (pa.array([9223372036854775807], pa.int64()), pa.lib.ArrowInvalid, pa.array([-1], pa.int8())),
+                (
+                    pa.array([9223372036854775807], pa.int64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-1], pa.int8()),
+                ),
             ],
             "int16": [
                 (
@@ -976,8 +1055,16 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, -1, 32767, -32768, None], pa.int16()),
                 ),
                 # Overflow: safe=True raises, safe=False wraps
-                (pa.array([32768], pa.int64()), pa.lib.ArrowInvalid, pa.array([-32768], pa.int16())),
-                (pa.array([-32769], pa.int64()), pa.lib.ArrowInvalid, pa.array([32767], pa.int16())),
+                (
+                    pa.array([32768], pa.int64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-32768], pa.int16()),
+                ),
+                (
+                    pa.array([-32769], pa.int64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([32767], pa.int16()),
+                ),
             ],
             "int32": [
                 (
@@ -985,8 +1072,16 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, -1, 2147483647, -2147483648, None], pa.int32()),
                 ),
                 # Overflow: safe=True raises, safe=False wraps
-                (pa.array([2147483648], pa.int64()), pa.lib.ArrowInvalid, pa.array([-2147483648], pa.int32())),
-                (pa.array([-2147483649], pa.int64()), pa.lib.ArrowInvalid, pa.array([2147483647], pa.int32())),
+                (
+                    pa.array([2147483648], pa.int64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-2147483648], pa.int32()),
+                ),
+                (
+                    pa.array([-2147483649], pa.int64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([2147483647], pa.int32()),
+                ),
             ],
             "int64": [
                 (pa.array([0, 1, -1, None], pa.int64()), pa.array([0, 1, -1, None], pa.int64())),
@@ -1017,8 +1112,16 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, 4294967295, None], pa.uint32()),
                 ),
                 # Overflow: safe=True raises, safe=False wraps
-                (pa.array([4294967296], pa.int64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint32())),
-                (pa.array([-1], pa.int64()), pa.lib.ArrowInvalid, pa.array([4294967295], pa.uint32())),
+                (
+                    pa.array([4294967296], pa.int64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.uint32()),
+                ),
+                (
+                    pa.array([-1], pa.int64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([4294967295], pa.uint32()),
+                ),
             ],
             "uint64": [
                 (
@@ -1026,8 +1129,16 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, 9223372036854775807, None], pa.uint64()),
                 ),
                 # Negative overflow: safe=True raises, safe=False wraps
-                (pa.array([-1], pa.int64()), pa.lib.ArrowInvalid, pa.array([18446744073709551615], pa.uint64())),
-                (pa.array([-9223372036854775808], pa.int64()), pa.lib.ArrowInvalid, pa.array([9223372036854775808], pa.uint64())),
+                (
+                    pa.array([-1], pa.int64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([18446744073709551615], pa.uint64()),
+                ),
+                (
+                    pa.array([-9223372036854775808], pa.int64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([9223372036854775808], pa.uint64()),
+                ),
             ],
             "float16": [
                 (
@@ -1036,7 +1147,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 ),
                 (pa.array([2048], pa.int64()), _make_float16_array([2048.0])),
                 # Large int overflows to inf with safe=False
-                (pa.array([9223372036854775807], pa.int64()), pa.lib.ArrowInvalid, _make_float16_array([float('inf')])),
+                (
+                    pa.array([9223372036854775807], pa.int64()),
+                    pa.lib.ArrowInvalid,
+                    _make_float16_array([float("inf")]),
+                ),
             ],
             "float32": [
                 (
@@ -1045,7 +1160,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 ),
                 (pa.array([16777216], pa.int64()), pa.array([16777216.0], pa.float32())),
                 # Large int loses precision with safe=False
-                (pa.array([9223372036854775807], pa.int64()), pa.lib.ArrowInvalid, pa.array([9.223372036854776e+18], pa.float32())),
+                (
+                    pa.array([9223372036854775807], pa.int64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([9.223372036854776e18], pa.float32()),
+                ),
             ],
             "float64": [
                 (
@@ -1057,7 +1176,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([9007199254740992.0], pa.float64()),
                 ),
                 # Precision loss: safe=True raises, safe=False truncates
-                (pa.array([9007199254740993], pa.int64()), pa.lib.ArrowInvalid, pa.array([9007199254740992.0], pa.float64())),
+                (
+                    pa.array([9007199254740993], pa.int64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([9007199254740992.0], pa.float64()),
+                ),
             ],
             # === Non-numerical types ===
             "bool": [
@@ -1435,7 +1558,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, 32767, None], pa.int16()),
                 ),
                 # Overflow: safe=True raises, safe=False wraps
-                (pa.array([32768], pa.uint16()), pa.lib.ArrowInvalid, pa.array([-32768], pa.int16())),
+                (
+                    pa.array([32768], pa.uint16()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-32768], pa.int16()),
+                ),
                 (pa.array([65535], pa.uint16()), pa.lib.ArrowInvalid, pa.array([-1], pa.int16())),
             ],
             "int32": [
@@ -1594,7 +1721,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 (pa.array([0, 1, 127, None], pa.uint32()), pa.array([0, 1, 127, None], pa.int8())),
                 # Overflow: safe=True raises, safe=False wraps
                 (pa.array([128], pa.uint32()), pa.lib.ArrowInvalid, pa.array([-128], pa.int8())),
-                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid, pa.array([-1], pa.int8())),
+                (
+                    pa.array([4294967295], pa.uint32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-1], pa.int8()),
+                ),
             ],
             "int16": [
                 (
@@ -1602,8 +1733,16 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, 32767, None], pa.int16()),
                 ),
                 # Overflow: safe=True raises, safe=False wraps
-                (pa.array([32768], pa.uint32()), pa.lib.ArrowInvalid, pa.array([-32768], pa.int16())),
-                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid, pa.array([-1], pa.int16())),
+                (
+                    pa.array([32768], pa.uint32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-32768], pa.int16()),
+                ),
+                (
+                    pa.array([4294967295], pa.uint32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-1], pa.int16()),
+                ),
             ],
             "int32": [
                 (
@@ -1611,8 +1750,16 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, 2147483647, None], pa.int32()),
                 ),
                 # Overflow: safe=True raises, safe=False wraps
-                (pa.array([2147483648], pa.uint32()), pa.lib.ArrowInvalid, pa.array([-2147483648], pa.int32())),
-                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid, pa.array([-1], pa.int32())),
+                (
+                    pa.array([2147483648], pa.uint32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-2147483648], pa.int32()),
+                ),
+                (
+                    pa.array([4294967295], pa.uint32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-1], pa.int32()),
+                ),
             ],
             "int64": [
                 (
@@ -1626,7 +1773,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 (pa.array([0, 1, 255, None], pa.uint32()), pa.array([0, 1, 255, None], pa.uint8())),
                 # Overflow: safe=True raises, safe=False wraps
                 (pa.array([256], pa.uint32()), pa.lib.ArrowInvalid, pa.array([0], pa.uint8())),
-                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid, pa.array([255], pa.uint8())),
+                (
+                    pa.array([4294967295], pa.uint32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([255], pa.uint8()),
+                ),
             ],
             "uint16": [
                 (
@@ -1635,7 +1786,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 ),
                 # Overflow: safe=True raises, safe=False wraps
                 (pa.array([65536], pa.uint32()), pa.lib.ArrowInvalid, pa.array([0], pa.uint16())),
-                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid, pa.array([65535], pa.uint16())),
+                (
+                    pa.array([4294967295], pa.uint32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([65535], pa.uint16()),
+                ),
             ],
             "uint32": [
                 (
@@ -1657,13 +1812,21 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 (pa.array([0, 1, None], pa.uint32()), _make_float16_array([0.0, 1.0, None])),
                 (pa.array([2048], pa.uint32()), _make_float16_array([2048.0])),
                 # Large uint overflows to inf with safe=False
-                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid, _make_float16_array([float('inf')])),
+                (
+                    pa.array([4294967295], pa.uint32()),
+                    pa.lib.ArrowInvalid,
+                    _make_float16_array([float("inf")]),
+                ),
             ],
             "float32": [
                 (pa.array([0, 1, None], pa.uint32()), pa.array([0.0, 1.0, None], pa.float32())),
                 (pa.array([16777216], pa.uint32()), pa.array([16777216.0], pa.float32())),
                 # Large uint loses precision with safe=False
-                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid, pa.array([4294967296.0], pa.float32())),
+                (
+                    pa.array([4294967295], pa.uint32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([4294967296.0], pa.float32()),
+                ),
             ],
             "float64": [
                 (
@@ -1764,7 +1927,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 (pa.array([0, 1, 127, None], pa.uint64()), pa.array([0, 1, 127, None], pa.int8())),
                 # Overflow: safe=True raises, safe=False wraps
                 (pa.array([128], pa.uint64()), pa.lib.ArrowInvalid, pa.array([-128], pa.int8())),
-                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid, pa.array([-1], pa.int8())),
+                (
+                    pa.array([18446744073709551615], pa.uint64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-1], pa.int8()),
+                ),
             ],
             "int16": [
                 (
@@ -1772,8 +1939,16 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, 32767, None], pa.int16()),
                 ),
                 # Overflow: safe=True raises, safe=False wraps
-                (pa.array([32768], pa.uint64()), pa.lib.ArrowInvalid, pa.array([-32768], pa.int16())),
-                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid, pa.array([-1], pa.int16())),
+                (
+                    pa.array([32768], pa.uint64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-32768], pa.int16()),
+                ),
+                (
+                    pa.array([18446744073709551615], pa.uint64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-1], pa.int16()),
+                ),
             ],
             "int32": [
                 (
@@ -1781,8 +1956,16 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, 2147483647, None], pa.int32()),
                 ),
                 # Overflow: safe=True raises, safe=False wraps
-                (pa.array([2147483648], pa.uint64()), pa.lib.ArrowInvalid, pa.array([-2147483648], pa.int32())),
-                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid, pa.array([-1], pa.int32())),
+                (
+                    pa.array([2147483648], pa.uint64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-2147483648], pa.int32()),
+                ),
+                (
+                    pa.array([18446744073709551615], pa.uint64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-1], pa.int32()),
+                ),
             ],
             "int64": [
                 (
@@ -1790,14 +1973,26 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, 9223372036854775807, None], pa.int64()),
                 ),
                 # Overflow: safe=True raises, safe=False wraps
-                (pa.array([9223372036854775808], pa.uint64()), pa.lib.ArrowInvalid, pa.array([-9223372036854775808], pa.int64())),
-                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid, pa.array([-1], pa.int64())),
+                (
+                    pa.array([9223372036854775808], pa.uint64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-9223372036854775808], pa.int64()),
+                ),
+                (
+                    pa.array([18446744073709551615], pa.uint64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-1], pa.int64()),
+                ),
             ],
             "uint8": [
                 (pa.array([0, 1, 255, None], pa.uint64()), pa.array([0, 1, 255, None], pa.uint8())),
                 # Overflow: safe=True raises, safe=False wraps
                 (pa.array([256], pa.uint64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint8())),
-                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid, pa.array([255], pa.uint8())),
+                (
+                    pa.array([18446744073709551615], pa.uint64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([255], pa.uint8()),
+                ),
             ],
             "uint16": [
                 (
@@ -1806,7 +2001,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 ),
                 # Overflow: safe=True raises, safe=False wraps
                 (pa.array([65536], pa.uint64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint16())),
-                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid, pa.array([65535], pa.uint16())),
+                (
+                    pa.array([18446744073709551615], pa.uint64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([65535], pa.uint16()),
+                ),
             ],
             "uint32": [
                 (
@@ -1814,8 +2013,16 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, 4294967295, None], pa.uint32()),
                 ),
                 # Overflow: safe=True raises, safe=False wraps
-                (pa.array([4294967296], pa.uint64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint32())),
-                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid, pa.array([4294967295], pa.uint32())),
+                (
+                    pa.array([4294967296], pa.uint64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.uint32()),
+                ),
+                (
+                    pa.array([18446744073709551615], pa.uint64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([4294967295], pa.uint32()),
+                ),
             ],
             "uint64": [
                 (
@@ -1832,13 +2039,21 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 (pa.array([0, 1, None], pa.uint64()), _make_float16_array([0.0, 1.0, None])),
                 (pa.array([2048], pa.uint64()), _make_float16_array([2048.0])),
                 # Large uint overflows to inf with safe=False
-                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid, _make_float16_array([float('inf')])),
+                (
+                    pa.array([18446744073709551615], pa.uint64()),
+                    pa.lib.ArrowInvalid,
+                    _make_float16_array([float("inf")]),
+                ),
             ],
             "float32": [
                 (pa.array([0, 1, None], pa.uint64()), pa.array([0.0, 1.0, None], pa.float32())),
                 (pa.array([16777216], pa.uint64()), pa.array([16777216.0], pa.float32())),
                 # Large uint loses precision with safe=False
-                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid, pa.array([1.8446744073709552e+19], pa.float32())),
+                (
+                    pa.array([18446744073709551615], pa.uint64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([1.8446744073709552e19], pa.float32()),
+                ),
             ],
             "float64": [
                 (pa.array([0, 1, None], pa.uint64()), pa.array([0.0, 1.0, None], pa.float64())),
@@ -1847,7 +2062,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([9007199254740992.0], pa.float64()),
                 ),
                 # Precision loss: safe=True raises, safe=False truncates
-                (pa.array([9007199254740993], pa.uint64()), pa.lib.ArrowInvalid, pa.array([9007199254740992.0], pa.float64())),
+                (
+                    pa.array([9007199254740993], pa.uint64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([9007199254740992.0], pa.float64()),
+                ),
             ],
             # === Non-numerical types ===
             "bool": [
@@ -1950,13 +2169,25 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, -1, 127, -128, None], pa.int8()),
                 ),
                 # fractional values: safe=False truncates
-                (_make_float16_array([1.5, -0.5]), pa.lib.ArrowInvalid, pa.array([1, 0], pa.int8())),
+                (
+                    _make_float16_array([1.5, -0.5]),
+                    pa.lib.ArrowInvalid,
+                    pa.array([1, 0], pa.int8()),
+                ),
                 # overflow int8 range: safe=False wraps
                 (_make_float16_array([128.0]), pa.lib.ArrowInvalid, pa.array([-128], pa.int8())),
                 (_make_float16_array([-129.0]), pa.lib.ArrowInvalid, pa.array([127], pa.int8())),
                 # special: NaN, Inf: safe=False produces implementation-defined value
-                (_make_float16_array([float("nan")]), pa.lib.ArrowInvalid, pa.array([0], pa.int8())),
-                (_make_float16_array([float("inf")]), pa.lib.ArrowInvalid, pa.array([-1], pa.int8())),
+                (
+                    _make_float16_array([float("nan")]),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.int8()),
+                ),
+                (
+                    _make_float16_array([float("inf")]),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-1], pa.int8()),
+                ),
             ],
             "int16": [
                 # Note: float16 can only represent integers exactly up to 2048
@@ -1969,7 +2200,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 # float16 max (65504) overflows int16 max (32767): safe=False wraps
                 (_make_float16_array([f16_max]), pa.lib.ArrowInvalid, pa.array([-32], pa.int16())),
                 # NaN: safe=False produces implementation-defined value
-                (_make_float16_array([float("nan")]), pa.lib.ArrowInvalid, pa.array([0], pa.int16())),
+                (
+                    _make_float16_array([float("nan")]),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.int16()),
+                ),
             ],
             "int32": [
                 (
@@ -1979,9 +2214,17 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 # fractional: safe=False truncates
                 (_make_float16_array([1.5]), pa.lib.ArrowInvalid, pa.array([1], pa.int32())),
                 # inf: safe=False produces implementation-defined value
-                (_make_float16_array([float("inf")]), pa.lib.ArrowInvalid, pa.array([2147483647], pa.int32())),
+                (
+                    _make_float16_array([float("inf")]),
+                    pa.lib.ArrowInvalid,
+                    pa.array([2147483647], pa.int32()),
+                ),
                 # NaN: safe=False produces implementation-defined value
-                (_make_float16_array([float("nan")]), pa.lib.ArrowInvalid, pa.array([0], pa.int32())),
+                (
+                    _make_float16_array([float("nan")]),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.int32()),
+                ),
             ],
             "int64": [
                 (
@@ -1991,9 +2234,17 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 # fractional: safe=False truncates
                 (_make_float16_array([1.5]), pa.lib.ArrowInvalid, pa.array([1], pa.int64())),
                 # -inf: safe=False produces implementation-defined value
-                (_make_float16_array([float("-inf")]), pa.lib.ArrowInvalid, pa.array([-9223372036854775808], pa.int64())),
+                (
+                    _make_float16_array([float("-inf")]),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-9223372036854775808], pa.int64()),
+                ),
                 # NaN: safe=False produces implementation-defined value
-                (_make_float16_array([float("nan")]), pa.lib.ArrowInvalid, pa.array([0], pa.int64())),
+                (
+                    _make_float16_array([float("nan")]),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.int64()),
+                ),
             ],
             "uint8": [
                 (
@@ -2005,7 +2256,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 # overflow uint8 range: safe=False wraps
                 (_make_float16_array([256.0]), pa.lib.ArrowInvalid, pa.array([0], pa.uint8())),
                 # NaN: safe=False produces implementation-defined value
-                (_make_float16_array([float("nan")]), pa.lib.ArrowInvalid, pa.array([0], pa.uint8())),
+                (
+                    _make_float16_array([float("nan")]),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.uint8()),
+                ),
             ],
             "uint16": [
                 # Note: float16 can only represent integers exactly up to 2048
@@ -2018,7 +2273,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 # fractional: safe=False truncates
                 (_make_float16_array([1.5]), pa.lib.ArrowInvalid, pa.array([1], pa.uint16())),
                 # inf: safe=False produces implementation-defined value
-                (_make_float16_array([float("inf")]), pa.lib.ArrowInvalid, pa.array([65535], pa.uint16())),
+                (
+                    _make_float16_array([float("inf")]),
+                    pa.lib.ArrowInvalid,
+                    pa.array([65535], pa.uint16()),
+                ),
             ],
             "uint32": [
                 (
@@ -2030,7 +2289,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 # fractional: safe=False truncates
                 (_make_float16_array([1.5]), pa.lib.ArrowInvalid, pa.array([1], pa.uint32())),
                 # NaN: safe=False produces implementation-defined value
-                (_make_float16_array([float("nan")]), pa.lib.ArrowInvalid, pa.array([0], pa.uint32())),
+                (
+                    _make_float16_array([float("nan")]),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.uint32()),
+                ),
             ],
             "uint64": [
                 (
@@ -2042,7 +2305,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 # fractional: safe=False truncates
                 (_make_float16_array([1.5]), pa.lib.ArrowInvalid, pa.array([1], pa.uint64())),
                 # -inf: safe=False produces implementation-defined value
-                (_make_float16_array([float("-inf")]), pa.lib.ArrowInvalid, pa.array([0], pa.uint64())),
+                (
+                    _make_float16_array([float("-inf")]),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.uint64()),
+                ),
             ],
             "float16": [
                 # identity cast: normal values + special values
@@ -2448,17 +2715,41 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, -1, 127, -128, None], pa.int8()),
                 ),
                 # fractional: safe=False truncates
-                (pa.array([1.5, 0.1, 127.9], pa.float64()), pa.lib.ArrowInvalid, pa.array([1, 0, 127], pa.int8())),
+                (
+                    pa.array([1.5, 0.1, 127.9], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([1, 0, 127], pa.int8()),
+                ),
                 # overflow: safe=False wraps
                 (pa.array([128.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([-128], pa.int8())),
                 (pa.array([-129.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([127], pa.int8())),
                 # === SPECIAL VALUES: safe=False produces implementation-defined values ===
-                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.int8())),
-                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([-1], pa.int8())),
-                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.int8())),
+                (
+                    pa.array([float("nan")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.int8()),
+                ),
+                (
+                    pa.array([float("inf")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-1], pa.int8()),
+                ),
+                (
+                    pa.array([float("-inf")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.int8()),
+                ),
                 # mixed array with special value
-                (pa.array([1.0, float("nan")], pa.float64()), pa.lib.ArrowInvalid, pa.array([1, 0], pa.int8())),
-                (pa.array([0.0, float("inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0, -1], pa.int8())),
+                (
+                    pa.array([1.0, float("nan")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([1, 0], pa.int8()),
+                ),
+                (
+                    pa.array([0.0, float("inf")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0, -1], pa.int8()),
+                ),
             ],
             "int16": [
                 (
@@ -2468,12 +2759,32 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 # fractional: safe=False truncates
                 (pa.array([1.5], pa.float64()), pa.lib.ArrowInvalid, pa.array([1], pa.int16())),
                 # overflow: safe=False wraps
-                (pa.array([32768.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([-32768], pa.int16())),
-                (pa.array([-32769.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([32767], pa.int16())),
+                (
+                    pa.array([32768.0], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-32768], pa.int16()),
+                ),
+                (
+                    pa.array([-32769.0], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([32767], pa.int16()),
+                ),
                 # === SPECIAL VALUES: safe=False produces implementation-defined values ===
-                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.int16())),
-                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([-1], pa.int16())),
-                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.int16())),
+                (
+                    pa.array([float("nan")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.int16()),
+                ),
+                (
+                    pa.array([float("inf")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-1], pa.int16()),
+                ),
+                (
+                    pa.array([float("-inf")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.int16()),
+                ),
             ],
             "int32": [
                 (
@@ -2483,12 +2794,32 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 # fractional: safe=False truncates
                 (pa.array([1.5], pa.float64()), pa.lib.ArrowInvalid, pa.array([1], pa.int32())),
                 # overflow: safe=False wraps/saturates
-                (pa.array([2147483648.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([2147483647], pa.int32())),
-                (pa.array([-2147483649.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([-2147483648], pa.int32())),
+                (
+                    pa.array([2147483648.0], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([2147483647], pa.int32()),
+                ),
+                (
+                    pa.array([-2147483649.0], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-2147483648], pa.int32()),
+                ),
                 # === SPECIAL VALUES: safe=False produces implementation-defined values ===
-                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.int32())),
-                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([2147483647], pa.int32())),
-                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([-2147483648], pa.int32())),
+                (
+                    pa.array([float("nan")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.int32()),
+                ),
+                (
+                    pa.array([float("inf")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([2147483647], pa.int32()),
+                ),
+                (
+                    pa.array([float("-inf")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-2147483648], pa.int32()),
+                ),
             ],
             "int64": [
                 (
@@ -2503,11 +2834,27 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     _get_float_to_int_boundary_expected(pa.int64()),
                 ),
                 # truly overflow: safe=False saturates
-                (pa.array([1e19], pa.float64()), pa.lib.ArrowInvalid, pa.array([9223372036854775807], pa.int64())),
+                (
+                    pa.array([1e19], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([9223372036854775807], pa.int64()),
+                ),
                 # === SPECIAL VALUES: safe=False produces implementation-defined values ===
-                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.int64())),
-                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([9223372036854775807], pa.int64())),
-                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([-9223372036854775808], pa.int64())),
+                (
+                    pa.array([float("nan")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.int64()),
+                ),
+                (
+                    pa.array([float("inf")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([9223372036854775807], pa.int64()),
+                ),
+                (
+                    pa.array([float("-inf")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-9223372036854775808], pa.int64()),
+                ),
                 # large but valid: 2^53 is exactly representable in float64
                 (
                     pa.array([9007199254740992.0], pa.float64()),
@@ -2524,9 +2871,21 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 # overflow: safe=False wraps
                 (pa.array([256.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint8())),
                 # === SPECIAL VALUES: safe=False produces implementation-defined values ===
-                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint8())),
-                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([255], pa.uint8())),
-                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint8())),
+                (
+                    pa.array([float("nan")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.uint8()),
+                ),
+                (
+                    pa.array([float("inf")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([255], pa.uint8()),
+                ),
+                (
+                    pa.array([float("-inf")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.uint8()),
+                ),
             ],
             "uint16": [
                 (
@@ -2534,13 +2893,33 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, 65535, None], pa.uint16()),
                 ),
                 # negative: safe=False wraps
-                (pa.array([-1.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([65535], pa.uint16())),
+                (
+                    pa.array([-1.0], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([65535], pa.uint16()),
+                ),
                 # overflow: safe=False wraps
-                (pa.array([65536.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint16())),
+                (
+                    pa.array([65536.0], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.uint16()),
+                ),
                 # === SPECIAL VALUES: safe=False produces implementation-defined values ===
-                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([65535], pa.uint16())),
-                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint16())),
-                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint16())),
+                (
+                    pa.array([float("inf")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([65535], pa.uint16()),
+                ),
+                (
+                    pa.array([float("-inf")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.uint16()),
+                ),
+                (
+                    pa.array([float("nan")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.uint16()),
+                ),
             ],
             "uint32": [
                 (
@@ -2550,11 +2929,27 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 # negative: safe=False wraps
                 (pa.array([-1.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint32())),
                 # overflow: safe=False wraps
-                (pa.array([4294967296.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([4294967295], pa.uint32())),
+                (
+                    pa.array([4294967296.0], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([4294967295], pa.uint32()),
+                ),
                 # === SPECIAL VALUES: safe=False produces implementation-defined values ===
-                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint32())),
-                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([4294967295], pa.uint32())),
-                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint32())),
+                (
+                    pa.array([float("nan")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.uint32()),
+                ),
+                (
+                    pa.array([float("inf")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([4294967295], pa.uint32()),
+                ),
+                (
+                    pa.array([float("-inf")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0], pa.uint32()),
+                ),
             ],
             "uint64": [
                 (
@@ -2562,7 +2957,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, 9007199254740992, None], pa.uint64()),
                 ),
                 # negative/fractional/nan: safe=False wraps/truncates
-                (pa.array([-1.0, 1.5, float("nan")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0, 1, 0], pa.uint64())),
+                (
+                    pa.array([-1.0, 1.5, float("nan")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0, 1, 0], pa.uint64()),
+                ),
             ],
             "float16": [
                 # normal values + special values
@@ -4765,7 +5164,9 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 (
                     pa.array([ts_lossy], pa.timestamp("us")),
                     pa.lib.ArrowInvalid,
-                    pa.array([epoch_us_lossless // 1000000], pa.timestamp("s", tz="America/New_York")),
+                    pa.array(
+                        [epoch_us_lossless // 1000000], pa.timestamp("s", tz="America/New_York")
+                    ),
                 ),
             ],
             "timestamp_s_tz_shanghai": [
@@ -5030,7 +5431,9 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 (
                     pa.array([epoch_ns_lossy], pa.timestamp("ns")),
                     pa.lib.ArrowInvalid,
-                    pa.array([epoch_ns_lossless // 1000000000], pa.timestamp("s", tz="America/New_York")),
+                    pa.array(
+                        [epoch_ns_lossless // 1000000000], pa.timestamp("s", tz="America/New_York")
+                    ),
                 ),
             ],
             "timestamp_s_tz_shanghai": [
@@ -5045,7 +5448,9 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 (
                     pa.array([epoch_ns_lossy], pa.timestamp("ns")),
                     pa.lib.ArrowInvalid,
-                    pa.array([epoch_ns_lossless // 1000000000], pa.timestamp("s", tz="Asia/Shanghai")),
+                    pa.array(
+                        [epoch_ns_lossless // 1000000000], pa.timestamp("s", tz="Asia/Shanghai")
+                    ),
                 ),
             ],
             # timestamp[ns] -> duration (not supported)
@@ -5822,7 +6227,9 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 (
                     pa.array([epoch_us_lossy], pa.timestamp("us", tz="UTC")),
                     pa.lib.ArrowInvalid,
-                    pa.array([epoch_us_lossless // 1000000], pa.timestamp("s", tz="America/New_York")),
+                    pa.array(
+                        [epoch_us_lossless // 1000000], pa.timestamp("s", tz="America/New_York")
+                    ),
                 ),
             ],
             "timestamp_s_tz_shanghai": [
@@ -6144,7 +6551,9 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 (
                     pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")),
                     pa.lib.ArrowInvalid,
-                    pa.array([epoch_ns_lossless // 1000000000], pa.timestamp("s", tz="America/New_York")),
+                    pa.array(
+                        [epoch_ns_lossless // 1000000000], pa.timestamp("s", tz="America/New_York")
+                    ),
                 ),
             ],
             "timestamp_s_tz_shanghai": [
@@ -6159,7 +6568,9 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                 (
                     pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")),
                     pa.lib.ArrowInvalid,
-                    pa.array([epoch_ns_lossless // 1000000000], pa.timestamp("s", tz="Asia/Shanghai")),
+                    pa.array(
+                        [epoch_ns_lossless // 1000000000], pa.timestamp("s", tz="Asia/Shanghai")
+                    ),
                 ),
             ],
             # timestamp[ns,tz] -> duration (not supported)
@@ -7412,7 +7823,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([t_lossless, None], pa.time32("s")),
                 ),
                 # Lossy: safe=False truncates
-                (pa.array([t], pa.time32("ms")), pa.lib.ArrowInvalid, pa.array([t_lossless], pa.time32("s"))),
+                (
+                    pa.array([t], pa.time32("ms")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([t_lossless], pa.time32("s")),
+                ),
             ],
             "time32_ms": [
                 (pa.array([t, None], pa.time32("ms")), pa.array([t, None], pa.time32("ms"))),
@@ -7505,7 +7920,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([t_lossless, None], pa.time32("s")),
                 ),
                 # Lossy: safe=False truncates
-                (pa.array([t], pa.time64("us")), pa.lib.ArrowInvalid, pa.array([t_lossless], pa.time32("s"))),
+                (
+                    pa.array([t], pa.time64("us")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([t_lossless], pa.time32("s")),
+                ),
             ],
             "time32_ms": [
                 (
@@ -7617,7 +8036,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([t_lossless, None], pa.time32("s")),
                 ),
                 # Lossy: safe=False truncates
-                (pa.array([t_ns], pa.time64("ns")), pa.lib.ArrowInvalid, pa.array([t_lossless], pa.time32("s"))),
+                (
+                    pa.array([t_ns], pa.time64("ns")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([t_lossless], pa.time32("s")),
+                ),
             ],
             "time32_ms": [
                 (
@@ -7637,7 +8060,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([t_lossless, None], pa.time64("us")),
                 ),
                 # Lossy: safe=False truncates (keeps us precision)
-                (pa.array([t_ns], pa.time64("ns")), pa.lib.ArrowInvalid, pa.array([t], pa.time64("us"))),
+                (
+                    pa.array([t_ns], pa.time64("ns")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([t], pa.time64("us")),
+                ),
             ],
             "time64_ns": [
                 (pa.array([t_ns, None], pa.time64("ns")), pa.array([t, None], pa.time64("ns"))),

--- a/python/pyspark/tests/upstream/pyarrow/test_pyarrow_array_cast.py
+++ b/python/pyspark/tests/upstream/pyarrow/test_pyarrow_array_cast.py
@@ -233,7 +233,15 @@ class PyArrowNumericalCastTests(unittest.TestCase):
         return True
 
     def _run_cast_tests(self, casts_dict, source_type_name):
-        """Run cast tests for a single source type."""
+        """Run cast tests for a single source type, testing both safe=True and safe=False.
+
+        Test case format: (src_arr, expected_safe_true, expected_safe_false)
+        - expected_safe_true: Expected result with safe=True (pa.Array or Exception type)
+        - expected_safe_false: Expected result with safe=False, or None if same as safe=True
+
+        For backward compatibility, 2-element tuples (src_arr, expected) are treated as
+        (src_arr, expected, None) - i.e., same behavior for both safe modes.
+        """
         import pyarrow as pa
 
         # All scalar types (non-nested)
@@ -307,37 +315,59 @@ class PyArrowNumericalCastTests(unittest.TestCase):
             if tgt_type_name not in target_results:
                 target_results[tgt_type_name] = {"success": False, "failure": False}
 
-            for i, (src_arr, expected) in enumerate(test_pairs):
+            for i, test_pair in enumerate(test_pairs):
+                # Parse test case: support both 2-tuple and 3-tuple formats
+                if len(test_pair) == 2:
+                    src_arr, expected_safe_true = test_pair
+                    expected_safe_false = None  # Same as safe=True
+                else:
+                    src_arr, expected_safe_true, expected_safe_false = test_pair
+
+                # If expected_safe_false is None, use same expectation as safe=True
+                if expected_safe_false is None:
+                    expected_safe_false = expected_safe_true
+
                 case_id = f"{source_type_name}->{tgt_type_name}[{i}]"
 
-                try:
-                    if isinstance(expected, type) and issubclass(expected, Exception):
-                        target_results[tgt_type_name]["failure"] = True
-                        try:
-                            result = src_arr.cast(tgt_pa_type)
-                            failed_cases.append(
-                                f"{case_id}: expected {expected.__name__}, got success: {result.to_pylist()}"
-                            )
-                        except expected:
-                            pass
-                        except Exception as e:
-                            failed_cases.append(
-                                f"{case_id}: expected {expected.__name__}, got {type(e).__name__}: {e}"
-                            )
-                    elif isinstance(expected, pa.Array):
-                        target_results[tgt_type_name]["success"] = True
-                        try:
-                            result = src_arr.cast(tgt_pa_type)
-                            if not self._arrays_equal_nan_aware(result, expected):
+                # Test both safe=True and safe=False
+                for safe_mode, expected in [(True, expected_safe_true), (False, expected_safe_false)]:
+                    mode_str = "safe=True" if safe_mode else "safe=False"
+                    case_id_with_mode = f"{case_id} ({mode_str})"
+
+                    try:
+                        if isinstance(expected, type) and issubclass(expected, Exception):
+                            if safe_mode:
+                                target_results[tgt_type_name]["failure"] = True
+                            try:
+                                result = src_arr.cast(tgt_pa_type, safe=safe_mode)
                                 failed_cases.append(
-                                    f"{case_id}: mismatch, expected {expected.to_pylist()}, got {result.to_pylist()}"
+                                    f"{case_id_with_mode}: expected {expected.__name__}, "
+                                    f"got success: {result.to_pylist()}"
                                 )
-                        except Exception as e:
-                            failed_cases.append(
-                                f"{case_id}: expected success, got {type(e).__name__}: {e}"
-                            )
-                except Exception as e:
-                    failed_cases.append(f"{case_id}: test error: {e}")
+                            except expected:
+                                pass
+                            except Exception as e:
+                                failed_cases.append(
+                                    f"{case_id_with_mode}: expected {expected.__name__}, "
+                                    f"got {type(e).__name__}: {e}"
+                                )
+                        elif isinstance(expected, pa.Array):
+                            if safe_mode:
+                                target_results[tgt_type_name]["success"] = True
+                            try:
+                                result = src_arr.cast(tgt_pa_type, safe=safe_mode)
+                                if not self._arrays_equal_nan_aware(result, expected):
+                                    failed_cases.append(
+                                        f"{case_id_with_mode}: mismatch, "
+                                        f"expected {expected.to_pylist()}, got {result.to_pylist()}"
+                                    )
+                            except Exception as e:
+                                failed_cases.append(
+                                    f"{case_id_with_mode}: expected success, "
+                                    f"got {type(e).__name__}: {e}"
+                                )
+                    except Exception as e:
+                        failed_cases.append(f"{case_id_with_mode}: test error: {e}")
 
         # Record results in class-level storage for golden file
         if source_type_name not in self.__class__._cast_results:
@@ -389,23 +419,27 @@ class PyArrowNumericalCastTests(unittest.TestCase):
             ],
             "uint8": [
                 (pa.array([0, 1, 127, None], pa.int8()), pa.array([0, 1, 127, None], pa.uint8())),
-                (pa.array([-1], pa.int8()), pa.lib.ArrowInvalid),
-                (pa.array([-128], pa.int8()), pa.lib.ArrowInvalid),
+                # Negative values overflow: safe=True raises, safe=False wraps
+                (pa.array([-1], pa.int8()), pa.lib.ArrowInvalid, pa.array([255], pa.uint8())),
+                (pa.array([-128], pa.int8()), pa.lib.ArrowInvalid, pa.array([128], pa.uint8())),
             ],
             "uint16": [
                 (pa.array([0, 1, 127, None], pa.int8()), pa.array([0, 1, 127, None], pa.uint16())),
-                (pa.array([-1], pa.int8()), pa.lib.ArrowInvalid),
-                (pa.array([-128], pa.int8()), pa.lib.ArrowInvalid),
+                # Negative values overflow: safe=True raises, safe=False wraps
+                (pa.array([-1], pa.int8()), pa.lib.ArrowInvalid, pa.array([65535], pa.uint16())),
+                (pa.array([-128], pa.int8()), pa.lib.ArrowInvalid, pa.array([65408], pa.uint16())),
             ],
             "uint32": [
                 (pa.array([0, 1, 127, None], pa.int8()), pa.array([0, 1, 127, None], pa.uint32())),
-                (pa.array([-1], pa.int8()), pa.lib.ArrowInvalid),
-                (pa.array([-128], pa.int8()), pa.lib.ArrowInvalid),
+                # Negative values overflow: safe=True raises, safe=False wraps
+                (pa.array([-1], pa.int8()), pa.lib.ArrowInvalid, pa.array([4294967295], pa.uint32())),
+                (pa.array([-128], pa.int8()), pa.lib.ArrowInvalid, pa.array([4294967168], pa.uint32())),
             ],
             "uint64": [
                 (pa.array([0, 1, 127, None], pa.int8()), pa.array([0, 1, 127, None], pa.uint64())),
-                (pa.array([-1], pa.int8()), pa.lib.ArrowInvalid),
-                (pa.array([-128], pa.int8()), pa.lib.ArrowInvalid),
+                # Negative values overflow: safe=True raises, safe=False wraps
+                (pa.array([-1], pa.int8()), pa.lib.ArrowInvalid, pa.array([18446744073709551615], pa.uint64())),
+                (pa.array([-128], pa.int8()), pa.lib.ArrowInvalid, pa.array([18446744073709551488], pa.uint64())),
             ],
             # int8 -> floats
             "float16": [
@@ -533,8 +567,9 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, -1, 127, -128, None], pa.int16()),
                     pa.array([0, 1, -1, 127, -128, None], pa.int8()),
                 ),
-                (pa.array([128], pa.int16()), pa.lib.ArrowInvalid),
-                (pa.array([-129], pa.int16()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([128], pa.int16()), pa.lib.ArrowInvalid, pa.array([-128], pa.int8())),
+                (pa.array([-129], pa.int16()), pa.lib.ArrowInvalid, pa.array([127], pa.int8())),
             ],
             "int16": [
                 (pa.array([0, 1, -1, None], pa.int16()), pa.array([0, 1, -1, None], pa.int16())),
@@ -553,32 +588,36 @@ class PyArrowNumericalCastTests(unittest.TestCase):
             ],
             "uint8": [
                 (pa.array([0, 1, 255, None], pa.int16()), pa.array([0, 1, 255, None], pa.uint8())),
-                (pa.array([256], pa.int16()), pa.lib.ArrowInvalid),
-                (pa.array([-1], pa.int16()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([256], pa.int16()), pa.lib.ArrowInvalid, pa.array([0], pa.uint8())),
+                (pa.array([-1], pa.int16()), pa.lib.ArrowInvalid, pa.array([255], pa.uint8())),
             ],
             "uint16": [
                 (
                     pa.array([0, 1, 32767, None], pa.int16()),
                     pa.array([0, 1, 32767, None], pa.uint16()),
                 ),
-                (pa.array([-1], pa.int16()), pa.lib.ArrowInvalid),
-                (pa.array([-32768], pa.int16()), pa.lib.ArrowInvalid),
+                # Negative overflow: safe=True raises, safe=False wraps
+                (pa.array([-1], pa.int16()), pa.lib.ArrowInvalid, pa.array([65535], pa.uint16())),
+                (pa.array([-32768], pa.int16()), pa.lib.ArrowInvalid, pa.array([32768], pa.uint16())),
             ],
             "uint32": [
                 (
                     pa.array([0, 1, 32767, None], pa.int16()),
                     pa.array([0, 1, 32767, None], pa.uint32()),
                 ),
-                (pa.array([-1], pa.int16()), pa.lib.ArrowInvalid),
-                (pa.array([-32768], pa.int16()), pa.lib.ArrowInvalid),
+                # Negative overflow: safe=True raises, safe=False wraps
+                (pa.array([-1], pa.int16()), pa.lib.ArrowInvalid, pa.array([4294967295], pa.uint32())),
+                (pa.array([-32768], pa.int16()), pa.lib.ArrowInvalid, pa.array([4294934528], pa.uint32())),
             ],
             "uint64": [
                 (
                     pa.array([0, 1, 32767, None], pa.int16()),
                     pa.array([0, 1, 32767, None], pa.uint64()),
                 ),
-                (pa.array([-1], pa.int16()), pa.lib.ArrowInvalid),
-                (pa.array([-32768], pa.int16()), pa.lib.ArrowInvalid),
+                # Negative overflow: safe=True raises, safe=False wraps
+                (pa.array([-1], pa.int16()), pa.lib.ArrowInvalid, pa.array([18446744073709551615], pa.uint64())),
+                (pa.array([-32768], pa.int16()), pa.lib.ArrowInvalid, pa.array([18446744073709518848], pa.uint64())),
             ],
             # int16 -> floats
             "float16": [
@@ -711,16 +750,18 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, -1, 127, -128, None], pa.int32()),
                     pa.array([0, 1, -1, 127, -128, None], pa.int8()),
                 ),
-                (pa.array([128], pa.int32()), pa.lib.ArrowInvalid),
-                (pa.array([2147483647], pa.int32()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([128], pa.int32()), pa.lib.ArrowInvalid, pa.array([-128], pa.int8())),
+                (pa.array([2147483647], pa.int32()), pa.lib.ArrowInvalid, pa.array([-1], pa.int8())),
             ],
             "int16": [
                 (
                     pa.array([0, 1, -1, 32767, -32768, None], pa.int32()),
                     pa.array([0, 1, -1, 32767, -32768, None], pa.int16()),
                 ),
-                (pa.array([32768], pa.int32()), pa.lib.ArrowInvalid),
-                (pa.array([-32769], pa.int32()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([32768], pa.int32()), pa.lib.ArrowInvalid, pa.array([-32768], pa.int16())),
+                (pa.array([-32769], pa.int32()), pa.lib.ArrowInvalid, pa.array([32767], pa.int16())),
             ],
             "int32": [
                 (pa.array([0, 1, -1, None], pa.int32()), pa.array([0, 1, -1, None], pa.int32())),
@@ -740,32 +781,36 @@ class PyArrowNumericalCastTests(unittest.TestCase):
             ],
             "uint8": [
                 (pa.array([0, 1, 255, None], pa.int32()), pa.array([0, 1, 255, None], pa.uint8())),
-                (pa.array([256], pa.int32()), pa.lib.ArrowInvalid),
-                (pa.array([-1], pa.int32()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([256], pa.int32()), pa.lib.ArrowInvalid, pa.array([0], pa.uint8())),
+                (pa.array([-1], pa.int32()), pa.lib.ArrowInvalid, pa.array([255], pa.uint8())),
             ],
             "uint16": [
                 (
                     pa.array([0, 1, 65535, None], pa.int32()),
                     pa.array([0, 1, 65535, None], pa.uint16()),
                 ),
-                (pa.array([65536], pa.int32()), pa.lib.ArrowInvalid),
-                (pa.array([-1], pa.int32()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([65536], pa.int32()), pa.lib.ArrowInvalid, pa.array([0], pa.uint16())),
+                (pa.array([-1], pa.int32()), pa.lib.ArrowInvalid, pa.array([65535], pa.uint16())),
             ],
             "uint32": [
                 (
                     pa.array([0, 1, 2147483647, None], pa.int32()),
                     pa.array([0, 1, 2147483647, None], pa.uint32()),
                 ),
-                (pa.array([-1], pa.int32()), pa.lib.ArrowInvalid),
-                (pa.array([-2147483648], pa.int32()), pa.lib.ArrowInvalid),
+                # Negative overflow: safe=True raises, safe=False wraps
+                (pa.array([-1], pa.int32()), pa.lib.ArrowInvalid, pa.array([4294967295], pa.uint32())),
+                (pa.array([-2147483648], pa.int32()), pa.lib.ArrowInvalid, pa.array([2147483648], pa.uint32())),
             ],
             "uint64": [
                 (
                     pa.array([0, 1, 2147483647, None], pa.int32()),
                     pa.array([0, 1, 2147483647, None], pa.uint64()),
                 ),
-                (pa.array([-1], pa.int32()), pa.lib.ArrowInvalid),
-                (pa.array([-2147483648], pa.int32()), pa.lib.ArrowInvalid),
+                # Negative overflow: safe=True raises, safe=False wraps
+                (pa.array([-1], pa.int32()), pa.lib.ArrowInvalid, pa.array([18446744073709551615], pa.uint64())),
+                (pa.array([-2147483648], pa.int32()), pa.lib.ArrowInvalid, pa.array([18446744071562067968], pa.uint64())),
             ],
             "float16": [
                 (
@@ -773,7 +818,8 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     _make_float16_array([0.0, 1.0, -1.0, None]),
                 ),
                 (pa.array([2048], pa.int32()), _make_float16_array([2048.0])),
-                (pa.array([2147483647], pa.int32()), pa.lib.ArrowInvalid),
+                # Large int overflows to inf with safe=False
+                (pa.array([2147483647], pa.int32()), pa.lib.ArrowInvalid, _make_float16_array([float('inf')])),
             ],
             "float32": [
                 (
@@ -781,7 +827,8 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0.0, 1.0, -1.0, None], pa.float32()),
                 ),
                 (pa.array([16777216], pa.int32()), pa.array([16777216.0], pa.float32())),
-                (pa.array([2147483647], pa.int32()), pa.lib.ArrowInvalid),
+                # Large int loses precision with safe=False
+                (pa.array([2147483647], pa.int32()), pa.lib.ArrowInvalid, pa.array([2147483648.0], pa.float32())),
             ],
             "float64": [
                 (
@@ -919,24 +966,27 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0, 1, -1, 127, -128, None], pa.int64()),
                     pa.array([0, 1, -1, 127, -128, None], pa.int8()),
                 ),
-                (pa.array([128], pa.int64()), pa.lib.ArrowInvalid),
-                (pa.array([9223372036854775807], pa.int64()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([128], pa.int64()), pa.lib.ArrowInvalid, pa.array([-128], pa.int8())),
+                (pa.array([9223372036854775807], pa.int64()), pa.lib.ArrowInvalid, pa.array([-1], pa.int8())),
             ],
             "int16": [
                 (
                     pa.array([0, 1, -1, 32767, -32768, None], pa.int64()),
                     pa.array([0, 1, -1, 32767, -32768, None], pa.int16()),
                 ),
-                (pa.array([32768], pa.int64()), pa.lib.ArrowInvalid),
-                (pa.array([-32769], pa.int64()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([32768], pa.int64()), pa.lib.ArrowInvalid, pa.array([-32768], pa.int16())),
+                (pa.array([-32769], pa.int64()), pa.lib.ArrowInvalid, pa.array([32767], pa.int16())),
             ],
             "int32": [
                 (
                     pa.array([0, 1, -1, 2147483647, -2147483648, None], pa.int64()),
                     pa.array([0, 1, -1, 2147483647, -2147483648, None], pa.int32()),
                 ),
-                (pa.array([2147483648], pa.int64()), pa.lib.ArrowInvalid),
-                (pa.array([-2147483649], pa.int64()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([2147483648], pa.int64()), pa.lib.ArrowInvalid, pa.array([-2147483648], pa.int32())),
+                (pa.array([-2147483649], pa.int64()), pa.lib.ArrowInvalid, pa.array([2147483647], pa.int32())),
             ],
             "int64": [
                 (pa.array([0, 1, -1, None], pa.int64()), pa.array([0, 1, -1, None], pa.int64())),
@@ -948,32 +998,36 @@ class PyArrowNumericalCastTests(unittest.TestCase):
             ],
             "uint8": [
                 (pa.array([0, 1, 255, None], pa.int64()), pa.array([0, 1, 255, None], pa.uint8())),
-                (pa.array([256], pa.int64()), pa.lib.ArrowInvalid),
-                (pa.array([-1], pa.int64()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([256], pa.int64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint8())),
+                (pa.array([-1], pa.int64()), pa.lib.ArrowInvalid, pa.array([255], pa.uint8())),
             ],
             "uint16": [
                 (
                     pa.array([0, 1, 65535, None], pa.int64()),
                     pa.array([0, 1, 65535, None], pa.uint16()),
                 ),
-                (pa.array([65536], pa.int64()), pa.lib.ArrowInvalid),
-                (pa.array([-1], pa.int64()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([65536], pa.int64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint16())),
+                (pa.array([-1], pa.int64()), pa.lib.ArrowInvalid, pa.array([65535], pa.uint16())),
             ],
             "uint32": [
                 (
                     pa.array([0, 1, 4294967295, None], pa.int64()),
                     pa.array([0, 1, 4294967295, None], pa.uint32()),
                 ),
-                (pa.array([4294967296], pa.int64()), pa.lib.ArrowInvalid),
-                (pa.array([-1], pa.int64()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([4294967296], pa.int64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint32())),
+                (pa.array([-1], pa.int64()), pa.lib.ArrowInvalid, pa.array([4294967295], pa.uint32())),
             ],
             "uint64": [
                 (
                     pa.array([0, 1, 9223372036854775807, None], pa.int64()),
                     pa.array([0, 1, 9223372036854775807, None], pa.uint64()),
                 ),
-                (pa.array([-1], pa.int64()), pa.lib.ArrowInvalid),
-                (pa.array([-9223372036854775808], pa.int64()), pa.lib.ArrowInvalid),
+                # Negative overflow: safe=True raises, safe=False wraps
+                (pa.array([-1], pa.int64()), pa.lib.ArrowInvalid, pa.array([18446744073709551615], pa.uint64())),
+                (pa.array([-9223372036854775808], pa.int64()), pa.lib.ArrowInvalid, pa.array([9223372036854775808], pa.uint64())),
             ],
             "float16": [
                 (
@@ -981,7 +1035,8 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     _make_float16_array([0.0, 1.0, -1.0, None]),
                 ),
                 (pa.array([2048], pa.int64()), _make_float16_array([2048.0])),
-                (pa.array([9223372036854775807], pa.int64()), pa.lib.ArrowInvalid),
+                # Large int overflows to inf with safe=False
+                (pa.array([9223372036854775807], pa.int64()), pa.lib.ArrowInvalid, _make_float16_array([float('inf')])),
             ],
             "float32": [
                 (
@@ -989,7 +1044,8 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0.0, 1.0, -1.0, None], pa.float32()),
                 ),
                 (pa.array([16777216], pa.int64()), pa.array([16777216.0], pa.float32())),
-                (pa.array([9223372036854775807], pa.int64()), pa.lib.ArrowInvalid),
+                # Large int loses precision with safe=False
+                (pa.array([9223372036854775807], pa.int64()), pa.lib.ArrowInvalid, pa.array([9.223372036854776e+18], pa.float32())),
             ],
             "float64": [
                 (
@@ -1000,7 +1056,8 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([9007199254740992], pa.int64()),
                     pa.array([9007199254740992.0], pa.float64()),
                 ),
-                (pa.array([9007199254740993], pa.int64()), pa.lib.ArrowInvalid),
+                # Precision loss: safe=True raises, safe=False truncates
+                (pa.array([9007199254740993], pa.int64()), pa.lib.ArrowInvalid, pa.array([9007199254740992.0], pa.float64())),
             ],
             # === Non-numerical types ===
             "bool": [
@@ -1224,8 +1281,9 @@ class PyArrowNumericalCastTests(unittest.TestCase):
         casts = {
             "int8": [
                 (pa.array([0, 1, 127, None], pa.uint8()), pa.array([0, 1, 127, None], pa.int8())),
-                (pa.array([128], pa.uint8()), pa.lib.ArrowInvalid),
-                (pa.array([255], pa.uint8()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([128], pa.uint8()), pa.lib.ArrowInvalid, pa.array([-128], pa.int8())),
+                (pa.array([255], pa.uint8()), pa.lib.ArrowInvalid, pa.array([-1], pa.int8())),
             ],
             "int16": [
                 (pa.array([0, 1, 255, None], pa.uint8()), pa.array([0, 1, 255, None], pa.int16())),
@@ -1367,16 +1425,18 @@ class PyArrowNumericalCastTests(unittest.TestCase):
         casts = {
             "int8": [
                 (pa.array([0, 1, 127, None], pa.uint16()), pa.array([0, 1, 127, None], pa.int8())),
-                (pa.array([128], pa.uint16()), pa.lib.ArrowInvalid),
-                (pa.array([65535], pa.uint16()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([128], pa.uint16()), pa.lib.ArrowInvalid, pa.array([-128], pa.int8())),
+                (pa.array([65535], pa.uint16()), pa.lib.ArrowInvalid, pa.array([-1], pa.int8())),
             ],
             "int16": [
                 (
                     pa.array([0, 1, 32767, None], pa.uint16()),
                     pa.array([0, 1, 32767, None], pa.int16()),
                 ),
-                (pa.array([32768], pa.uint16()), pa.lib.ArrowInvalid),
-                (pa.array([65535], pa.uint16()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([32768], pa.uint16()), pa.lib.ArrowInvalid, pa.array([-32768], pa.int16())),
+                (pa.array([65535], pa.uint16()), pa.lib.ArrowInvalid, pa.array([-1], pa.int16())),
             ],
             "int32": [
                 (
@@ -1396,8 +1456,9 @@ class PyArrowNumericalCastTests(unittest.TestCase):
             ],
             "uint8": [
                 (pa.array([0, 1, 255, None], pa.uint16()), pa.array([0, 1, 255, None], pa.uint8())),
-                (pa.array([256], pa.uint16()), pa.lib.ArrowInvalid),
-                (pa.array([65535], pa.uint16()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([256], pa.uint16()), pa.lib.ArrowInvalid, pa.array([0], pa.uint8())),
+                (pa.array([65535], pa.uint16()), pa.lib.ArrowInvalid, pa.array([255], pa.uint8())),
             ],
             "uint16": [
                 (
@@ -1531,24 +1592,27 @@ class PyArrowNumericalCastTests(unittest.TestCase):
         casts = {
             "int8": [
                 (pa.array([0, 1, 127, None], pa.uint32()), pa.array([0, 1, 127, None], pa.int8())),
-                (pa.array([128], pa.uint32()), pa.lib.ArrowInvalid),
-                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([128], pa.uint32()), pa.lib.ArrowInvalid, pa.array([-128], pa.int8())),
+                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid, pa.array([-1], pa.int8())),
             ],
             "int16": [
                 (
                     pa.array([0, 1, 32767, None], pa.uint32()),
                     pa.array([0, 1, 32767, None], pa.int16()),
                 ),
-                (pa.array([32768], pa.uint32()), pa.lib.ArrowInvalid),
-                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([32768], pa.uint32()), pa.lib.ArrowInvalid, pa.array([-32768], pa.int16())),
+                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid, pa.array([-1], pa.int16())),
             ],
             "int32": [
                 (
                     pa.array([0, 1, 2147483647, None], pa.uint32()),
                     pa.array([0, 1, 2147483647, None], pa.int32()),
                 ),
-                (pa.array([2147483648], pa.uint32()), pa.lib.ArrowInvalid),
-                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([2147483648], pa.uint32()), pa.lib.ArrowInvalid, pa.array([-2147483648], pa.int32())),
+                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid, pa.array([-1], pa.int32())),
             ],
             "int64": [
                 (
@@ -1560,16 +1624,18 @@ class PyArrowNumericalCastTests(unittest.TestCase):
             ],
             "uint8": [
                 (pa.array([0, 1, 255, None], pa.uint32()), pa.array([0, 1, 255, None], pa.uint8())),
-                (pa.array([256], pa.uint32()), pa.lib.ArrowInvalid),
-                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([256], pa.uint32()), pa.lib.ArrowInvalid, pa.array([0], pa.uint8())),
+                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid, pa.array([255], pa.uint8())),
             ],
             "uint16": [
                 (
                     pa.array([0, 1, 65535, None], pa.uint32()),
                     pa.array([0, 1, 65535, None], pa.uint16()),
                 ),
-                (pa.array([65536], pa.uint32()), pa.lib.ArrowInvalid),
-                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([65536], pa.uint32()), pa.lib.ArrowInvalid, pa.array([0], pa.uint16())),
+                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid, pa.array([65535], pa.uint16())),
             ],
             "uint32": [
                 (
@@ -1590,12 +1656,14 @@ class PyArrowNumericalCastTests(unittest.TestCase):
             "float16": [
                 (pa.array([0, 1, None], pa.uint32()), _make_float16_array([0.0, 1.0, None])),
                 (pa.array([2048], pa.uint32()), _make_float16_array([2048.0])),
-                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid),
+                # Large uint overflows to inf with safe=False
+                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid, _make_float16_array([float('inf')])),
             ],
             "float32": [
                 (pa.array([0, 1, None], pa.uint32()), pa.array([0.0, 1.0, None], pa.float32())),
                 (pa.array([16777216], pa.uint32()), pa.array([16777216.0], pa.float32())),
-                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid),
+                # Large uint loses precision with safe=False
+                (pa.array([4294967295], pa.uint32()), pa.lib.ArrowInvalid, pa.array([4294967296.0], pa.float32())),
             ],
             "float64": [
                 (
@@ -1694,53 +1762,60 @@ class PyArrowNumericalCastTests(unittest.TestCase):
         casts = {
             "int8": [
                 (pa.array([0, 1, 127, None], pa.uint64()), pa.array([0, 1, 127, None], pa.int8())),
-                (pa.array([128], pa.uint64()), pa.lib.ArrowInvalid),
-                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([128], pa.uint64()), pa.lib.ArrowInvalid, pa.array([-128], pa.int8())),
+                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid, pa.array([-1], pa.int8())),
             ],
             "int16": [
                 (
                     pa.array([0, 1, 32767, None], pa.uint64()),
                     pa.array([0, 1, 32767, None], pa.int16()),
                 ),
-                (pa.array([32768], pa.uint64()), pa.lib.ArrowInvalid),
-                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([32768], pa.uint64()), pa.lib.ArrowInvalid, pa.array([-32768], pa.int16())),
+                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid, pa.array([-1], pa.int16())),
             ],
             "int32": [
                 (
                     pa.array([0, 1, 2147483647, None], pa.uint64()),
                     pa.array([0, 1, 2147483647, None], pa.int32()),
                 ),
-                (pa.array([2147483648], pa.uint64()), pa.lib.ArrowInvalid),
-                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([2147483648], pa.uint64()), pa.lib.ArrowInvalid, pa.array([-2147483648], pa.int32())),
+                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid, pa.array([-1], pa.int32())),
             ],
             "int64": [
                 (
                     pa.array([0, 1, 9223372036854775807, None], pa.uint64()),
                     pa.array([0, 1, 9223372036854775807, None], pa.int64()),
                 ),
-                (pa.array([9223372036854775808], pa.uint64()), pa.lib.ArrowInvalid),
-                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([9223372036854775808], pa.uint64()), pa.lib.ArrowInvalid, pa.array([-9223372036854775808], pa.int64())),
+                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid, pa.array([-1], pa.int64())),
             ],
             "uint8": [
                 (pa.array([0, 1, 255, None], pa.uint64()), pa.array([0, 1, 255, None], pa.uint8())),
-                (pa.array([256], pa.uint64()), pa.lib.ArrowInvalid),
-                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([256], pa.uint64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint8())),
+                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid, pa.array([255], pa.uint8())),
             ],
             "uint16": [
                 (
                     pa.array([0, 1, 65535, None], pa.uint64()),
                     pa.array([0, 1, 65535, None], pa.uint16()),
                 ),
-                (pa.array([65536], pa.uint64()), pa.lib.ArrowInvalid),
-                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([65536], pa.uint64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint16())),
+                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid, pa.array([65535], pa.uint16())),
             ],
             "uint32": [
                 (
                     pa.array([0, 1, 4294967295, None], pa.uint64()),
                     pa.array([0, 1, 4294967295, None], pa.uint32()),
                 ),
-                (pa.array([4294967296], pa.uint64()), pa.lib.ArrowInvalid),
-                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid),
+                # Overflow: safe=True raises, safe=False wraps
+                (pa.array([4294967296], pa.uint64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint32())),
+                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid, pa.array([4294967295], pa.uint32())),
             ],
             "uint64": [
                 (
@@ -1756,12 +1831,14 @@ class PyArrowNumericalCastTests(unittest.TestCase):
             "float16": [
                 (pa.array([0, 1, None], pa.uint64()), _make_float16_array([0.0, 1.0, None])),
                 (pa.array([2048], pa.uint64()), _make_float16_array([2048.0])),
-                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid),
+                # Large uint overflows to inf with safe=False
+                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid, _make_float16_array([float('inf')])),
             ],
             "float32": [
                 (pa.array([0, 1, None], pa.uint64()), pa.array([0.0, 1.0, None], pa.float32())),
                 (pa.array([16777216], pa.uint64()), pa.array([16777216.0], pa.float32())),
-                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid),
+                # Large uint loses precision with safe=False
+                (pa.array([18446744073709551615], pa.uint64()), pa.lib.ArrowInvalid, pa.array([1.8446744073709552e+19], pa.float32())),
             ],
             "float64": [
                 (pa.array([0, 1, None], pa.uint64()), pa.array([0.0, 1.0, None], pa.float64())),
@@ -1769,7 +1846,8 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([9007199254740992], pa.uint64()),
                     pa.array([9007199254740992.0], pa.float64()),
                 ),
-                (pa.array([9007199254740993], pa.uint64()), pa.lib.ArrowInvalid),
+                # Precision loss: safe=True raises, safe=False truncates
+                (pa.array([9007199254740993], pa.uint64()), pa.lib.ArrowInvalid, pa.array([9007199254740992.0], pa.float64())),
             ],
             # === Non-numerical types ===
             "bool": [
@@ -1871,14 +1949,14 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     _make_float16_array([0.0, 1.0, -1.0, 127.0, -128.0, None]),
                     pa.array([0, 1, -1, 127, -128, None], pa.int8()),
                 ),
-                # fractional values -> ArrowInvalid
-                (_make_float16_array([1.5, -0.5]), pa.lib.ArrowInvalid),
-                # overflow int8 range
-                (_make_float16_array([128.0]), pa.lib.ArrowInvalid),
-                (_make_float16_array([-129.0]), pa.lib.ArrowInvalid),
-                # special: NaN, Inf -> ArrowInvalid for int
-                (_make_float16_array([float("nan")]), pa.lib.ArrowInvalid),
-                (_make_float16_array([float("inf")]), pa.lib.ArrowInvalid),
+                # fractional values: safe=False truncates
+                (_make_float16_array([1.5, -0.5]), pa.lib.ArrowInvalid, pa.array([1, 0], pa.int8())),
+                # overflow int8 range: safe=False wraps
+                (_make_float16_array([128.0]), pa.lib.ArrowInvalid, pa.array([-128], pa.int8())),
+                (_make_float16_array([-129.0]), pa.lib.ArrowInvalid, pa.array([127], pa.int8())),
+                # special: NaN, Inf: safe=False produces implementation-defined value
+                (_make_float16_array([float("nan")]), pa.lib.ArrowInvalid, pa.array([0], pa.int8())),
+                (_make_float16_array([float("inf")]), pa.lib.ArrowInvalid, pa.array([-1], pa.int8())),
             ],
             "int16": [
                 # Note: float16 can only represent integers exactly up to 2048
@@ -1886,39 +1964,48 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     _make_float16_array([0.0, 1.0, -1.0, 2048.0, -2048.0, None]),
                     pa.array([0, 1, -1, 2048, -2048, None], pa.int16()),
                 ),
-                (_make_float16_array([1.5]), pa.lib.ArrowInvalid),
-                # float16 max (65504) overflows int16 max (32767)
-                (_make_float16_array([f16_max]), pa.lib.ArrowInvalid),
-                (_make_float16_array([float("nan")]), pa.lib.ArrowInvalid),
+                # fractional: safe=False truncates
+                (_make_float16_array([1.5]), pa.lib.ArrowInvalid, pa.array([1], pa.int16())),
+                # float16 max (65504) overflows int16 max (32767): safe=False wraps
+                (_make_float16_array([f16_max]), pa.lib.ArrowInvalid, pa.array([-32], pa.int16())),
+                # NaN: safe=False produces implementation-defined value
+                (_make_float16_array([float("nan")]), pa.lib.ArrowInvalid, pa.array([0], pa.int16())),
             ],
             "int32": [
                 (
                     _make_float16_array([0.0, 1.0, -1.0, f16_max, None]),
                     pa.array([0, 1, -1, 65504, None], pa.int32()),
                 ),
-                (_make_float16_array([1.5]), pa.lib.ArrowInvalid),
-                (_make_float16_array([float("inf")]), pa.lib.ArrowInvalid),
-                (_make_float16_array([float("nan")]), pa.lib.ArrowInvalid),
+                # fractional: safe=False truncates
+                (_make_float16_array([1.5]), pa.lib.ArrowInvalid, pa.array([1], pa.int32())),
+                # inf: safe=False produces implementation-defined value
+                (_make_float16_array([float("inf")]), pa.lib.ArrowInvalid, pa.array([2147483647], pa.int32())),
+                # NaN: safe=False produces implementation-defined value
+                (_make_float16_array([float("nan")]), pa.lib.ArrowInvalid, pa.array([0], pa.int32())),
             ],
             "int64": [
                 (
                     _make_float16_array([0.0, 1.0, -1.0, f16_max, None]),
                     pa.array([0, 1, -1, 65504, None], pa.int64()),
                 ),
-                (_make_float16_array([1.5]), pa.lib.ArrowInvalid),
-                (_make_float16_array([float("-inf")]), pa.lib.ArrowInvalid),
-                (_make_float16_array([float("nan")]), pa.lib.ArrowInvalid),
+                # fractional: safe=False truncates
+                (_make_float16_array([1.5]), pa.lib.ArrowInvalid, pa.array([1], pa.int64())),
+                # -inf: safe=False produces implementation-defined value
+                (_make_float16_array([float("-inf")]), pa.lib.ArrowInvalid, pa.array([-9223372036854775808], pa.int64())),
+                # NaN: safe=False produces implementation-defined value
+                (_make_float16_array([float("nan")]), pa.lib.ArrowInvalid, pa.array([0], pa.int64())),
             ],
             "uint8": [
                 (
                     _make_float16_array([0.0, 1.0, 255.0, None]),
                     pa.array([0, 1, 255, None], pa.uint8()),
                 ),
-                # negative values -> ArrowInvalid for unsigned
-                (_make_float16_array([-1.0]), pa.lib.ArrowInvalid),
-                # overflow uint8 range
-                (_make_float16_array([256.0]), pa.lib.ArrowInvalid),
-                (_make_float16_array([float("nan")]), pa.lib.ArrowInvalid),
+                # negative values: safe=False wraps
+                (_make_float16_array([-1.0]), pa.lib.ArrowInvalid, pa.array([255], pa.uint8())),
+                # overflow uint8 range: safe=False wraps
+                (_make_float16_array([256.0]), pa.lib.ArrowInvalid, pa.array([0], pa.uint8())),
+                # NaN: safe=False produces implementation-defined value
+                (_make_float16_array([float("nan")]), pa.lib.ArrowInvalid, pa.array([0], pa.uint8())),
             ],
             "uint16": [
                 # Note: float16 can only represent integers exactly up to 2048
@@ -1926,28 +2013,36 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     _make_float16_array([0.0, 1.0, 2048.0, None]),
                     pa.array([0, 1, 2048, None], pa.uint16()),
                 ),
-                (_make_float16_array([-1.0]), pa.lib.ArrowInvalid),
-                # fractional
-                (_make_float16_array([1.5]), pa.lib.ArrowInvalid),
-                (_make_float16_array([float("inf")]), pa.lib.ArrowInvalid),
+                # negative: safe=False wraps
+                (_make_float16_array([-1.0]), pa.lib.ArrowInvalid, pa.array([65535], pa.uint16())),
+                # fractional: safe=False truncates
+                (_make_float16_array([1.5]), pa.lib.ArrowInvalid, pa.array([1], pa.uint16())),
+                # inf: safe=False produces implementation-defined value
+                (_make_float16_array([float("inf")]), pa.lib.ArrowInvalid, pa.array([65535], pa.uint16())),
             ],
             "uint32": [
                 (
                     _make_float16_array([0.0, 1.0, f16_max, None]),
                     pa.array([0, 1, 65504, None], pa.uint32()),
                 ),
-                (_make_float16_array([-1.0]), pa.lib.ArrowInvalid),
-                (_make_float16_array([1.5]), pa.lib.ArrowInvalid),
-                (_make_float16_array([float("nan")]), pa.lib.ArrowInvalid),
+                # negative: safe=False wraps
+                (_make_float16_array([-1.0]), pa.lib.ArrowInvalid, pa.array([0], pa.uint32())),
+                # fractional: safe=False truncates
+                (_make_float16_array([1.5]), pa.lib.ArrowInvalid, pa.array([1], pa.uint32())),
+                # NaN: safe=False produces implementation-defined value
+                (_make_float16_array([float("nan")]), pa.lib.ArrowInvalid, pa.array([0], pa.uint32())),
             ],
             "uint64": [
                 (
                     _make_float16_array([0.0, 1.0, f16_max, None]),
                     pa.array([0, 1, 65504, None], pa.uint64()),
                 ),
-                (_make_float16_array([-1.0]), pa.lib.ArrowInvalid),
-                (_make_float16_array([1.5]), pa.lib.ArrowInvalid),
-                (_make_float16_array([float("-inf")]), pa.lib.ArrowInvalid),
+                # negative: safe=False wraps
+                (_make_float16_array([-1.0]), pa.lib.ArrowInvalid, pa.array([0], pa.uint64())),
+                # fractional: safe=False truncates
+                (_make_float16_array([1.5]), pa.lib.ArrowInvalid, pa.array([1], pa.uint64())),
+                # -inf: safe=False produces implementation-defined value
+                (_make_float16_array([float("-inf")]), pa.lib.ArrowInvalid, pa.array([0], pa.uint64())),
             ],
             "float16": [
                 # identity cast: normal values + special values
@@ -2082,17 +2177,24 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0.0, 1.0, -1.0, 127.0, -128.0, None], pa.float32()),
                     pa.array([0, 1, -1, 127, -128, None], pa.int8()),
                 ),
+                # fractional/overflow/special: safe=False truncates/wraps
                 (
                     pa.array([1.5, 128.0, float("nan")], pa.float32()),
                     pa.lib.ArrowInvalid,
-                ),  # fractional/overflow/special
+                    pa.array([1, -128, 0], pa.int8()),
+                ),
             ],
             "int16": [
                 (
                     pa.array([0.0, 1.0, -1.0, 32767.0, -32768.0, None], pa.float32()),
                     pa.array([0, 1, -1, 32767, -32768, None], pa.int16()),
                 ),
-                (pa.array([1.5, 32768.0, float("inf")], pa.float32()), pa.lib.ArrowInvalid),
+                # fractional/overflow/inf: safe=False truncates/wraps
+                (
+                    pa.array([1.5, 32768.0, float("inf")], pa.float32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([1, -32768, -1], pa.int16()),
+                ),
             ],
             "int32": [
                 (
@@ -2104,39 +2206,66 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([2147483648.0], pa.float32()),
                     _get_float_to_int_boundary_expected(pa.int32()),
                 ),
+                # fractional/overflow/special: safe=False truncates/wraps
                 (
                     pa.array([1.5, 3e9, float("nan")], pa.float32()),
                     pa.lib.ArrowInvalid,
-                ),  # fractional/overflow/special
+                    pa.array([1, 2147483647, 0], pa.int32()),
+                ),
             ],
             "int64": [
                 (
                     pa.array([0.0, 1.0, -1.0, None], pa.float32()),
                     pa.array([0, 1, -1, None], pa.int64()),
                 ),
-                (pa.array([1.5, f32_max, float("inf")], pa.float32()), pa.lib.ArrowInvalid),
+                # fractional/overflow/inf: safe=False truncates
+                (
+                    pa.array([1.5, f32_max, float("inf")], pa.float32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([1, 9223372036854775807, 9223372036854775807], pa.int64()),
+                ),
             ],
             "uint8": [
                 (
                     pa.array([0.0, 1.0, 255.0, None], pa.float32()),
                     pa.array([0, 1, 255, None], pa.uint8()),
                 ),
-                (pa.array([-1.0, 256.0, float("nan")], pa.float32()), pa.lib.ArrowInvalid),
+                # negative/overflow/nan: safe=False wraps
+                (
+                    pa.array([-1.0, 256.0, float("nan")], pa.float32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([255, 0, 0], pa.uint8()),
+                ),
             ],
             "uint16": [
                 (
                     pa.array([0.0, 1.0, 65535.0, None], pa.float32()),
                     pa.array([0, 1, 65535, None], pa.uint16()),
                 ),
-                (pa.array([-1.0, 65536.0, float("inf")], pa.float32()), pa.lib.ArrowInvalid),
+                # negative/overflow/inf: safe=False wraps
+                (
+                    pa.array([-1.0, 65536.0, float("inf")], pa.float32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([65535, 0, 65535], pa.uint16()),
+                ),
             ],
             "uint32": [
                 (pa.array([0.0, 1.0, None], pa.float32()), pa.array([0, 1, None], pa.uint32())),
-                (pa.array([-1.0, 1.5, float("nan")], pa.float32()), pa.lib.ArrowInvalid),
+                # negative/fractional/nan: safe=False wraps/truncates
+                (
+                    pa.array([-1.0, 1.5, float("nan")], pa.float32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0, 1, 0], pa.uint32()),
+                ),
             ],
             "uint64": [
                 (pa.array([0.0, 1.0, None], pa.float32()), pa.array([0, 1, None], pa.uint64())),
-                (pa.array([-1.0, 1.5, float("-inf")], pa.float32()), pa.lib.ArrowInvalid),
+                # negative/fractional/-inf: safe=False wraps/truncates
+                (
+                    pa.array([-1.0, 1.5, float("-inf")], pa.float32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([0, 1, 0], pa.uint64()),
+                ),
             ],
             "float16": [
                 # values within float16 range
@@ -2244,7 +2373,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([1.5, -2.5], pa.float32()),
                     pa.array([Decimal("1.5"), Decimal("-2.5")], pa.decimal128(38, 10)),
                 ),
-                (pa.array([float("nan")], pa.float32()), pa.lib.ArrowInvalid),
+                # NaN: safe=False produces 0
+                (
+                    pa.array([float("nan")], pa.float32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([Decimal("0E-10")], pa.decimal128(38, 10)),
+                ),
             ],
             "decimal256": [
                 (
@@ -2253,7 +2387,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                         [Decimal("0"), Decimal("1"), Decimal("-1"), None], pa.decimal256(76, 10)
                     ),
                 ),
-                (pa.array([float("inf")], pa.float32()), pa.lib.ArrowInvalid),
+                # inf: safe=False produces 0
+                (
+                    pa.array([float("inf")], pa.float32()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([Decimal("0E-10")], pa.decimal256(76, 10)),
+                ),
             ],
             "date32": [(pa.array([0.0], pa.float32()), pa.lib.ArrowNotImplementedError)],
             "date64": [(pa.array([0.0], pa.float32()), pa.lib.ArrowNotImplementedError)],
@@ -2308,62 +2447,67 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0.0, 1.0, -1.0, 127.0, -128.0, None], pa.float64()),
                     pa.array([0, 1, -1, 127, -128, None], pa.int8()),
                 ),
-                # fractional
-                (pa.array([1.5, 0.1, 127.9], pa.float64()), pa.lib.ArrowInvalid),
-                # overflow
-                (pa.array([128.0], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([-129.0], pa.float64()), pa.lib.ArrowInvalid),
-                # === SPECIAL VALUES: NaN, Inf, -Inf -> ArrowInvalid for int ===
-                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid),
-                # mixed array with special value fails
-                (pa.array([1.0, float("nan")], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([0.0, float("inf")], pa.float64()), pa.lib.ArrowInvalid),
+                # fractional: safe=False truncates
+                (pa.array([1.5, 0.1, 127.9], pa.float64()), pa.lib.ArrowInvalid, pa.array([1, 0, 127], pa.int8())),
+                # overflow: safe=False wraps
+                (pa.array([128.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([-128], pa.int8())),
+                (pa.array([-129.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([127], pa.int8())),
+                # === SPECIAL VALUES: safe=False produces implementation-defined values ===
+                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.int8())),
+                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([-1], pa.int8())),
+                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.int8())),
+                # mixed array with special value
+                (pa.array([1.0, float("nan")], pa.float64()), pa.lib.ArrowInvalid, pa.array([1, 0], pa.int8())),
+                (pa.array([0.0, float("inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0, -1], pa.int8())),
             ],
             "int16": [
                 (
                     pa.array([0.0, 1.0, -1.0, 32767.0, -32768.0, None], pa.float64()),
                     pa.array([0, 1, -1, 32767, -32768, None], pa.int16()),
                 ),
-                (pa.array([1.5], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([32768.0], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([-32769.0], pa.float64()), pa.lib.ArrowInvalid),
-                # === SPECIAL VALUES ===
-                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid),
+                # fractional: safe=False truncates
+                (pa.array([1.5], pa.float64()), pa.lib.ArrowInvalid, pa.array([1], pa.int16())),
+                # overflow: safe=False wraps
+                (pa.array([32768.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([-32768], pa.int16())),
+                (pa.array([-32769.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([32767], pa.int16())),
+                # === SPECIAL VALUES: safe=False produces implementation-defined values ===
+                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.int16())),
+                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([-1], pa.int16())),
+                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.int16())),
             ],
             "int32": [
                 (
                     pa.array([0.0, 1.0, -1.0, 2147483647.0, -2147483648.0, None], pa.float64()),
                     pa.array([0, 1, -1, 2147483647, -2147483648, None], pa.int32()),
                 ),
-                (pa.array([1.5], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([2147483648.0], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([-2147483649.0], pa.float64()), pa.lib.ArrowInvalid),
-                # === SPECIAL VALUES ===
-                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid),
+                # fractional: safe=False truncates
+                (pa.array([1.5], pa.float64()), pa.lib.ArrowInvalid, pa.array([1], pa.int32())),
+                # overflow: safe=False wraps/saturates
+                (pa.array([2147483648.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([2147483647], pa.int32())),
+                (pa.array([-2147483649.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([-2147483648], pa.int32())),
+                # === SPECIAL VALUES: safe=False produces implementation-defined values ===
+                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.int32())),
+                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([2147483647], pa.int32())),
+                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([-2147483648], pa.int32())),
             ],
             "int64": [
                 (
                     pa.array([0.0, 1.0, -1.0, None], pa.float64()),
                     pa.array([0, 1, -1, None], pa.int64()),
                 ),
-                (pa.array([1.5], pa.float64()), pa.lib.ArrowInvalid),
+                # fractional: safe=False truncates
+                (pa.array([1.5], pa.float64()), pa.lib.ArrowInvalid, pa.array([1], pa.int64())),
                 # float64 9223372036854775808.0 boundary: behavior varies across environments
                 (
                     pa.array([9223372036854775808.0], pa.float64()),
                     _get_float_to_int_boundary_expected(pa.int64()),
                 ),
-                # truly overflow - values beyond int64 range
-                (pa.array([1e19], pa.float64()), pa.lib.ArrowInvalid),
-                # === SPECIAL VALUES ===
-                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid),
+                # truly overflow: safe=False saturates
+                (pa.array([1e19], pa.float64()), pa.lib.ArrowInvalid, pa.array([9223372036854775807], pa.int64())),
+                # === SPECIAL VALUES: safe=False produces implementation-defined values ===
+                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.int64())),
+                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([9223372036854775807], pa.int64())),
+                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([-9223372036854775808], pa.int64())),
                 # large but valid: 2^53 is exactly representable in float64
                 (
                     pa.array([9007199254740992.0], pa.float64()),
@@ -2375,43 +2519,50 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([0.0, 1.0, 255.0, None], pa.float64()),
                     pa.array([0, 1, 255, None], pa.uint8()),
                 ),
-                (pa.array([-1.0], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([256.0], pa.float64()), pa.lib.ArrowInvalid),
-                # === SPECIAL VALUES: all fail for unsigned ===
-                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid),
+                # negative: safe=False wraps
+                (pa.array([-1.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([255], pa.uint8())),
+                # overflow: safe=False wraps
+                (pa.array([256.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint8())),
+                # === SPECIAL VALUES: safe=False produces implementation-defined values ===
+                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint8())),
+                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([255], pa.uint8())),
+                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint8())),
             ],
             "uint16": [
                 (
                     pa.array([0.0, 1.0, 65535.0, None], pa.float64()),
                     pa.array([0, 1, 65535, None], pa.uint16()),
                 ),
-                (pa.array([-1.0], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([65536.0], pa.float64()), pa.lib.ArrowInvalid),
-                # === SPECIAL VALUES ===
-                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid),
+                # negative: safe=False wraps
+                (pa.array([-1.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([65535], pa.uint16())),
+                # overflow: safe=False wraps
+                (pa.array([65536.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint16())),
+                # === SPECIAL VALUES: safe=False produces implementation-defined values ===
+                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([65535], pa.uint16())),
+                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint16())),
+                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint16())),
             ],
             "uint32": [
                 (
                     pa.array([0.0, 1.0, 4294967295.0, None], pa.float64()),
                     pa.array([0, 1, 4294967295, None], pa.uint32()),
                 ),
-                (pa.array([-1.0], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([4294967296.0], pa.float64()), pa.lib.ArrowInvalid),
-                # === SPECIAL VALUES ===
-                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid),
-                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid),
+                # negative: safe=False wraps
+                (pa.array([-1.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint32())),
+                # overflow: safe=False wraps
+                (pa.array([4294967296.0], pa.float64()), pa.lib.ArrowInvalid, pa.array([4294967295], pa.uint32())),
+                # === SPECIAL VALUES: safe=False produces implementation-defined values ===
+                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint32())),
+                (pa.array([float("inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([4294967295], pa.uint32())),
+                (pa.array([float("-inf")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0], pa.uint32())),
             ],
             "uint64": [
                 (
                     pa.array([0.0, 1.0, 9007199254740992.0, None], pa.float64()),
                     pa.array([0, 1, 9007199254740992, None], pa.uint64()),
                 ),
-                (pa.array([-1.0, 1.5, float("nan")], pa.float64()), pa.lib.ArrowInvalid),
+                # negative/fractional/nan: safe=False wraps/truncates
+                (pa.array([-1.0, 1.5, float("nan")], pa.float64()), pa.lib.ArrowInvalid, pa.array([0, 1, 0], pa.uint64())),
             ],
             "float16": [
                 # normal values + special values
@@ -2511,7 +2662,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                         pa.decimal128(38, 10),
                     ),
                 ),
-                (pa.array([float("nan"), float("inf")], pa.float64()), pa.lib.ArrowInvalid),
+                # NaN/inf: safe=False produces 0
+                (
+                    pa.array([float("nan"), float("inf")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([Decimal("0E-10"), Decimal("0E-10")], pa.decimal128(38, 10)),
+                ),
             ],
             "decimal256": [
                 (
@@ -2521,7 +2677,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                         pa.decimal256(76, 10),
                     ),
                 ),
-                (pa.array([float("nan")], pa.float64()), pa.lib.ArrowInvalid),
+                # NaN: safe=False produces 0
+                (
+                    pa.array([float("nan")], pa.float64()),
+                    pa.lib.ArrowInvalid,
+                    pa.array([Decimal("0E-10")], pa.decimal256(76, 10)),
+                ),
             ],
             "date32": [(pa.array([0.0], pa.float64()), pa.lib.ArrowNotImplementedError)],
             "date64": [(pa.array([0.0], pa.float64()), pa.lib.ArrowNotImplementedError)],
@@ -3129,9 +3290,9 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array(["你好", None], pa.string()),
                 ),
                 (pa.array(["😀".encode("utf-8")], pa.binary()), pa.array(["😀"], pa.string())),
-                # Invalid UTF-8 sequences -> ArrowInvalid
-                (pa.array([b"\xff\xfe"], pa.binary()), pa.lib.ArrowInvalid),
-                (pa.array([b"\x80\x81\x82"], pa.binary()), pa.lib.ArrowInvalid),
+                # Invalid UTF-8 sequences: safe=True -> ArrowInvalid, safe=False -> UnicodeDecodeError
+                (pa.array([b"\xff\xfe"], pa.binary()), pa.lib.ArrowInvalid, UnicodeDecodeError),
+                (pa.array([b"\x80\x81\x82"], pa.binary()), pa.lib.ArrowInvalid, UnicodeDecodeError),
             ],
             "large_string": [
                 (
@@ -3435,17 +3596,23 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     ),
                     pa.array([0, 1, -1, None], pa.int8()),
                 ),
+                # fractional: safe=False truncates
                 (
                     pa.array([Decimal("1.5")], pa.decimal128(38, 10)),
                     pa.lib.ArrowInvalid,
-                ),  # fractional
+                    pa.array([1], pa.int8()),
+                ),
                 # Boundary: int8 max/min
                 (
                     pa.array([Decimal("127"), Decimal("-128")], pa.decimal128(38, 10)),
                     pa.array([127, -128], pa.int8()),
                 ),
-                # Overflow: beyond int8 range
-                (pa.array([Decimal("128")], pa.decimal128(38, 10)), pa.lib.ArrowInvalid),
+                # Overflow: safe=False wraps
+                (
+                    pa.array([Decimal("128")], pa.decimal128(38, 10)),
+                    pa.lib.ArrowInvalid,
+                    pa.array([-128], pa.int8()),
+                ),
             ],
             "int16": [
                 (
@@ -3469,10 +3636,11 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([Decimal("9223372036854775807")], pa.decimal128(38, 0)),
                     pa.array([9223372036854775807], pa.int64()),
                 ),  # int64 max
-                # Overflow: int64 max + 1
+                # Overflow: safe=False wraps
                 (
                     pa.array([Decimal("9223372036854775808")], pa.decimal128(38, 0)),
                     pa.lib.ArrowInvalid,
+                    pa.array([-9223372036854775808], pa.int64()),
                 ),
             ],
             "uint8": [
@@ -4302,7 +4470,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([ts_lossless, None], pa.timestamp("ms")),
                     pa.array([epoch_ms_lossless // 1000, None], pa.timestamp("s")),
                 ),
-                (pa.array([ts_lossy], pa.timestamp("ms")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([ts_lossy], pa.timestamp("ms")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ms_lossless // 1000], pa.timestamp("s")),
+                ),
             ],
             "timestamp_ms": [
                 (
@@ -4328,7 +4501,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([ts_lossless, None], pa.timestamp("ms")),
                     pa.array([epoch_ms_lossless // 1000, None], pa.timestamp("s", tz="UTC")),
                 ),
-                (pa.array([ts_lossy], pa.timestamp("ms")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([ts_lossy], pa.timestamp("ms")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ms_lossless // 1000], pa.timestamp("s", tz="UTC")),
+                ),
             ],
             "timestamp_ms_tz": [
                 (
@@ -4355,7 +4533,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                         [epoch_ms_lossless // 1000, None], pa.timestamp("s", tz="America/New_York")
                     ),
                 ),
-                (pa.array([ts_lossy], pa.timestamp("ms")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([ts_lossy], pa.timestamp("ms")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ms_lossless // 1000], pa.timestamp("s", tz="America/New_York")),
+                ),
             ],
             "timestamp_s_tz_shanghai": [
                 (
@@ -4364,7 +4547,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                         [epoch_ms_lossless // 1000, None], pa.timestamp("s", tz="Asia/Shanghai")
                     ),
                 ),
-                (pa.array([ts_lossy], pa.timestamp("ms")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([ts_lossy], pa.timestamp("ms")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ms_lossless // 1000], pa.timestamp("s", tz="Asia/Shanghai")),
+                ),
             ],
             # timestamp[ms] -> duration (not supported)
             "duration_s": [
@@ -4385,7 +4573,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([ts_lossless, None], pa.timestamp("ms")),
                     pa.array([datetime.time(12, 30, 45), None], pa.time32("s")),
                 ),
-                (pa.array([ts_lossy], pa.timestamp("ms")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([ts_lossy], pa.timestamp("ms")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([datetime.time(12, 30, 45)], pa.time32("s")),
+                ),
             ],
             "time32_ms": [
                 (
@@ -4492,14 +4685,24 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([ts_lossless, None], pa.timestamp("us")),
                     pa.array([epoch_us_lossless // 1000000, None], pa.timestamp("s")),
                 ),
-                (pa.array([ts_lossy], pa.timestamp("us")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([ts_lossy], pa.timestamp("us")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_us_lossless // 1000000], pa.timestamp("s")),
+                ),
             ],
             "timestamp_ms": [
                 (
                     pa.array([ts_lossless, None], pa.timestamp("us")),
                     pa.array([epoch_us_lossless // 1000, None], pa.timestamp("ms")),
                 ),
-                (pa.array([ts_lossy], pa.timestamp("us")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps ms precision)
+                (
+                    pa.array([ts_lossy], pa.timestamp("us")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_us_lossless // 1000 + 123], pa.timestamp("ms")),  # 123ms
+                ),
             ],
             "timestamp_us": [
                 (
@@ -4519,14 +4722,24 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([ts_lossless, None], pa.timestamp("us")),
                     pa.array([epoch_us_lossless // 1000000, None], pa.timestamp("s", tz="UTC")),
                 ),
-                (pa.array([ts_lossy], pa.timestamp("us")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([ts_lossy], pa.timestamp("us")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_us_lossless // 1000000], pa.timestamp("s", tz="UTC")),
+                ),
             ],
             "timestamp_ms_tz": [
                 (
                     pa.array([ts_lossless, None], pa.timestamp("us")),
                     pa.array([epoch_us_lossless // 1000, None], pa.timestamp("ms", tz="UTC")),
                 ),
-                (pa.array([ts_lossy], pa.timestamp("us")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps ms precision)
+                (
+                    pa.array([ts_lossy], pa.timestamp("us")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_us_lossless // 1000 + 123], pa.timestamp("ms", tz="UTC")),
+                ),
             ],
             "timestamp_us_tz": [
                 (
@@ -4548,7 +4761,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                         pa.timestamp("s", tz="America/New_York"),
                     ),
                 ),
-                (pa.array([ts_lossy], pa.timestamp("us")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([ts_lossy], pa.timestamp("us")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_us_lossless // 1000000], pa.timestamp("s", tz="America/New_York")),
+                ),
             ],
             "timestamp_s_tz_shanghai": [
                 (
@@ -4557,7 +4775,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                         [epoch_us_lossless // 1000000, None], pa.timestamp("s", tz="Asia/Shanghai")
                     ),
                 ),
-                (pa.array([ts_lossy], pa.timestamp("us")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([ts_lossy], pa.timestamp("us")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_us_lossless // 1000000], pa.timestamp("s", tz="Asia/Shanghai")),
+                ),
             ],
             # timestamp[us] -> duration (not supported)
             "duration_s": [
@@ -4578,14 +4801,24 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([ts_lossless, None], pa.timestamp("us")),
                     pa.array([datetime.time(12, 30, 45), None], pa.time32("s")),
                 ),
-                (pa.array([ts_lossy], pa.timestamp("us")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([ts_lossy], pa.timestamp("us")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([datetime.time(12, 30, 45)], pa.time32("s")),
+                ),
             ],
             "time32_ms": [
                 (
                     pa.array([ts_lossless, None], pa.timestamp("us")),
                     pa.array([datetime.time(12, 30, 45), None], pa.time32("ms")),
                 ),
-                (pa.array([ts_lossy], pa.timestamp("us")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps ms precision)
+                (
+                    pa.array([ts_lossy], pa.timestamp("us")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([datetime.time(12, 30, 45, 123000)], pa.time32("ms")),
+                ),
             ],
             "time64_us": [
                 (
@@ -4705,22 +4938,36 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([epoch_ns_lossless, None], pa.timestamp("ns")),
                     pa.array([epoch_ns_lossless // 1000000000, None], pa.timestamp("s")),
                 ),
-                # Lossy conversion fails with safe=True
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ns_lossless // 1000000000], pa.timestamp("s")),
+                ),
             ],
             "timestamp_ms": [
                 (
                     pa.array([epoch_ns_lossless, None], pa.timestamp("ns")),
                     pa.array([epoch_ns_lossless // 1000000, None], pa.timestamp("ms")),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps ms precision)
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ns_lossless // 1000000 + 123], pa.timestamp("ms")),
+                ),
             ],
             "timestamp_us": [
                 (
                     pa.array([epoch_ns_lossless, None], pa.timestamp("ns")),
                     pa.array([epoch_ns_lossless // 1000, None], pa.timestamp("us")),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps us precision)
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ns_lossless // 1000 + 123456], pa.timestamp("us")),
+                ),
             ],
             "timestamp_ns": [
                 (
@@ -4734,21 +4981,36 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([epoch_ns_lossless, None], pa.timestamp("ns")),
                     pa.array([epoch_ns_lossless // 1000000000, None], pa.timestamp("s", tz="UTC")),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ns_lossless // 1000000000], pa.timestamp("s", tz="UTC")),
+                ),
             ],
             "timestamp_ms_tz": [
                 (
                     pa.array([epoch_ns_lossless, None], pa.timestamp("ns")),
                     pa.array([epoch_ns_lossless // 1000000, None], pa.timestamp("ms", tz="UTC")),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps ms precision)
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ns_lossless // 1000000 + 123], pa.timestamp("ms", tz="UTC")),
+                ),
             ],
             "timestamp_us_tz": [
                 (
                     pa.array([epoch_ns_lossless, None], pa.timestamp("ns")),
                     pa.array([epoch_ns_lossless // 1000, None], pa.timestamp("us", tz="UTC")),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps us precision)
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ns_lossless // 1000 + 123456], pa.timestamp("us", tz="UTC")),
+                ),
             ],
             "timestamp_ns_tz": [
                 (
@@ -4764,7 +5026,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                         pa.timestamp("s", tz="America/New_York"),
                     ),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ns_lossless // 1000000000], pa.timestamp("s", tz="America/New_York")),
+                ),
             ],
             "timestamp_s_tz_shanghai": [
                 (
@@ -4774,7 +5041,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                         pa.timestamp("s", tz="Asia/Shanghai"),
                     ),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ns_lossless // 1000000000], pa.timestamp("s", tz="Asia/Shanghai")),
+                ),
             ],
             # timestamp[ns] -> duration (not supported)
             "duration_s": [
@@ -4795,21 +5067,36 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([epoch_ns_lossless, None], pa.timestamp("ns")),
                     pa.array([datetime.time(12, 30, 45), None], pa.time32("s")),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([datetime.time(12, 30, 45)], pa.time32("s")),
+                ),
             ],
             "time32_ms": [
                 (
                     pa.array([epoch_ns_lossless, None], pa.timestamp("ns")),
                     pa.array([datetime.time(12, 30, 45), None], pa.time32("ms")),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps ms precision)
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([datetime.time(12, 30, 45, 123000)], pa.time32("ms")),
+                ),
             ],
             "time64_us": [
                 (
                     pa.array([epoch_ns_lossless, None], pa.timestamp("ns")),
                     pa.array([datetime.time(12, 30, 45), None], pa.time64("us")),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps us precision)
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([datetime.time(12, 30, 45, 123456)], pa.time64("us")),
+                ),
             ],
             "time64_ns": [
                 (
@@ -5164,7 +5451,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([epoch_ms_lossless, None], pa.timestamp("ms", tz="UTC")),
                     pa.array([epoch_ms_lossless // 1000, None], pa.timestamp("s")),
                 ),
-                (pa.array([epoch_ms_lossy], pa.timestamp("ms", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([epoch_ms_lossy], pa.timestamp("ms", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ms_lossless // 1000], pa.timestamp("s")),
+                ),
             ],
             "timestamp_ms": [
                 (
@@ -5190,7 +5482,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([epoch_ms_lossless, None], pa.timestamp("ms", tz="UTC")),
                     pa.array([epoch_ms_lossless // 1000, None], pa.timestamp("s", tz="UTC")),
                 ),
-                (pa.array([epoch_ms_lossy], pa.timestamp("ms", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([epoch_ms_lossy], pa.timestamp("ms", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ms_lossless // 1000], pa.timestamp("s", tz="UTC")),
+                ),
             ],
             "timestamp_ms_tz": [
                 (
@@ -5217,7 +5514,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                         [epoch_ms_lossless // 1000, None], pa.timestamp("s", tz="America/New_York")
                     ),
                 ),
-                (pa.array([epoch_ms_lossy], pa.timestamp("ms", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([epoch_ms_lossy], pa.timestamp("ms", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ms_lossless // 1000], pa.timestamp("s", tz="America/New_York")),
+                ),
             ],
             "timestamp_s_tz_shanghai": [
                 (
@@ -5226,7 +5528,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                         [epoch_ms_lossless // 1000, None], pa.timestamp("s", tz="Asia/Shanghai")
                     ),
                 ),
-                (pa.array([epoch_ms_lossy], pa.timestamp("ms", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([epoch_ms_lossy], pa.timestamp("ms", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ms_lossless // 1000], pa.timestamp("s", tz="Asia/Shanghai")),
+                ),
             ],
             # timestamp[ms,tz] -> duration (not supported)
             "duration_s": [
@@ -5259,7 +5566,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([epoch_ms_lossless, None], pa.timestamp("ms", tz="UTC")),
                     pa.array([datetime.time(12, 30, 45), None], pa.time32("s")),
                 ),
-                (pa.array([epoch_ms_lossy], pa.timestamp("ms", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([epoch_ms_lossy], pa.timestamp("ms", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([datetime.time(12, 30, 45)], pa.time32("s")),
+                ),
             ],
             "time32_ms": [
                 (
@@ -5430,14 +5742,24 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([epoch_us_lossless, None], pa.timestamp("us", tz="UTC")),
                     pa.array([epoch_us_lossless // 1000000, None], pa.timestamp("s")),
                 ),
-                (pa.array([epoch_us_lossy], pa.timestamp("us", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([epoch_us_lossy], pa.timestamp("us", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_us_lossless // 1000000], pa.timestamp("s")),
+                ),
             ],
             "timestamp_ms": [
                 (
                     pa.array([epoch_us_lossless, None], pa.timestamp("us", tz="UTC")),
                     pa.array([epoch_us_lossless // 1000, None], pa.timestamp("ms")),
                 ),
-                (pa.array([epoch_us_lossy], pa.timestamp("us", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps ms precision)
+                (
+                    pa.array([epoch_us_lossy], pa.timestamp("us", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_us_lossless // 1000 + 123], pa.timestamp("ms")),
+                ),
             ],
             "timestamp_us": [
                 (
@@ -5457,14 +5779,24 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([epoch_us_lossless, None], pa.timestamp("us", tz="UTC")),
                     pa.array([epoch_us_lossless // 1000000, None], pa.timestamp("s", tz="UTC")),
                 ),
-                (pa.array([epoch_us_lossy], pa.timestamp("us", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([epoch_us_lossy], pa.timestamp("us", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_us_lossless // 1000000], pa.timestamp("s", tz="UTC")),
+                ),
             ],
             "timestamp_ms_tz": [
                 (
                     pa.array([epoch_us_lossless, None], pa.timestamp("us", tz="UTC")),
                     pa.array([epoch_us_lossless // 1000, None], pa.timestamp("ms", tz="UTC")),
                 ),
-                (pa.array([epoch_us_lossy], pa.timestamp("us", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps ms precision)
+                (
+                    pa.array([epoch_us_lossy], pa.timestamp("us", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_us_lossless // 1000 + 123], pa.timestamp("ms", tz="UTC")),
+                ),
             ],
             "timestamp_us_tz": [
                 (
@@ -5486,7 +5818,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                         pa.timestamp("s", tz="America/New_York"),
                     ),
                 ),
-                (pa.array([epoch_us_lossy], pa.timestamp("us", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([epoch_us_lossy], pa.timestamp("us", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_us_lossless // 1000000], pa.timestamp("s", tz="America/New_York")),
+                ),
             ],
             "timestamp_s_tz_shanghai": [
                 (
@@ -5495,7 +5832,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                         [epoch_us_lossless // 1000000, None], pa.timestamp("s", tz="Asia/Shanghai")
                     ),
                 ),
-                (pa.array([epoch_us_lossy], pa.timestamp("us", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([epoch_us_lossy], pa.timestamp("us", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_us_lossless // 1000000], pa.timestamp("s", tz="Asia/Shanghai")),
+                ),
             ],
             # timestamp[us,tz] -> duration (not supported)
             "duration_s": [
@@ -5528,14 +5870,24 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([epoch_us_lossless, None], pa.timestamp("us", tz="UTC")),
                     pa.array([datetime.time(12, 30, 45), None], pa.time32("s")),
                 ),
-                (pa.array([epoch_us_lossy], pa.timestamp("us", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([epoch_us_lossy], pa.timestamp("us", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([datetime.time(12, 30, 45)], pa.time32("s")),
+                ),
             ],
             "time32_ms": [
                 (
                     pa.array([epoch_us_lossless, None], pa.timestamp("us", tz="UTC")),
                     pa.array([datetime.time(12, 30, 45), None], pa.time32("ms")),
                 ),
-                (pa.array([epoch_us_lossy], pa.timestamp("us", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps ms precision)
+                (
+                    pa.array([epoch_us_lossy], pa.timestamp("us", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([datetime.time(12, 30, 45, 123000)], pa.time32("ms")),
+                ),
             ],
             "time64_us": [
                 (
@@ -5700,21 +6052,36 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([epoch_ns_lossless, None], pa.timestamp("ns", tz="UTC")),
                     pa.array([epoch_ns_lossless // 1000000000, None], pa.timestamp("s")),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ns_lossless // 1000000000], pa.timestamp("s")),
+                ),
             ],
             "timestamp_ms": [
                 (
                     pa.array([epoch_ns_lossless, None], pa.timestamp("ns", tz="UTC")),
                     pa.array([epoch_ns_lossless // 1000000, None], pa.timestamp("ms")),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps ms precision)
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ns_lossless // 1000000 + 123], pa.timestamp("ms")),
+                ),
             ],
             "timestamp_us": [
                 (
                     pa.array([epoch_ns_lossless, None], pa.timestamp("ns", tz="UTC")),
                     pa.array([epoch_ns_lossless // 1000, None], pa.timestamp("us")),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps us precision)
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ns_lossless // 1000 + 123456], pa.timestamp("us")),
+                ),
             ],
             "timestamp_ns": [
                 (
@@ -5728,21 +6095,36 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([epoch_ns_lossless, None], pa.timestamp("ns", tz="UTC")),
                     pa.array([epoch_ns_lossless // 1000000000, None], pa.timestamp("s", tz="UTC")),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ns_lossless // 1000000000], pa.timestamp("s", tz="UTC")),
+                ),
             ],
             "timestamp_ms_tz": [
                 (
                     pa.array([epoch_ns_lossless, None], pa.timestamp("ns", tz="UTC")),
                     pa.array([epoch_ns_lossless // 1000000, None], pa.timestamp("ms", tz="UTC")),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps ms precision)
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ns_lossless // 1000000 + 123], pa.timestamp("ms", tz="UTC")),
+                ),
             ],
             "timestamp_us_tz": [
                 (
                     pa.array([epoch_ns_lossless, None], pa.timestamp("ns", tz="UTC")),
                     pa.array([epoch_ns_lossless // 1000, None], pa.timestamp("us", tz="UTC")),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps us precision)
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ns_lossless // 1000 + 123456], pa.timestamp("us", tz="UTC")),
+                ),
             ],
             "timestamp_ns_tz": [
                 (
@@ -5758,7 +6140,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                         pa.timestamp("s", tz="America/New_York"),
                     ),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ns_lossless // 1000000000], pa.timestamp("s", tz="America/New_York")),
+                ),
             ],
             "timestamp_s_tz_shanghai": [
                 (
@@ -5768,7 +6155,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                         pa.timestamp("s", tz="Asia/Shanghai"),
                     ),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([epoch_ns_lossless // 1000000000], pa.timestamp("s", tz="Asia/Shanghai")),
+                ),
             ],
             # timestamp[ns,tz] -> duration (not supported)
             "duration_s": [
@@ -5801,21 +6193,36 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([epoch_ns_lossless, None], pa.timestamp("ns", tz="UTC")),
                     pa.array([datetime.time(12, 30, 45), None], pa.time32("s")),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([datetime.time(12, 30, 45)], pa.time32("s")),
+                ),
             ],
             "time32_ms": [
                 (
                     pa.array([epoch_ns_lossless, None], pa.timestamp("ns", tz="UTC")),
                     pa.array([datetime.time(12, 30, 45), None], pa.time32("ms")),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps ms precision)
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([datetime.time(12, 30, 45, 123000)], pa.time32("ms")),
+                ),
             ],
             "time64_us": [
                 (
                     pa.array([epoch_ns_lossless, None], pa.timestamp("ns", tz="UTC")),
                     pa.array([datetime.time(12, 30, 45), None], pa.time64("us")),
                 ),
-                (pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps us precision)
+                (
+                    pa.array([epoch_ns_lossy], pa.timestamp("ns", tz="UTC")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([datetime.time(12, 30, 45, 123456)], pa.time64("us")),
+                ),
             ],
             "time64_ns": [
                 (
@@ -6541,7 +6948,12 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([dur_ms, None], pa.duration("ms")),
                     pa.array([dur_ms // 1000, None], pa.duration("s")),
                 ),
-                (pa.array([dur_ms_lossy], pa.duration("ms")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([dur_ms_lossy], pa.duration("ms")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([dur_ms // 1000], pa.duration("s")),
+                ),
             ],
             "duration_ms": [
                 (
@@ -6662,14 +7074,24 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([dur_us, None], pa.duration("us")),
                     pa.array([dur_us // 1000000, None], pa.duration("s")),
                 ),
-                (pa.array([dur_us_lossy], pa.duration("us")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([dur_us_lossy], pa.duration("us")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([dur_us // 1000000], pa.duration("s")),
+                ),
             ],
             "duration_ms": [
                 (
                     pa.array([dur_us, None], pa.duration("us")),
                     pa.array([dur_us // 1000, None], pa.duration("ms")),
                 ),
-                (pa.array([dur_us_lossy], pa.duration("us")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([dur_us_lossy], pa.duration("us")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([dur_us // 1000], pa.duration("ms")),
+                ),
             ],
             "duration_us": [
                 (
@@ -6784,21 +7206,36 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([dur_ns, None], pa.duration("ns")),
                     pa.array([dur_ns // 1000000000, None], pa.duration("s")),
                 ),
-                (pa.array([dur_ns_lossy], pa.duration("ns")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([dur_ns_lossy], pa.duration("ns")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([dur_ns // 1000000000], pa.duration("s")),
+                ),
             ],
             "duration_ms": [
                 (
                     pa.array([dur_ns, None], pa.duration("ns")),
                     pa.array([dur_ns // 1000000, None], pa.duration("ms")),
                 ),
-                (pa.array([dur_ns_lossy], pa.duration("ns")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([dur_ns_lossy], pa.duration("ns")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([dur_ns // 1000000], pa.duration("ms")),
+                ),
             ],
             "duration_us": [
                 (
                     pa.array([dur_ns, None], pa.duration("ns")),
                     pa.array([dur_ns // 1000, None], pa.duration("us")),
                 ),
-                (pa.array([dur_ns_lossy], pa.duration("ns")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (
+                    pa.array([dur_ns_lossy], pa.duration("ns")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([dur_ns // 1000], pa.duration("us")),
+                ),
             ],
             "duration_ns": [
                 (
@@ -6974,7 +7411,8 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([t_lossless, None], pa.time32("ms")),
                     pa.array([t_lossless, None], pa.time32("s")),
                 ),
-                (pa.array([t], pa.time32("ms")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (pa.array([t], pa.time32("ms")), pa.lib.ArrowInvalid, pa.array([t_lossless], pa.time32("s"))),
             ],
             "time32_ms": [
                 (pa.array([t, None], pa.time32("ms")), pa.array([t, None], pa.time32("ms"))),
@@ -7066,14 +7504,20 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([t_lossless, None], pa.time64("us")),
                     pa.array([t_lossless, None], pa.time32("s")),
                 ),
-                (pa.array([t], pa.time64("us")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (pa.array([t], pa.time64("us")), pa.lib.ArrowInvalid, pa.array([t_lossless], pa.time32("s"))),
             ],
             "time32_ms": [
                 (
                     pa.array([t_lossless, None], pa.time64("us")),
                     pa.array([t_lossless, None], pa.time32("ms")),
                 ),
-                (pa.array([t], pa.time64("us")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps ms precision)
+                (
+                    pa.array([t], pa.time64("us")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([datetime.time(12, 30, 45, 123000)], pa.time32("ms")),
+                ),
             ],
             "time64_us": [
                 (pa.array([t, None], pa.time64("us")), pa.array([t, None], pa.time64("us"))),
@@ -7172,21 +7616,28 @@ class PyArrowNumericalCastTests(unittest.TestCase):
                     pa.array([t_ns_lossless, None], pa.time64("ns")),
                     pa.array([t_lossless, None], pa.time32("s")),
                 ),
-                (pa.array([t_ns], pa.time64("ns")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates
+                (pa.array([t_ns], pa.time64("ns")), pa.lib.ArrowInvalid, pa.array([t_lossless], pa.time32("s"))),
             ],
             "time32_ms": [
                 (
                     pa.array([t_ns_lossless, None], pa.time64("ns")),
                     pa.array([t_lossless, None], pa.time32("ms")),
                 ),
-                (pa.array([t_ns], pa.time64("ns")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps ms precision)
+                (
+                    pa.array([t_ns], pa.time64("ns")),
+                    pa.lib.ArrowInvalid,
+                    pa.array([datetime.time(12, 30, 45, 123000)], pa.time32("ms")),
+                ),
             ],
             "time64_us": [
                 (
                     pa.array([t_ns_lossless, None], pa.time64("ns")),
                     pa.array([t_lossless, None], pa.time64("us")),
                 ),
-                (pa.array([t_ns], pa.time64("ns")), pa.lib.ArrowInvalid),
+                # Lossy: safe=False truncates (keeps us precision)
+                (pa.array([t_ns], pa.time64("ns")), pa.lib.ArrowInvalid, pa.array([t], pa.time64("us"))),
             ],
             "time64_ns": [
                 (pa.array([t_ns, None], pa.time64("ns")), pa.array([t, None], pa.time64("ns"))),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR extends the PyArrow array cast tests to cover both `safe=True` and `safe=False` behaviors in each test case.

Changes:
1. **Modified `_run_cast_tests` method**: Now tests both `safe=True` and `safe=False` modes for each test case
2. **Extended test case format**: Support 3-tuple format `(src_arr, expected_safe_true, expected_safe_false)` where `expected_safe_false=None` means same behavior as `safe=True`
3. **Updated 200+ test cases**: All overflow/truncation cases now explicitly specify the `safe=False` behavior (wrapping, truncation, or saturation)

Categories of `safe=False` behavior covered:
- **Integer overflow**: Negative-to-unsigned wraps (e.g., `-1` → `255` for uint8)
- **Integer narrowing**: Value wraps on overflow (e.g., `128` as int16 → `-128` as int8)
- **Float-to-integer**: Truncation and saturation for out-of-range values
- **Timestamp/Duration precision loss**: Truncation when casting to coarser units
- **Decimal overflow**: Wrapping behavior for values exceeding integer limits

### Why are the changes needed?

The existing tests only covered `safe=True` behavior. This PR adds comprehensive coverage for `safe=False` to ensure PySpark correctly handles PyArrow's overflow/truncation semantics, which is important for data processing pipelines that need to handle edge cases gracefully.

Part of [SPARK-54936](https://issues.apache.org/jira/browse/SPARK-54936)

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

All 39 tests in `PyArrowNumericalCastTests` pass with the updated test framework.

### Was this patch authored or co-authored using generative AI tooling?

Yes