### PR TITLE
[SPARK-55354][CORE][DOCS] Fix `ExecutorAllocationClient` comment to include `Kubernetes`

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationClient.scala
@@ -22,7 +22,7 @@ import org.apache.spark.util.ArrayImplicits._
 
 /**
  * A client that communicates with the cluster manager to request or kill executors.
- * This is currently supported only in YARN mode.
+ * This is currently supported only in Kubernetes and YARN mode.
  */
 private[spark] trait ExecutorAllocationClient {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `ExecutorAllocationClient` comment to include `Kubernetes`.

### Why are the changes needed?

`KubernetesClusterSchedulerBackend` extends `CoarseGrainedSchedulerBackend` which extends `ExecutorAllocationClient`. The previous comment is outdated because it was written 12 years ago.

https://github.com/apache/spark/blob/ca1e3e7371ec36719886bbac18bde75203a57020/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala#L56

https://github.com/apache/spark/blob/ca1e3e7371ec36719886bbac18bde75203a57020/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala#L58-L59

### Does this PR introduce _any_ user-facing change?

No, this is a class description change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.