### PR TITLE
[SPARK-55304][SS][PYTHON] Introduce support of Admission Control and Trigger.AvailableNow in Python data source - streaming reader

### DIFF
--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -714,25 +714,55 @@ class DataSourceStreamReader(ABC):
             messageParameters={"feature": "initialOffset"},
         )
 
-    def latestOffset(self) -> dict:
+    from pyspark.sql.streaming.datasource import ReadAllAvailable, ReadLimit
+
+    # FIXME: Will this work without abstractmethod marker?
+    # @abstractmethod
+    def latestOffset(self, start: dict, readLimit: ReadLimit) -> dict:
         """
-        Returns the most recent offset available.
+        FIXME: docstring needed
 
-        Returns
-        -------
-        dict
-            A dict or recursive dict whose key and value are primitive types, which includes
-            Integer, String and Boolean.
-
-        Examples
-        --------
-        >>> def latestOffset(self):
-        ...     return {"parititon-1": {"index": 3, "closed": True}, "partition-2": {"index": 5}}
+        /**
+        * Returns the most recent offset available given a read limit. The start offset can be used
+        * to figure out how much new data should be read given the limit. Users should implement this
+        * method instead of latestOffset for a MicroBatchStream or getOffset for Source.
+        * <p>
+        * When this method is called on a `Source`, the source can return `null` if there is no
+        * data to process. In addition, for the very first micro-batch, the `startOffset` will be
+        * null as well.
+        * <p>
+        * When this method is called on a MicroBatchStream, the `startOffset` will be `initialOffset`
+        * for the very first micro-batch. The source can return `null` if there is no data to process.
+        */
         """
         raise PySparkNotImplementedError(
             errorClass="NOT_IMPLEMENTED",
             messageParameters={"feature": "latestOffset"},
         )
+
+    def getDefaultReadLimit(self) -> ReadLimit:
+        """
+          FIXME: docstring needed
+
+        /**
+         * Returns the read limits potentially passed to the data source through options when creating
+         * the data source.
+         */
+        """
+        return ReadAllAvailable()
+
+    def reportLatestOffset(self) -> Optional[dict]:
+        """
+          FIXME: docstring needed
+
+        /**
+         * Returns the most recent offset available.
+         * <p>
+         * The source can return `null`, if there is no data to process or the source does not support
+         * to this method.
+         */
+        """
+        return None
 
     def partitions(self, start: dict, end: dict) -> Sequence[InputPartition]:
         """

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -909,7 +909,6 @@ class SimpleDataSourceStreamReader(ABC):
         ...
 
 
-
 class DataSourceWriter(ABC):
     """
     A base class for data source writers. Data source writers are responsible for saving

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -909,6 +909,61 @@ class SimpleDataSourceStreamReader(ABC):
         ...
 
 
+class ReadLimit(ABC):
+    pass
+
+
+class ReadAllAvailable(ReadLimit):
+    def __init__(self):
+        pass
+
+
+class SupportsAdmissionControl(ABC):
+    @abstractmethod
+    def latestOffset(self, start: dict, readLimit: ReadLimit) -> dict:
+        """
+        FIXME: docstring needed
+
+      /**
+       * Returns the most recent offset available given a read limit. The start offset can be used
+       * to figure out how much new data should be read given the limit. Users should implement this
+       * method instead of latestOffset for a MicroBatchStream or getOffset for Source.
+       * <p>
+       * When this method is called on a `Source`, the source can return `null` if there is no
+       * data to process. In addition, for the very first micro-batch, the `startOffset` will be
+       * null as well.
+       * <p>
+       * When this method is called on a MicroBatchStream, the `startOffset` will be `initialOffset`
+       * for the very first micro-batch. The source can return `null` if there is no data to process.
+       */
+        """
+        pass
+
+
+class SupportsTriggerAvailableNow(ABC):
+    @abstractmethod
+    def prepareForTriggerAvailableNow(self) -> None:
+        """
+        FIXME: docstring needed
+
+        /**
+         * This will be called at the beginning of streaming queries with Trigger.AvailableNow, to let the
+         * source record the offset for the current latest data at the time (a.k.a the target offset for
+         * the query). The source will behave as if there is no new data coming in after the target
+         * offset, i.e., the source will not return an offset higher than the target offset when
+         * {@link #latestOffset(Offset, ReadLimit) latestOffset} is called.
+         * <p>
+         * Note that there is an exception on the first uncommitted batch after a restart, where the end
+         * offset is not derived from the current latest offset. Sources need to take special
+         * considerations if wanting to assert such relation. One possible way is to have an internal
+         * flag in the source to indicate whether it is Trigger.AvailableNow, set the flag in this method,
+         * and record the target offset in the first call of
+         * {@link #latestOffset(Offset, ReadLimit) latestOffset}.
+         */
+        """
+        pass
+
+
 class DataSourceWriter(ABC):
     """
     A base class for data source writers. Data source writers are responsible for saving

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -716,8 +716,6 @@ class DataSourceStreamReader(ABC):
 
     from pyspark.sql.streaming.datasource import ReadAllAvailable, ReadLimit
 
-    # FIXME: Will this work without abstractmethod marker?
-    # @abstractmethod
     def latestOffset(self, start: dict, readLimit: ReadLimit) -> dict:
         """
         FIXME: docstring needed

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -909,60 +909,6 @@ class SimpleDataSourceStreamReader(ABC):
         ...
 
 
-class ReadLimit(ABC):
-    pass
-
-
-class ReadAllAvailable(ReadLimit):
-    def __init__(self):
-        pass
-
-
-class SupportsAdmissionControl(ABC):
-    @abstractmethod
-    def latestOffset(self, start: dict, readLimit: ReadLimit) -> dict:
-        """
-        FIXME: docstring needed
-
-      /**
-       * Returns the most recent offset available given a read limit. The start offset can be used
-       * to figure out how much new data should be read given the limit. Users should implement this
-       * method instead of latestOffset for a MicroBatchStream or getOffset for Source.
-       * <p>
-       * When this method is called on a `Source`, the source can return `null` if there is no
-       * data to process. In addition, for the very first micro-batch, the `startOffset` will be
-       * null as well.
-       * <p>
-       * When this method is called on a MicroBatchStream, the `startOffset` will be `initialOffset`
-       * for the very first micro-batch. The source can return `null` if there is no data to process.
-       */
-        """
-        pass
-
-
-class SupportsTriggerAvailableNow(ABC):
-    @abstractmethod
-    def prepareForTriggerAvailableNow(self) -> None:
-        """
-        FIXME: docstring needed
-
-        /**
-         * This will be called at the beginning of streaming queries with Trigger.AvailableNow, to let the
-         * source record the offset for the current latest data at the time (a.k.a the target offset for
-         * the query). The source will behave as if there is no new data coming in after the target
-         * offset, i.e., the source will not return an offset higher than the target offset when
-         * {@link #latestOffset(Offset, ReadLimit) latestOffset} is called.
-         * <p>
-         * Note that there is an exception on the first uncommitted batch after a restart, where the end
-         * offset is not derived from the current latest offset. Sources need to take special
-         * considerations if wanting to assert such relation. One possible way is to have an internal
-         * flag in the source to indicate whether it is Trigger.AvailableNow, set the flag in this method,
-         * and record the target offset in the first call of
-         * {@link #latestOffset(Offset, ReadLimit) latestOffset}.
-         */
-        """
-        pass
-
 
 class DataSourceWriter(ABC):
     """

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -715,7 +715,7 @@ class DataSourceStreamReader(ABC):
             messageParameters={"feature": "initialOffset"},
         )
 
-    def latestOffset(self, start: dict, readLimit: ReadLimit) -> dict:
+    def latestOffset(self, start: dict, limit: ReadLimit) -> dict:
         """
         Returns the most recent offset available given a read limit. The start offset can be used
         to figure out how much new data should be read given the limit.
@@ -744,7 +744,7 @@ class DataSourceStreamReader(ABC):
         ----------
         start : dict
             The start offset of the microbatch to continue reading from.
-        readLimit : :class:`ReadLimit`
+        limit : :class:`ReadLimit`
             The limit on the amount of data to be returned by this call.
 
         Returns
@@ -756,12 +756,12 @@ class DataSourceStreamReader(ABC):
         Examples
         --------
         >>> from pyspark.sql.streaming.datasource import ReadAllAvailable, ReadMaxRows
-        >>> def latestOffset(self, start, readLimit):
+        >>> def latestOffset(self, start, limit):
         ...     # Assume the source has 10 new records between start and latest offset
-        ...     if isinstance(readLimit, ReadAllAvailable):
+        ...     if isinstance(limit, ReadAllAvailable):
         ...        return {"index": start["index"] + 10}
-        ...     else:  # e.g., readLimit is ReadMaxRows(5)
-        ...        return {"index": start["index"] + min(10, readLimit.maxRows)}
+        ...     else:  # e.g., limit is ReadMaxRows(5)
+        ...        return {"index": start["index"] + min(10, limit.maxRows)}
         """
         raise PySparkNotImplementedError(
             errorClass="NOT_IMPLEMENTED",

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -721,9 +721,9 @@ class DataSourceStreamReader(ABC):
         to figure out how much new data should be read given the limit.
 
         The `start` will be provided from the return value of :meth:`initialOffset()` for
-        the very first micro-batch, and the offset continues from the last micro-batch for the
-        following. The source can return the same offset as start offset if there is no data to
-        process.
+        the very first micro-batch, and for subsequent micro-batches, the start offset is the
+        ending offset from the previous micro-batch. The source can return the `start` parameter
+        as it is, if there is no data to process.
 
         :class:`ReadLimit` can be used by the source to limit the amount of data returned in this
         call. The implementation should implement :meth:`getDefaultReadLimit()` to provide the

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -736,9 +736,7 @@ class DataSourceStreamReader(ABC):
         engine; e.g. if the readLimit is :class:`ReadAllAvailable`, the source must ignore the read
         limit configured through options.
 
-        NOTE: Previous Spark versions didn't have start offset and read limit parameters for this
-        method. While Spark will ensure the backward compatibility for existing data sources, the
-        new data sources are strongly encouraged to implement this new method signature.
+        .. versionadded:: 4.2.0
 
         Parameters
         ----------
@@ -763,6 +761,9 @@ class DataSourceStreamReader(ABC):
         ...     else:  # e.g., limit is ReadMaxRows(5)
         ...        return {"index": start["index"] + min(10, limit.maxRows)}
         """
+        # NOTE: Previous Spark versions didn't have start offset and read limit parameters for this
+        # method. While Spark will ensure the backward compatibility for existing data sources, the
+        # new data sources are strongly encouraged to implement this new method signature.
         raise PySparkNotImplementedError(
             errorClass="NOT_IMPLEMENTED",
             messageParameters={"feature": "latestOffset"},
@@ -776,6 +777,8 @@ class DataSourceStreamReader(ABC):
 
         Implementing this method is optional. By default, it returns :class:`ReadAllAvailable`,
         which means there is no limit on the amount of data returned by :meth:`latestOffset()`.
+
+        .. versionadded:: 4.2.0
         """
         return ReadAllAvailable()
 
@@ -785,6 +788,8 @@ class DataSourceStreamReader(ABC):
         offset in the streaming query status.
         The source can return `None`, if there is no data to process or the source does not support
         to this method.
+
+        .. versionadded:: 4.2.0
 
         Returns
         -------

--- a/python/pyspark/sql/datasource_internal.py
+++ b/python/pyspark/sql/datasource_internal.py
@@ -19,7 +19,7 @@
 import json
 import copy
 from itertools import chain
-from typing import Iterator, List, Optional, Sequence, Tuple, Type, Dict
+from typing import Iterator, List, Sequence, Tuple, Type, Dict
 
 from pyspark.sql.datasource import (
     DataSource,
@@ -94,9 +94,9 @@ class _SimpleStreamReaderWrapper(DataSourceStreamReader):
 
     def latestOffset(self, start: dict, readLimit: ReadLimit) -> dict:  # type: ignore[override]
         assert start is not None, "start offset should not be None"
-        assert isinstance(readLimit, ReadAllAvailable), (
-            "simple stream reader does not support read limit"
-        )
+        assert isinstance(
+            readLimit, ReadAllAvailable
+        ), "simple stream reader does not support read limit"
 
         (iter, end) = self.simple_reader.read(start)
         self.cache.append(PrefetchedCacheEntry(start, end, iter))

--- a/python/pyspark/sql/datasource_internal.py
+++ b/python/pyspark/sql/datasource_internal.py
@@ -70,13 +70,9 @@ class _SimpleStreamReaderWrapper(DataSourceStreamReader):
     so that :class:`SimpleDataSourceStreamReader` can integrate with streaming engine like an
     ordinary :class:`DataSourceStreamReader`.
 
-    current_offset tracks the latest progress of the record prefetching, it is initialized to be
-    initialOffset() when query start for the first time or initialized to be the end offset of
-    the last planned batch when query restarts.
-
     When streaming engine calls latestOffset(), the wrapper calls read() that starts from
-    current_offset, prefetches and cache the data, then updates the current_offset to be
-    the end offset of the new data.
+    start provided via the parameter of latestOffset(), prefetches and cache the data, then updates
+    the current_offset to be the end offset of the new data.
 
     When streaming engine call planInputPartitions(start, end), the wrapper get the prefetched data
     from cache and send it to JVM along with the input partitions.

--- a/python/pyspark/sql/datasource_internal.py
+++ b/python/pyspark/sql/datasource_internal.py
@@ -30,7 +30,6 @@ from pyspark.sql.datasource import (
 from pyspark.sql.streaming.datasource import (
     ReadAllAvailable,
     ReadLimit,
-    SupportsAdmissionControl,
     ReadMaxBytes,
     ReadMaxRows,
     ReadMinRows,
@@ -65,7 +64,7 @@ class PrefetchedCacheEntry:
         self.iterator = iterator
 
 
-class _SimpleStreamReaderWrapper(DataSourceStreamReader, SupportsAdmissionControl):
+class _SimpleStreamReaderWrapper(DataSourceStreamReader):
     """
     A private class that wrap :class:`SimpleDataSourceStreamReader` in prefetch and cache pattern,
     so that :class:`SimpleDataSourceStreamReader` can integrate with streaming engine like an

--- a/python/pyspark/sql/datasource_internal.py
+++ b/python/pyspark/sql/datasource_internal.py
@@ -92,10 +92,10 @@ class _SimpleStreamReaderWrapper(DataSourceStreamReader):
         # We do not consider providing different read limit on simple stream reader.
         return ReadAllAvailable()
 
-    def latestOffset(self, start: dict, readLimit: ReadLimit) -> dict:  # type: ignore[override]
+    def latestOffset(self, start: dict, limit: ReadLimit) -> dict:  # type: ignore[override]
         assert start is not None, "start offset should not be None"
         assert isinstance(
-            readLimit, ReadAllAvailable
+            limit, ReadAllAvailable
         ), "simple stream reader does not support read limit"
 
         (iter, end) = self.simple_reader.read(start)

--- a/python/pyspark/sql/datasource_internal.py
+++ b/python/pyspark/sql/datasource_internal.py
@@ -92,7 +92,7 @@ class _SimpleStreamReaderWrapper(DataSourceStreamReader):
         # We do not consider providing different read limit on simple stream reader.
         return ReadAllAvailable()
 
-    def latestOffset(self, start: dict, limit: ReadLimit) -> dict:  # type: ignore[override]
+    def latestOffset(self, start: dict, limit: ReadLimit) -> dict:
         assert start is not None, "start offset should not be None"
         assert isinstance(
             limit, ReadAllAvailable

--- a/python/pyspark/sql/streaming/datasource.py
+++ b/python/pyspark/sql/streaming/datasource.py
@@ -16,7 +16,6 @@
 #
 
 from abc import ABC, abstractmethod
-from typing import Optional
 
 
 class ReadLimit(ABC):

--- a/python/pyspark/sql/streaming/datasource.py
+++ b/python/pyspark/sql/streaming/datasource.py
@@ -117,52 +117,6 @@ class ReadMaxBytes(ReadLimit):
         return {"max_bytes": self.max_bytes}
 
 
-class SupportsAdmissionControl(ABC):
-    def getDefaultReadLimit(self) -> ReadLimit:
-        """
-          FIXME: docstring needed
-
-        /**
-         * Returns the read limits potentially passed to the data source through options when creating
-         * the data source.
-         */
-        """
-        return ReadAllAvailable()
-
-    @abstractmethod
-    def latestOffset(self, start: dict, readLimit: ReadLimit) -> dict:
-        """
-          FIXME: docstring needed
-
-        /**
-         * Returns the most recent offset available given a read limit. The start offset can be used
-         * to figure out how much new data should be read given the limit. Users should implement this
-         * method instead of latestOffset for a MicroBatchStream or getOffset for Source.
-         * <p>
-         * When this method is called on a `Source`, the source can return `null` if there is no
-         * data to process. In addition, for the very first micro-batch, the `startOffset` will be
-         * null as well.
-         * <p>
-         * When this method is called on a MicroBatchStream, the `startOffset` will be `initialOffset`
-         * for the very first micro-batch. The source can return `null` if there is no data to process.
-         */
-        """
-        pass
-
-    def reportLatestOffset(self) -> Optional[dict]:
-        """
-          FIXME: docstring needed
-
-        /**
-         * Returns the most recent offset available.
-         * <p>
-         * The source can return `null`, if there is no data to process or the source does not support
-         * to this method.
-         */
-        """
-        return None
-
-
 class SupportsTriggerAvailableNow(ABC):
     @abstractmethod
     def prepareForTriggerAvailableNow(self) -> None:

--- a/python/pyspark/sql/streaming/datasource.py
+++ b/python/pyspark/sql/streaming/datasource.py
@@ -16,7 +16,8 @@
 #
 
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import Optional
+
 
 class ReadLimit(ABC):
     @classmethod
@@ -116,69 +117,48 @@ class ReadMaxBytes(ReadLimit):
         return {"max_bytes": self.max_bytes}
 
 
-class CompositeReadLimit(ReadLimit):
-    def __init__(self, readLimits: List[ReadLimit]) -> None:
-        self.readLimits = readLimits
-
-    @classmethod
-    def type_name(cls) -> str:
-        return "CompositeReadLimit"
-
-    @classmethod
-    def load(cls, params: dict) -> "CompositeReadLimit":
-        read_limits = []
-        for rl_params in params["readLimits"]:
-            rl_type = rl_params["type"]
-            rl = READ_LIMIT_REGISTRY.get(rl_type, rl_params)
-            read_limits.append(rl)
-        return CompositeReadLimit(read_limits)
-
-    def _dump(self) -> dict:
-        return {"readLimits": [rl.dump() for rl in self.readLimits]}
-
-
 class SupportsAdmissionControl(ABC):
     def getDefaultReadLimit(self) -> ReadLimit:
         """
-        FIXME: docstring needed
+          FIXME: docstring needed
 
-      /**
-       * Returns the read limits potentially passed to the data source through options when creating
-       * the data source.
-       */
+        /**
+         * Returns the read limits potentially passed to the data source through options when creating
+         * the data source.
+         */
         """
         return ReadAllAvailable()
 
     @abstractmethod
     def latestOffset(self, start: dict, readLimit: ReadLimit) -> dict:
         """
-        FIXME: docstring needed
+          FIXME: docstring needed
 
-      /**
-       * Returns the most recent offset available given a read limit. The start offset can be used
-       * to figure out how much new data should be read given the limit. Users should implement this
-       * method instead of latestOffset for a MicroBatchStream or getOffset for Source.
-       * <p>
-       * When this method is called on a `Source`, the source can return `null` if there is no
-       * data to process. In addition, for the very first micro-batch, the `startOffset` will be
-       * null as well.
-       * <p>
-       * When this method is called on a MicroBatchStream, the `startOffset` will be `initialOffset`
-       * for the very first micro-batch. The source can return `null` if there is no data to process.
-       */
+        /**
+         * Returns the most recent offset available given a read limit. The start offset can be used
+         * to figure out how much new data should be read given the limit. Users should implement this
+         * method instead of latestOffset for a MicroBatchStream or getOffset for Source.
+         * <p>
+         * When this method is called on a `Source`, the source can return `null` if there is no
+         * data to process. In addition, for the very first micro-batch, the `startOffset` will be
+         * null as well.
+         * <p>
+         * When this method is called on a MicroBatchStream, the `startOffset` will be `initialOffset`
+         * for the very first micro-batch. The source can return `null` if there is no data to process.
+         */
         """
         pass
 
     def reportLatestOffset(self) -> Optional[dict]:
         """
-        FIXME: docstring needed
+          FIXME: docstring needed
 
-      /**
-       * Returns the most recent offset available.
-       * <p>
-       * The source can return `null`, if there is no data to process or the source does not support
-       * to this method.
-       */
+        /**
+         * Returns the most recent offset available.
+         * <p>
+         * The source can return `null`, if there is no data to process or the source does not support
+         * to this method.
+         */
         """
         return None
 

--- a/python/pyspark/sql/streaming/datasource.py
+++ b/python/pyspark/sql/streaming/datasource.py
@@ -1,0 +1,207 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from abc import ABC, abstractmethod
+from typing import List, Optional
+
+class ReadLimit(ABC):
+    @classmethod
+    @abstractmethod
+    def type_name(cls) -> str:
+        pass
+
+    @classmethod
+    @abstractmethod
+    def load(cls, params: dict) -> "ReadLimit":
+        pass
+
+    def dump(self) -> dict:
+        params = self._dump()
+        params.update({"type": self.type_name()})
+        return params
+
+    @abstractmethod
+    def _dump(self) -> dict:
+        pass
+
+
+class ReadAllAvailable(ReadLimit):
+    @classmethod
+    def type_name(cls) -> str:
+        return "ReadAllAvailable"
+
+    @classmethod
+    def load(cls, params: dict) -> "ReadAllAvailable":
+        return ReadAllAvailable()
+
+    def _dump(self) -> dict:
+        return {}
+
+
+class ReadMinRows(ReadLimit):
+    def __init__(self, min_rows: int) -> None:
+        self.min_rows = min_rows
+
+    @classmethod
+    def type_name(cls) -> str:
+        return "ReadMinRows"
+
+    @classmethod
+    def load(cls, params: dict) -> "ReadMinRows":
+        return ReadMinRows(params["min_rows"])
+
+    def _dump(self) -> dict:
+        return {"min_rows": self.min_rows}
+
+
+class ReadMaxRows(ReadLimit):
+    def __init__(self, max_rows: int) -> None:
+        self.max_rows = max_rows
+
+    @classmethod
+    def type_name(cls) -> str:
+        return "ReadMaxRows"
+
+    @classmethod
+    def load(cls, params: dict) -> "ReadMaxRows":
+        return ReadMaxRows(params["max_rows"])
+
+    def _dump(self) -> dict:
+        return {"max_rows": self.max_rows}
+
+
+class ReadMaxFiles(ReadLimit):
+    def __init__(self, max_files: int) -> None:
+        self.max_files = max_files
+
+    @classmethod
+    def type_name(cls) -> str:
+        return "ReadMaxFiles"
+
+    @classmethod
+    def load(cls, params: dict) -> "ReadMaxFiles":
+        return ReadMaxFiles(params["max_files"])
+
+    def _dump(self) -> dict:
+        return {"max_files": self.max_files}
+
+
+class ReadMaxBytes(ReadLimit):
+    def __init__(self, max_bytes: int) -> None:
+        self.max_bytes = max_bytes
+
+    @classmethod
+    def type_name(cls) -> str:
+        return "ReadMaxBytes"
+
+    @classmethod
+    def load(cls, params: dict) -> "ReadMaxBytes":
+        return ReadMaxBytes(params["max_bytes"])
+
+    def _dump(self) -> dict:
+        return {"max_bytes": self.max_bytes}
+
+
+class CompositeReadLimit(ReadLimit):
+    def __init__(self, readLimits: List[ReadLimit]) -> None:
+        self.readLimits = readLimits
+
+    @classmethod
+    def type_name(cls) -> str:
+        return "CompositeReadLimit"
+
+    @classmethod
+    def load(cls, params: dict) -> "CompositeReadLimit":
+        read_limits = []
+        for rl_params in params["readLimits"]:
+            rl_type = rl_params["type"]
+            rl = READ_LIMIT_REGISTRY.get(rl_type, rl_params)
+            read_limits.append(rl)
+        return CompositeReadLimit(read_limits)
+
+    def _dump(self) -> dict:
+        return {"readLimits": [rl.dump() for rl in self.readLimits]}
+
+
+class SupportsAdmissionControl(ABC):
+    def getDefaultReadLimit(self) -> ReadLimit:
+        """
+        FIXME: docstring needed
+
+      /**
+       * Returns the read limits potentially passed to the data source through options when creating
+       * the data source.
+       */
+        """
+        return ReadAllAvailable()
+
+    @abstractmethod
+    def latestOffset(self, start: dict, readLimit: ReadLimit) -> dict:
+        """
+        FIXME: docstring needed
+
+      /**
+       * Returns the most recent offset available given a read limit. The start offset can be used
+       * to figure out how much new data should be read given the limit. Users should implement this
+       * method instead of latestOffset for a MicroBatchStream or getOffset for Source.
+       * <p>
+       * When this method is called on a `Source`, the source can return `null` if there is no
+       * data to process. In addition, for the very first micro-batch, the `startOffset` will be
+       * null as well.
+       * <p>
+       * When this method is called on a MicroBatchStream, the `startOffset` will be `initialOffset`
+       * for the very first micro-batch. The source can return `null` if there is no data to process.
+       */
+        """
+        pass
+
+    def reportLatestOffset(self) -> Optional[dict]:
+        """
+        FIXME: docstring needed
+
+      /**
+       * Returns the most recent offset available.
+       * <p>
+       * The source can return `null`, if there is no data to process or the source does not support
+       * to this method.
+       */
+        """
+        return None
+
+
+class SupportsTriggerAvailableNow(ABC):
+    @abstractmethod
+    def prepareForTriggerAvailableNow(self) -> None:
+        """
+        FIXME: docstring needed
+
+        /**
+         * This will be called at the beginning of streaming queries with Trigger.AvailableNow, to let the
+         * source record the offset for the current latest data at the time (a.k.a the target offset for
+         * the query). The source will behave as if there is no new data coming in after the target
+         * offset, i.e., the source will not return an offset higher than the target offset when
+         * {@link #latestOffset(Offset, ReadLimit) latestOffset} is called.
+         * <p>
+         * Note that there is an exception on the first uncommitted batch after a restart, where the end
+         * offset is not derived from the current latest offset. Sources need to take special
+         * considerations if wanting to assert such relation. One possible way is to have an internal
+         * flag in the source to indicate whether it is Trigger.AvailableNow, set the flag in this method,
+         * and record the target offset in the first call of
+         * {@link #latestOffset(Offset, ReadLimit) latestOffset}.
+         */
+        """
+        pass

--- a/python/pyspark/sql/streaming/datasource.py
+++ b/python/pyspark/sql/streaming/datasource.py
@@ -20,27 +20,80 @@ from typing import Optional
 
 
 class ReadLimit(ABC):
+    """
+    Specifies limits on how much data to read from a streaming source when
+    determining the latest offset.
+    """
+
     @classmethod
     @abstractmethod
     def type_name(cls) -> str:
+        """
+        The name of this :class:`ReadLimit` type. This is used to register the type into registry.
+
+        Returns
+        -------
+        str
+            The name of this :class:`ReadLimit` type.
+        """
         pass
 
     @classmethod
     @abstractmethod
     def load(cls, params: dict) -> "ReadLimit":
+        """
+        Create an instance of :class:`ReadLimit` from parameters.
+
+        Parameter
+        ---------
+        params : dict
+            The parameters to create the :class:`ReadLimit`. type name isn't included.
+
+        Returns
+        -------
+        ReadLimit
+            The created :class:`ReadLimit` instance.
+        """
         pass
 
     def dump(self) -> dict:
+        """
+        Method to serialize this :class:`ReadLimit` instance. Implementations of :class:`ReadLimit`
+        are expected to not implement this method directly and rather implement the
+        :meth:`_dump()` method.
+
+        Returns
+        -------
+        dict
+            A dictionary containing the serialized parameters of this :class:`ReadLimit`,
+            including the type name.
+        """
         params = self._dump()
         params.update({"type": self.type_name()})
         return params
 
     @abstractmethod
     def _dump(self) -> dict:
+        """
+        Method to serialize this :class:`ReadLimit` instance. Implementations of :class:`ReadLimit`
+        are expected to implement this method to handle their specific parameters. type name will
+        be handled in the :meth:`dump()` method.
+
+        Returns
+        -------
+        dict
+            A dictionary containing the serialized parameters of this :class:`ReadLimit`,
+            excluding the type name.
+        """
         pass
 
 
 class ReadAllAvailable(ReadLimit):
+    """
+    A :class:`ReadLimit` that indicates to read all available data, regardless of the given source
+    options.
+    """
+
     @classmethod
     def type_name(cls) -> str:
         return "ReadAllAvailable"
@@ -54,6 +107,16 @@ class ReadAllAvailable(ReadLimit):
 
 
 class ReadMinRows(ReadLimit):
+    """
+    A :class:`ReadLimit` that indicates to read minimum N rows. If there is less than N rows
+    available for read, the source should skip producing a new offset to read and wait until more
+    data arrives.
+
+    Note that the semantic does not work properly with Trigger.AvailableNow since the source
+    may end up waiting forever for more data to arrive. It is the source's responsibility to
+    handle this case properly.
+    """
+
     def __init__(self, min_rows: int) -> None:
         self.min_rows = min_rows
 
@@ -70,6 +133,11 @@ class ReadMinRows(ReadLimit):
 
 
 class ReadMaxRows(ReadLimit):
+    """
+    A :class:`ReadLimit` that indicates to read maximum N rows. The source should not read more
+    than N rows when determining the latest offset.
+    """
+
     def __init__(self, max_rows: int) -> None:
         self.max_rows = max_rows
 
@@ -86,6 +154,11 @@ class ReadMaxRows(ReadLimit):
 
 
 class ReadMaxFiles(ReadLimit):
+    """
+    A :class:`ReadLimit` that indicates to read maximum N files. The source should not read more
+    than N files when determining the latest offset.
+    """
+
     def __init__(self, max_files: int) -> None:
         self.max_files = max_files
 
@@ -102,6 +175,11 @@ class ReadMaxFiles(ReadLimit):
 
 
 class ReadMaxBytes(ReadLimit):
+    """
+    A :class:`ReadLimit` that indicates to read maximum N bytes. The source should not read more
+    than N bytes when determining the latest offset.
+    """
+
     def __init__(self, max_bytes: int) -> None:
         self.max_bytes = max_bytes
 
@@ -118,24 +196,31 @@ class ReadMaxBytes(ReadLimit):
 
 
 class SupportsTriggerAvailableNow(ABC):
+    """
+    A mixin interface for streaming sources that support Trigger.AvailableNow. This interface can
+    be added to both :class:`DataSourceStreamReader` and :class:`SimpleDataSourceStreamReader`.
+    """
+
     @abstractmethod
     def prepareForTriggerAvailableNow(self) -> None:
         """
-        FIXME: docstring needed
+        This will be called at the beginning of streaming queries with Trigger.AvailableNow, to let
+        the source record the offset for the current latest data at the time (a.k.a the target
+        offset for the query). The source must behave as if there is no new data coming in after
+        the target offset, i.e., the source must not return an offset higher than the target offset
+        when :meth:`DataSourceStreamReader.latestOffset()` is called.
 
-        /**
-         * This will be called at the beginning of streaming queries with Trigger.AvailableNow, to let the
-         * source record the offset for the current latest data at the time (a.k.a the target offset for
-         * the query). The source will behave as if there is no new data coming in after the target
-         * offset, i.e., the source will not return an offset higher than the target offset when
-         * {@link #latestOffset(Offset, ReadLimit) latestOffset} is called.
-         * <p>
-         * Note that there is an exception on the first uncommitted batch after a restart, where the end
-         * offset is not derived from the current latest offset. Sources need to take special
-         * considerations if wanting to assert such relation. One possible way is to have an internal
-         * flag in the source to indicate whether it is Trigger.AvailableNow, set the flag in this method,
-         * and record the target offset in the first call of
-         * {@link #latestOffset(Offset, ReadLimit) latestOffset}.
-         */
+        The source can extend the semantic of "current latest data" based on its own logic, but the
+        extended semantic must not violate the expectation that the source will not read any data
+        which is added later than the time this method has called.
+
+        Note that it is the source's responsibility to ensure that calling
+        :meth:`DataSourceStreamReader.latestOffset()` or :meth:`SimpleDataSourceStreamReader.read()`
+        after calling this method will eventually reach the target offset, and finally returns the
+        same offset as given start parameter, to indicate that there is no more data to read. This
+        includes the case where the query is restarted and the source is asked to read from the
+        offset being journaled in previous run - source should take care of exceptional cases like
+        new partition has added during the restart, etc, to ensure that the query run will be
+        completed at some point.
         """
         pass

--- a/python/pyspark/sql/streaming/datasource.py
+++ b/python/pyspark/sql/streaming/datasource.py
@@ -19,6 +19,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import ClassVar
 
+
 class ReadLimit:
     """
     Specifies limits on how much data to read from a streaming source when
@@ -54,6 +55,7 @@ class ReadMinRows(ReadLimit):
     may end up waiting forever for more data to arrive. It is the source's responsibility to
     handle this case properly.
     """
+
     min_rows: int
 
 
@@ -63,6 +65,7 @@ class ReadMaxRows(ReadLimit):
     A :class:`ReadLimit` that indicates to read maximum N rows. The source should not read more
     than N rows when determining the latest offset.
     """
+
     max_rows: int
 
 
@@ -72,6 +75,7 @@ class ReadMaxFiles(ReadLimit):
     A :class:`ReadLimit` that indicates to read maximum N files. The source should not read more
     than N files when determining the latest offset.
     """
+
     max_files: int
 
 
@@ -81,6 +85,7 @@ class ReadMaxBytes(ReadLimit):
     A :class:`ReadLimit` that indicates to read maximum N bytes. The source should not read more
     than N bytes when determining the latest offset.
     """
+
     max_bytes: int
 
 

--- a/python/pyspark/sql/streaming/datasource.py
+++ b/python/pyspark/sql/streaming/datasource.py
@@ -22,6 +22,15 @@ class ReadLimit(ABC):
     """
     Specifies limits on how much data to read from a streaming source when
     determining the latest offset.
+
+    As of Spark 4.2.0, only built-in implementations of :class:`ReadLimit` are supported. Please
+    refer to the following classes for the supported types:
+
+    - :class:`ReadAllAvailable`
+    - :class:`ReadMinRows`
+    - :class:`ReadMaxRows`
+    - :class:`ReadMaxFiles`
+    - :class:`ReadMaxBytes`
     """
 
     @classmethod

--- a/python/pyspark/sql/streaming/datasource.py
+++ b/python/pyspark/sql/streaming/datasource.py
@@ -17,7 +17,6 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import ClassVar
 
 
 class ReadLimit:

--- a/python/pyspark/sql/streaming/datasource.py
+++ b/python/pyspark/sql/streaming/datasource.py
@@ -16,9 +16,10 @@
 #
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import ClassVar
 
-
-class ReadLimit(ABC):
+class ReadLimit:
     """
     Specifies limits on how much data to read from a streaming source when
     determining the latest offset.
@@ -33,87 +34,16 @@ class ReadLimit(ABC):
     - :class:`ReadMaxBytes`
     """
 
-    @classmethod
-    @abstractmethod
-    def type_name(cls) -> str:
-        """
-        The name of this :class:`ReadLimit` type. This is used to register the type into registry.
 
-        Returns
-        -------
-        str
-            The name of this :class:`ReadLimit` type.
-        """
-        pass
-
-    @classmethod
-    @abstractmethod
-    def load(cls, params: dict) -> "ReadLimit":
-        """
-        Create an instance of :class:`ReadLimit` from parameters.
-
-        Parameter
-        ---------
-        params : dict
-            The parameters to create the :class:`ReadLimit`. type name isn't included.
-
-        Returns
-        -------
-        ReadLimit
-            The created :class:`ReadLimit` instance.
-        """
-        pass
-
-    def dump(self) -> dict:
-        """
-        Method to serialize this :class:`ReadLimit` instance. Implementations of :class:`ReadLimit`
-        are expected to not implement this method directly and rather implement the
-        :meth:`_dump()` method.
-
-        Returns
-        -------
-        dict
-            A dictionary containing the serialized parameters of this :class:`ReadLimit`,
-            including the type name.
-        """
-        params = self._dump()
-        params.update({"type": self.type_name()})
-        return params
-
-    @abstractmethod
-    def _dump(self) -> dict:
-        """
-        Method to serialize this :class:`ReadLimit` instance. Implementations of :class:`ReadLimit`
-        are expected to implement this method to handle their specific parameters. type name will
-        be handled in the :meth:`dump()` method.
-
-        Returns
-        -------
-        dict
-            A dictionary containing the serialized parameters of this :class:`ReadLimit`,
-            excluding the type name.
-        """
-        pass
-
-
+@dataclass
 class ReadAllAvailable(ReadLimit):
     """
     A :class:`ReadLimit` that indicates to read all available data, regardless of the given source
     options.
     """
 
-    @classmethod
-    def type_name(cls) -> str:
-        return "ReadAllAvailable"
 
-    @classmethod
-    def load(cls, params: dict) -> "ReadAllAvailable":
-        return ReadAllAvailable()
-
-    def _dump(self) -> dict:
-        return {}
-
-
+@dataclass
 class ReadMinRows(ReadLimit):
     """
     A :class:`ReadLimit` that indicates to read minimum N rows. If there is less than N rows
@@ -124,83 +54,34 @@ class ReadMinRows(ReadLimit):
     may end up waiting forever for more data to arrive. It is the source's responsibility to
     handle this case properly.
     """
-
-    def __init__(self, min_rows: int) -> None:
-        self.min_rows = min_rows
-
-    @classmethod
-    def type_name(cls) -> str:
-        return "ReadMinRows"
-
-    @classmethod
-    def load(cls, params: dict) -> "ReadMinRows":
-        return ReadMinRows(params["min_rows"])
-
-    def _dump(self) -> dict:
-        return {"min_rows": self.min_rows}
+    min_rows: int
 
 
+@dataclass
 class ReadMaxRows(ReadLimit):
     """
     A :class:`ReadLimit` that indicates to read maximum N rows. The source should not read more
     than N rows when determining the latest offset.
     """
-
-    def __init__(self, max_rows: int) -> None:
-        self.max_rows = max_rows
-
-    @classmethod
-    def type_name(cls) -> str:
-        return "ReadMaxRows"
-
-    @classmethod
-    def load(cls, params: dict) -> "ReadMaxRows":
-        return ReadMaxRows(params["max_rows"])
-
-    def _dump(self) -> dict:
-        return {"max_rows": self.max_rows}
+    max_rows: int
 
 
+@dataclass
 class ReadMaxFiles(ReadLimit):
     """
     A :class:`ReadLimit` that indicates to read maximum N files. The source should not read more
     than N files when determining the latest offset.
     """
-
-    def __init__(self, max_files: int) -> None:
-        self.max_files = max_files
-
-    @classmethod
-    def type_name(cls) -> str:
-        return "ReadMaxFiles"
-
-    @classmethod
-    def load(cls, params: dict) -> "ReadMaxFiles":
-        return ReadMaxFiles(params["max_files"])
-
-    def _dump(self) -> dict:
-        return {"max_files": self.max_files}
+    max_files: int
 
 
+@dataclass
 class ReadMaxBytes(ReadLimit):
     """
     A :class:`ReadLimit` that indicates to read maximum N bytes. The source should not read more
     than N bytes when determining the latest offset.
     """
-
-    def __init__(self, max_bytes: int) -> None:
-        self.max_bytes = max_bytes
-
-    @classmethod
-    def type_name(cls) -> str:
-        return "ReadMaxBytes"
-
-    @classmethod
-    def load(cls, params: dict) -> "ReadMaxBytes":
-        return ReadMaxBytes(params["max_bytes"])
-
-    def _dump(self) -> dict:
-        return {"max_bytes": self.max_bytes}
+    max_bytes: int
 
 
 class SupportsTriggerAvailableNow(ABC):

--- a/python/pyspark/sql/streaming/listener.py
+++ b/python/pyspark/sql/streaming/listener.py
@@ -921,7 +921,7 @@ class SourceProgress(dict):
                 return value
             else:
                 return json.dumps(value)
-        
+
         return cls(
             jdict=j,
             description=j["description"],

--- a/python/pyspark/sql/streaming/listener.py
+++ b/python/pyspark/sql/streaming/listener.py
@@ -914,12 +914,20 @@ class SourceProgress(dict):
 
     @classmethod
     def fromJson(cls, j: Dict[str, Any]) -> "SourceProgress":
+        def _to_json_string(value: Any) -> str:
+            """Convert offset value to JSON string. If already a string, return as-is.
+            If a dict/list, JSON-encode it."""
+            if isinstance(value, str):
+                return value
+            else:
+                return json.dumps(value)
+        
         return cls(
             jdict=j,
             description=j["description"],
-            startOffset=str(j["startOffset"]),
-            endOffset=str(j["endOffset"]),
-            latestOffset=str(j["latestOffset"]),
+            startOffset=_to_json_string(j["startOffset"]),
+            endOffset=_to_json_string(j["endOffset"]),
+            latestOffset=_to_json_string(j["latestOffset"]),
             numInputRows=j["numInputRows"],
             inputRowsPerSecond=j["inputRowsPerSecond"],
             processedRowsPerSecond=j["processedRowsPerSecond"],

--- a/python/pyspark/sql/streaming/python_streaming_source_runner.py
+++ b/python/pyspark/sql/streaming/python_streaming_source_runner.py
@@ -31,11 +31,13 @@ from pyspark.serializers import (
 from pyspark.sql.datasource import (
     DataSource,
     DataSourceStreamReader,
+)
+from pyspark.sql.streaming.datasource import (
     ReadAllAvailable,
     SupportsAdmissionControl,
-    SupportsTriggerAvailableNow
+    SupportsTriggerAvailableNow,
 )
-from pyspark.sql.datasource_internal import _SimpleStreamReaderWrapper, _streamReader
+from pyspark.sql.datasource_internal import _SimpleStreamReaderWrapper, _streamReader, ReadLimitRegistry
 from pyspark.sql.pandas.serializers import ArrowStreamSerializer
 from pyspark.sql.types import (
     _parse_datatype_json_string,
@@ -60,6 +62,8 @@ COMMIT_FUNC_ID = 887
 CHECK_SUPPORTED_FEATURES_ID = 888
 PREPARE_FOR_TRIGGER_AVAILABLE_NOW_FUNC_ID = 889
 LATEST_OFFSET_ADMISSION_CONTROL_FUNC_ID = 890
+GET_DEFAULT_READ_LIMIT_FUNC_ID = 891
+REPORT_LATEST_OFFSET_FUNC_ID = 892
 
 PREFETCHED_RECORDS_NOT_FOUND = 0
 NON_EMPTY_PYARROW_RECORD_BATCHES = 1
@@ -68,9 +72,12 @@ EMPTY_PYARROW_RECORD_BATCHES = 2
 SUPPORTS_ADMISSION_CONTROL = 1
 SUPPORTS_TRIGGER_AVAILABLE_NOW = 1 << 1
 
+READ_LIMIT_REGISTRY = ReadLimitRegistry()
+
 
 def initial_offset_func(reader: DataSourceStreamReader, outfile: IO) -> None:
     offset = reader.initialOffset()
+    # raise Exception(f"Debug info for initial offset: offset: {offset}, json: {json.dumps(offset).encode('utf-8')}")
     write_with_length(json.dumps(offset).encode("utf-8"), outfile)
 
 
@@ -165,17 +172,35 @@ def prepare_for_trigger_available_now_func(reader, outfile):
 def latest_offset_admission_control_func(reader, infile, outfile):
     start_offset_dict = json.loads(utf8_deserializer.loads(infile))
 
-    limit_type = read_int(infile)
-    if limit_type == 0:
-        # ReadAllAvailable
-        limit = ReadAllAvailable()
-    else:
-        # FIXME: raise error
-        # FIXME: code for not supported?
-        raise Exception("Only ReadAllAvailable is supported for latestOffsetAdmissionControl.")
+    limit = json.loads(utf8_deserializer.loads(infile))
+    limit_obj = READ_LIMIT_REGISTRY.get(limit["type"], limit)
 
-    offset = reader.latestOffset(start_offset_dict, limit)
+    offset = reader.latestOffset(start_offset_dict, limit_obj)
     write_with_length(json.dumps(offset).encode("utf-8"), outfile)
+
+
+def get_default_read_limit_func(reader, outfile):
+    if isinstance(reader, SupportsAdmissionControl):
+        limit = reader.getDefaultReadLimit()
+    else:
+        limit = READ_ALL_AVAILABLE
+
+    write_with_length(json.dumps(limit.dump()).encode("utf-8"), outfile)
+
+
+def report_latest_offset_func(reader, outfile):
+    if isinstance(reader, _SimpleStreamReaderWrapper):
+        # We do not consider providing latest offset on simple stream reader.
+        write_int(0, outfile)
+    else:
+        if isinstance(reader, SupportsAdmissionControl):
+            offset = reader.reportLatestOffset()
+            if offset is None:
+                write_int(0, outfile)
+            else:
+                write_with_length(json.dumps(offset).encode("utf-8"), outfile)
+        else:
+            write_int(0, outfile)
 
 
 def main(infile: IO, outfile: IO) -> None:
@@ -244,6 +269,10 @@ def main(infile: IO, outfile: IO) -> None:
                     prepare_for_trigger_available_now_func(reader, outfile)
                 elif func_id == LATEST_OFFSET_ADMISSION_CONTROL_FUNC_ID:
                     latest_offset_admission_control_func(reader, infile, outfile)
+                elif func_id == GET_DEFAULT_READ_LIMIT_FUNC_ID:
+                    get_default_read_limit_func(reader, outfile)
+                elif func_id == REPORT_LATEST_OFFSET_FUNC_ID:
+                    report_latest_offset_func(reader, outfile)
                 else:
                     raise IllegalArgumentException(
                         errorClass="UNSUPPORTED_OPERATION",

--- a/python/pyspark/sql/streaming/python_streaming_source_runner.py
+++ b/python/pyspark/sql/streaming/python_streaming_source_runner.py
@@ -28,7 +28,13 @@ from pyspark.serializers import (
     write_with_length,
     SpecialLengths,
 )
-from pyspark.sql.datasource import DataSource, DataSourceStreamReader
+from pyspark.sql.datasource import (
+    DataSource,
+    DataSourceStreamReader,
+    ReadAllAvailable,
+    SupportsAdmissionControl,
+    SupportsTriggerAvailableNow
+)
 from pyspark.sql.datasource_internal import _SimpleStreamReaderWrapper, _streamReader
 from pyspark.sql.pandas.serializers import ArrowStreamSerializer
 from pyspark.sql.types import (
@@ -51,10 +57,16 @@ INITIAL_OFFSET_FUNC_ID = 884
 LATEST_OFFSET_FUNC_ID = 885
 PARTITIONS_FUNC_ID = 886
 COMMIT_FUNC_ID = 887
+CHECK_SUPPORTED_FEATURES_ID = 888
+PREPARE_FOR_TRIGGER_AVAILABLE_NOW_FUNC_ID = 889
+LATEST_OFFSET_ADMISSION_CONTROL_FUNC_ID = 890
 
 PREFETCHED_RECORDS_NOT_FOUND = 0
 NON_EMPTY_PYARROW_RECORD_BATCHES = 1
 EMPTY_PYARROW_RECORD_BATCHES = 2
+
+SUPPORTS_ADMISSION_CONTROL = 1
+SUPPORTS_TRIGGER_AVAILABLE_NOW = 1 << 1
 
 
 def initial_offset_func(reader: DataSourceStreamReader, outfile: IO) -> None:
@@ -114,6 +126,56 @@ def send_batch_func(
         serializer.dump_stream(batches, outfile)
     else:
         write_int(EMPTY_PYARROW_RECORD_BATCHES, outfile)
+
+
+def check_support_func(reader, outfile):
+    support_flags = 0
+    if isinstance(reader, _SimpleStreamReaderWrapper):
+        # We consider the method of `read` in simple_reader to already have admission control
+        # into it.
+        support_flags |= SUPPORTS_TRIGGER_AVAILABLE_NOW
+        if isinstance(reader.simple_reader, SupportsTriggerAvailableNow):
+            support_flags |= SUPPORTS_TRIGGER_AVAILABLE_NOW
+    else:
+        if isinstance(reader, SupportsAdmissionControl):
+            support_flags |= SUPPORTS_ADMISSION_CONTROL
+        if isinstance(reader, SupportsTriggerAvailableNow):
+            support_flags |= SUPPORTS_TRIGGER_AVAILABLE_NOW
+    write_int(support_flags, outfile)
+
+
+def prepare_for_trigger_available_now_func(reader, outfile):
+    if isinstance(reader, _SimpleStreamReaderWrapper):
+        if isinstance(reader.simple_reader, SupportsTriggerAvailableNow):
+            reader.simple_reader.prepareForTriggerAvailableNow()
+        else:
+            # FIXME: code for not supported? or should it be assertion?
+            raise Exception("prepareForTriggerAvailableNow is not supported by the "
+                            "underlying simple reader.")
+    else:
+        if isinstance(reader, SupportsTriggerAvailableNow):
+            reader.prepareForTriggerAvailableNow()
+        else:
+            # FIXME: code for not supported? or should it be assertion?
+            raise Exception("prepareForTriggerAvailableNow is not supported by the "
+                            "stream reader.")
+    write_int(0, outfile)
+
+
+def latest_offset_admission_control_func(reader, infile, outfile):
+    start_offset_dict = json.loads(utf8_deserializer.loads(infile))
+
+    limit_type = read_int(infile)
+    if limit_type == 0:
+        # ReadAllAvailable
+        limit = ReadAllAvailable()
+    else:
+        # FIXME: raise error
+        # FIXME: code for not supported?
+        raise Exception("Only ReadAllAvailable is supported for latestOffsetAdmissionControl.")
+
+    offset = reader.latestOffset(start_offset_dict, limit)
+    write_with_length(json.dumps(offset).encode("utf-8"), outfile)
 
 
 def main(infile: IO, outfile: IO) -> None:
@@ -176,6 +238,12 @@ def main(infile: IO, outfile: IO) -> None:
                     )
                 elif func_id == COMMIT_FUNC_ID:
                     commit_func(reader, infile, outfile)
+                elif func_id == CHECK_SUPPORTED_FEATURES_ID:
+                    check_support_func(reader, outfile)
+                elif func_id == PREPARE_FOR_TRIGGER_AVAILABLE_NOW_FUNC_ID:
+                    prepare_for_trigger_available_now_func(reader, outfile)
+                elif func_id == LATEST_OFFSET_ADMISSION_CONTROL_FUNC_ID:
+                    latest_offset_admission_control_func(reader, infile, outfile)
                 else:
                     raise IllegalArgumentException(
                         errorClass="UNSUPPORTED_OPERATION",

--- a/python/pyspark/sql/streaming/python_streaming_source_runner.py
+++ b/python/pyspark/sql/streaming/python_streaming_source_runner.py
@@ -58,7 +58,6 @@ from pyspark.worker_util import (
     utf8_deserializer,
 )
 
-from pyspark.sql.streaming.datasource import ReadAllAvailable
 
 INITIAL_OFFSET_FUNC_ID = 884
 LATEST_OFFSET_FUNC_ID = 885
@@ -86,7 +85,7 @@ def initial_offset_func(reader: DataSourceStreamReader, outfile: IO) -> None:
 
 
 def latest_offset_func(reader: DataSourceStreamReader, outfile: IO) -> None:
-    offset = reader.latestOffset()
+    offset = reader.latestOffset()  # type: ignore[call-arg]
     write_with_length(json.dumps(offset).encode("utf-8"), outfile)
 
 
@@ -149,6 +148,7 @@ def check_support_func(reader: DataSourceStreamReader, outfile: IO) -> None:
             support_flags |= SUPPORTS_TRIGGER_AVAILABLE_NOW
     else:
         import inspect
+
         sig = inspect.signature(reader.latestOffset)
         if len(sig.parameters) == 0:
             # old signature of latestOffset()
@@ -188,7 +188,7 @@ def latest_offset_admission_control_func(
     limit = json.loads(utf8_deserializer.loads(infile))
     limit_obj = READ_LIMIT_REGISTRY.get(limit["type"], limit)
 
-    offset = reader.latestOffset(start_offset_dict, limit_obj)  # type: ignore[call-arg]
+    offset = reader.latestOffset(start_offset_dict, limit_obj)
     write_with_length(json.dumps(offset).encode("utf-8"), outfile)
 
 

--- a/python/pyspark/sql/streaming/python_streaming_source_runner.py
+++ b/python/pyspark/sql/streaming/python_streaming_source_runner.py
@@ -145,7 +145,6 @@ def check_support_func(reader: DataSourceStreamReader, outfile: IO) -> None:
     if isinstance(reader, _SimpleStreamReaderWrapper):
         # We consider the method of `read` in simple_reader to already have admission control
         # into it.
-        support_flags |= SUPPORTS_TRIGGER_AVAILABLE_NOW
         if isinstance(reader.simple_reader, SupportsTriggerAvailableNow):
             support_flags |= SUPPORTS_TRIGGER_AVAILABLE_NOW
     else:

--- a/python/pyspark/sql/streaming/python_streaming_source_runner.py
+++ b/python/pyspark/sql/streaming/python_streaming_source_runner.py
@@ -187,7 +187,7 @@ def latest_offset_admission_control_func(
     start_offset_dict = json.loads(utf8_deserializer.loads(infile))
 
     limit = json.loads(utf8_deserializer.loads(infile))
-    limit_obj = READ_LIMIT_REGISTRY.get(limit["_type"], limit)
+    limit_obj = READ_LIMIT_REGISTRY.get(limit)
 
     offset = reader.latestOffset(start_offset_dict, limit_obj)
     write_with_length(json.dumps(offset).encode("utf-8"), outfile)

--- a/python/pyspark/sql/streaming/python_streaming_source_runner.py
+++ b/python/pyspark/sql/streaming/python_streaming_source_runner.py
@@ -195,7 +195,9 @@ def latest_offset_admission_control_func(
 
 def get_default_read_limit_func(reader: DataSourceStreamReader, outfile: IO) -> None:
     limit = reader.getDefaultReadLimit()
-    limit_as_dict = dataclasses.asdict(limit) | {"_type": limit.__class__.__name__}
+    limit_as_dict = dataclasses.asdict(limit) | {  # type: ignore[call-overload]
+        "_type": limit.__class__.__name__
+    }
     write_with_length(json.dumps(limit_as_dict).encode("utf-8"), outfile)
 
 

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -26,8 +26,14 @@ from pyspark.sql.datasource import (
     DataSourceStreamWriter,
     DataSourceStreamArrowWriter,
     SimpleDataSourceStreamReader,
-    SupportsTriggerAvailableNow,
     WriterCommitMessage,
+)
+from pyspark.sql.streaming.datasource import (
+    ReadAllAvailable,
+    ReadLimit,
+    ReadMaxRows,
+    SupportsAdmissionControl,
+    SupportsTriggerAvailableNow,
 )
 from pyspark.sql.streaming import StreamingQueryException
 from pyspark.sql.types import Row
@@ -142,13 +148,6 @@ class BasePythonStreamingDataSourceTestsMixin:
         return TestDataSource
 
     def _get_test_data_source_for_admission_control(self):
-        from pyspark.sql.streaming.datasource import (
-            ReadAllAvailable,
-            ReadLimit,
-            ReadMaxRows,
-            SupportsAdmissionControl,
-        )
-
         class TestDataStreamReader(DataSourceStreamReader, SupportsAdmissionControl):
             def initialOffset(self):
                 return {"partition-1": 0}

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -353,7 +353,7 @@ class BasePythonStreamingDataSourceTestsMixin:
         q = df.writeStream.trigger(once=True).foreachBatch(check_batch).start()
         q.awaitTermination()
         self.assertIsNone(q.exception(), "No exception has to be propagated.")
-        self.assertTrue(q.recentProgress.length == 1)
+        self.assertTrue(len(q.recentProgress) == 1)
         self.assertTrue(q.lastProgress.numInputRows == 10)
         self.assertTrue(q.lastProgress.sources[0].numInputRows == 10)
         self.assertTrue(q.lastProgress.sources[0].latestOffset == """{"partition-1": 1000000}""")
@@ -383,7 +383,7 @@ class BasePythonStreamingDataSourceTestsMixin:
         q.awaitTermination(timeout=30)
         self.assertIsNone(q.exception(), "No exception has to be propagated.")
         # 2 rows * 5 batches = 10 rows
-        self.assertTrue(q.recentProgress.length == 5)
+        self.assertTrue(len(q.recentProgress) == 5)
         for progress in q.recentProgress:
             self.assertTrue(progress.numInputRows == 2)
             self.assertTrue(q.lastProgress.sources[0].numInputRows == 2)

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -357,7 +357,7 @@ class BasePythonStreamingDataSourceTestsMixin:
         self.assertEqual(len(q.recentProgress), 1)
         self.assertEqual(q.lastProgress.numInputRows, 10)
         self.assertEqual(q.lastProgress.sources[0].numInputRows, 10)
-        self.assertEqual(q.lastProgress.sources[0].latestOffset, """{"partition-1": 1000000}""")
+        self.assertEqual(q.lastProgress.sources[0].latestOffset, """{'partition-1': 1000000}""")
 
     def test_stream_reader_admission_control_processing_time_trigger(self):
         self.spark.dataSource.register(self._get_test_data_source_for_admission_control())
@@ -388,7 +388,7 @@ class BasePythonStreamingDataSourceTestsMixin:
         for progress in q.recentProgress:
             self.assertEqual(progress.numInputRows, 2)
             self.assertEqual(q.lastProgress.sources[0].numInputRows, 2)
-            self.assertEqual(q.lastProgress.sources[0].latestOffset, """{"partition-1": 1000000}""")
+            self.assertEqual(q.lastProgress.sources[0].latestOffset, """{'partition-1': 1000000}""")
 
     def test_simple_stream_reader(self):
         class SimpleStreamReader(SimpleDataSourceStreamReader):

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -32,7 +32,6 @@ from pyspark.sql.streaming.datasource import (
     ReadAllAvailable,
     ReadLimit,
     ReadMaxRows,
-    SupportsAdmissionControl,
     SupportsTriggerAvailableNow,
 )
 from pyspark.sql.streaming import StreamingQueryException
@@ -148,7 +147,7 @@ class BasePythonStreamingDataSourceTestsMixin:
         return TestDataSource
 
     def _get_test_data_source_for_admission_control(self):
-        class TestDataStreamReader(DataSourceStreamReader, SupportsAdmissionControl):
+        class TestDataStreamReader(DataSourceStreamReader):
             def initialOffset(self):
                 return {"partition-1": 0}
 

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -243,7 +243,7 @@ class BasePythonStreamingDataSourceTestsMixin:
             def reportLatestOffset(self):
                 return {"partition-1": 1000000}
 
-            def prepare_for_trigger_available_now(self) -> None:
+            def prepareForTriggerAvailableNow(self) -> None:
                 self.desired_end_offset = {"partition-1": 10}
 
             def partitions(self, start: dict, end: dict):

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -190,15 +190,15 @@ class BasePythonStreamingDataSourceTestsMixin:
             def getDefaultReadLimit(self):
                 return ReadMaxRows(2)
 
-            def latestOffset(self, start: dict, readLimit: ReadLimit):
+            def latestOffset(self, start: dict, limit: ReadLimit):
                 start_idx = start["partition-1"]
-                if isinstance(readLimit, ReadAllAvailable):
+                if isinstance(limit, ReadAllAvailable):
                     end_offset = start_idx + 10
                 else:
                     assert isinstance(
-                        readLimit, ReadMaxRows
-                    ), "Expected ReadMaxRows read limit but got " + str(type(readLimit))
-                    end_offset = start_idx + readLimit.max_rows
+                        limit, ReadMaxRows
+                    ), "Expected ReadMaxRows read limit but got " + str(type(limit))
+                    end_offset = start_idx + limit.max_rows
                 return {"partition-1": end_offset}
 
             def reportLatestOffset(self):
@@ -229,16 +229,16 @@ class BasePythonStreamingDataSourceTestsMixin:
             def getDefaultReadLimit(self):
                 return ReadMaxRows(2)
 
-            def latestOffset(self, start: dict, readLimit: ReadLimit):
+            def latestOffset(self, start: dict, limit: ReadLimit):
                 start_idx = start["partition-1"]
-                if isinstance(readLimit, ReadAllAvailable):
+                if isinstance(limit, ReadAllAvailable):
                     end_offset = start_idx + 10
                 else:
                     assert isinstance(
-                        readLimit, ReadMaxRows
-                    ), "Expected ReadMaxRows read limit but got " + str(type(readLimit))
+                        limit, ReadMaxRows
+                    ), "Expected ReadMaxRows read limit but got " + str(type(limit))
                     end_offset = min(
-                        start_idx + readLimit.max_rows, self.desired_end_offset["partition-1"]
+                        start_idx + limit.max_rows, self.desired_end_offset["partition-1"]
                     )
                 return {"partition-1": end_offset}
 

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -353,10 +353,10 @@ class BasePythonStreamingDataSourceTestsMixin:
         q = df.writeStream.trigger(once=True).foreachBatch(check_batch).start()
         q.awaitTermination()
         self.assertIsNone(q.exception(), "No exception has to be propagated.")
-        self.assertTrue(len(q.recentProgress) == 1)
-        self.assertTrue(q.lastProgress.numInputRows == 10)
-        self.assertTrue(q.lastProgress.sources[0].numInputRows == 10)
-        self.assertTrue(q.lastProgress.sources[0].latestOffset == """{"partition-1": 1000000}""")
+        self.assertEqual(len(q.recentProgress), 1)
+        self.assertEqual(q.lastProgress.numInputRows, 10)
+        self.assertEqual(q.lastProgress.sources[0].numInputRows, 10)
+        self.assertEqual(q.lastProgress.sources[0].latestOffset, """{"partition-1": 1000000}""")
 
     def test_stream_reader_admission_control_processing_time_trigger(self):
         self.spark.dataSource.register(self._get_test_data_source_for_admission_control())
@@ -383,12 +383,12 @@ class BasePythonStreamingDataSourceTestsMixin:
         q.awaitTermination(timeout=30)
         self.assertIsNone(q.exception(), "No exception has to be propagated.")
         # 2 rows * 5 batches = 10 rows
-        self.assertTrue(len(q.recentProgress) == 5)
+        self.assertEqual(len(q.recentProgress), 5)
         for progress in q.recentProgress:
-            self.assertTrue(progress.numInputRows == 2)
-            self.assertTrue(q.lastProgress.sources[0].numInputRows == 2)
-            self.assertTrue(
-                q.lastProgress.sources[0].latestOffset == """{"partition-1": 1000000}"""
+            self.assertEqual(progress.numInputRows, 2)
+            self.assertEqual(q.lastProgress.sources[0].numInputRows, 2)
+            self.assertEqual(
+                q.lastProgress.sources[0].latestOffset, """{"partition-1": 1000000}"""
             )
 
     def test_simple_stream_reader(self):

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -149,10 +149,7 @@ class BasePythonStreamingDataSourceTestsMixin:
             SupportsAdmissionControl,
         )
 
-        class TestDataStreamReader(
-            DataSourceStreamReader,
-            SupportsAdmissionControl
-        ):
+        class TestDataStreamReader(DataSourceStreamReader, SupportsAdmissionControl):
             def initialOffset(self):
                 return {"partition-1": 0}
 
@@ -164,8 +161,9 @@ class BasePythonStreamingDataSourceTestsMixin:
                 if isinstance(readLimit, ReadAllAvailable):
                     end_offset = start_idx + 10
                 else:
-                    assert isinstance(readLimit, ReadMaxRows), ("Expected ReadMaxRows read limit but got "
-                                                                + str(type(readLimit)))
+                    assert isinstance(
+                        readLimit, ReadMaxRows
+                    ), "Expected ReadMaxRows read limit but got " + str(type(readLimit))
                     end_offset = start_idx + readLimit.max_rows
                 return {"partition-1": end_offset}
 
@@ -183,6 +181,7 @@ class BasePythonStreamingDataSourceTestsMixin:
         class TestDataSource(DataSource):
             def schema(self) -> str:
                 return "id INT"
+
             def streamReader(self, schema):
                 return TestDataStreamReader()
 
@@ -337,7 +336,7 @@ class BasePythonStreamingDataSourceTestsMixin:
             def read(self, start: dict):
                 start_idx = start["offset"]
                 end_offset = min(start_idx + 2, self.desired_end_offset["offset"])
-                it = iter([(i, ) for i in range(start_idx, end_offset)])
+                it = iter([(i,) for i in range(start_idx, end_offset)])
                 return (it, {"offset": end_offset})
 
             def commit(self, end):

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -359,8 +359,7 @@ class BasePythonStreamingDataSourceTestsMixin:
         self.assertEqual(q.lastProgress.numInputRows, 10)
         self.assertEqual(q.lastProgress.sources[0].numInputRows, 10)
         self.assertEqual(
-            json.loads(q.lastProgress.sources[0].latestOffset),
-            {"partition-1": 1000000}
+            json.loads(q.lastProgress.sources[0].latestOffset), {"partition-1": 1000000}
         )
 
     def test_stream_reader_admission_control_processing_time_trigger(self):
@@ -393,8 +392,7 @@ class BasePythonStreamingDataSourceTestsMixin:
             self.assertEqual(progress.numInputRows, 2)
             self.assertEqual(q.lastProgress.sources[0].numInputRows, 2)
             self.assertEqual(
-                json.loads(q.lastProgress.sources[0].latestOffset),
-                {"partition-1": 1000000}
+                json.loads(q.lastProgress.sources[0].latestOffset), {"partition-1": 1000000}
             )
 
     def test_simple_stream_reader(self):

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -64,21 +64,21 @@ def wait_for_condition(query, condition_fn, timeout_sec=30):
             # Collect context for debugging
             exception_info = query.exception()
             recent_progresses = query.recentProgress
-            
+
             error_msg = (
                 f"Timeout after {timeout_sec} seconds waiting for condition. "
                 f"Query exception: {exception_info}. "
                 f"Recent progress count: {len(recent_progresses)}. "
             )
-            
+
             if recent_progresses:
                 error_msg += f"Last progress: {recent_progresses[-1]}. "
                 error_msg += f"All recent progresses: {recent_progresses}"
             else:
                 error_msg += "No progress recorded."
-            
+
             raise TimeoutError(error_msg)
-        
+
         time.sleep(sleep_interval)
 
 

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -236,8 +236,9 @@ class BasePythonStreamingDataSourceTestsMixin:
                     assert isinstance(
                         readLimit, ReadMaxRows
                     ), "Expected ReadMaxRows read limit but got " + str(type(readLimit))
-                    end_offset = min(start_idx + readLimit.max_rows,
-                                     self.desired_end_offset["partition-1"])
+                    end_offset = min(
+                        start_idx + readLimit.max_rows, self.desired_end_offset["partition-1"]
+                    )
                 return {"partition-1": end_offset}
 
             def reportLatestOffset(self):
@@ -387,9 +388,7 @@ class BasePythonStreamingDataSourceTestsMixin:
         for progress in q.recentProgress:
             self.assertEqual(progress.numInputRows, 2)
             self.assertEqual(q.lastProgress.sources[0].numInputRows, 2)
-            self.assertEqual(
-                q.lastProgress.sources[0].latestOffset, """{"partition-1": 1000000}"""
-            )
+            self.assertEqual(q.lastProgress.sources[0].latestOffset, """{"partition-1": 1000000}""")
 
     def test_simple_stream_reader(self):
         class SimpleStreamReader(SimpleDataSourceStreamReader):

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -83,7 +83,7 @@ class BasePythonStreamingDataSourceTestsMixin:
                 return {"offset": 0}
 
             def latestOffset(self, start, limit):
-                return {"offset": start + 2}
+                return {"offset": start["offset"] + 2}
 
             def partitions(self, start, end):
                 return [RangePartition(start["offset"], end["offset"])]
@@ -236,7 +236,8 @@ class BasePythonStreamingDataSourceTestsMixin:
                     assert isinstance(
                         readLimit, ReadMaxRows
                     ), "Expected ReadMaxRows read limit but got " + str(type(readLimit))
-                    end_offset = min(start_idx + readLimit.max_rows, self.desired_end_offset)
+                    end_offset = min(start_idx + readLimit.max_rows,
+                                     self.desired_end_offset["partition-1"])
                 return {"partition-1": end_offset}
 
             def reportLatestOffset(self):

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -18,6 +18,7 @@ import os
 import tempfile
 import time
 import unittest
+import json
 
 from pyspark.sql.datasource import (
     DataSource,
@@ -357,7 +358,10 @@ class BasePythonStreamingDataSourceTestsMixin:
         self.assertEqual(len(q.recentProgress), 1)
         self.assertEqual(q.lastProgress.numInputRows, 10)
         self.assertEqual(q.lastProgress.sources[0].numInputRows, 10)
-        self.assertEqual(q.lastProgress.sources[0].latestOffset, """{'partition-1': 1000000}""")
+        self.assertEqual(
+            json.loads(q.lastProgress.sources[0].latestOffset),
+            {"partition-1": 1000000}
+        )
 
     def test_stream_reader_admission_control_processing_time_trigger(self):
         self.spark.dataSource.register(self._get_test_data_source_for_admission_control())
@@ -388,7 +392,10 @@ class BasePythonStreamingDataSourceTestsMixin:
         for progress in q.recentProgress:
             self.assertEqual(progress.numInputRows, 2)
             self.assertEqual(q.lastProgress.sources[0].numInputRows, 2)
-            self.assertEqual(q.lastProgress.sources[0].latestOffset, """{'partition-1': 1000000}""")
+            self.assertEqual(
+                json.loads(q.lastProgress.sources[0].latestOffset),
+                {"partition-1": 1000000}
+            )
 
     def test_simple_stream_reader(self):
         class SimpleStreamReader(SimpleDataSourceStreamReader):

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
@@ -17,9 +17,10 @@
 package org.apache.spark.sql.execution.datasources.v2.python
 
 import org.apache.spark.SparkEnv
+import org.apache.spark.api.python.PythonFunction
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReaderFactory}
-import org.apache.spark.sql.connector.read.streaming.{AcceptsLatestSeenOffset, MicroBatchStream, Offset}
+import org.apache.spark.sql.connector.read.streaming.{AcceptsLatestSeenOffset, MicroBatchStream, Offset, ReadLimit, SupportsAdmissionControl, SupportsTriggerAvailableNow}
 import org.apache.spark.sql.execution.datasources.v2.python.PythonMicroBatchStream.nextStreamId
 import org.apache.spark.sql.execution.python.streaming.PythonStreamingSourceRunner
 import org.apache.spark.sql.types.StructType
@@ -32,14 +33,12 @@ class PythonMicroBatchStream(
     ds: PythonDataSourceV2,
     shortName: String,
     outputSchema: StructType,
-    options: CaseInsensitiveStringMap
+    options: CaseInsensitiveStringMap,
+    runner: PythonStreamingSourceRunner
   )
   extends MicroBatchStream
   with Logging
   with AcceptsLatestSeenOffset {
-  private def createDataSourceFunc =
-    ds.source.createPythonFunction(
-      ds.getOrCreateDataSourceInPython(shortName, options, Some(outputSchema)).dataSource)
 
   private val streamId = nextStreamId
   private var nextBlockId = 0L
@@ -48,10 +47,6 @@ class PythonMicroBatchStream(
   // Cache the result of planInputPartitions() because it may involve sending data
   // from python to JVM.
   private var cachedInputPartition: Option[(String, String, PythonStreamingInputPartition)] = None
-
-  private val runner: PythonStreamingSourceRunner =
-    new PythonStreamingSourceRunner(createDataSourceFunc, outputSchema)
-  runner.init()
 
   override def initialOffset(): Offset = PythonStreamingSourceOffset(runner.initialOffset())
 
@@ -110,10 +105,61 @@ class PythonMicroBatchStream(
   override def deserializeOffset(json: String): Offset = PythonStreamingSourceOffset(json)
 }
 
+class PythonMicroBatchStreamWithAdmissionControl(
+    ds: PythonDataSourceV2,
+    shortName: String,
+    outputSchema: StructType,
+    options: CaseInsensitiveStringMap,
+    runner: PythonStreamingSourceRunner)
+  extends PythonMicroBatchStream(ds, shortName, outputSchema, options, runner)
+  with SupportsAdmissionControl {
+
+  override def latestOffset(): Offset = {
+    throw new IllegalStateException("latestOffset without parameters is not expected to be " +
+      "called. Please use latestOffset(startOffset: Offset, limit: ReadLimit) instead.")
+  }
+
+  override def latestOffset(startOffset: Offset, limit: ReadLimit): Offset = {
+    PythonStreamingSourceOffset(runner.latestOffset(startOffset, limit))
+  }
+}
+
+class PythonMicroBatchStreamWithTriggerAvailableNow(
+    ds: PythonDataSourceV2,
+    shortName: String,
+    outputSchema: StructType,
+    options: CaseInsensitiveStringMap,
+    runner: PythonStreamingSourceRunner)
+  extends PythonMicroBatchStreamWithAdmissionControl(ds, shortName, outputSchema, options, runner)
+  with SupportsTriggerAvailableNow {
+
+  override def prepareForTriggerAvailableNow(): Unit = {
+    runner.prepareForTriggerAvailableNow()
+  }
+}
+
 object PythonMicroBatchStream {
   private var currentId = 0
   def nextStreamId: Int = synchronized {
     currentId = currentId + 1
     currentId
+  }
+
+  def createPythonStreamingSourceRunner(
+      ds: PythonDataSourceV2,
+      shortName: String,
+      outputSchema: StructType,
+      options: CaseInsensitiveStringMap): PythonStreamingSourceRunner = {
+
+    // Below methods were called during the construction of PythonMicroBatchStream, so there is no
+    // timing/sequencing issue of calling them in here.
+    def createDataSourceFunc: PythonFunction =
+      ds.source.createPythonFunction(
+        ds.getOrCreateDataSourceInPython(
+          shortName,
+          options,
+          Some(outputSchema)).dataSource)
+
+    new PythonStreamingSourceRunner(createDataSourceFunc, outputSchema)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonMicroBatchStream.scala
@@ -29,6 +29,8 @@ import org.apache.spark.storage.{PythonStreamBlockId, StorageLevel}
 
 case class PythonStreamingSourceOffset(json: String) extends Offset
 
+case class PythonStreamingSourceReadLimit(json: String) extends ReadLimit
+
 class PythonMicroBatchStream(
     ds: PythonDataSourceV2,
     shortName: String,
@@ -121,6 +123,20 @@ class PythonMicroBatchStreamWithAdmissionControl(
 
   override def latestOffset(startOffset: Offset, limit: ReadLimit): Offset = {
     PythonStreamingSourceOffset(runner.latestOffset(startOffset, limit))
+  }
+
+  override def getDefaultReadLimit: ReadLimit = {
+    val readLimitJson = runner.getDefaultReadLimit()
+    PythonStreamingSourceReadLimit(readLimitJson)
+  }
+
+  override def reportLatestOffset(): Offset = {
+    val offsetJson = runner.reportLatestOffset()
+    if (offsetJson == null) {
+      null
+    } else {
+      PythonStreamingSourceOffset(offsetJson)
+    }
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
@@ -20,12 +20,15 @@ package org.apache.spark.sql.execution.python.streaming
 
 import java.io.{BufferedInputStream, BufferedOutputStream, DataInputStream, DataOutputStream}
 import java.nio.channels.Channels
+
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
+
 import org.apache.arrow.vector.ipc.ArrowStreamReader
+
 import org.apache.spark.SparkEnv
 import org.apache.spark.api.python.{PythonFunction, PythonWorker, PythonWorkerFactory, PythonWorkerUtils, SpecialLengths}
-import org.apache.spark.internal.{LogKeys, Logging}
+import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.internal.LogKeys.PYTHON_EXEC
 import org.apache.spark.internal.config.BUFFER_SIZE
 import org.apache.spark.internal.config.Python.PYTHON_AUTH_SOCKET_TIMEOUT
@@ -36,7 +39,7 @@ import org.apache.spark.sql.execution.datasources.v2.python.PythonStreamingSourc
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.ArrowUtils
-import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnVector, ColumnarBatch}
+import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch, ColumnVector}
 
 object PythonStreamingSourceRunner {
   // When the python process for python_streaming_source_runner receives one of the

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
@@ -58,7 +58,7 @@ object PythonStreamingSourceRunner {
   val PREFETCHED_RECORDS_NOT_FOUND = 0
   val NON_EMPTY_PYARROW_RECORD_BATCHES = 1
   val EMPTY_PYARROW_RECORD_BATCHES = 2
-  val READ_ALL_AVAILABLE_JSON = """{"type": "ReadAllAvailable"}"""
+  val READ_ALL_AVAILABLE_JSON = """{"_type": "ReadAllAvailable"}"""
 
   case class SupportedFeatures(admissionControl: Boolean, triggerAvailableNow: Boolean)
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
@@ -18,7 +18,9 @@ package org.apache.spark.sql.execution.python.streaming
 
 import java.io.File
 import java.util.concurrent.CountDownLatch
+
 import scala.concurrent.duration._
+
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.IntegratedUDFTestUtils.{createUserDefinedPythonDataSource, shouldTestPandasUDFs}
@@ -697,7 +699,8 @@ class PythonStreamingDataSourceSuite extends PythonDataSourceSuiteBase {
        |        if isinstance(readLimit, ReadAllAvailable):
        |            end_offset = start_idx + 10
        |        else:
-       |            assert isinstance(readLimit, ReadMaxRows), ("Expected ReadMaxRows read limit but got "
+       |            assert isinstance(readLimit, ReadMaxRows), ("Expected ReadMaxRows read "
+       |                                                        "limit but got "
        |                                                        + str(type(readLimit)))
        |            end_offset = start_idx + readLimit.max_rows
        |        return {"partition-1": end_offset}
@@ -744,7 +747,8 @@ class PythonStreamingDataSourceSuite extends PythonDataSourceSuiteBase {
        |        if isinstance(readLimit, ReadAllAvailable):
        |            end_offset = start_idx + 5
        |        else:
-       |            assert isinstance(readLimit, ReadMaxRows), ("Expected ReadMaxRows read limit but got "
+       |            assert isinstance(readLimit, ReadMaxRows), ("Expected ReadMaxRows read "
+       |                                                        "limit but got "
        |                                                        + str(type(readLimit)))
        |            end_offset = start_idx + readLimit.max_rows
        |        end_offset = min(end_offset, self.desired_end_offset)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
@@ -1097,9 +1097,10 @@ class PythonStreamingDataSourceSuite extends PythonDataSourceSuiteBase {
          |
          |    def latestOffset(self, start, limit):
          |        self.call_count += 1
-         |        # For odd call counts, return the same offset (simulating no new data)
-         |        # For even call counts, advance the offset by 2
-         |        if self.call_count % 2 == 1:
+         |        # For odd batches (call count - 1 is odd), return the same offset
+         |        # (simulating no new data)
+         |        # For even batches, advance the offset by 2
+         |        if (self.call_count - 1) % 2 == 1:
          |            # Return current offset without advancing
          |            return start
          |        else:

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
@@ -694,15 +694,15 @@ class PythonStreamingDataSourceSuite extends PythonDataSourceSuiteBase {
        |        return {"partition-1": 0}
        |    def getDefaultReadLimit(self):
        |        return ReadMaxRows(2)
-       |    def latestOffset(self, start: dict, readLimit: ReadLimit):
+       |    def latestOffset(self, start: dict, limit: ReadLimit):
        |        start_idx = start["partition-1"]
-       |        if isinstance(readLimit, ReadAllAvailable):
+       |        if isinstance(limit, ReadAllAvailable):
        |            end_offset = start_idx + 10
        |        else:
-       |            assert isinstance(readLimit, ReadMaxRows), ("Expected ReadMaxRows read "
-       |                                                        "limit but got "
-       |                                                        + str(type(readLimit)))
-       |            end_offset = start_idx + readLimit.max_rows
+       |            assert isinstance(limit, ReadMaxRows), ("Expected ReadMaxRows read "
+       |                                                    "limit but got "
+       |                                                    + str(type(limit)))
+       |            end_offset = start_idx + limit.max_rows
        |        return {"partition-1": end_offset}
        |    def reportLatestOffset(self):
        |        return {"partition-1": 1000000}
@@ -742,15 +742,15 @@ class PythonStreamingDataSourceSuite extends PythonDataSourceSuiteBase {
        |        return {"partition-1": 0}
        |    def getDefaultReadLimit(self):
        |        return ReadMaxRows(2)
-       |    def latestOffset(self, start: dict, readLimit: ReadLimit):
+       |    def latestOffset(self, start: dict, limit: ReadLimit):
        |        start_idx = start["partition-1"]
-       |        if isinstance(readLimit, ReadAllAvailable):
+       |        if isinstance(limit, ReadAllAvailable):
        |            end_offset = start_idx + 5
        |        else:
-       |            assert isinstance(readLimit, ReadMaxRows), ("Expected ReadMaxRows read "
-       |                                                        "limit but got "
-       |                                                        + str(type(readLimit)))
-       |            end_offset = start_idx + readLimit.max_rows
+       |            assert isinstance(limit, ReadMaxRows), ("Expected ReadMaxRows read "
+       |                                                    "limit but got "
+       |                                                    + str(type(limit)))
+       |            end_offset = start_idx + limit.max_rows
        |        end_offset = min(end_offset, self.desired_end_offset)
        |        return {"partition-1": end_offset}
        |    def reportLatestOffset(self):

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
@@ -212,7 +212,7 @@ class PythonStreamingDataSourceSimpleSuite extends PythonDataSourceSuiteBase {
         eventually(timeout(30.seconds)) {
           assert(q.recentProgress.length >= 5,
             s"Expected at least 5 progress updates but got ${q.recentProgress.length}. " +
-            s"Query exception: ${q.exception()}. " +
+            s"Query exception: ${q.exception}. " +
             s"Recent progress: ${q.recentProgress.mkString(", ")}")
         }
         q.stop()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
@@ -209,8 +209,11 @@ class PythonStreamingDataSourceSimpleSuite extends PythonDataSourceSuiteBase {
           .format("json")
           .start(outputDir.getAbsolutePath)
 
-        while (q.recentProgress.length < 5) {
-          Thread.sleep(200)
+        eventually(timeout(30.seconds)) {
+          assert(q.recentProgress.length >= 5,
+            s"Expected at least 5 progress updates but got ${q.recentProgress.length}. " +
+            s"Query exception: ${q.exception()}. " +
+            s"Recent progress: ${q.recentProgress.mkString(", ")}")
         }
         q.stop()
         q.awaitTermination()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to introduce the support of Admission Control and Trigger.AvailableNow in Python data source - streaming reader.

To support Admission control, we propose to change `DataSourceStreamReader` interface as following:
(Created a table to perform side-by-side comparison)

| **Before** | **After** |
| :---: | :---: |
| `class DataSourceStreamReader(ABC):` | `class DataSourceStreamReader(ABC):` |
| `def initialOffset(self) -> dict` | `def initialOffset(self) -> dict` |
| `def latestOffset() -> dict` | `def latestOffset(self, start: dict, limit: ReadLimit) -> dict` |
|  | `# NOTE: Optional to implement, default = ReadAllAvailable()` |
|  | `def getDefaultReadLimit(self) -> ReadLimit` |
|  | `# NOTE: Optional to implement, default = None` |
|  | `def reportLatestOffset(self) -> Optional[dict]` |
| `def partitions(self, start: dict, end: dict) -> Sequence[InputPartition]` | `def partitions(self, start: dict, end: dict) -> Sequence[InputPartition]` |
| `@abstractmethod def read(self, partition: InputPartition) -> Union[Iterator[Tuple], Iterator["RecordBatch"]]` | `@abstractmethod def read(self, partition: InputPartition) -> Union[Iterator[Tuple], Iterator["RecordBatch"]]` |
| `def commit(self, end: dict) -> None` | `def commit(self, end: dict) -> None` |
| `def stop(self) -> None` | `def stop(self) -> None` |

The main change is following:

* The method signature for `latestOffset` is changed. The method is mandatory.
* The method `getDefaultReadLimit` is added, as optional.
* The method `reportLatestOffset` is added, as optional.

This way, new implementations would support Admission Control by default. We ensure the engine can handle the case of the old method signature, via Python’s built-in inspect module (similar to Java’s reflection). If the method “latestOffset” is implemented without parameters, we fall back to the source which does not enable admission control. For all new sources, implementing latestOffset with parameters is strongly recommended.

ReadLimit interface and built-in implementations will be available for source implementations to leverage. Built-in implementations are as follows: `ReadAllAvailable`, `ReadMinRows`, `ReadMaxRows`, `ReadMaxFiles`, `ReadMaxBytes`. We won’t support custom implementation of `ReadLimit` interface at this point since it requires major efforts and we don’t see a demand, but we can plan for it if there is a strong demand.

We do not make any change to `SimpleDataSourceStreamReader` for Admission Control, since it is designed for small data fetch and could be considered as already limiting the data. We could still add the `ReadLimit` later if we see strong demand of limiting the fetch size via the source option.

To support `Trigger.AvailableNow`, we propose to introduce a new interface as following:

```
class SupportsTriggerAvailableNow(ABC):
  @abstractmethod
  def prepareForTriggerAvailableNow(self) -> None
```

The above interface can be “mixed-up” with both `DataSourceStreamReader` and `SimpleDataSourceStreamReader`. It won’t work with `DataSourceStreamReader` implementations having the old method signature of `latestOffset()`, likewise mentioned above.

### Why are the changes needed?

This is to catch up with supported features in Scala DSv2 API, which we got reports from developers that missing features block them to implement some data sources.

### Does this PR introduce _any_ user-facing change?

Yes, users implementing streaming reader via python data source API will be able to add the support of Admission Control and Trigger.AvailableNow, which had been major lacks of features.

### How was this patch tested?

New UTs.

### Was this patch authored or co-authored using generative AI tooling?

Co-authored using claude-4.5-sonnet