### PR TITLE
[SPARK-55395][SQL][FOLLOW-UP] Delete obsolete `withSequenceColumn`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
@@ -2058,14 +2058,6 @@ class Dataset[T] private[sql](
   ////////////////////////////////////////////////////////////////////////////
 
   /**
-   * It adds a new long column with the name `name` that increases one by one.
-   * This is for 'distributed-sequence' default index in pandas API on Spark.
-   */
-  private[sql] def withSequenceColumn(name: String) = {
-    select(Column(DistributedSequenceID(Literal(true))).alias(name), col("*"))
-  }
-
-  /**
    * Converts a JavaRDD to a PythonRDD.
    */
   private[sql] def javaToPython: JavaRDD[Array[Byte]] = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2406,7 +2406,7 @@ class DataFrameSuite extends QueryTest
     }
   }
 
-  test("SPARK-36338: DataFrame.withSequenceColumn should append unique sequence IDs") {
+  test("SPARK-36338: AttachDistributedSequence should append unique sequence IDs") {
     val ids = spark.range(10).repartition(5).select(
       Column.internalFn("distributed_sequence_id").alias("default_index"), col("id"))
     assert(ids.collect().map(_.getLong(0)).toSet === Range(0, 10).toSet)


### PR DESCRIPTION

### What changes were proposed in this pull request?
Delete obsolete `withSequenceColumn` from `Dataset`


### Why are the changes needed?
this method was originally added for pandas api on spark, but after python side refactoring, this method has been unused for a while


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no