### PR TITLE
[SPARK-55086][PYTHON] Add DataSourceReader.pushFilters to Python Data Source API docs

### DIFF
--- a/python/docs/source/reference/pyspark.sql/datasource.rst
+++ b/python/docs/source/reference/pyspark.sql/datasource.rst
@@ -31,6 +31,7 @@ Python Data Source
     DataSource.streamReader
     DataSource.writer
     DataSourceReader.partitions
+    DataSourceReader.pushFilters
     DataSourceReader.read
     DataSourceRegistration.register
     DataSourceStreamReader.commit


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `DataSourceReader.pushFilters` to the autosummary list in `python/docs/source/reference/pyspark.sql/datasource.rst`.

The method documentation page already existed at `python/docs/source/reference/pyspark.sql/api/pyspark.sql.datasource.DataSourceReader.pushFilters.rst`, but it wasn't linked from the main Python Data Source reference page.

### Why are the changes needed?

This fixes [SPARK-55086](https://issues.apache.org/jira/browse/SPARK-55086). The `pushFilters` method has complete documentation in the source code and a generated API page, but it was missing from the main Python Data Source API documentation index, making it difficult for users to discover this API.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only change that adds a missing link to an existing API documentation page.

### How was this patch tested?

Built the documentation locally using Sphinx:
1. Activated the virtual environment in `python/docs/.venv`
2. Ran `make.bat html` to build the documentation
3. Verified that `DataSourceReader.pushFilters` now appears in the methods list on the Python Data Source page (`reference/pyspark.sql/datasource.html`)
4. Confirmed that clicking the link navigates to the correct API documentation page

### Was this patch authored or co-authored using generative AI tooling?

Yes. Generated-by: Cursor AI Assistant