### PR TITLE
[SPARK-55382][CORE] Make `Executor` to log `Running Spark version`

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -257,6 +257,7 @@ private[spark] class Executor(
 
   logInfo(log"Starting executor ID ${MDC(LogKeys.EXECUTOR_ID, executorId)}" +
     log" on host ${MDC(HOST, executorHostname)}")
+  logInfo(log"Running Spark version ${MDC(LogKeys.SPARK_VERSION, org.apache.spark.SPARK_VERSION)}")
   logInfo(log"OS info ${MDC(OS_NAME, Utils.osName)}," +
     log" ${MDC(OS_VERSION, Utils.osVersion)}, " +
     log"${MDC(OS_ARCH, Utils.osArch)}")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `Executor` to log `Running Spark version`.

### Why are the changes needed?

Like `Master/Worker/Driver(SparkContext)`, we had better log `Running Spark version` consistently when `Executor` starts. Especially, in K8s environment, executor pods are running only `Executor` without `Master/Worker/Driver` JVM. So, there is no way to get the Spark version from the log.

```
$ git grep 'Running Spark version'
core/src/main/scala/org/apache/spark/SparkContext.scala:  logInfo(log"Running Spark version ${MDC(LogKeys.SPARK_VERSION, SPARK_VERSION)}")
core/src/main/scala/org/apache/spark/deploy/master/Master.scala:    logInfo(log"Running Spark version" +
core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala:    logInfo(log"Running Spark version ${MDC(SPARK_VERSION, org.apache.spark.SPARK_VERSION)}")
```

### Does this PR introduce _any_ user-facing change?

No behavior change. Only a user will get the additional log.

### How was this patch tested?

Manually run the executor.

**BEFORE**
```
26/02/05 18:23:45 INFO Executor: Starting executor ID 0 on host 127.0.0.1
26/02/05 18:23:45 INFO Executor: OS info Mac OS X, 26.3, aarch64
26/02/05 18:23:45 INFO Executor: Java version 21.0.10+7-LTS 
```

**AFTER**
```
26/02/05 18:23:45 INFO Executor: Starting executor ID 0 on host 127.0.0.1
26/02/05 18:23:45 INFO Executor: Running Spark version 4.2.0-SNAPSHOT
26/02/05 18:23:45 INFO Executor: OS info Mac OS X, 26.3, aarch64
26/02/05 18:23:45 INFO Executor: Java version 21.0.10+7-LTS 
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`