### PR TITLE
[SPARK-55376][PS] Make numeric_only argument in groupby functions accept only boolean with pandas 3

### DIFF
--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -92,7 +92,6 @@ from pyspark.pandas.utils import (
     name_like_string,
     same_anchor,
     scol_for,
-    validate_numeric_only,
     verify_temp_column_name,
     log_advice,
 )
@@ -493,7 +492,9 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         a  1.0  True  3.0
         b  NaN  None  NaN
         """
-        validate_numeric_only(numeric_only)
+        if LooseVersion(pd.__version__) >= "3.0.0":
+            if not isinstance(numeric_only, bool):
+                raise ValueError("numeric_only accepts only Boolean values")
         if not isinstance(min_count, int):
             raise TypeError("min_count must be integer")
 
@@ -564,7 +565,9 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         a  2.0  True  4.0
         b  NaN  None  NaN
         """
-        validate_numeric_only(numeric_only)
+        if LooseVersion(pd.__version__) >= "3.0.0":
+            if not isinstance(numeric_only, bool):
+                raise ValueError("numeric_only accepts only Boolean values")
         if not isinstance(min_count, int):
             raise TypeError("min_count must be integer")
 
@@ -629,7 +632,9 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         a  2.0  True  4.0
         b  NaN  None  NaN
         """
-        validate_numeric_only(numeric_only)
+        if LooseVersion(pd.__version__) >= "3.0.0":
+            if not isinstance(numeric_only, bool):
+                raise ValueError("numeric_only accepts only Boolean values")
         if not isinstance(min_count, int):
             raise TypeError("min_count must be integer")
 
@@ -676,7 +681,9 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         1  3.0  1.333333  0.333333
         2  4.0  1.500000  1.000000
         """
-        validate_numeric_only(numeric_only)
+        if LooseVersion(pd.__version__) >= "3.0.0":
+            if not isinstance(numeric_only, bool):
+                raise ValueError("numeric_only accepts only Boolean values")
         self._validate_agg_columns(numeric_only=numeric_only, function_name="median")
 
         return self._reduce_for_stat_function(
@@ -807,7 +814,9 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         a  1.0  False  3.0
         b  NaN   None  NaN
         """
-        validate_numeric_only(numeric_only)
+        if LooseVersion(pd.__version__) >= "3.0.0":
+            if not isinstance(numeric_only, bool):
+                raise ValueError("numeric_only accepts only Boolean values")
         if not isinstance(min_count, int):
             raise TypeError("min_count must be integer")
 
@@ -925,7 +934,9 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         pyspark.pandas.Series.groupby
         pyspark.pandas.DataFrame.groupby
         """
-        validate_numeric_only(numeric_only)
+        if LooseVersion(pd.__version__) >= "3.0.0":
+            if not isinstance(numeric_only, bool):
+                raise ValueError("numeric_only accepts only Boolean values")
         if numeric_only is not None and not isinstance(numeric_only, bool):
             raise TypeError("numeric_only must be None or bool")
         if not isinstance(min_count, int):
@@ -987,7 +998,9 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         pyspark.pandas.Series.groupby
         pyspark.pandas.DataFrame.groupby
         """
-        validate_numeric_only(numeric_only)
+        if LooseVersion(pd.__version__) >= "3.0.0":
+            if not isinstance(numeric_only, bool):
+                raise ValueError("numeric_only accepts only Boolean values")
         if not isinstance(ddof, int):
             raise TypeError("ddof must be integer")
 
@@ -1256,7 +1269,9 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         1  NaN  2.0  0.0
         2  NaN NaN  NaN
         """
-        validate_numeric_only(numeric_only)
+        if LooseVersion(pd.__version__) >= "3.0.0":
+            if not isinstance(numeric_only, bool):
+                raise ValueError("numeric_only accepts only Boolean values")
         if not isinstance(min_count, int):
             raise TypeError("min_count must be integer")
 
@@ -3504,7 +3519,9 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         3.0    7.0
         Name: b, dtype: float64
         """
-        validate_numeric_only(numeric_only)
+        if LooseVersion(pd.__version__) >= "3.0.0":
+            if not isinstance(numeric_only, bool):
+                raise ValueError("numeric_only accepts only Boolean values")
         if not isinstance(accuracy, int):
             raise TypeError(
                 "accuracy must be an integer; however, got [%s]" % type(accuracy).__name__
@@ -4063,7 +4080,9 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         2 B  1.000000       NaN
           C       NaN  1.000000
         """
-        validate_numeric_only(numeric_only)
+        if LooseVersion(pd.__version__) >= "3.0.0":
+            if not isinstance(numeric_only, bool):
+                raise ValueError("numeric_only accepts only Boolean values")
         if method not in ["pearson", "spearman", "kendall"]:
             raise ValueError(f"Invalid method {method}")
 

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -92,6 +92,7 @@ from pyspark.pandas.utils import (
     name_like_string,
     same_anchor,
     scol_for,
+    validate_numeric_only,
     verify_temp_column_name,
     log_advice,
 )
@@ -492,6 +493,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         a  1.0  True  3.0
         b  NaN  None  NaN
         """
+        validate_numeric_only(numeric_only)
         if not isinstance(min_count, int):
             raise TypeError("min_count must be integer")
 
@@ -562,6 +564,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         a  2.0  True  4.0
         b  NaN  None  NaN
         """
+        validate_numeric_only(numeric_only)
         if not isinstance(min_count, int):
             raise TypeError("min_count must be integer")
 
@@ -626,6 +629,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         a  2.0  True  4.0
         b  NaN  None  NaN
         """
+        validate_numeric_only(numeric_only)
         if not isinstance(min_count, int):
             raise TypeError("min_count must be integer")
 
@@ -672,6 +676,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         1  3.0  1.333333  0.333333
         2  4.0  1.500000  1.000000
         """
+        validate_numeric_only(numeric_only)
         self._validate_agg_columns(numeric_only=numeric_only, function_name="median")
 
         return self._reduce_for_stat_function(
@@ -802,6 +807,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         a  1.0  False  3.0
         b  NaN   None  NaN
         """
+        validate_numeric_only(numeric_only)
         if not isinstance(min_count, int):
             raise TypeError("min_count must be integer")
 
@@ -919,6 +925,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         pyspark.pandas.Series.groupby
         pyspark.pandas.DataFrame.groupby
         """
+        validate_numeric_only(numeric_only)
         if numeric_only is not None and not isinstance(numeric_only, bool):
             raise TypeError("numeric_only must be None or bool")
         if not isinstance(min_count, int):
@@ -980,6 +987,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         pyspark.pandas.Series.groupby
         pyspark.pandas.DataFrame.groupby
         """
+        validate_numeric_only(numeric_only)
         if not isinstance(ddof, int):
             raise TypeError("ddof must be integer")
 
@@ -1248,6 +1256,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         1  NaN  2.0  0.0
         2  NaN NaN  NaN
         """
+        validate_numeric_only(numeric_only)
         if not isinstance(min_count, int):
             raise TypeError("min_count must be integer")
 
@@ -3495,6 +3504,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         3.0    7.0
         Name: b, dtype: float64
         """
+        validate_numeric_only(numeric_only)
         if not isinstance(accuracy, int):
             raise TypeError(
                 "accuracy must be an integer; however, got [%s]" % type(accuracy).__name__
@@ -4053,6 +4063,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         2 B  1.000000       NaN
           C       NaN  1.000000
         """
+        validate_numeric_only(numeric_only)
         if method not in ["pearson", "spearman", "kendall"]:
             raise ValueError(f"Invalid method {method}")
 

--- a/python/pyspark/pandas/tests/groupby/test_stat.py
+++ b/python/pyspark/pandas/tests/groupby/test_stat.py
@@ -25,6 +25,9 @@ from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
+using_pandas3 = LooseVersion(pd.__version__) >= "3.0.0"
+
+
 class GroupbyStatTestingFuncMixin:
     # TODO: All statistical functions should leverage this utility
     def _test_stat_func(
@@ -51,13 +54,6 @@ class GroupbyStatTestingFuncMixin:
                 with self.assertRaises(expected_error):
                     func(ps_groupby_obj)
 
-    @property
-    def expected_error_numeric_only(self) -> Optional[Type[Exception]]:
-        if LooseVersion(pd.__version__) < "3.0.0":
-            return None
-        else:
-            return ValueError
-
 
 class GroupbyStatMixin(GroupbyStatTestingFuncMixin):
     @property
@@ -81,7 +77,7 @@ class GroupbyStatMixin(GroupbyStatTestingFuncMixin):
             # pandas < 3 raises an error when numeric_only is False or None
             self._test_stat_func(
                 lambda groupby_obj: groupby_obj.mean(numeric_only=None),
-                expected_error=self.expected_error_numeric_only,
+                expected_error=ValueError if using_pandas3 else None,
             )
         psdf = self.psdf
         with self.assertRaises(TypeError):
@@ -92,7 +88,7 @@ class GroupbyStatMixin(GroupbyStatTestingFuncMixin):
         self._test_stat_func(lambda groupby_obj: groupby_obj.min(min_count=2))
         self._test_stat_func(
             lambda groupby_obj: groupby_obj.min(numeric_only=None),
-            expected_error=self.expected_error_numeric_only,
+            expected_error=ValueError if using_pandas3 else None,
         )
         self._test_stat_func(lambda groupby_obj: groupby_obj.min(numeric_only=True))
         self._test_stat_func(lambda groupby_obj: groupby_obj.min(numeric_only=True, min_count=2))
@@ -102,7 +98,7 @@ class GroupbyStatMixin(GroupbyStatTestingFuncMixin):
         self._test_stat_func(lambda groupby_obj: groupby_obj.max(min_count=2))
         self._test_stat_func(
             lambda groupby_obj: groupby_obj.max(numeric_only=None),
-            expected_error=self.expected_error_numeric_only,
+            expected_error=ValueError if using_pandas3 else None,
         )
         self._test_stat_func(lambda groupby_obj: groupby_obj.max(numeric_only=True))
         self._test_stat_func(lambda groupby_obj: groupby_obj.max(numeric_only=True, min_count=2))
@@ -127,7 +123,7 @@ class GroupbyStatMixin(GroupbyStatTestingFuncMixin):
         )
         self._test_stat_func(
             lambda groupby_obj: groupby_obj.sum(numeric_only=None),
-            expected_error=self.expected_error_numeric_only,
+            expected_error=ValueError if using_pandas3 else None,
         )
 
     def test_median(self):
@@ -158,7 +154,7 @@ class GroupbyStatMixin(GroupbyStatTestingFuncMixin):
             # pandas < 3 raises an error when numeric_only is False or None
             self._test_stat_func(
                 lambda groupby_obj: groupby_obj.median(numeric_only=None),
-                expected_error=self.expected_error_numeric_only,
+                expected_error=ValueError if using_pandas3 else None,
             )
 
 

--- a/python/pyspark/pandas/tests/groupby/test_stat.py
+++ b/python/pyspark/pandas/tests/groupby/test_stat.py
@@ -14,18 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from typing import Optional, Tuple, Type
 
 import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
+from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupbyStatTestingFuncMixin:
     # TODO: All statistical functions should leverage this utility
-    def _test_stat_func(self, func, check_exact=True):
+    def _test_stat_func(
+        self, func, check_exact=True, expected_error: Optional[Tuple[Type[Exception], str]] = None
+    ):
         pdf, psdf = self.pdf, self.psdf
         for p_groupby_obj, ps_groupby_obj in [
             # Against DataFrameGroupBy
@@ -35,11 +39,23 @@ class GroupbyStatTestingFuncMixin:
             # Against SeriesGroupBy
             (pdf.groupby("A")["B"], psdf.groupby("A")["B"]),
         ]:
-            self.assert_eq(
-                func(p_groupby_obj).sort_index(),
-                func(ps_groupby_obj).sort_index(),
-                check_exact=check_exact,
-            )
+            if expected_error is None:
+                self.assert_eq(
+                    func(p_groupby_obj).sort_index(),
+                    func(ps_groupby_obj).sort_index(),
+                    check_exact=check_exact,
+                )
+            else:
+                error_type, error_message = expected_error
+                self.assertRaisesRegex(error_type, error_message, lambda: func(p_groupby_obj))
+                self.assertRaisesRegex(error_type, error_message, lambda: func(ps_groupby_obj))
+
+    @property
+    def expected_error_numeric_only(self) -> Optional[Tuple[Type[Exception], str]]:
+        if LooseVersion(pd.__version__) >= LooseVersion("3.0"):
+            return (ValueError, "numeric_only accepts only Boolean values")
+        else:
+            return None
 
 
 class GroupbyStatMixin(GroupbyStatTestingFuncMixin):
@@ -60,6 +76,12 @@ class GroupbyStatMixin(GroupbyStatTestingFuncMixin):
 
     def test_mean(self):
         self._test_stat_func(lambda groupby_obj: groupby_obj.mean(numeric_only=True))
+        if LooseVersion(pd.__version__) >= LooseVersion("3.0"):
+            # pandas < 3 raises an error when numeric_only is False or None
+            self._test_stat_func(
+                lambda groupby_obj: groupby_obj.mean(numeric_only=None),
+                expected_error=self.expected_error_numeric_only,
+            )
         psdf = self.psdf
         with self.assertRaises(TypeError):
             psdf.groupby("A")["C"].mean()
@@ -67,14 +89,20 @@ class GroupbyStatMixin(GroupbyStatTestingFuncMixin):
     def test_min(self):
         self._test_stat_func(lambda groupby_obj: groupby_obj.min())
         self._test_stat_func(lambda groupby_obj: groupby_obj.min(min_count=2))
-        self._test_stat_func(lambda groupby_obj: groupby_obj.min(numeric_only=None))
+        self._test_stat_func(
+            lambda groupby_obj: groupby_obj.min(numeric_only=None),
+            expected_error=self.expected_error_numeric_only,
+        )
         self._test_stat_func(lambda groupby_obj: groupby_obj.min(numeric_only=True))
         self._test_stat_func(lambda groupby_obj: groupby_obj.min(numeric_only=True, min_count=2))
 
     def test_max(self):
         self._test_stat_func(lambda groupby_obj: groupby_obj.max())
         self._test_stat_func(lambda groupby_obj: groupby_obj.max(min_count=2))
-        self._test_stat_func(lambda groupby_obj: groupby_obj.max(numeric_only=None))
+        self._test_stat_func(
+            lambda groupby_obj: groupby_obj.max(numeric_only=None),
+            expected_error=self.expected_error_numeric_only,
+        )
         self._test_stat_func(lambda groupby_obj: groupby_obj.max(numeric_only=True))
         self._test_stat_func(lambda groupby_obj: groupby_obj.max(numeric_only=True, min_count=2))
 
@@ -95,6 +123,10 @@ class GroupbyStatMixin(GroupbyStatTestingFuncMixin):
         self.assert_eq(
             pdf.groupby("A").sum(min_count=3).sort_index(),
             psdf.groupby("A").sum(min_count=3).sort_index(),
+        )
+        self._test_stat_func(
+            lambda groupby_obj: groupby_obj.sum(numeric_only=None),
+            expected_error=self.expected_error_numeric_only,
         )
 
     def test_median(self):
@@ -120,6 +152,13 @@ class GroupbyStatMixin(GroupbyStatTestingFuncMixin):
 
         with self.assertRaisesRegex(TypeError, "accuracy must be an integer; however"):
             psdf.groupby("a").median(accuracy="a")
+
+        if LooseVersion(pd.__version__) >= LooseVersion("3.0"):
+            # pandas < 3 raises an error when numeric_only is False or None
+            self._test_stat_func(
+                lambda groupby_obj: groupby_obj.median(numeric_only=None),
+                expected_error=self.expected_error_numeric_only,
+            )
 
 
 class GroupbyStatTests(

--- a/python/pyspark/pandas/tests/groupby/test_stat_adv.py
+++ b/python/pyspark/pandas/tests/groupby/test_stat_adv.py
@@ -19,10 +19,9 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
-from pyspark.pandas.tests.groupby.test_stat import GroupbyStatTestingFuncMixin
+from pyspark.pandas.tests.groupby.test_stat import GroupbyStatTestingFuncMixin, using_pandas3
 
 
 class GroupbyStatAdvMixin(GroupbyStatTestingFuncMixin):
@@ -87,7 +86,7 @@ class GroupbyStatAdvMixin(GroupbyStatTestingFuncMixin):
         self._test_stat_func(lambda groupby_obj: groupby_obj.first())
         self._test_stat_func(
             lambda groupby_obj: groupby_obj.first(numeric_only=None),
-            expected_error=self.expected_error_numeric_only,
+            expected_error=ValueError if using_pandas3 else None,
         )
         self._test_stat_func(lambda groupby_obj: groupby_obj.first(numeric_only=True))
 
@@ -114,7 +113,7 @@ class GroupbyStatAdvMixin(GroupbyStatTestingFuncMixin):
         self._test_stat_func(lambda groupby_obj: groupby_obj.last())
         self._test_stat_func(
             lambda groupby_obj: groupby_obj.last(numeric_only=None),
-            expected_error=self.expected_error_numeric_only,
+            expected_error=ValueError if using_pandas3 else None,
         )
         self._test_stat_func(lambda groupby_obj: groupby_obj.last(numeric_only=True))
 

--- a/python/pyspark/pandas/tests/groupby/test_stat_adv.py
+++ b/python/pyspark/pandas/tests/groupby/test_stat_adv.py
@@ -19,6 +19,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
+from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.tests.groupby.test_stat import GroupbyStatTestingFuncMixin
@@ -84,7 +85,10 @@ class GroupbyStatAdvMixin(GroupbyStatTestingFuncMixin):
 
     def test_first(self):
         self._test_stat_func(lambda groupby_obj: groupby_obj.first())
-        self._test_stat_func(lambda groupby_obj: groupby_obj.first(numeric_only=None))
+        self._test_stat_func(
+            lambda groupby_obj: groupby_obj.first(numeric_only=None),
+            expected_error=self.expected_error_numeric_only,
+        )
         self._test_stat_func(lambda groupby_obj: groupby_obj.first(numeric_only=True))
 
         pdf = pd.DataFrame(
@@ -108,7 +112,10 @@ class GroupbyStatAdvMixin(GroupbyStatTestingFuncMixin):
 
     def test_last(self):
         self._test_stat_func(lambda groupby_obj: groupby_obj.last())
-        self._test_stat_func(lambda groupby_obj: groupby_obj.last(numeric_only=None))
+        self._test_stat_func(
+            lambda groupby_obj: groupby_obj.last(numeric_only=None),
+            expected_error=self.expected_error_numeric_only,
+        )
         self._test_stat_func(lambda groupby_obj: groupby_obj.last(numeric_only=True))
 
         pdf = pd.DataFrame(

--- a/python/pyspark/pandas/tests/groupby/test_stat_func.py
+++ b/python/pyspark/pandas/tests/groupby/test_stat_func.py
@@ -44,7 +44,7 @@ class FuncTestsMixin(GroupbyStatTestingFuncMixin):
         self._test_stat_func(
             lambda groupby_obj: groupby_obj.var(numeric_only=True), check_exact=False
         )
-        if LooseVersion(pd.__version__) >= LooseVersion("3.0"):
+        if LooseVersion(pd.__version__) >= "3.0.0":
             # pandas < 3 raises an error when numeric_only is False or None
             self._test_stat_func(
                 lambda groupby_obj: groupby_obj.var(numeric_only=None),
@@ -61,15 +61,15 @@ class FuncTestsMixin(GroupbyStatTestingFuncMixin):
             psdf.groupby("A").median().sort_index(),
             expected,
         )
-        if LooseVersion(pd.__version__) >= LooseVersion("3.0"):
-            self._test_stat_func(
-                lambda groupby_obj: groupby_obj.median(numeric_only=None),
-                expected_error=self.expected_error_numeric_only,
-            )
-        else:
+        if LooseVersion(pd.__version__) < "3.0.0":
             self.assert_eq(
                 psdf.groupby("A").median(numeric_only=None).sort_index(),
                 expected,
+            )
+        else:
+            self._test_stat_func(
+                lambda groupby_obj: groupby_obj.median(numeric_only=None),
+                expected_error=self.expected_error_numeric_only,
             )
         self.assert_eq(
             psdf.groupby("A").median(numeric_only=False).sort_index(),
@@ -109,7 +109,7 @@ class FuncTestsMixin(GroupbyStatTestingFuncMixin):
             pdf.groupby("A").sum().sort_index(),
             check_exact=False,
         )
-        if LooseVersion(pd.__version__) >= LooseVersion("3.0"):
+        if LooseVersion(pd.__version__) >= "3.0.0":
             # pandas < 3 raises an error when numeric_only is False or None
             self._test_stat_func(
                 lambda groupby_obj: groupby_obj.sum(numeric_only=None),

--- a/python/pyspark/pandas/tests/groupby/test_stat_func.py
+++ b/python/pyspark/pandas/tests/groupby/test_stat_func.py
@@ -21,7 +21,7 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.pandas.tests.groupby.test_stat import GroupbyStatTestingFuncMixin
+from pyspark.pandas.tests.groupby.test_stat import GroupbyStatTestingFuncMixin, using_pandas3
 
 
 class FuncTestsMixin(GroupbyStatTestingFuncMixin):
@@ -48,7 +48,7 @@ class FuncTestsMixin(GroupbyStatTestingFuncMixin):
             # pandas < 3 raises an error when numeric_only is False or None
             self._test_stat_func(
                 lambda groupby_obj: groupby_obj.var(numeric_only=None),
-                expected_error=self.expected_error_numeric_only,
+                expected_error=ValueError if using_pandas3 else None,
             )
 
         pdf, psdf = self.pdf, self.psdf
@@ -69,7 +69,7 @@ class FuncTestsMixin(GroupbyStatTestingFuncMixin):
         else:
             self._test_stat_func(
                 lambda groupby_obj: groupby_obj.median(numeric_only=None),
-                expected_error=self.expected_error_numeric_only,
+                expected_error=ValueError if using_pandas3 else None,
             )
         self.assert_eq(
             psdf.groupby("A").median(numeric_only=False).sort_index(),
@@ -113,7 +113,7 @@ class FuncTestsMixin(GroupbyStatTestingFuncMixin):
             # pandas < 3 raises an error when numeric_only is False or None
             self._test_stat_func(
                 lambda groupby_obj: groupby_obj.sum(numeric_only=None),
-                expected_error=self.expected_error_numeric_only,
+                expected_error=ValueError if using_pandas3 else None,
             )
 
 

--- a/python/pyspark/pandas/tests/groupby/test_stat_prod.py
+++ b/python/pyspark/pandas/tests/groupby/test_stat_prod.py
@@ -20,6 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
+from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.pandas.tests.groupby.test_stat import GroupbyStatTestingFuncMixin
 
@@ -64,6 +65,13 @@ class ProdTestsMixin(GroupbyStatTestingFuncMixin):
                 psdf.groupby("A").prod(min_count=n).sort_index(),
                 almost=True,
             )
+            if LooseVersion(pd.__version__) >= LooseVersion("3.0"):
+                # pandas < 3 raises an error when numeric_only is False or None
+                self._test_stat_func(
+                    lambda groupby_obj: groupby_obj.prod(numeric_only=None, min_count=n),
+                    check_exact=False,
+                    expected_error=self.expected_error_numeric_only,
+                )
 
 
 class ProdTests(

--- a/python/pyspark/pandas/tests/groupby/test_stat_prod.py
+++ b/python/pyspark/pandas/tests/groupby/test_stat_prod.py
@@ -22,7 +22,7 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.pandas.tests.groupby.test_stat import GroupbyStatTestingFuncMixin
+from pyspark.pandas.tests.groupby.test_stat import GroupbyStatTestingFuncMixin, using_pandas3
 
 
 class ProdTestsMixin(GroupbyStatTestingFuncMixin):
@@ -70,7 +70,7 @@ class ProdTestsMixin(GroupbyStatTestingFuncMixin):
                 self._test_stat_func(
                     lambda groupby_obj: groupby_obj.prod(numeric_only=None, min_count=n),
                     check_exact=False,
-                    expected_error=self.expected_error_numeric_only,
+                    expected_error=ValueError if using_pandas3 else None,
                 )
 
 

--- a/python/pyspark/pandas/tests/groupby/test_stat_prod.py
+++ b/python/pyspark/pandas/tests/groupby/test_stat_prod.py
@@ -65,7 +65,7 @@ class ProdTestsMixin(GroupbyStatTestingFuncMixin):
                 psdf.groupby("A").prod(min_count=n).sort_index(),
                 almost=True,
             )
-            if LooseVersion(pd.__version__) >= LooseVersion("3.0"):
+            if LooseVersion(pd.__version__) >= "3.0.0":
                 # pandas < 3 raises an error when numeric_only is False or None
                 self._test_stat_func(
                     lambda groupby_obj: groupby_obj.prod(numeric_only=None, min_count=n),

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -47,7 +47,6 @@ from pyspark.sql import functions as F, Column, DataFrame as PySparkDataFrame, S
 from pyspark.sql.types import DoubleType
 from pyspark.sql.utils import is_remote
 from pyspark.errors import PySparkTypeError, UnsupportedOperationException
-from pyspark.loose_version import LooseVersion
 from pyspark import pandas as ps  # noqa: F401
 from pyspark.pandas._typing import (
     Axis,
@@ -814,12 +813,6 @@ def validate_mode(mode: str) -> str:
             "['w', 'a', 'w+', 'a+', 'overwrite', 'append', 'ignore', 'error', 'errorifexists']",
         )
     return mode
-
-
-def validate_numeric_only(numeric_only: Optional[bool]) -> None:
-    if LooseVersion(pd.__version__) >= "3.0.0":
-        if not isinstance(numeric_only, bool):
-            raise ValueError("numeric_only accepts only Boolean values")
 
 
 @overload

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -47,6 +47,7 @@ from pyspark.sql import functions as F, Column, DataFrame as PySparkDataFrame, S
 from pyspark.sql.types import DoubleType
 from pyspark.sql.utils import is_remote
 from pyspark.errors import PySparkTypeError, UnsupportedOperationException
+from pyspark.loose_version import LooseVersion
 from pyspark import pandas as ps  # noqa: F401
 from pyspark.pandas._typing import (
     Axis,
@@ -813,6 +814,11 @@ def validate_mode(mode: str) -> str:
             "['w', 'a', 'w+', 'a+', 'overwrite', 'append', 'ignore', 'error', 'errorifexists']",
         )
     return mode
+
+
+def validate_numeric_only(numeric_only: Optional[bool]) -> None:
+    if LooseVersion(pd.__version__) >= LooseVersion("3.0") and not isinstance(numeric_only, bool):
+        raise ValueError("numeric_only accepts only Boolean values")
 
 
 @overload

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -817,8 +817,9 @@ def validate_mode(mode: str) -> str:
 
 
 def validate_numeric_only(numeric_only: Optional[bool]) -> None:
-    if LooseVersion(pd.__version__) >= LooseVersion("3.0") and not isinstance(numeric_only, bool):
-        raise ValueError("numeric_only accepts only Boolean values")
+    if LooseVersion(pd.__version__) >= "3.0.0":
+        if not isinstance(numeric_only, bool):
+            raise ValueError("numeric_only accepts only Boolean values")
 
 
 @overload


### PR DESCRIPTION
### What changes were proposed in this pull request?

Makes `numeric_only` argument in `groupby` functions accept only boolean with pandas 3.

### Why are the changes needed?

pandas 3 doesn't accept non-boolean values, like `None`, for `numeric_only` argument in `groupby` functions anymore.

We should follow this behavior when working with pandas 3.

Note: some functions in `DataFrame` and `Series` also have `numeric_only` argument, but they don't raise an exception or even show warnings, so they are left as they are for now.

### Does this PR introduce _any_ user-facing change?

Yes, `numeric_only` argument in `groupby` functions won't accept non-boolean values when working with pandas 3.

### How was this patch tested?

Updated the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
