### PR TITLE
[SPARK-55624][PS][TESTS] Ignore ArrowDtype in tests with pandas 3

### DIFF
--- a/python/pyspark/testing/pandasutils.py
+++ b/python/pyspark/testing/pandasutils.py
@@ -32,6 +32,15 @@ try:
 except ImportError:
     pass
 
+try:
+    from pyspark.sql.pandas.utils import require_minimum_pyarrow_version
+
+    require_minimum_pyarrow_version()
+    import pyarrow as pa
+except ImportError:
+    pass
+
+from pyspark.loose_version import LooseVersion
 import pyspark.pandas as ps
 from pyspark.pandas.frame import DataFrame
 from pyspark.pandas.indexes import Index
@@ -439,9 +448,9 @@ class PandasOnSparkTestUtils:
                 )
             else:
                 if not isinstance(left, (pd.DataFrame, pd.Index, pd.Series)):
-                    left = left.to_pandas()
+                    left = self._ignore_arrow_dtypes(left.to_pandas())
                 if not isinstance(right, (pd.DataFrame, pd.Index, pd.Series)):
-                    right = right.to_pandas()
+                    right = self._ignore_arrow_dtypes(right.to_pandas())
 
                 if not check_row_order:
                     if isinstance(left, pd.DataFrame) and len(left.columns) > 0:
@@ -454,8 +463,8 @@ class PandasOnSparkTestUtils:
                 else:
                     _assert_pandas_equal(left, right, checkExact=check_exact)
 
-        lobj = self._to_pandas(left)
-        robj = self._to_pandas(right)
+        lobj = self._ignore_arrow_dtypes(self._to_pandas(left))
+        robj = self._ignore_arrow_dtypes(self._to_pandas(right))
         if isinstance(lobj, (pd.DataFrame, pd.Series, pd.Index)):
             if almost:
                 _assert_pandas_almost_equal(lobj, robj, rtol=rtol, atol=atol)
@@ -480,6 +489,25 @@ class PandasOnSparkTestUtils:
         if isinstance(obj, (DataFrame, Series, Index)):
             return obj.to_pandas()
         else:
+            return obj
+
+    @staticmethod
+    def _ignore_arrow_dtypes(obj: Any):
+        if LooseVersion(pd.__version__) < "3.0.0":
+            return obj
+        else:
+            if isinstance(obj, pd.DataFrame):
+                arrow_boolean_columns = [
+                    col
+                    for col in obj.columns
+                    if isinstance(col.dtype, pd.ArrowDtype)
+                    and col.dtype.pyarrow_dtype == pa.bool_()
+                ]
+                if arrow_boolean_columns:
+                    return obj.astype({col: "boolean" for col in arrow_boolean_columns})
+            elif isinstance(obj, (pd.Series, pd.Index)):
+                if isinstance(obj.dtype, pd.ArrowDtype) and obj.dtype.pyarrow_dtype == pa.bool_():
+                    return obj.astype("boolean")
             return obj
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Ignores `ArrowDtype` in tests with pandas 3.

### Why are the changes needed?

The `ArrowDtype` is used for the result of the predicates operations on some dtypes in pandas 3 by default, but the values should be same as `BooleanDtype`.

It should be ignored in tests.

```py
>>> pser = pd.Series(["x", "y", "z", None], dtype="string")
>>> other_pser = pd.Series([None, "z", "y", "x"], dtype="string")
>>>
>>> pser == other_pser
0     <NA>
1    False
2    False
3     <NA>
dtype: bool[pyarrow]
>>> (pser == other_pser).astype("boolean")
0     <NA>
1    False
2    False
3     <NA>
dtype: boolean
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Updated the test util.

### Was this patch authored or co-authored using generative AI tooling?

No.
