### PR TITLE
[SPARK-55583][PYTHON] Validate Arrow schema types in Python data source

### DIFF
--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -692,6 +692,40 @@ class BasePythonDataSourceTestsMixin:
         ):
             self.spark.read.format("arrowbatch").schema("key int, dummy string").load().show()
 
+        # SPARK-55583: Validate Arrow schema types, not just column count/names.
+        # The data source declares "key string, value string" but read() yields
+        # a RecordBatch with (int32, string), causing an Arrow schema type mismatch.
+        class MismatchedTypeDataSource(DataSource):
+            @classmethod
+            def name(cls):
+                return "arrowbatch_type_mismatch"
+
+            def schema(self):
+                return "key string, value string"
+
+            def reader(self, schema: str):
+                return MismatchedTypeReader()
+
+        class MismatchedTypeReader(DataSourceReader):
+            def read(self, partition):
+                keys = pa.array([1, 2], type=pa.int32())
+                values = pa.array(["a", "b"], type=pa.string())
+                batch = pa.RecordBatch.from_arrays(
+                    [keys, values],
+                    schema=pa.schema([("key", pa.int32()), ("value", pa.string())]),
+                )
+                yield batch
+
+            def partitions(self):
+                return [InputPartition(0)]
+
+        self.spark.dataSource.register(MismatchedTypeDataSource)
+        with self.assertRaisesRegex(
+            PythonException,
+            "DATA_SOURCE_RETURN_SCHEMA_MISMATCH",
+        ):
+            self.spark.read.format("arrowbatch_type_mismatch").load().show()
+
     def test_arrow_batch_sink(self):
         class TestDataSource(DataSource):
             @classmethod

--- a/python/pyspark/sql/worker/plan_data_source_read.py
+++ b/python/pyspark/sql/worker/plan_data_source_read.py
@@ -101,6 +101,17 @@ def records_to_arrow_batches(
                         "actual": str(first_element.schema.names),
                     },
                 )
+        # Validate that the Arrow schema types match the expected output schema.
+        # This prevents cryptic errors from Arrow's VectorLoader when the batch
+        # buffer layout doesn't match what the JVM expects (e.g., SPARK-55583).
+        if not pa_schema.equals(first_element.schema):
+            raise PySparkRuntimeError(
+                errorClass="DATA_SOURCE_RETURN_SCHEMA_MISMATCH",
+                messageParameters={
+                    "expected": str(pa_schema),
+                    "actual": str(first_element.schema),
+                },
+            )
 
         yield first_element
         for element in output_iter:

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
@@ -451,7 +451,7 @@ class PythonStreamingDataSourceSimpleSuite extends PythonDataSourceSuiteBase {
       cause,
       condition = "PYTHON_STREAMING_DATA_SOURCE_RUNTIME_ERROR",
       parameters = Map(
-        "action" -> "read",
+        "action" -> "planPartitions",
         "msg" -> "(?s).*DATA_SOURCE_RETURN_SCHEMA_MISMATCH.*"
       )
     )

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/streaming/PythonStreamingDataSourceSuite.scala
@@ -444,13 +444,15 @@ class PythonStreamingDataSourceSimpleSuite extends PythonDataSourceSuiteBase {
     }
     assert(err.getCause.isInstanceOf[SparkException])
     val cause = err.getCause.asInstanceOf[SparkException]
+    // SPARK-55583: Python streaming data source wraps all Python exceptions as
+    // PYTHON_STREAMING_DATA_SOURCE_RUNTIME_ERROR. The underlying schema mismatch
+    // error (DATA_SOURCE_RETURN_SCHEMA_MISMATCH) is preserved in the message.
     checkErrorMatchPVals(
       cause,
-      condition = "ARROW_TYPE_MISMATCH",
+      condition = "PYTHON_STREAMING_DATA_SOURCE_RUNTIME_ERROR",
       parameters = Map(
-        "operation" -> "Python streaming data source read",
-        "outputTypes" -> "StructType\\(StructField\\(id,IntegerType,false\\)\\)",
-        "actualDataTypes" -> "StructType\\(StructField\\(id,StringType,true\\)\\)"
+        "action" -> "read",
+        "msg" -> "(?s).*DATA_SOURCE_RETURN_SCHEMA_MISMATCH.*"
       )
     )
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds Arrow schema type validation for the `pa.RecordBatch` code path in Python data source reads. The fix adds a `pa_schema.equals(first_element.schema)` check after the existing column name validation in `records_to_arrow_batches()`, raising a clear `DATA_SOURCE_RETURN_SCHEMA_MISMATCH` error with the expected and actual Arrow schemas.

### Why are the changes needed?

When a Python data source returns a `pa.RecordBatch` with data types that don't match the declared schema, the resulting JVM-side errors are confusing and do not indicate the root cause. For example:

- `IllegalArgumentException: not all nodes, buffers and variadicBufferCounts were consumed` from `VectorLoader.load()`
- `UnsupportedOperationException: Cannot call the method "getUTF8String" of ArrowColumnVector$ArrowVectorAccessor`

These errors give no indication that the issue is a schema type mismatch in the Python data source's `read()` method. 

### Does this PR introduce _any_ user-facing change?

Yes. Previously, returning a `pa.RecordBatch` with mismatched types from a Python data source would result in cryptic JVM errors. Now it raises a clear `DATA_SOURCE_RETURN_SCHEMA_MISMATCH` error showing the expected and actual Arrow schemas.

Example error msg:
```
PySparkRuntimeError: [DATA_SOURCE_RETURN_SCHEMA_MISMATCH]
  Return schema mismatch in the result from 'read' method.
  Expected: <expected_schema>, Found: <actual_schema>
```

Example error msg for streaming:
```
  [PYTHON_STREAMING_DATA_SOURCE_RUNTIME_ERROR]
  Failed when Python streaming data source perform planPartitions:
  PySparkRuntimeError: [DATA_SOURCE_RETURN_SCHEMA_MISMATCH]
  Return schema mismatch in the result from 'read' method.
  Expected: <expected_schema>, Found: <actual_schema>
```

### How was this patch tested?

Added a test case in `test_python_datasource.py::test_arrow_batch_data_source`.

### Was this patch authored or co-authored using generative AI tooling?

No