### PR TITLE
[SPARK-55379][PS][TESTS] Add some ops tests back and their parity tests

### DIFF
--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_boolean_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_boolean_ops.py
@@ -35,6 +35,7 @@ class BooleanOpsParityTests(
 
 class BooleanExtensionOpsParityTests(
     BooleanExtensionOpsTestsMixin,
+    PandasOnSparkTestUtils,
     OpsTestBase,
     ReusedConnectTestCase,
 ):

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_boolean_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_boolean_ops.py
@@ -15,7 +15,10 @@
 # limitations under the License.
 #
 
-from pyspark.pandas.tests.data_type_ops.test_boolean_ops import BooleanOpsTestsMixin
+from pyspark.pandas.tests.data_type_ops.test_boolean_ops import (
+    BooleanOpsTestsMixin,
+    BooleanExtensionOpsTestsMixin,
+)
 from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 from pyspark.testing.connectutils import ReusedConnectTestCase
@@ -24,6 +27,14 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 class BooleanOpsParityTests(
     BooleanOpsTestsMixin,
     PandasOnSparkTestUtils,
+    OpsTestBase,
+    ReusedConnectTestCase,
+):
+    pass
+
+
+class BooleanExtensionOpsParityTests(
+    BooleanExtensionOpsTestsMixin,
     OpsTestBase,
     ReusedConnectTestCase,
 ):

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_datetime_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_datetime_ops.py
@@ -30,6 +30,13 @@ class DatetimeOpsParityTests(
     pass
 
 
+class DatetimeNTZOpsParityTests(DatetimeOpsParityTests):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.spark.conf.set("spark.sql.timestampType", "timestamp_ntz")
+
+
 if __name__ == "__main__":
     from pyspark.testing import main
 

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_num_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_num_ops.py
@@ -15,7 +15,11 @@
 # limitations under the License.
 #
 
-from pyspark.pandas.tests.data_type_ops.test_num_ops import NumOpsTestsMixin
+from pyspark.pandas.tests.data_type_ops.test_num_ops import (
+    NumOpsTestsMixin,
+    IntegralExtensionOpsTestsMixin,
+    FractionalExtensionOpsTestsMixin,
+)
 from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 from pyspark.testing.connectutils import ReusedConnectTestCase
@@ -24,6 +28,22 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 class NumOpsParityTests(
     NumOpsTestsMixin,
     PandasOnSparkTestUtils,
+    OpsTestBase,
+    ReusedConnectTestCase,
+):
+    pass
+
+
+class IntegralExtensionOpsParityTests(
+    IntegralExtensionOpsTestsMixin,
+    OpsTestBase,
+    ReusedConnectTestCase,
+):
+    pass
+
+
+class FractionalExtensionOpsParityTests(
+    FractionalExtensionOpsTestsMixin,
     OpsTestBase,
     ReusedConnectTestCase,
 ):

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_num_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_num_ops.py
@@ -36,6 +36,7 @@ class NumOpsParityTests(
 
 class IntegralExtensionOpsParityTests(
     IntegralExtensionOpsTestsMixin,
+    PandasOnSparkTestUtils,
     OpsTestBase,
     ReusedConnectTestCase,
 ):
@@ -44,6 +45,7 @@ class IntegralExtensionOpsParityTests(
 
 class FractionalExtensionOpsParityTests(
     FractionalExtensionOpsTestsMixin,
+    PandasOnSparkTestUtils,
     OpsTestBase,
     ReusedConnectTestCase,
 ):

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_string_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_string_ops.py
@@ -15,7 +15,10 @@
 # limitations under the License.
 #
 
-from pyspark.pandas.tests.data_type_ops.test_string_ops import StringOpsTestsMixin
+from pyspark.pandas.tests.data_type_ops.test_string_ops import (
+    StringOpsTestsMixin,
+    StringExtensionOpsTestsMixin,
+)
 from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 from pyspark.testing.connectutils import ReusedConnectTestCase
@@ -24,6 +27,14 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 class StringOpsParityTests(
     StringOpsTestsMixin,
     PandasOnSparkTestUtils,
+    OpsTestBase,
+    ReusedConnectTestCase,
+):
+    pass
+
+
+class StringExtensionOpsParityTests(
+    StringExtensionOpsTestsMixin,
     OpsTestBase,
     ReusedConnectTestCase,
 ):

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_string_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_string_ops.py
@@ -35,6 +35,7 @@ class StringOpsParityTests(
 
 class StringExtensionOpsParityTests(
     StringExtensionOpsTestsMixin,
+    PandasOnSparkTestUtils,
     OpsTestBase,
     ReusedConnectTestCase,
 ):

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -404,7 +404,7 @@ class BooleanOpsTestsMixin:
 @unittest.skipIf(
     not extension_object_dtypes_available, "pandas extension object dtypes are not available"
 )
-class BooleanExtensionOpsTest(OpsTestBase):
+class BooleanExtensionOpsTestsMixin:
     @property
     def boolean_pdf(self):
         return pd.DataFrame(
@@ -833,6 +833,14 @@ class BooleanExtensionOpsTest(OpsTestBase):
 
 class BooleanOpsTests(
     BooleanOpsTestsMixin,
+    OpsTestBase,
+    PandasOnSparkTestCase,
+):
+    pass
+
+
+class BooleanExtensionOpsTests(
+    BooleanExtensionOpsTestsMixin,
     OpsTestBase,
     PandasOnSparkTestCase,
 ):

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -201,7 +201,7 @@ class NumOpsTestsMixin:
 
 
 @unittest.skipIf(not extension_dtypes_available, "pandas extension dtypes are not available")
-class IntegralExtensionOpsTest(OpsTestBase):
+class IntegralExtensionOpsTestsMixin:
     @property
     def intergral_extension_psers(self):
         return [pd.Series([1, 2, 3, None], dtype=dtype) for dtype in self.integral_extension_dtypes]
@@ -331,7 +331,7 @@ class IntegralExtensionOpsTest(OpsTestBase):
 @unittest.skipIf(
     not extension_float_dtypes_available, "pandas extension float dtypes are not available"
 )
-class FractionalExtensionOpsTest(OpsTestBase):
+class FractionalExtensionOpsTestsMixin:
     @property
     def fractional_extension_psers(self):
         return [
@@ -434,6 +434,22 @@ class FractionalExtensionOpsTest(OpsTestBase):
 
 class NumOpsTests(
     NumOpsTestsMixin,
+    OpsTestBase,
+    PandasOnSparkTestCase,
+):
+    pass
+
+
+class IntegralExtensionOpsTests(
+    IntegralExtensionOpsTestsMixin,
+    OpsTestBase,
+    PandasOnSparkTestCase,
+):
+    pass
+
+
+class FractionalExtensionOpsTests(
+    FractionalExtensionOpsTestsMixin,
     OpsTestBase,
     PandasOnSparkTestCase,
 ):

--- a/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
@@ -241,7 +241,7 @@ class StringOpsTests(
 @unittest.skipIf(
     not extension_object_dtypes_available, "pandas extension object dtypes are not available"
 )
-class StringExtensionOpsTest(StringOpsTests):
+class StringExtensionOpsTestsMixin:
     @property
     def pser(self):
         return pd.Series(["x", "y", "z", None], dtype="string")
@@ -340,6 +340,14 @@ class StringExtensionOpsTest(StringOpsTests):
                 self.pser >= self.other_pser, (self.psser >= self.other_psser).sort_index()
             )
             self.check_extension(self.pser >= self.pser, (self.psser >= self.psser).sort_index())
+
+
+class StringExtensionOpsTests(
+    StringExtensionOpsTestsMixin,
+    OpsTestBase,
+    PandasOnSparkTestCase,
+):
+    pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds some ops tests back and their parity tests.

### Why are the changes needed?

After some refactoring at apache/spark#44637, `OpsTestBase` is not a `TestCase` anymore, but there are some tests extending it but not `TestCase`.

Also parity tests for some tests are missing.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Updated and added the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
