### PR TITLE
[SPARK-55540][DOCS] Fix capitalization inconsistency in PySpark Overview "Live Notebook" link

### DIFF
--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -96,7 +96,7 @@ rst_epilog = """
 .. _binder: https://mybinder.org/v2/gh/apache/spark/{0}?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb
 .. |binder_df| replace:: Live Notebook: DataFrame
 .. _binder_df: https://mybinder.org/v2/gh/apache/spark/{0}?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb
-.. |binder_ps| replace:: Live Notebook: pandas API on Spark
+.. |binder_ps| replace:: Live Notebook: Pandas API on Spark
 .. _binder_ps: https://mybinder.org/v2/gh/apache/spark/{0}?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_ps.ipynb
 .. |binder_connect| replace:: Live Notebook: Spark Connect
 .. _binder_connect: https://mybinder.org/v2/gh/apache/spark/{0}?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_connect.ipynb


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixes a capitalization inconsistency in the "Pandas API on Spark" section of the PySpark Overview page. The "Live Notebook" link title was using lowercase "pandas", while adjacent links and headers used capitalized "Pandas".

### Why are the changes needed?
To maintain consistency in documentation and branding.

### Does this PR introduce _any_ user-facing change?
No (Documentation only)

### How was this patch tested?
Manual verification (Documentation build)

Closes #54358