### PR TITLE
[SPARK-55472][PS] Raise `AttributeError` from methods removed in pandas 3

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -68,6 +68,8 @@ from pandas.core.dtypes.common import infer_dtype_from_object  # type: ignore[at
 from pandas.core.accessor import CachedAccessor  # type: ignore[attr-defined]
 from pandas.core.dtypes.inference import is_sequence  # type: ignore[attr-defined]
 
+from pyspark._globals import _NoValue, _NoValueType
+from pyspark.loose_version import LooseVersion
 from pyspark.errors import PySparkValueError
 from pyspark import StorageLevel
 from pyspark.sql import Column as PySparkColumn, DataFrame as PySparkDataFrame, functions as F
@@ -6108,7 +6110,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
     def fillna(
         self,
         value: Optional[Union[Any, Dict[Name, Any]]] = None,
-        method: Optional[str] = None,
+        method: Union[Optional[str], _NoValueType] = _NoValue,
         axis: Optional[Axis] = None,
         inplace: bool = False,
         limit: Optional[int] = None,
@@ -6178,7 +6180,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         We can also propagate non-null values forward or backward.
 
-        >>> df.fillna(method='ffill')
+        >>> df.fillna(method='ffill')  # doctest: +SKIP
              A    B    C  D
         0  NaN  2.0  NaN  0
         1  3.0  4.0  NaN  1
@@ -6196,6 +6198,28 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         2  0.0  1.0  2.0  5
         3  0.0  3.0  1.0  4
         """
+        if LooseVersion(pd.__version__) < "3.0.0":
+            if method is not _NoValue:
+                method = None
+        else:
+            if method is not _NoValue:
+                raise TypeError(
+                    "The `method` parameter is not supported in pandas 3.0.0 and later. "
+                )
+            method = None
+
+        return self._fillna_with_method(
+            value=value, method=method, axis=axis, inplace=inplace, limit=limit  # type: ignore[arg-type]
+        )
+
+    def _fillna_with_method(
+        self,
+        value: Optional[Union[Any, Dict[Name, Any]]] = None,
+        method: Optional[str] = None,
+        axis: Optional[Axis] = None,
+        inplace: bool = False,
+        limit: Optional[int] = None,
+    ) -> Optional["DataFrame"]:
         axis = validate_axis(axis)
         if axis != 0:
             raise NotImplementedError("fillna currently only works for axis=0 or axis='index'")
@@ -6603,7 +6627,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Get the rows for the last 3 days:
 
-        >>> psdf.last('3D')
+        >>> psdf.last('3D')  # doctest: +SKIP
                     A
         2018-04-13  3
         2018-04-15  4
@@ -6612,6 +6636,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         3 observed days in the dataset, and therefore data for 2018-04-11 was
         not returned.
         """
+        if LooseVersion(pd.__version__) < "3.0.0":
+            return self._last(offset)
+        else:
+            raise AttributeError(
+                "The `last` method is not supported in pandas 3.0.0 and later. "
+                "Please create a mask and filter using `.loc` instead"
+            )
+
+    def _last(self, offset: Union[str, DateOffset]) -> "DataFrame":
         warnings.warn(
             "last is deprecated and will be removed in a future version. "
             "Please create a mask and filter using `.loc` instead",
@@ -6667,7 +6700,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         Get the rows for the last 3 days:
 
-        >>> psdf.first('3D')
+        >>> psdf.first('3D')  # doctest: +SKIP
                     A
         2018-04-09  1
         2018-04-11  2
@@ -6676,6 +6709,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         3 observed days in the dataset, and therefore data for 2018-04-13 was
         not returned.
         """
+        if LooseVersion(pd.__version__) < "3.0.0":
+            return self._first(offset)
+        else:
+            raise AttributeError(
+                "The `first` method is not supported in pandas 3.0.0 and later. "
+                "Please create a mask and filter using `.loc` instead"
+            )
+
+    def _first(self, offset: Union[str, DateOffset]) -> "DataFrame":
         warnings.warn(
             "first is deprecated and will be removed in a future version. "
             "Please create a mask and filter using `.loc` instead",
@@ -8105,17 +8147,26 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         x  1  2  3
         y  4  5  6
         z  7  8  9
-        >>> psdf.swapaxes(i=1, j=0)
+        >>> psdf.swapaxes(i=1, j=0)  # doctest: +SKIP
            x  y  z
         a  1  4  7
         b  2  5  8
         c  3  6  9
-        >>> psdf.swapaxes(i=1, j=1)
+        >>> psdf.swapaxes(i=1, j=1)  # doctest: +SKIP
            a  b  c
         x  1  2  3
         y  4  5  6
         z  7  8  9
         """
+        if LooseVersion(pd.__version__) < "3.0.0":
+            return self._swapaxes(i, j, copy)
+        else:
+            raise AttributeError(
+                "The `swapaxes` method is not supported in pandas 3.0.0 and later. "
+                "Please use the `transpose` method instead"
+            )
+
+    def _swapaxes(self, i: Axis, j: Axis, copy: bool = True) -> "DataFrame":
         assert copy is True
 
         i = validate_axis(i)

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -6199,7 +6199,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         3  0.0  3.0  1.0  4
         """
         if LooseVersion(pd.__version__) < "3.0.0":
-            if method is not _NoValue:
+            if method is _NoValue:
                 method = None
         else:
             if method is not _NoValue:

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -39,6 +39,8 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import is_list_like
 
+from pyspark._globals import _NoValue, _NoValueType
+from pyspark.loose_version import LooseVersion
 from pyspark.sql import Column, functions as F
 from pyspark.sql.internal import InternalFunction as SF
 from pyspark.sql.types import (
@@ -3312,6 +3314,17 @@ class Frame(object, metaclass=ABCMeta):
     def fillna(
         self: FrameLike,
         value: Optional[Any] = None,
+        method: Union[Optional[str], _NoValueType] = _NoValue,
+        axis: Optional[Axis] = None,
+        inplace: bool_type = False,
+        limit: Optional[int] = None,
+    ) -> FrameLike:
+        pass
+
+    @abstractmethod
+    def _fillna_with_method(
+        self: FrameLike,
+        value: Optional[Any] = None,
         method: Optional[str] = None,
         axis: Optional[Axis] = None,
         inplace: bool_type = False,
@@ -3394,9 +3407,23 @@ class Frame(object, metaclass=ABCMeta):
         3    1.0
         dtype: float64
         """
-        return self.fillna(method="bfill", axis=axis, inplace=inplace, limit=limit)
+        return self._fillna_with_method(method="bfill", axis=axis, inplace=inplace, limit=limit)
 
-    backfill = bfill
+    def backfill(
+        self: FrameLike,
+        axis: Optional[Axis] = None,
+        inplace: bool_type = False,
+        limit: Optional[int] = None,
+    ) -> FrameLike:
+        if LooseVersion(pd.__version__) < "3.0.0":
+            return self.bfill(axis=axis, inplace=inplace, limit=limit)
+        else:
+            raise AttributeError(
+                "The `backfill` method is not supported in pandas 3.0.0 and later. Use `bfill` instead."
+            )
+
+    if LooseVersion(pd.__version__) < "3.0.0":
+        backfill.__doc__ = bfill.__doc__
 
     # TODO: add 'downcast' when value parameter exists
     def ffill(
@@ -3473,9 +3500,23 @@ class Frame(object, metaclass=ABCMeta):
         3    3.0
         dtype: float64
         """
-        return self.fillna(method="ffill", axis=axis, inplace=inplace, limit=limit)
+        return self._fillna_with_method(method="ffill", axis=axis, inplace=inplace, limit=limit)
 
-    pad = ffill
+    def pad(
+        self: FrameLike,
+        axis: Optional[Axis] = None,
+        inplace: bool_type = False,
+        limit: Optional[int] = None,
+    ) -> FrameLike:
+        if LooseVersion(pd.__version__) < "3.0.0":
+            return self.ffill(axis=axis, inplace=inplace, limit=limit)
+        else:
+            raise AttributeError(
+                "The `pad` method is not supported in pandas 3.0.0 and later. Use `ffill` instead."
+            )
+
+    if LooseVersion(pd.__version__) < "3.0.0":
+        pad.__doc__ = ffill.__doc__
 
     # TODO: add 'axis', 'inplace', 'downcast'
     def interpolate(

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -2597,20 +2597,37 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
 
         We can also propagate non-null values forward or backward in group.
 
-        >>> df.groupby(['A'])['B'].fillna(method='ffill').sort_index()
+        >>> df.groupby(['A'])['B'].fillna(method='ffill').sort_index()  # doctest: +SKIP
         0    2.0
         1    4.0
         2    NaN
         3    3.0
         Name: B, dtype: float64
 
-        >>> df.groupby(['A']).fillna(method='bfill').sort_index()
+        >>> df.groupby(['A']).fillna(method='bfill').sort_index()  # doctest: +SKIP
              B    C  D
         0  2.0  NaN  0
         1  4.0  NaN  1
         2  3.0  1.0  5
         3  3.0  1.0  4
         """
+        if LooseVersion(pd.__version__) < "3.0.0":
+            return self._fillna(value=value, method=method, axis=axis, inplace=inplace, limit=limit)
+        else:
+            raise AttributeError(
+                "The `fillna` method is not supported in pandas 3.0.0 and later. "
+                "Use obj.ffill() or obj.bfill() for forward or backward filling instead. "
+                "If you want to fill with a single value, use DataFrame.fillna instead"
+            )
+
+    def _fillna(
+        self,
+        value: Optional[Any] = None,
+        method: Optional[str] = None,
+        axis: Optional[Axis] = None,
+        inplace: bool = False,
+        limit: Optional[int] = None,
+    ) -> FrameLike:
         should_resolve = method is not None
         if should_resolve:
             warnings.warn(
@@ -2673,7 +2690,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         2  3.0  1.0  5
         3  3.0  1.0  4
         """
-        return self.fillna(method="bfill", limit=limit)
+        return self._fillna(method="bfill", limit=limit)
 
     def ffill(self, limit: Optional[int] = None) -> FrameLike:
         """
@@ -2722,7 +2739,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         2  NaN  NaN  5
         3  3.0  1.0  4
         """
-        return self.fillna(method="ffill", limit=limit)
+        return self._fillna(method="ffill", limit=limit)
 
     def _limit(self, n: int, asc: bool) -> FrameLike:
         """

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -45,6 +45,7 @@ from pandas.io.formats.printing import pprint_thing  # type: ignore[import-not-f
 from pandas.api.types import CategoricalDtype, is_hashable
 from pandas._libs import lib
 
+from pyspark.loose_version import LooseVersion
 from pyspark.sql.column import Column
 from pyspark.sql import functions as F
 from pyspark.sql.types import (
@@ -2370,16 +2371,21 @@ class Index(IndexOpsMixin):
         Returns False for string type.
 
         >>> psidx = ps.Index(["A", "B", "C", "D"])
-        >>> psidx.holds_integer()
+        >>> psidx.holds_integer()  # doctest: +SKIP
         False
 
         Returns False for float type.
 
         >>> psidx = ps.Index([1.1, 2.2, 3.3, 4.4])
-        >>> psidx.holds_integer()
+        >>> psidx.holds_integer()  # doctest: +SKIP
         False
         """
-        return isinstance(self.spark.data_type, IntegralType)
+        if LooseVersion(pd.__version__) < "3.0.0":
+            return isinstance(self.spark.data_type, IntegralType)
+        else:
+            raise AttributeError(
+                "The `holds_integer` method is not supported in pandas 3.0.0 and later. "
+            )
 
     def intersection(self, other: Union[DataFrame, Series, "Index", List]) -> "Index":
         """

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -2187,7 +2187,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Name: x, dtype: object
         """
         if LooseVersion(pd.__version__) < "3.0.0":
-            if method is not _NoValue:
+            if method is _NoValue:
                 method = None
         else:
             if method is not _NoValue:

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -57,6 +57,7 @@ from pandas.api.types import (
 )
 from pandas.tseries.frequencies import DateOffset  # type: ignore[attr-defined]
 
+from pyspark._globals import _NoValue, _NoValueType
 from pyspark.loose_version import LooseVersion
 from pyspark.sql import (
     functions as F,
@@ -2098,7 +2099,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     def fillna(
         self,
         value: Optional[Any] = None,
-        method: Optional[str] = None,
+        method: Union[Optional[str], _NoValueType] = _NoValue,
         axis: Optional[Axis] = None,
         inplace: bool = False,
         limit: Optional[int] = None,
@@ -2167,7 +2168,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         We can also propagate non-null values forward or backward.
 
-        >>> s.fillna(method='ffill')
+        >>> s.fillna(method='ffill')  # doctest: +SKIP
         0    NaN
         1    2.0
         2    3.0
@@ -2177,7 +2178,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Name: x, dtype: float64
 
         >>> s = ps.Series([np.nan, 'a', 'b', 'c', np.nan], name='x')
-        >>> s.fillna(method='ffill')
+        >>> s.fillna(method='ffill')  # doctest: +SKIP
         0    None
         1       a
         2       b
@@ -2185,6 +2186,28 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         4       c
         Name: x, dtype: object
         """
+        if LooseVersion(pd.__version__) < "3.0.0":
+            if method is not _NoValue:
+                method = None
+        else:
+            if method is not _NoValue:
+                raise TypeError(
+                    "The `method` parameter is not supported in pandas 3.0.0 and later. "
+                )
+            method = None
+
+        return self._fillna_with_method(
+            value=value, method=method, axis=axis, inplace=inplace, limit=limit  # type: ignore[arg-type]
+        )
+
+    def _fillna_with_method(
+        self,
+        value: Optional[Any] = None,
+        method: Optional[str] = None,
+        axis: Optional[Axis] = None,
+        inplace: bool = False,
+        limit: Optional[int] = None,
+    ) -> Optional["Series"]:
         psser = self._fillna(value=value, method=method, axis=axis, limit=limit)
 
         if method is not None:
@@ -2783,7 +2806,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Get the rows for the last 3 days:
 
-        >>> psser.last('3D')
+        >>> psser.last('3D')  # doctest: +SKIP
         2018-04-13    3
         2018-04-15    4
         dtype: int64
@@ -2792,6 +2815,15 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         3 observed days in the dataset, and therefore data for 2018-04-11 was
         not returned.
         """
+        if LooseVersion(pd.__version__) < "3.0.0":
+            return self._last(offset)
+        else:
+            raise AttributeError(
+                "The `last` method is not supported in pandas 3.0.0 and later. "
+                "Please create a mask and filter using `.loc` instead"
+            )
+
+    def _last(self, offset: Union[str, DateOffset]) -> "Series":
         warnings.warn(
             "last is deprecated and will be removed in a future version. "
             "Please create a mask and filter using `.loc` instead",
@@ -2837,7 +2869,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Get the rows for the first 3 days:
 
-        >>> psser.first('3D')
+        >>> psser.first('3D')  # doctest: +SKIP
         2018-04-09    1
         2018-04-11    2
         dtype: int64
@@ -2846,6 +2878,15 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         3 observed days in the dataset, and therefore data for 2018-04-13 was
         not returned.
         """
+        if LooseVersion(pd.__version__) < "3.0.0":
+            return self._first(offset)
+        else:
+            raise AttributeError(
+                "The `first` method is not supported in pandas 3.0.0 and later. "
+                "Please create a mask and filter using `.loc` instead"
+            )
+
+    def _first(self, offset: Union[str, DateOffset]) -> "Series":
         warnings.warn(
             "first is deprecated and will be removed in a future version. "
             "Please create a mask and filter using `.loc` instead",
@@ -3217,12 +3258,21 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         z    3
         dtype: int64
         >>>
-        >>> psser.swapaxes(0, 0)
+        >>> psser.swapaxes(0, 0)  # doctest: +SKIP
         x    1
         y    2
         z    3
         dtype: int64
         """
+        if LooseVersion(pd.__version__) < "3.0.0":
+            return self._swapaxes(i, j, copy)
+        else:
+            raise AttributeError(
+                "The `swapaxes` method is not supported in pandas 3.0.0 and later. "
+                "Please use the `transpose` method instead"
+            )
+
+    def _swapaxes(self, i: Axis, j: Axis, copy: bool = True) -> "Series":
         warnings.warn(
             "'Series.swapaxes' is deprecated and will be removed in a future version. "
             "Please use 'Series.transpose' instead.",
@@ -5121,7 +5171,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             ), "If 'regex' is True then 'to_replace' must be a string"
 
         if to_replace is None:
-            return self.fillna(method="ffill")
+            return self._fillna_with_method(method="ffill")
         if not isinstance(to_replace, (str, list, tuple, dict, int, float)):
             raise TypeError("'to_replace' should be one of str, list, tuple, dict, int, float")
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_fillna.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_fillna.py
@@ -18,6 +18,7 @@
 import pandas as pd
 
 from pyspark import pandas as ps
+from pyspark.loose_version import LooseVersion
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
@@ -47,41 +48,53 @@ class GroupByFillNAMixin:
         psdf = ps.from_pandas(pdf)
         kkey = ps.from_pandas(pkey)
 
-        self.assert_eq(
-            psdf.groupby(kkey).fillna(0).sort_index(), pdf.groupby(pkey).fillna(0).sort_index()
-        )
-        self.assert_eq(
-            psdf.groupby(kkey)["C"].fillna(0).sort_index(),
-            pdf.groupby(pkey)["C"].fillna(0).sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby(kkey)[["C"]].fillna(0).sort_index(),
-            pdf.groupby(pkey)[["C"]].fillna(0).sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby(kkey).fillna(method="bfill").sort_index(),
-            pdf.groupby(pkey).fillna(method="bfill").sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby(kkey)["C"].fillna(method="bfill").sort_index(),
-            pdf.groupby(pkey)["C"].fillna(method="bfill").sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby(kkey)[["C"]].fillna(method="bfill").sort_index(),
-            pdf.groupby(pkey)[["C"]].fillna(method="bfill").sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby(kkey).fillna(method="ffill").sort_index(),
-            pdf.groupby(pkey).fillna(method="ffill").sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby(kkey)["C"].fillna(method="ffill").sort_index(),
-            pdf.groupby(pkey)["C"].fillna(method="ffill").sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby(kkey)[["C"]].fillna(method="ffill").sort_index(),
-            pdf.groupby(pkey)[["C"]].fillna(method="ffill").sort_index(),
-        )
+        if LooseVersion(pd.__version__) < "3.0.0":
+            self.assert_eq(
+                psdf.groupby(kkey).fillna(0).sort_index(), pdf.groupby(pkey).fillna(0).sort_index()
+            )
+            self.assert_eq(
+                psdf.groupby(kkey)["C"].fillna(0).sort_index(),
+                pdf.groupby(pkey)["C"].fillna(0).sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby(kkey)[["C"]].fillna(0).sort_index(),
+                pdf.groupby(pkey)[["C"]].fillna(0).sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby(kkey).fillna(method="bfill").sort_index(),
+                pdf.groupby(pkey).fillna(method="bfill").sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby(kkey)["C"].fillna(method="bfill").sort_index(),
+                pdf.groupby(pkey)["C"].fillna(method="bfill").sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby(kkey)[["C"]].fillna(method="bfill").sort_index(),
+                pdf.groupby(pkey)[["C"]].fillna(method="bfill").sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby(kkey).fillna(method="ffill").sort_index(),
+                pdf.groupby(pkey).fillna(method="ffill").sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby(kkey)["C"].fillna(method="ffill").sort_index(),
+                pdf.groupby(pkey)["C"].fillna(method="ffill").sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby(kkey)[["C"]].fillna(method="ffill").sort_index(),
+                pdf.groupby(pkey)[["C"]].fillna(method="ffill").sort_index(),
+            )
+        else:
+            with self.assertRaises(AttributeError):
+                psdf.groupby(kkey).fillna(0)
+            with self.assertRaises(AttributeError):
+                psdf.groupby(kkey)["C"].fillna(0)
+            with self.assertRaises(AttributeError):
+                psdf.groupby(kkey)[["C"]].fillna(0)
+            with self.assertRaises(AttributeError):
+                psdf.groupby(kkey).fillna(method="bfill")
+            with self.assertRaises(AttributeError):
+                psdf.groupby(kkey)["C"].fillna(method="bfill")
 
 
 class GroupByFillNATests(

--- a/python/pyspark/pandas/tests/groupby/test_missing_data.py
+++ b/python/pyspark/pandas/tests/groupby/test_missing_data.py
@@ -20,6 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
+from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
@@ -36,95 +37,111 @@ class GroupbyMissingDataMixin:
         )
         psdf = ps.from_pandas(pdf)
 
-        self.assert_eq(
-            psdf.groupby("A").fillna(0).sort_index(), pdf.groupby("A").fillna(0).sort_index()
-        )
-        self.assert_eq(
-            psdf.groupby("A")["C"].fillna(0).sort_index(),
-            pdf.groupby("A")["C"].fillna(0).sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby("A")[["C"]].fillna(0).sort_index(),
-            pdf.groupby("A")[["C"]].fillna(0).sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby("A").fillna(method="bfill").sort_index(),
-            pdf.groupby("A").fillna(method="bfill").sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby("A")["C"].fillna(method="bfill").sort_index(),
-            pdf.groupby("A")["C"].fillna(method="bfill").sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby("A")[["C"]].fillna(method="bfill").sort_index(),
-            pdf.groupby("A")[["C"]].fillna(method="bfill").sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby("A").fillna(method="ffill").sort_index(),
-            pdf.groupby("A").fillna(method="ffill").sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby("A")["C"].fillna(method="ffill").sort_index(),
-            pdf.groupby("A")["C"].fillna(method="ffill").sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby("A")[["C"]].fillna(method="ffill").sort_index(),
-            pdf.groupby("A")[["C"]].fillna(method="ffill").sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby(psdf.A // 5).fillna(method="bfill").sort_index(),
-            pdf.groupby(pdf.A // 5).fillna(method="bfill").sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby(psdf.A // 5)["C"].fillna(method="bfill").sort_index(),
-            pdf.groupby(pdf.A // 5)["C"].fillna(method="bfill").sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby(psdf.A // 5)[["C"]].fillna(method="bfill").sort_index(),
-            pdf.groupby(pdf.A // 5)[["C"]].fillna(method="bfill").sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby(psdf.A // 5).fillna(method="ffill").sort_index(),
-            pdf.groupby(pdf.A // 5).fillna(method="ffill").sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby(psdf.A // 5)["C"].fillna(method="ffill").sort_index(),
-            pdf.groupby(pdf.A // 5)["C"].fillna(method="ffill").sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby(psdf.A // 5)[["C"]].fillna(method="ffill").sort_index(),
-            pdf.groupby(pdf.A // 5)[["C"]].fillna(method="ffill").sort_index(),
-        )
-        self.assert_eq(
-            psdf.C.rename().groupby(psdf.A).fillna(0).sort_index(),
-            pdf.C.rename().groupby(pdf.A).fillna(0).sort_index(),
-        )
-        self.assert_eq(
-            psdf.C.groupby(psdf.A.rename()).fillna(0).sort_index(),
-            pdf.C.groupby(pdf.A.rename()).fillna(0).sort_index(),
-        )
-        self.assert_eq(
-            psdf.C.rename().groupby(psdf.A.rename()).fillna(0).sort_index(),
-            pdf.C.rename().groupby(pdf.A.rename()).fillna(0).sort_index(),
-        )
+        if LooseVersion(pd.__version__) < "3.0.0":
+            self.assert_eq(
+                psdf.groupby("A").fillna(0).sort_index(), pdf.groupby("A").fillna(0).sort_index()
+            )
+            self.assert_eq(
+                psdf.groupby("A")["C"].fillna(0).sort_index(),
+                pdf.groupby("A")["C"].fillna(0).sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby("A")[["C"]].fillna(0).sort_index(),
+                pdf.groupby("A")[["C"]].fillna(0).sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby("A").fillna(method="bfill").sort_index(),
+                pdf.groupby("A").fillna(method="bfill").sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby("A")["C"].fillna(method="bfill").sort_index(),
+                pdf.groupby("A")["C"].fillna(method="bfill").sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby("A")[["C"]].fillna(method="bfill").sort_index(),
+                pdf.groupby("A")[["C"]].fillna(method="bfill").sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby("A").fillna(method="ffill").sort_index(),
+                pdf.groupby("A").fillna(method="ffill").sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby("A")["C"].fillna(method="ffill").sort_index(),
+                pdf.groupby("A")["C"].fillna(method="ffill").sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby("A")[["C"]].fillna(method="ffill").sort_index(),
+                pdf.groupby("A")[["C"]].fillna(method="ffill").sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby(psdf.A // 5).fillna(method="bfill").sort_index(),
+                pdf.groupby(pdf.A // 5).fillna(method="bfill").sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby(psdf.A // 5)["C"].fillna(method="bfill").sort_index(),
+                pdf.groupby(pdf.A // 5)["C"].fillna(method="bfill").sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby(psdf.A // 5)[["C"]].fillna(method="bfill").sort_index(),
+                pdf.groupby(pdf.A // 5)[["C"]].fillna(method="bfill").sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby(psdf.A // 5).fillna(method="ffill").sort_index(),
+                pdf.groupby(pdf.A // 5).fillna(method="ffill").sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby(psdf.A // 5)["C"].fillna(method="ffill").sort_index(),
+                pdf.groupby(pdf.A // 5)["C"].fillna(method="ffill").sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby(psdf.A // 5)[["C"]].fillna(method="ffill").sort_index(),
+                pdf.groupby(pdf.A // 5)[["C"]].fillna(method="ffill").sort_index(),
+            )
+            self.assert_eq(
+                psdf.C.rename().groupby(psdf.A).fillna(0).sort_index(),
+                pdf.C.rename().groupby(pdf.A).fillna(0).sort_index(),
+            )
+            self.assert_eq(
+                psdf.C.groupby(psdf.A.rename()).fillna(0).sort_index(),
+                pdf.C.groupby(pdf.A.rename()).fillna(0).sort_index(),
+            )
+            self.assert_eq(
+                psdf.C.rename().groupby(psdf.A.rename()).fillna(0).sort_index(),
+                pdf.C.rename().groupby(pdf.A.rename()).fillna(0).sort_index(),
+            )
+        else:
+            with self.assertRaises(AttributeError):
+                psdf.groupby("A").fillna(0)
+            with self.assertRaises(AttributeError):
+                psdf.groupby("A")["C"].fillna(0)
+            with self.assertRaises(AttributeError):
+                psdf.groupby("A")[["C"]].fillna(0)
+            with self.assertRaises(AttributeError):
+                psdf.groupby("A").fillna(method="bfill")
 
         # multi-index columns
         columns = pd.MultiIndex.from_tuples([("X", "A"), ("X", "B"), ("Y", "C"), ("Z", "D")])
         pdf.columns = columns
         psdf.columns = columns
 
-        self.assert_eq(
-            psdf.groupby(("X", "A")).fillna(0).sort_index(),
-            pdf.groupby(("X", "A")).fillna(0).sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby(("X", "A")).fillna(method="bfill").sort_index(),
-            pdf.groupby(("X", "A")).fillna(method="bfill").sort_index(),
-        )
-        self.assert_eq(
-            psdf.groupby(("X", "A")).fillna(method="ffill").sort_index(),
-            pdf.groupby(("X", "A")).fillna(method="ffill").sort_index(),
-        )
+        if LooseVersion(pd.__version__) < "3.0.0":
+            self.assert_eq(
+                psdf.groupby(("X", "A")).fillna(0).sort_index(),
+                pdf.groupby(("X", "A")).fillna(0).sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby(("X", "A")).fillna(method="bfill").sort_index(),
+                pdf.groupby(("X", "A")).fillna(method="bfill").sort_index(),
+            )
+            self.assert_eq(
+                psdf.groupby(("X", "A")).fillna(method="ffill").sort_index(),
+                pdf.groupby(("X", "A")).fillna(method="ffill").sort_index(),
+            )
+        else:
+            with self.assertRaises(AttributeError):
+                psdf.groupby(("X", "A")).fillna(0)
+            with self.assertRaises(AttributeError):
+                psdf.groupby(("X", "A")).fillna(method="bfill")
 
     def test_ffill(self):
         idx = np.random.rand(4 * 3)

--- a/python/pyspark/pandas/tests/io/test_io.py
+++ b/python/pyspark/pandas/tests/io/test_io.py
@@ -109,8 +109,8 @@ class FrameIOMixin:
 
         def check_style():
             # If the value is negative, the text color will be displayed as red.
-            pdf_style = pdf.style.applymap(style_negative, props="color:red;")
-            psdf_style = psdf.style.applymap(style_negative, props="color:red;")
+            pdf_style = pdf.style.map(style_negative, props="color:red;")
+            psdf_style = psdf.style.map(style_negative, props="color:red;")
 
             # Test whether the same shape as pandas table is created including the color.
             self.assert_eq(pdf_style.to_latex(), psdf_style.to_latex())

--- a/python/pyspark/pandas/tests/series/test_missing_data.py
+++ b/python/pyspark/pandas/tests/series/test_missing_data.py
@@ -19,6 +19,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
+from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
@@ -206,26 +207,34 @@ class SeriesMissingDataMixin:
         psdf = ps.from_pandas(pdf)
         pser, psser = pdf.x, psdf.x
 
-        self.assert_eq(pser.pad(), psser.pad())
+        if LooseVersion(pd.__version__) < "3.0.0":
+            self.assert_eq(pser.pad(), psser.pad())
 
-        # Test `inplace=True`
-        pser.pad(inplace=True)
-        psser.pad(inplace=True)
-        self.assert_eq(pser, psser)
-        self.assert_eq(pdf, psdf)
+            # Test `inplace=True`
+            pser.pad(inplace=True)
+            psser.pad(inplace=True)
+            self.assert_eq(pser, psser)
+            self.assert_eq(pdf, psdf)
+        else:
+            with self.assertRaises(AttributeError):
+                psser.pad()
 
     def test_backfill(self):
         pdf = pd.DataFrame({"x": [np.nan, 2, 3, 4, np.nan, 6]})
         psdf = ps.from_pandas(pdf)
         pser, psser = pdf.x, psdf.x
 
-        self.assert_eq(pser.backfill().sort_index(), psser.backfill().sort_index())
+        if LooseVersion(pd.__version__) < "3.0.0":
+            self.assert_eq(pser.backfill().sort_index(), psser.backfill().sort_index())
 
-        # Test `inplace=True`
-        pser.backfill(inplace=True)
-        psser.backfill(inplace=True)
-        self.assert_eq(pser.sort_index(), psser.sort_index())
-        self.assert_eq(pdf.sort_index(), psdf.sort_index())
+            # Test `inplace=True`
+            pser.backfill(inplace=True)
+            psser.backfill(inplace=True)
+            self.assert_eq(pser.sort_index(), psser.sort_index())
+            self.assert_eq(pdf.sort_index(), psdf.sort_index())
+        else:
+            with self.assertRaises(AttributeError):
+                psser.backfill()
 
 
 class SeriesMissingDataTests(

--- a/python/pyspark/pandas/tests/series/test_missing_data.py
+++ b/python/pyspark/pandas/tests/series/test_missing_data.py
@@ -59,15 +59,19 @@ class SeriesMissingDataMixin:
         pser.loc[3] = np.nan
         psser.loc[3] = np.nan
 
-        self.assert_eq(psser.fillna(0), pser.fillna(0))
-        self.assert_eq(psser.fillna(method="ffill"), pser.fillna(method="ffill"))
-        self.assert_eq(
-            psser.fillna(method="bfill").sort_index(), pser.fillna(method="bfill").sort_index()
-        )
-        self.assert_eq(
-            psser.fillna(method="backfill").sort_index(),
-            pser.fillna(method="backfill").sort_index(),
-        )
+        if LooseVersion(pd.__version__) < "3.0.0":
+            self.assert_eq(psser.fillna(0), pser.fillna(0))
+            self.assert_eq(psser.fillna(method="ffill"), pser.fillna(method="ffill"))
+            self.assert_eq(
+                psser.fillna(method="bfill").sort_index(), pser.fillna(method="bfill").sort_index()
+            )
+            self.assert_eq(
+                psser.fillna(method="backfill").sort_index(),
+                pser.fillna(method="backfill").sort_index(),
+            )
+        else:
+            with self.assertRaises(TypeError):
+                psser.fillna(method="ffill")
 
         # inplace fillna on non-nullable column
         pdf = pd.DataFrame({"a": [1, 2, None], "b": [1, 2, 3]})

--- a/python/pyspark/pandas/tests/series/test_series.py
+++ b/python/pyspark/pandas/tests/series/test_series.py
@@ -25,6 +25,7 @@ import pandas as pd
 from pyspark.ml.linalg import SparseVector
 
 from pyspark import pandas as ps
+from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import (
     PandasOnSparkTestCase,
     SPARK_CONF_ARROW_ENABLED,
@@ -148,22 +149,36 @@ class SeriesTestsMixin:
         self.assert_eq(psser.head(-10), pser.head(-10))
 
     def test_last(self):
-        with self.assertRaises(TypeError):
-            self.psser.last("1D")
-
         index = pd.date_range("2018-04-09", periods=4, freq="2D")
         pser = pd.Series([1, 2, 3, 4], index=index)
         psser = ps.from_pandas(pser)
-        self.assert_eq(psser.last("1D"), pser.last("1D"))
+
+        if LooseVersion(pd.__version__) < "3.0.0":
+            self.assert_eq(psser.last("1D"), pser.last("1D"))
+
+            with self.assertRaises(TypeError):
+                self.psser.last("1D")
+        else:
+            with self.assertRaises(AttributeError):
+                psser.last("1D")
+            with self.assertRaises(AttributeError):
+                self.psser.last("1D")
 
     def test_first(self):
-        with self.assertRaises(TypeError):
-            self.psser.first("1D")
-
         index = pd.date_range("2018-04-09", periods=4, freq="2D")
         pser = pd.Series([1, 2, 3, 4], index=index)
         psser = ps.from_pandas(pser)
-        self.assert_eq(psser.first("1D"), pser.first("1D"))
+
+        if LooseVersion(pd.__version__) < "3.0.0":
+            self.assert_eq(psser.first("1D"), pser.first("1D"))
+
+            with self.assertRaises(TypeError):
+                self.psser.first("1D")
+        else:
+            with self.assertRaises(AttributeError):
+                psser.first("1D")
+            with self.assertRaises(AttributeError):
+                self.psser.first("1D")
 
     def test_rename(self):
         pser = pd.Series([1, 2, 3, 4, 5, 6, 7], name="x")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Raises `AttributeError` from methods removed in pandas 3.

- `DataFrame`/`Series`: `backfill`, `pad`, `first`, `last`, `swapaxes`
- `GroupBy`: `fillna`
- `Index`: `hold_integer`

### Why are the changes needed?

There are some methods removed in pandas 3, which should raise `AttributeError` in pandas API on Spark, too.

### Does this PR introduce _any_ user-facing change?

Yes, the methods removed in pandas 3 will raise `AttributeError` with pandas 3.

### How was this patch tested?

Updated the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
