### PR TITLE
[SPARK-55575][SQL][TESTS] Upgrade `MySQL` JDBC driver to `9.6.0`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
       --enable-native-access=ALL-UNNAMED
     </extraJavaTestArgs>
     <mariadb.java.client.version>3.5.7</mariadb.java.client.version>
-    <mysql.connector.version>9.2.0</mysql.connector.version>
+    <mysql.connector.version>9.6.0</mysql.connector.version>
     <postgresql.version>42.7.7</postgresql.version>
     <db2.jcc.version>11.5.9.0</db2.jcc.version>
     <mssql.jdbc.version>13.2.1.jre11</mssql.jdbc.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `MySQL` JDBC driver to `9.6.0`.

### Why are the changes needed?

To maintain JDBC test coverage up-to-date with the latest MySQL JDBC driver.
- https://dev.mysql.com/doc/relnotes/connector-j/en/news-9-6-0.html (2026-01-21)
- https://dev.mysql.com/doc/relnotes/connector-j/en/news-9-5-0.html (2025-10-22)
- https://dev.mysql.com/doc/relnotes/connector-j/en/news-9-4-0.html (2025-07-22)
- https://dev.mysql.com/doc/relnotes/connector-j/en/news-9-3-0.html (2025-04-15)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`