### PR TITLE
[SPARK-55403][PS] Fix `no attribute 'draw'` error in the plot tests with pandas 3

### DIFF
--- a/python/pyspark/pandas/plot/matplotlib.py
+++ b/python/pyspark/pandas/plot/matplotlib.py
@@ -23,6 +23,7 @@ import matplotlib as mat
 import numpy as np
 from matplotlib.axes._base import _process_plot_format  # type: ignore[attr-defined]
 from matplotlib.figure import Figure
+import pandas as pd
 from pandas.core.dtypes.inference import is_list_like
 from pandas.io.formats.printing import pprint_thing  # type: ignore[import-untyped]
 from pandas.plotting._matplotlib import (  # type: ignore[import-untyped]
@@ -968,5 +969,10 @@ def _plot(data, x=None, y=None, subplots=False, ax=None, kind="line", **kwds):
 
         plot_obj = klass(data, subplots=subplots, ax=ax, kind=kind, **kwds)
     plot_obj.generate()
-    plot_obj.draw()
+    if LooseVersion(pd.__version__) < "3.0.0":
+        plot_obj.draw()
+    else:
+        import matplotlib.pyplot as plt
+
+        plt.draw_if_interactive()
     return plot_obj.result


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes `no attribute 'draw'` error in the plot tests with pandas 3.

### Why are the changes needed?

The plot tests fail with the following error working with pandas 3:

```
Traceback (most recent call last):
...
  File "/.../python/pyspark/pandas/plot/matplotlib.py", line 971, in _plot
    plot_obj.draw()
    ^^^^^^^^^^^^^
AttributeError: 'PandasOnSparkAreaPlot' object has no attribute 'draw'
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing tests should pass.

### Was this patch authored or co-authored using generative AI tooling?

No.
