### PR TITLE
[SPARK-55334][PYTHON] Enable `TimestampType` and `TimestampNTZType` in `convert_numpy`

### DIFF
--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -1135,7 +1135,7 @@ class ArrowArrayConversion:
         arr: Union["pa.Array", "pa.ChunkedArray"],
     ) -> Union["pa.Array", "pa.ChunkedArray"]:
         """
-        1, always drop the timezone for TimestampType;
+        1, always drop the timezone from TimestampType;
         2, coerce_temporal_nanoseconds: coerce timestamp time units to nanoseconds
         """
         import pyarrow as pa


### PR DESCRIPTION

### What changes were proposed in this pull request?
Enable TimestampType in `convert_numpy`


### Why are the changes needed?
to replace old conversion


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no