### PR TITLE
[MINOR][INFRA] Use `lsb_release -a` to display the container os version

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -934,7 +934,6 @@ jobs:
     - name: List Python packages
       shell: 'script -q -e -c "bash {0}"'
       run: |
-        uname -a
         lsb_release -a
         if [[ "$BRANCH" == 'branch-3.5' || "$BRANCH" == 'branch-4.0' ]]; then
           python3.9 --version
@@ -1116,7 +1115,6 @@ jobs:
     - name: List Python packages
       if: inputs.branch != 'branch-3.5' && inputs.branch != 'branch-4.0'
       run: |
-        uname -a
         lsb_release -a
         python3.11 -m pip list
     - name: Install dependencies for documentation generation

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -632,7 +632,7 @@ jobs:
       env: ${{ fromJSON(inputs.envs) }}
       shell: 'script -q -e -c "bash {0}"'
       run: |
-        uname -a
+        lsb_release -a
         for py in $(echo $PYTHON_TO_TEST | tr "," "\n")
         do
           $py --version
@@ -934,6 +934,8 @@ jobs:
     - name: List Python packages
       shell: 'script -q -e -c "bash {0}"'
       run: |
+        uname -a
+        lsb_release -a
         if [[ "$BRANCH" == 'branch-3.5' || "$BRANCH" == 'branch-4.0' ]]; then
           python3.9 --version
           python3.9 -m pip list
@@ -1113,7 +1115,10 @@ jobs:
       run: python3.9 -m pip list
     - name: List Python packages
       if: inputs.branch != 'branch-3.5' && inputs.branch != 'branch-4.0'
-      run: python3.11 -m pip list
+      run: |
+        uname -a
+        lsb_release -a
+        python3.11 -m pip list
     - name: Install dependencies for documentation generation
       run: |
         # Keep the version of Bundler here in sync with the following locations:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Use `lsb_release -a` to display the container os version


### Why are the changes needed?
`uname -a` always show the host os version


### Does this PR introduce _any_ user-facing change?
no, infra-only


### How was this patch tested?
check in `lint` job which is currently based on ubuntu 22.04.

```
uname -a
lsb_release -a
```

outputs

```
Linux ffe3f795a8eb 6.11.0-1018-azure #18~24.04.1-Ubuntu SMP Sat Jun 28 04:46:03 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 22.04.5 LTS
Release:	22.04
Codename:	jammy
```

https://github.com/zhengruifeng/spark/actions/runs/21808410627/job/62915850607

### Was this patch authored or co-authored using generative AI tooling?
no
