### PR TITLE
[SPARK-55448][CONNECT] Fix query events loss when session closes during query execution

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5916,9 +5916,9 @@
           "operationId: <operationId> with status <currentStatus> is not within statuses <validStatuses> for event <eventStatus>"
         ]
       },
-      "STATE_CONSISTENCY_EXECUTION_STATE_TRANSITION_INVALID_SESSION_NOT_STARTED" : {
+      "STATE_CONSISTENCY_EXECUTION_STATE_TRANSITION_INVALID_SESSION_STATUS_MISMATCH" : {
         "message" : [
-          "sessionId: <sessionId> with status <sessionStatus> is not Started for event <eventStatus>"
+          "sessionId: <sessionId> with status <sessionStatus> is not within valid statuses <validStatuses> for event <eventStatus>"
         ]
       },
       "STATE_CONSISTENCY_NO_BATCHES_AVAILABLE" : {

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/IllegalStateErrors.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/IllegalStateErrors.scala
@@ -46,16 +46,18 @@ object IllegalStateErrors {
         "validStatuses" -> validStatuses.map(_.toString).mkString(", "),
         "eventStatus" -> eventStatus.toString))
 
-  def executionStateTransitionInvalidSessionNotStarted(
+  def executionStateTransitionInvalidSessionStatus(
       sessionId: String,
       sessionStatus: SessionStatus,
+      validStatuses: List[SessionStatus],
       eventStatus: ExecuteStatus): SparkIllegalStateException =
     new SparkIllegalStateException(
       errorClass = "SPARK_CONNECT_ILLEGAL_STATE." +
-        "STATE_CONSISTENCY_EXECUTION_STATE_TRANSITION_INVALID_SESSION_NOT_STARTED",
+        "STATE_CONSISTENCY_EXECUTION_STATE_TRANSITION_INVALID_SESSION_STATUS_MISMATCH",
       messageParameters = Map(
         "sessionId" -> sessionId,
         "sessionStatus" -> sessionStatus.toString,
+        "validStatuses" -> validStatuses.map(_.toString).mkString(", "),
         "eventStatus" -> eventStatus.toString))
 
   def executeHolderAlreadyExists(operationId: String): SparkIllegalStateException =

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
@@ -361,10 +361,12 @@ case class ExecuteEventsManager(executeHolder: ExecuteHolder, clock: Clock) {
         validStatuses,
         eventStatus)
     }
-    if (sessionHolder.eventManager.status != SessionStatus.Started) {
-      throw IllegalStateErrors.executionStateTransitionInvalidSessionNotStarted(
+    val validSessionStatuses = List(SessionStatus.Started, SessionStatus.Closed)
+    if (!validSessionStatuses.contains(sessionHolder.eventManager.status)) {
+      throw IllegalStateErrors.executionStateTransitionInvalidSessionStatus(
         sessionHolder.sessionId,
         sessionStatus,
+        validSessionStatuses,
         eventStatus)
     }
     _status = eventStatus

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/IllegalStateErrorsSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/IllegalStateErrorsSuite.scala
@@ -56,16 +56,18 @@ class IllegalStateErrorsSuite extends SparkFunSuite {
     assert(error.getMessage.contains(currentStatus.toString))
   }
 
-  test("executionStateTransitionInvalidSessionNotStarted should construct error correctly") {
+  test("executionStateTransitionInvalidSessionStatus should construct error correctly") {
     val sessionId = "session-456"
     val sessionStatus = SessionStatus.Pending
+    val validStatuses = List(SessionStatus.Started, SessionStatus.Closed)
     val eventStatus = ExecuteStatus.Started
-    val error = IllegalStateErrors.executionStateTransitionInvalidSessionNotStarted(
+    val error = IllegalStateErrors.executionStateTransitionInvalidSessionStatus(
       sessionId,
       sessionStatus,
+      validStatuses,
       eventStatus)
     val expectedCondition = "SPARK_CONNECT_ILLEGAL_STATE." +
-      "STATE_CONSISTENCY_EXECUTION_STATE_TRANSITION_INVALID_SESSION_NOT_STARTED"
+      "STATE_CONSISTENCY_EXECUTION_STATE_TRANSITION_INVALID_SESSION_STATUS_MISMATCH"
     assert(error.getCondition.contains(expectedCondition))
     assert(error.getMessage.contains(sessionId))
     assert(error.getMessage.contains(sessionStatus.toString))
@@ -176,9 +178,10 @@ class IllegalStateErrorsSuite extends SparkFunSuite {
         ExecuteStatus.Pending,
         List(ExecuteStatus.Started),
         ExecuteStatus.Analyzed),
-      IllegalStateErrors.executionStateTransitionInvalidSessionNotStarted(
+      IllegalStateErrors.executionStateTransitionInvalidSessionStatus(
         "session",
         SessionStatus.Pending,
+        List(SessionStatus.Started, SessionStatus.Closed),
         ExecuteStatus.Started),
       IllegalStateErrors.executeHolderAlreadyExists("op"),
       IllegalStateErrors.executeHolderAlreadyExistsGraphId("graph"),

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/ExecuteEventsManagerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/ExecuteEventsManagerSuite.scala
@@ -371,6 +371,25 @@ class ExecuteEventsManagerSuite
     }
   }
 
+  test("SPARK-55448: terminal events can be posted when session is Closed") {
+    val events = setupEvents(ExecuteStatus.Started, SessionStatus.Closed)
+    events.postCanceled()
+    val expectedCancelEvent = SparkListenerConnectOperationCanceled(
+      events.executeHolder.jobTag,
+      DEFAULT_QUERY_ID,
+      DEFAULT_CLOCK.getTimeMillis())
+    verify(events.executeHolder.sessionHolder.session.sparkContext.listenerBus, times(1))
+      .post(expectedCancelEvent)
+
+    events.postClosed()
+    val expectedClosedEvent = SparkListenerConnectOperationClosed(
+      events.executeHolder.jobTag,
+      DEFAULT_QUERY_ID,
+      DEFAULT_CLOCK.getTimeMillis())
+    verify(events.executeHolder.sessionHolder.session.sparkContext.listenerBus, times(1))
+      .post(expectedClosedEvent)
+  }
+
   test("terminationReason is None initially") {
     val events = setupEvents(ExecuteStatus.Pending)
     assert(events.terminationReason.isEmpty)


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Allow Spark Connect to send query events after the session is closed. 


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
A race condition exists between Spark Connect session closure and execution cleanup. When a session closes while an execution is still running: 

1. SessionHolder.close() interrupts active executions via removeAllExecutionsForSession(), then transitions the session status to Closed via eventManager.postClosed() 
2. The interrupted execution thread's finally block calls ExecuteHolder.cleanup(), which attempts to post terminal events (postCanceled, postClosed) through ExecuteEventsManager
3. ExecuteEventsManager.assertStatus() requires sessionStatus == SessionStatus.Started, but the session is now Closed by the original thread handling SessionHolder.close().
4. An IllegalStateException is thrown, silently swallowing the terminal events.
5. Any downstream listeners never receive the Canceled/Closed events for the operation, leaving it appearing as perpetually running

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added unit tests. 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Code v2.1.37