### PR TITLE
[SPARK-55578][SQL][TESTS] Improve `DockerJDBCIntegrationSuite` to support `sleepBeforeTesting`

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
@@ -210,6 +210,7 @@ abstract class DockerJDBCIntegrationSuite
         assert(response.getState.getRunning)
       }
       jdbcUrl = db.getJdbcUrl(dockerIp, externalPort)
+      sleepBeforeTesting()
       var conn: Connection = null
       eventually(connectionTimeout, interval(1.second)) {
         conn = getConnection()
@@ -254,6 +255,11 @@ abstract class DockerJDBCIntegrationSuite
    * Prepare databases and tables for testing.
    */
   def dataPreparation(connection: Connection): Unit
+
+  /**
+   * Sleep for a while before testing.
+   */
+  def sleepBeforeTesting(): Unit = {}
 
   private def cleanupContainer(): Unit = {
     if (docker != null && container != null && !keepContainer) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `DockerJDBCIntegrationSuite` to support `sleepBeforeTesting`

### Why are the changes needed?

Some DBMS images enter `Running` status even they are not ready to receive the connnection. This new API will help us handle those images.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.