### PR TITLE
[SPARK-55363][PS][TESTS][FOLLOW-UP] Also fix `test_num_mul_div` to ignore NaN vs. None

### DIFF
--- a/python/pyspark/pandas/tests/data_type_ops/test_num_mul_div.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_mul_div.py
@@ -38,17 +38,25 @@ class NumMulDivTestsMixin:
         pdf, psdf = self.pdf, self.psdf
         for col in self.numeric_df_cols:
             pser, psser = pdf[col], psdf[col]
-            self.assert_eq(pser * pser, psser * psser, check_exact=False)
-            self.assert_eq(pser * pser.astype(bool), psser * psser.astype(bool), check_exact=False)
-            self.assert_eq(pser * True, psser * True, check_exact=False)
-            self.assert_eq(pser * False, psser * False, check_exact=False)
+            ignore_null = self.ignore_null(col)
+            self.assert_eq(pser * pser, psser * psser, check_exact=False, ignore_null=ignore_null)
+            self.assert_eq(
+                pser * pser.astype(bool),
+                psser * psser.astype(bool),
+                check_exact=False,
+                ignore_null=ignore_null,
+            )
+            self.assert_eq(pser * True, psser * True, check_exact=False, ignore_null=ignore_null)
+            self.assert_eq(pser * False, psser * False, check_exact=False, ignore_null=ignore_null)
 
             if psser.dtype in [int, np.int32]:
                 self.assert_eq(pser * pdf["string"], psser * psdf["string"])
             else:
                 self.assertRaises(TypeError, lambda: psser * psdf["string"])
 
-            self.assert_eq(pser * pdf["bool"], psser * psdf["bool"], check_exact=False)
+            self.assert_eq(
+                pser * pdf["bool"], psser * psdf["bool"], check_exact=False, ignore_null=ignore_null
+            )
 
             self.assertRaises(TypeError, lambda: psser * psdf["datetime"])
             self.assertRaises(TypeError, lambda: psser * psdf["date"])


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of apache/spark#54146.

Also fixes `test_num_mul_div` to ignore `NaN` vs. `None`.

### Why are the changes needed?

The fix was not included in apache/spark#54146.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Updated the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
