### PR TITLE
[SPARK-55387][CORE][UI] Fix DAG visualization not rendering due to malformed DOT label

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
+++ b/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
@@ -269,7 +269,7 @@ private[spark] object RDDOperationGraph extends Logging {
     val label = StringEscapeUtils.escapeJava(
       s"${node.name} [${node.id}]$isCached$isBarrier$outputDeterministicLevel" +
         s"<br>$escapedCallsite")
-    s"""${node.id} [id="node_${node.id}" labelType="html" label="$label}"]"""
+    s"""${node.id} [id="node_${node.id}" labelType="html" label="$label"]"""
   }
 
   /** Update the dot representation of the RDDOperationGraph in cluster to subgraph.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes a typo in `RDDOperationGraph.scala` where an extra `}` character was accidentally added to the DOT node label string, causing the DAG visualization to fail rendering in both Jobs and Stages pages of the Spark Web UI.

**Before (broken):**
```scala
s"""${node.id} [id="node_${node.id}" labelType="html" label="$label}"]"""
```

**After (fixed):**
```scala
s"""${node.id} [id="node_${node.id}" labelType="html" label="$label"]"""
```

### Why are the changes needed?

The DAG visualization in the Spark Web UI is completely broken. Instead of rendering the graph, it shows the raw DOT source text. This affects both Jobs and Stages views across all browsers (Firefox, Edge, Chrome) and both Spark Shell and PySpark.

This regression was introduced in SPARK-45274 (PR #43053).

### Does this PR introduce _any_ user-facing change?

Yes. The DAG visualization in the Spark Web UI will render correctly again.

**Before:** Raw DOT graph source displayed instead of visualization
**After:** Properly rendered DAG graph

### How was this patch tested?

- Existing unit tests pass: `RDDOperationGraphSuite`, `UISeleniumSuite` (DAG visualization test)
- Manual verification with `sc.range(0, 10, 1, 4).count()` in spark-shell

### Was this patch authored or co-authored using generative AI tooling?

No.