### PR TITLE
[SPARK-55636][CONNECT] Add detailed errors in case of deduplication of invalid columns

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/InvalidInputErrors.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/InvalidInputErrors.scala
@@ -54,8 +54,10 @@ object InvalidInputErrors {
     InvalidPlanInput(
       "Deduplicate requires to either deduplicate on all columns or a subset of columns")
 
-  def invalidDeduplicateColumn(colName: String): InvalidPlanInput =
-    InvalidPlanInput(s"Invalid deduplicate column $colName")
+  def invalidDeduplicateColumn(colName: String, fieldNames: String): InvalidPlanInput =
+    InvalidPlanInput(
+      "UNRESOLVED_COLUMN_AMONG_FIELD_NAMES",
+      Map("colName" -> colName, "fieldNames" -> fieldNames))
 
   def functionEvalTypeNotSupported(evalType: Int): InvalidPlanInput =
     InvalidPlanInput(s"Function with EvalType: $evalType is not supported")

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1440,12 +1440,12 @@ class SparkConnectPlanner(
       else Deduplicate(allColumns, queryExecution.analyzed)
     } else {
       val toGroupColumnNames = rel.getColumnNamesList.asScala.toSeq
-      val fieldNames = allColumns.map(_.name).mkString(", ")
       val groupCols = toGroupColumnNames.flatMap { (colName: String) =>
         // It is possibly there are more than one columns with the same name,
         // so we call filter instead of find.
         val cols = allColumns.filter(col => resolver(col.name, colName))
         if (cols.isEmpty) {
+          val fieldNames = allColumns.map(_.name).mkString(", ")
           throw InvalidInputErrors.invalidDeduplicateColumn(colName, fieldNames)
         }
         cols

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1440,12 +1440,13 @@ class SparkConnectPlanner(
       else Deduplicate(allColumns, queryExecution.analyzed)
     } else {
       val toGroupColumnNames = rel.getColumnNamesList.asScala.toSeq
+      val fieldNames = allColumns.map(_.name).mkString(", ")
       val groupCols = toGroupColumnNames.flatMap { (colName: String) =>
         // It is possibly there are more than one columns with the same name,
         // so we call filter instead of find.
         val cols = allColumns.filter(col => resolver(col.name, colName))
         if (cols.isEmpty) {
-          throw InvalidInputErrors.invalidDeduplicateColumn(colName)
+          throw InvalidInputErrors.invalidDeduplicateColumn(colName, fieldNames)
         }
         cols
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

This PR updates the error handling for invalid deduplicate column names in Spark Connect to use the standard `UNRESOLVED_COLUMN_AMONG_FIELD_NAMES` error class instead of throwing INTERNAL_ERROR, a generic error message.

Example | Classic | Connect (Before) | Connect (After)
-- | -- | -- | --
<img width="497" height="264" alt="image" src="https://github.com/user-attachments/assets/15f9327c-b119-4e00-bcc8-9a85cb477413" /> | Cannot resolve column name "artist_id" among (id, song_name, artist_name). | [[INTERNAL_ERROR](https://docs.databricks.com/error-messages/error-classes.html#internal_error)] Invalid deduplicate column artist_id SQLSTATE: XX000 | [[UNRESOLVED_COLUMN_AMONG_FIELD_NAMES](https://docs.databricks.com/error-messages/error-classes.html#unresolved_column_among_field_names)] Cannot resolve column name "artist_id" among (id, song_name, artist_name). SQLSTATE: 42703
<img width="618" height="344" alt="image" src="https://github.com/user-attachments/assets/dd5e9c63-59e6-4fd2-997a-b4d1387dbdca" /> | Cannot resolve column name "cont.f1" among (id, cont). | [[INTERNAL_ERROR](https://docs.databricks.com/error-messages/error-classes.html#internal_error)] Invalid deduplicate column cont.f1 SQLSTATE: XX000 | [[UNRESOLVED_COLUMN_AMONG_FIELD_NAMES](https://docs.databricks.com/error-messages/error-classes.html#unresolved_column_among_field_names)] Cannot resolve column name "cont.f1" among (id, cont). SQLSTATE: 42703
<img width="462" height="204" alt="image" src="https://github.com/user-attachments/assets/1ce2c96c-e1f6-4dac-8dfa-be5f7807f563" /> | works | works | works
<img width="526" height="248" alt="image" src="https://github.com/user-attachments/assets/be55ca70-527f-4d0b-87e8-bdbb0a66d88c" /> | Cannot resolve column name "song.names" among (id, song.name, artist_name). | [[INTERNAL_ERROR](https://docs.databricks.com/error-messages/error-classes.html#internal_error)] Invalid deduplicate column song.names SQLSTATE: XX000 | [[UNRESOLVED_COLUMN_AMONG_FIELD_NAMES](https://docs.databricks.com/error-messages/error-classes.html#unresolved_column_among_field_names)] Cannot resolve column name "song.names" among (id, song.name, artist_name). SQLSTATE: 42703
<img width="630" height="323" alt="image" src="https://github.com/user-attachments/assets/e48d1bee-e7a1-41ac-b1cd-cb55b5439065" /> | works | works | works
<img width="625" height="333" alt="image" src="https://github.com/user-attachments/assets/17823344-f63d-4de3-9d7e-380906092e33" /> | Cannot resolve column name "cont.value" among (id, cont.val). | [[INTERNAL_ERROR](https://docs.databricks.com/error-messages/error-classes.html#internal_error)] Invalid deduplicate column cont.value SQLSTATE: XX000 | [[UNRESOLVED_COLUMN_AMONG_FIELD_NAMES](https://docs.databricks.com/error-messages/error-classes.html#unresolved_column_among_field_names)] Cannot resolve column name "cont.value" among (id, cont.val). SQLSTATE: 42703
<img width="665" height="331" alt="image" src="https://github.com/user-attachments/assets/10a82231-603e-4487-bf9a-408875d6e15d" /> | <img width="167" height="117" alt="image" src="https://github.com/user-attachments/assets/acb15971-dae6-4a9a-ac9d-79192504f90f" /> | same | same

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
The previous error message in Spark Connect was not consistent with classic Spark and lacked helpful context.
This change aligns Spark Connect error messages with classic Spark, providing users with:
1. The correct error class (`UNRESOLVED_COLUMN_AMONG_FIELD_NAMES` instead of `INTERNAL_ERROR`).
2. The correct SQLSTATE (42703 instead of XX000).
3. A list of available column names to help users fix the issue.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Yes. Error messages for invalid deduplicate column names in Spark Connect are now more detailed and consistent with classic Spark.
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Tested with a custom image with the proposed changes.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
