### PR TITLE
[SPARK-55640][Geo][SQL] Propagate WKB parsing errors for Geometry and Geography

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -7742,6 +7742,12 @@
     ],
     "sqlState" : "42601"
   },
+  "WKB_PARSE_ERROR" : {
+    "message" : [
+      "Error parsing WKB: <parseError> at position <pos>"
+    ],
+    "sqlState" : "22023"
+  },
   "WRITE_STREAM_NOT_ALLOWED" : {
     "message" : [
       "`writeStream` can be called only on streaming Dataset/DataFrame."

--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -1483,6 +1483,12 @@
       "Value for `<arg_name>` must be between <lower_bound> and <upper_bound> (inclusive), got <actual>"
     ]
   },
+  "WKB_PARSE_ERROR" : {
+    "message" : [
+      "Error parsing WKB: <parseError> at position <pos>"
+    ],
+    "sqlState" : "22023"
+  },
   "WRONG_NUM_ARGS_FOR_HIGHER_ORDER_FUNCTION": {
     "message": [
       "Function `<func_name>` should take between 1 and 3 arguments, but the provided function takes <num_args>."

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -3604,7 +3604,7 @@ class FunctionsTestsMixin:
 
     def test_st_geogfromwkb(self):
         df = self.spark.createDataFrame(
-            [(bytes.fromhex("0101000000000000000000F03F0000000000000040"))],
+            [(bytes.fromhex("0101000000000000000000F03F0000000000000040"),)],
             ["wkb"],
         )
         results = df.select(
@@ -3615,7 +3615,7 @@ class FunctionsTestsMixin:
         )
         self.assertEqual(results, [expected])
         # ST_GeogFromWKB with invalid WKB.
-        df = self.spark.createDataFrame([(bytearray(b'\x6f'),)], ["wkb"])
+        df = self.spark.createDataFrame([(bytearray(b"\x6f"),)], ["wkb"])
         with self.assertRaises(IllegalArgumentException) as error_context:
             df.select(F.st_geogfromwkb("wkb")).collect()
         self.assertIn("[WKB_PARSE_ERROR]", str(error_context.exception))
@@ -3638,7 +3638,7 @@ class FunctionsTestsMixin:
         )
         self.assertEqual(results, [expected])
         # ST_GeomFromWKB with invalid WKB.
-        df = self.spark.createDataFrame([(bytearray(b'\x6f'),)], ["wkb"])
+        df = self.spark.createDataFrame([(bytearray(b"\x6f"),)], ["wkb"])
         with self.assertRaises(IllegalArgumentException) as error_context:
             df.select(F.st_geomfromwkb("wkb")).collect()
         self.assertIn("[WKB_PARSE_ERROR]", str(error_context.exception))

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geometry.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geometry.java
@@ -17,8 +17,10 @@
 package org.apache.spark.sql.catalyst.util;
 
 import org.apache.spark.sql.catalyst.util.geo.GeometryModel;
+import org.apache.spark.sql.catalyst.util.geo.WkbParseException;
 import org.apache.spark.sql.catalyst.util.geo.WkbReader;
 import org.apache.spark.sql.catalyst.util.geo.WkbWriter;
+import org.apache.spark.sql.errors.QueryExecutionErrors;
 import org.apache.spark.unsafe.types.GeometryVal;
 
 import java.nio.ByteBuffer;
@@ -80,13 +82,17 @@ public final class Geometry implements Geo {
 
   // Returns a Geometry object with the specified SRID value by parsing the input WKB.
   public static Geometry fromWkb(byte[] wkb, int srid) {
-    WkbReader reader = new WkbReader();
-    reader.read(wkb); // Validate WKB
+    try {
+      WkbReader reader = new WkbReader();
+      reader.read(wkb); // Validate WKB
 
-    byte[] bytes = new byte[HEADER_SIZE + wkb.length];
-    ByteBuffer.wrap(bytes).order(DEFAULT_ENDIANNESS).putInt(srid);
-    System.arraycopy(wkb, 0, bytes, WKB_OFFSET, wkb.length);
-    return fromBytes(bytes);
+      byte[] bytes = new byte[HEADER_SIZE + wkb.length];
+      ByteBuffer.wrap(bytes).order(DEFAULT_ENDIANNESS).putInt(srid);
+      System.arraycopy(wkb, 0, bytes, WKB_OFFSET, wkb.length);
+      return fromBytes(bytes);
+    } catch (WkbParseException e) {
+      throw QueryExecutionErrors.wkbParseError(e.getParseError(), e.getPosition());
+    }
   }
 
   // Overload for the WKB reader where we use the default SRID for Geometry.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/geo/WkbParseException.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/geo/WkbParseException.java
@@ -19,40 +19,27 @@ package org.apache.spark.sql.catalyst.util.geo;
 /**
  * Exception thrown when parsing WKB data fails.
  */
-class WkbParseException extends RuntimeException {
+public class WkbParseException extends RuntimeException {
+  private final String parseError;
   private final long position;
-  private final String wkbString;
+  private final byte[] wkb;
 
-  WkbParseException(String message, long position, byte[] wkb) {
-    super(formatMessage(message, position, wkb));
+  WkbParseException(String parseError, long position, byte[] wkb) {
+    super();
+    this.parseError = parseError;
     this.position = position;
-    this.wkbString = wkb != null ? bytesToHex(wkb) : "";
+    this.wkb = wkb;
   }
 
-  private static String formatMessage(String message, long position, byte[] wkb) {
-    String baseMessage = message + " at position " + position;
-    if (wkb != null && wkb.length > 0) {
-      baseMessage += " in WKB: " + bytesToHex(wkb);
-    }
-    return baseMessage;
+  public String getParseError() {
+    return parseError;
   }
 
-  private static String bytesToHex(byte[] bytes) {
-    if (bytes == null || bytes.length == 0) {
-      return "";
-    }
-    StringBuilder sb = new StringBuilder(bytes.length * 2);
-    for (byte b : bytes) {
-      sb.append(String.format("%02X", b));
-    }
-    return sb.toString();
-  }
-
-  long getPosition() {
+  public long getPosition() {
     return position;
   }
 
-  String getWkbString() {
-    return wkbString;
+  public byte[] getWkb() {
+    return wkb;
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/geo/WkbReader.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/geo/WkbReader.java
@@ -222,7 +222,7 @@ public class WkbReader {
 
     // Check that we have enough bytes for header (endianness byte + 4-byte type)
     if (currentWkb.length < WkbUtil.BYTE_SIZE + WkbUtil.TYPE_SIZE) {
-      throw new WkbParseException("WKB data too short", 0, currentWkb);
+      throw new WkbParseException("Unexpected end of WKB buffer", 0, currentWkb);
     }
 
     // Create buffer wrapping the entire byte array

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -676,6 +676,15 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
     stInvalidSridValueError(srid.toString)
   }
 
+  def wkbParseError(msg: String, pos: String): SparkIllegalArgumentException = {
+    new SparkIllegalArgumentException(errorClass = "WKB_PARSE_ERROR",
+      messageParameters = Map("parseError" -> msg, "pos" -> pos))
+  }
+
+  def wkbParseError(msg: String, pos: Long): SparkIllegalArgumentException = {
+    wkbParseError(msg, pos.toString)
+  }
+
   def withSuggestionIntervalArithmeticOverflowError(
       suggestedFunc: String,
       context: QueryContext): ArithmeticException = {

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/util/geo/WkbGeographyTest.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/util/geo/WkbGeographyTest.java
@@ -629,7 +629,7 @@ public class WkbGeographyTest extends WkbTestBase {
     byte[] wkb = makePointWkb2D(200.0, 0.0);
     WkbParseException ex = Assertions.assertThrows(
         WkbParseException.class, () -> geographyReader1().read(wkb));
-    String msg = ex.getMessage();
+    String msg = ex.getParseError();
     Assertions.assertTrue(msg.contains("Invalid coordinate value"));
   }
 }

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/util/geo/WkbReaderWriterAdvancedTest.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/util/geo/WkbReaderWriterAdvancedTest.java
@@ -55,8 +55,7 @@ public class WkbReaderWriterAdvancedTest extends WkbTestBase {
     if (expectedValidateError) {
       WkbParseException ex = Assertions.assertThrows(
         WkbParseException.class, () -> validateReader.read(wkbLittle, 0));
-      Assertions.assertTrue(ex.getMessage().toUpperCase().contains(wkbHexLittle.toUpperCase()),
-        "Exception message should contain the WKB hex: " + wkbHexLittle);
+      Assertions.assertSame(wkbLittle, ex.getWkb());
       geomLittle = noValidateReader.read(wkbLittle, 0);
     } else {
       geomLittle = validateReader.read(wkbLittle, 0);
@@ -73,8 +72,7 @@ public class WkbReaderWriterAdvancedTest extends WkbTestBase {
     if (expectedValidateError) {
       WkbParseException ex = Assertions.assertThrows(
         WkbParseException.class, () -> validateReader.read(wkbBig, 0));
-      Assertions.assertTrue(ex.getMessage().toUpperCase().contains(wkbHexBig.toUpperCase()),
-        "Exception message should contain the WKB hex: " + wkbHexBig);
+      Assertions.assertSame(wkbBig, ex.getWkb());
       geomBig = noValidateReader.read(wkbBig, 0);
     } else {
       geomBig = validateReader.read(wkbBig, 0);
@@ -1198,7 +1196,7 @@ public class WkbReaderWriterAdvancedTest extends WkbTestBase {
       WkbReader geographyReader = new WkbReader(true);
       WkbParseException ex = Assertions.assertThrows(
           WkbParseException.class, () -> geographyReader.read(wkb, 0));
-      Assertions.assertTrue(ex.getMessage().contains("Invalid coordinate value"));
+      Assertions.assertTrue(ex.getParseError().contains("Invalid coordinate value"));
       // Geography mode without validation should accept non-geographic coordinate values.
       WkbReader noValidateGeographyReader = new WkbReader(0, true);
       Assertions.assertDoesNotThrow(() -> noValidateGeographyReader.read(wkb, 0));

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/GeographyExecutionSuite.java
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/GeographyExecutionSuite.java
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.util;
 
+import org.apache.spark.SparkIllegalArgumentException;
 import org.apache.spark.unsafe.types.GeographyVal;
 import org.junit.jupiter.api.Test;
 
@@ -110,6 +111,17 @@ class GeographyExecutionSuite {
     assertNotNull(geography);
     assertArrayEquals(wkb, geography.toWkb());
     assertEquals(4326, geography.srid());
+  }
+
+  @Test
+  void testFromWkbInvalidWkb() {
+    byte[] invalidWkb = new byte[]{111};
+    SparkIllegalArgumentException exception = assertThrows(
+      SparkIllegalArgumentException.class,
+      () -> Geometry.fromWkb(invalidWkb)
+    );
+    assertEquals("WKB_PARSE_ERROR", exception.getCondition());
+    assertTrue(exception.getMessage().contains("Unexpected end of WKB buffer"));
   }
 
   /** Tests for Geography EWKB parsing. */

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/GeometryExecutionSuite.java
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/GeometryExecutionSuite.java
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.util;
 
+import org.apache.spark.SparkIllegalArgumentException;
 import org.apache.spark.unsafe.types.GeometryVal;
 import org.junit.jupiter.api.Test;
 
@@ -113,6 +114,17 @@ class GeometryExecutionSuite {
     assertNotNull(geometry);
     assertArrayEquals(wkb, geometry.toWkb());
     assertEquals(0, geometry.srid());
+  }
+
+  @Test
+  void testFromWkbInvalidWkb() {
+    byte[] invalidWkb = new byte[]{111};
+    SparkIllegalArgumentException exception = assertThrows(
+      SparkIllegalArgumentException.class,
+      () -> Geometry.fromWkb(invalidWkb)
+    );
+    assertEquals("WKB_PARSE_ERROR", exception.getCondition());
+    assertTrue(exception.getMessage().contains("Unexpected end of WKB buffer"));
   }
 
   /** Tests for Geometry EWKB parsing. */

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/st-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/st-functions.sql.out
@@ -312,6 +312,45 @@ Project [hex(st_asbinary(st_geomfromwkb(0x0101000000000000000000F03F000000000000
 
 
 -- !query
+SELECT ST_AsBinary(ST_GeogFromWKB(NULL))
+-- !query analysis
+Project [st_asbinary(st_geogfromwkb(cast(null as binary))) AS st_asbinary(st_geogfromwkb(NULL))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT hex(ST_AsBinary(ST_GeogFromWKB(X'0101000000000000000000F03F0000000000000040')))
+-- !query analysis
+Project [hex(st_asbinary(st_geogfromwkb(0x0101000000000000000000F03F0000000000000040))) AS hex(st_asbinary(st_geogfromwkb(X'0101000000000000000000F03F0000000000000040')))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT ST_GeogFromWKB(X'6F')
+-- !query analysis
+Project [st_geogfromwkb(0x6F) AS st_geogfromwkb(X'6F')#x]
++- OneRowRelation
+
+
+-- !query
+SELECT COUNT(*) FROM geodata WHERE ST_GeogFromWKB(wkb) IS NULL AND wkb IS NOT NULL
+-- !query analysis
+Aggregate [count(1) AS count(1)#xL]
++- Filter (isnull(st_geogfromwkb(wkb#x)) AND isnotnull(wkb#x))
+   +- SubqueryAlias spark_catalog.default.geodata
+      +- Relation spark_catalog.default.geodata[wkb#x] parquet
+
+
+-- !query
+SELECT COUNT(*) FROM geodata WHERE ST_AsBinary(ST_GeogFromWKB(wkb)) <> wkb
+-- !query analysis
+Aggregate [count(1) AS count(1)#xL]
++- Filter NOT (st_asbinary(st_geogfromwkb(wkb#x)) = wkb#x)
+   +- SubqueryAlias spark_catalog.default.geodata
+      +- Relation spark_catalog.default.geodata[wkb#x] parquet
+
+
+-- !query
 SELECT ST_AsBinary(ST_GeomFromWKB(NULL))
 -- !query analysis
 Project [st_asbinary(st_geomfromwkb(cast(null as binary), 0)) AS st_asbinary(st_geomfromwkb(NULL, 0))#x]
@@ -370,6 +409,20 @@ org.apache.spark.SparkIllegalArgumentException
     "srid" : "9999"
   }
 }
+
+
+-- !query
+SELECT ST_GeomFromWKB(X'6F')
+-- !query analysis
+Project [st_geomfromwkb(0x6F, 0) AS st_geomfromwkb(X'6F', 0)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT ST_GeomFromWKB(X'6F', 4326)
+-- !query analysis
+Project [st_geomfromwkb(0x6F, 4326) AS st_geomfromwkb(X'6F', 4326)#x]
++- OneRowRelation
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/inputs/st-functions.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/st-functions.sql
@@ -65,6 +65,18 @@ SELECT typeof(IF(wkb IS NOT NULL, ST_GeomFromWKB(wkb)::GEOMETRY(ANY), ST_GeomFro
 SELECT hex(ST_AsBinary(ST_GeogFromWKB(X'0101000000000000000000f03f0000000000000040'))) AS result;
 SELECT hex(ST_AsBinary(ST_GeomFromWKB(X'0101000000000000000000f03f0000000000000040'))) AS result;
 
+---- ST_GeogFromWKB
+
+-- 1. Driver-level queries.
+SELECT ST_AsBinary(ST_GeogFromWKB(NULL));
+SELECT hex(ST_AsBinary(ST_GeogFromWKB(X'0101000000000000000000F03F0000000000000040')));
+-- Error handling: invalid WKB.
+SELECT ST_GeogFromWKB(X'6F');
+
+-- 2. Table-level queries.
+SELECT COUNT(*) FROM geodata WHERE ST_GeogFromWKB(wkb) IS NULL AND wkb IS NOT NULL;
+SELECT COUNT(*) FROM geodata WHERE ST_AsBinary(ST_GeogFromWKB(wkb)) <> wkb;
+
 ---- ST_GeomFromWKB
 
 -- 1. Driver-level queries.
@@ -76,6 +88,9 @@ SELECT hex(ST_AsBinary(ST_GeomFromWKB(X'0101000000000000000000F03F00000000000000
 -- Error handling: invalid SRID.
 SELECT ST_GeomFromWKB(X'0101000000000000000000F03F0000000000000040', -1);
 SELECT ST_GeomFromWKB(X'0101000000000000000000F03F0000000000000040', 9999);
+-- Error handling: invalid WKB.
+SELECT ST_GeomFromWKB(X'6F');
+SELECT ST_GeomFromWKB(X'6F', 4326);
 
 -- 2. Table-level queries.
 SELECT COUNT(*) FROM geodata WHERE ST_GeomFromWKB(wkb) IS NULL AND wkb IS NOT NULL;

--- a/sql/core/src/test/resources/sql-tests/results/st-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/st-functions.sql.out
@@ -348,6 +348,54 @@ struct<result:string>
 
 
 -- !query
+SELECT ST_AsBinary(ST_GeogFromWKB(NULL))
+-- !query schema
+struct<st_asbinary(st_geogfromwkb(NULL)):binary>
+-- !query output
+NULL
+
+
+-- !query
+SELECT hex(ST_AsBinary(ST_GeogFromWKB(X'0101000000000000000000F03F0000000000000040')))
+-- !query schema
+struct<hex(st_asbinary(st_geogfromwkb(X'0101000000000000000000F03F0000000000000040'))):string>
+-- !query output
+0101000000000000000000F03F0000000000000040
+
+
+-- !query
+SELECT ST_GeogFromWKB(X'6F')
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkIllegalArgumentException
+{
+  "errorClass" : "WKB_PARSE_ERROR",
+  "sqlState" : "22023",
+  "messageParameters" : {
+    "parseError" : "Unexpected end of WKB buffer",
+    "pos" : "0"
+  }
+}
+
+
+-- !query
+SELECT COUNT(*) FROM geodata WHERE ST_GeogFromWKB(wkb) IS NULL AND wkb IS NOT NULL
+-- !query schema
+struct<count(1):bigint>
+-- !query output
+0
+
+
+-- !query
+SELECT COUNT(*) FROM geodata WHERE ST_AsBinary(ST_GeogFromWKB(wkb)) <> wkb
+-- !query schema
+struct<count(1):bigint>
+-- !query output
+0
+
+
+-- !query
 SELECT ST_AsBinary(ST_GeomFromWKB(NULL))
 -- !query schema
 struct<st_asbinary(st_geomfromwkb(NULL, 0)):binary>
@@ -413,6 +461,38 @@ org.apache.spark.SparkIllegalArgumentException
   "sqlState" : "22023",
   "messageParameters" : {
     "srid" : "9999"
+  }
+}
+
+
+-- !query
+SELECT ST_GeomFromWKB(X'6F')
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkIllegalArgumentException
+{
+  "errorClass" : "WKB_PARSE_ERROR",
+  "sqlState" : "22023",
+  "messageParameters" : {
+    "parseError" : "Unexpected end of WKB buffer",
+    "pos" : "0"
+  }
+}
+
+
+-- !query
+SELECT ST_GeomFromWKB(X'6F', 4326)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkIllegalArgumentException
+{
+  "errorClass" : "WKB_PARSE_ERROR",
+  "sqlState" : "22023",
+  "messageParameters" : {
+    "parseError" : "Unexpected end of WKB buffer",
+    "pos" : "0"
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/STFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/STFunctionsSuite.scala
@@ -58,7 +58,7 @@ class STFunctionsSuite extends QueryTest with SharedSparkSession {
     val df_invalid = Seq(Array[Byte](111)).toDF("wkb")
     checkError(
       exception = intercept[SparkIllegalArgumentException] {
-        df_invalid.select(st_geogfromwkb(unhex($"wkb"))).collect()
+        df_invalid.select(st_geogfromwkb($"wkb")).collect()
       },
       condition = "WKB_PARSE_ERROR",
       parameters = Map("parseError" -> "Unexpected end of WKB buffer", "pos" -> "0")
@@ -93,7 +93,7 @@ class STFunctionsSuite extends QueryTest with SharedSparkSession {
     val df_invalid = Seq(Array[Byte](111)).toDF("wkb")
     checkError(
       exception = intercept[SparkIllegalArgumentException] {
-        df_invalid.select(st_geomfromwkb(unhex($"wkb"))).collect()
+        df_invalid.select(st_geomfromwkb($"wkb")).collect()
       },
       condition = "WKB_PARSE_ERROR",
       parameters = Map("parseError" -> "Unexpected end of WKB buffer", "pos" -> "0")

--- a/sql/core/src/test/scala/org/apache/spark/sql/STFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/STFunctionsSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql
 
+import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
@@ -43,6 +44,27 @@ class STFunctionsSuite extends QueryTest with SharedSparkSession {
         "0101000000000000000000f03f0000000000000040"))
   }
 
+  test("st_geogfromwkb") {
+    // Test data: Well-Known Binary (WKB) representations.
+    val df = Seq[(String)](
+      (
+        "0101000000000000000000f03f0000000000000040"
+      )).toDF("wkb")
+    // ST_GeogFromWKB.
+    checkAnswer(
+      df.select(lower(hex(st_asbinary(st_geogfromwkb(unhex($"wkb"))))).as("col0")),
+      Row("0101000000000000000000f03f0000000000000040"))
+    // ST_GeogFromWKB with invalid WKB.
+    val df_invalid = Seq(Array[Byte](111)).toDF("wkb")
+    checkError(
+      exception = intercept[SparkIllegalArgumentException] {
+        df_invalid.select(st_geogfromwkb(unhex($"wkb"))).collect()
+      },
+      condition = "WKB_PARSE_ERROR",
+      parameters = Map("parseError" -> "Unexpected end of WKB buffer", "pos" -> "0")
+    )
+  }
+
   test("st_geomfromwkb") {
     // Test data: Well-Known Binary (WKB) representations.
     val df = Seq[(String, Int)](
@@ -59,6 +81,23 @@ class STFunctionsSuite extends QueryTest with SharedSparkSession {
         "0101000000000000000000f03f0000000000000040",
         "0101000000000000000000f03f0000000000000040",
         "0101000000000000000000f03f0000000000000040"))
+    // ST_GeomFromWKB with invalid SRID.
+    checkError(
+      exception = intercept[SparkIllegalArgumentException] {
+        df.select(st_geomfromwkb(unhex($"wkb"), lit(-1))).collect()
+      },
+      condition = "ST_INVALID_SRID_VALUE",
+      parameters = Map("srid" -> "-1")
+    )
+    // ST_GeomFromWKB with invalid WKB.
+    val df_invalid = Seq(Array[Byte](111)).toDF("wkb")
+    checkError(
+      exception = intercept[SparkIllegalArgumentException] {
+        df_invalid.select(st_geomfromwkb(unhex($"wkb"))).collect()
+      },
+      condition = "WKB_PARSE_ERROR",
+      parameters = Map("parseError" -> "Unexpected end of WKB buffer", "pos" -> "0")
+    )
   }
 
   /** ST accessor expressions. */


### PR DESCRIPTION
### What changes were proposed in this pull request?
WKB reader was implemented for Geometry and Geography, but only using internal exception handling. This PR addresses this by introducing proper user-facing error classes for WKB parsing.


### Why are the changes needed?
Propagate the WKB parsing errors properly to the user.


### Does this PR introduce _any_ user-facing change?
Yes, users now get proper errors for invalid WKB parsing.


### How was this patch tested?
Added new unit tests and end-to-end SQL tests for WKB parsing.


### Was this patch authored or co-authored using generative AI tooling?
No.
