### PR TITLE
[SPARK-55541][Geo][SQL] Support Geometry and Geography in catalyst type converters

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
@@ -646,6 +646,8 @@ object CatalystTypeConverters {
     case seq: Seq[Any] => new GenericArrayData(seq.map(convertToCatalyst).toArray)
     case r: Row => InternalRow(r.toSeq.map(convertToCatalyst): _*)
     case arr: Array[Byte] => arr
+    case g: org.apache.spark.sql.types.Geometry => STUtils.stGeomFromWKB(g.getBytes, g.getSrid)
+    case g: org.apache.spark.sql.types.Geography => STUtils.stGeogFromWKB(g.getBytes)
     case arr: Array[Char] => StringConverter.toCatalyst(arr)
     case arr: Array[_] => new GenericArrayData(arr.map(convertToCatalyst))
     case map: Map[_, _] =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.{SparkFunSuite, SparkIllegalArgumentException}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData
 import org.apache.spark.sql.catalyst.plans.SQLHelper
-import org.apache.spark.sql.catalyst.util.{DateTimeConstants, DateTimeUtils, GenericArrayData, IntervalUtils, STUtils}
+import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, DateTimeConstants, DateTimeUtils, GenericArrayData, IntervalUtils, STUtils}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.types.DayTimeIntervalType._
@@ -584,6 +584,39 @@ class CatalystTypeConvertersSuite extends SparkFunSuite with SQLHelper {
       STUtils.stAsBinary(element.asInstanceOf[GeometryVal]), pointWkb))
   }
 
+  test("convertToCatalyst with Geometry nested in Array") {
+    val geom = Geometry.fromWKB(pointWkb, 0)
+    val result = CatalystTypeConverters.convertToCatalyst(Array(geom))
+    assert(result.isInstanceOf[GenericArrayData])
+    val array = result.asInstanceOf[GenericArrayData]
+    assert(array.numElements() === 1)
+    val element = array.get(0, GeometryType("ANY"))
+    assert(element.isInstanceOf[GeometryVal])
+    assert(java.util.Arrays.equals(
+      STUtils.stAsBinary(element.asInstanceOf[GeometryVal]), pointWkb))
+  }
+
+  test("convertToCatalyst with Geometry nested in Map") {
+    val geom = Geometry.fromWKB(pointWkb, 0)
+    val result = CatalystTypeConverters.convertToCatalyst(Map("key" -> geom))
+    assert(result.isInstanceOf[ArrayBasedMapData])
+    val mapData = result.asInstanceOf[ArrayBasedMapData]
+    val value = mapData.valueArray.get(0, GeometryType("ANY"))
+    assert(value.isInstanceOf[GeometryVal])
+    assert(java.util.Arrays.equals(
+      STUtils.stAsBinary(value.asInstanceOf[GeometryVal]), pointWkb))
+  }
+
+  test("convertToCatalyst with Geometry nested in Row") {
+    val geom = Geometry.fromWKB(pointWkb, 0)
+    val result = CatalystTypeConverters.convertToCatalyst(Row(geom))
+    assert(result.isInstanceOf[InternalRow])
+    val element = result.asInstanceOf[InternalRow].get(0, GeometryType("ANY"))
+    assert(element.isInstanceOf[GeometryVal])
+    assert(java.util.Arrays.equals(
+      STUtils.stAsBinary(element.asInstanceOf[GeometryVal]), pointWkb))
+  }
+
   test("convertToCatalyst with Geography nested in Seq") {
     val geog = Geography.fromWKB(pointWkb, 4326)
     val result = CatalystTypeConverters.convertToCatalyst(Seq(geog))
@@ -591,6 +624,39 @@ class CatalystTypeConvertersSuite extends SparkFunSuite with SQLHelper {
     val array = result.asInstanceOf[GenericArrayData]
     assert(array.numElements() === 1)
     val element = array.get(0, GeographyType("ANY"))
+    assert(element.isInstanceOf[GeographyVal])
+    assert(java.util.Arrays.equals(
+      STUtils.stAsBinary(element.asInstanceOf[GeographyVal]), pointWkb))
+  }
+
+  test("convertToCatalyst with Geography nested in Array") {
+    val geog = Geography.fromWKB(pointWkb, 4326)
+    val result = CatalystTypeConverters.convertToCatalyst(Array(geog))
+    assert(result.isInstanceOf[GenericArrayData])
+    val array = result.asInstanceOf[GenericArrayData]
+    assert(array.numElements() === 1)
+    val element = array.get(0, GeographyType("ANY"))
+    assert(element.isInstanceOf[GeographyVal])
+    assert(java.util.Arrays.equals(
+      STUtils.stAsBinary(element.asInstanceOf[GeographyVal]), pointWkb))
+  }
+
+  test("convertToCatalyst with Geography nested in Map") {
+    val geog = Geography.fromWKB(pointWkb, 4326)
+    val result = CatalystTypeConverters.convertToCatalyst(Map("key" -> geog))
+    assert(result.isInstanceOf[ArrayBasedMapData])
+    val mapData = result.asInstanceOf[ArrayBasedMapData]
+    val value = mapData.valueArray.get(0, GeographyType("ANY"))
+    assert(value.isInstanceOf[GeographyVal])
+    assert(java.util.Arrays.equals(
+      STUtils.stAsBinary(value.asInstanceOf[GeographyVal]), pointWkb))
+  }
+
+  test("convertToCatalyst with Geography nested in Row") {
+    val geog = Geography.fromWKB(pointWkb, 4326)
+    val result = CatalystTypeConverters.convertToCatalyst(Row(geog))
+    assert(result.isInstanceOf[InternalRow])
+    val element = result.asInstanceOf[InternalRow].get(0, GeographyType("ANY"))
     assert(element.isInstanceOf[GeographyVal])
     assert(java.util.Arrays.equals(
       STUtils.stAsBinary(element.asInstanceOf[GeographyVal]), pointWkb))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.types.DayTimeIntervalType._
 import org.apache.spark.sql.types.YearMonthIntervalType._
-import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
+import org.apache.spark.unsafe.types.{CalendarInterval, GeographyVal, GeometryVal, UTF8String}
 
 class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
 
@@ -654,5 +654,35 @@ class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
       assert(expr.contextIndependentFoldable,
         s"Expression $expr should not be context independent foldable")
     }
+  }
+
+  test("Literal.create with null Geography value") {
+    val lit = Literal.create(null, GeographyType(4326))
+    assert(lit.dataType === GeographyType(4326))
+    assert(lit.value === null)
+  }
+
+  test("Literal.create with Geography value") {
+    val pointBytes = "010100000000000000000031400000000000001C40"
+      .grouped(2).map(Integer.parseInt(_, 16).toByte).toArray
+    val geog = Geography.fromWKB(pointBytes, 4326)
+    val lit = Literal.create(geog, GeographyType(4326))
+    assert(lit.dataType === GeographyType(4326))
+    assert(lit.value.isInstanceOf[GeographyVal])
+  }
+
+  test("Literal.create with null Geometry value") {
+    val lit = Literal.create(null, GeometryType(0))
+    assert(lit.dataType === GeometryType(0))
+    assert(lit.value === null)
+  }
+
+  test("Literal.create with Geometry value") {
+    val pointBytes = "010100000000000000000031400000000000001C40"
+      .grouped(2).map(Integer.parseInt(_, 16).toByte).toArray
+    val geom = Geometry.fromWKB(pointBytes, 0)
+    val lit = Literal.create(geom, GeometryType(0))
+    assert(lit.dataType === GeometryType(0))
+    assert(lit.value.isInstanceOf[GeometryVal])
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `Geometry` and `Geography` handling in `CatalystTypeConverters`, which fixes code paths that route through `convertToCatalyst - `Literal.create`, `ExpressionEvalHelper.create_row`, and recursive conversion of geospatial values nested inside Seq, Array, Map, or Row.

### Why are the changes needed?
Previously, `Geometry` and `Geography` fell through to default conversion ending up returned as raw client objects instead of the proper internal Catalyst representations (`GeometryVal` and `GeographyVal`). Without these changes, certain code paths would silently pass through unconverted client-side objects, leading to type mismatches/exceptions downstream.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Added unit tests for geospatial type conversion in `CatalystTypeConvertersSuite` and `LiteralExpressionSuite`.


### Was this patch authored or co-authored using generative AI tooling?
Yes, Claude Opus 4.6.
