### PR TITLE
[SPARK-55405][PYTHON][TESTS][FOLLOW-UP] Add ARM overrides for float-to-int unsafe cast golden file mismatches

### DIFF
--- a/.github/workflows/build_python_3.12_arm.yml
+++ b/.github/workflows/build_python_3.12_arm.yml
@@ -30,5 +30,6 @@ jobs:
       packages: write
     name: Run
     uses: ./.github/workflows/python_hosted_runner_test.yml
+    if: github.repository == 'apache/spark'
     with:
       os: ubuntu-24.04-arm

--- a/.github/workflows/build_python_3.12_arm.yml
+++ b/.github/workflows/build_python_3.12_arm.yml
@@ -30,6 +30,5 @@ jobs:
       packages: write
     name: Run
     uses: ./.github/workflows/python_hosted_runner_test.yml
-    if: github.repository == 'apache/spark'
     with:
       os: ubuntu-24.04-arm


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add hardcoded ARM (aarch64/arm64) overrides in `_overrides_unsafe()` for 34 float-to-integer unsafe cast golden file mismatches. Also rename `_version_overrides_safe/unsafe` to `_overrides_safe/unsafe` since overrides now cover both version and platform differences.

### Why are the changes needed?

The PyArrow array cast golden files are generated on x86. On ARM, unsafe float-to-integer casts produce different results due to IEEE 754 implementation-defined behavior:

- **ARM FCVT instructions** saturate on overflow: `inf` → type max, `-inf` → type min, `nan` → 0
- **x86 SSE/AVX** returns "integer indefinite" values (typically `0x80...0`)
- **Negative float → unsigned int**: ARM saturates to 0, x86 may wrap

This caused `test_scalar_cast_matrix_unsafe` to fail on Ubuntu 24.04 ARM CI runners with 34 mismatches across three categories:
- `float*:standard` → `uint*` (negative float -1.5 → unsigned int)
- `float*:special` → `int*` (inf/nan → signed int)
- `float*:special` → `uint*` (inf/nan → unsigned int)

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Verified with [ARM CI run](https://github.com/Yicong-Huang/spark/actions/runs/21966674224) on my fork.

### Was this patch authored or co-authored using generative AI tooling?

No