### PR TITLE
[SPARK-55658][PYTHON] SparkSessionBuilder.create in PySpark classic should mirror getOrCreate path as much as possible

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -612,14 +612,14 @@ class SparkSession(SparkConversionMixin):
                 with self._lock:
                     instantiated_session = SparkSession._instantiatedSession
                     # Get SparkContext
-                    if instantiated_session is None or instantiated_session._sc._jsc is None:
+                    if instantiated_session is not None and instantiated_session._sc._jsc is not None:
+                        sc = instantiated_session._sc
+                    else:
                         sparkConf = SparkConf()
                         for key, value in self._options.items():
                             sparkConf.set(key, value)
                         # This SparkContext may be an existing one.
                         sc = SparkContext.getOrCreate(sparkConf)
-                    else:
-                        sc = instantiated_session._sc
                     jSparkSessionClass = SparkSession._get_j_spark_session_class(sc._jvm)
                     # Create a new SparkSession in the JVM
                     jSparkSession = jSparkSessionClass.builder().config(self._options).create()

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -612,7 +612,10 @@ class SparkSession(SparkConversionMixin):
                 with self._lock:
                     instantiated_session = SparkSession._instantiatedSession
                     # Get SparkContext
-                    if instantiated_session is not None and instantiated_session._sc._jsc is not None:
+                    if (
+                        instantiated_session is not None
+                        and instantiated_session._sc._jsc is not None
+                    ):
                         sc = instantiated_session._sc
                     else:
                         sparkConf = SparkConf()

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -610,16 +610,16 @@ class SparkSession(SparkConversionMixin):
                 from pyspark.core.context import SparkContext
 
                 with self._lock:
-                    session = SparkSession._instantiatedSession
+                    instantiated_session = SparkSession._instantiatedSession
                     # Get SparkContext
-                    if session is None or session._sc._jsc is None:
+                    if instantiated_session is None or instantiated_session._sc._jsc is None:
                         sparkConf = SparkConf()
                         for key, value in self._options.items():
                             sparkConf.set(key, value)
                         # This SparkContext may be an existing one.
                         sc = SparkContext.getOrCreate(sparkConf)
                     else:
-                        sc = session._sc
+                        sc = instantiated_session._sc
                     jSparkSessionClass = SparkSession._get_j_spark_session_class(sc._jvm)
                     # Create a new SparkSession in the JVM
                     jSparkSession = jSparkSessionClass.builder().config(self._options).create()

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -616,6 +616,19 @@ class SparkSessionBuilderCreateTests(unittest.TestCase, PySparkErrorTestUtils):
         finally:
             session2.stop()
 
+    def test_create_does_not_construct_spark_conf_when_session_exists(self):
+        """Ensure SparkConf() is not called when a valid session already exists."""
+        self.session = self._get_builder().create()
+        with unittest.mock.patch(
+            "pyspark.sql.session.SparkConf"
+        ) as mock_spark_conf:
+            session2 = self._get_builder().create()
+            try:
+                mock_spark_conf.assert_not_called()
+                self.assertIs(session2.sparkContext, self.session.sparkContext)
+            finally:
+                session2.stop()
+
 
 class SparkSessionProfileTests(unittest.TestCase, PySparkErrorTestUtils):
     def setUp(self):

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -619,9 +619,7 @@ class SparkSessionBuilderCreateTests(unittest.TestCase, PySparkErrorTestUtils):
     def test_create_does_not_construct_spark_conf_when_session_exists(self):
         """Ensure SparkConf() is not called when a valid session already exists."""
         self.session = self._get_builder().create()
-        with unittest.mock.patch(
-            "pyspark.sql.session.SparkConf"
-        ) as mock_spark_conf:
+        with unittest.mock.patch("pyspark.sql.session.SparkConf") as mock_spark_conf:
             session2 = self._get_builder().create()
             try:
                 mock_spark_conf.assert_not_called()

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -627,6 +627,21 @@ class SparkSessionBuilderCreateTests(unittest.TestCase, PySparkErrorTestUtils):
             finally:
                 session2.stop()
 
+    def test_create_applies_mutable_conf_to_second_session(self):
+        """
+        Ensure that mutable SQL configs passed to create() are applied per-session
+        even when a valid SparkSession already exists.
+        """
+        key = "spark.sql.shuffle.partitions"
+        self.session = self._get_builder().config(key, "5").create()
+        self.assertEqual(self.session.conf.get(key), "5")
+        session2 = self._get_builder().config(key, "7").create()
+        try:
+            self.assertEqual(session2.conf.get(key), "7")
+            self.assertIs(session2.sparkContext, self.session.sparkContext)
+        finally:
+            session2.stop()
+
 
 class SparkSessionProfileTests(unittest.TestCase, PySparkErrorTestUtils):
     def setUp(self):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
As titled this is a minor hygiene improvement which brings the create and getOrCreate codepaths closer together. Prior to this PR, the create codepath would always create a new SparkConf and pass that to SparkContext.getOrCreate. When a SparkSession/Context already exists, the creation of the SparkConf is not required at all and the SparkContext can be fetched from the instantiated session.

Note that this change only modifies SparkSessionBuilder.create in PySpark classic which was recently added [here](https://github.com/apache/spark/pull/53820).

### Why are the changes needed?
Code hygiene

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
We mainly rely on existing tests for the create codepath. We also add a test to verify that a SparkConf is not created when there is an existing session.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No