### PR TITLE
[SPARK-55637][SQL][TESTS] Generalize `postgres-krb-setup.sh` to find config files

### DIFF
--- a/connector/docker-integration-tests/src/test/resources/postgres-krb-setup.sh
+++ b/connector/docker-integration-tests/src/test/resources/postgres-krb-setup.sh
@@ -16,6 +16,6 @@
 # limitations under the License.
 #
 
-sed -i 's/host all all all .*/host all all all gss/g' /var/lib/postgresql/data/pg_hba.conf
-echo "krb_server_keyfile='/docker-entrypoint-initdb.d/postgres.keytab'" >> /var/lib/postgresql/data/postgresql.conf
+sed -i 's/host all all all .*/host all all all gss/g' $(find /var/lib/postgresql -name pg_hba.conf)
+echo "krb_server_keyfile='/docker-entrypoint-initdb.d/postgres.keytab'" >> $(find /var/lib/postgresql -name postgresql.conf)
 psql -U postgres -c "CREATE ROLE \"postgres/__IP_ADDRESS_REPLACE_ME__@EXAMPLE.COM\" LOGIN SUPERUSER"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to generalize `postgres-krb-setup.sh` to find config files instead of using static locations.

### Why are the changes needed?

To improve `PostgresKrbIntegrationSuite` to handle different PostgreSQL image via `POSTGRES_DOCKER_IMAGE_NAME`.

Currently, `PostgresKrbIntegrationSuite` fails for other `PostgreSQL` images.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`