### PR TITLE
[SPARK-55455][BUILD] Upgrade `RoaringBitmap` to 1.6.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -258,7 +258,7 @@ parquet-jackson/1.17.0//parquet-jackson-1.17.0.jar
 pickle/1.5//pickle-1.5.jar
 py4j/0.10.9.9//py4j-0.10.9.9.jar
 remotetea-oncrpc/1.1.2//remotetea-oncrpc-1.1.2.jar
-roaringbitmap/1.5.3//roaringbitmap-1.5.3.jar
+roaringbitmap/1.6.0//roaringbitmap-1.6.0.jar
 rocksdbjni/9.8.4//rocksdbjni-9.8.4.jar
 scala-compiler/2.13.18//scala-compiler-2.13.18.jar
 scala-library/2.13.18//scala-library-2.13.18.jar

--- a/pom.xml
+++ b/pom.xml
@@ -932,7 +932,7 @@
       <dependency>
         <groupId>com.github.RoaringBitmap.RoaringBitmap</groupId>
         <artifactId>roaringbitmap</artifactId>
-        <version>1.5.3</version>
+        <version>1.6.0</version>
       </dependency>
       <!-- Netty Begin -->
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `RoaringBitmap` to 1.6.0.

### Why are the changes needed?

To use the latest bug fixed versions.
- https://github.com/RoaringBitmap/RoaringBitmap/releases/tag/1.6.0
- https://github.com/RoaringBitmap/RoaringBitmap/releases/tag/1.5.4

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`