### PR TITLE
[SPARK-55282][PYTHON][CONNECT] Avoid using worker_util in the Driver-side

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -66,7 +66,7 @@ from google.protobuf import text_format, any_pb2
 from google.rpc import error_details_pb2
 
 from pyspark.util import is_remote_only, disable_gc
-from pyspark.accumulators import SpecialAccumulatorIds
+from pyspark.accumulators import SpecialAccumulatorIds, pickleSer
 from pyspark.version import __version__
 from pyspark.traceback_utils import CallSite
 from pyspark.resource.information import ResourceInformation
@@ -1550,8 +1550,6 @@ class SparkConnectClient(object):
                 logger.debug("Received observed metric batch.")
                 for observed_metrics in self._build_observed_metrics(b.observed_metrics):
                     if observed_metrics.name == "__python_accumulator__":
-                        from pyspark.worker_util import pickleSer
-
                         for metric in observed_metrics.metrics:
                             (aid, update) = pickleSer.loads(LiteralExpression._to_value(metric))
                             if aid == SpecialAccumulatorIds.SQL_UDF_PROFIER:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Avoid using `worker_util` in the Driver-side.

### Why are the changes needed?

The `worker_util` module is supposed to be used in the worker processes.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing tests should pass.

### Was this patch authored or co-authored using generative AI tooling?

No.