### PR TITLE
[SPARK-55622][SQL][TESTS] Add test for DSV2 Tables with multi-part names on SessionCatalog

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTable.scala
@@ -266,7 +266,7 @@ object InMemoryTable {
 
 /**
  * A metadata table that returns snapshot (commit) information for a parent table.
- * Simulates data source metadata tables like Iceberg's db.table.snapshots.
+ * Simulates data source tables with multi-part identifiers, ex Iceberg's db.table.snapshots.
  */
 class InMemorySnapshotsTable(parentTable: InMemoryTable) extends Table with SupportsRead {
   override def name(): String = parentTable.name + ".snapshots"

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSessionCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSessionCatalogSuite.scala
@@ -17,9 +17,11 @@
 
 package org.apache.spark.sql.connector
 
+import java.util.Locale
+
 import org.scalatest.BeforeAndAfter
 
-import org.apache.spark.sql.{DataFrame, QueryTest, SaveMode}
+import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, SaveMode}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
 import org.apache.spark.sql.connector.catalog._
@@ -108,23 +110,28 @@ class InMemoryTableSessionCatalog extends TestV2SessionCatalogBase[InMemoryTable
   }
 
   override def loadTable(ident: Identifier): Table = {
-    // Check for metadata table pattern: namespace = [db, tableName], name = "snapshots"
-    // This simulates how Iceberg handles metadata tables like db.table.snapshots
-    if (ident.name() == "snapshots" && ident.namespace().length >= 1) {
-      val parentTableName = ident.namespace().last
-      val parentNamespace = ident.namespace().dropRight(1)
-      val parentIdent = Identifier.of(
-        if (parentNamespace.isEmpty) Array("default") else parentNamespace,
-        parentTableName)
-
-      val parentTable = super.loadTable(parentIdent).asInstanceOf[InMemoryTable]
-      return new InMemorySnapshotsTable(parentTable)
-    }
-
     val identToUse = Option(InMemoryTableSessionCatalog.customIdentifierResolution)
       .map(_(ident))
       .getOrElse(ident)
-    super.loadTable(identToUse)
+
+    // For single-part namespaces, follow Iceberg's pattern: first try to load the table
+    // normally, fall back to metadata table resolution only on NoSuchTableException
+    try {
+      super.loadTable(identToUse)
+    } catch {
+      case _: AnalysisException if identToUse.name().toLowerCase(Locale.ROOT) == "snapshots" =>
+        loadSnapshotTable(identToUse)
+    }
+  }
+
+  private def loadSnapshotTable(ident: Identifier): InMemorySnapshotsTable = {
+    val parentTableName = ident.namespace().last
+    val parentNamespace = ident.namespace().dropRight(1)
+    val parentIdent = Identifier.of(
+      if (parentNamespace.isEmpty) Array("default") else parentNamespace,
+      parentTableName)
+    val parentTable = super.loadTable(parentIdent).asInstanceOf[InMemoryTable]
+    new InMemorySnapshotsTable(parentTable)
   }
 
   override def alterTable(ident: Identifier, changes: TableChange*): Table = {


### PR DESCRIPTION


### What changes were proposed in this pull request?
Add a unit test for Iceberg's case of supporting multi part identifiers in SessionCatalog (for metadata tables).  Add a fake metadata table to InMemoryDataSource.


### Why are the changes needed?
It can increase Spark coverage to catch issue like: https://github.com/apache/spark/pull/54247


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Ran the added test


### Was this patch authored or co-authored using generative AI tooling?
Yes, cursor claude 4.5 opus