### PR TITLE
[SPARK-55335][PYTHON][TESTS] Use eventually instead of hard-coded wait for datasource test

### DIFF
--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -35,6 +35,7 @@ from pyspark.testing.sqlutils import (
     pyarrow_requirement_message,
 )
 from pyspark.testing import assertDataFrameEqual
+from pyspark.testing.utils import eventually
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 
 
@@ -399,48 +400,56 @@ class BasePythonStreamingDataSourceTestsMixin:
                 .start()
             )
 
-            # Wait a bit for data to be processed, then stop
-            time.sleep(6)  # Allow a few batches to run
+            @eventually(
+                timeout=20,
+                interval=2.0,
+                catch_assertions=True,
+                expected_exceptions=(json.JSONDecodeError,),
+            )
+            def check():
+                # Since we're writing actual JSON files, verify commit metadata and written files
+                commit_files = [f for f in os.listdir(temp_dir) if f.startswith("commit_")]
+                self.assertTrue(len(commit_files) > 0, "No commit files were created")
+
+                # Read and verify commit metadata - check all commits for any with data
+                total_committed_rows = 0
+                total_committed_batches = 0
+
+                for commit_file in commit_files:
+                    with open(os.path.join(temp_dir, commit_file), "r") as f:
+                        commit_data = json.load(f)
+                        total_committed_rows += commit_data.get("total_rows", 0)
+                        total_committed_batches += commit_data.get("total_batches", 0)
+
+                # We should have both committed data AND JSON files written
+                json_files = [
+                    f
+                    for f in os.listdir(temp_dir)
+                    if f.startswith("partition_") and f.endswith(".json")
+                ]
+
+                # Verify that we have both committed data AND JSON files
+                has_committed_data = total_committed_rows > 0
+                has_json_files = len(json_files) > 0
+
+                self.assertTrue(
+                    has_committed_data,
+                    f"Expected committed data but got {total_committed_rows} rows",
+                )
+                self.assertTrue(
+                    has_json_files, f"Expected JSON files but found {len(json_files)} files"
+                )
+
+                # Verify JSON files contain valid data
+                for json_file in json_files:
+                    with open(os.path.join(temp_dir, json_file), "r") as f:
+                        data = json.load(f)
+                        self.assertTrue(len(data) > 0, f"JSON file {json_file} is empty")
+
+            check()
+
             query.stop()
             query.awaitTermination()
-
-            # Since we're writing actual JSON files, verify commit metadata and written files
-            commit_files = [f for f in os.listdir(temp_dir) if f.startswith("commit_")]
-            self.assertTrue(len(commit_files) > 0, "No commit files were created")
-
-            # Read and verify commit metadata - check all commits for any with data
-            total_committed_rows = 0
-            total_committed_batches = 0
-
-            for commit_file in commit_files:
-                with open(os.path.join(temp_dir, commit_file), "r") as f:
-                    commit_data = json.load(f)
-                    total_committed_rows += commit_data.get("total_rows", 0)
-                    total_committed_batches += commit_data.get("total_batches", 0)
-
-            # We should have both committed data AND JSON files written
-            json_files = [
-                f
-                for f in os.listdir(temp_dir)
-                if f.startswith("partition_") and f.endswith(".json")
-            ]
-
-            # Verify that we have both committed data AND JSON files
-            has_committed_data = total_committed_rows > 0
-            has_json_files = len(json_files) > 0
-
-            self.assertTrue(
-                has_committed_data, f"Expected committed data but got {total_committed_rows} rows"
-            )
-            self.assertTrue(
-                has_json_files, f"Expected JSON files but found {len(json_files)} files"
-            )
-
-            # Verify JSON files contain valid data
-            for json_file in json_files:
-                with open(os.path.join(temp_dir, json_file), "r") as f:
-                    data = json.load(f)
-                    self.assertTrue(len(data) > 0, f"JSON file {json_file} is empty")
 
         finally:
             # Clean up

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -421,35 +421,31 @@ class BasePythonStreamingDataSourceTestsMixin:
                         total_committed_rows += commit_data.get("total_rows", 0)
                         total_committed_batches += commit_data.get("total_batches", 0)
 
-                # We should have both committed data AND JSON files written
-                json_files = [
-                    f
-                    for f in os.listdir(temp_dir)
-                    if f.startswith("partition_") and f.endswith(".json")
-                ]
-
-                # Verify that we have both committed data AND JSON files
-                has_committed_data = total_committed_rows > 0
-                has_json_files = len(json_files) > 0
-
                 self.assertTrue(
-                    has_committed_data,
+                    total_committed_rows > 0,
                     f"Expected committed data but got {total_committed_rows} rows",
                 )
-                self.assertTrue(
-                    has_json_files, f"Expected JSON files but found {len(json_files)} files"
-                )
-
-                # Verify JSON files contain valid data
-                for json_file in json_files:
-                    with open(os.path.join(temp_dir, json_file), "r") as f:
-                        data = json.load(f)
-                        self.assertTrue(len(data) > 0, f"JSON file {json_file} is empty")
 
             check()
 
             query.stop()
             query.awaitTermination()
+
+            json_files = [
+                f
+                for f in os.listdir(temp_dir)
+                if f.startswith("partition_") and f.endswith(".json")
+            ]
+
+            self.assertTrue(
+                len(json_files) > 0, f"Expected JSON files but found {len(json_files)} files"
+            )
+
+            # Verify JSON files contain valid data
+            for json_file in json_files:
+                with open(os.path.join(temp_dir, json_file), "r") as f:
+                    data = json.load(f)
+                    self.assertTrue(len(data) > 0, f"JSON file {json_file} is empty")
 
         finally:
             # Clean up


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Instead of a hard-coded `time.sleep(6)`, do a `eventually` until we have some rows committed. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

coverage run is slower than normal runs, which could result in no committed row for this test. Using eventually can guarantee some rows to be there while not waiting too long.

https://github.com/apache/spark/actions/runs/21586206793/job/62195041694

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Locally passed.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.