### PR TITLE
[MINOR][PYTHON] Fix typo: convert_timestample -> convert_timestamp

### DIFF
--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -801,25 +801,25 @@ class ArrowTableToRowsConversion:
 
         elif isinstance(dataType, TimestampType):
 
-            def convert_timestample(value: Any) -> Any:
+            def convert_timestamp(value: Any) -> Any:
                 if value is None:
                     return None
                 else:
                     assert isinstance(value, datetime.datetime)
                     return value.astimezone().replace(tzinfo=None)
 
-            return convert_timestample
+            return convert_timestamp
 
         elif isinstance(dataType, TimestampNTZType):
 
-            def convert_timestample_ntz(value: Any) -> Any:
+            def convert_timestamp_ntz(value: Any) -> Any:
                 if value is None:
                     return None
                 else:
                     assert isinstance(value, datetime.datetime)
                     return value
 
-            return convert_timestample_ntz
+            return convert_timestamp_ntz
 
         elif isinstance(dataType, UserDefinedType):
             udt: UserDefinedType = dataType


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix typo in internal function names: `convert_timestample` → `convert_timestamp` and `convert_timestample_ntz` → `convert_timestamp_ntz` in `ArrowTableToRowsConversion._create_converter`.

### Why are the changes needed?

The typo was introduced in SPARK-41746 (`5e0a82e590d`) and later moved as-is in SPARK-51206. These are internal closure names so there's no functional impact, but fixing the spelling improves readability.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No test changes needed — internal function name only.

### Was this patch authored or co-authored using generative AI tooling?

No