### PR TITLE
[SPARK-55647][SQL] Fix `ConstantPropagation` incorrectly replacing attributes with non-binary-stable collations

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
@@ -2248,4 +2248,17 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
         Seq())
     }
   }
+
+  test("ConstantPropagation does not replace attributes with non-binary-stable collation") {
+    val tableName = "t1"
+    withTable(tableName) {
+      sql(s"CREATE TABLE $tableName (c STRING COLLATE UTF8_LCASE)")
+      sql(s"INSERT INTO $tableName VALUES ('hello'), ('HELLO')")
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableName WHERE c = 'hello' AND c = 'HELLO' COLLATE UNICODE"),
+        Row("HELLO")
+      )
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
* `ConstantPropagation` optimizer rule substitutes attributes with literals derived from equality                                                                                                                                              
    predicates (e.g. `c = 'hello'`), then propagates them into other conditions in the same                                                                                                                                                      
    conjunction. This is unsafe for non-binary-stable collations (e.g. `UTF8_LCASE`) where                                                                                                                                                
    equality is non-identity: `c = 'hello'` (case-insensitive) does not imply `c` holds exactly                                                                                                                                                  
    the bytes `'hello'` - it could also be `'HELLO'`, `'Hello'`, etc.                                                                                                                                                                            
 * Substituting `c → 'hello'` in a second condition like `c = 'HELLO' COLLATE UNICODE` turns it                                                                                                                                                 
    into the constant expression `'hello' = 'HELLO' COLLATE UNICODE`, which is always `false`,                                                                                                                                                   
    producing incorrect results.                                                                                                                                                                                                                 
 * Fixed by guarding `safeToReplace` with `isBinaryStable(ar.dataType)` so propagation is skipped                                                                                                                                               
    for attributes whose type is not binary-stable.


### Why are the changes needed?
Bug fix.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
New unit test.


### Was this patch authored or co-authored using generative AI tooling?
No.