### PR TITLE
[SPARK-55359][CORE] Promote `TaskResourceRequest` to `Stable`

### DIFF
--- a/core/src/main/scala/org/apache/spark/resource/TaskResourceRequest.scala
+++ b/core/src/main/scala/org/apache/spark/resource/TaskResourceRequest.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.resource
 
-import org.apache.spark.annotation.{Evolving, Since}
+import org.apache.spark.annotation.{Since, Stable}
 
 /**
  * A task resource request. This is used in conjunction with the [[ResourceProfile]] to
@@ -32,7 +32,7 @@ import org.apache.spark.annotation.{Evolving, Since}
  *               lets you configure X number of tasks to run on a single resource,
  *               ie amount equals 0.5 translates into 2 tasks per resource address.
  */
-@Evolving
+@Stable
 @Since("3.1.0")
 class TaskResourceRequest(val resourceName: String, val amount: Double)
   extends Serializable {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to promote `TaskResourceRequest` to `Stable` at Apache Spark 4.2.0.

### Why are the changes needed?

Apache Spark 3.0.0 introduced `TaskResourceRequest` on 2019-11-25.
- https://github.com/apache/spark/pull/26284

Apache Spark 3.1.0 promoted it to the public `Evolving` API on 2020-06-02.
- https://github.com/apache/spark/pull/28697

Apache Spark 4.0.0 allows fractions by loosing `assertion` only on 2024-01-04.
- https://github.com/apache/spark/pull/43494

There is no change over 2 year and additionally `TaskResourceRequest` class's member variables and methods has been serving stably over 6 years. We had better promote it `Stable` from 4.2.0.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.