### PR TITLE
[SPARK-54835][SQL][TESTS][FOLLOWUP] Drain listener bus before registering listener in test

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
@@ -2155,6 +2155,8 @@ class DataSourceV2DataFrameSuite
     }
 
     try {
+      // drain listener bus before registering the listener.
+      sparkContext.listenerBus.waitUntilEmpty()
       spark.listenerManager.register(listener)
       val t = "testcat.ns1.ns2.tbl"
       withTable(t) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a followup to #53596. In the test "CTAS/RTAS should trigger two query executions", we drain the listener bus before registering the `QueryExecutionListener`, to avoid events from other tests breaking this test with unexpected `executionCount` increments.

### Why are the changes needed?

Without draining the listener bus first, pending events from previous tests could fire after the listener is registered, causing flaky test failures. Other test suites follow this same pattern.

### Does this PR introduce _any_ user-facing change?

No. Test-only change.

### How was this patch tested?

Existing test.

### Was this patch authored or co-authored using generative AI tooling?

Yes.


Made with [Cursor](https://cursor.com)