### PR TITLE
[SPARK-55500][4.1][SQL] Fix analyzer cycle between `ApplyDefaultCollation`, `ExtractWindowExpressions` and `CollationTypeCasts`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCasts.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCasts.scala
@@ -18,8 +18,15 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
 object CollationTypeCasts extends TypeCoercionRule {
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    // Pre-tag CommonExpressionRefs with the collation context of their definitions
+    // before the bottom-up expression transformation processes inner expressions.
+    super.apply(CollationTypeCoercion.preTagCommonExpressionRefs(plan))
+  }
+
   override val transform: PartialFunction[Expression, Expression] = {
     case e if !e.childrenResolved => e
     case withChildrenResolved => CollationTypeCoercion(withChildrenResolved)

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
@@ -1508,6 +1508,62 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  test("Window functions with implicit collation rule") {
+    val table = "table"
+    withTable(table) {
+      sql(s"CREATE TABLE $table(s1 string, s2 string collate utf8_lcase, i int)")
+      sql(s"INSERT INTO $table VALUES ('aA', 'aA', 2), ('Aa', 'Aa', 1)," +
+        s"('ab', 'ab', 3), ('aa', 'aa', 1)")
+
+      checkAnswer(
+        sql(s"select s1 collate unicode = " +
+          s"(first(s1) over (partition by s1 order by i)) from $table;"),
+        Seq(Row(true), Row(true), Row(true), Row(true)))
+      checkAnswer(
+        sql(s"select s1 = " +
+          s"(first(s1 collate unicode) over (partition by s1 order by i)) from $table;"),
+        Seq(Row(true), Row(true), Row(true), Row(true)))
+      checkAnswer(
+        sql(s"select s2 = " +
+          s"(first(s2) over (partition by s2 order by i)) from $table;"),
+        Seq(Row(true), Row(true), Row(true), Row(true)))
+    }
+  }
+
+  test("CommonExpressionRef inherits different collation strengths") {
+    val table = "table"
+    // Implicit collation strength
+    withTable(table) {
+      sql(s"CREATE TABLE $table (c1 STRING COLLATE UTF8_LCASE)")
+      sql(s"INSERT INTO $table VALUES ('test'), ('OTHER')")
+
+      checkAnswer(
+        sql(s"SELECT NULLIF(c1, 'TEST') FROM $table"),
+        Seq(Row(null), Row("OTHER"))
+      )
+    }
+
+    // Explicit collation strength
+    withTable(table) {
+      sql(s"CREATE TABLE $table (c1 STRING COLLATE UNICODE)")
+      sql(s"INSERT INTO $table VALUES ('test'), ('OTHER')")
+      checkAnswer(
+        sql(s"SELECT NULLIF('test' COLLATE UTF8_LCASE, c1) FROM $table"),
+        Seq(Row(null), Row("test"))
+      )
+    }
+
+    // Default collation strength
+    withTable(table) {
+      sql(s"CREATE TABLE $table (c1 STRING COLLATE UNICODE_CI)")
+      sql(s"INSERT INTO $table VALUES ('TEST'), ('OTHER')")
+      checkAnswer(
+        sql(s"SELECT NULLIF('test', c1) FROM $table"),
+        Seq(Row(null), Row("test"))
+      )
+    }
+  }
+
   test("hash join should be used for collated strings if sort merge join is not forced") {
     val t1 = "T_1"
     val t2 = "T_2"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Call `CollationTypeCasts` immediately to avoid cycle between `ApplyDefaultCollation`, `ExtractWindowExpressions` and `CollationTypeCasts`.
                                                                                                                                                                                                                                                 
Example:                                                                                                                                                                                                                                       
  ```sql                                                                                                                                                                                                                                         
  CREATE TABLE t (c1 STRING, c2 STRING);  -- c1 is UTF8_BINARY                                                                                                                                                                                   
  CREATE TABLE t2 DEFAULT COLLATION UTF8_LCASE AS
    SELECT c1 = 'HELLO', ROW_NUMBER() OVER (PARTITION BY c1 ORDER BY c2) FROM t;
```

  Analyzer runs rules in batches sequentially, and the rule order is:
  `ApplyDefaultCollation` -> `ExtractWindowExpressions` -> `CollationTypeCasts`.

Iteration 1:
  - `ApplyDefaultCollation` applies `UTF8_LCASE` collation to the literal `'HELLO'`. Expression `EqualTo` (`c1 = 'HELLO'`) is not resolved after this because c1 and the literal have different types.
  - `ExtractWindowExpressions` tries to extract the window expressions, but it can't because it expects the whole projectList to be resolved (both `EqualTo` and `ROW_NUMBER()`). `EqualTo` is not resolved, so it can't apply the rule.
  - `CollationTypeCasts` applies coercion rules, changing the type of the literal to the default `StringType` again (because that's the type of the column). Now `EqualTo` is resolved.

Iteration 2:
  - `ApplyDefaultCollation` again applies `UTF8_LCASE` collation to the literal, because its type is default `StringType` again.
  - `ExtractWindowExpressions` again can't extract the window expressions for the same reason as before.
  - `CollationTypeCasts` applies the same coercion rules again, changing the type of the literal back to the default `StringType`.

 This cycle continues, and the plan never gets resolved. By calling `CollationTypeCasts` right after this rule, we ensure that other rules like `ExtractWindowExpressions` that expect resolved expressions can be applied.


### Why are the changes needed?
Bug fix.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
New tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
