### PR TITLE
[SPARK-55590][SQL][TESTS] Add `mysql-connector-j` test dependency to `sql/core` module

### DIFF
--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -191,6 +191,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <version>${mysql.connector.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mariadb.jdbc</groupId>
       <artifactId>mariadb-java-client</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `mysql-connector-j` test dependency to `sql/core` module.

### Why are the changes needed?

`JDBCSuite` requires `mysql-connector-j` client. Previously, it seems that `MariaDB` connector are used unintentionally. We should fix this.

https://github.com/apache/spark/blob/cb3ff7234c2c649bc0b6bb4b1c3465fb1e955600/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala#L1413-L1420

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

**BEFORE**

```
$ build/sbt "sql/testOnly org.apache.spark.sql.jdbc.JDBCSuite -- -z SPARK-18419"
...
[info] JDBCSuite:
08:32:54.125 WARN org.apache.hadoop.util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
08:32:55.894 ERROR org.apache.spark.sql.execution.datasources.jdbc.connection.ConnectionProvider: Failed to load built-in provider.
[info] - SPARK-18419: Fix `asConnectionProperties` to filter case-insensitively *** FAILED *** (13 milliseconds)
[info]   java.sql.SQLException: No suitable driver
...
```

**AFTER**

```
$ build/sbt "sql/testOnly org.apache.spark.sql.jdbc.JDBCSuite -- -z SPARK-18419"
...
[info] JDBCSuite:
[info] - SPARK-18419: Fix `asConnectionProperties` to filter case-insensitively (13 milliseconds)
[info] Run completed in 2 seconds, 967 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 19 s, completed Feb 18, 2026, 8:32:08 AM
```

### Was this patch authored or co-authored using generative AI tooling?

No.