### PR TITLE
[SPARK-55477] Add SequentialUnionManager for managing sequential source processing

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/SequentialUnionManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/SequentialUnionManager.scala
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.plans.logical.SequentialStreamingUnion
+import org.apache.spark.sql.connector.read.streaming.{SparkDataStream, SupportsTriggerAvailableNow}
+import org.apache.spark.sql.execution.streaming.checkpointing.SequentialUnionOffset
+
+/**
+ * Manages the state and lifecycle of a SequentialStreamingUnion during streaming execution.
+ *
+ * This manager tracks:
+ * - Which source is currently active
+ * - Which sources have been completed
+ * - Transitions between sources
+ * - Just-in-time preparation of sources with AvailableNow semantics
+ *
+ * Execution model (sequential child consumption):
+ * {{{
+ * while (cur_child < num_children - 1):
+ *   prepare(cur_child)              # Just-in-time AvailableNow preparation
+ *   while (child_has_data):         # Inner drain loop
+ *     process_batch()
+ *   record_completion()             # Atomically record in offset log
+ *   cur_child++                     # Move to next source
+ * }}}
+ *
+ * @param sequentialUnion The logical plan node for the sequential union
+ * @param sourceNames     Ordered list of source names (must match children order)
+ * @param sourceMap       Mapping from source name to SparkDataStream instance
+ */
+class SequentialUnionManager(
+    sequentialUnion: SequentialStreamingUnion,
+    sourceNames: Seq[String],
+    sourceMap: Map[String, SparkDataStream]) extends Logging {
+
+  // Validate inputs
+  require(sourceNames.nonEmpty, "sourceNames must not be empty")
+  require(sourceNames.size >= 2, "SequentialStreamingUnion requires at least 2 sources")
+  require(sourceNames.size == sequentialUnion.children.size,
+    s"Number of source names (${sourceNames.size}) must match number of children " +
+      s"(${sequentialUnion.children.size})")
+  require(sourceNames.forall(sourceMap.contains),
+    s"All source names must have corresponding entries in sourceMap. " +
+      s"Missing: ${sourceNames.filterNot(sourceMap.contains).mkString(", ")}")
+
+  // Mutable state tracking
+  private var _activeSourceIndex: Int = 0
+  private var _completedSources: Set[String] = Set.empty
+
+  /**
+   * Get the name of the currently active source.
+   */
+  def activeSourceName: String = sourceNames(_activeSourceIndex)
+
+  /**
+   * Get the SparkDataStream instance for the currently active source.
+   */
+  def activeSource: SparkDataStream = sourceMap(activeSourceName)
+
+  /**
+   * Check if we're currently on the final source.
+   * The final source is special - it runs with the user's trigger, not AvailableNow.
+   */
+  def isOnFinalSource: Boolean = _activeSourceIndex == sourceNames.length - 1
+
+  /**
+   * Get the set of all completed source names.
+   */
+  def completedSources: Set[String] = _completedSources
+
+  /**
+   * Check if a specific source is currently active.
+   */
+  def isSourceActive(name: String): Boolean = name == activeSourceName
+
+  /**
+   * Check if a specific source has been completed.
+   */
+  def isSourceCompleted(name: String): Boolean = _completedSources.contains(name)
+
+  /**
+   * Get the index of the currently active source.
+   */
+  def activeSourceIndex: Int = _activeSourceIndex
+
+  /**
+   * Prepare the current active source with AvailableNow semantics.
+   * Called just-in-time before draining each non-final source.
+   *
+   * Just-in-time preparation (vs preparing all upfront):
+   * - Each source gets freshest bound point at the time it starts
+   * - Simpler recovery - don't need to track which sources were prepared
+   * - Natural flow: prepare -> drain -> transition -> prepare next -> drain -> ...
+   *
+   * How AvailableNow bounding works (source-specific internals):
+   * - FileStreamSource: pre-fetches file list, subsequent `latestOffset()` uses bounded list
+   * - CloudFiles (AutoLoader): sets `triggerAvailableNow=true` and records trigger time,
+   *   async producers discover files up to that timestamp, then signal completion via
+   *   `areAllProducersCompleted` / `setAndWaitAllConsumersCompleted()`
+   * - Delta: bounds to a specific table version
+   * - Kafka: bounds to specific partition offsets
+   *
+   * All sources eventually manifest completion as `latestOffset == startOffset`
+   * (no new data), which is how the execution layer detects exhaustion.
+   */
+  def prepareActiveSourceForAvailableNow(): Unit = {
+    require(!isOnFinalSource, "Final source should not use AvailableNow preparation")
+
+    val source = activeSource
+    source match {
+      case s: SupportsTriggerAvailableNow =>
+        logInfo(s"Preparing source '$activeSourceName' for AvailableNow draining " +
+          s"(index: ${_activeSourceIndex})")
+        s.prepareForTriggerAvailableNow()
+      case _ =>
+        // For sources that don't support SupportsTriggerAvailableNow, they should be wrapped
+        // with AvailableNowSourceWrapper or AvailableNowMicroBatchStreamWrapper by the caller
+        logWarning(s"Source '$activeSourceName' does not implement SupportsTriggerAvailableNow. " +
+          s"It should be wrapped with an AvailableNow wrapper before being passed to " +
+          s"SequentialUnionManager.")
+    }
+
+    logInfo(s"Source '$activeSourceName' prepared for AvailableNow draining")
+  }
+
+  /**
+   * Mark current source as complete and advance to next.
+   * Returns the new SequentialUnionOffset representing the updated state.
+   *
+   * IMPORTANT: This should only be called after the current source has been exhausted
+   * (latestOffset == startOffset, meaning no new data).
+   */
+  def transitionToNextSource(): SequentialUnionOffset = {
+    require(!isOnFinalSource, "Cannot transition past final source")
+
+    val completedName = activeSourceName
+    _completedSources = _completedSources + completedName
+    _activeSourceIndex += 1
+
+    logInfo(s"Sequential union transitioning from '$completedName' to '$activeSourceName' " +
+      s"(completed sources: ${_completedSources.mkString(", ")})")
+
+    currentOffset
+  }
+
+  /**
+   * Get current offset representing sequential union state.
+   * This offset will be persisted in the offset log alongside individual source offsets.
+   */
+  def currentOffset: SequentialUnionOffset = {
+    SequentialUnionOffset(
+      activeSourceName = activeSourceName,
+      allSourceNames = sourceNames,
+      completedSourceNames = _completedSources
+    )
+  }
+
+  /**
+   * Restore state from a previously persisted offset.
+   * Called on query restart to resume from the correct point.
+   *
+   * Recovery follows AvailableNow semantics:
+   * - If we crash during a source's processing, we re-prepare that source and continue draining
+   * - Completed sources are skipped (they won't be re-prepared or re-processed)
+   * - The active source at the time of the checkpoint becomes the active source on restart
+   */
+  def restoreFromOffset(offset: SequentialUnionOffset): Unit = {
+    // Validate that the offset is compatible with current sources
+    require(offset.allSourceNames == sourceNames,
+      s"Source names in offset (${offset.allSourceNames.mkString(", ")}) do not match " +
+        s"current source names (${sourceNames.mkString(", ")}). Cannot restore.")
+
+    _activeSourceIndex = sourceNames.indexOf(offset.activeSourceName)
+    require(_activeSourceIndex >= 0,
+      s"Active source '${offset.activeSourceName}' from offset not found in current sources")
+
+    _completedSources = offset.completedSourceNames
+
+    logInfo(s"Restored sequential union state from checkpoint: " +
+      s"active='${offset.activeSourceName}' (index: ${_activeSourceIndex}), " +
+      s"completed=${_completedSources.mkString(", ")}")
+  }
+
+  /**
+   * Get the initial offset for a new query (no checkpoint).
+   * Starts with the first source as active and no completed sources.
+   */
+  def initialOffset: SequentialUnionOffset = {
+    SequentialUnionOffset(
+      activeSourceName = sourceNames.head,
+      allSourceNames = sourceNames,
+      completedSourceNames = Set.empty
+    )
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/SequentialUnionManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/SequentialUnionManagerSuite.scala
@@ -1,0 +1,428 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming
+
+import org.mockito.Mockito._
+import org.scalatestplus.mockito.MockitoSugar
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, SequentialStreamingUnion}
+import org.apache.spark.sql.connector.read.streaming.{SparkDataStream, SupportsTriggerAvailableNow}
+import org.apache.spark.sql.execution.streaming.checkpointing.SequentialUnionOffset
+import org.apache.spark.sql.types.IntegerType
+
+/**
+ * Test suite for [[SequentialUnionManager]], which manages the lifecycle and state
+ * transitions of sequential source processing in streaming queries.
+ */
+class SequentialUnionManagerSuite extends SparkFunSuite with MockitoSugar {
+
+  /**
+   * Helper to create a mock SparkDataStream with SupportsTriggerAvailableNow.
+   */
+  private def createMockSource(name: String): SparkDataStream with SupportsTriggerAvailableNow = {
+    val source = mock[SparkDataStream with SupportsTriggerAvailableNow]
+    when(source.toString).thenReturn(name)
+    source
+  }
+
+  /**
+   * Helper to create a SequentialStreamingUnion with the specified number of children.
+   */
+  private def createSequentialUnion(numChildren: Int): SequentialStreamingUnion = {
+    val children = (1 to numChildren).map { i =>
+      LocalRelation(Seq(AttributeReference("id", IntegerType)()), isStreaming = true)
+    }
+    SequentialStreamingUnion(children, byName = false, allowMissingCol = false)
+  }
+
+  test("SequentialUnionManager - initialization with valid inputs") {
+    val sourceNames = Seq("source1", "source2", "source3")
+    val sources = sourceNames.map(createMockSource)
+    val sourceMap = sourceNames.zip(sources).toMap
+    val sequentialUnion = createSequentialUnion(3)
+
+    val manager = new SequentialUnionManager(sequentialUnion, sourceNames, sourceMap)
+
+    assert(manager.activeSourceName === "source1")
+    assert(manager.activeSourceIndex === 0)
+    assert(manager.completedSources.isEmpty)
+    assert(!manager.isOnFinalSource)
+  }
+
+  test("SequentialUnionManager - activeSource returns correct source") {
+    val sourceNames = Seq("delta-historical", "kafka-live")
+    val sources = sourceNames.map(createMockSource)
+    val sourceMap = sourceNames.zip(sources).toMap
+    val sequentialUnion = createSequentialUnion(2)
+
+    val manager = new SequentialUnionManager(sequentialUnion, sourceNames, sourceMap)
+
+    assert(manager.activeSource === sources.head)
+    assert(manager.activeSourceName === "delta-historical")
+  }
+
+  test("SequentialUnionManager - isOnFinalSource detection") {
+    val sourceNames = Seq("source1", "source2", "source3")
+    val sources = sourceNames.map(createMockSource)
+    val sourceMap = sourceNames.zip(sources).toMap
+    val sequentialUnion = createSequentialUnion(3)
+
+    val manager = new SequentialUnionManager(sequentialUnion, sourceNames, sourceMap)
+
+    assert(!manager.isOnFinalSource) // First source
+
+    // Transition to second source
+    manager.transitionToNextSource()
+    assert(!manager.isOnFinalSource) // Second source
+
+    // Transition to final source
+    manager.transitionToNextSource()
+    assert(manager.isOnFinalSource) // Final source
+  }
+
+  test("SequentialUnionManager - transitionToNextSource updates state") {
+    val sourceNames = Seq("source1", "source2", "source3")
+    val sources = sourceNames.map(createMockSource)
+    val sourceMap = sourceNames.zip(sources).toMap
+    val sequentialUnion = createSequentialUnion(3)
+
+    val manager = new SequentialUnionManager(sequentialUnion, sourceNames, sourceMap)
+
+    assert(manager.activeSourceName === "source1")
+    assert(manager.completedSources.isEmpty)
+
+    // Transition to source2
+    val offset1 = manager.transitionToNextSource()
+    assert(manager.activeSourceName === "source2")
+    assert(manager.completedSources === Set("source1"))
+    assert(offset1.activeSourceName === "source2")
+    assert(offset1.completedSourceNames === Set("source1"))
+
+    // Transition to source3
+    val offset2 = manager.transitionToNextSource()
+    assert(manager.activeSourceName === "source3")
+    assert(manager.completedSources === Set("source1", "source2"))
+    assert(offset2.activeSourceName === "source3")
+    assert(offset2.completedSourceNames === Set("source1", "source2"))
+  }
+
+  test("SequentialUnionManager - transitionToNextSource fails on final source") {
+    val sourceNames = Seq("source1", "source2")
+    val sources = sourceNames.map(createMockSource)
+    val sourceMap = sourceNames.zip(sources).toMap
+    val sequentialUnion = createSequentialUnion(2)
+
+    val manager = new SequentialUnionManager(sequentialUnion, sourceNames, sourceMap)
+
+    // Transition to final source
+    manager.transitionToNextSource()
+    assert(manager.isOnFinalSource)
+
+    // Should fail when trying to transition past final source
+    val ex = intercept[IllegalArgumentException] {
+      manager.transitionToNextSource()
+    }
+    assert(ex.getMessage.contains("Cannot transition past final source"))
+  }
+
+  test("SequentialUnionManager - currentOffset reflects state") {
+    val sourceNames = Seq("source1", "source2", "source3")
+    val sources = sourceNames.map(createMockSource)
+    val sourceMap = sourceNames.zip(sources).toMap
+    val sequentialUnion = createSequentialUnion(3)
+
+    val manager = new SequentialUnionManager(sequentialUnion, sourceNames, sourceMap)
+
+    val offset = manager.currentOffset
+    assert(offset.activeSourceName === "source1")
+    assert(offset.allSourceNames === sourceNames)
+    assert(offset.completedSourceNames.isEmpty)
+
+    // After transition
+    manager.transitionToNextSource()
+    val offset2 = manager.currentOffset
+    assert(offset2.activeSourceName === "source2")
+    assert(offset2.completedSourceNames === Set("source1"))
+  }
+
+  test("SequentialUnionManager - initialOffset creates correct state") {
+    val sourceNames = Seq("source1", "source2")
+    val sources = sourceNames.map(createMockSource)
+    val sourceMap = sourceNames.zip(sources).toMap
+    val sequentialUnion = createSequentialUnion(2)
+
+    val manager = new SequentialUnionManager(sequentialUnion, sourceNames, sourceMap)
+
+    val initialOffset = manager.initialOffset
+    assert(initialOffset.activeSourceName === "source1")
+    assert(initialOffset.allSourceNames === sourceNames)
+    assert(initialOffset.completedSourceNames.isEmpty)
+  }
+
+  test("SequentialUnionManager - restoreFromOffset with valid offset") {
+    val sourceNames = Seq("source1", "source2", "source3")
+    val sources = sourceNames.map(createMockSource)
+    val sourceMap = sourceNames.zip(sources).toMap
+    val sequentialUnion = createSequentialUnion(3)
+
+    val manager = new SequentialUnionManager(sequentialUnion, sourceNames, sourceMap)
+
+    // Create offset representing middle state
+    val offset = SequentialUnionOffset(
+      activeSourceName = "source2",
+      allSourceNames = sourceNames,
+      completedSourceNames = Set("source1")
+    )
+
+    manager.restoreFromOffset(offset)
+
+    assert(manager.activeSourceName === "source2")
+    assert(manager.activeSourceIndex === 1)
+    assert(manager.completedSources === Set("source1"))
+  }
+
+  test("SequentialUnionManager - restoreFromOffset with final source") {
+    val sourceNames = Seq("source1", "source2", "source3")
+    val sources = sourceNames.map(createMockSource)
+    val sourceMap = sourceNames.zip(sources).toMap
+    val sequentialUnion = createSequentialUnion(3)
+
+    val manager = new SequentialUnionManager(sequentialUnion, sourceNames, sourceMap)
+
+    // Create offset representing final source state
+    val offset = SequentialUnionOffset(
+      activeSourceName = "source3",
+      allSourceNames = sourceNames,
+      completedSourceNames = Set("source1", "source2")
+    )
+
+    manager.restoreFromOffset(offset)
+
+    assert(manager.activeSourceName === "source3")
+    assert(manager.activeSourceIndex === 2)
+    assert(manager.isOnFinalSource)
+    assert(manager.completedSources === Set("source1", "source2"))
+  }
+
+  test("SequentialUnionManager - restoreFromOffset fails with mismatched source names") {
+    val sourceNames = Seq("source1", "source2", "source3")
+    val sources = sourceNames.map(createMockSource)
+    val sourceMap = sourceNames.zip(sources).toMap
+    val sequentialUnion = createSequentialUnion(3)
+
+    val manager = new SequentialUnionManager(sequentialUnion, sourceNames, sourceMap)
+
+    // Offset with different source names
+    val offset = SequentialUnionOffset(
+      activeSourceName = "different2",
+      allSourceNames = Seq("different1", "different2", "different3"),
+      completedSourceNames = Set("different1")
+    )
+
+    val ex = intercept[IllegalArgumentException] {
+      manager.restoreFromOffset(offset)
+    }
+    assert(ex.getMessage.contains("Source names in offset"))
+    assert(ex.getMessage.contains("do not match"))
+  }
+
+  test("SequentialUnionManager - restoreFromOffset validates offset activeSource") {
+    val sourceNames = Seq("source1", "source2", "source3")
+    val sources = sourceNames.map(createMockSource)
+    val sourceMap = sourceNames.zip(sources).toMap
+    val sequentialUnion = createSequentialUnion(3)
+
+    val manager = new SequentialUnionManager(sequentialUnion, sourceNames, sourceMap)
+
+    // Note: SequentialUnionOffset validates activeSource in its constructor,
+    // so we can't create an invalid offset. This test confirms that behavior.
+    val ex = intercept[IllegalArgumentException] {
+      SequentialUnionOffset(
+        activeSourceName = "nonexistent",
+        allSourceNames = sourceNames,
+        completedSourceNames = Set.empty
+      )
+    }
+    assert(ex.getMessage.contains("activeSourceName"))
+    assert(ex.getMessage.contains("must be in allSourceNames"))
+  }
+
+  test("SequentialUnionManager - isSourceActive checks") {
+    val sourceNames = Seq("source1", "source2", "source3")
+    val sources = sourceNames.map(createMockSource)
+    val sourceMap = sourceNames.zip(sources).toMap
+    val sequentialUnion = createSequentialUnion(3)
+
+    val manager = new SequentialUnionManager(sequentialUnion, sourceNames, sourceMap)
+
+    assert(manager.isSourceActive("source1"))
+    assert(!manager.isSourceActive("source2"))
+    assert(!manager.isSourceActive("source3"))
+
+    manager.transitionToNextSource()
+
+    assert(!manager.isSourceActive("source1"))
+    assert(manager.isSourceActive("source2"))
+    assert(!manager.isSourceActive("source3"))
+  }
+
+  test("SequentialUnionManager - isSourceCompleted checks") {
+    val sourceNames = Seq("source1", "source2", "source3")
+    val sources = sourceNames.map(createMockSource)
+    val sourceMap = sourceNames.zip(sources).toMap
+    val sequentialUnion = createSequentialUnion(3)
+
+    val manager = new SequentialUnionManager(sequentialUnion, sourceNames, sourceMap)
+
+    assert(!manager.isSourceCompleted("source1"))
+    assert(!manager.isSourceCompleted("source2"))
+    assert(!manager.isSourceCompleted("source3"))
+
+    manager.transitionToNextSource()
+
+    assert(manager.isSourceCompleted("source1"))
+    assert(!manager.isSourceCompleted("source2"))
+    assert(!manager.isSourceCompleted("source3"))
+
+    manager.transitionToNextSource()
+
+    assert(manager.isSourceCompleted("source1"))
+    assert(manager.isSourceCompleted("source2"))
+    assert(!manager.isSourceCompleted("source3"))
+  }
+
+  test("SequentialUnionManager - prepareActiveSourceForAvailableNow calls source") {
+    val sourceNames = Seq("source1", "source2")
+    val sources = sourceNames.map(createMockSource)
+    val sourceMap = sourceNames.zip(sources).toMap
+    val sequentialUnion = createSequentialUnion(2)
+
+    val manager = new SequentialUnionManager(sequentialUnion, sourceNames, sourceMap)
+
+    // Prepare first source
+    manager.prepareActiveSourceForAvailableNow()
+    verify(sources(0), times(1)).prepareForTriggerAvailableNow()
+
+    // Transition and prepare second source
+    manager.transitionToNextSource()
+
+    // Should fail on final source
+    val ex = intercept[IllegalArgumentException] {
+      manager.prepareActiveSourceForAvailableNow()
+    }
+    assert(ex.getMessage.contains("Final source should not use AvailableNow preparation"))
+  }
+
+  test("SequentialUnionManager - validation: empty sourceNames") {
+    val ex = intercept[IllegalArgumentException] {
+      new SequentialUnionManager(
+        createSequentialUnion(0),
+        Seq.empty,
+        Map.empty
+      )
+    }
+    assert(ex.getMessage.contains("sourceNames must not be empty"))
+  }
+
+  test("SequentialUnionManager - validation: minimum 2 sources required") {
+    val ex = intercept[IllegalArgumentException] {
+      val source = createMockSource("source1")
+      new SequentialUnionManager(
+        createSequentialUnion(1),
+        Seq("source1"),
+        Map("source1" -> source)
+      )
+    }
+    assert(ex.getMessage.contains("requires at least 2 sources"))
+  }
+
+  test("SequentialUnionManager - validation: sourceNames count mismatch") {
+    val sourceNames = Seq("source1", "source2")
+    val sources = sourceNames.map(createMockSource)
+    val sourceMap = sourceNames.zip(sources).toMap
+
+    val ex = intercept[IllegalArgumentException] {
+      new SequentialUnionManager(
+        createSequentialUnion(3), // 3 children
+        sourceNames,               // 2 names
+        sourceMap
+      )
+    }
+    assert(ex.getMessage.contains("Number of source names"))
+    assert(ex.getMessage.contains("must match number of children"))
+  }
+
+  test("SequentialUnionManager - validation: missing source in map") {
+    val sourceNames = Seq("source1", "source2", "source3")
+    val sources = sourceNames.take(2).map(createMockSource)
+    val sourceMap = sourceNames.take(2).zip(sources).toMap // Missing source3
+
+    val ex = intercept[IllegalArgumentException] {
+      new SequentialUnionManager(
+        createSequentialUnion(3),
+        sourceNames,
+        sourceMap
+      )
+    }
+    assert(ex.getMessage.contains("All source names must have corresponding entries"))
+    assert(ex.getMessage.contains("Missing"))
+  }
+
+  test("SequentialUnionManager - multiple sources lifecycle") {
+    val sourceNames = Seq("delta-2023", "delta-2024", "delta-2025", "kafka-live")
+    val sources = sourceNames.map(createMockSource)
+    val sourceMap = sourceNames.zip(sources).toMap
+    val sequentialUnion = createSequentialUnion(4)
+
+    val manager = new SequentialUnionManager(sequentialUnion, sourceNames, sourceMap)
+
+    // Initial state
+    assert(manager.activeSourceName === "delta-2023")
+    assert(manager.completedSources.isEmpty)
+    assert(!manager.isOnFinalSource)
+
+    // Transition through all sources
+    manager.prepareActiveSourceForAvailableNow()
+    verify(sources(0), times(1)).prepareForTriggerAvailableNow()
+    manager.transitionToNextSource()
+
+    assert(manager.activeSourceName === "delta-2024")
+    assert(manager.completedSources === Set("delta-2023"))
+    manager.prepareActiveSourceForAvailableNow()
+    verify(sources(1), times(1)).prepareForTriggerAvailableNow()
+    manager.transitionToNextSource()
+
+    assert(manager.activeSourceName === "delta-2025")
+    assert(manager.completedSources === Set("delta-2023", "delta-2024"))
+    manager.prepareActiveSourceForAvailableNow()
+    verify(sources(2), times(1)).prepareForTriggerAvailableNow()
+    manager.transitionToNextSource()
+
+    // Final source
+    assert(manager.activeSourceName === "kafka-live")
+    assert(manager.completedSources === Set("delta-2023", "delta-2024", "delta-2025"))
+    assert(manager.isOnFinalSource)
+
+    // Final source should not be prepared with AvailableNow
+    intercept[IllegalArgumentException] {
+      manager.prepareActiveSourceForAvailableNow()
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This adds SequentialUnionManager, which manages state and lifecycle for SequentialStreamingUnion nodes during streaming execution. The manager:

- Tracks which source is currently active in a sequential union
- Manages transitions between sources when exhaustion is detected
- Handles just-in-time preparation of sources with AvailableNow semantics
- Provides serializable offset representation for checkpoint recovery


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This component manages source activation for Sequential Union

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No