### PR TITLE
[SPARK-55301][SS] Re-enable all dimension in OfflineStateRepartitionIntegrationSuites

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionIntegrationSuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.execution.streaming.runtime.{MemoryStream, Streaming
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{OutputMode, Trigger}
 import org.apache.spark.sql.streaming.util.StreamManualClock
+import org.apache.spark.tags.SlowSQLTest
 
 /**
  * Integration test suite helper class for OfflineStateRepartitionRunner with stateful operators.
@@ -193,10 +194,7 @@ abstract class OfflineStateRepartitionIntegrationSuiteBase extends StateDataSour
   }
 
   def testWithChangelogConfig(testName: String)(testFun: => Unit): Unit = {
-    // TODO[SPARK-55301]: add test with changelog checkpointing disabled after SPARK increases
-    // its test timeout because CI signal "sql - other tests" is timing out after adding the
-    // integration tests
-    Seq(true).foreach { changelogCheckpointingEnabled =>
+    Seq(true, false).foreach { changelogCheckpointingEnabled =>
       test(s"$testName - enableChangelogCheckpointing=$changelogCheckpointingEnabled") {
         withSQLConf(
           "spark.sql.streaming.stateStore.rocksdb.changelogCheckpointing.enabled" ->
@@ -227,6 +225,7 @@ abstract class OfflineStateRepartitionIntegrationSuiteBase extends StateDataSour
 /**
  * Integration test suite for OfflineStateRepartitionRunner with single-column family operators.
  */
+@SlowSQLTest
 class OfflineStateRepartitionCkptV1IntegrationSuite
   extends OfflineStateRepartitionIntegrationSuiteBase {
 
@@ -530,6 +529,7 @@ class OfflineStateRepartitionCkptV1IntegrationSuite
   }
 }
 
+@SlowSQLTest
 class OfflineStateRepartitionCkptV2IntegrationSuite
   extends OfflineStateRepartitionCkptV1IntegrationSuite {
   override def beforeAll(): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionJoinIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionJoinIntegrationSuite.scala
@@ -18,10 +18,12 @@ package org.apache.spark.sql.execution.streaming.state
 
 import org.apache.spark.sql.execution.datasources.v2.state.{StateSourceOptions, StreamStreamJoinTestUtils}
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.tags.SlowSQLTest
 
 /**
  * Integration test suite for stream-stream join operator repartitioning.
  */
+@SlowSQLTest
 class OfflineStateRepartitionJoinCkptV1IntegrationSuite
   extends OfflineStateRepartitionIntegrationSuiteBase {
 
@@ -77,6 +79,7 @@ class OfflineStateRepartitionJoinCkptV1IntegrationSuite
   }
 }
 
+@SlowSQLTest
 class OfflineStateRepartitionJoinCkptV2IntegrationSuite
   extends OfflineStateRepartitionJoinCkptV1IntegrationSuite {
   override def beforeAll(): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionTransformWithStateIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionTransformWithStateIntegrationSuite.scala
@@ -26,7 +26,6 @@ import org.apache.spark.sql.functions.{col, timestamp_seconds}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{InputEvent, ListStateTTLProcessor, MapInputEvent, MapOutputEvent, MapStateTTLProcessor, MaxEventTimeStatefulProcessor, OutputEvent, OutputMode, RunningCountStatefulProcessorWithProcTimeTimer, TimeMode, Trigger, TTLConfig, ValueStateTTLProcessor}
 import org.apache.spark.sql.streaming.util.{MultiStateVarProcessor, MultiStateVarProcessorTestUtils, TimerTestUtils, TTLProcessorUtils}
-import org.apache.spark.tags.SlowSQLTest
 
 /**
  * Integration test suite for transformWithState operator repartitioning.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionTransformWithStateIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionTransformWithStateIntegrationSuite.scala
@@ -31,7 +31,6 @@ import org.apache.spark.tags.SlowSQLTest
 /**
  * Integration test suite for transformWithState operator repartitioning.
  */
-@SlowSQLTest
 class OfflineStateRepartitionTransformWithStateCkptV1IntegrationSuite
   extends OfflineStateRepartitionIntegrationSuiteBase {
 
@@ -484,7 +483,6 @@ class OfflineStateRepartitionTransformWithStateCkptV1IntegrationSuite
   }
 }
 
-@SlowSQLTest
 class OfflineStateRepartitionTransformWithStateCkptV2IntegrationSuite
   extends OfflineStateRepartitionTransformWithStateCkptV1IntegrationSuite {
   override def beforeAll(): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionTransformWithStateIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OfflineStateRepartitionTransformWithStateIntegrationSuite.scala
@@ -26,10 +26,12 @@ import org.apache.spark.sql.functions.{col, timestamp_seconds}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{InputEvent, ListStateTTLProcessor, MapInputEvent, MapOutputEvent, MapStateTTLProcessor, MaxEventTimeStatefulProcessor, OutputEvent, OutputMode, RunningCountStatefulProcessorWithProcTimeTimer, TimeMode, Trigger, TTLConfig, ValueStateTTLProcessor}
 import org.apache.spark.sql.streaming.util.{MultiStateVarProcessor, MultiStateVarProcessorTestUtils, TimerTestUtils, TTLProcessorUtils}
+import org.apache.spark.tags.SlowSQLTest
 
 /**
  * Integration test suite for transformWithState operator repartitioning.
  */
+@SlowSQLTest
 class OfflineStateRepartitionTransformWithStateCkptV1IntegrationSuite
   extends OfflineStateRepartitionIntegrationSuiteBase {
 
@@ -82,9 +84,7 @@ class OfflineStateRepartitionTransformWithStateCkptV1IntegrationSuite
 
   def testWithDifferentEncodingType(testNamePrefix: String)
       (testFun: Int => Unit): Unit = {
-    // TODO[SPARK-55301]: add test with "avro" encoding format after SPARK increases test timeout
-    // because CI signal "sql - other tests" is timing out after adding the integration tests
-    Seq("unsaferow").foreach { encodingFormat =>
+    Seq("unsaferow", "avro").foreach { encodingFormat =>
       testWithAllRepartitionOperations(
         s"$testNamePrefix (encoding = $encodingFormat)") { newPartitions =>
         withSQLConf(SQLConf.STREAMING_STATE_STORE_ENCODING_FORMAT.key -> encodingFormat) {
@@ -484,6 +484,7 @@ class OfflineStateRepartitionTransformWithStateCkptV1IntegrationSuite
   }
 }
 
+@SlowSQLTest
 class OfflineStateRepartitionTransformWithStateCkptV2IntegrationSuite
   extends OfflineStateRepartitionTransformWithStateCkptV1IntegrationSuite {
   override def beforeAll(): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR re-enable all dimensions in OfflineStateRepartitionIntegrationSuites (encoding type and enableChangelogCheckpoint), and adds the @SlowSQLTest tag to all offline state repartition integration test suites, moving them from the sql-other CI job to the sql slow-tests CI job.
Test suites tagged with **@SlowSQLTest:**
- OfflineStateRepartitionCkptV1IntegrationSuite
- OfflineStateRepartitionCkptV2IntegrationSuite
- OfflineStateRepartitionJoinCkptV1IntegrationSuite
- OfflineStateRepartitionJoinCkptV2IntegrationSuite
- OfflineStateRepartitionTransformWithStateCkptV1IntegrationSuite
- OfflineStateRepartitionTransformWithStateCkptV2IntegrationSuite

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The offline state repartition integration tests are long-running tests that were causing the sql-other CI job to take significantly longer than other SQL CI jobs. By moving these tests to the sql slow-tests job, we can:
Re-enable all previous test dimensions that were disabled due to CI time constraints
Better balance CI job runtimes across different SQL test jobs

CI Job | Runtime
-- | --
ExtendedSQLTest | 1 hr 21 min
SlowSQLTest | 1 hr 29 min
sql-other | 1 hr 40 min (excluding enabled current integration suites)


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
NO

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
existing tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
yes