### PR TITLE
[SPARK-55562][SQL] Simplify null handling for error classes in Spark exceptions

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/SparkException.scala
+++ b/common/utils/src/main/scala/org/apache/spark/SparkException.scala
@@ -181,7 +181,7 @@ private[spark] case class ExecutorDeadException(message: String)
 private[spark] class SparkUpgradeException private(
     message: String,
     cause: Option[Throwable],
-    errorClass: Option[String],
+    errorClass: String,
     messageParameters: Map[String, String],
     sqlState: Option[String] = None)
   extends RuntimeException(message, cause.orNull) with SparkThrowable {
@@ -193,7 +193,7 @@ private[spark] class SparkUpgradeException private(
     this(
       SparkThrowableHelper.getMessage(errorClass, messageParameters),
       Option(cause),
-      Option(errorClass),
+      errorClass,
       messageParameters
     )
   }
@@ -206,7 +206,7 @@ private[spark] class SparkUpgradeException private(
     this(
       SparkThrowableHelper.getMessage(errorClass, messageParameters),
       Option(cause),
-      Option(errorClass),
+      errorClass,
       messageParameters,
       sqlState
     )
@@ -214,7 +214,7 @@ private[spark] class SparkUpgradeException private(
 
   override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
 
-  override def getCondition: String = errorClass.orNull
+  override def getCondition: String = errorClass
 
   override def getSqlState: String = sqlState.getOrElse(super.getSqlState)
 }
@@ -224,7 +224,7 @@ private[spark] class SparkUpgradeException private(
  */
 private[spark] class SparkArithmeticException private(
     message: String,
-    errorClass: Option[String],
+    errorClass: String,
     messageParameters: Map[String, String],
     context: Array[QueryContext],
     sqlState: Option[String] = None)
@@ -237,7 +237,7 @@ private[spark] class SparkArithmeticException private(
     summary: String) = {
     this(
       SparkThrowableHelper.getMessage(errorClass, messageParameters, summary),
-      Option(errorClass),
+      errorClass,
       messageParameters,
       context
     )
@@ -250,7 +250,7 @@ private[spark] class SparkArithmeticException private(
     sqlState: Option[String]) = {
     this(
       SparkThrowableHelper.getMessage(errorClass, messageParameters, ""),
-      Option(errorClass),
+      errorClass,
       messageParameters,
       context,
       sqlState
@@ -264,7 +264,7 @@ private[spark] class SparkArithmeticException private(
 
   override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
 
-  override def getCondition: String = errorClass.orNull
+  override def getCondition: String = errorClass
 
   override def getSqlState: String = sqlState.getOrElse(super.getSqlState)
 
@@ -276,7 +276,7 @@ private[spark] class SparkArithmeticException private(
  */
 private[spark] class SparkUnsupportedOperationException private(
   message: String,
-  errorClass: Option[String],
+  errorClass: String,
   messageParameters: Map[String, String],
   sqlState: Option[String] = None)
   extends UnsupportedOperationException(message) with SparkThrowable {
@@ -286,7 +286,7 @@ private[spark] class SparkUnsupportedOperationException private(
     messageParameters: Map[String, String]) = {
     this(
       SparkThrowableHelper.getMessage(errorClass, messageParameters),
-      Option(errorClass),
+      errorClass,
       messageParameters
     )
   }
@@ -297,7 +297,7 @@ private[spark] class SparkUnsupportedOperationException private(
     sqlState: Option[String]) = {
     this(
       SparkThrowableHelper.getMessage(errorClass, messageParameters),
-      Option(errorClass),
+      errorClass,
       messageParameters,
       sqlState
     )
@@ -312,14 +312,14 @@ private[spark] class SparkUnsupportedOperationException private(
   def this(errorClass: String) = {
     this(
       SparkThrowableHelper.getMessage(errorClass, Map.empty[String, String]),
-      Option(errorClass),
+      errorClass,
       Map.empty,
       None)
   }
 
   override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
 
-  override def getCondition: String = errorClass.orNull
+  override def getCondition: String = errorClass
 
   override def getSqlState: String = sqlState.getOrElse(super.getSqlState)
 }
@@ -381,7 +381,7 @@ private[spark] class SparkConcurrentModificationException(
  */
 private[spark] class SparkDateTimeException private(
     message: String,
-    errorClass: Option[String],
+    errorClass: String,
     messageParameters: Map[String, String],
     context: Array[QueryContext],
     cause: Option[Throwable],
@@ -395,7 +395,7 @@ private[spark] class SparkDateTimeException private(
     summary: String) = {
     this(
       SparkThrowableHelper.getMessage(errorClass, messageParameters, summary),
-      Option(errorClass),
+      errorClass,
       messageParameters,
       context,
       cause = None
@@ -410,7 +410,7 @@ private[spark] class SparkDateTimeException private(
     cause: Option[Throwable]) = {
     this(
       SparkThrowableHelper.getMessage(errorClass, messageParameters, summary),
-      Option(errorClass),
+      errorClass,
       messageParameters,
       context,
       cause.orElse(None)
@@ -426,7 +426,7 @@ private[spark] class SparkDateTimeException private(
     sqlState: Option[String]) = {
     this(
       SparkThrowableHelper.getMessage(errorClass, messageParameters, summary),
-      Option(errorClass),
+      errorClass,
       messageParameters,
       context,
       cause.orElse(None),
@@ -441,7 +441,7 @@ private[spark] class SparkDateTimeException private(
 
   override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
 
-  override def getCondition: String = errorClass.orNull
+  override def getCondition: String = errorClass
 
   override def getSqlState: String = sqlState.getOrElse(super.getSqlState)
 
@@ -471,7 +471,7 @@ private[spark] class SparkFileNotFoundException(
  */
 private[spark] class SparkNumberFormatException private(
     message: String,
-    errorClass: Option[String],
+    errorClass: String,
     messageParameters: Map[String, String],
     context: Array[QueryContext],
     sqlState: Option[String] = None)
@@ -485,7 +485,7 @@ private[spark] class SparkNumberFormatException private(
     summary: String) = {
     this(
       SparkThrowableHelper.getMessage(errorClass, messageParameters, summary),
-      Option(errorClass),
+      errorClass,
       messageParameters,
       context
     )
@@ -498,7 +498,7 @@ private[spark] class SparkNumberFormatException private(
     sqlState: Option[String]) = {
     this(
       SparkThrowableHelper.getMessage(errorClass, messageParameters, ""),
-      Option(errorClass),
+      errorClass,
       messageParameters,
       context,
       sqlState
@@ -512,7 +512,7 @@ private[spark] class SparkNumberFormatException private(
 
   override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
 
-  override def getCondition: String = errorClass.orNull
+  override def getCondition: String = errorClass
 
   override def getSqlState: String = sqlState.getOrElse(super.getSqlState)
 
@@ -525,7 +525,7 @@ private[spark] class SparkNumberFormatException private(
 private[spark] class SparkIllegalArgumentException private(
     message: String,
     cause: Option[Throwable],
-    errorClass: Option[String],
+    errorClass: String,
     messageParameters: Map[String, String],
     context: Array[QueryContext],
     sqlState: Option[String] = None)
@@ -541,7 +541,7 @@ private[spark] class SparkIllegalArgumentException private(
     this(
       SparkThrowableHelper.getMessage(errorClass, messageParameters, summary),
       Option(cause),
-      Option(errorClass),
+      errorClass,
       messageParameters,
       context
     )
@@ -557,7 +557,7 @@ private[spark] class SparkIllegalArgumentException private(
     this(
       SparkThrowableHelper.getMessage(errorClass, messageParameters, summary),
       Option(cause),
-      Option(errorClass),
+      errorClass,
       messageParameters,
       context,
       sqlState
@@ -585,7 +585,7 @@ private[spark] class SparkIllegalArgumentException private(
 
   override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
 
-  override def getCondition: String = errorClass.orNull
+  override def getCondition: String = errorClass
 
   override def getSqlState: String = sqlState.getOrElse(super.getSqlState)
 
@@ -617,7 +617,7 @@ private[spark] class SparkIllegalStateException(
 private[spark] class SparkRuntimeException private(
     message: String,
     cause: Option[Throwable],
-    errorClass: Option[String],
+    errorClass: String,
     messageParameters: Map[String, String],
     context: Array[QueryContext],
     sqlState: Option[String])
@@ -632,7 +632,7 @@ private[spark] class SparkRuntimeException private(
     this(
       SparkThrowableHelper.getMessage(errorClass, messageParameters, summary),
       Option(cause),
-      Option(errorClass),
+      errorClass,
       messageParameters,
       context,
       None
@@ -648,7 +648,7 @@ private[spark] class SparkRuntimeException private(
     this(
       SparkThrowableHelper.getMessage(errorClass, messageParameters, ""),
       Option(cause),
-      Option(errorClass),
+      errorClass,
       messageParameters,
       context,
       sqlState
@@ -657,7 +657,7 @@ private[spark] class SparkRuntimeException private(
 
   override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
 
-  override def getCondition: String = errorClass.orNull
+  override def getCondition: String = errorClass
 
   override def getSqlState: String = sqlState.getOrElse(super.getSqlState)
 
@@ -667,7 +667,7 @@ private[spark] class SparkRuntimeException private(
 private[spark] class SparkPythonException private(
     message: String,
     cause: Option[Throwable],
-    errorClass: Option[String],
+    errorClass: String,
     messageParameters: Map[String, String],
     context: Array[QueryContext],
     sqlState: Option[String])
@@ -682,7 +682,7 @@ private[spark] class SparkPythonException private(
     this(
       SparkThrowableHelper.getMessage(errorClass, messageParameters, summary),
       Option(cause),
-      Option(errorClass),
+      errorClass,
       messageParameters,
       context,
       None
@@ -691,7 +691,7 @@ private[spark] class SparkPythonException private(
 
   override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
 
-  override def getCondition: String = errorClass.orNull
+  override def getCondition: String = errorClass
 
   override def getSqlState: String = sqlState.getOrElse(super.getSqlState)
 
@@ -743,7 +743,7 @@ private[spark] class SparkSecurityException(
  */
 private[spark] class SparkArrayIndexOutOfBoundsException private(
   message: String,
-  errorClass: Option[String],
+  errorClass: String,
   messageParameters: Map[String, String],
   context: Array[QueryContext],
   sqlState: Option[String] = None)
@@ -757,7 +757,7 @@ private[spark] class SparkArrayIndexOutOfBoundsException private(
     summary: String) = {
     this(
       SparkThrowableHelper.getMessage(errorClass, messageParameters, summary),
-      Option(errorClass),
+      errorClass,
       messageParameters,
       context
     )
@@ -770,7 +770,7 @@ private[spark] class SparkArrayIndexOutOfBoundsException private(
     sqlState: Option[String]) = {
     this(
       SparkThrowableHelper.getMessage(errorClass, messageParameters, ""),
-      Option(errorClass),
+      errorClass,
       messageParameters,
       context,
       sqlState
@@ -784,7 +784,7 @@ private[spark] class SparkArrayIndexOutOfBoundsException private(
 
   override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
 
-  override def getCondition: String = errorClass.orNull
+  override def getCondition: String = errorClass
 
   override def getSqlState: String = sqlState.getOrElse(super.getSqlState)
 

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -129,7 +129,7 @@ private[spark] case class ChainedPythonFunctions(funcs: Seq[PythonFunction])
 private[spark] class PythonException(
     msg: String,
     cause: Throwable,
-    errorClass: Option[String],
+    errorClass: String,
     messageParameters: Map[String, String],
     context: Array[QueryContext])
   extends RuntimeException(msg, cause) with SparkThrowable {
@@ -143,7 +143,7 @@ private[spark] class PythonException(
     this(
       SparkThrowableHelper.getMessage(errorClass, messageParameters, summary),
       cause,
-      Option(errorClass),
+      errorClass,
       messageParameters,
       context
     )
@@ -151,7 +151,7 @@ private[spark] class PythonException(
 
   override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
 
-  override def getCondition: String = errorClass.orNull
+  override def getCondition: String = errorClass
   override def getQueryContext: Array[QueryContext] = context
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Use String for errorClass instead of Option[String] in Spark exception classes that implement SparkThrowable (in SparkException.scala and PythonRDD.scala). Constructors no longer wrap with Option(errorClass) and getCondition returns the string directly.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
SparkThrowableHelper.getMessage already assumes errorClass is non-null and would throw if it were null. Using Option[String] was redundant and inconsistent with that contract.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. The visibility of changed constructors is private[spark], so this is an internal API change only.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes