### PR TITLE
[SPARK-55406][PYTHON][CONNECT] Reimplement the thread pool for ExecutePlanResponseReattachableIterator

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -753,7 +753,7 @@ class SparkConnectClient(object):
         self._plan_compression_threshold: Optional[int] = None  # Will be fetched lazily
         self._plan_compression_algorithm: Optional[str] = None  # Will be fetched lazily
 
-        self._release_futures = weakref.WeakSet()
+        self._release_futures: weakref.WeakSet[concurrent.futures.Future] = weakref.WeakSet()
 
         # cleanup ml cache if possible
         atexit.register(self._cleanup_ml_cache)
@@ -1277,6 +1277,7 @@ class SparkConnectClient(object):
         Close the channel.
         """
         concurrent.futures.wait(self._release_futures)
+        ExecutePlanResponseReattachableIterator.shutdown_threadpool_if_idle()
         self._channel.close()
         self._closed = True
 

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -23,7 +23,7 @@ from threading import RLock
 import uuid
 from collections.abc import Generator
 from typing import Optional, Any, Iterator, Iterable, Tuple, Callable, cast, ClassVar
-from concurrent.futures import Future,ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 import os
 import weakref
 
@@ -59,10 +59,12 @@ class ExecutePlanResponseReattachableIterator(Generator):
 
     _lock: ClassVar[RLock] = RLock()
     _release_thread_pool_instance: Optional[ThreadPoolExecutor] = None
-    _instances: ClassVar[weakref.WeakSet["ExecutePlanResponseReattachableIterator"]] = weakref.WeakSet()
+    _instances: ClassVar[
+        weakref.WeakSet["ExecutePlanResponseReattachableIterator"]
+    ] = weakref.WeakSet()
 
     def __new__(cls, *args, **kwargs) -> "ExecutePlanResponseReattachableIterator":
-        instance =  super().__new__(cls)
+        instance = super().__new__(cls)
         cls._instances.add(instance)
         return instance
 
@@ -123,7 +125,9 @@ class ExecutePlanResponseReattachableIterator(Generator):
             return self._release_thread_pool_instance
         with self._lock:
             if self._release_thread_pool_instance is None:
-                self._release_thread_pool_instance = ThreadPoolExecutor(max_workers=os.cpu_count() or 8)
+                self._release_thread_pool_instance = ThreadPoolExecutor(
+                    max_workers=os.cpu_count() or 8
+                )
             return self._release_thread_pool_instance
 
     @classmethod

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -130,7 +130,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
     def shutdown_threadpool_if_idle(cls) -> None:
         with cls._lock:
             if not cls._instances and cls._release_thread_pool_instance is not None:
-                cls._release_thread_pool_instance.shutdown()
+                cls._release_thread_pool_instance.shutdown(wait=False)
                 cls._release_thread_pool_instance = None
 
     def send(self, value: Any) -> pb2.ExecutePlanResponse:

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -121,8 +121,6 @@ class ExecutePlanResponseReattachableIterator(Generator):
 
     @property
     def _release_thread_pool(self) -> ThreadPoolExecutor:
-        if self._release_thread_pool_instance is not None:
-            return self._release_thread_pool_instance
         with self._lock:
             if self._release_thread_pool_instance is None:
                 self._release_thread_pool_instance = ThreadPoolExecutor(

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -22,9 +22,10 @@ check_dependencies(__name__)
 from threading import RLock
 import uuid
 from collections.abc import Generator
-from typing import Optional, Any, Iterator, Iterable, Tuple, Callable, cast, Type, ClassVar
-from concurrent.futures import ThreadPoolExecutor
+from typing import Optional, Any, Iterator, Iterable, Tuple, Callable, cast, ClassVar
+from concurrent.futures import Future,ThreadPoolExecutor
 import os
+import weakref
 
 import grpc
 from grpc_status import rpc_status
@@ -56,34 +57,8 @@ class ExecutePlanResponseReattachableIterator(Generator):
     ReleaseExecute RPCs that instruct the server to release responses that it already processed.
     """
 
-    # Lock to manage the pool
     _lock: ClassVar[RLock] = RLock()
     _release_thread_pool_instance: Optional[ThreadPoolExecutor] = None
-
-    @classmethod
-    def _get_or_create_release_thread_pool(cls) -> ThreadPoolExecutor:
-        # Perform a first check outside the critical path.
-        if cls._release_thread_pool_instance is not None:
-            return cls._release_thread_pool_instance
-        with cls._lock:
-            if cls._release_thread_pool_instance is None:
-                max_workers = os.cpu_count() or 8
-                cls._release_thread_pool_instance = ThreadPoolExecutor(max_workers=max_workers)
-            return cls._release_thread_pool_instance
-
-    @classmethod
-    def shutdown(cls: Type["ExecutePlanResponseReattachableIterator"]) -> None:
-        """
-        When the channel is closed, this method will be called before, to make sure all
-        outstanding calls are closed.
-        """
-        with cls._lock:
-            if cls._release_thread_pool_instance is not None:
-                thread_pool = cls._release_thread_pool_instance
-                cls._release_thread_pool_instance = None
-                # This method could be called within the thread pool so don't wait for the
-                # shutdown to complete. Otherwise it could deadlock.
-                thread_pool.shutdown(wait=False)
 
     def __init__(
         self,
@@ -92,9 +67,9 @@ class ExecutePlanResponseReattachableIterator(Generator):
         retrying: Callable[[], Retrying],
         metadata: Iterable[Tuple[str, str]],
     ):
-        self._release_thread_pool  # Trigger initialization
         self._request = request
         self._retrying = retrying
+        self._release_futures = weakref.WeakSet()
         if request.operation_id:
             self._operation_id = request.operation_id
         else:
@@ -133,8 +108,17 @@ class ExecutePlanResponseReattachableIterator(Generator):
         self._current: Optional[pb2.ExecutePlanResponse] = None
 
     @property
+    def release_futures(self) -> weakref.WeakSet[Future]:
+        return self._release_futures
+
+    @property
     def _release_thread_pool(self) -> ThreadPoolExecutor:
-        return self._get_or_create_release_thread_pool()
+        if self._release_thread_pool_instance is not None:
+            return self._release_thread_pool_instance
+        with self._lock:
+            if self._release_thread_pool_instance is None:
+                self._release_thread_pool_instance = ThreadPoolExecutor(max_workers=os.cpu_count() or 8)
+            return self._release_thread_pool_instance
 
     def send(self, value: Any) -> pb2.ExecutePlanResponse:
         # will trigger reattach in case the stream completed without result_complete
@@ -214,11 +198,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
             except Exception as e:
                 logger.warn(f"ReleaseExecute failed with exception: {e}.")
 
-        with self._lock:
-            if self._release_thread_pool_instance is not None:
-                thread_pool = self._release_thread_pool
-                if not thread_pool._shutdown:
-                    thread_pool.submit(target)
+        self._release_futures.add(self._release_thread_pool.submit(target))
 
     def _release_all(self) -> None:
         """
@@ -241,11 +221,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
             except Exception as e:
                 logger.warn(f"ReleaseExecute failed with exception: {e}.")
 
-        with self._lock:
-            if self._release_thread_pool_instance is not None:
-                thread_pool = self._release_thread_pool
-                if not thread_pool._shutdown:
-                    thread_pool.submit(target)
+        self._release_futures.add(self._release_thread_pool.submit(target))
         self._result_complete = True
 
     def _call_iter(self, iter_fun: Callable) -> Any:

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -121,6 +121,11 @@ class ExecutePlanResponseReattachableIterator(Generator):
 
     @property
     def _release_thread_pool(self) -> ThreadPoolExecutor:
+        if self._release_thread_pool_instance is not None:
+            # It's impossible for the thread pool to shutdown when the iterator is still alive
+            # We can safely return the thread pool instance here as long as it is not used
+            # by external objects.
+            return self._release_thread_pool_instance
         with self._lock:
             if self._release_thread_pool_instance is None:
                 self._release_thread_pool_instance = ThreadPoolExecutor(

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -63,7 +63,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
         weakref.WeakSet["ExecutePlanResponseReattachableIterator"]
     ] = weakref.WeakSet()
 
-    def __new__(cls, *args, **kwargs) -> "ExecutePlanResponseReattachableIterator":
+    def __new__(cls, *args: Any, **kwargs: Any) -> "ExecutePlanResponseReattachableIterator":
         instance = super().__new__(cls)
         cls._instances.add(instance)
         return instance


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Reimplemented the thread pool mechanism for ExecutePlanResponseReattachableIterator.
* Number of `ExecutePlanResponseReattachableIterator` instances is counted with `WeakSet` so we know when to release the thread pool
* Instead of relying on thread pool to finish, we collect the futures for each release task and wait for them in the client

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The current implementation is fundamentally wrong. It tries to shutdown a thread pool for a class from client instances. We could have multiple client instances in a process and flipping the state of a global class would just cause racing issues.

For example, the old code can return a thread pool in a thread which could be shutdown before it is used.

The original reason that we "shutdown" the thread pool is because we need the client to wait for the release requests to finish. That can't justify waiting for the whole thread pool (or shut it down) because it can be shared with other clients. We actually have a deadlock caused by it.

Now we collect futures explicitly for each `ExecutePlanResponseReattachableIterator` call and when we need to close the client, just wait for those future to be done.

Notice that we will not keep these futures longer than they should be. We used `WeakSet` which means if the future has no reference, it will still be garbage collected properly. We won't use more memory because we keep track of these. In normal cases the set will probably be empty because all the release tasks are done.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Simple local test passed. Waiting for CI.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.