### PR TITLE
[MINOR][PYTHON][TESTS] Fix `test_time_zone_against_map_in_arrow` for tzdata on ubuntu 24

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_udf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf.py
@@ -109,7 +109,6 @@ class ArrowUDFTestsMixin:
             "America/Los_Angeles",
             "Pacific/Honolulu",
             "Europe/Amsterdam",
-            "US/Pacific",
         ]:
             with self.sql_conf({"spark.sql.session.timeZone": tz}):
                 # There is a time-zone conversion in df.collect:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix `test_time_zone_against_map_in_arrow` for tzdata on ubuntu 24


### Why are the changes needed?
`US/Pacific` is no longer a valid timezone in `tzdata` on ubuntu 24, it needs additional packages like `tzdata-legacy` on ubuntu 24.

### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
manually check


### Was this patch authored or co-authored using generative AI tooling?
no