### PR TITLE
[SPARK-55594][INFRA] Fix `test_report.yml` to ignore `pages.yml`

### DIFF
--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -26,7 +26,9 @@ on:
 
 jobs:
   test_report:
-    if: "!contains(fromJson('[\"skipped\", \"cancelled\"]'), github.event.workflow_run.conclusion)"
+    if: >
+      github.event.workflow_run.path != '.github/workflows/pages.yml' &&
+      !contains(fromJson('["skipped", "cancelled"]'), github.event.workflow_run.conclusion)
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `test_report.yml` to ignore `pages.yml`.

### Why are the changes needed?

Currently, CIs seems to have a corner case where the `test_report` job fails on `GitHub Pages deployment` like the following with `No test results found!` error. We had better ignore `pages.yml`.

<img width="652" height="200" alt="Screenshot 2026-02-18 at 11 35 32" src="https://github.com/user-attachments/assets/b2849e0f-be90-45b4-9ca9-dabf336b06b5" />

<img width="729" height="189" alt="Screenshot 2026-02-18 at 11 35 52" src="https://github.com/user-attachments/assets/b046a91c-39a6-4373-a0cf-5d09e6f947d1" />


### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`