### PR TITLE
fix(tests): add missing main block to test_session.py

### DIFF
--- a/python/pyspark/sql/tests/connect/test_session.py
+++ b/python/pyspark/sql/tests/connect/test_session.py
@@ -104,3 +104,9 @@ class SparkSessionTestCase(unittest.TestCase):
         s3 = RemoteSparkSession.builder.remote("sc://other").getOrCreate()
 
         self.assertIsNot(s1, s3)
+
+
+if __name__ == "__main__":
+    from pyspark.testing import main
+
+    main()


### PR DESCRIPTION
Fixes #54405

The `test_session.py` file was missing the `if __name__ == '__main__'` block that allows it to be executed directly and included in CI runs. This follows the pattern established in other test files throughout the codebase.

This simple addition resolves the issue where these tests were not being executed in CI, ensuring better test coverage going forward.

**Changes:**
- Added standard main block to `python/pyspark/sql/tests/connect/test_session.py`
- Follows the same pattern used in other test files (imports `main` from `pyspark.testing`)

**Testing:**
The file can now be executed directly with `python test_session.py`.