### PR TITLE
[SPARK-55389][PYTHON] Consolidate `SQL_MAP_ARROW_ITER_UDF` wrapper, mapper, and serializer logic

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -148,7 +148,7 @@ class ArrowStreamGroupSerializer(ArrowStreamSerializer):
 
     Parameters
     ----------
-    num_dataframes : int
+    num_dfs : int
         Number of dataframes per group in the input stream.
 
         * ``0`` — a single IPC stream of raw ``pa.RecordBatch`` (no grouping protocol).
@@ -165,9 +165,9 @@ class ArrowStreamGroupSerializer(ArrowStreamSerializer):
         Default is ``False`` so subclasses that override ``dump_stream`` are not affected.
     """
 
-    def __init__(self, num_dataframes=0, write_start_stream=False):
+    def __init__(self, num_dfs=0, write_start_stream=False):
         super().__init__()
-        self._num_dataframes = num_dataframes
+        self._num_dfs = num_dfs
         self._write_start_stream = write_start_stream
 
     def _load_group_dataframes(self, stream, num_dfs: int = 1):
@@ -244,10 +244,10 @@ class ArrowStreamGroupSerializer(ArrowStreamSerializer):
         yield from itertools.chain([first], batch_iterator)
 
     def load_stream(self, stream):
-        if self._num_dataframes == 0:
+        if self._num_dfs == 0:
             yield from super().load_stream(stream)
         else:
-            yield from self._load_group_dataframes(stream, num_dfs=self._num_dataframes)
+            yield from self._load_group_dataframes(stream, num_dfs=self._num_dfs)
 
     def dump_stream(self, iterator, stream):
         if self._write_start_stream:

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -158,14 +158,16 @@ class ArrowStreamSerializer(Serializer):
             reader = pa.ipc.open_stream(stream)
             for batch in reader:
                 yield batch
+        elif self._num_dfs == 1:
+            # Grouped loading: yield single dataframe groups
+            for (batches,) in self._load_group_dataframes(stream, num_dfs=1):
+                yield batches
         elif self._num_dfs == 2:
             # Cogrouped loading: yield tuples of (left_batches, right_batches)
             for left_batches, right_batches in self._load_group_dataframes(stream, num_dfs=2):
                 yield left_batches, right_batches
         else:
-            # Grouped loading: yield single dataframe groups
-            for (batches,) in self._load_group_dataframes(stream, num_dfs=1):
-                yield batches
+            assert False, f"Unexpected num_dfs: {self._num_dfs}"
 
     def _load_group_dataframes(self, stream, num_dfs: int = 1) -> Iterator:
         """

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -230,15 +230,17 @@ def verify_result(expected_type: type) -> Callable[[Any], Iterator]:
         The expected Python/PyArrow type for each element
         (e.g. pa.RecordBatch, pa.Array).
     """
-    label: str = "{}.{}".format(expected_type.__module__.split(".")[0], expected_type.__name__)
+
+    package = getattr(inspect.getmodule(expected_type), "__package__", "")
+    label: str = f"{package}.{expected_type.__name__}"
 
     def check_element(element: Any) -> Any:
         if not isinstance(element, expected_type):
             raise PySparkTypeError(
                 errorClass="UDF_RETURN_TYPE",
                 messageParameters={
-                    "expected": "iterator of {}".format(label),
-                    "actual": "iterator of {}".format(type(element).__name__),
+                    "expected": f"iterator of {label}",
+                    "actual": f"iterator of {type(element).__name__}",
                 },
             )
         return element
@@ -248,7 +250,7 @@ def verify_result(expected_type: type) -> Callable[[Any], Iterator]:
             raise PySparkTypeError(
                 errorClass="UDF_RETURN_TYPE",
                 messageParameters={
-                    "expected": "iterator of {}".format(label),
+                    "expected": f"iterator of {label}",
                     "actual": type(result).__name__,
                 },
             )

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2828,7 +2828,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
         import pyarrow as pa
 
         assert num_udfs == 1, "One MAP_ARROW_ITER UDF expected here."
-        udf_func = udfs[0]
+        udf_func: Callable[[Iterator[pa.RecordBatch]], Iterator[pa.RecordBatch]] = udfs[0]
 
         def func(
             split_index: int, batches: Iterator["pa.RecordBatch"]

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -60,7 +60,7 @@ from pyspark.sql.pandas.serializers import (
     GroupPandasUDFSerializer,
     CogroupArrowUDFSerializer,
     CogroupPandasUDFSerializer,
-    ArrowStreamUDFSerializer,
+    ArrowStreamGroupSerializer,
     ApplyInPandasWithStateSerializer,
     TransformWithStateInPandasSerializer,
     TransformWithStateInPandasInitStateSerializer,
@@ -215,6 +215,59 @@ def report_times(outfile, boot, init, finish, processing_time_ms):
 def chain(f, g):
     """chain two functions together"""
     return lambda *a: g(f(*a))
+
+
+def verify_iterator_result(expected_type, expected_type_label: str):
+    """
+    Create a ``Iterator → Iterator`` mapper that verifies iterability and element types.
+
+    Returns a function that, given a UDF result, checks that it is iterable and
+    lazily type-checks each element on consumption via :func:`map`.
+
+    Parameters
+    ----------
+    expected_type : type
+        The expected Python/PyArrow type for each element
+        (e.g. ``pa.RecordBatch``, ``pa.Array``).
+    expected_type_label : str
+        Human-readable label for the expected type
+        (e.g. ``"pyarrow.RecordBatch"``, ``"pyarrow.Array"``).
+
+    Returns
+    -------
+    Callable[[Any], Iterator]
+        A function that takes a UDF result and returns a lazy iterator
+        yielding each element after verifying its type.
+
+    Raises
+    ------
+    PySparkTypeError
+        If the result is not iterable, or any element does not match ``expected_type``.
+    """
+
+    def _check_element(element):
+        if not isinstance(element, expected_type):
+            raise PySparkTypeError(
+                errorClass="UDF_RETURN_TYPE",
+                messageParameters={
+                    "expected": "iterator of {}".format(expected_type_label),
+                    "actual": "iterator of {}".format(type(element).__name__),
+                },
+            )
+        return element
+
+    def _check_iterable(result):
+        if not isinstance(result, Iterator) and not hasattr(result, "__iter__"):
+            raise PySparkTypeError(
+                errorClass="UDF_RETURN_TYPE",
+                messageParameters={
+                    "expected": "iterator of {}".format(expected_type_label),
+                    "actual": type(result).__name__,
+                },
+            )
+        return map(_check_element, result)
+
+    return _check_iterable
 
 
 def wrap_udf(f, args_offsets, kwargs_offsets, return_type):
@@ -561,41 +614,6 @@ def wrap_arrow_array_iter_udf(f, return_type, runner_conf):
                 errorClass="UDF_RETURN_TYPE",
                 messageParameters={
                     "expected": "iterator of pyarrow.Array",
-                    "actual": "iterator of {}".format(type(elem).__name__),
-                },
-            )
-
-        return elem
-
-    return lambda *iterator: map(
-        lambda res: (res, arrow_return_type), map(verify_element, verify_result(f(*iterator)))
-    )
-
-
-def wrap_arrow_batch_iter_udf(f, return_type, runner_conf):
-    arrow_return_type = to_arrow_type(
-        return_type, timezone="UTC", prefers_large_types=runner_conf.use_large_var_types
-    )
-
-    def verify_result(result):
-        if not isinstance(result, Iterator) and not hasattr(result, "__iter__"):
-            raise PySparkTypeError(
-                errorClass="UDF_RETURN_TYPE",
-                messageParameters={
-                    "expected": "iterator of pyarrow.RecordBatch",
-                    "actual": type(result).__name__,
-                },
-            )
-        return result
-
-    def verify_element(elem):
-        import pyarrow as pa
-
-        if not isinstance(elem, pa.RecordBatch):
-            raise PySparkTypeError(
-                errorClass="UDF_RETURN_TYPE",
-                messageParameters={
-                    "expected": "iterator of pyarrow.RecordBatch",
                     "actual": "iterator of {}".format(type(elem).__name__),
                 },
             )
@@ -1406,7 +1424,7 @@ def read_single_udf(pickleSer, infile, eval_type, runner_conf, udf_index):
     elif eval_type == PythonEvalType.SQL_MAP_PANDAS_ITER_UDF:
         return args_offsets, wrap_pandas_batch_iter_udf(func, return_type, runner_conf)
     elif eval_type == PythonEvalType.SQL_MAP_ARROW_ITER_UDF:
-        return args_offsets, wrap_arrow_batch_iter_udf(func, return_type, runner_conf)
+        return func
     elif eval_type == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF:
         argspec = inspect.getfullargspec(chained_func)  # signature was lost when wrapping it
         return args_offsets, wrap_grouped_map_pandas_udf(func, return_type, argspec, runner_conf)
@@ -2749,7 +2767,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
                 runner_conf.arrow_max_records_per_batch
             )
         elif eval_type == PythonEvalType.SQL_MAP_ARROW_ITER_UDF:
-            ser = ArrowStreamUDFSerializer()
+            ser = ArrowStreamGroupSerializer(num_dataframes=0, write_start_stream=True)
         elif eval_type in (
             PythonEvalType.SQL_SCALAR_ARROW_UDF,
             PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF,
@@ -2819,21 +2837,55 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
         for i in range(num_udfs)
     ]
 
+    if eval_type == PythonEvalType.SQL_MAP_ARROW_ITER_UDF:
+        import pyarrow as pa
+
+        assert num_udfs == 1, "One MAP_ARROW_ITER UDF expected here."
+        udf_func = udfs[0]
+
+        def func(
+            split_index: int, batches: Iterator["pa.RecordBatch"]
+        ) -> Iterator["pa.RecordBatch"]:
+            """
+            Apply mapInArrow UDF.
+
+            Parameters
+            ----------
+            split_index : int
+                Spark partition index (unused).
+            batches : Iterator[pa.RecordBatch]
+                Raw batches from the JVM, each containing a single struct column.
+
+            Yields
+            ------
+            pa.RecordBatch
+                Output batches with columns wrapped back into a struct column.
+            """
+            # flatten → UDF → verify → wrap
+            input_batches: Iterator[pa.RecordBatch] = map(
+                ArrowBatchTransformer.flatten_struct, batches
+            )
+            output_batches: Iterator[pa.RecordBatch] = udf_func(input_batches)
+            verified: Iterator[pa.RecordBatch] = verify_iterator_result(
+                pa.RecordBatch, "pyarrow.RecordBatch"
+            )(output_batches)
+            yield from map(ArrowBatchTransformer.wrap_struct, verified)
+
+        # profiling is not supported for UDF
+        return func, None, ser, ser
+
     is_scalar_iter = eval_type in (
         PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF,
         PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF,
     )
     is_map_pandas_iter = eval_type == PythonEvalType.SQL_MAP_PANDAS_ITER_UDF
-    is_map_arrow_iter = eval_type == PythonEvalType.SQL_MAP_ARROW_ITER_UDF
 
-    if is_scalar_iter or is_map_pandas_iter or is_map_arrow_iter:
+    if is_scalar_iter or is_map_pandas_iter:
         # TODO: Better error message for num_udfs != 1
         if is_scalar_iter:
             assert num_udfs == 1, "One SCALAR_ITER UDF expected here."
         if is_map_pandas_iter:
             assert num_udfs == 1, "One MAP_PANDAS_ITER UDF expected here."
-        if is_map_arrow_iter:
-            assert num_udfs == 1, "One MAP_ARROW_ITER UDF expected here."
 
         arg_offsets, udf = udfs[0]
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2832,9 +2832,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
         assert num_udfs == 1, "One MAP_ARROW_ITER UDF expected here."
         udf_func: Callable[[Iterator[pa.RecordBatch]], Iterator[pa.RecordBatch]] = udfs[0]
 
-        def func(
-            split_index: int, batches: Iterator["pa.RecordBatch"]
-        ) -> Iterator["pa.RecordBatch"]:
+        def func(split_index: int, batches: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
             """Apply mapInArrow UDF"""
 
             # Pre-processing

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -54,13 +54,13 @@ from pyspark.sql.conversion import (
 )
 from pyspark.sql.functions import SkipRestOfInputTableException
 from pyspark.sql.pandas.serializers import (
+    ArrowStreamSerializer,
     ArrowStreamPandasUDFSerializer,
     ArrowStreamPandasUDTFSerializer,
     ArrowStreamGroupUDFSerializer,
     GroupPandasUDFSerializer,
     CogroupArrowUDFSerializer,
     CogroupPandasUDFSerializer,
-    ArrowStreamGroupSerializer,
     ApplyInPandasWithStateSerializer,
     TransformWithStateInPandasSerializer,
     TransformWithStateInPandasInitStateSerializer,
@@ -2754,7 +2754,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
                 runner_conf.arrow_max_records_per_batch
             )
         elif eval_type == PythonEvalType.SQL_MAP_ARROW_ITER_UDF:
-            ser = ArrowStreamGroupSerializer(num_dfs=0, write_start_stream=True)
+            ser = ArrowStreamSerializer(write_start_stream=True)
         elif eval_type in (
             PythonEvalType.SQL_SCALAR_ARROW_UDF,
             PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Consolidate the `SQL_MAP_ARROW_ITER_UDF` (`mapInArrow`) execution path so that all input transformation, UDF invocation, result verification, and output transformation live in a single block.

- Remove `wrap_arrow_batch_iter_udf`; inline its logic into the mapper as an explicit `flatten → UDF → verify → wrap` pipeline with type annotations.
- Let`ArrowStreamSerializer` accept arguments to support grouped-loading and optionally send `START_ARROW_STREAM`. This is intended as the single serializer base that all UDF eval types will gradually migrate to, replacing the current per-eval-type serializer subclasses.
- Extract a reusable `verify_iterator_result` helper for iterable/element-type checking.

### Why are the changes needed?

Part of [SPARK-55388](https://issues.apache.org/jira/browse/SPARK-55388). The existing logic for this eval type is scattered across a wrapper function, a shared mapper branch, and the serializer. After this change the full data flow is visible in one place.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing `mapInArrow` tests (`test_pandas_map.py`, `test_arrow_map.py`).

### Was this patch authored or co-authored using generative AI tooling?

No.