### PR TITLE
[SPARK-55353][SQL] Disable SQLAppStatusListener when UI is disabled

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -121,17 +121,17 @@ private[sql] class SharedState(
   val statusStore: SQLAppStatusStore = {
     val kvStore = sparkContext.statusStore.store.asInstanceOf[ElementTrackingStore]
     // Only create SQLAppStatusListener when UI is enabled to avoid memory overhead
-    // Check both the configuration value and whether UI object exists
-    val uiEnabled = sparkContext.conf.getBoolean("spark.ui.enabled", true)
-    val uiExists = sparkContext.ui.isDefined
-    if (uiEnabled || uiExists) {
+    // Create listener if UI exists or spark.ui.enabled is true (including default)
+    val shouldCreateListener = sparkContext.ui.isDefined ||
+      sparkContext.conf.getBoolean("spark.ui.enabled", true)
+    if (shouldCreateListener) {
       val listener = new SQLAppStatusListener(conf, kvStore, live = true)
       sparkContext.listenerBus.addToStatusQueue(listener)
       val statusStore = new SQLAppStatusStore(kvStore, Some(listener))
       sparkContext.ui.foreach(new SQLTab(statusStore, _))
       statusStore
     } else {
-      // When UI is disabled, create a minimal status store without listener
+      // When UI is explicitly disabled, create a minimal status store without listener
       new SQLAppStatusStore(kvStore, None)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SharedStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SharedStateSuite.scala
@@ -68,4 +68,12 @@ class SharedStateSuite extends SharedSparkSession {
     SQLConf.get.setConfString("spark.sql.catalog.spark_catalog.defaultDatabase",
       SessionCatalog.DEFAULT_DATABASE)
   }
+
+  test("SPARK-55353: SQLAppStatusListener should be created when UI is enabled") {
+    // Default behavior: SQLAppStatusListener should be created when UI is enabled
+    val statusStore = spark.sharedState.statusStore
+    assert(statusStore != null)
+    assert(statusStore.listener.isDefined,
+      "SQLAppStatusListener should be created when spark.ui.enabled=true")
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -31,7 +31,6 @@ import org.apache.hadoop.hive.serde2.`lazy`.LazySimpleSerDe
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config
-import org.apache.spark.internal.config.UI._
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.catalog.ExternalCatalogWithListener
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
@@ -61,8 +60,6 @@ object TestHive
         .set(HiveUtils.HIVE_METASTORE_BARRIER_PREFIXES.key,
           "org.apache.spark.sql.hive.execution.PairSerDe")
         .set(WAREHOUSE_PATH.key, TestHiveContext.makeWarehouseDir().toURI.getPath)
-        // SPARK-8910
-        .set(UI_ENABLED, false)
         .set(config.UNSAFE_EXCEPTION_ON_MEMORY_LEAK, true)
         // Hive changed the default of hive.metastore.disallow.incompatible.col.type.changes
         // from false to true. For details, see the JIRA HIVE-12320 and HIVE-17764.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch modifies SharedState to skip SQLAppStatusListener creation when Spark UI is disabled (spark.ui.enabled=false).

### Why are the changes needed?

Complex SQL queries with many stages and tasks cause driver OOM due to excessive AccumulatorMetadata objects held by SQLAppStatusListener.

**Memory regression from Spark 3.2 to 3.5:**
- Accumulator count per task increased 4x due to new metrics (SPARK-36620, SPARK-40711, SPARK-43214)
- Example: 155 stages × 1000 tasks × 100 accumulators = 15.5M objects (~1.5GB driver memory)
- Same query runs on 3.2.2 with 2GB driver but OOMs on 3.5.7 with 8GB driver

By reusing the existing spark.ui.enabled configuration, users can disable UI to reduce memory overhead without needing a separate configuration.

### Does this PR introduce any user-facing change?

No new configuration is added. The behavior change is:

When spark.ui.enabled=false:
- SQLAppStatusListener is not created, significantly reducing driver memory usage
- No SQL tab in live Spark UI (expected since UI is disabled)
- Event logs are still written for History Server analysis

### How was this patch tested?

- Added unit tests in SharedStateSuite to verify SQLAppStatusListener creation behavior
- Tested with production workload: OOM resolved when spark.ui.enabled=false

### Was this patch authored or co-authored using generative AI tooling?

No.