### PR TITLE
[SPARK-55267][INFRA] Make sbt less verbose in github actions

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -145,11 +145,18 @@ def exec_maven(mvn_args=()):
     run_cmd(flags + mvn_args)
 
 
-def exec_sbt(sbt_args=()):
+def exec_sbt(sbt_args=(), quiet=None):
     """Will call SBT in the current directory with the list of mvn_args passed
     in and returns the subprocess for any further processing"""
 
+    if quiet is None:
+        # If running in GitHub Actions, reduce verbosity
+        quiet = "GITHUB_ACTIONS" in os.environ
+
     sbt_cmd = [os.path.join(SPARK_HOME, "build", "sbt")] + sbt_args
+
+    if quiet:
+        sbt_cmd += ["-error"]
 
     sbt_output_filter = re.compile(
         b"^.*[info].*Resolving" + b"|" + b"^.*[warn].*Merging" + b"|" + b"^.*[info].*Including"
@@ -254,11 +261,7 @@ def build_spark_sbt(extra_profiles):
 
     print("[info] Building Spark using SBT with these arguments: ", " ".join(profiles_and_goals))
 
-    if "GITHUB_ACTIONS" in os.environ:
-        # Reduce verbosity in GitHub Actions logs
-        exec_sbt(["-error"] + profiles_and_goals)
-    else:
-        exec_sbt(profiles_and_goals)
+    exec_sbt(profiles_and_goals)
 
 
 def build_spark_unidoc_sbt(extra_profiles):
@@ -344,7 +347,7 @@ def run_scala_tests_sbt(test_modules, test_profiles):
         "[info] Running Spark tests using SBT with these arguments: ", " ".join(profiles_and_goals)
     )
 
-    exec_sbt(profiles_and_goals)
+    exec_sbt(profiles_and_goals, quiet=False)
 
 
 def run_scala_tests(build_tool, extra_profiles, test_modules, excluded_tags, included_tags):

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -254,7 +254,11 @@ def build_spark_sbt(extra_profiles):
 
     print("[info] Building Spark using SBT with these arguments: ", " ".join(profiles_and_goals))
 
-    exec_sbt(profiles_and_goals)
+    if "GITHUB_ACTIONS" in os.environ:
+        # Reduce verbosity in GitHub Actions logs
+        exec_sbt(["-error"] + profiles_and_goals)
+    else:
+        exec_sbt(profiles_and_goals)
 
 
 def build_spark_unidoc_sbt(extra_profiles):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

For all github actions, do not print warning/info logs to stdout.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We print thousands of warning messages and no one cares of them. These lines flooded the stdout which makes finding the interesting part super difficult. Also github takes seconds to even load the log because there are too many lines.

If we don't care about it, just don't print it.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Let's see the result of CI.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No