### PR TITLE
[SPARK-55286][INFRA] Add test summary to GitHub Actions for better failure visibility

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -393,6 +393,13 @@ jobs:
         path: |
           **/target/test-reports/*.xml
           **/target/surefire-reports/*.xml
+    - name: Test Summary
+      if: always()
+      uses: test-summary/action@v2
+      with:
+        paths: |
+          **/target/test-reports/*.xml
+          **/target/surefire-reports/*.xml
     - name: Upload unit tests log files
       if: ${{ !success() }}
       uses: actions/upload-artifact@v4
@@ -675,6 +682,13 @@ jobs:
         path: |
           **/target/test-reports/*.xml
           **/target/surefire-reports/*.xml
+    - name: Test Summary
+      if: always()
+      uses: test-summary/action@v2
+      with:
+        paths: |
+          **/target/test-reports/*.xml
+          **/target/surefire-reports/*.xml
     - name: Upload unit tests log files
       env: ${{ fromJSON(inputs.envs) }}
       if: ${{ !success() }}
@@ -757,6 +771,13 @@ jobs:
       with:
         name: test-results-sparkr--${{ inputs.java }}-${{ inputs.hadoop }}-hive2.3
         path: |
+          **/target/test-reports/*.xml
+          **/target/surefire-reports/*.xml
+    - name: Test Summary
+      if: always()
+      uses: test-summary/action@v2
+      with:
+        paths: |
           **/target/test-reports/*.xml
           **/target/surefire-reports/*.xml
 
@@ -1248,6 +1269,13 @@ jobs:
         path: |
           **/target/test-reports/*.xml
           **/target/surefire-reports/*.xml
+    - name: Test Summary
+      if: always()
+      uses: test-summary/action@v2
+      with:
+        paths: |
+          **/target/test-reports/*.xml
+          **/target/surefire-reports/*.xml
     - name: Upload unit tests log files
       if: ${{ !success() }}
       uses: actions/upload-artifact@v4
@@ -1315,6 +1343,13 @@ jobs:
       with:
         name: test-results-docker-integration--${{ inputs.java }}-${{ inputs.hadoop }}-hive2.3
         path: |
+          **/target/test-reports/*.xml
+          **/target/surefire-reports/*.xml
+    - name: Test Summary
+      if: always()
+      uses: test-summary/action@v2
+      with:
+        paths: |
           **/target/test-reports/*.xml
           **/target/surefire-reports/*.xml
     - name: Upload unit tests log files


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds `test-summary/action@v2` to GitHub Actions workflows to display test failures directly in the job summary.

**Jobs updated:**
- `build` - Scala/Java unit tests
- `pyspark` - Python tests
- `sparkr` - R tests
- `tpcds` - TPC-DS benchmark tests
- `docker-integration-tests` - Docker integration tests

The action parses JUnit XML test reports and generates a summary table showing:
- Failed tests grouped by class/suite name
- Error messages and stack traces
- Pass/fail/skip statistics

### Why are the changes needed?

Currently, GitHub Actions CI generates verbose logs that make it hard to find test failures quickly. Developers have to scroll through extensive log output to identify which tests failed.

With this change, test failures appear directly in the GitHub Actions workflow summary, making it easy to identify failures at a glance.

**Example output:**
| Result | Test |
|--------|------|
| ❌ | org.apache.spark.sql.SomeTestSuite › testMethod1 |
| ❌ | org.apache.spark.sql.SomeTestSuite › testMethod2 |

### Does this PR introduce _any_ user-facing change?

No. This only affects the CI/CD workflow display.

### How was this patch tested?

- YAML syntax validated locally
- The `test-summary/action` is a well-maintained GitHub Action with 1000+ stars
- Uses `if: always()` to ensure summary is generated even when tests fail

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot