### PR TITLE
[SPARK-55585][K8S]: Allow executor feature steps to create resources

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -463,6 +463,7 @@ class ExecutorPodsAllocator(
         kubernetesClient.pods().inNamespace(namespace).resource(podWithAttachedContainer).create()
       try {
         addOwnerReference(createdExecutorPod, resources)
+        kubernetesClient.resourceList(resources: _*).forceConflicts().serverSideApply()
         resources
           .filter(_.getKind == "PersistentVolumeClaim")
           .foreach { resource =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Applies resources provided by the executor feature step.

### Why are the changes needed?
Spark provides feature steps that allow for custom configuration of Kubernetes driver and executor pods. While driver feature steps can create resources, executor feature steps cannot.

The `KubernetesExecutorSpec` allows for defining `executorKubernetesResources`, but they are not created (applied) by the `ExecutorPodsAllocator`. Only PVCs are specifically created right now.

### Does this PR introduce _any_ user-facing change?
Kubernetes resources defined by an executor feature step are actually created.

### How was this patch tested?
Unit test.

### Was this patch authored or co-authored using generative AI tooling?
No