### PR TITLE
[SPARK-55340][SQL] Add helper for name to data type

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -122,6 +122,10 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
   private lazy val nameToIndex: Map[String, Int] = SparkCollectionUtils.toMapWithIndex(fieldNames)
   private lazy val nameToIndexCaseInsensitive: CaseInsensitiveMap[Int] =
     CaseInsensitiveMap[Int](nameToIndex.toMap)
+  lazy val nameToDataType: collection.immutable.Map[String, DataType] =
+    fields.map(f => f.name -> f.dataType).toMap
+  lazy val nameToDataTypeCaseInsensitive: CaseInsensitiveMap[DataType] =
+    CaseInsensitiveMap[DataType](nameToDataType)
 
   override def equals(that: Any): Boolean = {
     that match {


### PR DESCRIPTION

### What changes were proposed in this pull request?
Adding a helper for `StructType` for mapping the names to their data types.


### Why are the changes needed?
It is a needed helper for this Delta PR: https://github.com/delta-io/delta/pull/5987


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
NA


### Was this patch authored or co-authored using generative AI tooling?
No
