### PR TITLE
[SPARK-55577][PYTHON] Refactor SQL_SCALAR_ARROW_ITER_UDF wrapper, mapper, and serializer logic 

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -222,7 +222,7 @@ class ArrowStreamSerializer(Serializer):
         write_int(SpecialLengths.START_ARROW_STREAM, stream)
         yield from itertools.chain([first], batch_iterator)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "ArrowStreamSerializer(write_start_stream=%s, num_dfs=%d)" % (
             self._write_start_stream,
             self._num_dfs,

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -25,7 +25,7 @@ import time
 import inspect
 import itertools
 import json
-from typing import Any, Callable, Iterable, Iterator, Optional, Tuple
+from typing import Any, Callable, Iterable, Iterator, Optional, Tuple, Union
 
 from pyspark.accumulators import (
     SpecialAccumulatorIds,
@@ -50,6 +50,7 @@ from pyspark.sql.conversion import (
     LocalDataToArrowConversion,
     ArrowTableToRowsConversion,
     ArrowBatchTransformer,
+    coerce_arrow_array,
 )
 from pyspark.sql.functions import SkipRestOfInputTableException
 from pyspark.sql.pandas.serializers import (
@@ -65,7 +66,6 @@ from pyspark.sql.pandas.serializers import (
     TransformWithStateInPandasInitStateSerializer,
     TransformWithStateInPySparkRowSerializer,
     TransformWithStateInPySparkRowInitStateSerializer,
-    ArrowStreamArrowUDFSerializer,
     ArrowStreamAggPandasUDFSerializer,
     ArrowStreamAggArrowUDFSerializer,
     ArrowBatchUDFSerializer,
@@ -298,6 +298,52 @@ def verify_scalar_result(result: Any, num_rows: int) -> Any:
             },
         )
     return result
+
+
+def verify_iterator_exhausted(iterator: Iterator, error_class: str) -> None:
+    """Verify that an iterator has been fully consumed."""
+    try:
+        next(iterator)
+    except StopIteration:
+        pass
+    else:
+        raise PySparkRuntimeError(errorClass=error_class, messageParameters={})
+
+
+def verify_output_row_limit(
+    iterator: Iterator,
+    max_rows: Union[int, Callable[[], int]],
+    error_class: str,
+) -> Iterator:
+    """Yield elements while verifying total rows do not exceed a limit (fail-fast)."""
+    total_rows = 0
+    for element in iterator:
+        total_rows += len(element)
+        if total_rows > (max_rows() if callable(max_rows) else max_rows):
+            raise PySparkRuntimeError(errorClass=error_class, messageParameters={})
+        yield element
+
+
+def verify_output_row_count(
+    iterator: Iterator,
+    expected_rows: Union[int, Callable[[], int]],
+    error_class: str,
+) -> Iterator:
+    """Yield elements and verify final row count matches expected exactly."""
+    actual_rows = 0
+    for element in iterator:
+        actual_rows += len(element)
+        yield element
+
+    expected = expected_rows() if callable(expected_rows) else expected_rows
+    if actual_rows != expected:
+        raise PySparkRuntimeError(
+            errorClass=error_class,
+            messageParameters={
+                "output_length": str(actual_rows),
+                "input_length": str(expected),
+            },
+        )
 
 
 def wrap_udf(f, args_offsets, kwargs_offsets, return_type):
@@ -578,41 +624,6 @@ def verify_pandas_result(result, return_type, assign_cols_by_name, truncate_retu
                 errorClass="UDF_RETURN_TYPE",
                 messageParameters={"expected": "pandas.Series", "actual": type(result).__name__},
             )
-
-
-def wrap_arrow_array_iter_udf(f, return_type, runner_conf):
-    arrow_return_type = to_arrow_type(
-        return_type, timezone="UTC", prefers_large_types=runner_conf.use_large_var_types
-    )
-
-    def verify_result(result):
-        if not isinstance(result, Iterator) and not hasattr(result, "__iter__"):
-            raise PySparkTypeError(
-                errorClass="UDF_RETURN_TYPE",
-                messageParameters={
-                    "expected": "iterator of pyarrow.Array",
-                    "actual": type(result).__name__,
-                },
-            )
-        return result
-
-    def verify_element(elem):
-        import pyarrow as pa
-
-        if not isinstance(elem, pa.Array):
-            raise PySparkTypeError(
-                errorClass="UDF_RETURN_TYPE",
-                messageParameters={
-                    "expected": "iterator of pyarrow.Array",
-                    "actual": "iterator of {}".format(type(elem).__name__),
-                },
-            )
-
-        return elem
-
-    return lambda *iterator: map(
-        lambda res: (res, arrow_return_type), map(verify_element, verify_result(f(*iterator)))
-    )
 
 
 def wrap_cogrouped_map_arrow_udf(f, return_type, argspec, runner_conf):
@@ -1403,7 +1414,7 @@ def read_single_udf(pickleSer, infile, eval_type, runner_conf, udf_index):
     elif eval_type == PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF:
         return args_offsets, wrap_pandas_batch_iter_udf(func, return_type, runner_conf)
     elif eval_type == PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF:
-        return args_offsets, wrap_arrow_array_iter_udf(func, return_type, runner_conf)
+        return func, args_offsets, kwargs_offsets, return_type
     elif eval_type == PythonEvalType.SQL_MAP_PANDAS_ITER_UDF:
         return args_offsets, wrap_pandas_batch_iter_udf(func, return_type, runner_conf)
     elif eval_type == PythonEvalType.SQL_MAP_ARROW_ITER_UDF:
@@ -2761,11 +2772,9 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
         elif eval_type in (
             PythonEvalType.SQL_MAP_ARROW_ITER_UDF,
             PythonEvalType.SQL_SCALAR_ARROW_UDF,
+            PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF,
         ):
             ser = ArrowStreamSerializer(write_start_stream=True)
-        elif eval_type == PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF:
-            # Arrow cast and safe check are always enabled
-            ser = ArrowStreamArrowUDFSerializer(safecheck=True, arrow_cast=True)
         elif (
             eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF
             and not runner_conf.use_legacy_pandas_udf_conversion
@@ -2878,10 +2887,72 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
         # profiling is not supported for UDF
         return func, None, ser, ser
 
-    is_scalar_iter = eval_type in (
-        PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF,
-        PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF,
-    )
+    if eval_type == PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF:
+        import pyarrow as pa
+
+        assert num_udfs == 1, "One SCALAR_ARROW_ITER UDF expected here."
+        udf_func, args_offsets, kwargs_offsets, return_type = udfs[0]
+
+        # Pre-compute target Arrow type for output coercion
+        arrow_return_type = to_arrow_type(
+            return_type, timezone="UTC", prefers_large_types=runner_conf.use_large_var_types
+        )
+
+        def func(split_index: int, batches: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
+            """Apply scalar Arrow iterator UDF"""
+
+            num_input_rows = 0
+
+            def extract_args(batch: pa.RecordBatch):
+                nonlocal num_input_rows
+                args = tuple(batch.column(o) for o in args_offsets)
+                num_input_rows += batch.num_rows
+                return args[0] if len(args) == 1 else args
+
+            # Extract args from input batches (streaming)
+            args_iter = map(extract_args, batches)
+
+            # Call UDF and verify result type (iterator of pa.Array)
+            verified_iter = verify_result(pa.Array)(udf_func(args_iter))
+
+            # Process results: coerce type and assemble into RecordBatch
+            def process_results():
+                for result in verified_iter:
+                    result = coerce_arrow_array(
+                        result, arrow_return_type, safecheck=True, arrow_cast=True
+                    )
+                    yield pa.RecordBatch.from_arrays([result], ["_0"])
+
+            # Apply row limit check (fail-fast)
+            # TODO(SPARK-55579): Create Arrow-specific error class (e.g., ARROW_UDF_OUTPUT_EXCEEDS_INPUT_ROWS)
+            limited = verify_output_row_limit(
+                process_results(),
+                lambda: num_input_rows,
+                error_class="PANDAS_UDF_OUTPUT_EXCEEDS_INPUT_ROWS",
+            )
+
+            # Apply row count match check (final)
+            # TODO(SPARK-55579): Create Arrow-specific error class (e.g., RESULT_LENGTH_MISMATCH_FOR_SCALAR_ITER_ARROW_UDF)
+            matched = verify_output_row_count(
+                limited,
+                lambda: num_input_rows,
+                error_class="RESULT_LENGTH_MISMATCH_FOR_SCALAR_ITER_PANDAS_UDF",
+            )
+
+            # Yield batches
+            yield from matched
+
+            # Verify iterator consumed
+            # TODO(SPARK-55579): Create Arrow-specific error class (e.g., STOP_ITERATION_OCCURRED_FROM_SCALAR_ITER_ARROW_UDF)
+            verify_iterator_exhausted(
+                args_iter,
+                error_class="STOP_ITERATION_OCCURRED_FROM_SCALAR_ITER_PANDAS_UDF",
+            )
+
+        # profiling is not supported for UDF
+        return func, None, ser, ser
+
+    is_scalar_iter = eval_type == PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF
     is_map_pandas_iter = eval_type == PythonEvalType.SQL_MAP_PANDAS_ITER_UDF
 
     if is_scalar_iter or is_map_pandas_iter:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Refactor `SQL_SCALAR_ARROW_ITER_UDF` to use `ArrowStreamSerializer` as pure I/O, moving conversion logic from `ArrowStreamArrowUDFSerializer` into `read_udfs()` in `worker.py`.

### Why are the changes needed?

Part of SPARK-55388.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing Arrow UDF tests: `pyspark.sql.tests.arrow.test_arrow_udf`

`COLUMNS=120 asv run --python=same --bench "ScalarArrowIter" --attribute "repeat=(3,5,5.0)"` before and after:

**ScalarArrowIterUDFTimeBench** - Before (master):
```
=================== ============== ============ ===============
--                                      udf                    
------------------- -------------------------------------------
      scenario       identity_udf    sort_udf    nullcheck_udf 
=================== ============== ============ ===============
  sm_batch_few_col    66.9+-0.5ms    175+-0.4ms     52.0+-0.2ms 
 sm_batch_many_col    22.0+-0.2ms    39.7+-0.1ms    19.4+-0.2ms 
  lg_batch_few_col     461+-7ms       808+-8ms      262+-0.9ms  
 lg_batch_many_col    319+-0.5ms      358+-2ms       325+-2ms   
     pure_ints        107+-0.7ms      169+-2ms      86.3+-0.4ms 
    pure_floats        103+-1ms       563+-2ms      84.9+-0.4ms 
    pure_strings       115+-2ms       511+-3ms      90.4+-0.4ms 
      pure_ts          104+-2ms       213+-3ms      83.7+-0.7ms 
    mixed_types       98.5+-0.9ms     160+-1ms      77.9+-0.2ms 
=================== ============== ============ ===============
```

**ScalarArrowIterUDFTimeBench** - After (this PR):
```
=================== ============== ============ ===============
--                                      udf                    
------------------- -------------------------------------------
      scenario       identity_udf    sort_udf    nullcheck_udf 
=================== ============== ============ ===============
  sm_batch_few_col    65.0+-0.2ms    174+-0.5ms     50.7+-0.1ms 
 sm_batch_many_col    21.7+-0.1ms    39.5+-0.2ms    18.9+-0.3ms 
  lg_batch_few_col     448+-2ms       799+-3ms       262+-4ms   
 lg_batch_many_col    317+-0.2ms      367+-10ms     326+-0.7ms  
     pure_ints         107+-1ms      165+-0.6ms     84.2+-0.5ms 
    pure_floats       103+-0.6ms      562+-2ms      84.1+-0.9ms 
    pure_strings      112+-0.9ms      513+-2ms      91.7+-0.1ms 
      pure_ts          103+-2ms       209+-3ms      84.7+-0.3ms 
    mixed_types       99.6+-0.6ms    160+-0.2ms     77.7+-0.8ms 
=================== ============== ============ ===============
```

**ScalarArrowIterUDFPeakmemBench** - Before (master):
```
=================== ============== ========== ===============
--                                     udf                   
------------------- -----------------------------------------
      scenario       identity_udf   sort_udf   nullcheck_udf 
=================== ============== ========== ===============
  sm_batch_few_col       126M         127M          119M     
 sm_batch_many_col       121M         123M          119M     
  lg_batch_few_col       262M         264M          126M     
 lg_batch_many_col       142M         144M          129M     
     pure_ints           142M         143M          120M     
    pure_floats          159M         161M          120M     
    pure_strings         162M         165M          120M     
      pure_ts            158M         161M          120M     
    mixed_types          142M         143M          120M     
=================== ============== ========== ===============
```

**ScalarArrowIterUDFPeakmemBench** - After (this PR):
```
=================== ============== ========== ===============
--                                     udf                   
------------------- -----------------------------------------
      scenario       identity_udf   sort_udf   nullcheck_udf 
=================== ============== ========== ===============
  sm_batch_few_col       126M         127M          119M     
 sm_batch_many_col       121M         123M          120M     
  lg_batch_few_col       262M         264M          126M     
 lg_batch_many_col       142M         144M          129M     
     pure_ints           142M         143M          120M     
    pure_floats          160M         161M          120M     
    pure_strings         162M         165M          120M     
      pure_ts            160M         161M          120M     
    mixed_types          142M         143M          120M     
=================== ============== ========== ===============
```

**Summary**: Performance is neutral. Latency and peak memory are within noise margin before and after, confirming the refactor introduces no regression.

### Was this patch authored or co-authored using generative AI tooling?

No.