### PR TITLE
[SPARK-55625][PS] Fix StringOps to make `str` dtype work properly

### DIFF
--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -40,7 +40,7 @@ from pyspark.pandas.internal import (
     SPARK_DEFAULT_INDEX_NAME,
 )
 from pyspark.pandas.spark.accessors import SparkIndexOpsMethods
-from pyspark.pandas.typedef import extension_dtypes
+from pyspark.pandas.typedef.typehints import handle_dtype_as_extension_dtype
 from pyspark.pandas.utils import (
     ansi_mode_context,
     combine_frames,
@@ -228,7 +228,7 @@ def column_op(f: Callable[..., Column]) -> Callable[..., SeriesOrIndex]:
             field = InternalField.from_struct_field(
                 self._internal.spark_frame.select(scol).schema[0],
                 use_extension_dtypes=any(
-                    isinstance(col.dtype, extension_dtypes) for col in [self] + cols
+                    handle_dtype_as_extension_dtype(col.dtype) for col in [self] + cols
                 ),
             )
 

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -32,7 +32,7 @@ from pyspark.pandas.data_type_ops.base import (
     _as_string_type,
     _sanitize_list_like,
 )
-from pyspark.pandas.typedef import extension_dtypes, pandas_on_spark_type
+from pyspark.pandas.typedef import handle_dtype_as_extension_dtype, pandas_on_spark_type
 from pyspark.sql.types import BooleanType
 
 
@@ -124,7 +124,7 @@ class StringOps(DataTypeOps):
             return _as_categorical_type(index_ops, dtype, spark_type)
 
         if isinstance(spark_type, BooleanType):
-            if isinstance(dtype, extension_dtypes):
+            if handle_dtype_as_extension_dtype(dtype):
                 scol = index_ops.spark.column.cast(spark_type)
             else:
                 scol = F.when(index_ops.spark.column.isNull(), F.lit(False)).otherwise(

--- a/python/pyspark/pandas/internal.py
+++ b/python/pyspark/pandas/internal.py
@@ -50,7 +50,7 @@ from pyspark.pandas.data_type_ops.base import DataTypeOps
 from pyspark.pandas.typedef import (
     Dtype,
     as_spark_type,
-    extension_dtypes,
+    handle_dtype_as_extension_dtype,
     infer_pd_series_spark_type,
     spark_type_to_pandas_dtype,
 )
@@ -162,7 +162,7 @@ class InternalField:
     @property
     def is_extension_dtype(self) -> bool:
         """Return whether the dtype for the field is an extension type or not."""
-        return isinstance(self.dtype, extension_dtypes)
+        return handle_dtype_as_extension_dtype(self.dtype)
 
     def normalize_spark_type(self) -> "InternalField":
         """Return a new InternalField object with normalized Spark data type."""

--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -274,10 +274,7 @@ def spark_type_to_pandas_dtype(
                 return BooleanDtype()
             # StringType
             elif isinstance(spark_type, types.StringType):
-                if LooseVersion(pd.__version__) < "3.0.0":
-                    return StringDtype()
-                else:
-                    return StringDtype(na_value=np.nan)
+                return StringDtype()
 
         # FractionalType
         if extension_float_dtypes_available:
@@ -285,6 +282,10 @@ def spark_type_to_pandas_dtype(
                 return Float32Dtype()
             elif isinstance(spark_type, types.DoubleType):
                 return Float64Dtype()
+
+    if LooseVersion(pd.__version__) >= "3.0.0":
+        if extension_object_dtypes_available and isinstance(spark_type, types.StringType):
+            return StringDtype(na_value=np.nan)
 
     if isinstance(
         spark_type,
@@ -316,6 +317,16 @@ def spark_type_to_pandas_dtype(
                 spark_type, timezone="UTC", prefers_large_types=prefers_large_var_types
             ).to_pandas_dtype()
         )
+
+
+def handle_dtype_as_extension_dtype(tpe: Dtype) -> bool:
+    if LooseVersion(pd.__version__) < "3.0.0":
+        return isinstance(tpe, extension_dtypes)
+
+    if extension_object_dtypes_available:
+        if isinstance(tpe, StringDtype):
+            return tpe.na_value is pd.NA
+    return isinstance(tpe, extension_dtypes)
 
 
 def pandas_on_spark_type(tpe: Union[str, type, Dtype]) -> Tuple[Dtype, types.DataType]:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix `StringOps` to make `str` dtype work properly.

### Why are the changes needed?

In pandas 3, the default dtype for string is now `str` or `StringDtype(na_value=np.nan)`.
This is one of extension dtypes, but actually handled as if non-extension dtypes.

```py
>>> pser = pd.Series(["x", "y", "z", None])
>>> other_pser = pd.Series([None, "z", "y", "x"])
```

- pandas 2

```py
>>> pser
0       x
1       y
2       z
3    None
dtype: object
>>> other_pser
0    None
1       z
2       y
3       x
dtype: object
>>> pser == other_pser
0    False
1    False
2    False
3    False
dtype: bool
```

- pandas 3

```py
>>> pser
0      x
1      y
2      z
3    NaN
dtype: str
>>> other_pser
0    NaN
1      z
2      y
3      x
dtype: str
>>> pser == other_pser
0    False
1    False
2    False
3    False
dtype: bool
```

### Does this PR introduce _any_ user-facing change?

Yes, it will behave more like pandas 3.

### How was this patch tested?

The existing tests should pass.

### Was this patch authored or co-authored using generative AI tooling?

No.
