### PR TITLE
[SPARK-55603][K8S] Improve `removeExecutorFromK8s` to use `patch` instead of `edit` API

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsLifecycleManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsLifecycleManager.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.scheduler.cluster.k8s
 
 import java.util.concurrent.TimeUnit
-import java.util.function.UnaryOperator
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
@@ -25,6 +24,7 @@ import scala.jdk.CollectionConverters._
 import com.google.common.cache.CacheBuilder
 import io.fabric8.kubernetes.api.model.{Pod, PodBuilder}
 import io.fabric8.kubernetes.client.KubernetesClient
+import io.fabric8.kubernetes.client.dsl.base.{PatchContext, PatchType}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.deploy.ExecutorFailureTracker
@@ -63,6 +63,8 @@ private[spark] class ExecutorPodsLifecycleManager(
   private val inactivatedPods = mutable.HashSet.empty[Long]
 
   private val namespace = conf.get(KUBERNETES_NAMESPACE)
+
+  private val PATCH_CONTEXT = PatchContext.of(PatchType.STRATEGIC_MERGE)
 
   private val sparkContainerName = conf.get(KUBERNETES_EXECUTOR_PODTEMPLATE_CONTAINER_NAME)
     .getOrElse(DEFAULT_EXECUTOR_CONTAINER_NAME)
@@ -231,7 +233,11 @@ private[spark] class ExecutorPodsLifecycleManager(
           .pods()
           .inNamespace(namespace)
           .withName(updatedPod.getMetadata.getName)
-          .edit(executorInactivationFn)
+          .patch(PATCH_CONTEXT, new PodBuilder()
+            .editOrNewMetadata()
+              .addToLabels(SPARK_EXECUTOR_INACTIVE_LABEL, "true")
+            .endMetadata()
+            .build())
 
         inactivatedPods += execId
       }
@@ -321,10 +327,4 @@ private object ExecutorPodsLifecycleManager {
     }
     s"${code}${humanStr}"
   }
-
-  def executorInactivationFn: UnaryOperator[Pod] = (p: Pod) => new PodBuilder(p)
-    .editOrNewMetadata()
-    .addToLabels(SPARK_EXECUTOR_INACTIVE_LABEL, "true")
-    .endMetadata()
-    .build()
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `removeExecutorFromK8s` to use `patch` instead of `edit` API.

### Why are the changes needed?

**Network Efficiency**

- `edit` requires fetching the entire resource and sending the full updated resource back.
- `patch` only transmits the specific changes, making it much more network-efficient.

**Concurrency & Conflict Resolution**

- `edit` typically follows a Get -> Modify -> Update (PUT) pattern. Using this pattern creates a race condition where, if another client modifies the resource in between, a 409 Conflict error occurs due to a mismatched resourceVersion.
- `patch` sends only the changes (delta) to the server, where the merge is handled server-side. This significantly reduces the risk of conflicts, especially for simple operations like adding an annotation.

### Does this PR introduce _any_ user-facing change?

This will reduce the overhead of K8s control plane and the chance of 409 error.

### How was this patch tested?

Pass the CIs with newly updated test case.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`