### PR TITLE
[SPARK-55516][BUILD] Upgrade `ap-loader` to 4.3-12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
     <mima.version>1.1.4</mima.version>
 
     <!-- Version used in Profiler -->
-    <ap-loader.version>4.0-10</ap-loader.version>
+    <ap-loader.version>4.3-12</ap-loader.version>
 
     <CodeCacheSize>128m</CodeCacheSize>
     <!-- Needed for consistent times -->


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `ap-loader` to 4.3-12 for Java 25 support.

### Why are the changes needed?

To support the latest features including Java 25 support.

- https://github.com/jvm-profiling-tools/ap-loader/releases/tag/4.3-12
- https://github.com/jvm-profiling-tools/ap-loader/releases/tag/4.3-11
  - Native lock profiling
- https://github.com/jvm-profiling-tools/ap-loader/releases/tag/4.2.1-11
  - Do not block any signals during execution of a custom crash handler
- https://github.com/jvm-profiling-tools/ap-loader/releases/tag/4.2-10
  - Java Method Tracing and Latency Profiling
- https://github.com/jvm-profiling-tools/ap-loader/releases/tag/4.1-10
  - JDK 25 support

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`