### PR TITLE
[SPARK-55175][PYTHON] Extract `to_pandas` transformer from serializers

### DIFF
--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -105,6 +105,59 @@ class ArrowBatchTransformer:
             struct = pa.StructArray.from_arrays(batch.columns, fields=pa.struct(list(batch.schema)))
         return pa.RecordBatch.from_arrays([struct], ["_0"])
 
+    @classmethod
+    def to_pandas(
+        cls,
+        batch: Union["pa.RecordBatch", "pa.Table"],
+        timezone: str,
+        schema: Optional["StructType"] = None,
+        struct_in_pandas: str = "dict",
+        ndarray_as_list: bool = False,
+        df_for_struct: bool = False,
+    ) -> List[Union["pd.Series", "pd.DataFrame"]]:
+        """
+        Convert a RecordBatch or Table to a list of pandas Series.
+
+        Parameters
+        ----------
+        batch : pa.RecordBatch or pa.Table
+            The Arrow RecordBatch or Table to convert.
+        timezone : str
+            Timezone for timestamp conversion.
+        schema : StructType, optional
+            Spark schema for type conversion. If None, types are inferred from Arrow.
+        struct_in_pandas : str
+            How to represent struct in pandas ("dict", "row", etc.)
+        ndarray_as_list : bool
+            Whether to convert ndarray as list.
+        df_for_struct : bool
+            If True, convert struct columns to DataFrame instead of Series.
+
+        Returns
+        -------
+        List[Union[pd.Series, pd.DataFrame]]
+            List of pandas Series (or DataFrame if df_for_struct=True), one for each column.
+        """
+        import pandas as pd
+
+        import pyspark
+        from pyspark.sql.pandas.types import from_arrow_type
+
+        if batch.num_columns == 0:
+            return [pd.Series([pyspark._NoValue] * batch.num_rows)]
+
+        return [
+            ArrowArrayToPandasConversion.convert(
+                batch.column(i),
+                schema[i].dataType if schema is not None else from_arrow_type(batch.column(i).type),
+                timezone=timezone,
+                struct_in_pandas=struct_in_pandas,
+                ndarray_as_list=ndarray_as_list,
+                df_for_struct=df_for_struct,
+            )
+            for i in range(batch.num_columns)
+        ]
+
 
 class LocalDataToArrowConversion:
     """

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -20,7 +20,7 @@ Serializers for PyArrow and pandas conversions. See `pyspark.serializers` for mo
 """
 
 from itertools import groupby
-from typing import TYPE_CHECKING, Iterator, Optional
+from typing import TYPE_CHECKING, Any, Iterator, Optional, Tuple
 
 import pyspark
 from pyspark.errors import PySparkRuntimeError, PySparkTypeError, PySparkValueError
@@ -35,8 +35,8 @@ from pyspark.sql import Row
 from pyspark.sql.conversion import (
     LocalDataToArrowConversion,
     ArrowTableToRowsConversion,
-    ArrowArrayToPandasConversion,
     ArrowBatchTransformer,
+    ArrowArrayToPandasConversion,
 )
 from pyspark.sql.pandas.types import (
     from_arrow_type,
@@ -56,7 +56,6 @@ from pyspark.sql.types import (
 
 if TYPE_CHECKING:
     import pandas as pd
-    import pyarrow as pa
 
 
 class SpecialLengths:
@@ -574,28 +573,17 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
         """
         Deserialize ArrowRecordBatches to an Arrow table and return as a list of pandas.Series.
         """
-        import pandas as pd
-        import pyspark
-
-        batches = super().load_stream(stream)
-        for batch in batches:
-            if batch.num_columns == 0:
-                yield [pd.Series([pyspark._NoValue] * batch.num_rows)]
-            else:
-                pandas_batches = [
-                    ArrowArrayToPandasConversion.convert(
-                        batch.column(i),
-                        self._input_type[i].dataType
-                        if self._input_type is not None
-                        else from_arrow_type(batch.column(i).type),
-                        timezone=self._timezone,
-                        struct_in_pandas=self._struct_in_pandas,
-                        ndarray_as_list=self._ndarray_as_list,
-                        df_for_struct=self._df_for_struct,
-                    )
-                    for i in range(batch.num_columns)
-                ]
-                yield pandas_batches
+        yield from map(
+            lambda batch: ArrowBatchTransformer.to_pandas(
+                batch,
+                timezone=self._timezone,
+                schema=self._input_type,
+                struct_in_pandas=self._struct_in_pandas,
+                ndarray_as_list=self._ndarray_as_list,
+                df_for_struct=self._df_for_struct,
+            ),
+            super().load_stream(stream),
+        )
 
     def __repr__(self):
         return "ArrowStreamPandasSerializer"
@@ -1180,21 +1168,18 @@ class ArrowStreamAggPandasUDFSerializer(ArrowStreamPandasUDFSerializer):
         for (batches,) in self._load_group_dataframes(stream, num_dfs=1):
             # Lazily read and convert Arrow batches to pandas Series one at a time
             # from the stream. This avoids loading all batches into memory for the group
-            series_iter = (
-                tuple(
-                    ArrowArrayToPandasConversion.convert(
-                        c,
-                        self._input_type[i].dataType
-                        if self._input_type is not None
-                        else from_arrow_type(c.type),
+            series_iter = map(
+                lambda batch: tuple(
+                    ArrowBatchTransformer.to_pandas(
+                        batch,
                         timezone=self._timezone,
+                        schema=self._input_type,
                         struct_in_pandas=self._struct_in_pandas,
                         ndarray_as_list=self._ndarray_as_list,
                         df_for_struct=self._df_for_struct,
                     )
-                    for i, c in enumerate(batch.columns)
-                )
-                for batch in batches
+                ),
+                batches,
             )
             yield series_iter
             # Make sure the batches are fully iterated before getting the next group
@@ -1232,29 +1217,20 @@ class GroupPandasUDFSerializer(ArrowStreamPandasUDFSerializer):
         Each outer iterator element represents a group, containing an iterator of Series lists
         (one list per batch).
         """
-
-        def process_group(batches: "Iterator[pa.RecordBatch]"):
-            # Convert each Arrow batch to pandas Series list on-demand, yielding one list per batch
-            for batch in batches:
-                series = [
-                    ArrowArrayToPandasConversion.convert(
-                        batch.column(i),
-                        self._input_type[i].dataType
-                        if self._input_type is not None
-                        else from_arrow_type(batch.column(i).type),
-                        timezone=self._timezone,
-                        struct_in_pandas=self._struct_in_pandas,
-                        ndarray_as_list=self._ndarray_as_list,
-                        df_for_struct=self._df_for_struct,
-                    )
-                    for i in range(batch.num_columns)
-                ]
-                yield series
-
         for (batches,) in self._load_group_dataframes(stream, num_dfs=1):
             # Lazily read and convert Arrow batches one at a time from the stream
             # This avoids loading all batches into memory for the group
-            series_iter = process_group(batches)
+            series_iter = map(
+                lambda batch: ArrowBatchTransformer.to_pandas(
+                    batch,
+                    timezone=self._timezone,
+                    schema=self._input_type,
+                    struct_in_pandas=self._struct_in_pandas,
+                    ndarray_as_list=self._ndarray_as_list,
+                    df_for_struct=self._df_for_struct,
+                ),
+                batches,
+            )
             yield series_iter
             # Make sure the batches are fully iterated before getting the next group
             for _ in series_iter:
@@ -1302,33 +1278,16 @@ class CogroupPandasUDFSerializer(ArrowStreamPandasUDFSerializer):
         import pyarrow as pa
 
         for left_batches, right_batches in self._load_group_dataframes(stream, num_dfs=2):
-            yield (
-                [
-                    ArrowArrayToPandasConversion.convert(
-                        c,
-                        self._input_type[i].dataType
-                        if self._input_type is not None
-                        else from_arrow_type(c.type),
-                        timezone=self._timezone,
-                        struct_in_pandas=self._struct_in_pandas,
-                        ndarray_as_list=self._ndarray_as_list,
-                        df_for_struct=self._df_for_struct,
-                    )
-                    for i, c in enumerate(pa.Table.from_batches(left_batches).itercolumns())
-                ],
-                [
-                    ArrowArrayToPandasConversion.convert(
-                        c,
-                        self._input_type[i].dataType
-                        if self._input_type is not None
-                        else from_arrow_type(c.type),
-                        timezone=self._timezone,
-                        struct_in_pandas=self._struct_in_pandas,
-                        ndarray_as_list=self._ndarray_as_list,
-                        df_for_struct=self._df_for_struct,
-                    )
-                    for i, c in enumerate(pa.Table.from_batches(right_batches).itercolumns())
-                ],
+            yield tuple(
+                ArrowBatchTransformer.to_pandas(
+                    pa.Table.from_batches(batches),
+                    timezone=self._timezone,
+                    schema=self._input_type,
+                    struct_in_pandas=self._struct_in_pandas,
+                    ndarray_as_list=self._ndarray_as_list,
+                    df_for_struct=self._df_for_struct,
+                )
+                for batches in (left_batches, right_batches)
             )
 
 
@@ -1493,18 +1452,14 @@ class ApplyInPandasWithStateSerializer(ArrowStreamPandasUDFSerializer):
                     schema=state_schema,
                 )
 
-                state_arrow = pa.Table.from_batches([state_batch]).itercolumns()
-                state_pandas = [
-                    ArrowArrayToPandasConversion.convert(
-                        c,
-                        from_arrow_type(c.type),
-                        timezone=self._timezone,
-                        struct_in_pandas=self._struct_in_pandas,
-                        ndarray_as_list=self._ndarray_as_list,
-                        df_for_struct=self._df_for_struct,
-                    )
-                    for c in state_arrow
-                ][0]
+                state_pandas = ArrowBatchTransformer.to_pandas(
+                    state_batch,
+                    timezone=self._timezone,
+                    schema=None,
+                    struct_in_pandas=self._struct_in_pandas,
+                    ndarray_as_list=self._ndarray_as_list,
+                    df_for_struct=self._df_for_struct,
+                )[0]
 
                 for state_idx in range(0, len(state_pandas)):
                     state_info_col = state_pandas.iloc[state_idx]
@@ -1534,19 +1489,14 @@ class ApplyInPandasWithStateSerializer(ArrowStreamPandasUDFSerializer):
                         state_for_current_group = state
 
                     data_batch_for_group = data_batch.slice(data_start_offset, num_data_rows)
-                    data_arrow = pa.Table.from_batches([data_batch_for_group]).itercolumns()
-
-                    data_pandas = [
-                        ArrowArrayToPandasConversion.convert(
-                            c,
-                            from_arrow_type(c.type),
-                            timezone=self._timezone,
-                            struct_in_pandas=self._struct_in_pandas,
-                            ndarray_as_list=self._ndarray_as_list,
-                            df_for_struct=self._df_for_struct,
-                        )
-                        for c in data_arrow
-                    ]
+                    data_pandas = ArrowBatchTransformer.to_pandas(
+                        data_batch_for_group,
+                        timezone=self._timezone,
+                        schema=None,
+                        struct_in_pandas=self._struct_in_pandas,
+                        ndarray_as_list=self._ndarray_as_list,
+                        df_for_struct=self._df_for_struct,
+                    )
 
                     # state info
                     yield (
@@ -1792,7 +1742,6 @@ class TransformWithStateInPandasSerializer(ArrowStreamPandasUDFSerializer):
         Please refer the doc of inner function `generate_data_batches` for more details how
         this function works in overall.
         """
-        import pyarrow as pa
         import pandas as pd
         from pyspark.sql.streaming.stateful_processor_util import (
             TransformWithStateInPandasFuncMode,
@@ -1812,17 +1761,14 @@ class TransformWithStateInPandasSerializer(ArrowStreamPandasUDFSerializer):
             def row_stream():
                 for batch in batches:
                     self._update_batch_size_stats(batch)
-                    data_pandas = [
-                        ArrowArrayToPandasConversion.convert(
-                            c,
-                            from_arrow_type(c.type),
-                            timezone=self._timezone,
-                            struct_in_pandas=self._struct_in_pandas,
-                            ndarray_as_list=self._ndarray_as_list,
-                            df_for_struct=self._df_for_struct,
-                        )
-                        for c in pa.Table.from_batches([batch]).itercolumns()
-                    ]
+                    data_pandas = ArrowBatchTransformer.to_pandas(
+                        batch,
+                        timezone=self._timezone,
+                        schema=self._input_type,
+                        struct_in_pandas=self._struct_in_pandas,
+                        ndarray_as_list=self._ndarray_as_list,
+                        df_for_struct=self._df_for_struct,
+                    )
                     for row in pd.concat(data_pandas, axis=1).itertuples(index=False):
                         batch_key = tuple(row[s] for s in self.key_offsets)
                         yield (batch_key, row)
@@ -1944,48 +1890,35 @@ class TransformWithStateInPandasInitStateSerializer(TransformWithStateInPandasSe
              but each batch will have either init_data or input_data, not mix.
             """
 
+            def to_pandas(table):
+                return ArrowBatchTransformer.to_pandas(
+                    table,
+                    timezone=self._timezone,
+                    schema=self._input_type,
+                    struct_in_pandas=self._struct_in_pandas,
+                    ndarray_as_list=self._ndarray_as_list,
+                    df_for_struct=self._df_for_struct,
+                )
+
             def row_stream():
                 for batch in batches:
                     self._update_batch_size_stats(batch)
 
-                    flatten_state_table = flatten_columns(batch, "inputData")
-                    data_pandas = [
-                        ArrowArrayToPandasConversion.convert(
-                            c,
-                            self._input_type[i].dataType
-                            if self._input_type is not None
-                            else from_arrow_type(c.type),
-                            timezone=self._timezone,
-                            struct_in_pandas=self._struct_in_pandas,
-                            ndarray_as_list=self._ndarray_as_list,
-                            df_for_struct=self._df_for_struct,
-                        )
-                        for i, c in enumerate(flatten_state_table.itercolumns())
-                    ]
+                    data_table = flatten_columns(batch, "inputData")
+                    init_table = flatten_columns(batch, "initState")
 
-                    flatten_init_table = flatten_columns(batch, "initState")
-                    init_data_pandas = [
-                        ArrowArrayToPandasConversion.convert(
-                            c,
-                            self._input_type[i].dataType
-                            if self._input_type is not None
-                            else from_arrow_type(c.type),
-                            timezone=self._timezone,
-                            struct_in_pandas=self._struct_in_pandas,
-                            ndarray_as_list=self._ndarray_as_list,
-                            df_for_struct=self._df_for_struct,
-                        )
-                        for i, c in enumerate(flatten_init_table.itercolumns())
-                    ]
+                    # Check column count - empty table has no columns
+                    has_data = data_table.num_columns > 0
+                    has_init = init_table.num_columns > 0
 
-                    assert not (bool(init_data_pandas) and bool(data_pandas))
+                    assert not (has_data and has_init)
 
-                    if bool(data_pandas):
-                        for row in pd.concat(data_pandas, axis=1).itertuples(index=False):
+                    if has_data:
+                        for row in pd.concat(to_pandas(data_table), axis=1).itertuples(index=False):
                             batch_key = tuple(row[s] for s in self.key_offsets)
                             yield (batch_key, row, None)
-                    elif bool(init_data_pandas):
-                        for row in pd.concat(init_data_pandas, axis=1).itertuples(index=False):
+                    elif has_init:
+                        for row in pd.concat(to_pandas(init_table), axis=1).itertuples(index=False):
                             batch_key = tuple(row[s] for s in self.init_key_offsets)
                             yield (batch_key, None, row)
 
@@ -2152,7 +2085,6 @@ class TransformWithStateInPySparkRowInitStateSerializer(TransformWithStateInPySp
         from pyspark.sql.streaming.stateful_processor_util import (
             TransformWithStateInPandasFuncMode,
         )
-        from typing import Iterator, Any, Optional, Tuple
 
         def generate_data_batches(batches) -> Iterator[Tuple[Any, Optional[Any], Optional[Any]]]:
             """


### PR DESCRIPTION
This is a re-apply of #53963, which was reverted due to a failing CI job.

### What changes were proposed in this pull request?

Extract the `to_pandas` conversion logic from serializers into `ArrowBatchTransformer.to_pandas()`.
This refactors multiple serializers (`GroupPandasUDFSerializer`, `CogroupPandasUDFSerializer`, `ApplyInPandasWithStateSerializer`, etc.) to use the new transformer instead of inline conversion logic.

### Why are the changes needed?

This is part of Phase 1 of [SPARK-55159](https://issues.apache.org/jira/browse/SPARK-55159) to improve the composability of Arrow serializers by separating data transformation from serialization.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.