### PR TITLE
[SPARK-55507][PYTHON] Add None check for field.metadata in is_geometry and is_geography

### DIFF
--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -317,6 +317,7 @@ def is_geometry(at: "pa.DataType") -> bool:
     return any(
         (
             field.name == "wkb"
+            and field.metadata is not None
             and b"geometry" in field.metadata
             and field.metadata[b"geometry"] == b"true"
         )
@@ -333,6 +334,7 @@ def is_geography(at: "pa.DataType") -> bool:
     return any(
         (
             field.name == "wkb"
+            and field.metadata is not None
             and b"geography" in field.metadata
             and field.metadata[b"geography"] == b"true"
         )

--- a/python/pyspark/sql/tests/arrow/test_arrow.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow.py
@@ -849,19 +849,6 @@ class ArrowTestsMixin:
                     schema3 = from_arrow_schema(pa_schema2)
                     self.assertEqual(t, schema3)
 
-    def test_from_arrow_type_struct_with_wkb_field_no_metadata(self):
-        """SPARK-55507: is_geometry/is_geography should not crash when field has no metadata"""
-        import pyarrow as pa
-
-        # A struct with a field named "wkb" but no metadata should be treated as
-        # a regular struct, not crash with TypeError in is_geometry/is_geography.
-        arrow_type = pa.struct([pa.field("wkb", pa.binary()), pa.field("srid", pa.int32())])
-        spark_type = from_arrow_type(arrow_type)
-        self.assertIsInstance(spark_type, StructType)
-        self.assertEqual(len(spark_type.fields), 2)
-        self.assertEqual(spark_type.fields[0].name, "wkb")
-        self.assertEqual(spark_type.fields[1].name, "srid")
-
     def test_createDataFrame_with_ndarray(self):
         for arrow_enabled in [True, False]:
             with self.subTest(arrow_enabled=arrow_enabled):

--- a/python/pyspark/sql/tests/arrow/test_arrow.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow.py
@@ -849,6 +849,19 @@ class ArrowTestsMixin:
                     schema3 = from_arrow_schema(pa_schema2)
                     self.assertEqual(t, schema3)
 
+    def test_from_arrow_type_struct_with_wkb_field_no_metadata(self):
+        """SPARK-55507: is_geometry/is_geography should not crash when field has no metadata"""
+        import pyarrow as pa
+
+        # A struct with a field named "wkb" but no metadata should be treated as
+        # a regular struct, not crash with TypeError in is_geometry/is_geography.
+        arrow_type = pa.struct([pa.field("wkb", pa.binary()), pa.field("srid", pa.int32())])
+        spark_type = from_arrow_type(arrow_type)
+        self.assertIsInstance(spark_type, StructType)
+        self.assertEqual(len(spark_type.fields), 2)
+        self.assertEqual(spark_type.fields[0].name, "wkb")
+        self.assertEqual(spark_type.fields[1].name, "srid")
+
     def test_createDataFrame_with_ndarray(self):
         for arrow_enabled in [True, False]:
             with self.subTest(arrow_enabled=arrow_enabled):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `field.metadata is not None` check in `is_geometry()` and `is_geography()` before accessing `field.metadata` with the `in` operator.

### Why are the changes needed?

PyArrow struct fields have `metadata=None` by default. When `from_arrow_type()` encounters a struct with a field named `wkb` that has no metadata, `is_geometry()` / `is_geography()` crash with `TypeError: argument of type 'NoneType' is not iterable` because the code does `b"geometry" in field.metadata` without checking for `None` first.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Verified with a dedicated unit test (see commit a3fbd9b) that constructs a PyArrow struct with `wkb` and `srid` fields without metadata, confirming the `TypeError` before the fix and a clean pass after. The test was then removed (commit da08fdc) to reduce test burden since the fix is a trivial one-line defensive check.

### Was this patch authored or co-authored using generative AI tooling?

No