### PR TITLE
[SPARK-55574][SQL][TESTS] Upgrade `MariaDB` JDBC driver to `3.5.7` and revise test suites

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MariaDBKrbIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MariaDBKrbIntegrationSuite.scala
@@ -40,7 +40,7 @@ class MariaDBKrbIntegrationSuite extends DockerKrbJDBCIntegrationSuite {
   override val db = new MariaDBDatabaseOnDocker() {
 
     override def getJdbcUrl(ip: String, port: Int): String =
-      s"jdbc:mysql://$ip:$port/mysql?user=$principal"
+      s"jdbc:mysql://$ip:$port/mysql?user=$principal&permitMysqlScheme"
 
     override def beforeContainerStart(
         hostConfigBuilder: HostConfig,

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
@@ -377,12 +377,12 @@ class MySQLOverMariaConnectorIntegrationSuite extends MySQLIntegrationSuite {
   override val db = new MySQLDatabaseOnDocker {
     override def getJdbcUrl(ip: String, port: Int): String =
       s"jdbc:mysql://$ip:$port/mysql?user=root&password=rootpass&allowPublicKeyRetrieval=true" +
-        s"&useSSL=false"
+        s"&useSSL=false&permitMysqlScheme"
   }
 
   override def testConnection(): Unit = {
     Using.resource(getConnection()) { conn =>
-      assert(conn.getClass.getName === "org.mariadb.jdbc.MariaDbConnection")
+      assert(conn.getClass.getName === "org.mariadb.jdbc.Connection")
     }
   }
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -341,6 +341,6 @@ class MySQLOverMariaConnectorIntegrationSuite extends MySQLIntegrationSuite {
   override val db = new MySQLDatabaseOnDocker {
     override def getJdbcUrl(ip: String, port: Int): String =
       s"jdbc:mysql://$ip:$port/mysql?user=root&password=rootpass&allowPublicKeyRetrieval=true" +
-        s"&useSSL=false"
+        s"&useSSL=false&permitMysqlScheme"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -337,7 +337,7 @@
       -Dio.netty.handler.ssl.defaultEndpointVerificationAlgorithm=NONE
       --enable-native-access=ALL-UNNAMED
     </extraJavaTestArgs>
-    <mariadb.java.client.version>2.7.12</mariadb.java.client.version>
+    <mariadb.java.client.version>3.5.7</mariadb.java.client.version>
     <mysql.connector.version>9.2.0</mysql.connector.version>
     <postgresql.version>42.7.7</postgresql.version>
     <db2.jcc.version>11.5.9.0</db2.jcc.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `MariaDB` JDBC driver to `3.5.7` from `2.7.12` for Apache Spark 4.2.0.

### Why are the changes needed?

To maintain the JDBC test coverage up-to-date with the latest `MariaDB` JDBC driver.
- https://mariadb.com/docs/release-notes/connectors/java/3.5/3.5.7 (2025-12-07)
- https://mariadb.com/docs/release-notes/connectors/java/3.4/3.4.2 (2025-03-27)
- https://mariadb.com/docs/release-notes/connectors/java/3.3/3.3.4 (2025-03-27)
- https://mariadb.com/docs/release-notes/connectors/java/3.2/3.2.0 (2023-08-20)
- https://mariadb.com/docs/release-notes/connectors/java/3.1/3.1.4 (2023-05-01)
- https://mariadb.com/docs/release-notes/connectors/java/3.0/3.0.11 (2023-08-25)
 
Note that
- `MariaDB JDBC Client v3` was released 5 years ago (May 2021) and fixed the old issue which cause a conflict with `MySQL JDBC Driver`.
- In other words, `v3` client only accepts `jdbc:mariadb`. We need to have a test coverage for `v3`.
- Also, there is a legacy configuration, `permitMysqlScheme`, to preserve the old behavior. We use this to minimize the size of this PR. We can remove this `permitMysqlScheme` later.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`