### PR TITLE
[SPARK-55517][SQL] Optimize `VectorizedPlainValuesReader.readBytes()` with direct array access for heap buffers

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
@@ -287,10 +287,18 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
     int requiredBytes = total * 4;
     ByteBuffer buffer = getBuffer(requiredBytes);
 
-    for (int i = 0; i < total; i += 1) {
-      c.putByte(rowId + i, buffer.get());
-      // skip the next 3 bytes
-      buffer.position(buffer.position() + 3);
+    if (buffer.hasArray()) {
+      byte[] array = buffer.array();
+      int offset = buffer.arrayOffset() + buffer.position();
+      for (int i = 0; i < total; i++) {
+        c.putByte(rowId + i, array[offset + i * 4]);
+      }
+    } else {
+      for (int i = 0; i < total; i += 1) {
+        c.putByte(rowId + i, buffer.get());
+        // skip the next 3 bytes
+        buffer.position(buffer.position() + 3);
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR optimizes `VectorizedPlainValuesReader.readBytes()` method by adding a fast path for heap-backed `ByteBuffer`.

When the underlying `ByteBuffer` has a backing array (`buffer.hasArray()` returns true), use direct array access instead of calling `ByteBuffer.get()` and `ByteBuffer.position()` for each value.

**Before:**
```java
for (int i = 0; i < total; i += 1) {
    c.putByte(rowId + i, buffer.get());
    // skip the next 3 bytes
    buffer.position(buffer.position() + 3);
}
```

**After:**
```java
if (buffer.hasArray()) {
    byte[] array = buffer.array();
    int offset = buffer.arrayOffset() + buffer.position();
    for (int i = 0; i < total; i++) {
        c.putByte(rowId + i, array[offset + i * 4]);
    }
} else {
    for (int i = 0; i < total; i += 1) {
        c.putByte(rowId + i, buffer.get());
        buffer.position(buffer.position() + 3);
    }
}
```

### Why are the changes needed?

When Parquet stores data in Plain Values, `ByteType` values are stored as 4-byte little-endian integers, but only need to read the first byte of each 4-byte value. The original implementation uses `ByteBuffer.get()` followed by `buffer.position()` update for each value, which involves:
1. Virtual method call overhead for `ByteBuffer.get()`
2. Additional method call and position state update for `buffer.position()`

This pr uses direct array access when possible, which:
1. Eliminates virtual method call overhead
2. Avoids repeated `position()` updates


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
- Pass Github Actions
- A micro-benchmark that simulates changes with JMH to verify the performance improvement.

<details>
<summary><b>Benchmark Code (click to expand)</b></summary>

```java
package org.apache.spark.sql.execution.benchmark;

import java.nio.ByteBuffer;
import java.nio.ByteOrder;
import java.util.Random;
import java.util.concurrent.TimeUnit;

import org.openjdk.jmh.annotations.Benchmark;
import org.openjdk.jmh.annotations.BenchmarkMode;
import org.openjdk.jmh.annotations.Fork;
import org.openjdk.jmh.annotations.Level;
import org.openjdk.jmh.annotations.Measurement;
import org.openjdk.jmh.annotations.Mode;
import org.openjdk.jmh.annotations.OutputTimeUnit;
import org.openjdk.jmh.annotations.Scope;
import org.openjdk.jmh.annotations.Setup;
import org.openjdk.jmh.annotations.State;
import org.openjdk.jmh.annotations.Warmup;
import org.openjdk.jmh.infra.Blackhole;
import org.openjdk.jmh.runner.Runner;
import org.openjdk.jmh.runner.RunnerException;
import org.openjdk.jmh.runner.options.Options;
import org.openjdk.jmh.runner.options.OptionsBuilder;

@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
@Measurement(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
@Fork(1)
public class JITBranchOptimizationBenchmark {

    private static final int VALUES = 10_000_000;

    @State(Scope.Thread)
    public static class BenchmarkState {
        byte[] data;
        byte[] result;
        ByteBuffer heapBuffer;
        ByteBuffer directBuffer;

        @Setup(Level.Trial)
        public void setup() {
            data = new byte[VALUES * 4];
            result = new byte[VALUES];
            new Random(42).nextBytes(data);
            heapBuffer = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN);
            directBuffer = ByteBuffer.allocateDirect(VALUES * 4).order(ByteOrder.LITTLE_ENDIAN);
            directBuffer.put(data);
            directBuffer.flip();
        }

        ByteBuffer heapBuffer() {
            ByteBuffer buffer = heapBuffer.duplicate();
            buffer.clear();
            return buffer;
        }

        ByteBuffer directBuffer() {
            ByteBuffer buffer = directBuffer.duplicate();
            buffer.clear();
            return buffer;
        }
    }

    // ==================== Test Methods ====================

    /**
     * Old pattern: branch inside loop (pre-optimization)
     */
    private static void oldReadWithBranchInLoop(ByteBuffer buffer, byte[] result, Blackhole blackhole) {
        for (int i = 0; i < VALUES; i++) {
            byte value = buffer.get();
            result[i] = value;
            blackhole.consume(value);
            buffer.position(buffer.position() + 3);
        }
    }

    /**
     * New pattern: branch separated outside the loop (post-optimization)
     */
    private static void newReadWithBranchSeparation(ByteBuffer buffer, byte[] result, Blackhole blackhole) {
        if (buffer.hasArray()) {
            byte[] array = buffer.array();
            int offset = buffer.arrayOffset() + buffer.position();
            for (int i = 0; i < VALUES; i++) {
                byte value = array[offset + i * 4];
                result[i] = value;
                blackhole.consume(value);
            }
        } else {
            for (int i = 0; i < VALUES; i++) {
                byte value = buffer.get();
                result[i] = value;
                blackhole.consume(value);
                buffer.position(buffer.position() + 3);
            }
        }
    }

    @Benchmark
    public void oldHeapByteBuffer(BenchmarkState state, Blackhole blackhole) {
        oldReadWithBranchInLoop(state.heapBuffer(), state.result, blackhole);
    }

    @Benchmark
    public void newHeapByteBuffer(BenchmarkState state, Blackhole blackhole) {
        newReadWithBranchSeparation(state.heapBuffer(), state.result, blackhole);
    }

    @Benchmark
    public void oldDirectByteBuffer(BenchmarkState state, Blackhole blackhole) {
        oldReadWithBranchInLoop(state.directBuffer(), state.result, blackhole);
    }

    @Benchmark
    public void newDirectByteBuffer(BenchmarkState state, Blackhole blackhole) {
        newReadWithBranchSeparation(state.directBuffer(), state.result, blackhole);
    }

    public static void main(String[] args) throws RunnerException {
        Options options = new OptionsBuilder()
                .include(JITBranchOptimizationBenchmark.class.getSimpleName())
                .forks(1)
                .build();
        new Runner(options).run();
    }
}
```
</details>

Perform `build/sbt "sql/Test/runMain org.apache.spark.sql.execution.benchmark.JITBranchOptimizationBenchmark"` to conduct the test

**Benchmark results:**

- Java 17.0.18+8-LTS

```
Benchmark                                           Mode  Cnt        Score       Error  Units
JITBranchOptimizationBenchmark.newDirectByteBuffer  avgt   20  6839182.474 ± 42748.188  ns/op
JITBranchOptimizationBenchmark.newHeapByteBuffer    avgt   20  1814492.255 ± 62310.250  ns/op
JITBranchOptimizationBenchmark.oldDirectByteBuffer  avgt   20  6820495.839 ± 26196.840  ns/op
JITBranchOptimizationBenchmark.oldHeapByteBuffer    avgt   20  8653527.674 ± 41113.232  ns/op
```

For HeapBuffer: The time decreased from ~8.65ms to ~1.81ms, representing a 4.77-fold performance improvement.
For DirectBuffer: The time changed from ~6.82ms to ~6.84ms, with no significant performance difference observed.

- Java 21.0.10+7-LTS

```
Benchmark                                           Mode  Cnt        Score       Error  Units
JITBranchOptimizationBenchmark.newDirectByteBuffer  avgt   20  6935254.212 ± 53359.411  ns/op
JITBranchOptimizationBenchmark.newHeapByteBuffer    avgt   20  1819478.393 ± 10241.682  ns/op
JITBranchOptimizationBenchmark.oldDirectByteBuffer  avgt   20  6903326.626 ± 49768.304  ns/op
JITBranchOptimizationBenchmark.oldHeapByteBuffer    avgt   20  8687575.816 ± 49713.596  ns/op
```

For HeapBuffer: The time decreased from ~8.68ms to ~1.82ms, representing a 4.77-fold performance improvement.
For DirectBuffer: The time changed from ~6.90ms to ~6.93ms, with no significant performance difference observed.



### Was this patch authored or co-authored using generative AI tooling?
The benchmark code used for performance testing was generated by GitHub Copilot.
