### PR TITLE
[SPARK-55485][K8S] Add `Constants.POD_DELETION_COST` for reuse

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
@@ -108,6 +108,7 @@ object Constants {
   val NON_JVM_MEMORY_OVERHEAD_FACTOR = 0.4d
   val CONNECT_GRPC_BINDING_PORT = "spark.connect.grpc.binding.port"
   val EXIT_EXCEPTION_ANNOTATION = "spark.exit-exception"
+  val POD_DELETION_COST = "controller.kubernetes.io/pod-deletion-cost"
 
   // Hadoop Configuration
   val HADOOP_CONF_VOLUME = "hadoop-properties"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Constants.POD_DELETION_COST` for reuse.

### Why are the changes needed?

To allow the downstream projects like Apache Spark K8s Operator to reuse this constant.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`