### PR TITLE
[SPARK-55416][SS][PYTHON] Streaming Python Data Source memory leak when end-offset is not updated

### DIFF
--- a/python/docs/source/tutorial/sql/python_data_source.rst
+++ b/python/docs/source/tutorial/sql/python_data_source.rst
@@ -314,6 +314,8 @@ This is the same dummy streaming reader that generates 2 rows every batch implem
             raises a validation exception.
             For example, returning 2 records from start_idx 0 means end should
             be {"offset": 2} (i.e. start + 2).
+            When there is no data to read, you may return the same offset as end and
+            start,but you must provide an empty iterator.
             """
             start_idx = start["offset"]
             it = iter([(i,) for i in range(start_idx, start_idx + 2)])

--- a/python/docs/source/tutorial/sql/python_data_source.rst
+++ b/python/docs/source/tutorial/sql/python_data_source.rst
@@ -309,7 +309,11 @@ This is the same dummy streaming reader that generates 2 rows every batch implem
         def read(self, start: dict) -> Tuple[Iterator[Tuple], dict]:
             """
             Takes start offset as an input, return an iterator of tuples and
-            the start offset of next read.
+            the end offset (start offset for the next read). The end offset must
+            advance past the start offset when returning data; otherwise Spark
+            raises a validation exception.
+            For example, returning 2 records from start_idx 0 means end should
+            be {"offset": 2} (i.e. start + 2).
             """
             start_idx = start["offset"]
             it = iter([(i,) for i in range(start_idx, start_idx + 2)])

--- a/python/docs/source/tutorial/sql/python_data_source.rst
+++ b/python/docs/source/tutorial/sql/python_data_source.rst
@@ -315,7 +315,7 @@ This is the same dummy streaming reader that generates 2 rows every batch implem
             For example, returning 2 records from start_idx 0 means end should
             be {"offset": 2} (i.e. start + 2).
             When there is no data to read, you may return the same offset as end and
-            start,but you must provide an empty iterator.
+            start, but you must provide an empty iterator.
             """
             start_idx = start["offset"]
             it = iter([(i,) for i in range(start_idx, start_idx + 2)])

--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -1185,6 +1185,11 @@
       "SparkContext or SparkSession should be created first."
     ]
   },
+  "SIMPLE_STREAM_READER_OFFSET_DID_NOT_ADVANCE": {
+    "message": [
+      "SimpleDataSourceStreamReader.read() returned a non-empty batch but the end offset did not advance past the start offset. Returning end equal to start with data would cause the same batch to be processed repeatedly. The end offset must represent the position after the last record returned."
+    ]
+  },
   "SLICE_WITH_STEP": {
     "message": [
       "Slice with step is not supported."

--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -1185,9 +1185,9 @@
       "SparkContext or SparkSession should be created first."
     ]
   },
-  "SIMPLE_STREAM_READER_OFFSET_DID_NOT_ADVANCE": {
+  "STREAM_READER_OFFSET_DID_NOT_ADVANCE": {
     "message": [
-      "SimpleDataSourceStreamReader.read() returned a non-empty batch but the end offset did not advance past the start offset. Returning end equal to start with data would cause the same batch to be processed repeatedly. The end offset must represent the position after the last record returned."
+      "Stream reader read() returned a non-empty batch but the end offset did not advance past the start offset. Returning end equal to start with data would cause the same batch to be processed repeatedly. The end offset must represent the position after the last record returned."
     ]
   },
   "SLICE_WITH_STEP": {

--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -1185,6 +1185,11 @@
       "SparkContext or SparkSession should be created first."
     ]
   },
+  "SIMPLE_STREAM_READER_OFFSET_DID_NOT_ADVANCE": {
+    "message": [
+      "SimpleDataSourceStreamReader.read() returned a non-empty batch but the end offset: <end_offset> did not advance past the start offset: <start_offset>. The end offset must represent the position after the last record returned."
+    ]
+  },
   "SLICE_WITH_STEP": {
     "message": [
       "Slice with step is not supported."
@@ -1208,11 +1213,6 @@
   "STREAMING_CONNECT_SERIALIZATION_ERROR": {
     "message": [
       "Cannot serialize the function `<name>`. If you accessed the Spark session, or a DataFrame defined outside of the function, or any object that contains a Spark session, please be aware that they are not allowed in Spark Connect. For `foreachBatch`, please access the Spark session using `df.sparkSession`, where `df` is the first parameter in your `foreachBatch` function. For `StreamingQueryListener`, please access the Spark session using `self.spark`. For details please check out the PySpark doc for `foreachBatch` and `StreamingQueryListener`."
-    ]
-  },
-  "STREAM_READER_OFFSET_DID_NOT_ADVANCE": {
-    "message": [
-      "Stream reader read() returned a non-empty batch but the end offset did not advance past the start offset. Returning end equal to start with data would cause the same batch to be processed repeatedly. The end offset must represent the position after the last record returned."
     ]
   },
   "ST_INVALID_ALGORITHM_VALUE" : {

--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -1185,11 +1185,6 @@
       "SparkContext or SparkSession should be created first."
     ]
   },
-  "STREAM_READER_OFFSET_DID_NOT_ADVANCE": {
-    "message": [
-      "Stream reader read() returned a non-empty batch but the end offset did not advance past the start offset. Returning end equal to start with data would cause the same batch to be processed repeatedly. The end offset must represent the position after the last record returned."
-    ]
-  },
   "SLICE_WITH_STEP": {
     "message": [
       "Slice with step is not supported."
@@ -1213,6 +1208,11 @@
   "STREAMING_CONNECT_SERIALIZATION_ERROR": {
     "message": [
       "Cannot serialize the function `<name>`. If you accessed the Spark session, or a DataFrame defined outside of the function, or any object that contains a Spark session, please be aware that they are not allowed in Spark Connect. For `foreachBatch`, please access the Spark session using `df.sparkSession`, where `df` is the first parameter in your `foreachBatch` function. For `StreamingQueryListener`, please access the Spark session using `self.spark`. For details please check out the PySpark doc for `foreachBatch` and `StreamingQueryListener`."
+    ]
+  },
+  "STREAM_READER_OFFSET_DID_NOT_ADVANCE": {
+    "message": [
+      "Stream reader read() returned a non-empty batch but the end offset did not advance past the start offset. Returning end equal to start with data would cause the same batch to be processed repeatedly. The end offset must represent the position after the last record returned."
     ]
   },
   "ST_INVALID_ALGORITHM_VALUE" : {

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -928,10 +928,6 @@ class SimpleDataSourceStreamReader(ABC):
         Read all available data from start offset and return the offset that next read attempt
         starts from.
 
-        When there is data, the end offset must advance past the start offset; otherwise
-        Spark raises a validation exception. When there is no data to read, the implementation
-        may return the same offset as both start and end, but must provide an empty iterator.
-
         Parameters
         ----------
         start : dict

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -928,6 +928,10 @@ class SimpleDataSourceStreamReader(ABC):
         Read all available data from start offset and return the offset that next read attempt
         starts from.
 
+        When there is data, the end offset must advance past the start offset; otherwise
+        Spark raises a validation exception. When there is no data to read, the implementation
+        may return the same offset as both start and end, but must provide an empty iterator.
+
         Parameters
         ----------
         start : dict

--- a/python/pyspark/sql/datasource_internal.py
+++ b/python/pyspark/sql/datasource_internal.py
@@ -108,7 +108,7 @@ class _SimpleStreamReaderWrapper(DataSourceStreamReader):
         except StopIteration:
             return
         raise PySparkException(
-            errorClass="SIMPLE_STREAM_READER_OFFSET_DID_NOT_ADVANCE",
+            errorClass="STREAM_READER_OFFSET_DID_NOT_ADVANCE",
             messageParameters={},
         )
 

--- a/python/pyspark/sql/datasource_internal.py
+++ b/python/pyspark/sql/datasource_internal.py
@@ -100,7 +100,9 @@ class _SimpleStreamReaderWrapper(DataSourceStreamReader):
         appends the result to the cache; when end == start with empty iterator, does not
         cache (avoids unbounded cache growth).
         """
-        if end != start:
+        start_str = json.dumps(start)
+        end_str = json.dumps(end)
+        if end_str != start_str:
             self.cache.append(PrefetchedCacheEntry(start, end, it))
             return
         try:
@@ -110,8 +112,8 @@ class _SimpleStreamReaderWrapper(DataSourceStreamReader):
         raise PySparkException(
             errorClass="SIMPLE_STREAM_READER_OFFSET_DID_NOT_ADVANCE",
             messageParameters={
-                "start_offset": start,
-                "end_offset": end,
+                "start_offset": start_str,
+                "end_offset": end_str,
             },
         )
 

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -511,7 +511,7 @@ class BasePythonStreamingDataSourceTestsMixin:
         self.assertIsNone(q.exception(), "No exception has to be propagated.")
 
     def test_simple_stream_reader_offset_did_not_advance_raises(self):
-        """Validate that returning end == start with non-empty data raises STREAM_READER_OFFSET_DID_NOT_ADVANCE."""
+        """Validate that returning end == start with non-empty data raises SIMPLE_STREAM_READER_OFFSET_DID_NOT_ADVANCE."""
         from pyspark.sql.datasource_internal import _SimpleStreamReaderWrapper
 
         class BuggySimpleStreamReader(SimpleDataSourceStreamReader):
@@ -522,7 +522,7 @@ class BasePythonStreamingDataSourceTestsMixin:
                 # Bug: return same offset as end despite returning data
                 start_idx = start["offset"]
                 it = iter([(i,) for i in range(start_idx, start_idx + 3)])
-                return (it, {"offset": start_idx})
+                return (it, start)
 
             def readBetweenOffsets(self, start: dict, end: dict):
                 return iter([])
@@ -536,7 +536,7 @@ class BasePythonStreamingDataSourceTestsMixin:
             wrapper.latestOffset({"offset": 0}, ReadAllAvailable())
         self.assertEqual(
             cm.exception.getCondition(),
-            "STREAM_READER_OFFSET_DID_NOT_ADVANCE",
+            "SIMPLE_STREAM_READER_OFFSET_DID_NOT_ADVANCE",
         )
 
     def test_simple_stream_reader_empty_iterator_start_equals_end_allowed(self):
@@ -549,7 +549,7 @@ class BasePythonStreamingDataSourceTestsMixin:
 
             def read(self, start: dict):
                 # Valid: same offset as end but empty iterator (no data)
-                return (iter([]), {"offset": start["offset"]})
+                return (iter([]), start)
 
             def readBetweenOffsets(self, start: dict, end: dict):
                 return iter([])

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -41,6 +41,7 @@ from pyspark.testing.sqlutils import (
     have_pyarrow,
     pyarrow_requirement_message,
 )
+from pyspark.errors import PySparkException
 from pyspark.testing import assertDataFrameEqual
 from pyspark.testing.utils import eventually
 from pyspark.testing.sqlutils import ReusedSQLTestCase
@@ -508,6 +509,35 @@ class BasePythonStreamingDataSourceTestsMixin:
         q = df.writeStream.foreachBatch(check_batch).trigger(availableNow=True).start()
         q.awaitTermination(timeout=30)
         self.assertIsNone(q.exception(), "No exception has to be propagated.")
+
+    def test_simple_stream_reader_offset_did_not_advance_raises(self):
+        """Validate that returning end == start with non-empty data raises SIMPLE_STREAM_READER_OFFSET_DID_NOT_ADVANCE."""
+        from pyspark.sql.datasource_internal import _SimpleStreamReaderWrapper
+
+        class BuggySimpleStreamReader(SimpleDataSourceStreamReader):
+            def initialOffset(self):
+                return {"offset": 0}
+
+            def read(self, start: dict):
+                # Bug: return same offset as end despite returning data
+                start_idx = start["offset"]
+                it = iter([(i,) for i in range(start_idx, start_idx + 3)])
+                return (it, {"offset": start_idx})
+
+            def readBetweenOffsets(self, start: dict, end: dict):
+                return iter([])
+
+            def commit(self, end: dict):
+                pass
+
+        reader = BuggySimpleStreamReader()
+        wrapper = _SimpleStreamReaderWrapper(reader)
+        with self.assertRaises(PySparkException) as cm:
+            wrapper.latestOffset({"offset": 0}, ReadAllAvailable())
+        self.assertEqual(
+            cm.exception.getCondition(),
+            "SIMPLE_STREAM_READER_OFFSET_DID_NOT_ADVANCE",
+        )
 
     def test_stream_writer(self):
         input_dir = tempfile.TemporaryDirectory(prefix="test_data_stream_write_input")

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -511,7 +511,7 @@ class BasePythonStreamingDataSourceTestsMixin:
         self.assertIsNone(q.exception(), "No exception has to be propagated.")
 
     def test_simple_stream_reader_offset_did_not_advance_raises(self):
-        """Validate that returning end == start with non-empty data raises SIMPLE_STREAM_READER_OFFSET_DID_NOT_ADVANCE."""
+        """Validate that returning end == start with non-empty data raises STREAM_READER_OFFSET_DID_NOT_ADVANCE."""
         from pyspark.sql.datasource_internal import _SimpleStreamReaderWrapper
 
         class BuggySimpleStreamReader(SimpleDataSourceStreamReader):
@@ -536,7 +536,7 @@ class BasePythonStreamingDataSourceTestsMixin:
             wrapper.latestOffset({"offset": 0}, ReadAllAvailable())
         self.assertEqual(
             cm.exception.getCondition(),
-            "SIMPLE_STREAM_READER_OFFSET_DID_NOT_ADVANCE",
+            "STREAM_READER_OFFSET_DID_NOT_ADVANCE",
         )
 
     def test_simple_stream_reader_empty_iterator_start_equals_end_allowed(self):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In `_SimpleStreamReaderWrapper.latestOffset()`, validate that  custom implementation of datasource based on `SimpleDataSourceStreamReader.read()` does not return a non-empty batch with end == start. If it does, raise PySparkException with error class `SIMPLE_STREAM_READER_OFFSET_DID_NOT_ADVANCE` before appending to the cache. Empty batches with end == start remain allowed.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When a user implements read(start) incorrectly and returns:

- Same offset for both: end = start (e.g. both {"offset": 0}).
- Non-empty iterator: e.g. 2 rows.

If a reader returns end == start with data (e.g. return (it, {"offset": start_idx})), the wrapper keeps appending to its prefetch cache on every trigger while commit(end) never trims entries (first matching index is 0). The cache grows without bound and driver (non-JVM) memory increases until OOM. Validating and raising error before appending stops this and fails fast with a clear error.

Empty batches with end == start remain allowed , it will allow the Python data source to represent that there is no data to read.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Implementations that return end == start with a non-empty iterator now get PySparkException instead of unbounded memory growth. Empty batches with end == start are unchanged.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added unit test in `test_python_streaming_datasource.py`

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.