### PR TITLE
[SPARK-55619][SQL] Fix custom metrics in case of coalesced partitions

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -2840,6 +2840,21 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase {
     assert(metrics("number of rows read") == "3")
   }
 
+  test("SPARK-55619: Custom metrics of coalesced partitions") {
+    val items_partitions = Array(identity("id"))
+    createTable(items, itemsColumns, items_partitions)
+
+    sql(s"INSERT INTO testcat.ns.$items VALUES " +
+      "(1, 'aa', 40.0, cast('2020-01-01' as timestamp)), " +
+      "(2, 'bb', 10.0, cast('2021-01-01' as timestamp))")
+
+    val metrics = runAndFetchMetrics {
+      val df = sql(s"SELECT * FROM testcat.ns.$items").coalesce(1)
+      df.collect()
+    }
+    assert(metrics("number of rows read") == "2")
+  }
+
   test("SPARK-55411: Fix ArrayIndexOutOfBoundsException when join keys " +
     "are less than cluster keys") {
     withSQLConf(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds reverts [SPARK-52809](https://issues.apache.org/jira/browse/SPARK-52809) / https://github.com/apache/spark/pull/51503 and offers a new way to track most recently created reader and do a final metrics update in a task completion listener. The changes are required as `DataSourceRDD.compute()` can be called multiple times in thead/task when the `DataSourceRDD` gets coalesced. Please find an example in the new test.

### Why are the changes needed?
To calculate custom metrics correctly.

### Does this PR introduce _any_ user-facing change?
It fixes metrics calculation.

### How was this patch tested?
New UT is added.

### Was this patch authored or co-authored using generative AI tooling?
No.