### PR TITLE
[SPARK-55290][NETWORK][TESTS] Fix testReloadMissingTrustStore cross-device link error with JDK 21

### DIFF
--- a/common/network-common/src/test/java/org/apache/spark/network/ssl/ReloadingX509TrustManagerSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/ssl/ReloadingX509TrustManagerSuite.java
@@ -189,7 +189,9 @@ public class ReloadingX509TrustManagerSuite {
   public void testReloadMissingTrustStore() throws Exception {
     KeyPair kp = generateKeyPair("RSA");
     X509Certificate cert1 = generateCertificate("CN=Cert1", kp, 30, "SHA1withRSA");
-    File trustStore = new File("testmissing.jks");
+    File trustStore = File.createTempFile("testmissing", "jks");
+    trustStore.delete();
+    // trustStore is going to be re-created later so delete it on exit.
     trustStore.deleteOnExit();
     assertFalse(trustStore.exists());
     createTrustStore(trustStore, "password", "cert1", cert1);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace hardcoded filename with `File.createTempFile()` in `testReloadMissingTrustStore` to ensure the temporary `trustStore` file is created in the same filesystem as the test working directory.

### Why are the changes needed?

This change fixes a unit test bug.

JDK 21's `UnixFileSystem.move()` uses atomic rename operations that fail when moving files across different mounted filesystems. The test creates a temporary file in `/tmp` and attempts to move it to the current directory. When these locations are on different partitions, the atomic move fails with a `testmissing.jks: Cross-device link` error because the `rename()` system call cannot move files across different filesystems.

The fix ensures both temporary and target files are created in the same filesystem by eliminating the cross-filesystem move operation.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Verified `ReloadingX509TrustManagerSuite` passes with both JDK 21 and JDK 17:

`build/mvn -pl common/network-common -Dtest=ReloadingX509TrustManagerSuite test`

### Was this patch authored or co-authored using generative AI tooling?

No.
