### PR TITLE
[SPARK-55368][PYTHON][TESTS] Make sure `worker_util.py` can only be imported in python workers

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -324,6 +324,7 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
     envVars.put("PYTHON_UDF_BATCH_SIZE", batchSizeForPythonUDF.toString)
 
     envVars.put("SPARK_JOB_ARTIFACT_UUID", jobArtifactUUID.getOrElse("default"))
+    envVars.put("SPARK_PYTHON_RUNTIME", "PYTHON_WORKER")
 
     val (worker: PythonWorker, handle: Option[ProcessHandle]) = env.createPythonWorker(
       pythonExec, workerModule, daemonModule, envVars.asScala.toMap, useDaemon)

--- a/core/src/main/scala/org/apache/spark/api/python/StreamingPythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/StreamingPythonRunner.scala
@@ -73,6 +73,7 @@ private[spark] class StreamingPythonRunner(
     if (!connectUrl.isEmpty) {
       envVars.put("SPARK_CONNECT_LOCAL_URL", connectUrl)
     }
+    envVars.put("SPARK_PYTHON_RUNTIME", "PYTHON_WORKER")
 
     val workerFactory =
       new PythonWorkerFactory(pythonExec, workerModule, envVars.asScala.toMap, false)

--- a/python/pyspark/worker_util.py
+++ b/python/pyspark/worker_util.py
@@ -25,6 +25,10 @@ import sys
 from typing import Any, IO, Optional
 import warnings
 
+assert (
+    os.environ.get("SPARK_PYTHON_RUNTIME", "?") == "PYTHON_WORKER"
+), "This module can only be imported in python woker"
+
 # 'resource' is a Unix specific module.
 has_resource_module = True
 try:

--- a/python/pyspark/worker_util.py
+++ b/python/pyspark/worker_util.py
@@ -26,7 +26,7 @@ from typing import Any, IO, Optional
 import warnings
 
 assert (
-    os.environ.get("SPARK_PYTHON_RUNTIME", "?") == "PYTHON_WORKER"
+    os.environ.get("SPARK_PYTHON_RUNTIME") == "PYTHON_WORKER"
 ), "This module can only be imported in python woker"
 
 # 'resource' is a Unix specific module.

--- a/python/pyspark/worker_util.py
+++ b/python/pyspark/worker_util.py
@@ -25,9 +25,10 @@ import sys
 from typing import Any, IO, Optional
 import warnings
 
-assert (
-    os.environ.get("SPARK_PYTHON_RUNTIME") == "PYTHON_WORKER"
-), "This module can only be imported in python woker"
+if "SPARK_TESTING" in os.environ:
+    assert (
+        os.environ.get("SPARK_PYTHON_RUNTIME") == "PYTHON_WORKER"
+    ), "This module can only be imported in python woker"
 
 # 'resource' is a Unix specific module.
 has_resource_module = True

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonPlannerRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonPlannerRunner.scala
@@ -109,6 +109,7 @@ abstract class PythonPlannerRunner[T](func: PythonFunction) extends Logging {
     sessionUUID.foreach { uuid =>
       envVars.put("PYSPARK_SPARK_SESSION_UUID", uuid)
     }
+    envVars.put("SPARK_PYTHON_RUNTIME", "PYTHON_WORKER")
 
     EvaluatePython.registerPicklers()
     val pickler = new Pickler(/* useMemo = */ true,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingSourceRunner.scala
@@ -92,6 +92,7 @@ class PythonStreamingSourceRunner(
 
     envVars.put("SPARK_AUTH_SOCKET_TIMEOUT", authSocketTimeout.toString)
     envVars.put("SPARK_BUFFER_SIZE", bufferSize.toString)
+    envVars.put("SPARK_PYTHON_RUNTIME", "PYTHON_WORKER")
 
     val workerFactory =
       new PythonWorkerFactory(pythonExec, workerModule, envVars.asScala.toMap, false)


### PR DESCRIPTION

### What changes were proposed in this pull request?
Make sure `worker_util.py` can only be imported in python workers


### Why are the changes needed?
`worker_util.py` is expected to only available in python workers


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no