### PR TITLE
[SPARK-55224][PYTHON][FOLLOWUP] Remove redundant `use_legacy_pandas_udf_conversion` condition in serializer setup

### DIFF
--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2776,19 +2776,10 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
                 or eval_type == PythonEvalType.SQL_MAP_PANDAS_ITER_UDF
             )
             # Arrow-optimized Python UDF takes a struct type argument as a Row
-            # When legacy pandas conversion is enabled, use "row" and convert ndarray to list
             struct_in_pandas = (
-                "row"
-                if (
-                    eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF
-                    or runner_conf.use_legacy_pandas_udf_conversion
-                )
-                else "dict"
+                "row" if eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF else "dict"
             )
-            ndarray_as_list = (
-                eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF
-                or runner_conf.use_legacy_pandas_udf_conversion
-            )
+            ndarray_as_list = eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF
             # Arrow-optimized Python UDF takes input types
             input_type = (
                 _parse_datatype_json_string(utf8_deserializer.loads(infile))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the redundant `or runner_conf.use_legacy_pandas_udf_conversion` condition from `struct_in_pandas` and `ndarray_as_list` in `read_udfs`.

### Why are the changes needed?

When `use_legacy_pandas_udf_conversion=True`, `SQL_ARROW_BATCHED_UDF` falls through to the `else` branch where `eval_type == SQL_ARROW_BATCHED_UDF` is already `True` — the `or` is redundant. It also incorrectly affects other eval types (e.g., `SQL_SCALAR_PANDAS_UDF` would get `struct_in_pandas="row"` instead of `"dict"`).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UDF tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
