### PR TITLE
[SPARK-55614][BUILD] Add AGENTS.MD

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Apache Spark - AI Assistant Context
+# Apache Spark
 
 This file provides context and guidelines for AI coding assistants working with the Apache Spark codebase.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,14 @@
 # Apache Spark
 
-This file provides context and guidelines for AI agents working with the Apache Spark codebase.
+This file provides context and guidelines for AI coding assistants working with the Apache Spark codebase.
 
-## Build
+## Build and Test
 
-Prefer SBT via the wrapper script (not Maven):
-```bash
-./build/sbt compile
-./build/sbt "module/test"
-./build/sbt "module/testOnly *TestClassName"
-```
+Prefer building in sbt over maven:
 
+- **Building Spark**: [docs/building-spark.md](docs/building-spark.md)
+  - SBT build instructions: See the ["Building with SBT"](docs/building-spark.md#building-with-sbt) section
+  - SBT testing: See the ["Testing with SBT"](docs/building-spark.md#testing-with-sbt) section
+  - Running individual tests: See the ["Running Individual Tests"](docs/building-spark.md#running-individual-tests) section
+
+- **PySpark Testing**: [python/docs/source/development/testing.rst](python/docs/source/development/testing.rst)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Apache Spark
 
-This file provides context and guidelines for AI coding assistants working with the Apache Spark codebase.
+This file provides context and guidelines for AI agents working with the Apache Spark codebase.
 
 ## Build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Apache Spark - AI Assistant Context
+
+This file provides context and guidelines for AI coding assistants working with the Apache Spark codebase.
+
+## Build
+
+Prefer SBT via the wrapper script (not Maven):
+```bash
+./build/sbt compile
+./build/sbt "module/test"
+./build/sbt "module/testOnly *TestClassName"
+```
+


### PR DESCRIPTION

Closes #54386


### What changes were proposed in this pull request?
Add AGENTS.MD file

### Why are the changes needed?
It'd be nice to get Claude Code/ Cursor, etc to understand how to build Spark and run Spark tests for Spark development. By default, the developer documentation seems to make it use maven, which is much slower than SBT.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Tested in cursor


### Was this patch authored or co-authored using generative AI tooling?
By cursor