### PR TITLE
[SPARK-55484][K8S] Simplify `KubernetesClusterSchedulerBackend` by reducing private class variables

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -55,7 +55,6 @@ private[spark] class KubernetesClusterSchedulerBackend(
     watchEvents: ExecutorPodsWatchSnapshotSource,
     pollEvents: ExecutorPodsPollingSnapshotSource)
     extends CoarseGrainedSchedulerBackend(scheduler, sc.env.rpcEnv) {
-  private val appId = KubernetesConf.getKubernetesAppId()
 
   protected override val minRegisteredRatio =
     if (conf.get(SCHEDULER_MIN_REGISTERED_RESOURCES_RATIO).isEmpty) {
@@ -66,11 +65,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
 
   private val initialExecutors = SchedulerBackendUtils.getInitialTargetExecutorNumber(conf)
 
-  private val shouldDeleteDriverService = conf.get(KUBERNETES_DRIVER_SERVICE_DELETE_ON_TERMINATION)
-
-  private val shouldDeleteExecutors = conf.get(KUBERNETES_DELETE_EXECUTORS)
-
-  private val defaultProfile = scheduler.sc.resourceProfileManager.defaultResourceProfile
+  private val minRegisteredExecutors = initialExecutors * minRegisteredRatio
 
   private val namespace = conf.get(KUBERNETES_NAMESPACE)
 
@@ -107,13 +102,14 @@ private[spark] class KubernetesClusterSchedulerBackend(
    * @return The application ID
    */
   override def applicationId(): String = {
-    conf.getOption("spark.app.id").getOrElse(appId)
+    conf.getOption("spark.app.id").getOrElse(KubernetesConf.getKubernetesAppId())
   }
 
   override def start(): Unit = {
     super.start()
     // Must be called before setting the executors
     podAllocator.start(applicationId(), this)
+    val defaultProfile = scheduler.sc.resourceProfileManager.defaultResourceProfile
     val initExecs = Map(defaultProfile -> initialExecutors)
     podAllocator.setTotalExpectedExecutors(initExecs)
     lifecycleManager.start(this)
@@ -143,7 +139,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
       pollEvents.stop()
     }
 
-    if (shouldDeleteDriverService) {
+    if (conf.get(KUBERNETES_DRIVER_SERVICE_DELETE_ON_TERMINATION)) {
       Utils.tryLogNonFatalError {
         kubernetesClient
           .services()
@@ -163,7 +159,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
       }
     }
 
-    if (shouldDeleteExecutors) {
+    if (conf.get(KUBERNETES_DELETE_EXECUTORS)) {
 
       podAllocator.stop(applicationId())
 
@@ -195,7 +191,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
   }
 
   override def sufficientResourcesRegistered(): Boolean = {
-    totalRegisteredExecutors.get() >= initialExecutors * minRegisteredRatio
+    totalRegisteredExecutors.get() >= minRegisteredExecutors
   }
 
   override def getExecutorIds(): Seq[String] = synchronized {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to simplify `KubernetesClusterSchedulerBackend` by reducing private class variables.

### Why are the changes needed?

The following private class variables are used only once.

```scala
private val appId = KubernetesConf.getKubernetesAppId()
private val shouldDeleteDriverService = conf.get(KUBERNETES_DRIVER_SERVICE_DELETE_ON_TERMINATION)
private val shouldDeleteExecutors = conf.get(KUBERNETES_DELETE_EXECUTORS)
private val defaultProfile = scheduler.sc.resourceProfileManager.defaultResourceProfile
```

Instead, the following new private variable is added to avoid re-computation.

```scala
private val minRegisteredExecutors = initialExecutors * minRegisteredRatio
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.