### PR TITLE
[SPARK-55570][SQL][TESTS] Upgrade `MariaDB` image to `12.2.2`

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MariaDBDatabaseOnDocker.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MariaDBDatabaseOnDocker.scala
@@ -21,7 +21,7 @@ import org.apache.spark.internal.Logging
 
 abstract class MariaDBDatabaseOnDocker extends DatabaseOnDocker with Logging {
   override val imageName: String =
-    sys.env.getOrElse("MARIADB_DOCKER_IMAGE_NAME", "mariadb:11.4.5")
+    sys.env.getOrElse("MARIADB_DOCKER_IMAGE_NAME", "mariadb:12.2.2")
   override val env: Map[String, String] = Map(
     "MYSQL_ROOT_PASSWORD" -> "rootpass"
   )

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MariaDBKrbIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MariaDBKrbIntegrationSuite.scala
@@ -25,9 +25,9 @@ import org.apache.spark.sql.execution.datasources.jdbc.connection.SecureConnecti
 import org.apache.spark.tags.DockerTest
 
 /**
- * To run this test suite for a specific version (e.g., mariadb:11.4.5):
+ * To run this test suite for a specific version (e.g., mariadb:12.2.2):
  * {{{
- *   ENABLE_DOCKER_INTEGRATION_TESTS=1 MARIADB_DOCKER_IMAGE_NAME=mariadb:11.4.5
+ *   ENABLE_DOCKER_INTEGRATION_TESTS=1 MARIADB_DOCKER_IMAGE_NAME=mariadb:12.2.2
  *     ./build/sbt -Pdocker-integration-tests
  *     "docker-integration-tests/testOnly org.apache.spark.sql.jdbc.MariaDBKrbIntegrationSuite"
  * }}}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `MariaDB` image to `12.2.2` for Apache Spark 4.2.0.

### Why are the changes needed?

To maintain our JDBC test coverage up-to-date by testing against the latest version of MariaDB 12.2.2 which is a Stable (GA) release of MariaDB Community Server 12.2.
- https://mariadb.com/docs/release-notes/community-server/12.2/12.2.2 (2026-02-12)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`