### PR TITLE
[SPARK-55498][BUILD][TESTS] Upgrade `oracle-free` docker image to `23.26.1-slim`

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleDatabaseOnDocker.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleDatabaseOnDocker.scala
@@ -23,7 +23,7 @@ class OracleDatabaseOnDocker extends DatabaseOnDocker with Logging {
   // sarutak/oracle-free is a custom fork of gvenzl/oracle-free which allows to set timeout for
   // password initialization. See SPARK-54076 for details.
   lazy override val imageName =
-    sys.env.getOrElse("ORACLE_DOCKER_IMAGE_NAME", "sarutak/oracle-free:23.26.0-slim")
+    sys.env.getOrElse("ORACLE_DOCKER_IMAGE_NAME", "sarutak/oracle-free:23.26.1-slim")
   val oracle_password = "Th1s1sThe0racle#Pass"
   override val env = Map(
     "ORACLE_PWD" -> oracle_password, // oracle images uses this


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade `oracle-free` docker image to `23.26.1-slim`.

### Why are the changes needed?
Ensuring the JDBC source works with the newer Oracle Database.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Confirmed that Oracle related tests passed with the following command.
```
$ ENABLE_DOCKER_INTEGRATION_TESTS=1 build/sbt -Pdocker-integration-tests "testOnly org.apache.spark.sql.jdbc.*Oracle*"
```

### Was this patch authored or co-authored using generative AI tooling?
No.