### PR TITLE
[SPARK-55277][SQL] Add `protobuf_funcs` group for Protobuf SQL functions

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
@@ -48,8 +48,8 @@ public class ExpressionInfo {
             "bitwise_funcs", "collection_funcs", "predicate_funcs", "conditional_funcs",
             "conversion_funcs", "csv_funcs", "datetime_funcs", "generator_funcs", "hash_funcs",
             "json_funcs", "lambda_funcs", "map_funcs", "math_funcs", "misc_funcs",
-            "string_funcs", "struct_funcs", "window_funcs", "xml_funcs", "table_funcs",
-            "url_funcs", "variant_funcs", "vector_funcs", "st_funcs"));
+            "protobuf_funcs", "string_funcs", "struct_funcs", "window_funcs", "xml_funcs",
+            "table_funcs", "url_funcs", "variant_funcs", "vector_funcs", "st_funcs"));
 
     private static final Set<String> validSources =
             new HashSet<>(Arrays.asList("built-in", "hive", "python_udf", "scala_udf", "sql_udf",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/toFromProtobufSqlFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/toFromProtobufSqlFunctions.scala
@@ -58,7 +58,7 @@ import org.apache.spark.util.Utils
     To deserialize the data with a compatible and evolved schema, the expected Protobuf schema can be
     set via the corresponding option.
   """,
-  group = "misc_funcs",
+  group = "protobuf_funcs",
   since = "4.0.0"
 )
 // scalastyle:on line.size.limit
@@ -195,7 +195,7 @@ case class FromProtobuf(
       > SELECT _FUNC_(s, 'Person', '/path/to/descriptor.desc', map('emitDefaultValues', 'true')) IS NULL FROM (SELECT NULL AS s);
        [true]
   """,
-  group = "misc_funcs",
+  group = "protobuf_funcs",
   since = "4.0.0"
 )
 // scalastyle:on line.size.limit

--- a/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
@@ -59,8 +59,8 @@ class ExpressionInfoSuite extends SparkFunSuite with SharedSparkSession {
       "agg_funcs", "array_funcs", "avro_funcs", "binary_funcs", "bitwise_funcs", "collection_funcs",
       "predicate_funcs", "conditional_funcs", "conversion_funcs", "csv_funcs", "datetime_funcs",
       "generator_funcs", "hash_funcs", "json_funcs", "lambda_funcs", "map_funcs", "math_funcs",
-      "misc_funcs", "string_funcs", "struct_funcs", "window_funcs", "xml_funcs", "table_funcs",
-      "url_funcs", "variant_funcs", "vector_funcs", "st_funcs").sorted
+      "misc_funcs", "protobuf_funcs", "string_funcs", "struct_funcs", "window_funcs", "xml_funcs",
+      "table_funcs", "url_funcs", "variant_funcs", "vector_funcs", "st_funcs").sorted
     val invalidGroupName = "invalid_group_funcs"
     checkError(
       exception = intercept[SparkIllegalArgumentException] {

--- a/sql/gen-sql-functions-docs.py
+++ b/sql/gen-sql-functions-docs.py
@@ -36,7 +36,7 @@ groups = {
     "bitwise_funcs", "conversion_funcs", "csv_funcs",
     "xml_funcs", "lambda_funcs", "collection_funcs",
     "url_funcs", "hash_funcs", "struct_funcs",
-    "table_funcs", "variant_funcs"
+    "table_funcs", "variant_funcs", "protobuf_funcs"
 }
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Similar to how Avro functions have their own `avro_funcs` group, Protobuf functions (`from_protobuf`, `to_protobuf`) should have their own `protobuf_funcs` group instead of being grouped under `misc_funcs`.

This improves consistency with how other format-specific functions are organized and makes the documentation clearer for users.

Changes:
- Move `from_protobuf` and `to_protobuf` from `misc_funcs` to `protobuf_funcs`
- Add `protobuf_funcs` to the groups set in `gen-sql-functions-docs.py`

### Why are the changes needed?

Consistency with `avro_funcs`, `json_funcs`, `csv_funcs`, `xml_funcs` groupings.

### Does this PR introduce _any_ user-facing change?

No functional changes. The only difference is in how functions are grouped in documentation.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

Yes, GitHub Copilot was used to assist with this change.