### PR TITLE
[SPARK-55305][SQL][TESTS] Use `ParquetFooterReader.readFooter` uniformly in test code to read the footer

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
@@ -22,8 +22,10 @@ import scala.jdk.CollectionConverters._
 
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.column.ParquetProperties._
-import org.apache.parquet.hadoop.{ParquetFileReader, ParquetOutputFormat}
+import org.apache.parquet.format.converter.ParquetMetadataConverter
+import org.apache.parquet.hadoop.ParquetOutputFormat
 import org.apache.parquet.hadoop.ParquetWriter.DEFAULT_BLOCK_SIZE
+import org.apache.parquet.hadoop.util.HadoopInputFile
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.QueryTest
@@ -43,7 +45,8 @@ class ParquetRowIndexSuite extends QueryTest with SharedSparkSession {
   import testImplicits._
 
   private def readRowGroupRowCounts(path: String): Seq[Long] = {
-    ParquetFileReader.readFooter(spark.sessionState.newHadoopConf(), new Path(path))
+    val inputFile = HadoopInputFile.fromPath(new Path(path), spark.sessionState.newHadoopConf())
+    ParquetFooterReader.readFooter(inputFile, ParquetMetadataConverter.NO_FILTER)
       .getBlocks.asScala.toSeq.map(_.getRowCount)
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSuite.scala
@@ -22,11 +22,12 @@ import java.time.{Duration, Period}
 import java.time.temporal.ChronoUnit
 
 import org.apache.hadoop.fs.Path
-import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.format.converter.ParquetMetadataConverter
+import org.apache.parquet.hadoop.util.HadoopInputFile
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.execution.datasources.parquet.{ParquetCompressionCodec, ParquetTest}
+import org.apache.spark.sql.execution.datasources.parquet.{ParquetCompressionCodec, ParquetFooterReader, ParquetTest}
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.internal.SQLConf
 
@@ -214,7 +215,8 @@ class HiveParquetSuite extends QueryTest
 
       val conf = spark.sessionState.newHadoopConf()
       val file = parquetFiles.head
-      val footer = ParquetFileReader.readFooter(conf, new Path(file.getAbsolutePath))
+      val inputFile = HadoopInputFile.fromPath(new Path(file.getAbsolutePath), conf)
+      val footer = ParquetFooterReader.readFooter(inputFile, ParquetMetadataConverter.NO_FILTER)
 
       val codec = footer.getBlocks.get(0).getColumns.get(0).getCodec.name()
       assert(codec.equalsIgnoreCase(ParquetCompressionCodec.SNAPPY.lowerCaseName()),


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr change to use `ParquetFooterReader.readFooter` uniformly in Spark test code to read the footer.

### Why are the changes needed?
Use the methods encapsulated by Spark and avoid using deprecated APIs in `ParquetFileReader` (specifically, `ParquetFileReader#readFooter(Configuration, Path)` has been deprecated).


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions


### Was this patch authored or co-authored using generative AI tooling?
No