### PR TITLE
[SPARK-55345][PYTHON][PS] Do not pass unit and closed to Timedelta for pandas 3

### DIFF
--- a/python/pyspark/pandas/indexes/timedelta.py
+++ b/python/pyspark/pandas/indexes/timedelta.py
@@ -126,8 +126,11 @@ class TimedeltaIndex(Index):
             kwargs["freq"] = freq
 
         if LooseVersion(pd.__version__) < "3.0.0":
-            kwargs["unit"] = unit
-            kwargs["closed"] = closed
+            if unit is not _NoValue:
+                kwargs["unit"] = unit
+
+            if closed is not _NoValue:
+                kwargs["closed"] = closed
         else:
             if unit is not _NoValue:
                 raise ValueError("The 'unit' keyword is not supported in pandas 3.0.0 and later.")

--- a/python/pyspark/pandas/indexes/timedelta.py
+++ b/python/pyspark/pandas/indexes/timedelta.py
@@ -24,6 +24,7 @@ import numpy as np
 
 from pyspark import pandas as ps
 from pyspark._globals import _NoValue
+from pyspark.loose_version import LooseVersion
 from pyspark.pandas.indexes.base import Index
 from pyspark.pandas.missing.indexes import MissingPandasLikeTimedeltaIndex
 from pyspark.pandas.series import Series
@@ -94,14 +95,14 @@ class TimedeltaIndex(Index):
     def __new__(
         cls,
         data=None,
-        unit=None,
+        unit=_NoValue,
         freq=_NoValue,
-        closed=None,
+        closed=_NoValue,
         dtype=None,
         copy=False,
         name=None,
     ) -> "TimedeltaIndex":
-        if closed is not None:
+        if closed is not _NoValue:
             warnings.warn(
                 "The 'closed' keyword in TimedeltaIndex construction is deprecated "
                 "and will be removed in a future version.",
@@ -117,14 +118,22 @@ class TimedeltaIndex(Index):
 
         kwargs = dict(
             data=data,
-            unit=unit,
-            closed=closed,
             dtype=dtype,
             copy=copy,
             name=name,
         )
         if freq is not _NoValue:
             kwargs["freq"] = freq
+
+        if LooseVersion(pd.__version__) < "3.0.0":
+            kwargs["unit"] = unit
+            kwargs["closed"] = closed
+        else:
+            if unit is not _NoValue:
+                raise ValueError("The 'unit' keyword is not supported in pandas 3.0.0 and later.")
+
+            if closed is not _NoValue:
+                raise ValueError("The 'closed' keyword is not supported in pandas 3.0.0 and later.")
 
         return cast(TimedeltaIndex, ps.from_pandas(pd.TimedeltaIndex(**kwargs)))
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Raise an error if user tries to pass `unit` or `closed` to `TimedeltaIndex`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

pandas 3 does not support these two parameters anymore. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, it will behave more like pandas 3.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Local test does not report this error when constructing TimedeltaIndex.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.