### PR TITLE
[SPARK-55599][BUILD] Replaces dots to hyphens in release announcement pages

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -344,7 +344,7 @@ meta:
   _edit_last: '4'
   _wpas_done_all: '1'
 ---
-We are happy to announce the availability of <a href="{{site.baseurl}}/releases/spark-release-${RELEASE_VERSION}.html" title="Spark Release ${RELEASE_VERSION}">Apache Spark ${RELEASE_VERSION}</a>! Visit the <a href="{{site.baseurl}}/releases/spark-release-${RELEASE_VERSION}.html" title="Spark Release ${RELEASE_VERSION}">release notes</a> to read about the new features, or <a href="{{site.baseurl}}/downloads.html">download</a> the release today.
+We are happy to announce the availability of <a href="{{site.baseurl}}/releases/spark-release-${RELEASE_VERSION//./-}.html" title="Spark Release ${RELEASE_VERSION}">Apache Spark ${RELEASE_VERSION}</a>! Visit the <a href="{{site.baseurl}}/releases/spark-release-${RELEASE_VERSION//./-}.html" title="Spark Release ${RELEASE_VERSION}">release notes</a> to read about the new features, or <a href="{{site.baseurl}}/downloads.html">download</a> the release today.
 EOF
   fi
 
@@ -402,7 +402,7 @@ You can find the list of resolved issues and detailed changes in the [JIRA relea
 
 We would like to acknowledge all community members for contributing ${ACKNOWLEDGE}"
 
-    FILENAME="releases/_posts/${RELEASE_DATE}-spark-release-${RELEASE_VERSION}.md"
+    FILENAME="releases/_posts/${RELEASE_DATE}-spark-release-${RELEASE_VERSION//./-}.md"
     mkdir -p releases/_posts
     cat > "$FILENAME" <<EOF
 ---


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix the file name back to with hyphens, see

```

[TXT] | spark-release-4-0-0.html | 2026-02-10 09:21 | 134K |  
-- | -- | -- | -- | --
  | spark-release-4-0-1.html | 2026-02-10 09:21 | 25K |  
  | spark-release-4-0-2.html | 2026-02-10 09:21 | 11K |  
  | spark-release-4.1.0.html | 2026-02-10 09:21 | 69K |  

[TXT]	[spark-release-4-0-0.html](https://spark.apache.org/releases/spark-release-4-0-0.html)	2026-02-10 09:21	134K	 
[TXT]	[spark-release-4-0-1.html](https://spark.apache.org/releases/spark-release-4-0-1.html)	2026-02-10 09:21	25K	 
[TXT]	[spark-release-4-0-2.html](https://spark.apache.org/releases/spark-release-4-0-2.html)	2026-02-10 09:21	11K	 
[TXT]	[spark-release-4.1.0.html](https://spark.apache.org/releases/spark-release-4.1.0.html)	2026-02-10 09:21	69K
```

at https://spark.apache.org/releases/

### Why are the changes needed?

For consistency.

### Does this PR introduce _any_ user-facing change?

Virtually no.

### How was this patch tested?

Will be tested in the next release. Also manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.