### PR TITLE
[SPARK-55385][CORE][SQL][FOLLOW-UP] `getAncestorWithSamePartitionSizes` should stop at checkpointed ancestor

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/ZippedWithIndexRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ZippedWithIndexRDD.scala
@@ -42,7 +42,7 @@ class ZippedWithIndexRDD[T: ClassTag](prev: RDD[T]) extends RDD[(T, Long)](prev)
 
   private def getAncestorWithSamePartitionSizes(rdd: RDD[_]): RDD[_] = {
     rdd match {
-      case c: RDD[_] if c.getStorageLevel != StorageLevel.NONE => c
+      case c: RDD[_] if c.isCheckpointed || c.getStorageLevel != StorageLevel.NONE => c
       case m: MapPartitionsRDD[_, _] if m.preservesPartitionSizes =>
         getAncestorWithSamePartitionSizes(m.prev)
       case m: MapPartitionsWithEvaluatorRDD[_, _] if m.preservesPartitionSizes =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
`getAncestorWithSamePartitionSizes` should stop at checkpointed ancestor


### Why are the changes needed?
if the ancestor is already checkpointed, no matter reliably or locally, it should be returned


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no