### PR TITLE
[SPARK-55451][SQL] Cursors must start collecting results on OPEN, not first FETCH

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/FetchCursorExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/FetchCursorExec.scala
@@ -26,7 +26,6 @@ import org.apache.spark.sql.catalyst.analysis.{FakeLocalCatalog, FakeSystemCatal
 import org.apache.spark.sql.catalyst.catalog.VariableDefinition
 import org.apache.spark.sql.catalyst.expressions.{Attribute, CursorReference, Expression, Literal}
 import org.apache.spark.sql.catalyst.expressions.VariableReference
-import org.apache.spark.sql.classic.Dataset
 import org.apache.spark.sql.errors.DataTypeErrorsBase
 import org.apache.spark.sql.errors.QueryCompilationErrors.unresolvedVariableError
 import org.apache.spark.sql.execution.datasources.v2.LeafV2CommandExec

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/FetchCursorExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/FetchCursorExec.scala
@@ -24,7 +24,8 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{InternalRow, SqlScriptingContextManager}
 import org.apache.spark.sql.catalyst.analysis.{FakeLocalCatalog, FakeSystemCatalog}
 import org.apache.spark.sql.catalyst.catalog.VariableDefinition
-import org.apache.spark.sql.catalyst.expressions.{Attribute, CursorReference, Expression, Literal, VariableReference}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, CursorReference, Expression, Literal}
+import org.apache.spark.sql.catalyst.expressions.VariableReference
 import org.apache.spark.sql.classic.Dataset
 import org.apache.spark.sql.errors.DataTypeErrorsBase
 import org.apache.spark.sql.errors.QueryCompilationErrors.unresolvedVariableError
@@ -34,9 +35,10 @@ import org.apache.spark.sql.scripting.{CursorFetching, CursorOpened}
 /**
  * Physical plan node for fetching from cursors.
  *
- * Transitions cursor from Opened to Fetching state on first fetch (creating result iterator),
- * then fetches rows from the iterator on subsequent calls. Assigns fetched values to target
- * variables with ANSI store assignment rules.
+ * Fetches the next row from the result iterator that was created at OPEN time.
+ * On first fetch, transitions from Opened to Fetching state.
+ *
+ * Assigns fetched values to target variables with ANSI store assignment rules.
  *
  * @param cursor CursorReference resolved during analysis phase
  * @param targetVariables Variables to fetch into
@@ -57,24 +59,20 @@ case class FetchCursorExec(
         errorClass = "CURSOR_NOT_FOUND",
         messageParameters = Map("cursorName" -> toSQLId(cursorRef.definition.name))))
 
-    // Get or create iterator based on current state
-    val (iterator, analyzedQuery) = currentState match {
-      case CursorOpened(query) =>
-        // First fetch - create iterator and transition to Fetching state
-        // Use executeToIterator() to get InternalRow directly, avoiding conversion overhead
-        val df = Dataset.ofRows(
-          session.asInstanceOf[org.apache.spark.sql.classic.SparkSession],
-          query)
-        val iter = df.queryExecution.executedPlan.executeToIterator()
+    // Get iterator based on current state
+    val (iterator, outputSchema) = currentState match {
+      case CursorOpened(iter, schema) =>
+        // First fetch - transition to Fetching state
+        // Iterator was already created at OPEN time
         scriptingContext.updateCursorState(
           cursorRef.normalizedName,
           cursorRef.scopeLabel,
-          CursorFetching(query, iter))
-        (iter, query)
+          CursorFetching(iter, schema))
+        (iter, schema)
 
-      case CursorFetching(query, iter) =>
+      case CursorFetching(iter, schema) =>
         // Subsequent fetch - use existing iterator
-        (iter, query)
+        (iter, schema)
 
       case _ =>
         throw new AnalysisException(
@@ -98,10 +96,10 @@ case class FetchCursorExec(
         targetVariables.head,
         targetVariables.head.dataType.asInstanceOf[org.apache.spark.sql.types.StructType],
         currentRow,
-        analyzedQuery)
+        outputSchema)
     } else {
       // Regular case: one-to-one column-to-variable assignment
-      fetchIntoVariables(targetVariables, currentRow, analyzedQuery)
+      fetchIntoVariables(targetVariables, currentRow, outputSchema)
     }
 
     Nil
@@ -127,7 +125,7 @@ case class FetchCursorExec(
   private def fetchIntoVariables(
       targetVariables: Seq[VariableReference],
       currentRow: InternalRow,
-      analyzedQuery: org.apache.spark.sql.catalyst.plans.logical.LogicalPlan): Unit = {
+      outputSchema: Seq[Attribute]): Unit = {
     // Validate arity
     if (targetVariables.length != currentRow.numFields) {
       throw new AnalysisException(
@@ -139,10 +137,10 @@ case class FetchCursorExec(
 
     // Assign each column to its corresponding variable
     targetVariables.zipWithIndex.foreach { case (varRef, idx) =>
-      val sourceValue = currentRow.get(idx, analyzedQuery.output(idx).dataType)
+      val sourceValue = currentRow.get(idx, outputSchema(idx).dataType)
       val castedValue = applyCastIfNeeded(
         sourceValue,
-        analyzedQuery.output(idx).dataType,
+        outputSchema(idx).dataType,
         varRef.dataType)
 
       assignToVariable(varRef, castedValue)
@@ -225,7 +223,7 @@ case class FetchCursorExec(
       targetVar: VariableReference,
       structType: org.apache.spark.sql.types.StructType,
       currentRow: InternalRow,
-      analyzedQuery: org.apache.spark.sql.catalyst.plans.logical.LogicalPlan): Unit = {
+      outputSchema: Seq[Attribute]): Unit = {
     import org.apache.spark.sql.catalyst.expressions.{Cast, CreateStruct, Literal}
     import org.apache.spark.sql.catalyst.InternalRow
 
@@ -240,11 +238,11 @@ case class FetchCursorExec(
 
     // Build struct fields by extracting and casting cursor columns
     val fieldExpressions = structType.fields.zipWithIndex.map { case (field, idx) =>
-      val sourceValue = currentRow.get(idx, analyzedQuery.output(idx).dataType)
-      val sourceLiteral = Literal(sourceValue, analyzedQuery.output(idx).dataType)
+      val sourceValue = currentRow.get(idx, outputSchema(idx).dataType)
+      val sourceLiteral = Literal(sourceValue, outputSchema(idx).dataType)
 
       // Apply ANSI cast if types differ
-      if (analyzedQuery.output(idx).dataType == field.dataType) {
+      if (outputSchema(idx).dataType == field.dataType) {
         sourceLiteral
       } else {
         Cast(

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/CursorState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/CursorState.scala
@@ -32,25 +32,29 @@ sealed trait CursorState
 case object CursorDeclared extends CursorState
 
 /**
- * Cursor has been opened and query has been parsed/analyzed.
- * For parameterized cursors, the query here has parameters substituted.
+ * Cursor has been opened and result iterator has been created.
  *
- * @param analyzedQuery The analyzed logical plan with parameters bound
+ * CRITICAL: The iterator is created at OPEN time (not first FETCH) to ensure snapshot
+ * semantics. When executeToIterator() is called, Spark performs file discovery and
+ * captures Delta snapshots. This is the ONLY way to lock in the data snapshot at OPEN time.
+ *
+ * The iterator is lazy/incremental - it doesn't materialize all results, but it does
+ * lock in which files/versions will be read.
+ *
+ * @param resultIterator Iterator created at OPEN time (snapshot captured)
+ * @param outputSchema The output attributes (needed for type checking in FETCH)
  */
 case class CursorOpened(
-    analyzedQuery: org.apache.spark.sql.catalyst.plans.logical.LogicalPlan) extends CursorState
+    resultIterator: Iterator[org.apache.spark.sql.catalyst.InternalRow],
+    outputSchema: Seq[org.apache.spark.sql.catalyst.expressions.Attribute]) extends CursorState
 
 /**
- * Cursor is being fetched from - result iterator is active.
- * Uses executeToIterator() to avoid loading all data into memory at once.
- * Uses InternalRow format to avoid unnecessary conversions.
- *
- * @param analyzedQuery The analyzed logical plan
- * @param resultIterator Iterator over InternalRow results
+ * Cursor is being fetched from - same as CursorOpened but marks that fetching has begun.
+ * We keep this separate state for consistency and potential future use.
  */
 case class CursorFetching(
-    analyzedQuery: org.apache.spark.sql.catalyst.plans.logical.LogicalPlan,
-    resultIterator: Iterator[org.apache.spark.sql.catalyst.InternalRow]) extends CursorState
+    resultIterator: Iterator[org.apache.spark.sql.catalyst.InternalRow],
+    outputSchema: Seq[org.apache.spark.sql.catalyst.expressions.Attribute]) extends CursorState
 
 /**
  * Cursor has been closed and resources released.

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/CursorState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/CursorState.scala
@@ -17,6 +17,9 @@
 
 package org.apache.spark.sql.scripting
 
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
 /**
  * Sealed trait representing the lifecycle state of a cursor.
  * State transitions:
@@ -45,16 +48,16 @@ case object CursorDeclared extends CursorState
  * @param outputSchema The output attributes (needed for type checking in FETCH)
  */
 case class CursorOpened(
-    resultIterator: Iterator[org.apache.spark.sql.catalyst.InternalRow],
-    outputSchema: Seq[org.apache.spark.sql.catalyst.expressions.Attribute]) extends CursorState
+    resultIterator: Iterator[InternalRow],
+    outputSchema: Seq[Attribute]) extends CursorState
 
 /**
  * Cursor is being fetched from - same as CursorOpened but marks that fetching has begun.
  * We keep this separate state for consistency and potential future use.
  */
 case class CursorFetching(
-    resultIterator: Iterator[org.apache.spark.sql.catalyst.InternalRow],
-    outputSchema: Seq[org.apache.spark.sql.catalyst.expressions.Attribute]) extends CursorState
+    resultIterator: Iterator[InternalRow],
+    outputSchema: Seq[Attribute]) extends CursorState
 
 /**
  * Cursor has been closed and resources released.

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingCursorE2eSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingCursorE2eSuite.scala
@@ -359,7 +359,13 @@ END;""")
     )
   }
 
-  test("Test 20: Cursor sensitivity - cursor captures snapshot when opened") {
+  test("Test 20: Cursor sensitivity - INSENSITIVE cursors capture snapshot at OPEN") {
+    // Spark cursors are INSENSITIVE by default, which means they capture a snapshot when
+    // OPEN is called. The physical plan is generated at OPEN time, locking in file lists,
+    // Delta snapshots, and other data source metadata.
+    //
+    // This test verifies snapshot semantics: rows inserted AFTER OPEN but BEFORE first
+    // FETCH should NOT be visible to the cursor.
     sql("CREATE TABLE cursor_sensitivity_test (id INT, value STRING) USING parquet;")
     sql("INSERT INTO cursor_sensitivity_test VALUES (1, 'row1'), (2, 'row2');")
     val result = sql("""BEGIN
@@ -382,10 +388,10 @@ END;""")
   -- Step 4: OPEN the cursor (captures snapshot - should see rows 1-4)
   OPEN cur;
 
-  -- Step 5: Add more rows after OPEN
+  -- Step 5: Add more rows after OPEN but before first FETCH
   INSERT INTO cursor_sensitivity_test VALUES (5, 'row5'), (6, 'row6');
 
-  -- Step 6: Fetch rows - should see snapshot from OPEN time (4 rows)
+  -- Step 6: Fetch rows - should see snapshot from OPEN time (4 rows only)
   REPEAT
     FETCH cur INTO fetched_id, fetched_value;
     IF NOT nomorerows THEN
@@ -396,11 +402,11 @@ END;""")
   -- Step 7: Close the cursor
   CLOSE cur;
 
-  -- Step 8: Open the cursor again (should capture new snapshot)
+  -- Step 8: Open the cursor again (captures new snapshot with all 6 rows)
   SET nomorerows = false;
   OPEN cur;
 
-  -- Step 9: Fetch rows - demonstrates cursor behavior
+  -- Step 9: Fetch rows - should see all 6 rows now
   REPEAT
     FETCH cur INTO fetched_id, fetched_value;
     IF NOT nomorerows THEN
@@ -408,13 +414,13 @@ END;""")
     END IF;
   UNTIL nomorerows END REPEAT;
 
-  -- Return both counts
+  -- Return both counts (first=4, second=6)
   VALUES (row_count_first_open, row_count_second_open);
 
   CLOSE cur;
 END;""")
     checkAnswer(result, Seq(
-      Row(6, 6)))
+      Row(4, 6)))
   }
 
   test("Test 21: Basic parameterized cursor with positional parameters") {
@@ -1898,6 +1904,44 @@ END;""")
     // EXIT handlers execute and exit - no intermediate results are returned
     // The test succeeds if all cursor operations complete without errors
     checkAnswer(result, Seq(Row("Done")))
+  }
+
+  test("Test 92: Runtime error in cursor query caught at OPEN (snapshot semantics)") {
+    // With snapshot semantics, executeToIterator() is called at OPEN time to capture
+    // the data snapshot. This means query execution begins at OPEN, not at first FETCH.
+    //
+    // IMPORTANT: Runtime errors in the cursor query are now thrown at OPEN time because
+    // that's when execution starts. This is a consequence of implementing INSENSITIVE
+    // cursor semantics where the snapshot must be captured at OPEN.
+    //
+    // This test verifies that runtime errors (e.g., divide by zero) are caught at OPEN.
+    sql("CREATE TABLE cursor_row_error_test (id INT, value INT) USING parquet")
+    sql("INSERT INTO cursor_row_error_test VALUES (1, 10), (2, 0), (3, 5)")
+    try {
+      val result = sql("""BEGIN
+  DECLARE x INT;
+  DECLARE y INT;
+  DECLARE result STRING DEFAULT '';
+
+  DECLARE cur CURSOR FOR SELECT id, 100 / value AS result FROM cursor_row_error_test ORDER BY id;
+
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    SET result = result || ' | failed at open';
+
+  SET result = 'declared';
+  OPEN cur;  -- Fails here: executeToIterator() starts execution, hits divide-by-zero
+  SET result = 'opened';  -- Should NOT reach here
+  FETCH cur INTO x, y;
+  SET result = 'fetched: ' || x || ',' || y;  -- Should NOT reach here
+  END;
+
+  SELECT result;
+END;""")
+      // Should show DECLARE succeeded, but OPEN failed due to divide-by-zero
+      checkAnswer(result, Seq(Row("declared | failed at open")))
+    } finally {
+      sql("DROP TABLE IF EXISTS cursor_row_error_test")
+    }
   }
 
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingCursorE2eSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingCursorE2eSuite.scala
@@ -1919,20 +1919,22 @@ END;""")
     sql("INSERT INTO cursor_row_error_test VALUES (1, 10), (2, 0), (3, 5)")
     try {
       val result = sql("""BEGIN
+  DECLARE result STRING DEFAULT 'start';
   DECLARE x INT;
   DECLARE y INT;
-  DECLARE result STRING DEFAULT '';
 
-  DECLARE cur CURSOR FOR SELECT id, 100 / value AS result FROM cursor_row_error_test ORDER BY id;
+  BEGIN
+    DECLARE cur CURSOR FOR SELECT id, 100 / value AS result FROM cursor_row_error_test ORDER BY id;
 
-  DECLARE EXIT HANDLER FOR SQLEXCEPTION
-    SET result = result || ' | failed at open';
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+      SET result = result || ' | failed at open';
 
-  SET result = 'declared';
-  OPEN cur;  -- Fails here: executeToIterator() starts execution, hits divide-by-zero
-  SET result = 'opened';  -- Should NOT reach here
-  FETCH cur INTO x, y;
-  SET result = 'fetched: ' || x || ',' || y;  -- Should NOT reach here
+    SET result = 'declared';
+    OPEN cur;  -- Fails here: executeToIterator() starts execution, hits divide-by-zero
+    SET result = 'opened';  -- Should NOT reach here
+    FETCH cur INTO x, y;
+    SET result = 'fetched: ' || x || ',' || y;  -- Should NOT reach here
+  END;
 
   SELECT result;
 END;""")

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingCursorE2eSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingCursorE2eSuite.scala
@@ -1933,7 +1933,6 @@ END;""")
   SET result = 'opened';  -- Should NOT reach here
   FETCH cur INTO x, y;
   SET result = 'fetched: ' || x || ',' || y;  -- Should NOT reach here
-  END;
 
   SELECT result;
 END;""")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Cursors should use snapshot semantics pinned to the OPEN statement, not the first FETCH.
This change fixes that.
Ideally we would want to to simply collect the files, and not start scans at OPEN, so we do not get runtime errors on OPEN, but that is quite difficult. Starting the scans at OPEN ("do-at-open") is generally acceptable behavior though for an ASENSITIVE cursor.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Do get clean and standard compliant semantic

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No (unreleased feature)

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added more tests, veriofied existing tests change.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Claude Opus