### PR TITLE
[SPARK-55503][PYTHON][TESTS] Fix and enable test_dl_util.py

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -762,6 +762,7 @@ pyspark_ml = Module(
         "pyspark.ml.tests.tuning.test_tvs_io_basic",
         "pyspark.ml.tests.tuning.test_tvs_io_nested",
         "pyspark.ml.tests.tuning.test_tvs_io_pipeline",
+        "pyspark.ml.tests.test_dl_util",
         "pyspark.ml.tests.test_util",
         "pyspark.ml.tests.test_wrapper",
         "pyspark.ml.torch.tests.test_distributor",

--- a/python/pyspark/ml/tests/test_dl_util.py
+++ b/python/pyspark/ml/tests/test_dl_util.py
@@ -20,8 +20,6 @@ import textwrap
 from typing import Any, BinaryIO, Callable, Iterator
 import unittest
 
-from parameterized import parameterized
-
 from pyspark import cloudpickle
 from pyspark.ml.dl_util import FunctionPickler
 
@@ -47,8 +45,8 @@ class TestFunctionPickler(unittest.TestCase):
         fn_output = fn(*args, **kwargs)
         self.assertEqual(fn_output, output_value)
 
-    @parameterized.expand(
-        [
+    def test_pickle_fn_and_save(self):
+        for _, file_path_to_save, save_dir in [
             ("See if it pickles correctly with no path specified", "", ""),
             ("See if it pickles correctly with path specified", "silly_bear", ""),
             (
@@ -56,24 +54,22 @@ class TestFunctionPickler(unittest.TestCase):
                 "silly_bear",
                 "tmp_dir",
             ),
-        ]
-    )
-    def test_pickle_fn_and_save(self, _: str, file_path_to_save: str, save_dir: str):
-        x, y = 1, 3  # args of test_function
-        if save_dir != "":
-            os.makedirs(save_dir, exist_ok=True)
-        pickled_fn_path = FunctionPickler.pickle_fn_and_save(
-            TestFunctionPickler._test_function, file_path_to_save, save_dir, x, y
-        )
-        if file_path_to_save != "":
-            self.assertEqual(file_path_to_save, pickled_fn_path)
+        ]:
+            x, y = 1, 3  # args of test_function
+            if save_dir != "":
+                os.makedirs(save_dir, exist_ok=True)
+            pickled_fn_path = FunctionPickler.pickle_fn_and_save(
+                TestFunctionPickler._test_function, file_path_to_save, save_dir, x, y
+            )
+            if file_path_to_save != "":
+                self.assertEqual(file_path_to_save, pickled_fn_path)
 
-        with open(pickled_fn_path, "rb") as f:
-            self._check_if_test_function_pickled(f, TestFunctionPickler._test_function, 10, x, y)
-        os.remove(pickled_fn_path)
+            with open(pickled_fn_path, "rb") as f:
+                self._check_if_test_function_pickled(f, TestFunctionPickler._test_function, 10, x, y)
+            os.remove(pickled_fn_path)
 
-        if save_dir != "":
-            os.rmdir(save_dir)
+            if save_dir != "":
+                os.rmdir(save_dir)
 
     def test_getting_output_from_pickle_file(self):
         a, b = 2, 0  # arguments for _test_function
@@ -128,8 +124,8 @@ class TestFunctionPickler(unittest.TestCase):
         self.assertEqual(contents_one, contents_two)
         return contents_one == contents_two
 
-    @parameterized.expand(
-        [
+    def test_create_fn_run_script(self):
+        for _, prefix_test, suffix_test in [
             ("Check if it creates the correct file with no prefix nor suffix", "", ""),
             (
                 "Check if it creates the correct file with only prefix + body",
@@ -146,32 +142,30 @@ class TestFunctionPickler(unittest.TestCase):
                 "print('hello')\n",
                 "print('goodbye')\n",
             ),
-        ]
-    )
-    def test_create_fn_run_script(self, mesg: str, prefix_test: str, suffix_test: str):
-        arg1, arg2 = 3, 4
-        pickled_fn_path = FunctionPickler.pickle_fn_and_save(
-            TestFunctionPickler._test_function, "", "", arg1, arg2
-        )
-        fn_out_path = "output.pickled"
-        reference_path = "ref_result_file.py"
-        test_path = "test_result.py"
-        body_for_reference = self._create_code_snippet_body(pickled_fn_path, fn_out_path)
-
-        with self.create_reference_file(
-            body_for_reference, prefix=prefix_test, suffix=suffix_test, fname=reference_path
-        ) as _:
-            executable_file_path = FunctionPickler.create_fn_run_script(
-                pickled_fn_path,
-                fn_out_path,
-                test_path,
-                prefix_code=prefix_test,
-                suffix_code=suffix_test,
+        ]:
+            arg1, arg2 = 3, 4
+            pickled_fn_path = FunctionPickler.pickle_fn_and_save(
+                TestFunctionPickler._test_function, "", "", arg1, arg2
             )
-            self.assertTrue(self._are_two_files_identical(reference_path, executable_file_path))
-            os.remove(executable_file_path)
+            fn_out_path = "output.pickled"
+            reference_path = "ref_result_file.py"
+            test_path = "test_result.py"
+            body_for_reference = self._create_code_snippet_body(pickled_fn_path, fn_out_path)
 
-        os.remove(pickled_fn_path)
+            with self.create_reference_file(
+                body_for_reference, prefix=prefix_test, suffix=suffix_test, fname=reference_path
+            ) as _:
+                executable_file_path = FunctionPickler.create_fn_run_script(
+                    pickled_fn_path,
+                    fn_out_path,
+                    test_path,
+                    prefix_code=prefix_test,
+                    suffix_code=suffix_test,
+                )
+                self.assertTrue(self._are_two_files_identical(reference_path, executable_file_path))
+                os.remove(executable_file_path)
+
+            os.remove(pickled_fn_path)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests/test_dl_util.py
+++ b/python/pyspark/ml/tests/test_dl_util.py
@@ -65,7 +65,9 @@ class TestFunctionPickler(unittest.TestCase):
                 self.assertEqual(file_path_to_save, pickled_fn_path)
 
             with open(pickled_fn_path, "rb") as f:
-                self._check_if_test_function_pickled(f, TestFunctionPickler._test_function, 10, x, y)
+                self._check_if_test_function_pickled(
+                    f, TestFunctionPickler._test_function, 10, x, y
+                )
             os.remove(pickled_fn_path)
 
             if save_dir != "":


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

* Replaced `parameterized` with standard logic
* Add `test_dl_util` to `modules.py`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The 3rd party library `parameterized` is unnecessary and it's not used by any other tests. The test could run without it. Then we can add it to `modules.py`

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Locally it passed.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.