### PR TITLE
[SPARK-55156][PS] Deal with `include_groups` for `groupby.apply`

### DIFF
--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -58,6 +58,7 @@ from pyspark.sql.types import (
     StringType,
 )
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
+from pyspark._globals import _NoValue, _NoValueType
 from pyspark.loose_version import LooseVersion
 from pyspark.pandas._typing import Axis, FrameLike, Label, Name
 from pyspark.pandas.typedef import infer_return_type, DataFrameType, ScalarType, SeriesType
@@ -1808,7 +1809,13 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
             numeric_only=True,
         )
 
-    def apply(self, func: Callable, *args: Any, **kwargs: Any) -> Union[DataFrame, Series]:
+    def apply(
+        self,
+        func: Callable,
+        *args: Any,
+        include_groups: Union[bool, _NoValueType] = _NoValue,
+        **kwargs: Any,
+    ) -> Union[DataFrame, Series]:
         """
         Apply function `func` group-wise and combine the results together.
 
@@ -1963,6 +1970,24 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         if not callable(func):
             raise TypeError("%s object is not callable" % type(func).__name__)
 
+        if LooseVersion(pd.__version__) < "3.0.0":
+            if include_groups is _NoValue:
+                include_groups = True
+            if include_groups:
+                warnings.warn(
+                    "DataFrameGroupBy.apply operated on the grouping columns. "
+                    "This behavior is deprecated, and in a future version of pandas "
+                    "the grouping columns will be excluded from the operation. "
+                    "Either pass `include_groups=False` to exclude the groupings or "
+                    "explicitly select the grouping columns after groupby to silence this warning.",
+                    FutureWarning,
+                )
+        else:
+            if include_groups is _NoValue:
+                include_groups = False
+            if include_groups:
+                raise ValueError("include_groups=True is no longer allowed.")
+
         spec = inspect.getfullargspec(func)
         return_sig = spec.annotations.get("return", None)
         should_infer_schema = return_sig is None
@@ -1980,10 +2005,17 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
                 for label in psdf._internal.column_labels
                 if label not in self._column_labels_to_exclude
             ]
+            if not include_groups:
+                agg_columns = [
+                    col for col in agg_columns if all(col is not gkey for gkey in self._groupkeys)
+                ]
 
-        psdf, groupkey_labels, groupkey_names = GroupBy._prepare_group_map_apply(
-            psdf, self._groupkeys, agg_columns
-        )
+        (
+            psdf,
+            groupkey_labels,
+            groupkey_names,
+            groupkey_psser_names,
+        ) = GroupBy._prepare_group_map_apply(psdf, self._groupkeys, agg_columns)
 
         if LooseVersion(pd.__version__) < "3.0.0":
             from pandas.core.common import is_builtin_func  # type: ignore[import-not-found]
@@ -2014,8 +2046,8 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
             sample_limit = limit + 1 if limit else 2
             pdf = psdf.head(sample_limit)._to_internal_pandas()
             groupkeys = [
-                pdf[groupkey_name].rename(psser.name)
-                for groupkey_name, psser in zip(groupkey_names, self._groupkeys)
+                pdf[groupkey_name].rename(name)
+                for groupkey_name, name in zip(groupkey_names, groupkey_psser_names)
             ]
             grouped = pdf.groupby(groupkeys)
             if is_series_groupby:
@@ -2086,10 +2118,15 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
                 return_schema = StructType([field.struct_field for field in data_fields])
 
         def pandas_groupby_apply(pdf: pd.DataFrame) -> pd.DataFrame:
+            groupkeys = [
+                pdf[groupkey_name].rename(name)
+                for groupkey_name, name in zip(groupkey_names, groupkey_psser_names)
+            ]
+            grouped = pdf.groupby(groupkeys)
             if is_series_groupby:
-                pdf_or_ser = pdf.groupby(groupkey_names)[name].apply(pandas_apply, *args, **kwargs)
+                pdf_or_ser = grouped[name].apply(pandas_apply, *args, **kwargs)
             else:
-                pdf_or_ser = pdf.groupby(groupkey_names).apply(pandas_apply, *args, **kwargs)
+                pdf_or_ser = grouped.apply(pandas_apply, *args, **kwargs)
                 if should_return_series and isinstance(pdf_or_ser, pd.DataFrame):
                     pdf_or_ser = pdf_or_ser.stack()
 
@@ -2208,7 +2245,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
             psdf[agg_columns]._internal.resolved_copy.spark_frame.drop(*HIDDEN_COLUMNS).schema
         )
 
-        psdf, groupkey_labels, groupkey_names = GroupBy._prepare_group_map_apply(
+        psdf, groupkey_labels, groupkey_names, _ = GroupBy._prepare_group_map_apply(
             psdf, self._groupkeys, agg_columns
         )
 
@@ -2248,14 +2285,15 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
     @staticmethod
     def _prepare_group_map_apply(
         psdf: DataFrame, groupkeys: List[Series], agg_columns: List[Series]
-    ) -> Tuple[DataFrame, List[Label], List[str]]:
+    ) -> Tuple[DataFrame, List[Label], List[str], List[str]]:
         groupkey_labels: List[Label] = [
             verify_temp_column_name(psdf, "__groupkey_{}__".format(i))
             for i in range(len(groupkeys))
         ]
         psdf = psdf[[s.rename(label) for s, label in zip(groupkeys, groupkey_labels)] + agg_columns]
         groupkey_names = [label if len(label) > 1 else label[0] for label in groupkey_labels]
-        return DataFrame(psdf._internal.resolved_copy), groupkey_labels, groupkey_names  # type: ignore[return-value]
+        groupkey_psser_names = [psser.name for psser in groupkeys]
+        return DataFrame(psdf._internal.resolved_copy), groupkey_labels, groupkey_names, groupkey_psser_names  # type: ignore[return-value]
 
     @staticmethod
     def _spark_group_map_apply(
@@ -2762,7 +2800,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
                 if label not in self._column_labels_to_exclude
             ]
 
-        psdf, groupkey_labels, _ = GroupBy._prepare_group_map_apply(
+        psdf, groupkey_labels, _, _ = GroupBy._prepare_group_map_apply(
             psdf,
             self._groupkeys,
             agg_columns,
@@ -3144,7 +3182,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         spec = inspect.getfullargspec(func)
         return_sig = spec.annotations.get("return", None)
 
-        psdf, groupkey_labels, groupkey_names = GroupBy._prepare_group_map_apply(
+        psdf, groupkey_labels, groupkey_names, _ = GroupBy._prepare_group_map_apply(
             self._psdf, self._groupkeys, agg_columns=self._agg_columns
         )
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_apply.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_apply.py
@@ -60,6 +60,10 @@ class GroupByApplyMixin:
             pdf.groupby(["a", pkey]).apply(lambda x: x + x.min()).sort_index(),
         )
 
+    def test_apply_without_shortcut(self):
+        with ps.option_context("compute.shortcut_limit", 0):
+            self.test_apply()
+
 
 class GroupByApplyTests(
     GroupByApplyMixin,

--- a/python/pyspark/pandas/tests/test_categorical.py
+++ b/python/pyspark/pandas/tests/test_categorical.py
@@ -20,6 +20,7 @@ import pandas as pd
 from pandas.api.types import CategoricalDtype
 
 import pyspark.pandas as ps
+from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
 
 
@@ -340,8 +341,15 @@ class CategoricalTestsMixin:
 
         pdf, psdf = self.df_pair
 
-        def identity(df) -> ps.DataFrame[zip(psdf.columns, psdf.dtypes)]:
-            return df
+        if LooseVersion(pd.__version__) < "3.0.0":
+
+            def identity(df) -> ps.DataFrame[zip(psdf.columns, psdf.dtypes)]:
+                return df
+
+        else:
+
+            def identity(df) -> ps.DataFrame[zip(psdf.columns[1:], psdf.dtypes[1:])]:
+                return df
 
         self.assert_eq(
             psdf.groupby("a").apply(identity).sort_values(["b"]).reset_index(drop=True),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Deals with `include_groups` for `groupby.apply`.

- Added `include_groups` for `groupby.apply`
    - with pandas 2
      - `True` by default
      - If set to `False`, it behaves like pandas 3
    - with pandas 3
      - `False` by default
      - If set to `True`, it raises an exception

### Why are the changes needed?

`df.groupby.apply()` now has `include_groups=False` by default, which differs from our behavior.

For example:

```py
>>> import pandas as pd
>>> pdf = pd.DataFrame(
...     {"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 2, 3, 5, 8], "c": [1, 4, 9, 16, 25, 36]},
...     columns=["a", "b", "c"],
... )
```

- pandas 2

```py
>>> pd.__version__
'2.3.3'
>>> pdf.groupby("b").apply(lambda x: x + x.min())
      a   b   c
b
1 0   2   2   2
  1   3   2   5
2 2   6   4  18
3 3   8   6  32
5 4  10  10  50
8 5  12  16  72

>>> pdf.groupby("b").apply(lambda x: x + x.min(), include_groups=False)
      a   c
b
1 0   2   2
  1   3   5
2 2   6  18
3 3   8  32
5 4  10  50
8 5  12  72
```

- pandas 3

```py
>>> pd.__version__
'3.0.0'
>>> pdf.groupby("b").apply(lambda x: x + x.min())
      a   c
b
1 0   2   2
  1   3   5
2 2   6  18
3 3   8  32
5 4  10  50
8 5  12  72

>>> pdf.groupby("b").apply(lambda x: x + x.min(), include_groups=True)
Traceback (most recent call last):
...
ValueError: include_groups=True is no longer allowed.
```

### Does this PR introduce _any_ user-facing change?

Yes, it will behave more like pandas 3.

### How was this patch tested?

Updated the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
