### PR TITLE
Add tests for supported compression types in RocksDB.

### DIFF
--- a/docs/streaming/apis-on-dataframes-and-datasets.md
+++ b/docs/streaming/apis-on-dataframes-and-datasets.md
@@ -1899,7 +1899,7 @@ Here are the configs regarding to RocksDB instance of the state store provider:
   </tr>
   <tr>
     <td>spark.sql.streaming.stateStore.rocksdb.compression</td>
-    <td>Compression type used in RocksDB. The string is converted RocksDB compression type through RocksDB Java API getCompressionType(). </td>
+    <td>Compression type used in RocksDB. The string is converted RocksDB compression type through RocksDB Java API getCompressionType(). Supported values: "bzip2", "lz4", "lz4hc", "snappy", "z", "zstd".</td>
     <td>lz4</td>
   </tr>
 </table>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -1429,6 +1429,56 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
     }
   }
 
+  test("RocksDB: all compression types") {
+    val remoteDir = Utils.createTempDir().toString
+    new File(remoteDir).delete()
+
+    // Empty string falls back to no compression.
+    var conf = RocksDBConf().copy(compression = "")
+    withDB(remoteDir, conf = conf) { db =>
+      assert(db.rocksDbOptions.compressionType() == CompressionType.NO_COMPRESSION)
+    }
+
+    // Unknown config falls back to no compression.
+    conf = RocksDBConf().copy(compression = "foobar")
+    withDB(remoteDir, conf = conf) { db =>
+      assert(db.rocksDbOptions.compressionType() == CompressionType.NO_COMPRESSION)
+    }
+
+    // All 6 possible compression types are supported.
+    conf = RocksDBConf().copy(compression = "snappy")
+    withDB(remoteDir, conf = conf) { db =>
+      assert(db.rocksDbOptions.compressionType() == CompressionType.SNAPPY_COMPRESSION)
+    }
+
+    conf = RocksDBConf().copy(compression = "z")
+    withDB(remoteDir, conf = conf) { db =>
+      assert(db.rocksDbOptions.compressionType() == CompressionType.ZLIB_COMPRESSION)
+    }
+
+    conf = RocksDBConf().copy(compression = "bzip2")
+    withDB(remoteDir, conf = conf) { db =>
+      assert(db.rocksDbOptions.compressionType() == CompressionType.BZLIB2_COMPRESSION)
+    }
+
+    conf = RocksDBConf().copy(compression = "lz4")
+    withDB(remoteDir, conf = conf) { db =>
+      assert(db.rocksDbOptions.compressionType() == CompressionType.LZ4_COMPRESSION)
+    }
+
+    conf = RocksDBConf().copy(compression = "lz4hc")
+    withDB(remoteDir, conf = conf) { db =>
+      assert(db.rocksDbOptions.compressionType() == CompressionType.LZ4HC_COMPRESSION)
+    }
+
+    conf = RocksDBConf().copy(compression = "zstd")
+    withDB(remoteDir, conf = conf) { db =>
+      assert(db.rocksDbOptions.compressionType() == CompressionType.ZSTD_COMPRESSION)
+    }
+
+    // "xpress" is not supported.
+  }
+
   testWithColumnFamilies(
     "RocksDB: test includesPrefix parameter during changelog replay",
     TestWithChangelogCheckpointingEnabled) { colFamiliesEnabled =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

* Add a test that verifies that 6 compression types for RocksDB are supported.
* Document these 6 compression types in documentation.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We allow setting "spark.sql.streaming.stateStore.rocksdb.compression" config that specifies what compression types RocksDB will use (when using stateful operators). However, we don't explicitly list what types are supported and we don't have a unit test to require that these types are supported. 

In this PR we explicitly list 6 supported formats and add unit test to guarantee these are supported.

This will prevent changes that can break support for some of these compression types.

Note that one compression type, "xpress" is not supported. Trying to set it in config leads to an error:  `Compression type Xpress is not linked with the binary`. So we will not add a test for it and will not declare it as supported in documentation.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

A unit test for supported compression types.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.
