### PR TITLE
[SPARK-55649][K8S] Promote `Kubernetes(Driver|Executor)?FeatureConfigStep` traits to `Stable`

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1611,7 +1611,7 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>(none)</td>
   <td>
     Class names of an extra driver pod feature step implementing
-    `KubernetesFeatureConfigStep`. This is a developer API. Comma separated.
+    `KubernetesFeatureConfigStep`. This is a stable developer API. Comma separated.
     Runs after all of Spark internal feature steps. Since 3.3.0, your driver feature step
     can implement `KubernetesDriverCustomFeatureConfigStep` where the driver config
     is also available.
@@ -1632,7 +1632,7 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>(none)</td>
   <td>
     Class names of an extra executor pod feature step implementing
-    `KubernetesFeatureConfigStep`. This is a developer API. Comma separated.
+    `KubernetesFeatureConfigStep`. This is a stable developer API. Comma separated.
     Runs after all of Spark internal feature steps. Since 3.3.0, your executor feature step
     can implement `KubernetesExecutorCustomFeatureConfigStep` where the executor config
     is also available.

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KubernetesDriverCustomFeatureConfigStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KubernetesDriverCustomFeatureConfigStep.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.deploy.k8s.features
 
-import org.apache.spark.annotation.{DeveloperApi, Unstable}
+import org.apache.spark.annotation.{DeveloperApi, Since, Stable}
 import org.apache.spark.deploy.k8s.KubernetesDriverConf
 
 /**
@@ -65,8 +65,9 @@ import org.apache.spark.deploy.k8s.KubernetesDriverConf
  *   }
  * }}}
  */
-@Unstable
+@Stable
 @DeveloperApi
+@Since("3.3.0")
 trait KubernetesDriverCustomFeatureConfigStep extends KubernetesFeatureConfigStep {
   /**
    * Initialize the configuration for driver user feature step, this only applicable when user

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KubernetesExecutorCustomFeatureConfigStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KubernetesExecutorCustomFeatureConfigStep.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.deploy.k8s.features
 
-import org.apache.spark.annotation.{DeveloperApi, Unstable}
+import org.apache.spark.annotation.{DeveloperApi, Since, Stable}
 import org.apache.spark.deploy.k8s.KubernetesExecutorConf
 
 /**
@@ -65,8 +65,9 @@ import org.apache.spark.deploy.k8s.KubernetesExecutorConf
  *   }
  * }}}
  */
-@Unstable
+@Stable
 @DeveloperApi
+@Since("3.3.0")
 trait KubernetesExecutorCustomFeatureConfigStep extends KubernetesFeatureConfigStep {
   /**
    * Initialize the configuration for executor user feature step, this only applicable when user

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KubernetesFeatureConfigStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KubernetesFeatureConfigStep.scala
@@ -18,7 +18,7 @@ package org.apache.spark.deploy.k8s.features
 
 import io.fabric8.kubernetes.api.model.HasMetadata
 
-import org.apache.spark.annotation.{DeveloperApi, Unstable}
+import org.apache.spark.annotation.{DeveloperApi, Since, Stable}
 import org.apache.spark.deploy.k8s.SparkPod
 
 /**
@@ -27,8 +27,9 @@ import org.apache.spark.deploy.k8s.SparkPod
  * A collection of functions that together represent a "feature" in pods that are launched for
  * Spark drivers and executors.
  */
-@Unstable
+@Stable
 @DeveloperApi
+@Since("3.3.0")
 trait KubernetesFeatureConfigStep {
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to promote the following traits to `Stable` from Apache Spark 4.2.0:
- `KubernetesFeatureConfigStep`
- `KubernetesDriverCustomFeatureConfigStep`
- `KubernetesExecutorCustomFeatureConfigStep`

### Why are the changes needed?

Since Apache Spark 3.3.0, the `Kubernetes*FeatureConfigStep` traits have been serving stably without any modifications for 4 years. We had better promote them to `Stable`.
- https://github.com/apache/spark/pull/35345

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`