### PR TITLE
[SPARK-55176][PYTHON][FOLLOW-UP] Fix `_input_type` and `_arrow_cast` not defined in `ArrowStreamPandasSerializer`

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -425,6 +425,8 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
         struct_in_pandas: str = "dict",
         ndarray_as_list: bool = False,
         df_for_struct: bool = False,
+        input_type: Optional["StructType"] = None,
+        arrow_cast: bool = False,
     ):
         super().__init__()
         self._timezone = timezone
@@ -433,6 +435,10 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
         self._struct_in_pandas = struct_in_pandas
         self._ndarray_as_list = ndarray_as_list
         self._df_for_struct = df_for_struct
+        if input_type is not None:
+            assert isinstance(input_type, StructType)
+        self._input_type = input_type
+        self._arrow_cast = arrow_cast
 
     def _create_array(self, series, arrow_type, spark_type=None, arrow_cast=False):
         """
@@ -606,12 +612,10 @@ class ArrowStreamPandasUDFSerializer(ArrowStreamPandasSerializer):
             struct_in_pandas,
             ndarray_as_list,
             df_for_struct,
+            input_type,
+            arrow_cast,
         )
         self._assign_cols_by_name = assign_cols_by_name
-        self._arrow_cast = arrow_cast
-        if input_type is not None:
-            assert isinstance(input_type, StructType)
-        self._input_type = input_type
 
     def _create_struct_array(
         self,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR moves the definition of `_input_type` and `_arrow_cast` from `ArrowStreamPandasUDFSerializer` to its parent class `ArrowStreamPandasSerializer`.  

### Why are the changes needed?

This is a fix as `ArrowStreamPandasSerializer` needs those two parameters.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual verification that serializers work correctly with the refactored code.

### Was this patch authored or co-authored using generative AI tooling?

No.
