### PR TITLE
[SPARK-55573][SQL][TESTS] Upgrade `PostgreSQL` JDBC driver to `42.7.10` and revise test case

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -350,8 +350,7 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
     assert(rows(0).getSeq(21) == Seq("<(500.0,200.0),100.0>"))
     assert(rows(0).getSeq(22) == Seq("16/B374D848"))
     assert(rows(0).getSeq(23) == Seq("101010"))
-    assert(rows(0).getSeq(24) == Seq("0 years 0 mons 1 days 0 hours 0 mins 0.0 secs",
-      "0 years 0 mons 0 days 0 hours 2 mins 0.0 secs"))
+    assert(rows(0).getSeq(24) == Seq("1 days", "2 mins"))
     assert(rows(0).getSeq(25) == Seq("08:00:2b:01:02:03:04:05"))
     assert(rows(0).getSeq(26) == Seq("10:20:10,14,15"))
   }

--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,7 @@
     </extraJavaTestArgs>
     <mariadb.java.client.version>3.5.7</mariadb.java.client.version>
     <mysql.connector.version>9.6.0</mysql.connector.version>
-    <postgresql.version>42.7.7</postgresql.version>
+    <postgresql.version>42.7.10</postgresql.version>
     <db2.jcc.version>11.5.9.0</db2.jcc.version>
     <mssql.jdbc.version>13.2.1.jre11</mssql.jdbc.version>
     <ojdbc17.version>23.6.0.24.10</ojdbc17.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `PostgreSQL` JDBC driver to `42.7.10` and revise test case.

### Why are the changes needed?

To maintain `PostgreSQL` JDBC driver test coverage up-to-date.
- https://jdbc.postgresql.org/changelogs/2026-02-11-42/ (42.7.10)
- https://jdbc.postgresql.org/changelogs/2026-01-15-42/ (42.7.9)
- https://jdbc.postgresql.org/changelogs/2025-09-18-42/ (42.7.8)

### Does this PR introduce _any_ user-facing change?

No, this is a test dependency and test case revision.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`