### PR TITLE
[SPARK-55648][PS] Handle an unexpected keyword argument error `groupby(axis)` with pandas 3

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -13658,7 +13658,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
     def groupby(
         self,
         by: Union[Name, "Series", List[Union[Name, "Series"]]],
-        axis: Axis = 0,
+        axis: Union[Axis, _NoValueType] = _NoValue,
         as_index: bool = True,
         dropna: bool = True,
     ) -> "DataFrameGroupBy":

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -2397,7 +2397,7 @@ class Frame(object, metaclass=ABCMeta):
     def groupby(
         self: FrameLike,
         by: Union[Name, "Series", List[Union[Name, "Series"]]],
-        axis: Axis = 0,
+        axis: Union[Axis, _NoValueType] = _NoValue,
         as_index: bool = True,
         dropna: bool = True,
     ) -> "GroupBy[FrameLike]":
@@ -2518,9 +2518,16 @@ class Frame(object, metaclass=ABCMeta):
             raise ValueError("Grouper for '{}' not 1-dimensional".format(type(by).__name__))
         if not len(new_by):
             raise ValueError("No group keys passed!")
-        axis = validate_axis(axis)
-        if axis != 0:
-            raise NotImplementedError('axis should be either 0 or "index" currently.')
+
+        if LooseVersion(pd.__version__) < "3.0.0":
+            if axis is _NoValue:
+                axis = 0
+            axis = validate_axis(axis)
+            if axis != 0:
+                raise NotImplementedError('axis should be either 0 or "index" currently.')
+        else:
+            if axis is not _NoValue:
+                raise TypeError("The 'axis' keyword is not supported in pandas 3.0.0 and later.")
 
         return self._build_groupby(by=new_by, as_index=as_index, dropna=dropna)
 

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -2522,7 +2522,7 @@ class Frame(object, metaclass=ABCMeta):
         if LooseVersion(pd.__version__) < "3.0.0":
             if axis is _NoValue:
                 axis = 0
-            axis = validate_axis(axis)
+            axis = validate_axis(axis)  # type: ignore[arg-type]
             if axis != 0:
                 raise NotImplementedError('axis should be either 0 or "index" currently.')
         else:

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -7195,7 +7195,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     def groupby(
         self,
         by: Union[Name, "Series", List[Union[Name, "Series"]]],
-        axis: Axis = 0,
+        axis: Union[Axis, _NoValueType] = _NoValue,
         as_index: bool = True,
         dropna: bool = True,
     ) -> "SeriesGroupBy":


### PR DESCRIPTION
### What changes were proposed in this pull request?

Handles an unexpected keyword argument error `groupby(axis)` with pandas 3.

### Why are the changes needed?

The `axis` argument was removed from `groupby` in pandas 3.

### Does this PR introduce _any_ user-facing change?

Yes, it will behave more like pandas 3.

### How was this patch tested?

Updated the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
