### PR TITLE
[SPARK-55424][PYTHON] Explicitly pass the series name in `convert_numpy`

### DIFF
--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -1383,11 +1383,12 @@ class ArrowArrayToPandasConversion:
             assert types.is_struct(arr.type)
             assert len(spark_type.names) == len(arr.type.names), f"{spark_type} {arr.type} "
 
-            pdf: pd.DataFrame = pd.concat(
+            return pd.concat(
                 [
                     cls.convert_numpy(
                         field_arr,
                         spark_type=field.dataType,
+                        ser_name=field.name,
                         timezone=timezone,
                         struct_in_pandas=struct_in_pandas,
                         ndarray_as_list=ndarray_as_list,
@@ -1397,8 +1398,6 @@ class ArrowArrayToPandasConversion:
                 ],
                 axis=1,
             )
-            pdf.columns = spark_type.names  # type: ignore[assignment]
-            return pdf
 
         if ser_name is None:
             # Arrow array from batch.column(idx) contains name,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Explicitly pass the series name in `convert_numpy`


### Why are the changes needed?
Arrow array from `batch.column(idx)` contains name, and this name will be used to rename the pandas series returned by `array.to_pandas()`.

In `convert_legacy`, the first step is `array.to_pandas()`, so the name was kept.
 
In `convert_numpy`, complex conversion happened before `to_pandas()`, and this name will be dropped after pa.compute functions. We'd explicitly pass the series name instead of relying on arrow internal stuff `array._name`


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
