### PR TITLE
[SPARK-55624][PS][TESTS][FOLLOW-UP] Fix `_ignore_arrow_dtypes` util for DataFrame

### DIFF
--- a/python/pyspark/testing/pandasutils.py
+++ b/python/pyspark/testing/pandasutils.py
@@ -498,8 +498,8 @@ class PandasOnSparkTestUtils:
         else:
             if isinstance(obj, pd.DataFrame):
                 arrow_boolean_columns = [
-                    col
-                    for col in obj.columns
+                    name
+                    for name, col in obj.items()
                     if isinstance(col.dtype, pd.ArrowDtype)
                     and col.dtype.pyarrow_dtype == pa.bool_()
                 ]

--- a/python/pyspark/testing/pandasutils.py
+++ b/python/pyspark/testing/pandasutils.py
@@ -504,7 +504,7 @@ class PandasOnSparkTestUtils:
                     and col.dtype.pyarrow_dtype == pa.bool_()
                 ]
                 if arrow_boolean_columns:
-                    return obj.astype({col: "boolean" for col in arrow_boolean_columns})
+                    return obj.astype({name: "boolean" for name in arrow_boolean_columns})
             elif isinstance(obj, (pd.Series, pd.Index)):
                 if isinstance(obj.dtype, pd.ArrowDtype) and obj.dtype.pyarrow_dtype == pa.bool_():
                     return obj.astype("boolean")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of apache/spark#54412.

Fix `_ignore_arrow_dtypes` util for DataFrame.

### Why are the changes needed?

There is a bug in `_ignore_arrow_dtypes` for DataFrame case.

`obj.columns` will return a list of strings, instead of a list of `Series`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing tests should pass.

### Was this patch authored or co-authored using generative AI tooling?

No.
