### PR TITLE
[SPARK-55385][CORE][SQL][FOLLOWUP] Rename preservesDistribution to preservesPartitionSizes

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/MapPartitionsRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/MapPartitionsRDD.scala
@@ -35,10 +35,10 @@ import org.apache.spark.{Partition, TaskContext}
  * @param isOrderSensitive whether or not the function is order-sensitive. If it's order
  *                         sensitive, it may return totally different result when the input order
  *                         is changed. Mostly stateful functions are order-sensitive.
- * @param preservesDistribution Whether the input function preserves the data distribution,
- *                              that is, 1 number of partitions, and 2 number of rows per each
- *                              partition. This param is used to optimize the performance of
- *                              RDD.zipWithIndex.
+ * @param preservesPartitionSizes Whether the input function preserves the number of rows in each
+ *                                partition. This is true for 1:1 element mappings like `map`.
+ *                                Used to optimize `RDD.zipWithIndex` by counting rows on a
+ *                                cheaper ancestor RDD instead of the immediate parent.
  */
 private[spark] class MapPartitionsRDD[U: ClassTag, T: ClassTag](
     var prev: RDD[T],
@@ -46,7 +46,7 @@ private[spark] class MapPartitionsRDD[U: ClassTag, T: ClassTag](
     preservesPartitioning: Boolean = false,
     isFromBarrier: Boolean = false,
     isOrderSensitive: Boolean = false,
-    val preservesDistribution: Boolean = false)
+    val preservesPartitionSizes: Boolean = false)
   extends RDD[U](prev) {
 
   override val partitioner = if (preservesPartitioning) firstParent[T].partitioner else None

--- a/core/src/main/scala/org/apache/spark/rdd/MapPartitionsWithEvaluatorRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/MapPartitionsWithEvaluatorRDD.scala
@@ -24,7 +24,7 @@ import org.apache.spark.{Partition, PartitionEvaluatorFactory, TaskContext}
 private[spark] class MapPartitionsWithEvaluatorRDD[T : ClassTag, U : ClassTag](
     var prev: RDD[T],
     evaluatorFactory: PartitionEvaluatorFactory[T, U],
-    val preservesDistribution: Boolean = false)
+    val preservesPartitionSizes: Boolean = false)
   extends RDD[U](prev) {
 
   override def getPartitions: Array[Partition] = firstParent[T].partitions

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -94,14 +94,14 @@ case class ProjectExec(projectList: Seq[NamedExpression], child: SparkPlan)
     val evaluatorFactory = new ProjectEvaluatorFactory(projectList, child.output)
     if (conf.usePartitionEvaluator) {
       child.execute().mapPartitionsWithEvaluator(
-        evaluatorFactory, preservesDistribution = true
+        evaluatorFactory, preservesPartitionSizes = true
       )
     } else {
       child.execute().mapPartitionsWithIndexInternal(
         f = (index, iter) => {
           val evaluator = evaluatorFactory.createEvaluator()
           evaluator.eval(index, iter)
-        }, preservesDistribution = true
+        }, preservesPartitionSizes = true
       )
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to #54169. Rename `preservesDistribution` to `preservesPartitionSizes` and `getAncestorWithSameDistribution` to `getAncestorWithSamePartitionSizes`.

### Why are the changes needed?

The original name `preservesDistribution` is confusing because in Spark, "distribution" typically refers to how tuples are partitioned across cluster nodes (e.g., `HashPartitioning`, `ClusteredDistribution`). This field actually tracks whether the number of rows per partition is preserved (i.e., a 1:1 element mapping like `map`), which is used to optimize `RDD.zipWithIndex`. The new name `preservesPartitionSizes` is more precise and avoids confusion with the nearby `preservesPartitioning` parameter.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Existing tests. This is a pure rename with no functional changes.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor