### PR TITLE
[SPARK-55342][K8S] Fix `ExecutorPodsLifecycleEventHandler` to `ExecutorPodsLifecycleManager`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -129,7 +129,7 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
         "kubernetes-executor-snapshots-subscribers", 2)
     val snapshotsStore = new ExecutorPodsSnapshotsStoreImpl(subscribersExecutor, conf = sc.conf)
 
-    val executorPodsLifecycleEventHandler = new ExecutorPodsLifecycleManager(
+    val executorPodsLifecycleManager = new ExecutorPodsLifecycleManager(
       sc.conf,
       kubernetesClient,
       snapshotsStore)
@@ -153,7 +153,7 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
       schedulerExecutorService,
       snapshotsStore,
       executorPodsAllocator,
-      executorPodsLifecycleEventHandler,
+      executorPodsLifecycleManager,
       podsWatchEventSource,
       podsPollingEventSource)
   }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -50,7 +50,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
     executorService: ScheduledExecutorService,
     snapshotsStore: ExecutorPodsSnapshotsStore,
     podAllocator: AbstractPodsAllocator,
-    lifecycleEventHandler: ExecutorPodsLifecycleManager,
+    lifecycleManager: ExecutorPodsLifecycleManager,
     watchEvents: ExecutorPodsWatchSnapshotSource,
     pollEvents: ExecutorPodsPollingSnapshotSource)
     extends CoarseGrainedSchedulerBackend(scheduler, sc.env.rpcEnv) {
@@ -77,7 +77,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
   // order of the value of this annotation, ascending.
   private val podDeletionCostAnnotation = "controller.kubernetes.io/pod-deletion-cost"
 
-  // Allow removeExecutor to be accessible by ExecutorPodsLifecycleEventHandler
+  // Allow removeExecutor to be accessible by ExecutorPodsLifecycleManager
   private[k8s] def doRemoveExecutor(executorId: String, reason: ExecutorLossReason): Unit = {
     removeExecutor(executorId, reason)
   }
@@ -113,7 +113,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
     podAllocator.start(applicationId(), this)
     val initExecs = Map(defaultProfile -> initialExecutors)
     podAllocator.setTotalExpectedExecutors(initExecs)
-    lifecycleEventHandler.start(this)
+    lifecycleManager.start(this)
     watchEvents.start(applicationId())
     pollEvents.start(applicationId())
     if (!conf.get(KUBERNETES_EXECUTOR_DISABLE_CONFIGMAP)) {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackendSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackendSuite.scala
@@ -97,7 +97,7 @@ class KubernetesClusterSchedulerBackendSuite extends SparkFunSuite with BeforeAn
   private var podAllocator: ExecutorPodsAllocator = _
 
   @Mock
-  private var lifecycleEventHandler: ExecutorPodsLifecycleManager = _
+  private var lifecycleManager: ExecutorPodsLifecycleManager = _
 
   @Mock
   private var watchEvents: ExecutorPodsWatchSnapshotSource = _
@@ -141,7 +141,7 @@ class KubernetesClusterSchedulerBackendSuite extends SparkFunSuite with BeforeAn
       schedulerExecutorService,
       eventQueue,
       podAllocator,
-      lifecycleEventHandler,
+      lifecycleManager,
       watchEvents,
       pollEvents)
   }
@@ -154,7 +154,7 @@ class KubernetesClusterSchedulerBackendSuite extends SparkFunSuite with BeforeAn
     schedulerBackendUnderTest.start()
     verify(podAllocator).setTotalExpectedExecutors(Map(defaultProfile -> 3))
     verify(podAllocator).start(TEST_SPARK_APP_ID, schedulerBackendUnderTest)
-    verify(lifecycleEventHandler).start(schedulerBackendUnderTest)
+    verify(lifecycleManager).start(schedulerBackendUnderTest)
     verify(watchEvents).start(TEST_SPARK_APP_ID)
     verify(pollEvents).start(TEST_SPARK_APP_ID)
     verify(configMapResource).create()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `ExecutorPodsLifecycleEventHandler` to `ExecutorPodsLifecycleManager` in the code and comments because `ExecutorPodsLifecycleEventHandler` doesn't exist.

```scala
-  // Allow removeExecutor to be accessible by ExecutorPodsLifecycleEventHandler
+  // Allow removeExecutor to be accessible by ExecutorPodsLifecycleManager
```

```scala
- val executorPodsLifecycleEventHandler = new ExecutorPodsLifecycleManager(
+ val executorPodsLifecycleManager = new ExecutorPodsLifecycleManager(
```

```scala
- lifecycleEventHandler: ExecutorPodsLifecycleManager,
+ lifecycleManager: ExecutorPodsLifecycleManager,
```

### Why are the changes needed?

To be correct and consistent.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Opus 4.5` on `Claude Code v2.1.5`