### PR TITLE
[SPARK-55475][BUILD] Disable Maven Parallel PUT

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,2 @@
 -Dnisse.compat.osDetector
+-Daether.connector.basic.parallelPut=false


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to disable Maven Parallel PUT explicitly.

### Why are the changes needed?

ASF Infra team recommended to disable Maven parallel PUT due to [Parallel PUT problem in repository.apache.org with Apache Maven 3.9.12](https://infra.apache.org/blog/parallelputissue.html).

- https://github.com/apache/maven/issues/11634

Since we are using Maven 3.9.12, we might be affected although we didn't hit the issue yet during `4.2.0-preview2`.
- https://github.com/apache/spark/pull/53610

Although there are multiple ways to do this, I choose `Option (3)` from the ASF recommendation because it's easy to guarantee.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manually do the following.

```
$ mvn help:system | grep -E "nisse.compat.osDetector|aether.connector.basic.parallelPut"
nisse.compat.osDetector=true
aether.connector.basic.parallelPut=false
```

### Was this patch authored or co-authored using generative AI tooling?

No.