### PR TITLE
[SPARK-55606][CONNECT] Server-side implementation of GetStatus API

### DIFF
--- a/sql/connect/server/src/main/java/org/apache/spark/sql/connect/plugin/GetStatusPlugin.java
+++ b/sql/connect/server/src/main/java/org/apache/spark/sql/connect/plugin/GetStatusPlugin.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.plugin;
+
+import com.google.protobuf.Any;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.spark.sql.connect.service.SessionHolder;
+
+/**
+ * Plugin interface for extending GetStatus RPC behavior in Spark Connect.
+ *
+ * <p>Classes implementing this interface must be trivially constructable (have a no-argument
+ * constructor) and should not rely on internal state. The plugin is invoked during GetStatus
+ * request handling, allowing custom logic to be executed based on request extensions.
+ *
+ * <p>The GetStatus RPC message has two extension points:
+ * <ul>
+ *   <li>{@code GetStatusRequest.extensions} - request-level extensions</li>
+ *   <li>{@code GetStatusRequest.OperationStatusRequest.extensions} - operation-level extensions</li>
+ * </ul>
+ *
+ * <p>And corresponding response extension points:
+ * <ul>
+ *   <li>{@code GetStatusResponse.extensions} - response-level extensions</li>
+ *   <li>{@code GetStatusResponse.OperationStatus.extensions} - operation-level extensions</li>
+ * </ul>
+ */
+public interface GetStatusPlugin {
+
+    /**
+     * Process request-level extensions from a GetStatus request.
+     *
+     * <p>This method is called once per GetStatus request, before operation statuses are processed.
+     * Plugins can use the request extensions to customize behavior and return response extensions.
+     *
+     * @param sessionHolder the session holder for the current session
+     * @param requestExtensions the extensions from the GetStatus request
+     * @return optional list of response extensions to add to the GetStatusResponse;
+     *         return {@code Optional.empty()} if this plugin does not handle the request extensions
+     */
+    Optional<List<Any>> processRequestExtensions(
+        SessionHolder sessionHolder, List<Any> requestExtensions);
+
+    /**
+     * Process operation-level extensions from an OperationStatusRequest.
+     *
+     * <p>This method is called once per operation whose status is requested.
+     * Plugins can use the operation-level extensions to customize per-operation behavior.
+     *
+     * @param operationId the operation ID being queried
+     * @param sessionHolder the session holder for the current session
+     * @param operationExtensions the extensions from the OperationStatusRequest
+     * @return optional list of response extensions to add to the OperationStatus;
+     *         return {@code Optional.empty()} if this plugin does not handle the extensions
+     */
+    Optional<List<Any>> processOperationExtensions(
+        String operationId, SessionHolder sessionHolder, List<Any> operationExtensions);
+}

--- a/sql/connect/server/src/main/java/org/apache/spark/sql/connect/plugin/GetStatusPlugin.java
+++ b/sql/connect/server/src/main/java/org/apache/spark/sql/connect/plugin/GetStatusPlugin.java
@@ -34,7 +34,8 @@ import org.apache.spark.sql.connect.service.SessionHolder;
  * <p>The GetStatus RPC message has two extension points:
  * <ul>
  *   <li>{@code GetStatusRequest.extensions} - request-level extensions</li>
- *   <li>{@code GetStatusRequest.OperationStatusRequest.extensions} - operation-level extensions</li>
+ *   <li>{@code GetStatusRequest.OperationStatusRequest.extensions}
+ *       - operation-level extensions</li>
  * </ul>
  *
  * <p>And corresponding response extension points:

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -218,6 +218,18 @@ object Connect {
       .toSequence
       .createWithDefault(Nil)
 
+  val CONNECT_EXTENSIONS_GET_STATUS_CLASSES =
+    buildStaticConf("spark.connect.extensions.getStatus.classes")
+      .doc("""
+             |Comma separated list of classes that implement the trait
+             |org.apache.spark.sql.connect.plugin.GetStatusPlugin to support custom
+             |GetStatus extensions in proto.
+             |""".stripMargin)
+      .version("4.1.0")
+      .stringConf
+      .toSequence
+      .createWithDefault(Nil)
+
   val CONNECT_ML_BACKEND_CLASSES =
     buildConf("spark.connect.ml.backend.classes")
       .doc("""

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
@@ -59,8 +59,8 @@ object TerminationReason {
 }
 
 /**
- * Manage the lifecycle of an operation by tracking its status and termination reason.
- * Post request Connect events to @link org.apache.spark.scheduler.LiveListenerBus and serve as an
+ * Manage the lifecycle of an operation by tracking its status and termination reason. Post
+ * request Connect events to @link org.apache.spark.scheduler.LiveListenerBus and serve as an
  * information source for GetStatus RPC.
  *
  * {{{
@@ -136,15 +136,15 @@ case class ExecuteEventsManager(executeHolder: ExecuteHolder, clock: Clock) {
 
   /**
    * @return
-   *   The reason for termination, set when the operation finishes, fails, or is canceled.
-   *   Since the closed state itself does not convey why the operation ended, this value
-   *   preserves that information for later use.
+   *   The reason for termination, set when the operation finishes, fails, or is canceled. Since
+   *   the closed state itself does not convey why the operation ended, this value preserves that
+   *   information for later use.
    */
   private[connect] def terminationReason: Option[TerminationReason] = _terminationReason
 
   /**
-   * Updates the termination reason only if the new reason has a higher value than the current one.
-   * This established the ordering Canceled > Failed > Succeeded, which is consistent with
+   * Updates the termination reason only if the new reason has a higher value than the current
+   * one. This established the ordering Canceled > Failed > Succeeded, which is consistent with
    * ExecuteStatus ordering. This handles the cases when execution is interrupted or fails during
    * cleanup.
    */

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
@@ -118,7 +118,7 @@ case class ExecuteEventsManager(executeHolder: ExecuteHolder, clock: Clock) {
 
   private def sessionStatus = sessionHolder.eventManager.status
 
-  private var _status: ExecuteStatus = ExecuteStatus.Pending
+  @volatile private var _status: ExecuteStatus = ExecuteStatus.Pending
 
   private var error = Option.empty[Boolean]
 
@@ -126,7 +126,7 @@ case class ExecuteEventsManager(executeHolder: ExecuteHolder, clock: Clock) {
 
   private var producedRowCount = Option.empty[Long]
 
-  private var _terminationReason: Option[TerminationReason] = None
+  @volatile private var _terminationReason: Option[TerminationReason] = None
 
   /**
    * @return

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
@@ -47,7 +47,55 @@ object ExecuteStatus {
 }
 
 /**
- * Post request Connect events to @link org.apache.spark.scheduler.LiveListenerBus.
+ * Records why an operation terminated so that the reason remains available after the operation
+ * transitions to the closed state.
+ */
+sealed abstract class TerminationReason(val value: Int)
+
+object TerminationReason {
+  case object Succeeded extends TerminationReason(0)
+  case object Failed extends TerminationReason(1)
+  case object Canceled extends TerminationReason(2)
+}
+
+/**
+ * Manage the lifecycle of an operation by tracking its status and termination reason.
+ * Post request Connect events to @link org.apache.spark.scheduler.LiveListenerBus and serve as an
+ * information source for GetStatus RPC.
+ *
+ * {{{
+ *   +---------------------------------------------+
+ *   |     ExecuteEventsManager                    |
+ *   |                                             |
+ *   |  - Tracks operation lifecycle state         |
+ *   |  - Posts events to event bus                |
+ *   |  - Maintains termination info in memory     |
+ *   +---------------------------------------------+
+ *                        |
+ *            +-----------+-----------+
+ *            |                       |
+ *            v                       v
+ *   +------------------+    +------------------+
+ *   |  GetStatus RPC   |    |  Query History   |
+ *   |  (Direct API)    |    |  (Audit Log)     |
+ *   +------------------+    +------------------+
+ *
+ * State Mapping Matrix:
+ *
+ * ExecuteStatus        -> GetStatus API     -> Query History
+ * + TerminationReason
+ * ----------------------------------------------------------------
+ * Pending              -> RUNNING           -> (no event posted)
+ * Started              -> RUNNING           -> STARTED
+ * Analyzed             -> RUNNING           -> COMPILED
+ * ReadyForExecution    -> RUNNING           -> READY
+ * Finished             -> TERMINATING       -> FINISHED
+ * Failed               -> TERMINATING       -> FAILED
+ * Canceled             -> TERMINATING       -> CANCELED
+ * Closed+Succeeded     -> SUCCEEDED         -> CLOSED
+ * Closed+Failed        -> FAILED            -> CLOSED
+ * Closed+Canceled      -> CANCELLED         -> CLOSED
+ * }}}
  *
  * @param executeHolder:
  *   Request for which the events are generated.
@@ -78,11 +126,35 @@ case class ExecuteEventsManager(executeHolder: ExecuteHolder, clock: Clock) {
 
   private var producedRowCount = Option.empty[Long]
 
+  private var _terminationReason: Option[TerminationReason] = None
+
   /**
    * @return
    *   Last event posted by the Connect request
    */
   private[connect] def status: ExecuteStatus = _status
+
+  /**
+   * @return
+   *   The reason for termination, set when the operation finishes, fails, or is canceled.
+   *   Since the closed state itself does not convey why the operation ended, this value
+   *   preserves that information for later use.
+   */
+  private[connect] def terminationReason: Option[TerminationReason] = _terminationReason
+
+  /**
+   * Updates the termination reason only if the new reason has a higher value than the current one.
+   * This established the ordering Canceled > Failed > Succeeded, which is consistent with
+   * ExecuteStatus ordering. This handles the cases when execution is interrupted or fails during
+   * cleanup.
+   */
+  private def updateTerminationReason(newReason: TerminationReason): Unit = {
+    _terminationReason match {
+      case Some(currentReason) if currentReason.value >= newReason.value =>
+      case _ =>
+        _terminationReason = Some(newReason)
+    }
+  }
 
   /**
    * @return
@@ -184,6 +256,7 @@ case class ExecuteEventsManager(executeHolder: ExecuteHolder, clock: Clock) {
         ExecuteStatus.Failed),
       ExecuteStatus.Canceled)
     canceled = Some(true)
+    updateTerminationReason(TerminationReason.Canceled)
     listenerBus
       .post(SparkListenerConnectOperationCanceled(jobTag, operationId, clock.getTimeMillis()))
   }
@@ -203,6 +276,7 @@ case class ExecuteEventsManager(executeHolder: ExecuteHolder, clock: Clock) {
         ExecuteStatus.Finished),
       ExecuteStatus.Failed)
     error = Some(true)
+    updateTerminationReason(TerminationReason.Failed)
     listenerBus.post(
       SparkListenerConnectOperationFailed(
         jobTag,
@@ -224,6 +298,7 @@ case class ExecuteEventsManager(executeHolder: ExecuteHolder, clock: Clock) {
       List(ExecuteStatus.Started, ExecuteStatus.ReadyForExecution),
       ExecuteStatus.Finished)
     producedRowCount = producedRowsCountOpt
+    updateTerminationReason(TerminationReason.Succeeded)
 
     listenerBus
       .post(

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
@@ -331,6 +331,7 @@ private[connect] class ExecuteHolder(
       sparkSessionTags = sparkSessionTags,
       reattachable = reattachable,
       status = eventsManager.status,
+      terminationReason = eventsManager.terminationReason,
       creationTimeNs = creationTimeNs,
       lastAttachedRpcTimeNs = lastAttachedRpcTimeNs,
       closedTimeNs = closedTimeNs)
@@ -406,6 +407,7 @@ case class ExecuteInfo(
     sparkSessionTags: Set[String],
     reattachable: Boolean,
     status: ExecuteStatus,
+    terminationReason: Option[TerminationReason],
     creationTimeNs: Long,
     lastAttachedRpcTimeNs: Option[Long],
     closedTimeNs: Option[Long]) {

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
@@ -308,6 +308,8 @@ private[connect] class ExecuteHolder(
       responseObserver.removeAll()
       // Post "closed" to UI.
       eventsManager.postClosed()
+      // Update the termination info in the session holder after closure.
+      sessionHolder.closeOperation(this)
     }
   }
 
@@ -342,6 +344,16 @@ private[connect] class ExecuteHolder(
 
   /** Get the operation ID. */
   def operationId: String = key.operationId
+
+  def getTerminationInfo: TerminationInfo = {
+    TerminationInfo(
+      userId = sessionHolder.userId,
+      sessionId = sessionHolder.sessionId,
+      operationId = executeKey.operationId,
+      status = eventsManager.status,
+      terminationReason = eventsManager.terminationReason
+    )
+  }
 }
 
 private object ExecuteHolder {
@@ -414,3 +426,11 @@ case class ExecuteInfo(
 
   def key: ExecuteKey = ExecuteKey(userId, sessionId, operationId)
 }
+
+/** Minimal termination status information for inactive operations. */
+case class TerminationInfo(
+    userId: String,
+    sessionId: String,
+    operationId: String,
+    status: ExecuteStatus,
+    terminationReason: Option[TerminationReason])

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
@@ -351,8 +351,7 @@ private[connect] class ExecuteHolder(
       sessionId = sessionHolder.sessionId,
       operationId = executeKey.operationId,
       status = eventsManager.status,
-      terminationReason = eventsManager.terminationReason
-    )
+      terminationReason = eventsManager.terminationReason)
   }
 }
 

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -205,8 +205,8 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
   }
 
   /**
-   * Returns the TerminationInfo for an inactive operation if it exists in the cache.
-   * Cache expiration is configured with CONNECT_INACTIVE_OPERATIONS_CACHE_EXPIRATION_MINS.
+   * Returns the TerminationInfo for an inactive operation if it exists in the cache. Cache
+   * expiration is configured with CONNECT_INACTIVE_OPERATIONS_CACHE_EXPIRATION_MINS.
    *
    * @param operationId
    * @return
@@ -218,8 +218,8 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
   }
 
   /**
-   * Returns all inactive operations for this session. These are operations that were
-   * closed and are still in the cache. Cache expiration is configured with
+   * Returns all inactive operations for this session. These are operations that were closed and
+   * are still in the cache. Cache expiration is configured with
    * CONNECT_INACTIVE_OPERATIONS_CACHE_EXPIRATION_MINS.
    *
    * @return

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -96,16 +96,15 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
   // Set of active operation IDs for this session.
   private val activeOperationIds: mutable.Set[String] = mutable.Set.empty
 
-  // Cache of inactive operation IDs for this session, either completed, interrupted or abandoned.
-  // The Boolean is just a placeholder since Guava needs a <K, V> pair.
-  private lazy val inactiveOperationIds: Cache[String, Boolean] =
+  // Cache of inactive operations for this session, either completed, interrupted or abandoned.
+  private lazy val inactiveOperations: Cache[String, TerminationInfo] =
     CacheBuilder
       .newBuilder()
       .ticker(Ticker.systemTicker())
       .expireAfterAccess(
         SparkEnv.get.conf.get(Connect.CONNECT_INACTIVE_OPERATIONS_CACHE_EXPIRATION_MINS),
         TimeUnit.MINUTES)
-      .build[String, Boolean]()
+      .build[String, TerminationInfo]()
 
   // The cache that maps an error id to a throwable. The throwable in cache is independent to
   // each other.
@@ -197,7 +196,7 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
     if (activeOperationIds.contains(operationId)) {
       return Some(true)
     }
-    Option(inactiveOperationIds.getIfPresent(operationId)) match {
+    Option(inactiveOperations.getIfPresent(operationId)) match {
       case Some(_) =>
         return Some(false)
       case None =>
@@ -206,13 +205,38 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
   }
 
   /**
-   * Close an operation in this session by removing its operation ID.
+   * Returns the TerminationInfo for an inactive operation if it exists in the cache.
+   * Cache expiration is configured with CONNECT_INACTIVE_OPERATIONS_CACHE_EXPIRATION_MINS.
    *
-   * Called only by SparkConnectExecutionManager when an execution is ended.
+   * @param operationId
+   * @return
+   *   Some(TerminationInfo) if the operation was closed recently, None if no inactive operation
+   *   with this id is found.
    */
-  private[service] def closeOperation(operationId: String): Unit = {
-    inactiveOperationIds.put(operationId, true)
-    activeOperationIds.remove(operationId)
+  private[service] def getInactiveOperationInfo(operationId: String): Option[TerminationInfo] = {
+    Option(inactiveOperations.getIfPresent(operationId))
+  }
+
+  /**
+   * Returns all inactive operations for this session. These are operations that were
+   * closed and are still in the cache. Cache expiration is configured with
+   * CONNECT_INACTIVE_OPERATIONS_CACHE_EXPIRATION_MINS.
+   *
+   * @return
+   *   Sequence of TerminationInfo for inactive operations.
+   */
+  private[service] def listInactiveOperations(): Seq[TerminationInfo] = {
+    inactiveOperations.asMap().values().asScala.toSeq
+  }
+
+  /**
+   * Close an operation in this session by storing its TerminationInfo and removing from active
+   * set.
+   */
+  private[service] def closeOperation(executeHolder: ExecuteHolder): Unit = {
+    val terminationInfo = executeHolder.getTerminationInfo
+    inactiveOperations.put(terminationInfo.operationId, terminationInfo)
+    activeOperationIds.remove(terminationInfo.operationId)
   }
 
   /**
@@ -249,7 +273,7 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
       SparkConnectService.executionManager.getExecuteHolder(executeKey).foreach { executeHolder =>
         if (executeHolder.sparkSessionTags.contains(tag)) {
           if (executeHolder.interrupt()) {
-            closeOperation(operationId)
+            closeOperation(executeHolder)
             interruptedIds += operationId
           }
         }
@@ -268,7 +292,7 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
     val executeKey = ExecuteKey(userId, sessionId, operationId)
     SparkConnectService.executionManager.getExecuteHolder(executeKey).foreach { executeHolder =>
       if (executeHolder.interrupt()) {
-        closeOperation(operationId)
+        closeOperation(executeHolder)
         interruptedIds += operationId
       }
     }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -230,6 +230,18 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
   }
 
   /**
+   * Returns all active operation IDs for this session.
+   *
+   * @return
+   *   Sequence of operation IDs that are currently active.
+   */
+  private[service] def listActiveOperationIds(): Seq[String] = {
+    activeOperationIds.synchronized {
+      activeOperationIds.toSeq
+    }
+  }
+
+  /**
    * Close an operation in this session by storing its TerminationInfo and removing from active
    * set.
    */

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
@@ -157,12 +157,12 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
     // getting an INVALID_HANDLE.OPERATION_ABANDONED error on a retry.
     if (abandoned) {
       abandonedTombstones.put(key, executeHolder.getExecuteInfo)
-      executeHolder.sessionHolder.closeOperation(executeHolder.operationId)
+      executeHolder.sessionHolder.closeOperation(executeHolder)
     }
 
     // Remove the execution from the map *after* putting it in abandonedTombstones.
     executions.remove(key)
-    executeHolder.sessionHolder.closeOperation(executeHolder.operationId)
+    executeHolder.sessionHolder.closeOperation(executeHolder)
 
     updateLastExecutionTime()
 

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectGetStatusHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectGetStatusHandler.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.connect.service
 
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
+import scala.util.control.NonFatal
 
 import io.grpc.stub.StreamObserver
 
@@ -182,7 +183,7 @@ class SparkConnectGetStatusHandler(responseObserver: StreamObserver[proto.GetSta
           case None => Seq.empty
         }
       } catch {
-        case e: Throwable =>
+        case NonFatal(e) =>
           logWarning(
             log"Plugin ${MDC(LogKeys.CLASS_NAME, plugin.getClass.getName)} failed to process " +
               log"request extensions",
@@ -205,7 +206,7 @@ class SparkConnectGetStatusHandler(responseObserver: StreamObserver[proto.GetSta
           case None => Seq.empty
         }
       } catch {
-        case e: Throwable =>
+        case NonFatal(e) =>
           logWarning(
             log"Plugin ${MDC(LogKeys.CLASS_NAME, plugin.getClass.getName)} failed to process " +
               log"operation extensions for operation ${MDC(LogKeys.OPERATION_ID, operationId)}",

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectGetStatusHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectGetStatusHandler.scala
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.service
+
+import scala.jdk.CollectionConverters._
+
+import io.grpc.stub.StreamObserver
+
+import org.apache.spark.connect.proto
+import org.apache.spark.internal.Logging
+
+
+class SparkConnectGetStatusHandler(responseObserver: StreamObserver[proto.GetStatusResponse])
+    extends Logging {
+
+  def handle(request: proto.GetStatusRequest): Unit = {
+    val previousSessionId = request.hasClientObservedServerSideSessionId match {
+      case true => Some(request.getClientObservedServerSideSessionId)
+      case false => None
+    }
+    val sessionHolder = SparkConnectService.sessionManager.getIsolatedSession(
+      SessionKey(request.getUserContext.getUserId, request.getSessionId),
+      previousSessionId
+    )
+
+    val responseBuilder = proto.GetStatusResponse
+      .newBuilder()
+      .setSessionId(request.getSessionId)
+      .setServerSideSessionId(sessionHolder.serverSessionId)
+
+    if (request.hasOperationStatus) {
+      val operationStatusRequest = request.getOperationStatus
+      val requestedOperationIds = operationStatusRequest.getOperationIdsList.asScala.distinct.toSeq
+
+      val operationStatuses = if (requestedOperationIds.isEmpty) {
+        // If no specific operation IDs are requested,
+        //return status of all known operations in session
+        getAllOperationStatuses(sessionHolder)
+      } else {
+        // Return status only for the requested operation IDs
+        requestedOperationIds.map { operationId =>
+          getOperationStatus(sessionHolder, operationId)
+        }
+      }
+
+      operationStatuses.foreach(responseBuilder.addOperationStatuses)
+    }
+
+    responseObserver.onNext(responseBuilder.build())
+    responseObserver.onCompleted()
+  }
+
+
+  private def getOperationStatus(
+      sessionHolder: SessionHolder,
+      operationId: String): proto.GetStatusResponse.OperationStatus = {
+    val executeKey = ExecuteKey(sessionHolder.userId, sessionHolder.sessionId, operationId)
+
+    // First look up operation in active list, then in inactive. This ordering handles the case
+    // where a concurrent thread moves the operation to inactive, and we don't find it neither in
+    // active list, nor in inactive.
+    val activeState: Option[proto.GetStatusResponse.OperationStatus.OperationState] =
+      SparkConnectService.executionManager
+        .getExecuteHolder(executeKey)
+        .map { executeHolder =>
+          val info = executeHolder.getExecuteInfo
+          mapStatusToState(info.operationId, info.status, info.terminationReason)
+        }
+
+    // Check inactiveOperations - this status prevails over activeState.
+    val state = sessionHolder
+      .getInactiveOperationInfo(operationId)
+      .map { info =>
+        mapStatusToState(info.operationId, info.status, info.terminationReason)
+      }
+      .orElse(activeState)
+      .getOrElse(
+        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_UNKNOWN
+      )
+
+    buildOperationStatus(operationId, state)
+  }
+
+
+  private def getAllOperationStatuses(
+      sessionHolder: SessionHolder): Seq[proto.GetStatusResponse.OperationStatus] = {
+    val allOperationIds =
+      (sessionHolder.listActiveOperationIds() ++
+        sessionHolder.listInactiveOperations().map(_.operationId)).distinct
+
+    allOperationIds.map { operationId =>
+      getOperationStatus(sessionHolder, operationId)
+    }
+  }
+
+
+  private def mapStatusToState(
+      operationId: String,
+      status: ExecuteStatus,
+      terminationReason: Option[TerminationReason])
+      : proto.GetStatusResponse.OperationStatus.OperationState = {
+    status match {
+      case ExecuteStatus.Pending | ExecuteStatus.Started | ExecuteStatus.Analyzed |
+          ExecuteStatus.ReadyForExecution =>
+        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_RUNNING
+
+      // Finished, Failed, Canceled are terminating states - resources haven't been cleaned yet
+      case ExecuteStatus.Finished | ExecuteStatus.Failed | ExecuteStatus.Canceled =>
+        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_TERMINATING
+
+      case ExecuteStatus.Closed =>
+        if (terminationReason.isEmpty) {
+          // This should not happen: ExecuteEventsManager processes state transitions
+          // from a single thread at a time, so there are no concurrent changes and
+          // terminationReason should always be set before reaching Closed.
+          logError(
+            s"Operation $operationId is Closed but terminationReason is not set. " +
+              s"status=$status")
+        }
+        mapTerminationReasonToState(terminationReason)
+    }
+  }
+
+  private def mapTerminationReasonToState(
+      terminationReason: Option[TerminationReason])
+      : proto.GetStatusResponse.OperationStatus.OperationState = {
+    terminationReason match {
+      case Some(TerminationReason.Succeeded) =>
+        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_SUCCEEDED
+      case Some(TerminationReason.Failed) =>
+        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_FAILED
+      case Some(TerminationReason.Canceled) =>
+        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_CANCELLED
+      case None =>
+        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_UNKNOWN
+    }
+  }
+
+  private def buildOperationStatus(
+      operationId: String,
+      state: proto.GetStatusResponse.OperationStatus.OperationState)
+      : proto.GetStatusResponse.OperationStatus = {
+    proto.GetStatusResponse.OperationStatus
+      .newBuilder()
+      .setOperationId(operationId)
+      .setState(state)
+      .build()
+  }
+}

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectGetStatusHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectGetStatusHandler.scala
@@ -26,7 +26,6 @@ import org.apache.spark.connect.proto
 import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.sql.connect.plugin.SparkConnectPluginRegistry
 
-
 class SparkConnectGetStatusHandler(responseObserver: StreamObserver[proto.GetStatusResponse])
     extends Logging {
 
@@ -37,8 +36,7 @@ class SparkConnectGetStatusHandler(responseObserver: StreamObserver[proto.GetSta
     }
     val sessionHolder = SparkConnectService.sessionManager.getIsolatedSession(
       SessionKey(request.getUserContext.getUserId, request.getSessionId),
-      previousSessionId
-    )
+      previousSessionId)
 
     val responseBuilder = proto.GetStatusResponse
       .newBuilder()
@@ -51,7 +49,8 @@ class SparkConnectGetStatusHandler(responseObserver: StreamObserver[proto.GetSta
 
     if (request.hasOperationStatus) {
       val operationStatusRequest = request.getOperationStatus
-      val requestedOperationIds = operationStatusRequest.getOperationIdsList.asScala.distinct.toSeq
+      val requestedOperationIds =
+        operationStatusRequest.getOperationIdsList.asScala.distinct.toSeq
       val operationExtensions = operationStatusRequest.getExtensionsList
 
       val operationStatuses = if (requestedOperationIds.isEmpty) {
@@ -71,7 +70,6 @@ class SparkConnectGetStatusHandler(responseObserver: StreamObserver[proto.GetSta
     responseObserver.onNext(responseBuilder.build())
     responseObserver.onCompleted()
   }
-
 
   private def getOperationStatus(
       sessionHolder: SessionHolder,
@@ -98,16 +96,13 @@ class SparkConnectGetStatusHandler(responseObserver: StreamObserver[proto.GetSta
         mapStatusToState(info.operationId, info.status, info.terminationReason)
       }
       .orElse(activeState)
-      .getOrElse(
-        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_UNKNOWN
-      )
+      .getOrElse(proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_UNKNOWN)
 
     val responseExtensions =
       processOperationExtensionsViaPlugins(sessionHolder, operationExtensions, operationId)
 
     buildOperationStatus(operationId, state, responseExtensions)
   }
-
 
   private def getAllOperationStatuses(
       sessionHolder: SessionHolder,
@@ -121,7 +116,6 @@ class SparkConnectGetStatusHandler(responseObserver: StreamObserver[proto.GetSta
       getOperationStatus(sessionHolder, operationId, operationExtensions)
     }
   }
-
 
   private def mapStatusToState(
       operationId: String,
@@ -150,8 +144,7 @@ class SparkConnectGetStatusHandler(responseObserver: StreamObserver[proto.GetSta
     }
   }
 
-  private def mapTerminationReasonToState(
-      terminationReason: Option[TerminationReason])
+  private def mapTerminationReasonToState(terminationReason: Option[TerminationReason])
       : proto.GetStatusResponse.OperationStatus.OperationState = {
     terminationReason match {
       case Some(TerminationReason.Succeeded) =>
@@ -180,7 +173,8 @@ class SparkConnectGetStatusHandler(responseObserver: StreamObserver[proto.GetSta
 
   private def processRequestExtensionsViaPlugins(
       sessionHolder: SessionHolder,
-      requestExtensions: java.util.List[com.google.protobuf.Any]): Seq[com.google.protobuf.Any] = {
+      requestExtensions: java.util.List[com.google.protobuf.Any])
+      : Seq[com.google.protobuf.Any] = {
     SparkConnectPluginRegistry.getStatusRegistry.flatMap { plugin =>
       try {
         plugin.processRequestExtensions(sessionHolder, requestExtensions).toScala match {
@@ -204,8 +198,9 @@ class SparkConnectGetStatusHandler(responseObserver: StreamObserver[proto.GetSta
       operationId: String): Seq[com.google.protobuf.Any] = {
     SparkConnectPluginRegistry.getStatusRegistry.flatMap { plugin =>
       try {
-        plugin.processOperationExtensions(
-          operationId, sessionHolder, operationExtensions).toScala match {
+        plugin
+          .processOperationExtensions(operationId, sessionHolder, operationExtensions)
+          .toScala match {
           case Some(extensions) => extensions.asScala.toSeq
           case None => Seq.empty
         }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -246,6 +246,19 @@ class SparkConnectService(debug: Boolean) extends AsyncService with BindableServ
     }
   }
 
+  override def getStatus(
+      request: proto.GetStatusRequest,
+      responseObserver: StreamObserver[proto.GetStatusResponse]): Unit = {
+    try {
+      new SparkConnectGetStatusHandler(responseObserver).handle(request)
+    } catch
+      ErrorUtils.handleError(
+        "getStatus",
+        observer = responseObserver,
+        userId = request.getUserContext.getUserId,
+        sessionId = request.getSessionId)
+  }
+
   private def methodWithCustomMarshallers(
       methodDesc: MethodDescriptor[Message, Message]): MethodDescriptor[Message, Message] = {
     val recursionLimit =

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/SparkConnectTestUtils.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/SparkConnectTestUtils.scala
@@ -38,8 +38,7 @@ object SparkConnectTestUtils {
   /** Creates a dummy execute holder for use in tests. */
   def createDummyExecuteHolder(
       sessionHolder: SessionHolder,
-      command: proto.Command
-  ): ExecuteHolder = {
+      command: proto.Command): ExecuteHolder = {
     sessionHolder.eventManager.status_(SessionStatus.Started)
     val request = proto.ExecutePlanRequest
       .newBuilder()
@@ -47,15 +46,13 @@ object SparkConnectTestUtils {
         proto.Plan
           .newBuilder()
           .setCommand(command)
-          .build()
-      )
+          .build())
       .setSessionId(sessionHolder.sessionId)
       .setUserContext(
         proto.UserContext
           .newBuilder()
           .setUserId(sessionHolder.userId)
-          .build()
-      )
+          .build())
       .build()
     val executeHolder =
       SparkConnectService.executionManager.createExecuteHolder(request)

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/ExecuteEventsManagerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/ExecuteEventsManagerSuite.scala
@@ -341,6 +341,64 @@ class ExecuteEventsManagerSuite
     }
   }
 
+  test("terminationReason is None initially") {
+    val events = setupEvents(ExecuteStatus.Pending)
+    assert(events.terminationReason.isEmpty)
+  }
+
+  test("terminationReason is set to Succeeded after postFinished") {
+    val events = setupEvents(ExecuteStatus.Started)
+    assert(events.terminationReason.isEmpty)
+    events.postFinished()
+    assert(events.terminationReason.contains(TerminationReason.Succeeded))
+  }
+
+  test("terminationReason is set to Failed after postFailed") {
+    val events = setupEvents(ExecuteStatus.Started)
+    assert(events.terminationReason.isEmpty)
+    events.postFailed(DEFAULT_ERROR)
+    assert(events.terminationReason.contains(TerminationReason.Failed))
+  }
+
+  test("terminationReason is set to Canceled after postCanceled") {
+    val events = setupEvents(ExecuteStatus.Started)
+    assert(events.terminationReason.isEmpty)
+    events.postCanceled()
+    assert(events.terminationReason.contains(TerminationReason.Canceled))
+  }
+
+  test("terminationReason remains unchanged after postClosed") {
+    val events = setupEvents(ExecuteStatus.Started)
+    events.postFinished()
+    assert(events.terminationReason.contains(TerminationReason.Succeeded))
+    events.postClosed()
+    assert(events.terminationReason.contains(TerminationReason.Succeeded))
+  }
+
+  test("terminationReason: Canceled takes precedence over Succeeded") {
+    val events = setupEvents(ExecuteStatus.Started)
+    events.postFinished()
+    assert(events.terminationReason.contains(TerminationReason.Succeeded))
+    events.postCanceled()
+    assert(events.terminationReason.contains(TerminationReason.Canceled))
+  }
+
+  test("terminationReason: Canceled takes precedence over Failed") {
+    val events = setupEvents(ExecuteStatus.Started)
+    events.postFailed(DEFAULT_ERROR)
+    assert(events.terminationReason.contains(TerminationReason.Failed))
+    events.postCanceled()
+    assert(events.terminationReason.contains(TerminationReason.Canceled))
+  }
+
+  test("terminationReason: Failed takes precedence over Succeeded") {
+    val events = setupEvents(ExecuteStatus.Started)
+    events.postFinished()
+    assert(events.terminationReason.contains(TerminationReason.Succeeded))
+    events.postFailed(DEFAULT_ERROR)
+    assert(events.terminationReason.contains(TerminationReason.Failed))
+  }
+
   def setupEvents(
       executeStatus: ExecuteStatus,
       sessionStatus: SessionStatus = SessionStatus.Started): ExecuteEventsManager = {

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/GetStatusHandlerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/GetStatusHandlerSuite.scala
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.connect.service
+
+import java.util.UUID
+
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+
+import io.grpc.stub.StreamObserver
+
+import org.apache.spark.connect.proto
+import org.apache.spark.connect.proto.GetStatusResponse
+import org.apache.spark.sql.connect.SparkConnectTestUtils
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.util.ThreadUtils
+
+class GetStatusHandlerSuite extends SharedSparkSession {
+
+  // Default userId matching SparkConnectTestUtils.createDummySessionHolder default
+  private val defaultUserId = "testUser"
+
+  protected override def afterEach(): Unit = {
+    super.afterEach()
+    SparkConnectService.sessionManager.invalidateAllSessions()
+  }
+
+  private def sendGetStatusRequest(
+      sessionId: String,
+      userId: String = defaultUserId,
+      serverSideSessionId: Option[String] = None,
+      customize: proto.GetStatusRequest.Builder => Unit = _ => ()): GetStatusResponse = {
+    val userContext = proto.UserContext.newBuilder().setUserId(userId).build()
+    val requestBuilder = proto.GetStatusRequest
+      .newBuilder()
+      .setUserContext(userContext)
+      .setSessionId(sessionId)
+
+    serverSideSessionId.foreach(requestBuilder.setClientObservedServerSideSessionId)
+    customize(requestBuilder)
+
+    val request = requestBuilder.build()
+    val responseObserver = new GetStatusResponseObserver()
+    val handler = new SparkConnectGetStatusHandler(responseObserver)
+    handler.handle(request)
+
+    ThreadUtils.awaitResult(responseObserver.promise.future, 10.seconds)
+  }
+
+  private def sendGetOperationStatusRequest(
+      sessionId: String,
+      operationIds: Seq[String] = Seq.empty,
+      userId: String = defaultUserId,
+      serverSideSessionId: Option[String] = None): GetStatusResponse = {
+    sendGetStatusRequest(sessionId, userId, serverSideSessionId, { builder =>
+      val operationStatusRequest = proto.GetStatusRequest.OperationStatusRequest.newBuilder()
+      operationIds.foreach(operationStatusRequest.addOperationIds)
+      builder.setOperationStatus(operationStatusRequest)
+    })
+  }
+
+  test("GetStatus returns session info for new session") {
+    val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+    val response = sendGetStatusRequest(
+      sessionHolder.sessionId,
+      userId = sessionHolder.userId
+    )
+
+    assert(response.getSessionId == sessionHolder.sessionId)
+    assert(response.getServerSideSessionId.nonEmpty)
+  }
+
+  test("GetStatus without operation IDs returns all existing operations") {
+    val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+    val command = proto.Command.newBuilder().build()
+    val executeHolder1 = SparkConnectTestUtils.createDummyExecuteHolder(sessionHolder, command)
+    val executeHolder2 = SparkConnectTestUtils.createDummyExecuteHolder(sessionHolder, command)
+    val executeHolder3 = SparkConnectTestUtils.createDummyExecuteHolder(sessionHolder, command)
+
+    val response = sendGetOperationStatusRequest(
+      sessionHolder.sessionId,
+      userId = sessionHolder.userId)
+
+    val statuses = response.getOperationStatusesList.asScala
+    assert(statuses.size == 3)
+    val operationIds = statuses.map(_.getOperationId).toSet
+    assert(operationIds.contains(executeHolder1.operationId))
+    assert(operationIds.contains(executeHolder2.operationId))
+    assert(operationIds.contains(executeHolder3.operationId))
+  }
+
+  test("GetStatus returns UNKNOWN status for non-existent operation ID") {
+    val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+    val nonExistentOperationId = UUID.randomUUID().toString
+
+    val response = sendGetOperationStatusRequest(
+      sessionHolder.sessionId,
+      Seq(nonExistentOperationId),
+      userId = sessionHolder.userId)
+
+    val statuses = response.getOperationStatusesList.asScala
+    assert(statuses.size == 1)
+    assert(statuses.head.getOperationId == nonExistentOperationId)
+    assert(statuses.head.getState ==
+      proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_UNKNOWN)
+  }
+
+  test("GetStatus returns RUNNING status for active operation") {
+    val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+    val command = proto.Command.newBuilder().build()
+    val executeHolder = SparkConnectTestUtils.createDummyExecuteHolder(sessionHolder, command)
+
+    // The execute holder is created with Started status by createDummyExecuteHolder
+    val response = sendGetOperationStatusRequest(
+      sessionHolder.sessionId,
+      Seq(executeHolder.operationId),
+      sessionHolder.userId)
+
+    val statuses = response.getOperationStatusesList.asScala
+    assert(statuses.size == 1)
+    assert(statuses.head.getOperationId == executeHolder.operationId)
+    assert(statuses.head.getState ==
+      proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_RUNNING)
+  }
+}
+
+private class GetStatusResponseObserver extends StreamObserver[proto.GetStatusResponse] {
+  val promise: Promise[GetStatusResponse] = Promise()
+  override def onNext(value: proto.GetStatusResponse): Unit = promise.success(value)
+  override def onError(t: Throwable): Unit = promise.failure(t)
+  override def onCompleted(): Unit = {}
+}

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/GetStatusHandlerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/GetStatusHandlerSuite.scala
@@ -16,19 +16,95 @@
  */
 package org.apache.spark.sql.connect.service
 
-import java.util.UUID
+import java.util
+import java.util.{Optional, UUID}
 
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
+import com.google.protobuf
+import com.google.protobuf.StringValue
 import io.grpc.stub.StreamObserver
 
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.GetStatusResponse
 import org.apache.spark.sql.connect.SparkConnectTestUtils
+import org.apache.spark.sql.connect.plugin.{GetStatusPlugin, SparkConnectPluginRegistry}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.ThreadUtils
+
+/**
+ * A test-only base class for GetStatusPlugins that echo extensions back with configurable
+ * prefixes. For each input extension containing a StringValue, it produces a response extension
+ * with the value prefixed by "{requestPrefix}" or "{opPrefix}{operationId}:".
+ */
+abstract class EchoGetStatusPluginBase(requestPrefix: String, opPrefix: String)
+    extends GetStatusPlugin {
+
+  override def processRequestExtensions(
+      sessionHolder: SessionHolder,
+      requestExtensions: util.List[protobuf.Any]): Optional[util.List[protobuf.Any]] =
+    echoWithPrefix(requestExtensions, requestPrefix)
+
+  override def processOperationExtensions(
+      operationId: String,
+      sessionHolder: SessionHolder,
+      operationExtensions: util.List[protobuf.Any]): Optional[util.List[protobuf.Any]] =
+    echoWithPrefix(operationExtensions, s"$opPrefix$operationId:")
+
+  private def echoWithPrefix(
+      extensions: util.List[protobuf.Any],
+      prefix: String): Optional[util.List[protobuf.Any]] = {
+    if (extensions.isEmpty) return Optional.empty()
+    val result = new util.ArrayList[protobuf.Any]()
+    extensions.forEach { ext =>
+      if (ext.is(classOf[StringValue])) {
+        val value = ext.unpack(classOf[StringValue]).getValue
+        result.add(protobuf.Any.pack(StringValue.of(s"$prefix$value")))
+      }
+    }
+    Optional.of(result)
+  }
+}
+
+class EchoGetStatusPlugin
+    extends EchoGetStatusPluginBase("request-echo:", "op-echo:")
+
+class SecondEchoGetStatusPlugin
+    extends EchoGetStatusPluginBase("second-request:", "second-op:")
+
+/**
+ * A no-op plugin that always returns Optional.empty() for both request and operation extensions.
+ */
+class NoOpGetStatusPlugin extends GetStatusPlugin {
+  override def processRequestExtensions(
+      sessionHolder: SessionHolder,
+      requestExtensions: util.List[protobuf.Any]): Optional[util.List[protobuf.Any]] =
+    Optional.empty()
+
+  override def processOperationExtensions(
+      operationId: String,
+      sessionHolder: SessionHolder,
+      operationExtensions: util.List[protobuf.Any]): Optional[util.List[protobuf.Any]] =
+    Optional.empty()
+}
+
+/**
+ * A plugin that always throws a RuntimeException.
+ */
+class FailingGetStatusPlugin extends GetStatusPlugin {
+  override def processRequestExtensions(
+      sessionHolder: SessionHolder,
+      requestExtensions: util.List[protobuf.Any]): Optional[util.List[protobuf.Any]] =
+    throw new RuntimeException("request plugin failure")
+
+  override def processOperationExtensions(
+      operationId: String,
+      sessionHolder: SessionHolder,
+      operationExtensions: util.List[protobuf.Any]): Optional[util.List[protobuf.Any]] =
+    throw new RuntimeException("operation plugin failure")
+}
 
 class GetStatusHandlerSuite extends SharedSparkSession {
 
@@ -38,12 +114,14 @@ class GetStatusHandlerSuite extends SharedSparkSession {
   protected override def afterEach(): Unit = {
     super.afterEach()
     SparkConnectService.sessionManager.invalidateAllSessions()
+    SparkConnectPluginRegistry.reset()
   }
 
   private def sendGetStatusRequest(
       sessionId: String,
       userId: String = defaultUserId,
       serverSideSessionId: Option[String] = None,
+      requestExtensions: Seq[protobuf.Any] = Seq.empty,
       customize: proto.GetStatusRequest.Builder => Unit = _ => ()): GetStatusResponse = {
     val userContext = proto.UserContext.newBuilder().setUserId(userId).build()
     val requestBuilder = proto.GetStatusRequest
@@ -51,6 +129,7 @@ class GetStatusHandlerSuite extends SharedSparkSession {
       .setUserContext(userContext)
       .setSessionId(sessionId)
 
+    requestExtensions.foreach(requestBuilder.addExtensions)
     serverSideSessionId.foreach(requestBuilder.setClientObservedServerSideSessionId)
     customize(requestBuilder)
 
@@ -66,12 +145,16 @@ class GetStatusHandlerSuite extends SharedSparkSession {
       sessionId: String,
       operationIds: Seq[String] = Seq.empty,
       userId: String = defaultUserId,
-      serverSideSessionId: Option[String] = None): GetStatusResponse = {
-    sendGetStatusRequest(sessionId, userId, serverSideSessionId, { builder =>
-      val operationStatusRequest = proto.GetStatusRequest.OperationStatusRequest.newBuilder()
-      operationIds.foreach(operationStatusRequest.addOperationIds)
-      builder.setOperationStatus(operationStatusRequest)
-    })
+      serverSideSessionId: Option[String] = None,
+      requestExtensions: Seq[protobuf.Any] = Seq.empty,
+      operationExtensions: Seq[protobuf.Any] = Seq.empty): GetStatusResponse = {
+    sendGetStatusRequest(sessionId, userId, serverSideSessionId,
+      requestExtensions, { builder =>
+        val operationStatusRequest = proto.GetStatusRequest.OperationStatusRequest.newBuilder()
+        operationIds.foreach(operationStatusRequest.addOperationIds)
+        operationExtensions.foreach(operationStatusRequest.addExtensions)
+        builder.setOperationStatus(operationStatusRequest)
+      })
   }
 
   test("GetStatus returns session info for new session") {
@@ -136,6 +219,127 @@ class GetStatusHandlerSuite extends SharedSparkSession {
     assert(statuses.head.getOperationId == executeHolder.operationId)
     assert(statuses.head.getState ==
       proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_RUNNING)
+  }
+
+  test("GetStatus propagates both request and operation extensions via plugin") {
+    SparkConnectPluginRegistry.setGetStatusPluginsForTesting(Seq(new EchoGetStatusPlugin()))
+    val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+    val command = proto.Command.newBuilder().build()
+    val executeHolder1 = SparkConnectTestUtils.createDummyExecuteHolder(sessionHolder, command)
+    val executeHolder2 = SparkConnectTestUtils.createDummyExecuteHolder(sessionHolder, command)
+
+    val reqExt = protobuf.Any.pack(StringValue.of("req-data"))
+    val opExt = protobuf.Any.pack(StringValue.of("op-data"))
+    val response = sendGetOperationStatusRequest(
+      sessionHolder.sessionId,
+      operationIds = Seq(executeHolder1.operationId, executeHolder2.operationId),
+      userId = sessionHolder.userId,
+      requestExtensions = Seq(reqExt),
+      operationExtensions = Seq(opExt))
+
+    // Verify request-level extensions
+    val responseExtensions = response.getExtensionsList.asScala
+    assert(responseExtensions.size == 1)
+    assert(
+      responseExtensions.head.unpack(classOf[StringValue]).getValue == "request-echo:req-data")
+
+    // Verify operation-level extensions for both operations
+    val statuses = response.getOperationStatusesList.asScala
+    assert(statuses.size == 2)
+
+    val statusByOpId = statuses.map(s => s.getOperationId -> s).toMap
+    Seq(executeHolder1, executeHolder2).foreach { holder =>
+      val opStatus = statusByOpId(holder.operationId)
+      assert(opStatus.getState ==
+        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_RUNNING)
+
+      val opExtensions = opStatus.getExtensionsList.asScala
+      assert(opExtensions.size == 1)
+      assert(opExtensions.head.unpack(classOf[StringValue]).getValue ==
+        s"op-echo:${holder.operationId}:op-data")
+    }
+  }
+
+  test("GetStatus with no plugin returns no extensions") {
+    SparkConnectPluginRegistry.setGetStatusPluginsForTesting(Seq.empty)
+    val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+    val operationId = UUID.randomUUID().toString
+
+    val reqExt = protobuf.Any.pack(StringValue.of("ignored"))
+    val opExt = protobuf.Any.pack(StringValue.of("also-ignored"))
+    val response = sendGetOperationStatusRequest(
+      sessionHolder.sessionId,
+      operationIds = Seq(operationId),
+      userId = sessionHolder.userId,
+      requestExtensions = Seq(reqExt),
+      operationExtensions = Seq(opExt))
+
+    assert(response.getExtensionsList.isEmpty)
+    val statuses = response.getOperationStatusesList.asScala
+    assert(statuses.size == 1)
+    assert(statuses.head.getExtensionsList.isEmpty)
+  }
+
+  test("GetStatus aggregates extensions from multiple plugins, skipping empty ones") {
+    SparkConnectPluginRegistry.setGetStatusPluginsForTesting(
+      Seq(new EchoGetStatusPlugin(), new NoOpGetStatusPlugin(), new SecondEchoGetStatusPlugin()))
+    val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+    val command = proto.Command.newBuilder().build()
+    val executeHolder = SparkConnectTestUtils.createDummyExecuteHolder(sessionHolder, command)
+
+    val reqExt = protobuf.Any.pack(StringValue.of("hello"))
+    val opExt = protobuf.Any.pack(StringValue.of("world"))
+    val response = sendGetOperationStatusRequest(
+      sessionHolder.sessionId,
+      operationIds = Seq(executeHolder.operationId),
+      userId = sessionHolder.userId,
+      requestExtensions = Seq(reqExt),
+      operationExtensions = Seq(opExt))
+
+    val responseExtValues = response.getExtensionsList.asScala
+      .map(_.unpack(classOf[StringValue]).getValue)
+    assert(responseExtValues.size == 2)
+    assert(responseExtValues.contains("request-echo:hello"))
+    assert(responseExtValues.contains("second-request:hello"))
+
+    val statuses = response.getOperationStatusesList.asScala
+    assert(statuses.size == 1)
+    val opExtValues = statuses.head.getExtensionsList.asScala
+      .map(_.unpack(classOf[StringValue]).getValue)
+    assert(opExtValues.size == 2)
+    assert(opExtValues.contains(s"op-echo:${executeHolder.operationId}:world"))
+    assert(opExtValues.contains(s"second-op:${executeHolder.operationId}:world"))
+  }
+
+  test("GetStatus chain isolates plugin failures and collects from healthy plugins") {
+    SparkConnectPluginRegistry.setGetStatusPluginsForTesting(
+      Seq(new EchoGetStatusPlugin(), new FailingGetStatusPlugin(),
+        new SecondEchoGetStatusPlugin()))
+    val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+    val command = proto.Command.newBuilder().build()
+    val executeHolder = SparkConnectTestUtils.createDummyExecuteHolder(sessionHolder, command)
+
+    val reqExt = protobuf.Any.pack(StringValue.of("safe"))
+    val opExt = protobuf.Any.pack(StringValue.of("safe"))
+    val response = sendGetOperationStatusRequest(
+      sessionHolder.sessionId,
+      operationIds = Seq(executeHolder.operationId),
+      userId = sessionHolder.userId,
+      requestExtensions = Seq(reqExt),
+      operationExtensions = Seq(opExt))
+
+    val responseExtValues = response.getExtensionsList.asScala
+      .map(_.unpack(classOf[StringValue]).getValue)
+    assert(responseExtValues.size == 2)
+    assert(responseExtValues.contains("request-echo:safe"))
+    assert(responseExtValues.contains("second-request:safe"))
+
+    val opExtValues = response.getOperationStatusesList.asScala
+      .head.getExtensionsList.asScala
+      .map(_.unpack(classOf[StringValue]).getValue)
+    assert(opExtValues.size == 2)
+    assert(opExtValues.contains(s"op-echo:${executeHolder.operationId}:safe"))
+    assert(opExtValues.contains(s"second-op:${executeHolder.operationId}:safe"))
   }
 }
 

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManagerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManagerSuite.scala
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.connect.service
+
+import org.apache.spark.connect.proto
+import org.apache.spark.sql.connect.SparkConnectTestUtils
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Test suite for SparkConnectExecutionManager.
+ */
+class SparkConnectExecutionManagerSuite extends SharedSparkSession {
+
+  protected override def afterEach(): Unit = {
+    super.afterEach()
+    SparkConnectService.sessionManager.invalidateAllSessions()
+  }
+
+  private def executionManager: SparkConnectExecutionManager = {
+    SparkConnectService.executionManager
+  }
+
+  test("tombstone is updated with Closed status after removeExecuteHolder with abandoned") {
+    val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+    val command = proto.Command.newBuilder().build()
+    val executeHolder = SparkConnectTestUtils.createDummyExecuteHolder(sessionHolder, command)
+    val executeKey = executeHolder.key
+
+    executionManager.removeExecuteHolder(executeKey, abandoned = true)
+
+    val tombstoneInfo = executionManager.getAbandonedTombstone(executeKey)
+    assert(tombstoneInfo.isDefined, "Tombstone should exist for abandoned operation")
+
+    val info = tombstoneInfo.get
+    assert(info.status == ExecuteStatus.Closed,
+      s"Expected Closed status in tombstone, got ${info.status}")
+    assert(info.closedTimeNs.isDefined, "closedTimeNs should be set after close()")
+    assert(info.closedTimeNs.get > 0, "closedTimeNs should be > 0")
+  }
+
+  test("normal execution removal does not create tombstone") {
+    val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+    val command = proto.Command.newBuilder().build()
+    val executeHolder = SparkConnectTestUtils.createDummyExecuteHolder(sessionHolder, command)
+    val executeKey = executeHolder.key
+
+    executionManager.removeExecuteHolder(executeKey)
+
+    val tombstoneInfo = executionManager.getAbandonedTombstone(executeKey)
+    assert(tombstoneInfo.isEmpty,
+      "Tombstone should not exist for normal (non-abandoned) removal")
+  }
+
+  test("inactiveOperations cache has correct state after abandoned removal") {
+    val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+    val command = proto.Command.newBuilder().build()
+    val executeHolder = SparkConnectTestUtils.createDummyExecuteHolder(sessionHolder, command)
+    val operationId = executeHolder.operationId
+
+    executionManager.removeExecuteHolder(executeHolder.key, abandoned = true)
+
+    val inactiveInfo = sessionHolder.getInactiveOperationInfo(operationId)
+    assert(inactiveInfo.isDefined, "Operation should be in inactive operations cache")
+
+    val info = inactiveInfo.get
+    assert(info.status == ExecuteStatus.Closed,
+      s"Expected Closed status in inactive cache, got ${info.status}")
+    assert(info.terminationReason.isDefined,
+      "terminationReason should be set by postCanceled and captured by closeOperation")
+    assert(info.terminationReason.get == TerminationReason.Canceled,
+      s"Expected Canceled terminationReason for abandoned, got ${info.terminationReason}")
+  }
+
+  test("inactiveOperations cache has correct state after normal removal") {
+    val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+    val command = proto.Command.newBuilder().build()
+    val executeHolder = SparkConnectTestUtils.createDummyExecuteHolder(sessionHolder, command)
+    val operationId = executeHolder.operationId
+
+    assert(sessionHolder.getOperationStatus(operationId).contains(true),
+      "Operation should be active before removal")
+    assert(sessionHolder.getInactiveOperationInfo(operationId).isEmpty,
+      "Operation should not be in inactive cache before removal")
+
+    executionManager.removeExecuteHolder(executeHolder.key)
+
+    assert(sessionHolder.getOperationStatus(operationId).contains(false),
+      "Operation should be inactive after removal")
+    val inactiveInfo = sessionHolder.getInactiveOperationInfo(operationId)
+    assert(inactiveInfo.isDefined, "Operation should be in inactive cache after removal")
+
+    val info = inactiveInfo.get
+    assert(info.operationId == operationId, "Operation ID should match")
+    assert(info.status == ExecuteStatus.Closed,
+      s"Expected Closed status in inactive cache, got ${info.status}")
+  }
+}

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManagerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManagerSuite.scala
@@ -46,7 +46,8 @@ class SparkConnectExecutionManagerSuite extends SharedSparkSession {
     assert(tombstoneInfo.isDefined, "Tombstone should exist for abandoned operation")
 
     val info = tombstoneInfo.get
-    assert(info.status == ExecuteStatus.Closed,
+    assert(
+      info.status == ExecuteStatus.Closed,
       s"Expected Closed status in tombstone, got ${info.status}")
     assert(info.closedTimeNs.isDefined, "closedTimeNs should be set after close()")
     assert(info.closedTimeNs.get > 0, "closedTimeNs should be > 0")
@@ -61,8 +62,7 @@ class SparkConnectExecutionManagerSuite extends SharedSparkSession {
     executionManager.removeExecuteHolder(executeKey)
 
     val tombstoneInfo = executionManager.getAbandonedTombstone(executeKey)
-    assert(tombstoneInfo.isEmpty,
-      "Tombstone should not exist for normal (non-abandoned) removal")
+    assert(tombstoneInfo.isEmpty, "Tombstone should not exist for normal (non-abandoned) removal")
   }
 
   test("inactiveOperations cache has correct state after abandoned removal") {
@@ -77,11 +77,14 @@ class SparkConnectExecutionManagerSuite extends SharedSparkSession {
     assert(inactiveInfo.isDefined, "Operation should be in inactive operations cache")
 
     val info = inactiveInfo.get
-    assert(info.status == ExecuteStatus.Closed,
+    assert(
+      info.status == ExecuteStatus.Closed,
       s"Expected Closed status in inactive cache, got ${info.status}")
-    assert(info.terminationReason.isDefined,
+    assert(
+      info.terminationReason.isDefined,
       "terminationReason should be set by postCanceled and captured by closeOperation")
-    assert(info.terminationReason.get == TerminationReason.Canceled,
+    assert(
+      info.terminationReason.get == TerminationReason.Canceled,
       s"Expected Canceled terminationReason for abandoned, got ${info.terminationReason}")
   }
 
@@ -91,21 +94,25 @@ class SparkConnectExecutionManagerSuite extends SharedSparkSession {
     val executeHolder = SparkConnectTestUtils.createDummyExecuteHolder(sessionHolder, command)
     val operationId = executeHolder.operationId
 
-    assert(sessionHolder.getOperationStatus(operationId).contains(true),
+    assert(
+      sessionHolder.getOperationStatus(operationId).contains(true),
       "Operation should be active before removal")
-    assert(sessionHolder.getInactiveOperationInfo(operationId).isEmpty,
+    assert(
+      sessionHolder.getInactiveOperationInfo(operationId).isEmpty,
       "Operation should not be in inactive cache before removal")
 
     executionManager.removeExecuteHolder(executeHolder.key)
 
-    assert(sessionHolder.getOperationStatus(operationId).contains(false),
+    assert(
+      sessionHolder.getOperationStatus(operationId).contains(false),
       "Operation should be inactive after removal")
     val inactiveInfo = sessionHolder.getInactiveOperationInfo(operationId)
     assert(inactiveInfo.isDefined, "Operation should be in inactive cache after removal")
 
     val info = inactiveInfo.get
     assert(info.operationId == operationId, "Operation ID should match")
-    assert(info.status == ExecuteStatus.Closed,
+    assert(
+      info.status == ExecuteStatus.Closed,
       s"Expected Closed status in inactive cache, got ${info.status}")
   }
 }

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionHolderSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionHolderSuite.scala
@@ -431,6 +431,58 @@ class SparkConnectSessionHolderSuite extends SharedSparkSession {
     assert(ex.getMessage.contains("already exists"))
   }
 
+  test("getInactiveOperationInfo returns TerminationInfo for closed operations") {
+    val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+    val command = proto.Command.newBuilder().build()
+    val executeHolder = SparkConnectTestUtils.createDummyExecuteHolder(sessionHolder, command)
+    val operationId = executeHolder.operationId
+
+    sessionHolder.closeOperation(executeHolder)
+
+    val inactiveInfo = sessionHolder.getInactiveOperationInfo(operationId)
+    assert(inactiveInfo.isDefined)
+    assert(inactiveInfo.get.operationId == operationId)
+  }
+
+  test("getInactiveOperationInfo returns None for active operations") {
+    val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+    val command = proto.Command.newBuilder().build()
+    val executeHolder = SparkConnectTestUtils.createDummyExecuteHolder(sessionHolder, command)
+    val operationId = executeHolder.operationId
+
+    assert(sessionHolder.getInactiveOperationInfo(operationId) == None)
+  }
+
+  test("getInactiveOperationInfo returns None for unknown operations") {
+    val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+    assert(sessionHolder.getInactiveOperationInfo("unknown-op") == None)
+  }
+
+  test("listInactiveOperations returns all closed operations") {
+    val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+
+    val command = proto.Command.newBuilder().build()
+    val executeHolder1 = SparkConnectTestUtils.createDummyExecuteHolder(sessionHolder, command)
+    val executeHolder2 = SparkConnectTestUtils.createDummyExecuteHolder(sessionHolder, command)
+    val executeHolder3 = SparkConnectTestUtils.createDummyExecuteHolder(sessionHolder, command)
+
+    sessionHolder.closeOperation(executeHolder1)
+    sessionHolder.closeOperation(executeHolder2)
+    sessionHolder.closeOperation(executeHolder3)
+
+    val inactiveOps = sessionHolder.listInactiveOperations()
+    assert(inactiveOps.size == 3)
+    val inactiveOpIds = inactiveOps.map(_.operationId).toSet
+    assert(inactiveOpIds.contains(executeHolder1.operationId))
+    assert(inactiveOpIds.contains(executeHolder2.operationId))
+    assert(inactiveOpIds.contains(executeHolder3.operationId))
+  }
+
+  test("listInactiveOperations returns empty for new session") {
+    val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+    assert(sessionHolder.listInactiveOperations().isEmpty)
+  }
+
   test("Pipeline execution cache") {
     val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
     val graphId = "test_graph"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Server-side implementation of the GetStatus API:
- Introduce a variable in ExecuteEventsManager to track execution termination reason after it's closed.
- Track minimal execution termination information in SessionHolder's inactiveOperations cache.
- Use SessionHolder's activeOperations and inactiveOperations lists for determining execution status in GetStatus API handler.
- Add plugin interface for GetStatus operation for processing custom proto extensions.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

GetStatus API allows to monitor status of executions in a session, which is particularly useful in multithreaded clients.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. It's a new Spark Connect API.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
- New tests were added.
- E2E tests with checking for real (not mocked) execution lifecycles are coming in client-side PR.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude 4.6 Opus High
