### PR TITLE
[SPARK-55521][CONNECT] Make exception constructors for Spark Connect client private[spark]

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/SparkException.scala
+++ b/common/utils/src/main/scala/org/apache/spark/SparkException.scala
@@ -198,7 +198,7 @@ private[spark] class SparkUpgradeException private(
     )
   }
 
-  def this(
+  private[spark] def this(
     errorClass: String,
     messageParameters: Map[String, String],
     cause: Throwable,
@@ -243,7 +243,7 @@ private[spark] class SparkArithmeticException private(
     )
   }
 
-  def this(
+  private[spark] def this(
     errorClass: String,
     messageParameters: Map[String, String],
     context: Array[QueryContext],
@@ -291,7 +291,7 @@ private[spark] class SparkUnsupportedOperationException private(
     )
   }
 
-  def this(
+  private[spark] def this(
     errorClass: String,
     messageParameters: Map[String, String],
     sqlState: Option[String]) = {
@@ -417,7 +417,7 @@ private[spark] class SparkDateTimeException private(
     )
   }
 
-  def this(
+  private[spark] def this(
     errorClass: String,
     messageParameters: Map[String, String],
     context: Array[QueryContext],
@@ -491,7 +491,7 @@ private[spark] class SparkNumberFormatException private(
     )
   }
 
-  def this(
+  private[spark] def this(
     errorClass: String,
     messageParameters: Map[String, String],
     context: Array[QueryContext],
@@ -547,7 +547,7 @@ private[spark] class SparkIllegalArgumentException private(
     )
   }
 
-  def this(
+  private[spark] def this(
     errorClass: String,
     messageParameters: Map[String, String],
     context: Array[QueryContext],
@@ -639,7 +639,7 @@ private[spark] class SparkRuntimeException private(
     )
   }
 
-  def this(
+  private[spark] def this(
     errorClass: String,
     messageParameters: Map[String, String],
     cause: Throwable,
@@ -763,7 +763,7 @@ private[spark] class SparkArrayIndexOutOfBoundsException private(
     )
   }
 
-  def this(
+  private[spark] def this(
     errorClass: String,
     messageParameters: Map[String, String],
     context: Array[QueryContext],


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Restrict auxiliary constructors of several Spark exception classes (added in https://github.com/apache/spark/pull/52589) to `private[spark]` in `SparkException.scala`. Because only the Spark Connect client’s `GrpcExceptionConverter` should use them.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Error class/condition should map to one SQL state; exposing constructors that allow passing both error class/condition and sqlstate is error-prone (inconsistent pairs). Restricting to `private[spark]` limits use and avoids misuse.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes