### PR TITLE
[SPARK-55508][BUILD] Upgrade `compress-lzf` to 1.2.0

### DIFF
--- a/core/benchmarks/LZFBenchmark-jdk21-results.txt
+++ b/core/benchmarks/LZFBenchmark-jdk21-results.txt
@@ -2,18 +2,18 @@
 Benchmark LZFCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.8+9-LTS on Linux 6.11.0-1018-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 Compress small objects:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Compression 256000000 int values in parallel                594            606          11        430.9           2.3       1.0X
-Compression 256000000 int values single-threaded            570            572           1        449.0           2.2       1.0X
+Compression 256000000 int values in parallel                604            611           9        423.7           2.4       1.0X
+Compression 256000000 int values single-threaded            560            561           2        457.5           2.2       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.8+9-LTS on Linux 6.11.0-1018-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 Compress large objects:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Compression 1024 array values in 2 threads                23             25           1          0.0       22108.7       1.0X
-Compression 1024 array values single-threaded             32             33           0          0.0       31296.0       0.7X
+Compression 1024 array values in 1 threads                47             54           4          0.0       45412.7       1.0X
+Compression 1024 array values single-threaded             33             33           0          0.0       31870.0       1.4X
 
 

--- a/core/benchmarks/LZFBenchmark-results.txt
+++ b/core/benchmarks/LZFBenchmark-results.txt
@@ -2,18 +2,18 @@
 Benchmark LZFCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Linux 6.11.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Compress small objects:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Compression 256000000 int values in parallel                593            602           8        431.4           2.3       1.0X
-Compression 256000000 int values single-threaded            619            625           4        413.4           2.4       1.0X
+Compression 256000000 int values in parallel                577            587          15        443.3           2.3       1.0X
+Compression 256000000 int values single-threaded            572            573           1        447.9           2.2       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Linux 6.11.0-1018-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Compress large objects:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Compression 1024 array values in 1 threads                41             49           6          0.0       40204.2       1.0X
-Compression 1024 array values single-threaded             33             33           1          0.0       32005.2       1.3X
+Compression 1024 array values in 1 threads                46             49           1          0.0       44773.9       1.0X
+Compression 1024 array values single-threaded             34             35           1          0.0       33331.6       1.3X
 
 

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -47,7 +47,7 @@ commons-lang3/3.20.0//commons-lang3-3.20.0.jar
 commons-math3/3.6.1//commons-math3-3.6.1.jar
 commons-pool/1.5.4//commons-pool-1.5.4.jar
 commons-text/1.15.0//commons-text-1.15.0.jar
-compress-lzf/1.1.2//compress-lzf-1.1.2.jar
+compress-lzf/1.2.0//compress-lzf-1.2.0.jar
 curator-client/5.9.0//curator-client-5.9.0.jar
 curator-framework/5.9.0//curator-framework-5.9.0.jar
 curator-recipes/5.9.0//curator-recipes-5.9.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -888,7 +888,7 @@
       <dependency>
         <groupId>com.ning</groupId>
         <artifactId>compress-lzf</artifactId>
-        <version>1.1.2</version>
+        <version>1.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.xerial.snappy</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `compress-lzf` to 1.2.0.

### Why are the changes needed?

To use the latest bug fixed ones. Currently, we use 1.1.2 released 3 years ago (on 2023-01-29).

- https://github.com/ning/compress/releases/tag/compress-lzf-1.2.0 (2026-01-02)
- https://github.com/ning/compress/releases/tag/compress-lzf-1.1.3 (2025-09-26)

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.