### PR TITLE
[SPARK-55175][PYTHON][FOLLOW-UP] Remove unused `arrow_to_pandas` method

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -38,7 +38,6 @@ from pyspark.sql.conversion import (
     ArrowBatchTransformer,
 )
 from pyspark.sql.pandas.types import (
-    from_arrow_type,
     is_variant,
     to_arrow_type,
     _create_converter_from_pandas,

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -36,7 +36,6 @@ from pyspark.sql.conversion import (
     LocalDataToArrowConversion,
     ArrowTableToRowsConversion,
     ArrowBatchTransformer,
-    ArrowArrayToPandasConversion,
 )
 from pyspark.sql.pandas.types import (
     from_arrow_type,
@@ -440,17 +439,6 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
             assert isinstance(input_type, StructType)
         self._input_type = input_type
         self._arrow_cast = arrow_cast
-
-    def arrow_to_pandas(
-        self, arrow_column, idx, struct_in_pandas="dict", ndarray_as_list=False, spark_type=None
-    ):
-        return ArrowArrayToPandasConversion.convert_legacy(
-            arrow_column,
-            spark_type or from_arrow_type(arrow_column.type),
-            timezone=self._timezone,
-            struct_in_pandas=struct_in_pandas,
-            ndarray_as_list=ndarray_as_list,
-        )
 
     def _create_array(self, series, spark_type, *, arrow_cast=False, prefers_large_types=False):
         """


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Remove unused `arrow_to_pandas` method


### Why are the changes needed?
code clean up


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no