### PR TITLE
[SPARK-55356][SQL] Support alias for PIVOT clause

### DIFF
--- a/docs/sql-ref-syntax-qry-select-pivot.md
+++ b/docs/sql-ref-syntax-qry-select-pivot.md
@@ -27,7 +27,7 @@ The `PIVOT` clause is used for data perspective. We can get the aggregated value
 
 ```sql
 PIVOT ( { aggregate_expression [ AS aggregate_expression_alias ] } [ , ... ]
-    FOR column_list IN ( expression_list ) )
+    FOR column_list IN ( expression_list ) ) [[AS] alias]
 ```
 
 ### Parameters
@@ -47,7 +47,11 @@ PIVOT ( { aggregate_expression [ AS aggregate_expression_alias ] } [ , ... ]
 * **expression_list**
 
     Specifies new columns, which are used to match values in `column_list` as the aggregating condition. We can also add aliases for them.
-    
+
+* **alias**
+
+    Specifies an alias for the pivot result, which can be used to reference the pivot columns in the query.
+
 ### Examples
 
 ```sql
@@ -85,6 +89,21 @@ SELECT * FROM person
 | 300  | Street 3  | NULL  | NULL  | NULL  | NULL  |
 | 400  | Street 4  | NULL  | NULL  | NULL  | NULL  |
 +------+-----------+-------+-------+-------+-------+
+
+-- pivot result can be referenced via its alias
+SELECT pv.* FROM person
+    PIVOT (
+        SUM(age) AS a
+        FOR name IN ('John' AS john, 'Mike' AS mike)
+    ) AS pv;
++------+-----------+---------+---------+
+|  id  |  address  | john_a  | mike_a  |
++------+-----------+---------+---------+
+| 200  | Street 2  | NULL    | NULL    |
+| 100  | Street 1  | 30      | NULL    |
+| 300  | Street 3  | NULL    | 80      |
+| 400  | Street 4  | NULL    | NULL    |
++------+-----------+---------+---------+
 ```
 
 ### Related Statements

--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -930,7 +930,7 @@ groupingSet
     ;
 
 pivotClause
-    : PIVOT LEFT_PAREN aggregates=namedExpressionSeq FOR pivotColumn IN LEFT_PAREN pivotValues+=pivotValue (COMMA pivotValues+=pivotValue)* RIGHT_PAREN RIGHT_PAREN
+    : PIVOT LEFT_PAREN aggregates=namedExpressionSeq FOR pivotColumn IN LEFT_PAREN pivotValues+=pivotValue (COMMA pivotValues+=pivotValue)* RIGHT_PAREN RIGHT_PAREN (AS? errorCapturingIdentifier)?
     ;
 
 pivotColumn

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1986,7 +1986,14 @@ class AstBuilder extends DataTypeAstBuilder
           identifier => UnresolvedAttribute.quoted(getIdentifierText(identifier))).toSeq)
     }
     val pivotValues = ctx.pivotValues.asScala.map(visitPivotValue)
-    Pivot(None, pivotColumn, pivotValues.toSeq, aggregates, query)
+    val pivot = Pivot(None, pivotColumn, pivotValues.toSeq, aggregates, query)
+
+    if (ctx.errorCapturingIdentifier() != null) {
+      val alias = getIdentifierText(ctx.errorCapturingIdentifier())
+      SubqueryAlias(alias, pivot)
+    } else {
+      pivot
+    }
   }
 
   /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PivotParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PivotParserSuite.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.parser
+
+import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, UnresolvedAttribute, UnresolvedFunction}
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Pivot}
+
+class PivotParserSuite extends AnalysisTest {
+
+  import CatalystSqlParser._
+  import org.apache.spark.sql.catalyst.dsl.expressions._
+  import org.apache.spark.sql.catalyst.dsl.plans._
+
+  private def assertEqual(sqlCommand: String, plan: LogicalPlan): Unit = {
+    comparePlans(parsePlan(sqlCommand), plan, checkAnalysis = false)
+  }
+
+  test("pivot - alias") {
+    Seq(
+      "SELECT pv.* FROM t PIVOT (sum(a) FOR b IN (1, 2)) pv",
+      "SELECT pv.* FROM t PIVOT (sum(a) FOR b IN (1, 2)) AS pv"
+    ).foreach { sql =>
+      withClue(sql) {
+        assertEqual(
+          sql,
+          Pivot(
+            None,
+            UnresolvedAttribute("b"),
+            Seq(Literal(1), Literal(2)),
+            Seq(UnresolvedFunction("sum", Seq(UnresolvedAttribute("a")), isDistinct = false)),
+            table("t"))
+            .subquery("pv")
+            .select(star("pv"))
+        )
+      }
+    }
+  }
+
+  test("pivot - no alias") {
+    assertEqual(
+      "SELECT * FROM t PIVOT (sum(a) FOR b IN (1, 2))",
+      Pivot(
+        None,
+        UnresolvedAttribute("b"),
+        Seq(Literal(1), Literal(2)),
+        Seq(UnresolvedFunction("sum", Seq(UnresolvedAttribute("a")), isDistinct = false)),
+        table("t"))
+        .select(star())
+    )
+  }
+}

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pivot.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pivot.sql.out
@@ -791,3 +791,156 @@ Project [a#x, z#x, b#x, y#x, c#x, x#x, d#x, w#x, dotNET#xL, Java#xL]
                         +- Project [course#x, year#x, earnings#x]
                            +- SubqueryAlias courseSales
                               +- LocalRelation [course#x, year#x, earnings#x]
+
+
+-- !query
+SELECT pv.* FROM (
+  SELECT year, course, earnings FROM courseSales
+)
+PIVOT (
+  sum(earnings)
+  FOR course IN ('dotNET', 'Java')
+) AS pv
+-- !query analysis
+Project [year#x, dotNET#xL, Java#xL]
++- SubqueryAlias pv
+   +- Project [year#x, __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x[0] AS dotNET#xL, __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x[1] AS Java#xL]
+      +- Aggregate [year#x], [year#x, pivotfirst(course#x, sum(__auto_generated_subquery_name.earnings)#xL, dotNET, Java, 0, 0) AS __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x]
+         +- Aggregate [year#x, course#x], [year#x, course#x, sum(earnings#x) AS sum(__auto_generated_subquery_name.earnings)#xL]
+            +- SubqueryAlias __auto_generated_subquery_name
+               +- Project [year#x, course#x, earnings#x]
+                  +- SubqueryAlias coursesales
+                     +- View (`courseSales`, [course#x, year#x, earnings#x])
+                        +- Project [cast(course#x as string) AS course#x, cast(year#x as int) AS year#x, cast(earnings#x as int) AS earnings#x]
+                           +- Project [course#x, year#x, earnings#x]
+                              +- SubqueryAlias courseSales
+                                 +- LocalRelation [course#x, year#x, earnings#x]
+
+
+-- !query
+SELECT pv.* FROM (
+  SELECT year, course, earnings FROM courseSales
+)
+PIVOT (
+  sum(earnings)
+  FOR course IN ('dotNET', 'Java')
+) pv
+-- !query analysis
+Project [year#x, dotNET#xL, Java#xL]
++- SubqueryAlias pv
+   +- Project [year#x, __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x[0] AS dotNET#xL, __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x[1] AS Java#xL]
+      +- Aggregate [year#x], [year#x, pivotfirst(course#x, sum(__auto_generated_subquery_name.earnings)#xL, dotNET, Java, 0, 0) AS __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x]
+         +- Aggregate [year#x, course#x], [year#x, course#x, sum(earnings#x) AS sum(__auto_generated_subquery_name.earnings)#xL]
+            +- SubqueryAlias __auto_generated_subquery_name
+               +- Project [year#x, course#x, earnings#x]
+                  +- SubqueryAlias coursesales
+                     +- View (`courseSales`, [course#x, year#x, earnings#x])
+                        +- Project [cast(course#x as string) AS course#x, cast(year#x as int) AS year#x, cast(earnings#x as int) AS earnings#x]
+                           +- Project [course#x, year#x, earnings#x]
+                              +- SubqueryAlias courseSales
+                                 +- LocalRelation [course#x, year#x, earnings#x]
+
+
+-- !query
+SELECT pv.year, pv.dotNET, pv.Java FROM (
+  SELECT year, course, earnings FROM courseSales
+)
+PIVOT (
+  sum(earnings)
+  FOR course IN ('dotNET', 'Java')
+) AS pv
+-- !query analysis
+Project [year#x, dotNET#xL, Java#xL]
++- SubqueryAlias pv
+   +- Project [year#x, __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x[0] AS dotNET#xL, __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x[1] AS Java#xL]
+      +- Aggregate [year#x], [year#x, pivotfirst(course#x, sum(__auto_generated_subquery_name.earnings)#xL, dotNET, Java, 0, 0) AS __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x]
+         +- Aggregate [year#x, course#x], [year#x, course#x, sum(earnings#x) AS sum(__auto_generated_subquery_name.earnings)#xL]
+            +- SubqueryAlias __auto_generated_subquery_name
+               +- Project [year#x, course#x, earnings#x]
+                  +- SubqueryAlias coursesales
+                     +- View (`courseSales`, [course#x, year#x, earnings#x])
+                        +- Project [cast(course#x as string) AS course#x, cast(year#x as int) AS year#x, cast(earnings#x as int) AS earnings#x]
+                           +- Project [course#x, year#x, earnings#x]
+                              +- SubqueryAlias courseSales
+                                 +- LocalRelation [course#x, year#x, earnings#x]
+
+
+-- !query
+SELECT pv.year, pv.net, pv.jv FROM (
+  SELECT year, course, earnings FROM courseSales
+)
+PIVOT (
+  sum(earnings)
+  FOR course IN ('dotNET' as net, 'Java' as jv)
+) AS pv
+-- !query analysis
+Project [year#x, net#xL, jv#xL]
++- SubqueryAlias pv
+   +- Project [year#x, __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x[0] AS net#xL, __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x[1] AS jv#xL]
+      +- Aggregate [year#x], [year#x, pivotfirst(course#x, sum(__auto_generated_subquery_name.earnings)#xL, dotNET, Java, 0, 0) AS __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x]
+         +- Aggregate [year#x, course#x], [year#x, course#x, sum(earnings#x) AS sum(__auto_generated_subquery_name.earnings)#xL]
+            +- SubqueryAlias __auto_generated_subquery_name
+               +- Project [year#x, course#x, earnings#x]
+                  +- SubqueryAlias coursesales
+                     +- View (`courseSales`, [course#x, year#x, earnings#x])
+                        +- Project [cast(course#x as string) AS course#x, cast(year#x as int) AS year#x, cast(earnings#x as int) AS earnings#x]
+                           +- Project [course#x, year#x, earnings#x]
+                              +- SubqueryAlias courseSales
+                                 +- LocalRelation [course#x, year#x, earnings#x]
+
+
+-- !query
+SELECT pv.year, pv.dotNET, y.s FROM (
+  SELECT year, course, earnings FROM courseSales
+)
+PIVOT (
+  sum(earnings)
+  FOR course IN ('dotNET', 'Java')
+) AS pv
+JOIN years y ON pv.year = y.y
+-- !query analysis
+Project [year#x, dotNET#xL, s#x]
++- Join Inner, (year#x = y#x)
+   :- SubqueryAlias pv
+   :  +- Project [year#x, __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x[0] AS dotNET#xL, __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x[1] AS Java#xL]
+   :     +- Aggregate [year#x], [year#x, pivotfirst(course#x, sum(__auto_generated_subquery_name.earnings)#xL, dotNET, Java, 0, 0) AS __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x]
+   :        +- Aggregate [year#x, course#x], [year#x, course#x, sum(earnings#x) AS sum(__auto_generated_subquery_name.earnings)#xL]
+   :           +- SubqueryAlias __auto_generated_subquery_name
+   :              +- Project [year#x, course#x, earnings#x]
+   :                 +- SubqueryAlias coursesales
+   :                    +- View (`courseSales`, [course#x, year#x, earnings#x])
+   :                       +- Project [cast(course#x as string) AS course#x, cast(year#x as int) AS year#x, cast(earnings#x as int) AS earnings#x]
+   :                          +- Project [course#x, year#x, earnings#x]
+   :                             +- SubqueryAlias courseSales
+   :                                +- LocalRelation [course#x, year#x, earnings#x]
+   +- SubqueryAlias y
+      +- SubqueryAlias years
+         +- View (`years`, [y#x, s#x])
+            +- Project [cast(y#x as int) AS y#x, cast(s#x as int) AS s#x]
+               +- Project [y#x, s#x]
+                  +- SubqueryAlias years
+                     +- LocalRelation [y#x, s#x]
+
+
+-- !query
+SELECT pv.y, pv.dotNET_s, pv.Java_a FROM (
+  SELECT year y, course c, earnings e FROM courseSales
+)
+PIVOT (
+  sum(e) s, avg(e) a
+  FOR c IN ('dotNET', 'Java')
+) AS pv
+-- !query analysis
+Project [y#x, dotNET_s#xL, Java_a#x]
++- SubqueryAlias pv
+   +- Project [y#x, __pivot_sum(__auto_generated_subquery_name.e) AS s AS `sum(__auto_generated_subquery_name.e) AS s`#x[0] AS dotNET_s#xL, __pivot_avg(__auto_generated_subquery_name.e) AS a AS `avg(__auto_generated_subquery_name.e) AS a`#x[0] AS dotNET_a#x, __pivot_sum(__auto_generated_subquery_name.e) AS s AS `sum(__auto_generated_subquery_name.e) AS s`#x[1] AS Java_s#xL, __pivot_avg(__auto_generated_subquery_name.e) AS a AS `avg(__auto_generated_subquery_name.e) AS a`#x[1] AS Java_a#x]
+      +- Aggregate [y#x], [y#x, pivotfirst(c#x, sum(__auto_generated_subquery_name.e) AS s#xL, dotNET, Java, 0, 0) AS __pivot_sum(__auto_generated_subquery_name.e) AS s AS `sum(__auto_generated_subquery_name.e) AS s`#x, pivotfirst(c#x, avg(__auto_generated_subquery_name.e) AS a#x, dotNET, Java, 0, 0) AS __pivot_avg(__auto_generated_subquery_name.e) AS a AS `avg(__auto_generated_subquery_name.e) AS a`#x]
+         +- Aggregate [y#x, c#x], [y#x, c#x, sum(e#x) AS sum(__auto_generated_subquery_name.e) AS s#xL, avg(e#x) AS avg(__auto_generated_subquery_name.e) AS a#x]
+            +- SubqueryAlias __auto_generated_subquery_name
+               +- Project [year#x AS y#x, course#x AS c#x, earnings#x AS e#x]
+                  +- SubqueryAlias coursesales
+                     +- View (`courseSales`, [course#x, year#x, earnings#x])
+                        +- Project [cast(course#x as string) AS course#x, cast(year#x as int) AS year#x, cast(earnings#x as int) AS earnings#x]
+                           +- Project [course#x, year#x, earnings#x]
+                              +- SubqueryAlias courseSales
+                                 +- LocalRelation [course#x, year#x, earnings#x]

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pivot.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pivot.sql.out
@@ -792,79 +792,6 @@ Project [a#x, z#x, b#x, y#x, c#x, x#x, d#x, w#x, dotNET#xL, Java#xL]
                            +- SubqueryAlias courseSales
                               +- LocalRelation [course#x, year#x, earnings#x]
 
-
--- !query
-SELECT pv.* FROM (
-  SELECT year, course, earnings FROM courseSales
-)
-PIVOT (
-  sum(earnings)
-  FOR course IN ('dotNET', 'Java')
-) AS pv
--- !query analysis
-Project [year#x, dotNET#xL, Java#xL]
-+- SubqueryAlias pv
-   +- Project [year#x, __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x[0] AS dotNET#xL, __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x[1] AS Java#xL]
-      +- Aggregate [year#x], [year#x, pivotfirst(course#x, sum(__auto_generated_subquery_name.earnings)#xL, dotNET, Java, 0, 0) AS __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x]
-         +- Aggregate [year#x, course#x], [year#x, course#x, sum(earnings#x) AS sum(__auto_generated_subquery_name.earnings)#xL]
-            +- SubqueryAlias __auto_generated_subquery_name
-               +- Project [year#x, course#x, earnings#x]
-                  +- SubqueryAlias coursesales
-                     +- View (`courseSales`, [course#x, year#x, earnings#x])
-                        +- Project [cast(course#x as string) AS course#x, cast(year#x as int) AS year#x, cast(earnings#x as int) AS earnings#x]
-                           +- Project [course#x, year#x, earnings#x]
-                              +- SubqueryAlias courseSales
-                                 +- LocalRelation [course#x, year#x, earnings#x]
-
-
--- !query
-SELECT pv.* FROM (
-  SELECT year, course, earnings FROM courseSales
-)
-PIVOT (
-  sum(earnings)
-  FOR course IN ('dotNET', 'Java')
-) pv
--- !query analysis
-Project [year#x, dotNET#xL, Java#xL]
-+- SubqueryAlias pv
-   +- Project [year#x, __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x[0] AS dotNET#xL, __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x[1] AS Java#xL]
-      +- Aggregate [year#x], [year#x, pivotfirst(course#x, sum(__auto_generated_subquery_name.earnings)#xL, dotNET, Java, 0, 0) AS __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x]
-         +- Aggregate [year#x, course#x], [year#x, course#x, sum(earnings#x) AS sum(__auto_generated_subquery_name.earnings)#xL]
-            +- SubqueryAlias __auto_generated_subquery_name
-               +- Project [year#x, course#x, earnings#x]
-                  +- SubqueryAlias coursesales
-                     +- View (`courseSales`, [course#x, year#x, earnings#x])
-                        +- Project [cast(course#x as string) AS course#x, cast(year#x as int) AS year#x, cast(earnings#x as int) AS earnings#x]
-                           +- Project [course#x, year#x, earnings#x]
-                              +- SubqueryAlias courseSales
-                                 +- LocalRelation [course#x, year#x, earnings#x]
-
-
--- !query
-SELECT pv.year, pv.dotNET, pv.Java FROM (
-  SELECT year, course, earnings FROM courseSales
-)
-PIVOT (
-  sum(earnings)
-  FOR course IN ('dotNET', 'Java')
-) AS pv
--- !query analysis
-Project [year#x, dotNET#xL, Java#xL]
-+- SubqueryAlias pv
-   +- Project [year#x, __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x[0] AS dotNET#xL, __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x[1] AS Java#xL]
-      +- Aggregate [year#x], [year#x, pivotfirst(course#x, sum(__auto_generated_subquery_name.earnings)#xL, dotNET, Java, 0, 0) AS __pivot_sum(__auto_generated_subquery_name.earnings) AS `sum(__auto_generated_subquery_name.earnings)`#x]
-         +- Aggregate [year#x, course#x], [year#x, course#x, sum(earnings#x) AS sum(__auto_generated_subquery_name.earnings)#xL]
-            +- SubqueryAlias __auto_generated_subquery_name
-               +- Project [year#x, course#x, earnings#x]
-                  +- SubqueryAlias coursesales
-                     +- View (`courseSales`, [course#x, year#x, earnings#x])
-                        +- Project [cast(course#x as string) AS course#x, cast(year#x as int) AS year#x, cast(earnings#x as int) AS earnings#x]
-                           +- Project [course#x, year#x, earnings#x]
-                              +- SubqueryAlias courseSales
-                                 +- LocalRelation [course#x, year#x, earnings#x]
-
-
 -- !query
 SELECT pv.year, pv.net, pv.jv FROM (
   SELECT year, course, earnings FROM courseSales
@@ -896,7 +823,7 @@ SELECT pv.year, pv.dotNET, y.s FROM (
 PIVOT (
   sum(earnings)
   FOR course IN ('dotNET', 'Java')
-) AS pv
+) pv
 JOIN years y ON pv.year = y.y
 -- !query analysis
 Project [year#x, dotNET#xL, s#x]
@@ -920,27 +847,3 @@ Project [year#x, dotNET#xL, s#x]
                +- Project [y#x, s#x]
                   +- SubqueryAlias years
                      +- LocalRelation [y#x, s#x]
-
-
--- !query
-SELECT pv.y, pv.dotNET_s, pv.Java_a FROM (
-  SELECT year y, course c, earnings e FROM courseSales
-)
-PIVOT (
-  sum(e) s, avg(e) a
-  FOR c IN ('dotNET', 'Java')
-) AS pv
--- !query analysis
-Project [y#x, dotNET_s#xL, Java_a#x]
-+- SubqueryAlias pv
-   +- Project [y#x, __pivot_sum(__auto_generated_subquery_name.e) AS s AS `sum(__auto_generated_subquery_name.e) AS s`#x[0] AS dotNET_s#xL, __pivot_avg(__auto_generated_subquery_name.e) AS a AS `avg(__auto_generated_subquery_name.e) AS a`#x[0] AS dotNET_a#x, __pivot_sum(__auto_generated_subquery_name.e) AS s AS `sum(__auto_generated_subquery_name.e) AS s`#x[1] AS Java_s#xL, __pivot_avg(__auto_generated_subquery_name.e) AS a AS `avg(__auto_generated_subquery_name.e) AS a`#x[1] AS Java_a#x]
-      +- Aggregate [y#x], [y#x, pivotfirst(c#x, sum(__auto_generated_subquery_name.e) AS s#xL, dotNET, Java, 0, 0) AS __pivot_sum(__auto_generated_subquery_name.e) AS s AS `sum(__auto_generated_subquery_name.e) AS s`#x, pivotfirst(c#x, avg(__auto_generated_subquery_name.e) AS a#x, dotNET, Java, 0, 0) AS __pivot_avg(__auto_generated_subquery_name.e) AS a AS `avg(__auto_generated_subquery_name.e) AS a`#x]
-         +- Aggregate [y#x, c#x], [y#x, c#x, sum(e#x) AS sum(__auto_generated_subquery_name.e) AS s#xL, avg(e#x) AS avg(__auto_generated_subquery_name.e) AS a#x]
-            +- SubqueryAlias __auto_generated_subquery_name
-               +- Project [year#x AS y#x, course#x AS c#x, earnings#x AS e#x]
-                  +- SubqueryAlias coursesales
-                     +- View (`courseSales`, [course#x, year#x, earnings#x])
-                        +- Project [cast(course#x as string) AS course#x, cast(year#x as int) AS year#x, cast(earnings#x as int) AS earnings#x]
-                           +- Project [course#x, year#x, earnings#x]
-                              +- SubqueryAlias courseSales
-                                 +- LocalRelation [course#x, year#x, earnings#x]

--- a/sql/core/src/test/resources/sql-tests/inputs/pivot.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/pivot.sql
@@ -298,3 +298,58 @@ PIVOT (
   sum(Earnings)
   FOR Course IN ('dotNET', 'Java')
 );
+
+-- pivot with alias
+SELECT pv.* FROM (
+  SELECT year, course, earnings FROM courseSales
+)
+PIVOT (
+  sum(earnings)
+  FOR course IN ('dotNET', 'Java')
+) AS pv;
+
+-- pivot with alias (without AS keyword)
+SELECT pv.* FROM (
+  SELECT year, course, earnings FROM courseSales
+)
+PIVOT (
+  sum(earnings)
+  FOR course IN ('dotNET', 'Java')
+) pv;
+
+-- pivot with alias - qualified column references
+SELECT pv.year, pv.dotNET, pv.Java FROM (
+  SELECT year, course, earnings FROM courseSales
+)
+PIVOT (
+  sum(earnings)
+  FOR course IN ('dotNET', 'Java')
+) AS pv;
+
+-- pivot with alias and target column aliases
+SELECT pv.year, pv.net, pv.jv FROM (
+  SELECT year, course, earnings FROM courseSales
+)
+PIVOT (
+  sum(earnings)
+  FOR course IN ('dotNET' as net, 'Java' as jv)
+) AS pv;
+
+-- pivot with alias - join with another table
+SELECT pv.year, pv.dotNET, y.s FROM (
+  SELECT year, course, earnings FROM courseSales
+)
+PIVOT (
+  sum(earnings)
+  FOR course IN ('dotNET', 'Java')
+) AS pv
+JOIN years y ON pv.year = y.y;
+
+-- pivot with alias - multiple aggregations
+SELECT pv.y, pv.dotNET_s, pv.Java_a FROM (
+  SELECT year y, course c, earnings e FROM courseSales
+)
+PIVOT (
+  sum(e) s, avg(e) a
+  FOR c IN ('dotNET', 'Java')
+) AS pv;

--- a/sql/core/src/test/resources/sql-tests/inputs/pivot.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/pivot.sql
@@ -299,33 +299,6 @@ PIVOT (
   FOR Course IN ('dotNET', 'Java')
 );
 
--- pivot with alias
-SELECT pv.* FROM (
-  SELECT year, course, earnings FROM courseSales
-)
-PIVOT (
-  sum(earnings)
-  FOR course IN ('dotNET', 'Java')
-) AS pv;
-
--- pivot with alias (without AS keyword)
-SELECT pv.* FROM (
-  SELECT year, course, earnings FROM courseSales
-)
-PIVOT (
-  sum(earnings)
-  FOR course IN ('dotNET', 'Java')
-) pv;
-
--- pivot with alias - qualified column references
-SELECT pv.year, pv.dotNET, pv.Java FROM (
-  SELECT year, course, earnings FROM courseSales
-)
-PIVOT (
-  sum(earnings)
-  FOR course IN ('dotNET', 'Java')
-) AS pv;
-
 -- pivot with alias and target column aliases
 SELECT pv.year, pv.net, pv.jv FROM (
   SELECT year, course, earnings FROM courseSales
@@ -342,14 +315,5 @@ SELECT pv.year, pv.dotNET, y.s FROM (
 PIVOT (
   sum(earnings)
   FOR course IN ('dotNET', 'Java')
-) AS pv
+) pv
 JOIN years y ON pv.year = y.y;
-
--- pivot with alias - multiple aggregations
-SELECT pv.y, pv.dotNET_s, pv.Java_a FROM (
-  SELECT year y, course c, earnings e FROM courseSales
-)
-PIVOT (
-  sum(e) s, avg(e) a
-  FOR c IN ('dotNET', 'Java')
-) AS pv;

--- a/sql/core/src/test/resources/sql-tests/results/pivot.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pivot.sql.out
@@ -562,3 +562,94 @@ PIVOT (
 struct<a:string,z:string,b:string,y:string,c:string,x:string,d:string,w:string,dotNET:bigint,Java:bigint>
 -- !query output
 a	z	b	y	c	x	d	w	63000	50000
+
+
+-- !query
+SELECT pv.* FROM (
+  SELECT year, course, earnings FROM courseSales
+)
+PIVOT (
+  sum(earnings)
+  FOR course IN ('dotNET', 'Java')
+) AS pv
+-- !query schema
+struct<year:int,dotNET:bigint,Java:bigint>
+-- !query output
+2012	15000	20000
+2013	48000	30000
+
+
+-- !query
+SELECT pv.* FROM (
+  SELECT year, course, earnings FROM courseSales
+)
+PIVOT (
+  sum(earnings)
+  FOR course IN ('dotNET', 'Java')
+) pv
+-- !query schema
+struct<year:int,dotNET:bigint,Java:bigint>
+-- !query output
+2012	15000	20000
+2013	48000	30000
+
+
+-- !query
+SELECT pv.year, pv.dotNET, pv.Java FROM (
+  SELECT year, course, earnings FROM courseSales
+)
+PIVOT (
+  sum(earnings)
+  FOR course IN ('dotNET', 'Java')
+) AS pv
+-- !query schema
+struct<year:int,dotNET:bigint,Java:bigint>
+-- !query output
+2012	15000	20000
+2013	48000	30000
+
+
+-- !query
+SELECT pv.year, pv.net, pv.jv FROM (
+  SELECT year, course, earnings FROM courseSales
+)
+PIVOT (
+  sum(earnings)
+  FOR course IN ('dotNET' as net, 'Java' as jv)
+) AS pv
+-- !query schema
+struct<year:int,net:bigint,jv:bigint>
+-- !query output
+2012	15000	20000
+2013	48000	30000
+
+
+-- !query
+SELECT pv.year, pv.dotNET, y.s FROM (
+  SELECT year, course, earnings FROM courseSales
+)
+PIVOT (
+  sum(earnings)
+  FOR course IN ('dotNET', 'Java')
+) AS pv
+JOIN years y ON pv.year = y.y
+-- !query schema
+struct<year:int,dotNET:bigint,s:int>
+-- !query output
+2012	15000	1
+2013	48000	2
+
+
+-- !query
+SELECT pv.y, pv.dotNET_s, pv.Java_a FROM (
+  SELECT year y, course c, earnings e FROM courseSales
+)
+PIVOT (
+  sum(e) s, avg(e) a
+  FOR c IN ('dotNET', 'Java')
+) AS pv
+-- !query schema
+struct<y:int,dotNET_s:bigint,Java_a:double>
+-- !query output
+2012	15000	20000.0
+2013	48000	30000.0

--- a/sql/core/src/test/resources/sql-tests/results/pivot.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pivot.sql.out
@@ -565,51 +565,6 @@ a	z	b	y	c	x	d	w	63000	50000
 
 
 -- !query
-SELECT pv.* FROM (
-  SELECT year, course, earnings FROM courseSales
-)
-PIVOT (
-  sum(earnings)
-  FOR course IN ('dotNET', 'Java')
-) AS pv
--- !query schema
-struct<year:int,dotNET:bigint,Java:bigint>
--- !query output
-2012	15000	20000
-2013	48000	30000
-
-
--- !query
-SELECT pv.* FROM (
-  SELECT year, course, earnings FROM courseSales
-)
-PIVOT (
-  sum(earnings)
-  FOR course IN ('dotNET', 'Java')
-) pv
--- !query schema
-struct<year:int,dotNET:bigint,Java:bigint>
--- !query output
-2012	15000	20000
-2013	48000	30000
-
-
--- !query
-SELECT pv.year, pv.dotNET, pv.Java FROM (
-  SELECT year, course, earnings FROM courseSales
-)
-PIVOT (
-  sum(earnings)
-  FOR course IN ('dotNET', 'Java')
-) AS pv
--- !query schema
-struct<year:int,dotNET:bigint,Java:bigint>
--- !query output
-2012	15000	20000
-2013	48000	30000
-
-
--- !query
 SELECT pv.year, pv.net, pv.jv FROM (
   SELECT year, course, earnings FROM courseSales
 )
@@ -631,25 +586,10 @@ SELECT pv.year, pv.dotNET, y.s FROM (
 PIVOT (
   sum(earnings)
   FOR course IN ('dotNET', 'Java')
-) AS pv
+) pv
 JOIN years y ON pv.year = y.y
 -- !query schema
 struct<year:int,dotNET:bigint,s:int>
 -- !query output
 2012	15000	1
 2013	48000	2
-
-
--- !query
-SELECT pv.y, pv.dotNET_s, pv.Java_a FROM (
-  SELECT year y, course c, earnings e FROM courseSales
-)
-PIVOT (
-  sum(e) s, avg(e) a
-  FOR c IN ('dotNET', 'Java')
-) AS pv
--- !query schema
-struct<y:int,dotNET_s:bigint,Java_a:double>
--- !query output
-2012	15000	20000.0
-2013	48000	30000.0


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add support for alias in PIVOT clause, following the same syntax as [T-SQL](https://learn.microsoft.com/en-us/sql/t-sql/queries/from-using-pivot-and-unpivot?view=sql-server-ver17) and [BigQuery](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#pivot_operator).

Short spec to describe the improvement:
> Extend the `PIVOT` clause to accept an optional alias (`PIVOT (...) AS alias`), allowing the pivoted result set to be referenced by name in the surrounding query context. The alias qualifies all columns produced by the pivot operation, including both the grouping columns and the dynamically generated value columns. When an alias is provided, columns may be referenced as `alias.column_name`. When omitted, current unqualified resolution behaviour is preserved. In queries with multiple pivots or joins, the alias disambiguates column references. The alias scope is limited to the query block in which the pivot appears.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Main reason for the improvement is parity with platforms like SQL Server. When customers want to migrate, their queries using PIVOT alias can't be automatically transpiled, requiring a human in the loop.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, it introduces an optional alias and updates the documentation to reflect it. Change is fully backwards compatible.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added end-to-end tests in `SQLQueryTestSuite` and unit tests in `PivotParserSuite`.
```bash
build/sbt "catalyst/testOnly *PivotParserSuite"

build/sbt "sql/testOnly *SQLQueryTestSuite -- -z pivot.sql"
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Implemented with help of Claude Code.