### PR TITLE
[MINOR][PYTHON] Add `tabulate` in `dev/requirements.txt`

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -17,10 +17,10 @@ pyyaml>=3.11
 # PySpark test dependencies
 unittest-xml-reporting
 openpyxl
-tabulate
 
 # PySpark test dependencies (optional)
 coverage
+tabulate
 
 # Linter
 ruff==0.14.8

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -17,6 +17,7 @@ pyyaml>=3.11
 # PySpark test dependencies
 unittest-xml-reporting
 openpyxl
+tabulate
 
 # PySpark test dependencies (optional)
 coverage


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `tabulate` in `dev/requirements.txt`


### Why are the changes needed?
`tabulate` is used to generate markdown format golden file

### Does this PR introduce _any_ user-facing change?
no, dev-only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no