### PR TITLE
[SPARK-55377][K8S] Improve `labelDecommissioningExecs` to use `patch` instead of `edit` API

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -230,6 +230,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
   private def labelDecommissioningExecs(execIds: Seq[String]) = {
     // Only kick off the labeling task if we have a label.
     conf.get(KUBERNETES_EXECUTOR_DECOMMISSION_LABEL).foreach { label =>
+      val value = conf.get(KUBERNETES_EXECUTOR_DECOMMISSION_LABEL_VALUE).getOrElse("")
       val labelTask = new Runnable() {
         override def run(): Unit = Utils.tryLogNonFatalError {
           kubernetesClient.pods()
@@ -239,13 +240,12 @@ private[spark] class KubernetesClusterSchedulerBackend(
             .withLabelIn(SPARK_EXECUTOR_ID_LABEL, execIds: _*)
             .resources()
             .forEach { podResource =>
-              podResource.edit({ p: Pod =>
-                new PodBuilder(p).editOrNewMetadata()
-                  .addToLabels(label,
-                    conf.get(KUBERNETES_EXECUTOR_DECOMMISSION_LABEL_VALUE).getOrElse(""))
-                  .endMetadata()
-                  .build()})
-          }
+              podResource.patch(PATCH_CONTEXT, new PodBuilder()
+                .withNewMetadata()
+                .addToLabels(label, value)
+                .endMetadata()
+                .build())
+            }
         }
       }
       executorService.execute(labelTask)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackendSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackendSuite.scala
@@ -18,13 +18,13 @@ package org.apache.spark.scheduler.cluster.k8s
 
 import java.util.Arrays
 import java.util.concurrent.TimeUnit
-import java.util.function.UnaryOperator
 
 import scala.jdk.CollectionConverters._
 
 import io.fabric8.kubernetes.api.model.{ConfigMap, Pod, PodBuilder, PodList}
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.dsl.PodResource
+import io.fabric8.kubernetes.client.dsl.base.PatchContext
 import org.jmock.lib.concurrent.DeterministicScheduler
 import org.mockito.{ArgumentCaptor, Mock, MockitoAnnotations}
 import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
@@ -208,13 +208,13 @@ class KubernetesClusterSchedulerBackendSuite extends SparkFunSuite with BeforeAn
     verify(driverEndpointRef).send(RemoveExecutor("1", ExecutorKilled))
     verify(driverEndpointRef).send(RemoveExecutor("2", ExecutorKilled))
     verify(labeledPods, never()).delete()
-    verify(pod1op, never()).edit(any(classOf[UnaryOperator[Pod]]))
-    verify(pod2op, never()).edit(any(classOf[UnaryOperator[Pod]]))
+    verify(pod1op, never()).patch(any(classOf[PatchContext]), any(classOf[Pod]))
+    verify(pod2op, never()).patch(any(classOf[PatchContext]), any(classOf[Pod]))
     schedulerExecutorService.tick(sparkConf.get(KUBERNETES_DYN_ALLOC_KILL_GRACE_PERIOD) * 2,
       TimeUnit.MILLISECONDS)
     verify(labeledPods, never()).delete()
-    verify(pod1op, never()).edit(any(classOf[UnaryOperator[Pod]]))
-    verify(pod2op, never()).edit(any(classOf[UnaryOperator[Pod]]))
+    verify(pod1op, never()).patch(any(classOf[PatchContext]), any(classOf[Pod]))
+    verify(pod2op, never()).patch(any(classOf[PatchContext]), any(classOf[Pod]))
 
     when(labeledPods.resources()).thenReturn(Arrays.asList(pod1op).stream)
     val podList = mock(classOf[PodList])
@@ -226,8 +226,8 @@ class KubernetesClusterSchedulerBackendSuite extends SparkFunSuite with BeforeAn
     schedulerBackendUnderTest.doKillExecutors(Seq("1", "2"))
     verify(labeledPods, never()).delete()
     schedulerExecutorService.runUntilIdle()
-    verify(pod1op).edit(any(classOf[UnaryOperator[Pod]]))
-    verify(pod2op, never()).edit(any(classOf[UnaryOperator[Pod]]))
+    verify(pod1op).patch(any(classOf[PatchContext]), any(classOf[Pod]))
+    verify(pod2op, never()).patch(any(classOf[PatchContext]), any(classOf[Pod]))
     verify(labeledPods, never()).delete()
     schedulerExecutorService.tick(sparkConf.get(KUBERNETES_DYN_ALLOC_KILL_GRACE_PERIOD) * 2,
       TimeUnit.MILLISECONDS)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `labelDecommissioningExecs` to use `patch` instead of `edit` API.

### Why are the changes needed?

**Network Efficiency**

- `edit` requires fetching the entire resource and sending the full updated resource back.
- `patch` only transmits the specific changes, making it much more network-efficient.

**Concurrency & Conflict Resolution**

- `edit` typically follows a Get -> Modify -> Update (PUT) pattern. Using this pattern creates a race condition where, if another client modifies the resource in between, a 409 Conflict error occurs due to a mismatched resourceVersion.
- `patch` sends only the changes (delta) to the server, where the merge is handled server-side. This significantly reduces the risk of conflicts, especially for simple operations like adding an annotation.

### Does this PR introduce _any_ user-facing change?

This will reduce the overhead of K8s control plane and the chance of 409 error.

### How was this patch tested?

Pass the CIs with newly updated test case.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`