### PR TITLE
[SPARK-55434][INFRA] Add username and password at svn with rm at finalize step

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -565,7 +565,7 @@ EOF
   
   if [[ -n "$OLD_VERSION" ]]; then
     echo "Removing old version: spark-$OLD_VERSION"
-    svn rm "https://dist.apache.org/repos/dist/release/spark/spark-$OLD_VERSION" -m "Remove older $RELEASE_SERIES release after $RELEASE_VERSION"
+    svn rm "https://dist.apache.org/repos/dist/release/spark/spark-$OLD_VERSION" --username "$ASF_USERNAME" --password "$ASF_PASSWORD" --non-interactive -m "Remove older $RELEASE_SERIES release after $RELEASE_VERSION"
   else
     echo "No previous $RELEASE_SERIES version found to remove. Manually remove it if there is."
   fi


### PR DESCRIPTION
### What changes were proposed in this pull request?

```
+ OLD_VERSION=4.2.0-preview1
+ [[ -n 4.2.0-preview1 ]]
+ echo 'Removing old version: spark-4.2.0-preview1'
Removing old version: spark-4.2.0-preview1
+ svn rm https://dist.apache.org/repos/dist/release/spark/spark-4.2.0-preview1 -m 'Remove older 4.2 release after 4.2.0-preview2'
svn: E215004: Authentication failed and interactive prompting is disabled; see the --force-interactive option
svn: E215004: No more credentials or we tried too many times.
Authentication failed
```

We need to set password and username.


### Why are the changes needed?

Add username and password at svn with rm at finalize step

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested.


### Was this patch authored or co-authored using generative AI tooling?

No.