### PR TITLE
[SPARK-55383][INFRA] Only send test report to codecov in coverage run

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -669,13 +669,12 @@ jobs:
       env: ${{ fromJSON(inputs.envs) }}
       if: fromJSON(inputs.envs).PYSPARK_CODECOV == 'true'
       uses: codecov/codecov-action@v5
-      env:
-        CODECOV_TOKEN: ${{ secrets.codecov_token }}
       with:
         report_type: 'test_results'
         files: '**/target/test-reports/*.xml'
         flags: ${{ env.PYTHON_TO_TEST }}-${{ inputs.branch }}
         name: PySpark-Test-Results
+        token: ${{ secrets.codecov_token }}
     - name: Upload test results to report
       env: ${{ fromJSON(inputs.envs) }}
       if: always()

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -667,14 +667,15 @@ jobs:
         verbose: true
     - name: Upload test results to Codecov
       env: ${{ fromJSON(inputs.envs) }}
-      if: (!cancelled()) && github.repository == 'apache/spark'
+      if: fromJSON(inputs.envs).PYSPARK_CODECOV == 'true'
       uses: codecov/codecov-action@v5
+      env:
+        CODECOV_TOKEN: ${{ secrets.codecov_token }}
       with:
         report_type: 'test_results'
         files: '**/target/test-reports/*.xml'
         flags: ${{ env.PYTHON_TO_TEST }}-${{ inputs.branch }}
         name: PySpark-Test-Results
-        token: ${{ secrets.codecov_token }}
     - name: Upload test results to report
       env: ${{ fromJSON(inputs.envs) }}
       if: always()

--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -30,5 +30,3 @@ jobs:
       packages: write
     name: Run
     uses: ./.github/workflows/build_and_test.yml
-    secrets:
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/python_hosted_runner_test.yml
+++ b/.github/workflows/python_hosted_runner_test.yml
@@ -166,16 +166,6 @@ jobs:
             echo "Python Packaging Tests Enabled!"
           fi
           ./dev/run-tests --parallelism 1 --modules "$MODULES_TO_TEST" --python-executables "$PYTHON_TO_TEST"
-      - name: Upload test results to Codecov
-        env: ${{ fromJSON(inputs.envs) }}
-        if: (!cancelled()) && github.repository == 'apache/spark'
-        uses: codecov/codecov-action@v5
-        with:
-          report_type: 'test_results'
-          files: '**/target/test-reports/*.xml'
-          flags: ${{ env.PYTHON_TO_TEST }}-${{ inputs.branch }}-${{ inputs.os }}
-          name: PySpark-Test-Results
-          token: ${{ secrets.codecov_token }}
       - name: Upload test results to report
         env: ${{ fromJSON(inputs.envs) }}
         if: always()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Instead of trying to send test report on all main branch commits, we only send it for coverage run.

Also removed an unused coverage token.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We tried the test dashboard of codecov - https://app.codecov.io/github/apache/spark/tests but it's not super great.

* It can't parse the xml file to locate the failed test case. Instead it records a failure for the full test suite.
* It does not have a timeline so we don't really know if the test failed recently.
* The deduplication is bad.
* It messed up our coverage report - because the backend can't split the test and coverage report into their own category.

However it's not completely useless. The average time of tests actually helps us to locate slowest tests. It does not mess up with coverage report, as long as for each commit we have both the coverage report and test report.

So, we can do a report only on coverage run - single report each day for both coverage and test speed.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

CI should pass, hopefully coverage can recover.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.