### PR TITLE
[SPARK-55423][INFRA] Set `strategy.max-parrallel` to 20 for all GitHub Action jobs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -136,6 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         split: ${{fromJSON(needs.matrix-gen.outputs.matrix)}}
     env:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -242,6 +242,7 @@ jobs:
     timeout-minutes: 150
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         java:
           - ${{ inputs.java }}
@@ -526,6 +527,7 @@ jobs:
         --security-opt seccomp=unconfined
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         java:
           - ${{ inputs.java }}

--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -60,6 +60,7 @@ jobs:
     # timeout-minutes: 150
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         java:
           - ${{ inputs.java }}

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -36,6 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         # keep in sync with default value of workflow_dispatch input 'branch'
         branch: ${{ fromJSON( inputs.branch || '["master", "branch-4.1", "branch-4.0", "branch-3.5"]' ) }}

--- a/.github/workflows/python_hosted_runner_test.yml
+++ b/.github/workflows/python_hosted_runner_test.yml
@@ -63,6 +63,7 @@ jobs:
     # timeout-minutes: 150
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         java:
           - ${{ inputs.java }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to set `strategy.max-parrallel` to 20 for all GitHub Action jobs.

### Why are the changes needed?

ASF Infra team directly requested us via email in (private@spark) mailing list.

- https://lists.apache.org/thread/voqz9tp3m8wj00lp0y81n25qgvc90f3q

Here is `GitHub Action` syntax.
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategymax-parallel

<img width="762" height="112" alt="Screenshot 2026-02-07 at 21 09 02" src="https://github.com/user-attachments/assets/770d1b81-390b-49d1-8518-70cb20eb93af" />

### Does this PR introduce _any_ user-facing change?

No Apache Spark behavior change.
- Technically, for the PR builder, we use more 20 jobs on the PR contributor's GitHub repo. This job will be limited.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Opus 4.5` on `Claude Code`