### PR TITLE
[SPARK-55390][PYTHON] Consolidate SQL_SCALAR_ARROW_UDF wrapper, mapper, and serializer logic

### DIFF
--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -117,6 +117,10 @@ class ArrowBatchTransformer:
         """
         Enforce target schema on a RecordBatch by reordering columns and coercing types.
 
+        .. note::
+            Currently this function is only used by UDTF. The error messages
+            are UDTF-specific (see SPARK-55723).
+
         Parameters
         ----------
         batch : pa.RecordBatch
@@ -154,6 +158,8 @@ class ArrowBatchTransformer:
                 try:
                     arr = arr.cast(target_type=field.type, safe=safecheck)
                 except (pa.ArrowInvalid, pa.ArrowTypeError):
+                    # TODO(SPARK-55723): Unify error messages for all UDF types,
+                    #  not just UDTF.
                     raise PySparkRuntimeError(
                         errorClass="RESULT_COLUMNS_MISMATCH_FOR_ARROW_UDTF",
                         messageParameters={

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -228,12 +228,6 @@ class ArrowStreamSerializer(Serializer):
             self._num_dfs,
         )
 
-    def __repr__(self) -> str:
-        return "ArrowStreamGroupSerializer(num_dfs=%d, write_start_stream=%s)" % (
-            self._num_dfs,
-            self._write_start_stream,
-        )
-
 
 class ArrowStreamUDFSerializer(ArrowStreamSerializer):
     """

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -228,6 +228,12 @@ class ArrowStreamSerializer(Serializer):
             self._num_dfs,
         )
 
+    def __repr__(self) -> str:
+        return "ArrowStreamGroupSerializer(num_dfs=%d, write_start_stream=%s)" % (
+            self._num_dfs,
+            self._write_start_stream,
+        )
+
 
 class ArrowStreamUDFSerializer(ArrowStreamSerializer):
     """

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2855,12 +2855,9 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
         def func(
             split_index: int, batches: Iterator[pa.RecordBatch]
         ) -> Iterator[pa.RecordBatch]:
-            """Apply scalar Arrow UDFs: extract → call → assemble → enforce → verify."""
+            """Apply scalar Arrow UDFs"""
 
             def process_batch(input_batch: pa.RecordBatch) -> pa.RecordBatch:
-                """Apply UDFs, enforce schema, and verify row count."""
-                # Extract columns by offsets, group into args/kwargs, apply each UDF
-                # Assemble UDF results, enforce schema, verify row count
                 output_batch = pa.RecordBatch.from_arrays(
                     [
                         udf_func(

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2845,15 +2845,12 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
 
     if eval_type == PythonEvalType.SQL_SCALAR_ARROW_UDF:
         import pyarrow as pa
-        combined_return_type = StructType(
-            [StructField("_%d" % i, rt) for i, (_, _, _, rt) in enumerate(udfs)]
-        )
+        col_names = ["_%d" % i for i in range(len(udfs))]
         combined_arrow_schema = to_arrow_schema(
-            combined_return_type,
+            StructType([StructField(n, rt) for n, (_, _, _, rt) in zip(col_names, udfs)]),
             timezone="UTC",
             prefers_large_types=runner_conf.use_large_var_types,
         )
-        col_names = ["_%d" % i for i in range(len(udfs))]
 
         def func(
             split_index: int, batches: Iterator[pa.RecordBatch]

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2857,7 +2857,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
         ) -> Iterator[pa.RecordBatch]:
             """Apply scalar Arrow UDFs"""
 
-            def process_batch(input_batch: pa.RecordBatch) -> pa.RecordBatch:
+            for input_batch in batches:
                 output_batch = pa.RecordBatch.from_arrays(
                     [
                         udf_func(
@@ -2872,9 +2872,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
                     output_batch, combined_arrow_schema
                 )
                 verify_scalar_result(output_batch, input_batch.num_rows)
-                return output_batch
-
-            yield from map(process_batch, batches)
+                yield output_batch
 
         # profiling is not supported for UDF
         return func, None, ser, ser

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -278,21 +278,23 @@ def verify_scalar_result(result: Any, num_rows: int) -> Any:
     num_rows : int
         Expected number of rows (must match input batch size).
     """
-    if not hasattr(result, "__len__"):
+    try:
+        result_length = len(result)
+    except TypeError:
         raise PySparkTypeError(
             errorClass="UDF_RETURN_TYPE",
             messageParameters={
-                "expected": "pyarrow.Array",
+                "expected": "array-like object",
                 "actual": type(result).__name__,
             },
         )
-    if len(result) != num_rows:
+    if result_length != num_rows:
         raise PySparkRuntimeError(
             errorClass="SCHEMA_MISMATCH_FOR_PANDAS_UDF",
             messageParameters={
                 "udf_type": "arrow_udf",
                 "expected": str(num_rows),
-                "actual": str(len(result)),
+                "actual": str(result_length),
             },
         )
     return result
@@ -1405,7 +1407,7 @@ def read_single_udf(pickleSer, infile, eval_type, runner_conf, udf_index):
     elif eval_type == PythonEvalType.SQL_MAP_PANDAS_ITER_UDF:
         return args_offsets, wrap_pandas_batch_iter_udf(func, return_type, runner_conf)
     elif eval_type == PythonEvalType.SQL_MAP_ARROW_ITER_UDF:
-        return func
+        return func, None, None, None
     elif eval_type == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF:
         argspec = inspect.getfullargspec(chained_func)  # signature was lost when wrapping it
         return args_offsets, wrap_grouped_map_pandas_udf(func, return_type, argspec, runner_conf)
@@ -2823,7 +2825,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
         import pyarrow as pa
 
         assert num_udfs == 1, "One MAP_ARROW_ITER UDF expected here."
-        udf_func: Callable[[Iterator[pa.RecordBatch]], Iterator[pa.RecordBatch]] = udfs[0]
+        udf_func: Callable[[Iterator[pa.RecordBatch]], Iterator[pa.RecordBatch]] = udfs[0][0]
 
         def func(split_index: int, batches: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
             """Apply mapInArrow UDF"""

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2845,26 +2845,24 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
 
     if eval_type == PythonEvalType.SQL_SCALAR_ARROW_UDF:
         import pyarrow as pa
+        from pyspark.sql.pandas.types import to_arrow_schema
+
+        combined_return_type = StructType(
+            [StructField("_%d" % i, rt) for i, (_, _, _, rt) in enumerate(udfs)]
+        )
+        combined_arrow_schema = to_arrow_schema(
+            combined_return_type,
+            timezone="UTC",
+            prefers_large_types=runner_conf.use_large_var_types,
+        )
+        col_names = ["_%d" % i for i in range(len(udfs))]
 
         def func(
             split_index: int, batches: Iterator[pa.RecordBatch]
         ) -> Iterator[pa.RecordBatch]:
             """Apply scalar Arrow UDFs: extract → call → assemble → enforce → verify."""
-            from pyspark.sql.pandas.types import to_arrow_schema
 
-            # Pre-compute Arrow schema and per-UDF metadata (once per partition)
-            combined_return_type = StructType(
-                [StructField("_%d" % i, rt) for i, (_, _, _, rt) in enumerate(udfs)]
-            )
-            combined_arrow_schema = to_arrow_schema(
-                combined_return_type,
-                timezone="UTC",
-                prefers_large_types=runner_conf.use_large_var_types,
-            )
-
-            col_names = ["_%d" % i for i in range(len(udfs))]
-
-            def process_batch(input_batch: "pa.RecordBatch") -> "pa.RecordBatch":
+            def process_batch(input_batch: pa.RecordBatch) -> pa.RecordBatch:
                 """Apply UDFs, enforce schema, and verify row count."""
                 # Extract columns by offsets, group into args/kwargs, apply each UDF
                 # Assemble UDF results, enforce schema, verify row count

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -80,6 +80,7 @@ from pyspark.sql.types import (
     MapType,
     Row,
     StringType,
+    StructField,
     StructType,
     _create_row,
     _parse_datatype_json_string,
@@ -266,6 +267,37 @@ def verify_result(expected_type: type) -> Callable[[Any], Iterator]:
     return check
 
 
+def verify_scalar_result(result: Any, num_rows: int) -> Any:
+    """
+    Verify a scalar UDF result is array-like and has the expected number of rows.
+
+    Parameters
+    ----------
+    result : Any
+        The UDF result to verify.
+    num_rows : int
+        Expected number of rows (must match input batch size).
+    """
+    if not hasattr(result, "__len__"):
+        raise PySparkTypeError(
+            errorClass="UDF_RETURN_TYPE",
+            messageParameters={
+                "expected": "pyarrow.Array",
+                "actual": type(result).__name__,
+            },
+        )
+    if len(result) != num_rows:
+        raise PySparkRuntimeError(
+            errorClass="SCHEMA_MISMATCH_FOR_PANDAS_UDF",
+            messageParameters={
+                "udf_type": "arrow_udf",
+                "expected": str(num_rows),
+                "actual": str(len(result)),
+            },
+        )
+    return result
+
+
 def wrap_udf(f, args_offsets, kwargs_offsets, return_type):
     func, args_kwargs_offsets = wrap_kwargs_support(f, args_offsets, kwargs_offsets)
 
@@ -308,46 +340,6 @@ def wrap_scalar_pandas_udf(f, args_offsets, kwargs_offsets, return_type, runner_
         lambda *a: (
             verify_result_length(verify_result_type(func(*a)), len(a[0])),
             return_type,
-        ),
-    )
-
-
-def wrap_scalar_arrow_udf(f, args_offsets, kwargs_offsets, return_type, runner_conf):
-    func, args_kwargs_offsets = wrap_kwargs_support(f, args_offsets, kwargs_offsets)
-
-    arrow_return_type = to_arrow_type(
-        return_type, timezone="UTC", prefers_large_types=runner_conf.use_large_var_types
-    )
-
-    def verify_result_type(result):
-        if not hasattr(result, "__len__"):
-            pd_type = "pyarrow.Array"
-            raise PySparkTypeError(
-                errorClass="UDF_RETURN_TYPE",
-                messageParameters={
-                    "expected": pd_type,
-                    "actual": type(result).__name__,
-                },
-            )
-        return result
-
-    def verify_result_length(result, length):
-        if len(result) != length:
-            raise PySparkRuntimeError(
-                errorClass="SCHEMA_MISMATCH_FOR_PANDAS_UDF",
-                messageParameters={
-                    "udf_type": "arrow_udf",
-                    "expected": str(length),
-                    "actual": str(len(result)),
-                },
-            )
-        return result
-
-    return (
-        args_kwargs_offsets,
-        lambda *a: (
-            verify_result_length(verify_result_type(func(*a)), len(a[0])),
-            arrow_return_type,
         ),
     )
 
@@ -1403,7 +1395,7 @@ def read_single_udf(pickleSer, infile, eval_type, runner_conf, udf_index):
     if eval_type == PythonEvalType.SQL_SCALAR_PANDAS_UDF:
         return wrap_scalar_pandas_udf(func, args_offsets, kwargs_offsets, return_type, runner_conf)
     elif eval_type == PythonEvalType.SQL_SCALAR_ARROW_UDF:
-        return wrap_scalar_arrow_udf(func, args_offsets, kwargs_offsets, return_type, runner_conf)
+        return func, args_offsets, kwargs_offsets, return_type
     elif eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF:
         return wrap_arrow_batch_udf(func, args_offsets, kwargs_offsets, return_type, runner_conf)
     elif eval_type == PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF:
@@ -2766,10 +2758,9 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             )
         elif eval_type == PythonEvalType.SQL_MAP_ARROW_ITER_UDF:
             ser = ArrowStreamSerializer(write_start_stream=True)
-        elif eval_type in (
-            PythonEvalType.SQL_SCALAR_ARROW_UDF,
-            PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF,
-        ):
+        elif eval_type == PythonEvalType.SQL_SCALAR_ARROW_UDF:
+            ser = ArrowStreamGroupSerializer(num_dfs=0, write_start_stream=True)
+        elif eval_type == PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF:
             # Arrow cast and safe check are always enabled
             ser = ArrowStreamArrowUDFSerializer(safecheck=True, arrow_cast=True)
         elif (
@@ -2847,6 +2838,52 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             # Post-processing
             verified: Iterator[pa.RecordBatch] = verify_result(pa.RecordBatch)(output_batches)
             yield from map(ArrowBatchTransformer.wrap_struct, verified)
+
+        # profiling is not supported for UDF
+        return func, None, ser, ser
+
+    if eval_type == PythonEvalType.SQL_SCALAR_ARROW_UDF:
+        import pyarrow as pa
+
+        def func(  # type: ignore[misc]
+            split_index: int, batches: Iterator["pa.RecordBatch"]
+        ) -> Iterator["pa.RecordBatch"]:
+            """Apply scalar Arrow UDFs: extract → call → assemble → enforce → verify."""
+            from pyspark.sql.pandas.types import to_arrow_schema
+
+            # Pre-compute Arrow schema and per-UDF metadata (once per partition)
+            combined_return_type = StructType(
+                [StructField("_%d" % i, rt) for i, (_, _, _, rt) in enumerate(udfs)]
+            )
+            combined_arrow_schema = to_arrow_schema(
+                combined_return_type,
+                timezone="UTC",
+                prefers_large_types=runner_conf.use_large_var_types,
+            )
+
+            col_names = ["_%d" % i for i in range(len(udfs))]
+
+            def process_batch(input_batch: "pa.RecordBatch") -> "pa.RecordBatch":
+                """Apply UDFs, enforce schema, and verify row count."""
+                # Extract columns by offsets, group into args/kwargs, apply each UDF
+                # Assemble UDF results, enforce schema, verify row count
+                output_batch = pa.RecordBatch.from_arrays(
+                    [
+                        udf_func(
+                            *[input_batch.column(o) for o in args_offsets],
+                            **{k: input_batch.column(v) for k, v in kwargs_offsets.items()},
+                        )
+                        for udf_func, args_offsets, kwargs_offsets, _ in udfs
+                    ],
+                    col_names,
+                )
+                output_batch = ArrowBatchTransformer.enforce_schema(
+                    output_batch, combined_arrow_schema
+                )
+                verify_scalar_result(output_batch, input_batch.num_rows)
+                return output_batch
+
+            yield from map(process_batch, batches)
 
         # profiling is not supported for UDF
         return func, None, ser, ser

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2845,6 +2845,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
 
     if eval_type == PythonEvalType.SQL_SCALAR_ARROW_UDF:
         import pyarrow as pa
+
         col_names = ["_%d" % i for i in range(len(udfs))]
         combined_arrow_schema = to_arrow_schema(
             StructType([StructField(n, rt) for n, (_, _, _, rt) in zip(col_names, udfs)]),
@@ -2852,9 +2853,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             prefers_large_types=runner_conf.use_large_var_types,
         )
 
-        def func(
-            split_index: int, batches: Iterator[pa.RecordBatch]
-        ) -> Iterator[pa.RecordBatch]:
+        def func(split_index: int, batches: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
             """Apply scalar Arrow UDFs"""
 
             for input_batch in batches:

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2756,10 +2756,11 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             ser = TransformWithStateInPySparkRowInitStateSerializer(
                 arrow_max_records_per_batch=runner_conf.arrow_max_records_per_batch
             )
-        elif eval_type == PythonEvalType.SQL_MAP_ARROW_ITER_UDF:
+        elif eval_type in (
+            PythonEvalType.SQL_MAP_ARROW_ITER_UDF,
+            PythonEvalType.SQL_SCALAR_ARROW_UDF,
+        ):
             ser = ArrowStreamSerializer(write_start_stream=True)
-        elif eval_type == PythonEvalType.SQL_SCALAR_ARROW_UDF:
-            ser = ArrowStreamGroupSerializer(num_dfs=0, write_start_stream=True)
         elif eval_type == PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF:
             # Arrow cast and safe check are always enabled
             ser = ArrowStreamArrowUDFSerializer(safecheck=True, arrow_cast=True)
@@ -2845,9 +2846,9 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
     if eval_type == PythonEvalType.SQL_SCALAR_ARROW_UDF:
         import pyarrow as pa
 
-        def func(  # type: ignore[misc]
-            split_index: int, batches: Iterator["pa.RecordBatch"]
-        ) -> Iterator["pa.RecordBatch"]:
+        def func(
+            split_index: int, batches: Iterator[pa.RecordBatch]
+        ) -> Iterator[pa.RecordBatch]:
             """Apply scalar Arrow UDFs: extract → call → assemble → enforce → verify."""
             from pyspark.sql.pandas.types import to_arrow_schema
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -72,7 +72,7 @@ from pyspark.sql.pandas.serializers import (
     ArrowStreamUDTFSerializer,
     ArrowStreamArrowUDTFSerializer,
 )
-from pyspark.sql.pandas.types import to_arrow_type
+from pyspark.sql.pandas.types import to_arrow_schema, to_arrow_type
 from pyspark.sql.types import (
     ArrayType,
     BinaryType,
@@ -2845,8 +2845,6 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
 
     if eval_type == PythonEvalType.SQL_SCALAR_ARROW_UDF:
         import pyarrow as pa
-        from pyspark.sql.pandas.types import to_arrow_schema
-
         combined_return_type = StructType(
             [StructField("_%d" % i, rt) for i, (_, _, _, rt) in enumerate(udfs)]
         )


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR consolidates the `SQL_SCALAR_ARROW_UDF` execution path by:

1. Extracting `verify_scalar_result()` as a reusable helper to replace inline `verify_result_type` and `verify_result_length` closures in `wrap_scalar_arrow_udf`
2. Removing the dedicated `wrap_scalar_arrow_udf` wrapper and replacing it with the general `ArrowStreamGroupSerializer`-based path
3. Adding `ArrowBatchTransformer.enforce_schema()` to handle schema enforcement (column reordering and type coercion) in a centralized way 

### Why are the changes needed?

The scalar Arrow UDF path had its own dedicated wrapper (`wrap_scalar_arrow_udf`), mapper, and serializer logic that duplicated patterns already available in the consolidated `ArrowStreamGroupSerializer` infrastructure. This refactoring reduces code duplication and makes the UDF execution paths more consistent.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Existing tests for scalar Arrow UDFs.

### Benchmark Results

ASV microbenchmark comparison (`ScalarArrowUDFTimeBench`, `repeat=(3, 5, 5.0)`):

| Scenario | UDF | Before (master) | After (PR) | Delta |
|---|---|---|---|---|
| sm_batch_few_col | identity | 71.2±0.5ms | 71.1±0.8ms | -0.1% |
| sm_batch_few_col | sort | 186±1ms | 184±0.3ms | -1.1% |
| sm_batch_few_col | nullcheck | 55.7±0.9ms | 56.4±0.4ms | +1.3% |
| sm_batch_many_col | identity | 24.2±0.2ms | 23.6±0.06ms | -2.5% |
| sm_batch_many_col | sort | 43.0±0.8ms | 42.1±0.6ms | -2.1% |
| sm_batch_many_col | nullcheck | 20.6±0.3ms | 20.6±0.1ms | 0% |
| lg_batch_few_col | identity | 465±1ms | 465±9ms | 0% |
| lg_batch_few_col | sort | 824±1ms | 825±8ms | +0.1% |
| lg_batch_few_col | nullcheck | 271±2ms | 278±3ms | +2.6% |
| lg_batch_many_col | identity | 323±0.1ms | 321±0.9ms | -0.6% |
| lg_batch_many_col | sort | 358±3ms | 362±4ms | +1.1% |
| lg_batch_many_col | nullcheck | 326±2ms | 330±0.4ms | +1.2% |
| pure_ints | identity | 112±2ms | 113±4ms | +0.9% |
| pure_ints | sort | 179±0.6ms | 174±0.3ms | -2.8% |
| pure_ints | nullcheck | 89.9±0.6ms | 91.8±0.4ms | +2.1% |
| pure_floats | identity | 108±1ms | 108±0.2ms | 0% |
| pure_floats | sort | 569±1ms | 568±1ms | -0.2% |
| pure_floats | nullcheck | 88.6±0.6ms | 90.4±0.3ms | +2.0% |
| pure_strings | identity | 120±2ms | 120±0.3ms | 0% |
| pure_strings | sort | 522±0.9ms | 516±0.7ms | -1.2% |
| pure_strings | nullcheck | 97.5±0.4ms | 100.0±0.6ms | +2.6% |
| pure_ts | identity | 110±0.5ms | 110±1ms | 0% |
| pure_ts | sort | 216±0.7ms | 215±0.9ms | -0.5% |
| pure_ts | nullcheck | 89.0±0.2ms | 89.4±0.2ms | +0.4% |
| mixed_types | identity | 105±0.4ms | 105±0.2ms | 0% |
| mixed_types | sort | 166±0.6ms | 166±0.8ms | 0% |
| mixed_types | nullcheck | 84.2±0.6ms | 83.1±0.3ms | -1.3% |

Peak memory: no change (within 1M). All deltas within ±3% noise — no performance regression.

### Was this patch authored or co-authored using generative AI tooling?

No