### PR TITLE
[SPARK-19335][SPARK-38200][SQL] Add upserts for writing to JDBC

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -8320,6 +8320,11 @@
           "Update column nullability for MySQL and MS SQL Server."
         ]
       },
+      "UPSERT" : {
+        "message" : [
+          "Upsert not supported by JDBC dialect <class>."
+        ]
+      },
       "WRITE_FOR_BINARY_SOURCE" : {
         "message" : [
           "Write for the binary file data source."

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
@@ -156,6 +156,8 @@ class MsSqlServerIntegrationSuite extends SharedJDBCIntegrationSuite with Upsert
       "(2, '1996-01-01 01:23:46', 2.346, 2.345679)").executeUpdate()
   }
 
+  override val createTableOption = "; ALTER TABLE new_upsert_table ADD PRIMARY KEY (id, ts)"
+
   test("Basic test") {
     val df = spark.read.jdbc(jdbcUrl, "tbl", new Properties)
     val rows = df.collect()

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
@@ -40,7 +40,7 @@ import org.apache.spark.tags.DockerTest
  * }}}
  */
 @DockerTest
-class MsSqlServerIntegrationSuite extends SharedJDBCIntegrationSuite {
+class MsSqlServerIntegrationSuite extends SharedJDBCIntegrationSuite with UpsertTests {
   override val db = new MsSQLServerDatabaseOnDocker
 
   override def dataPreparation(conn: Connection): Unit = {
@@ -146,6 +146,14 @@ class MsSqlServerIntegrationSuite extends SharedJDBCIntegrationSuite {
       .executeUpdate()
     conn.prepareStatement("""INSERT INTO test_rowversion (myKey, myValue) VALUES (1, 0)""")
       .executeUpdate()
+
+    conn.prepareStatement("CREATE TABLE upsert (id INT, ts DATETIME, v1 FLOAT, v2 FLOAT, " +
+      "CONSTRAINT pk_upsert PRIMARY KEY (id, ts))").executeUpdate()
+    conn.prepareStatement("INSERT INTO upsert VALUES " +
+      "(1, '1996-01-01 01:23:45', 1.234, 1.234567), " +
+      "(1, '1996-01-01 01:23:46', 1.235, 1.234568), " +
+      "(2, '1996-01-01 01:23:45', 2.345, 2.345678), " +
+      "(2, '1996-01-01 01:23:46', 2.346, 2.345679)").executeUpdate()
   }
 
   test("Basic test") {

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLDatabaseOnDocker.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLDatabaseOnDocker.scala
@@ -27,5 +27,5 @@ class MySQLDatabaseOnDocker extends DatabaseOnDocker {
 
   override def getJdbcUrl(ip: String, port: Int): String =
     s"jdbc:mysql://$ip:$port/mysql?user=root&password=rootpass&allowPublicKeyRetrieval=true" +
-      s"&useSSL=false&disableMariaDbDriver"
+      s"&useSSL=false&disableMariaDbDriver&allowMultiQueries=true"
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
@@ -25,6 +25,7 @@ import java.util.Properties
 import scala.util.Using
 
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.ShortType
@@ -40,6 +41,8 @@ import org.apache.spark.tags.DockerTest
  */
 @DockerTest
 class MySQLIntegrationSuite extends SharedJDBCIntegrationSuite {
+  import testImplicits._
+
   override val db = new MySQLDatabaseOnDocker
 
   override def dataPreparation(conn: Connection): Unit = {
@@ -97,6 +100,14 @@ class MySQLIntegrationSuite extends SharedJDBCIntegrationSuite {
     conn.prepareStatement("CREATE TABLE TBL_GEOMETRY (col0 GEOMETRY)").executeUpdate()
     conn.prepareStatement("INSERT INTO TBL_GEOMETRY VALUES (ST_GeomFromText('POINT(0 0)'))")
       .executeUpdate()
+
+    conn.prepareStatement("CREATE TABLE upsert (id INTEGER, ts TIMESTAMP, v1 DOUBLE, v2 DOUBLE, " +
+      "PRIMARY KEY pk (id, ts))").executeUpdate()
+    conn.prepareStatement("INSERT INTO upsert VALUES " +
+      "(1, '1996-01-01 01:23:45', 1.234, 1.234567), " +
+      "(1, '1996-01-01 01:23:46', 1.235, 1.234568), " +
+      "(2, '1996-01-01 01:23:45', 2.345, 2.345678), " +
+      "(2, '1996-01-01 01:23:46', 2.346, 2.345679)").executeUpdate()
   }
 
   def testConnection(): Unit = {
@@ -247,7 +258,7 @@ class MySQLIntegrationSuite extends SharedJDBCIntegrationSuite {
     val df1 = spark.read.jdbc(jdbcUrl, "numbers", new Properties)
     val df2 = spark.read.jdbc(jdbcUrl, "dates", new Properties)
     val df3 = spark.read.jdbc(jdbcUrl, "strings", new Properties)
-    df1.write.jdbc(jdbcUrl, "numberscopy", new Properties)
+    df1.write.mode(SaveMode.Append).jdbc(jdbcUrl, "numberscopy", new Properties)
     df2.write.jdbc(jdbcUrl, "datescopy", new Properties)
     df3.write.jdbc(jdbcUrl, "stringscopy", new Properties)
   }
@@ -277,7 +288,6 @@ class MySQLIntegrationSuite extends SharedJDBCIntegrationSuite {
        """.stripMargin.replaceAll("\n", " "))
     assert(sql("select x, y from queryOption").collect().toSet == expectedResult)
   }
-
 
   test("SPARK-47478: all boolean synonyms read-write roundtrip") {
     val df = spark.read.jdbc(jdbcUrl, "bools", new Properties)
@@ -360,6 +370,43 @@ class MySQLIntegrationSuite extends SharedJDBCIntegrationSuite {
       .load()
     checkAnswer(df, Row("brown     ", "fox"))
   }
+
+  Seq(false, true).foreach { exists =>
+    test(s"Upsert ${if (exists) "" else "non-"}existing table") {
+      val df = Seq(
+        (1, Timestamp.valueOf("1996-01-01 01:23:46"), 1.235, 1.234568), // row unchanged
+        (2, Timestamp.valueOf("1996-01-01 01:23:45"), 2.346, 2.345678), // updates v1
+        (2, Timestamp.valueOf("1996-01-01 01:23:46"), 2.347, 2.345680), // updates v1 and v2
+        (3, Timestamp.valueOf("1996-01-01 01:23:45"), 3.456, 3.456789) // inserts new row
+      ).toDF("id", "ts", "v1", "v2").repartition(10)
+
+      val table = if (exists) "upsert" else "new_table"
+      val options = Map("numPartitions" -> "10", "upsert" -> "true")
+      df.write.mode(SaveMode.Append).options(options).jdbc(jdbcUrl, table, new Properties)
+
+      val actual = spark.read.jdbc(jdbcUrl, table, new Properties).collect.toSet
+      val existing = if (exists) {
+        Set((1, Timestamp.valueOf("1996-01-01 01:23:45"), 1.234, 1.234567))
+      } else {
+        Set.empty
+      }
+      val upsertedRows = Set(
+        (1, Timestamp.valueOf("1996-01-01 01:23:46"), 1.235, 1.234568),
+        (2, Timestamp.valueOf("1996-01-01 01:23:45"), 2.346, 2.345678),
+        (2, Timestamp.valueOf("1996-01-01 01:23:46"), 2.347, 2.345680),
+        (3, Timestamp.valueOf("1996-01-01 01:23:45"), 3.456, 3.456789)
+      )
+      val expected = (existing ++ upsertedRows).map { case (id, ts, v1, v2) =>
+        Row(Integer.valueOf(id), ts, v1.doubleValue(), v2.doubleValue())
+      }
+      assert(actual === expected)
+    }
+  }
+
+  test("Write with unspecified mode with upsert") { }
+  test("Write with overwrite mode with upsert") { }
+  test("Write with error-if-exists mode with upsert") { }
+  test("Write with ignore mode with upsert") { }
 }
 
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
@@ -25,7 +25,6 @@ import java.util.Properties
 import scala.util.Using
 
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.ShortType
@@ -40,9 +39,7 @@ import org.apache.spark.tags.DockerTest
  * }}}
  */
 @DockerTest
-class MySQLIntegrationSuite extends SharedJDBCIntegrationSuite {
-  import testImplicits._
-
+class MySQLIntegrationSuite extends SharedJDBCIntegrationSuite with UpsertTests {
   override val db = new MySQLDatabaseOnDocker
 
   override def dataPreparation(conn: Connection): Unit = {
@@ -370,43 +367,6 @@ class MySQLIntegrationSuite extends SharedJDBCIntegrationSuite {
       .load()
     checkAnswer(df, Row("brown     ", "fox"))
   }
-
-  Seq(false, true).foreach { exists =>
-    test(s"Upsert ${if (exists) "" else "non-"}existing table") {
-      val df = Seq(
-        (1, Timestamp.valueOf("1996-01-01 01:23:46"), 1.235, 1.234568), // row unchanged
-        (2, Timestamp.valueOf("1996-01-01 01:23:45"), 2.346, 2.345678), // updates v1
-        (2, Timestamp.valueOf("1996-01-01 01:23:46"), 2.347, 2.345680), // updates v1 and v2
-        (3, Timestamp.valueOf("1996-01-01 01:23:45"), 3.456, 3.456789) // inserts new row
-      ).toDF("id", "ts", "v1", "v2").repartition(10)
-
-      val table = if (exists) "upsert" else "new_table"
-      val options = Map("numPartitions" -> "10", "upsert" -> "true")
-      df.write.mode(SaveMode.Append).options(options).jdbc(jdbcUrl, table, new Properties)
-
-      val actual = spark.read.jdbc(jdbcUrl, table, new Properties).collect.toSet
-      val existing = if (exists) {
-        Set((1, Timestamp.valueOf("1996-01-01 01:23:45"), 1.234, 1.234567))
-      } else {
-        Set.empty
-      }
-      val upsertedRows = Set(
-        (1, Timestamp.valueOf("1996-01-01 01:23:46"), 1.235, 1.234568),
-        (2, Timestamp.valueOf("1996-01-01 01:23:45"), 2.346, 2.345678),
-        (2, Timestamp.valueOf("1996-01-01 01:23:46"), 2.347, 2.345680),
-        (3, Timestamp.valueOf("1996-01-01 01:23:45"), 3.456, 3.456789)
-      )
-      val expected = (existing ++ upsertedRows).map { case (id, ts, v1, v2) =>
-        Row(Integer.valueOf(id), ts, v1.doubleValue(), v2.doubleValue())
-      }
-      assert(actual === expected)
-    }
-  }
-
-  test("Write with unspecified mode with upsert") { }
-  test("Write with overwrite mode with upsert") { }
-  test("Write with error-if-exists mode with upsert") { }
-  test("Write with ignore mode with upsert") { }
 }
 
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
@@ -258,7 +258,7 @@ class MySQLIntegrationSuite extends SharedJDBCIntegrationSuite {
     val df1 = spark.read.jdbc(jdbcUrl, "numbers", new Properties)
     val df2 = spark.read.jdbc(jdbcUrl, "dates", new Properties)
     val df3 = spark.read.jdbc(jdbcUrl, "strings", new Properties)
-    df1.write.mode(SaveMode.Append).jdbc(jdbcUrl, "numberscopy", new Properties)
+    df1.write.jdbc(jdbcUrl, "numberscopy", new Properties)
     df2.write.jdbc(jdbcUrl, "datescopy", new Properties)
     df3.write.jdbc(jdbcUrl, "stringscopy", new Properties)
   }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
@@ -107,6 +107,8 @@ class MySQLIntegrationSuite extends SharedJDBCIntegrationSuite with UpsertTests 
       "(2, '1996-01-01 01:23:46', 2.346, 2.345679)").executeUpdate()
   }
 
+  override val createTableOption = "; ALTER TABLE new_upsert_table ADD PRIMARY KEY (id, ts)"
+
   def testConnection(): Unit = {
     Using.resource(getConnection()) { conn =>
       assert(conn.getClass.getName === "com.mysql.cj.jdbc.ConnectionImpl")
@@ -384,7 +386,7 @@ class MySQLOverMariaConnectorIntegrationSuite extends MySQLIntegrationSuite {
   override val db = new MySQLDatabaseOnDocker {
     override def getJdbcUrl(ip: String, port: Int): String =
       s"jdbc:mysql://$ip:$port/mysql?user=root&password=rootpass&allowPublicKeyRetrieval=true" +
-        s"&useSSL=false&permitMysqlScheme"
+        s"&useSSL=false&permitMysqlScheme&allowMultiQueries=true"
   }
 
   override def testConnection(): Unit = {

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -193,9 +193,7 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite with UpsertTes
       "(2, '1996-01-01 01:23:46', 2.346, 2.345679)").executeUpdate()
   }
 
-  override val upsertTestOptions = Map(
-    "createTableOptions" -> "; ALTER TABLE new_upsert_table ADD PRIMARY KEY (id, ts)"
-  )
+  override val createTableOption = "; ALTER TABLE new_upsert_table ADD PRIMARY KEY (id, ts)"
 
   test("Type mapping for various types") {
     val df = spark.read.jdbc(jdbcUrl, "bar", new Properties)

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -24,7 +24,7 @@ import java.time.LocalDateTime
 import java.util.Properties
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.{DataFrame, Row, SaveMode}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.internal.SQLConf
@@ -183,6 +183,14 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
     conn.prepareStatement("CREATE DOMAIN myint AS integer CHECK (VALUE > 0)").executeUpdate()
     conn.prepareStatement("CREATE TABLE domain_table (c1 myint)").executeUpdate()
     conn.prepareStatement("INSERT INTO domain_table VALUES (1)").executeUpdate()
+
+    conn.prepareStatement("CREATE TABLE upsert (id integer, ts timestamp, v1 double precision, " +
+      "v2 double precision, CONSTRAINT pk PRIMARY KEY (id, ts))").executeUpdate()
+    conn.prepareStatement("INSERT INTO upsert VALUES " +
+      "(1, '1996-01-01 01:23:45', 1.234, 1.234567), " +
+      "(1, '1996-01-01 01:23:46', 1.235, 1.234568), " +
+      "(2, '1996-01-01 01:23:45', 2.345, 2.345678), " +
+      "(2, '1996-01-01 01:23:46', 2.346, 2.345679)").executeUpdate()
   }
 
   test("Type mapping for various types") {
@@ -316,6 +324,40 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
         DateTimeUtils.toJavaTimestamp(1471022551949271L),
         DateTimeUtils.toJavaTimestamp(62551949000L)))
     }
+
+  test(s"Upsert existing table") {
+    val df = Seq(
+      (1, Timestamp.valueOf("1996-01-01 01:23:46"), 1.235, 1.234568), // row unchanged
+      (2, Timestamp.valueOf("1996-01-01 01:23:45"), 2.346, 2.345678), // updates v1
+      (2, Timestamp.valueOf("1996-01-01 01:23:46"), 2.347, 2.345680), // updates v1 and v2
+      (3, Timestamp.valueOf("1996-01-01 01:23:45"), 3.456, 3.456789) // inserts new row
+    ).toDF("id", "ts", "v1", "v2").repartition(10)
+
+    val options = Map("numPartitions" -> "10", "upsert" -> "true", "upsertKeyColumns" -> "id, ts")
+    df.write.mode(SaveMode.Append).options(options).jdbc(jdbcUrl, "upsert", new Properties)
+
+    val actual = spark.read.jdbc(jdbcUrl, "upsert", new Properties).collect.toSet
+    val expected = Set(
+      (1, Timestamp.valueOf("1996-01-01 01:23:45"), 1.234, 1.234567),
+      (1, Timestamp.valueOf("1996-01-01 01:23:46"), 1.235, 1.234568),
+      (2, Timestamp.valueOf("1996-01-01 01:23:45"), 2.346, 2.345678),
+      (2, Timestamp.valueOf("1996-01-01 01:23:46"), 2.347, 2.345680),
+      (3, Timestamp.valueOf("1996-01-01 01:23:45"), 3.456, 3.456789)
+    ).map { case (id, ts, v1, v2) =>
+      Row(Integer.valueOf(id), ts, v1.doubleValue(), v2.doubleValue())
+    }
+    assert(actual === expected)
+  }
+
+  test("SPARK-20557: column type TIMESTAMP with TIME ZONE and TIME with TIME ZONE " +
+    "should be recognized") {
+    // When using JDBC to read the columns of TIMESTAMP with TIME ZONE and TIME with TIME ZONE
+    // the actual types are java.sql.Types.TIMESTAMP and java.sql.Types.TIME
+    val dfRead = sqlContext.read.jdbc(jdbcUrl, "ts_with_timezone", new Properties)
+    val rows = dfRead.collect()
+    val types = rows(0).toSeq.map(x => x.getClass.toString)
+    assert(types(1).equals("class java.sql.Timestamp"))
+    assert(types(2).equals("class java.sql.Timestamp"))
   }
 
   test("SPARK-22291: Conversion error when transforming array types of " +

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -40,7 +40,7 @@ import org.apache.spark.tags.DockerTest
  * }}}
  */
 @DockerTest
-class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
+class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite with UpsertTests {
   override val db = new PostgresDatabaseOnDocker
 
   override def dataPreparation(conn: Connection): Unit = {
@@ -324,30 +324,6 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
         DateTimeUtils.toJavaTimestamp(1471022551949271L),
         DateTimeUtils.toJavaTimestamp(62551949000L)))
     }
-
-  test(s"Upsert existing table") {
-    val df = Seq(
-      (1, Timestamp.valueOf("1996-01-01 01:23:46"), 1.235, 1.234568), // row unchanged
-      (2, Timestamp.valueOf("1996-01-01 01:23:45"), 2.346, 2.345678), // updates v1
-      (2, Timestamp.valueOf("1996-01-01 01:23:46"), 2.347, 2.345680), // updates v1 and v2
-      (3, Timestamp.valueOf("1996-01-01 01:23:45"), 3.456, 3.456789) // inserts new row
-    ).toDF("id", "ts", "v1", "v2").repartition(10)
-
-    val options = Map("numPartitions" -> "10", "upsert" -> "true", "upsertKeyColumns" -> "id, ts")
-    df.write.mode(SaveMode.Append).options(options).jdbc(jdbcUrl, "upsert", new Properties)
-
-    val actual = spark.read.jdbc(jdbcUrl, "upsert", new Properties).collect.toSet
-    val expected = Set(
-      (1, Timestamp.valueOf("1996-01-01 01:23:45"), 1.234, 1.234567),
-      (1, Timestamp.valueOf("1996-01-01 01:23:46"), 1.235, 1.234568),
-      (2, Timestamp.valueOf("1996-01-01 01:23:45"), 2.346, 2.345678),
-      (2, Timestamp.valueOf("1996-01-01 01:23:46"), 2.347, 2.345680),
-      (3, Timestamp.valueOf("1996-01-01 01:23:45"), 3.456, 3.456789)
-    ).map { case (id, ts, v1, v2) =>
-      Row(Integer.valueOf(id), ts, v1.doubleValue(), v2.doubleValue())
-    }
-    assert(actual === expected)
-  }
 
   test("SPARK-20557: column type TIMESTAMP with TIME ZONE and TIME with TIME ZONE " +
     "should be recognized") {

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -193,6 +193,10 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite with UpsertTes
       "(2, '1996-01-01 01:23:46', 2.346, 2.345679)").executeUpdate()
   }
 
+  override val upsertTestOptions = Map(
+    "createTableOptions" -> "; ALTER TABLE new_upsert_table ADD PRIMARY KEY (id, ts)"
+  )
+
   test("Type mapping for various types") {
     val df = spark.read.jdbc(jdbcUrl, "bar", new Properties)
     val rows = df.collect().sortBy(_.toString())

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -24,7 +24,7 @@ import java.time.LocalDateTime
 import java.util.Properties
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.{DataFrame, Row, SaveMode}
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.internal.SQLConf
@@ -326,6 +326,7 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite with UpsertTes
         DateTimeUtils.toJavaTimestamp(1471022551949271L),
         DateTimeUtils.toJavaTimestamp(62551949000L)))
     }
+  }
 
   test("SPARK-20557: column type TIMESTAMP with TIME ZONE and TIME with TIME ZONE " +
     "should be recognized") {

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/UpsertTests.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/UpsertTests.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.jdbc
+
+import java.sql.Timestamp
+import java.util.Properties
+
+import org.apache.spark.sql.{Row, SaveMode}
+
+trait UpsertTests {
+  self: DockerJDBCIntegrationSuite =>
+
+  import testImplicits._
+
+  test(s"Upsert existing table") { doTestUpsert(true) }
+  test(s"Upsert non-existing table") { doTestUpsert(false) }
+
+  def doTestUpsert(tableExists: Boolean): Unit = {
+    val df = Seq(
+      (1, Timestamp.valueOf("1996-01-01 01:23:46"), 1.235, 1.234568), // row unchanged
+      (2, Timestamp.valueOf("1996-01-01 01:23:45"), 2.346, 2.345678), // updates v1
+      (2, Timestamp.valueOf("1996-01-01 01:23:46"), 2.347, 2.345680), // updates v1 and v2
+      (3, Timestamp.valueOf("1996-01-01 01:23:45"), 3.456, 3.456789) // inserts new row
+    ).toDF("id", "ts", "v1", "v2").repartition(1) // .repartition(10)
+
+    val table = if (tableExists) "upsert" else "new_table"
+    val options = Map("numPartitions" -> "10", "upsert" -> "true", "upsertKeyColumns" -> "id, ts")
+    df.write.mode(SaveMode.Append).options(options).jdbc(jdbcUrl, table, new Properties)
+
+    val actual = spark.read.jdbc(jdbcUrl, table, new Properties).collect.toSet
+    val existing = if (tableExists) {
+      Set((1, Timestamp.valueOf("1996-01-01 01:23:45"), 1.234, 1.234567))
+    } else {
+      Set.empty
+    }
+    val upsertedRows = Set(
+      (1, Timestamp.valueOf("1996-01-01 01:23:46"), 1.235, 1.234568),
+      (2, Timestamp.valueOf("1996-01-01 01:23:45"), 2.346, 2.345678),
+      (2, Timestamp.valueOf("1996-01-01 01:23:46"), 2.347, 2.345680),
+      (3, Timestamp.valueOf("1996-01-01 01:23:45"), 3.456, 3.456789)
+    )
+    val expected = (existing ++ upsertedRows).map { case (id, ts, v1, v2) =>
+      Row(Integer.valueOf(id), ts, v1.doubleValue(), v2.doubleValue())
+    }
+    assert(actual === expected)
+  }
+
+  test("Upsert null values") {}
+  test("Write with unspecified mode with upsert") {}
+  test("Write with overwrite mode with upsert") {}
+  test("Write with error-if-exists mode with upsert") {}
+  test("Write with ignore mode with upsert") {}
+}

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/UpsertTests.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/UpsertTests.scala
@@ -38,7 +38,7 @@ trait UpsertTests {
     Seq("ts", "id", "v1", "v2"),
     Seq("ts", "v1", "id", "v2"),
     Seq("ts", "v1", "v2", "id"),
-    Seq("v2", "v1", "ts", "id"),
+    Seq("v2", "v1", "ts", "id")
   ).foreach { columns =>
     test(s"Upsert with varying column order - ${columns.mkString(",")}") {
       doTestUpsert(tableExists = true, Some(columns))

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/UpsertTests.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/UpsertTests.scala
@@ -27,6 +27,8 @@ trait UpsertTests {
 
   import testImplicits._
 
+  def upsertTestOptions: Map[String, String] = Map.empty
+
   test(s"Upsert existing table") { doTestUpsert(true) }
   test(s"Upsert non-existing table") { doTestUpsert(false) }
 
@@ -38,8 +40,12 @@ trait UpsertTests {
       (3, Timestamp.valueOf("1996-01-01 01:23:45"), 3.456, 3.456789) // inserts new row
     ).toDF("id", "ts", "v1", "v2").repartition(1) // .repartition(10)
 
-    val table = if (tableExists) "upsert" else "new_table"
-    val options = Map("numPartitions" -> "10", "upsert" -> "true", "upsertKeyColumns" -> "id, ts")
+    val table = if (tableExists) "upsert" else "new_upsert_table"
+    val options = upsertTestOptions ++ Map(
+      "numPartitions" -> "10",
+      "upsert" -> "true",
+      "upsertKeyColumns" -> "id, ts"
+    )
     df.write.mode(SaveMode.Append).options(options).jdbc(jdbcUrl, table, new Properties)
 
     val actual = spark.read.jdbc(jdbcUrl, table, new Properties).collect.toSet

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/UpsertTests.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/UpsertTests.scala
@@ -31,8 +31,8 @@ trait UpsertTests {
   def createTableOption: String
   def upsertTestOptions: Map[String, String] = Map("createTableOptions" -> createTableOption)
 
-  test(s"Upsert existing table") { doTestUpsert(tableExists = true) }
-  test(s"Upsert non-existing table") { doTestUpsert(tableExists = false) }
+  test("Upsert existing table") { doTestUpsert(tableExists = true) }
+  test("Upsert non-existing table") { doTestUpsert(tableExists = false) }
 
   Seq(
     Seq("ts", "id", "v1", "v2"),
@@ -80,7 +80,7 @@ trait UpsertTests {
     assert(actual === expected)
   }
 
-  test(s"Upsert concurrency") {
+  test("Upsert concurrency") {
     // create a table with 100k rows
     val init =
       spark.range(100000)

--- a/docs/sql-data-sources-jdbc.md
+++ b/docs/sql-data-sources-jdbc.md
@@ -262,6 +262,19 @@ logging into the data sources.
   </tr>
 
   <tr>
+    <td><code>upsert, upsertKeyColumns</code></td>
+    <td>
+      These options are JDBC writer related options. They describe how to
+      use UPSERT feature for different JDBC dialects. The upsert option is applicable only when <code>SaveMode.Append</code> is enabled.
+      Set <code>upsert</code> to <code>true</code> to enable upsert append mode. The database is queried for the primary index to detect
+      the upsert key columns that are used to identify rows for update. The upsert key columns can be
+      defined via the <code>upsertKeyColumns</code> as a comma-separated list of column names.
+      Be aware that if the input data set has duplicate rows, the upsert operation is
+      non-deterministic, it is documented at the [upsert(merge) wiki:](https://en.wikipedia.org/wiki/Merge_(SQL)).
+    </td>
+  </tr>
+
+  <tr>
     <td><code>customSchema</code></td>
     <td>(none)</td>
     <td>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1709,6 +1709,14 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     tableDoesNotSupportError("truncates", table)
   }
 
+  def tableDoesNotSupportUpsertsError(table: String): Throwable = {
+    new AnalysisException(
+      errorClass = "_LEGACY_ERROR_TEMP_1121",
+      messageParameters = Map(
+        "cmd" -> "upserts",
+        "table" -> table))
+  }
+
   def tableDoesNotSupportPartitionManagementError(table: Table): Throwable = {
     tableDoesNotSupportError("partition management", table)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1685,44 +1685,40 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("changes" -> changesDesc))
   }
 
-  private def tableDoesNotSupportError(cmd: String, table: Table): Throwable = {
+  private def tableDoesNotSupportError(cmd: String, tableName: String): Throwable = {
     new AnalysisException(
       errorClass = "_LEGACY_ERROR_TEMP_1121",
       messageParameters = Map(
         "cmd" -> cmd,
-        "table" -> table.name))
+        "table" -> tableName))
   }
 
   def tableDoesNotSupportReadsError(table: Table): Throwable = {
-    tableDoesNotSupportError("reads", table)
+    tableDoesNotSupportError("reads", table.name)
   }
 
   def tableDoesNotSupportWritesError(table: Table): Throwable = {
-    tableDoesNotSupportError("writes", table)
+    tableDoesNotSupportError("writes", table.name)
   }
 
   def tableDoesNotSupportDeletesError(table: Table): Throwable = {
-    tableDoesNotSupportError("deletes", table)
+    tableDoesNotSupportError("deletes", table.name)
   }
 
   def tableDoesNotSupportTruncatesError(table: Table): Throwable = {
-    tableDoesNotSupportError("truncates", table)
+    tableDoesNotSupportError("truncates", table.name)
   }
 
-  def tableDoesNotSupportUpsertsError(table: String): Throwable = {
-    new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1121",
-      messageParameters = Map(
-        "cmd" -> "upserts",
-        "table" -> table))
+  def tableDoesNotSupportUpsertsError(tableName: String): Throwable = {
+    tableDoesNotSupportError("upserts", tableName)
   }
 
   def tableDoesNotSupportPartitionManagementError(table: Table): Throwable = {
-    tableDoesNotSupportError("partition management", table)
+    tableDoesNotSupportError("partition management", table.name)
   }
 
   def tableDoesNotSupportAtomicPartitionManagementError(table: Table): Throwable = {
-    tableDoesNotSupportError("atomic partition management", table)
+    tableDoesNotSupportError("atomic partition management", table.name)
   }
 
   def tableIsNotRowLevelOperationTableError(table: Table): Throwable = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -167,6 +167,7 @@ class JDBCOptions(
   // ------------------------------------------------------------
   // if to truncate the table from the JDBC database
   val isTruncate = parameters.getOrElse(JDBC_TRUNCATE, "false").toBoolean
+
   val isCascadeTruncate: Option[Boolean] = parameters.get(JDBC_CASCADE_TRUNCATE).map(_.toBoolean)
   // if to upsert the table in the JDBC database
   val isUpsert = parameters.getOrElse(JDBC_UPSERT, "false").toBoolean

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -167,8 +167,12 @@ class JDBCOptions(
   // ------------------------------------------------------------
   // if to truncate the table from the JDBC database
   val isTruncate = parameters.getOrElse(JDBC_TRUNCATE, "false").toBoolean
-
   val isCascadeTruncate: Option[Boolean] = parameters.get(JDBC_CASCADE_TRUNCATE).map(_.toBoolean)
+  // if to upsert the table in the JDBC database
+  val isUpsert = parameters.getOrElse(JDBC_UPSERT, "false").toBoolean
+  // the columns used to identify update and insert rows in upsert mode
+  val upsertKeyColumns = parameters.getOrElse(JDBC_UPSERT_KEY_COLUMNS, "").split(",").map(_.trim)
+
   // the create table option , which can be table_options or partition_options.
   // E.g., "CREATE TABLE t (name string) ENGINE=InnoDB DEFAULT CHARSET=utf8"
   // TODO: to reuse the existing partition parameters for those partition specific options
@@ -314,6 +318,8 @@ object JDBCOptions {
   val JDBC_BATCH_FETCH_SIZE = newOption("fetchsize")
   val JDBC_TRUNCATE = newOption("truncate")
   val JDBC_CASCADE_TRUNCATE = newOption("cascadeTruncate")
+  val JDBC_UPSERT = newOption("upsert")
+  val JDBC_UPSERT_KEY_COLUMNS = newOption("upsertKeyColumns")
   val JDBC_CREATE_TABLE_OPTIONS = newOption("createTableOptions")
   val JDBC_CREATE_TABLE_COLUMN_TYPES = newOption("createTableColumnTypes")
   val JDBC_CUSTOM_DATAFRAME_COLUMN_TYPES = newOption("customSchema")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcRelationProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcRelationProvider.scala
@@ -59,6 +59,7 @@ class JdbcRelationProvider extends CreatableRelationProvider
     val dialect = JdbcDialects.get(options.url)
     val conn = dialect.createConnectionFactory(options)(-1)
     try {
+      val upsert = mode == SaveMode.Append && options.isUpsert
       val tableExists = JdbcUtils.tableExists(conn, options)
       if (tableExists) {
         mode match {
@@ -67,17 +68,20 @@ class JdbcRelationProvider extends CreatableRelationProvider
               // In this case, we should truncate table and then load.
               truncateTable(conn, options)
               val tableSchema = JdbcUtils.getSchemaOption(conn, options)
-              saveTable(df, tableSchema, isCaseSensitive, options)
+              saveTable(df, tableSchema, isCaseSensitive, upsert, options)
             } else {
               // Otherwise, do not truncate the table, instead drop and recreate it
               dropTable(conn, options.table, options)
               createTable(conn, options.table, df.schema, isCaseSensitive, options)
-              saveTable(df, Some(df.schema), isCaseSensitive, options)
+              saveTable(df, Some(df.schema), isCaseSensitive, upsert, options)
             }
 
           case SaveMode.Append =>
+            if (options.isUpsert && !dialect.supportsUpsert()) {
+              throw QueryCompilationErrors.tableDoesNotSupportUpsertsError(options.table)
+            }
             val tableSchema = JdbcUtils.getSchemaOption(conn, options)
-            saveTable(df, tableSchema, isCaseSensitive, options)
+            saveTable(df, tableSchema, isCaseSensitive, upsert, options)
 
           case SaveMode.ErrorIfExists =>
             throw QueryCompilationErrors.tableOrViewAlreadyExistsError(options.table)
@@ -89,7 +93,7 @@ class JdbcRelationProvider extends CreatableRelationProvider
         }
       } else {
         createTable(conn, options.table, df.schema, isCaseSensitive, options)
-        saveTable(df, Some(df.schema), isCaseSensitive, options)
+        saveTable(df, Some(df.schema), isCaseSensitive, upsert, options)
       }
     } finally {
       conn.close()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -149,12 +149,12 @@ object JdbcUtils extends Logging with SQLConfHelper {
   }
 
   def getUpsertStatement(
-    table: String,
-    rddSchema: StructType,
-    tableSchema: Option[StructType],
-    isCaseSensitive: Boolean,
-    dialect: JdbcDialect,
-    options: JDBCOptions): String = {
+      table: String,
+      rddSchema: StructType,
+      tableSchema: Option[StructType],
+      isCaseSensitive: Boolean,
+      dialect: JdbcDialect,
+      options: JDBCOptions): String = {
     val columns = getInsertColumns(table, rddSchema, tableSchema, isCaseSensitive, dialect)
     dialect.getUpsertStatement(table, columns, isCaseSensitive, options)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -113,16 +113,13 @@ object JdbcUtils extends Logging with SQLConfHelper {
     JdbcDialects.get(url).isCascadingTruncateTable()
   }
 
-  /**
-   * Returns an Insert SQL statement for inserting a row into the target table via JDBC conn.
-   */
-  def getInsertStatement(
+  protected def getInsertColumns(
       table: String,
       rddSchema: StructType,
       tableSchema: Option[StructType],
       isCaseSensitive: Boolean,
-      dialect: JdbcDialect): String = {
-    val columns = if (tableSchema.isEmpty) {
+      dialect: JdbcDialect): Array[StructField] = {
+    if (tableSchema.isEmpty) {
       rddSchema.fields
     } else {
       // The generated insert statement needs to follow rddSchema's column sequence and
@@ -136,7 +133,30 @@ object JdbcUtils extends Logging with SQLConfHelper {
         }
       }
     }
+  }
+
+  /**
+   * Returns an Insert SQL statement for inserting a row into the target table via JDBC conn.
+   */
+  def getInsertStatement(
+      table: String,
+      rddSchema: StructType,
+      tableSchema: Option[StructType],
+      isCaseSensitive: Boolean,
+      dialect: JdbcDialect): String = {
+    val columns = getInsertColumns(table, rddSchema, tableSchema, isCaseSensitive, dialect)
     dialect.insertIntoTable(table, columns)
+  }
+
+  def getUpsertStatement(
+    table: String,
+    rddSchema: StructType,
+    tableSchema: Option[StructType],
+    isCaseSensitive: Boolean,
+    dialect: JdbcDialect,
+    options: JDBCOptions): String = {
+    val columns = getInsertColumns(table, rddSchema, tableSchema, isCaseSensitive, dialect)
+    dialect.getUpsertStatement(table, columns, isCaseSensitive, options)
   }
 
   /**
@@ -1048,6 +1068,7 @@ object JdbcUtils extends Logging with SQLConfHelper {
       df: DataFrame,
       tableSchema: Option[StructType],
       isCaseSensitive: Boolean,
+      upsert: Boolean,
       options: JdbcOptionsInWrite): Unit = {
     val url = options.url
     val table = options.table
@@ -1056,7 +1077,12 @@ object JdbcUtils extends Logging with SQLConfHelper {
     val batchSize = options.batchSize
     val isolationLevel = options.isolationLevel
 
-    val insertStmt = getInsertStatement(table, rddSchema, tableSchema, isCaseSensitive, dialect)
+    val insertStmt = if (upsert) {
+      getUpsertStatement(table, rddSchema, tableSchema, isCaseSensitive, dialect, options)
+    } else {
+      getInsertStatement(table, rddSchema, tableSchema, isCaseSensitive, dialect)
+    }
+
     val repartitionedDF = options.numPartitions match {
       case Some(n) if n <= 0 => throw QueryExecutionErrors.invalidJdbcNumPartitionsError(
         n, JDBCOptions.JDBC_NUM_PARTITIONS)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCWriteBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCWriteBuilder.scala
@@ -42,7 +42,8 @@ case class JDBCWriteBuilder(schema: StructType, options: JdbcOptionsInWrite) ext
         val conn = dialect.createConnectionFactory(options)(-1)
         JdbcUtils.truncateTable(conn, options)
       }
-      JdbcUtils.saveTable(data, Some(schema), SQLConf.get.caseSensitiveAnalysis, options)
+      JdbcUtils.saveTable(
+        data, Some(schema), SQLConf.get.caseSensitiveAnalysis, upsert = false, options)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -346,7 +346,10 @@ abstract class JdbcDialect extends Serializable with Logging {
       columns: Array[StructField],
       isCaseSensitive: Boolean,
       options: JDBCOptions): String =
-    throw new UnsupportedOperationException("upserts are not supported")
+    throw new SparkUnsupportedOperationException(
+      errorClass = "UNSUPPORTED_FEATURE.UPSERT",
+      messageParameters = Map(
+        "class" -> this.getClass.getSimpleName))
 
   /**
    * Returns the effective fetch size for reading from the JDBC source.

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -337,6 +337,17 @@ abstract class JdbcDialect extends Serializable with Logging {
       s"TRUNCATE TABLE $table"
   }
 
+  @Since("3.5.0")
+  def supportsUpsert(): Boolean = false
+
+  @Since("3.5.0")
+  def getUpsertStatement(
+      tableName: String,
+      columns: Array[StructField],
+      isCaseSensitive: Boolean,
+      options: JDBCOptions): String =
+    throw new UnsupportedOperationException("upserts are not supported")
+
   /**
    * Returns the effective fetch size for reading from the JDBC source.
    * By default, returns the user-specified fetchSize from JDBCOptions.

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -179,35 +179,34 @@ private case class MsSqlServerDialect() extends JdbcDialect with NoLegacyJDBCErr
 
   override def getUpsertStatement(
       tableName: String,
-      columns: Array[String],
-      types: Array[DataType],
+      columns: Array[StructField],
       isCaseSensitive: Boolean,
       options: JDBCOptions): String = {
-    val insertColumns = columns.mkString(", ")
-    val inputs = types
+    val insertColumns = columns.map(_.name).map(quoteIdentifier)
+    val inputs = columns
+      .map(_.dataType)
       .map(t => JdbcUtils.getJdbcType(t, this).databaseTypeDefinition)
       .zipWithIndex.map {
         case (t, idx) => s"DECLARE @param$idx $t; SET @param$idx = ?;"
       }.mkString("\n")
     val values = columns.indices.map(i => s"@param$i").mkString(", ")
-    val quotedUpsertKeyColumns = options.upsertKeyColumns.map(quoteIdentifier)
     val keyColumns = columns.zipWithIndex.filter {
-      case (col, _) => quotedUpsertKeyColumns.contains(col)
+      case (col, _) => options.upsertKeyColumns.contains(col.name)
     }
     val updateColumns = columns.zipWithIndex.filterNot {
-      case (col, _) => quotedUpsertKeyColumns.contains(col)
+      case (col, _) => options.upsertKeyColumns.contains(col.name)
     }
     val whereClause = keyColumns.map {
-      case (key, idx) => s"$key = @param$idx"
+      case (key, idx) => s"${quoteIdentifier(key.name)} = @param$idx"
     }.mkString(" AND ")
     val updateClause = updateColumns.map {
-      case (col, idx) => s"$col = @param$idx"
+      case (col, idx) => s"${quoteIdentifier(col.name)} = @param$idx"
     }.mkString(", ")
 
     s"""
        |$inputs
        |
-       |INSERT $tableName ($insertColumns)
+       |INSERT $tableName (${insertColumns.mkString(", ")})
        |SELECT $values
        |WHERE NOT EXISTS (
        |    SELECT 1

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.connector.expressions.{Expression, NullOrdering, SortDirection}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
-import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
+import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JdbcUtils}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.jdbc.MsSqlServerDialect.{GEOGRAPHY, GEOMETRY}
 import org.apache.spark.sql.types._
@@ -173,6 +173,55 @@ private case class MsSqlServerDialect() extends JdbcDialect with NoLegacyJDBCErr
       Some(JdbcType("SMALLINT", java.sql.Types.SMALLINT))
     case ByteType => Some(JdbcType("SMALLINT", java.sql.Types.TINYINT))
     case _ => None
+  }
+
+  override def supportsUpsert(): Boolean = true
+
+  override def getUpsertStatement(
+      tableName: String,
+      columns: Array[String],
+      types: Array[DataType],
+      isCaseSensitive: Boolean,
+      options: JDBCOptions): String = {
+    val insertColumns = columns.mkString(", ")
+    val inputs = types
+      .map(t => JdbcUtils.getJdbcType(t, this).databaseTypeDefinition)
+      .zipWithIndex.map {
+        case (t, idx) => s"DECLARE @param$idx $t; SET @param$idx = ?;"
+      }.mkString("\n")
+    val values = columns.indices.map(i => s"@param$i").mkString(", ")
+    val quotedUpsertKeyColumns = options.upsertKeyColumns.map(quoteIdentifier)
+    val keyColumns = columns.zipWithIndex.filter {
+      case (col, _) => quotedUpsertKeyColumns.contains(col)
+    }
+    val updateColumns = columns.zipWithIndex.filterNot {
+      case (col, _) => quotedUpsertKeyColumns.contains(col)
+    }
+    val whereClause = keyColumns.map {
+      case (key, idx) => s"$key = @param$idx"
+    }.mkString(" AND ")
+    val updateClause = updateColumns.map {
+      case (col, idx) => s"$col = @param$idx"
+    }.mkString(", ")
+
+    s"""
+       |$inputs
+       |
+       |INSERT $tableName ($insertColumns)
+       |SELECT $values
+       |WHERE NOT EXISTS (
+       |    SELECT 1
+       |    FROM $tableName WITH (UPDLOCK, SERIALIZABLE)
+       |    WHERE $whereClause
+       |)
+       |
+       |IF (@@ROWCOUNT = 0)
+       |BEGIN
+       |    UPDATE TOP (1) $tableName
+       |    SET $updateClause
+       |    WHERE $whereClause
+       |END
+       |""".stripMargin
   }
 
   override def isCascadingTruncateTable(): Option[Boolean] = Some(false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -235,15 +235,15 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
       columns: Array[StructField],
       isCaseSensitive: Boolean,
       options: JDBCOptions): String = {
-    val insertColumns = columns.mkString(", ")
+    val insertColumns = columns.map(_.name).map(quoteIdentifier)
     val placeholders = columns.map(_ => "?").mkString(",")
     val upsertKeyColumns = options.upsertKeyColumns.map(quoteIdentifier)
-    val updateColumns = columns.filterNot(c => upsertKeyColumns.contains(c.name))
+    val updateColumns = insertColumns.filterNot(upsertKeyColumns.contains)
     val updateClause =
       updateColumns.map(x => s"$x = VALUES($x)").mkString(", ")
 
     s"""
-       |INSERT INTO $tableName ($insertColumns)
+       |INSERT INTO $tableName (${insertColumns.mkString(", ")})
        |VALUES ( $placeholders )
        |ON DUPLICATE KEY UPDATE $updateClause
        |""".stripMargin

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -224,6 +224,31 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
     schemaBuilder.result()
   }
 
+  override def getTableExistsQuery(table: String): String = {
+    s"SELECT 1 FROM $table LIMIT 1"
+  }
+
+  override def supportsUpsert(): Boolean = true
+
+  override def getUpsertStatement(
+      tableName: String,
+      columns: Array[String],
+      isCaseSensitive: Boolean,
+      options: JDBCOptions): String = {
+    val insertColumns = columns.mkString(", ")
+    val placeholders = columns.map(_ => "?").mkString(",")
+    val upsertKeyColumns = options.upsertKeyColumns.map(quoteIdentifier)
+    val updateColumns = columns.filterNot(upsertKeyColumns.contains)
+    val updateClause =
+      updateColumns.map(x => s"$x = VALUES($x)").mkString(", ")
+
+    s"""
+       |INSERT INTO $tableName ($insertColumns)
+       |VALUES ( $placeholders )
+       |ON DUPLICATE KEY UPDATE $updateClause
+       |""".stripMargin
+  }
+
   override def isCascadingTruncateTable(): Option[Boolean] = Some(false)
 
   // See https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
@@ -367,7 +392,7 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
       }
     } catch {
       case _: Exception =>
-        logWarning("Cannot retrieved index info.")
+        logWarning("Cannot retrieve index info.")
     }
     indexMap.values.toArray
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -232,13 +232,13 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
 
   override def getUpsertStatement(
       tableName: String,
-      columns: Array[String],
+      columns: Array[StructField],
       isCaseSensitive: Boolean,
       options: JDBCOptions): String = {
     val insertColumns = columns.mkString(", ")
     val placeholders = columns.map(_ => "?").mkString(",")
     val upsertKeyColumns = options.upsertKeyColumns.map(quoteIdentifier)
-    val updateColumns = columns.filterNot(upsertKeyColumns.contains)
+    val updateColumns = columns.filterNot(c => upsertKeyColumns.contains(c.name))
     val updateClause =
       updateColumns.map(x => s"$x = VALUES($x)").mkString(", ")
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -224,10 +224,6 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
     schemaBuilder.result()
   }
 
-  override def getTableExistsQuery(table: String): String = {
-    s"SELECT 1 FROM $table LIMIT 1"
-  }
-
   override def supportsUpsert(): Boolean = true
 
   override def getUpsertStatement(

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -176,19 +176,18 @@ private case class PostgresDialect()
 
   override def getUpsertStatement(
       tableName: String,
-      columns: Array[String],
-      types: Array[DataType],
+      columns: Array[StructField],
       isCaseSensitive: Boolean,
       options: JDBCOptions): String = {
-    val insertColumns = columns.mkString(", ")
+    val insertColumns = columns.map(_.name).map(quoteIdentifier)
     val placeholders = columns.map(_ => "?").mkString(",")
     val upsertKeyColumns = options.upsertKeyColumns.map(quoteIdentifier)
-    val updateColumns = columns.filterNot(upsertKeyColumns.contains)
+    val updateColumns = insertColumns.filterNot(upsertKeyColumns.contains)
     val updateClause =
       updateColumns.map(x => s"$x = EXCLUDED.$x").mkString(", ")
 
     s"""
-       |INSERT INTO $tableName ($insertColumns)
+       |INSERT INTO $tableName (${insertColumns.mkString(", ")})
        |VALUES ( $placeholders )
        |ON CONFLICT (${upsertKeyColumns.mkString(", ")})
        |DO UPDATE SET $updateClause

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -177,6 +177,7 @@ private case class PostgresDialect()
   override def getUpsertStatement(
       tableName: String,
       columns: Array[String],
+      types: Array[DataType],
       isCaseSensitive: Boolean,
       options: JDBCOptions): String = {
     val insertColumns = columns.mkString(", ")

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -168,10 +168,6 @@ private case class PostgresDialect()
     case _ => None
   }
 
-  override def getTableExistsQuery(table: String): String = {
-    s"SELECT 1 FROM $table LIMIT 1"
-  }
-
   override def supportsUpsert(): Boolean = true
 
   override def getUpsertStatement(

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -168,6 +168,32 @@ private case class PostgresDialect()
     case _ => None
   }
 
+  override def getTableExistsQuery(table: String): String = {
+    s"SELECT 1 FROM $table LIMIT 1"
+  }
+
+  override def supportsUpsert(): Boolean = true
+
+  override def getUpsertStatement(
+      tableName: String,
+      columns: Array[String],
+      isCaseSensitive: Boolean,
+      options: JDBCOptions): String = {
+    val insertColumns = columns.mkString(", ")
+    val placeholders = columns.map(_ => "?").mkString(",")
+    val upsertKeyColumns = options.upsertKeyColumns.map(quoteIdentifier)
+    val updateColumns = columns.filterNot(upsertKeyColumns.contains)
+    val updateClause =
+      updateColumns.map(x => s"$x = EXCLUDED.$x").mkString(", ")
+
+    s"""
+       |INSERT INTO $tableName ($insertColumns)
+       |VALUES ( $placeholders )
+       |ON CONFLICT (${upsertKeyColumns.mkString(", ")})
+       |DO UPDATE SET $updateClause
+       |""".stripMargin
+  }
+
   override def isCascadingTruncateTable(): Option[Boolean] = Some(false)
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1227,22 +1227,42 @@ class JDBCSuite extends SharedSparkSession {
   }
 
   Seq(
-    ("MySQL",
-      JdbcDialects.get("jdbc:mysql://127.0.0.1/db"),
-      """
-        |INSERT INTO table (`id`, `time`, `value`, `comment`)
-        |VALUES ( ?,?,?,? )
-        |ON DUPLICATE KEY UPDATE `value` = VALUES(`value`), `comment` = VALUES(`comment`)
-        |""".stripMargin),
-    ("Postgres",
-      JdbcDialects.get("jdbc:postgresql://127.0.0.1/db"),
-      """
-        |INSERT INTO table ("id", "time", "value", "comment")
-        |VALUES ( ?,?,?,? )
-        |ON CONFLICT ("id", "time")
-        |DO UPDATE SET "value" = EXCLUDED."value", "comment" = EXCLUDED."comment"
-        |""".stripMargin)
-  ).foreach { case (label, dialect, expected) =>
+    (JdbcDialects.get("jdbc:mysql://127.0.0.1/db"),
+     """
+       |INSERT INTO table (`id`, `time`, `value`, `comment`)
+       |VALUES ( ?,?,?,? )
+       |ON DUPLICATE KEY UPDATE `value` = VALUES(`value`), `comment` = VALUES(`comment`)
+       |""".stripMargin),
+    (JdbcDialects.get("jdbc:postgresql://127.0.0.1/db"),
+     """
+       |INSERT INTO table ("id", "time", "value", "comment")
+       |VALUES ( ?,?,?,? )
+       |ON CONFLICT ("id", "time")
+       |DO UPDATE SET "value" = EXCLUDED."value", "comment" = EXCLUDED."comment"
+       |""".stripMargin),
+    (JdbcDialects.get("jdbc:sqlserver://localhost/db"),
+     """
+       |DECLARE @param0 BIGINT; SET @param0 = ?;
+       |DECLARE @param1 DATETIME; SET @param1 = ?;
+       |DECLARE @param2 DOUBLE PRECISION; SET @param2 = ?;
+       |DECLARE @param3 NVARCHAR(MAX); SET @param3 = ?;
+       |
+       |INSERT table ("id", "time", "value", "comment")
+       |SELECT @param0, @param1, @param2, @param3
+       |WHERE NOT EXISTS (
+       |    SELECT 1
+       |    FROM table WITH (UPDLOCK, SERIALIZABLE)
+       |    WHERE "id" = @param0 AND "time" = @param1
+       |)
+       |
+       |IF (@@ROWCOUNT = 0)
+       |BEGIN
+       |    UPDATE TOP (1) table
+       |    SET "value" = @param2, "comment" = @param3
+       |    WHERE "id" = @param0 AND "time" = @param1
+       |END
+       |""".stripMargin)
+  ).foreach { case (dialect, expected) =>
     test(s"upsert table query by dialect - ${dialect.getClass.getSimpleName.stripSuffix("$")}") {
       assert(dialect.supportsUpsert() === true)
 
@@ -1257,8 +1277,9 @@ class JDBCSuite extends SharedSparkSession {
       val table = "table"
       val columns = Array("id", "time", "value", "comment")
       val quotedColumns = columns.map(dialect.quoteIdentifier)
+      val types: Array[DataType] = Array(LongType, TimestampType, DoubleType, StringType)
       val isCaseSensitive = false
-      val stmt = dialect.getUpsertStatement(table, quotedColumns, isCaseSensitive, options)
+      val stmt = dialect.getUpsertStatement(table, quotedColumns, types, isCaseSensitive, options)
 
       assert(stmt === expected)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1275,11 +1275,14 @@ class JDBCSuite extends SharedSparkSession {
       }
 
       val table = "table"
-      val columns = Array("id", "time", "value", "comment")
-      val quotedColumns = columns.map(dialect.quoteIdentifier)
-      val types: Array[DataType] = Array(LongType, TimestampType, DoubleType, StringType)
+      val columns = Array(
+        StructField("id", LongType),
+        StructField("time", TimestampType),
+        StructField("value", DoubleType),
+        StructField("comment", StringType)
+      )
       val isCaseSensitive = false
-      val stmt = dialect.getUpsertStatement(table, quotedColumns, types, isCaseSensitive, options)
+      val stmt = dialect.getUpsertStatement(table, columns, isCaseSensitive, options)
 
       assert(stmt === expected)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -39,6 +39,7 @@ import org.apache.spark.sql.execution.{DataSourceScanExec, ExtendedMode, Project
 import org.apache.spark.sql.execution.command.{ExplainCommand, ShowCreateTableCommand}
 import org.apache.spark.sql.execution.datasources.{LogicalRelation, LogicalRelationWithTable}
 import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JDBCPartition, JDBCRelation, JdbcUtils}
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions.JDBC_UPSERT_KEY_COLUMNS
 import org.apache.spark.sql.execution.metric.InputOutputMetricsHelper
 import org.apache.spark.sql.functions.{lit, percentile_approx}
 import org.apache.spark.sql.internal.SQLConf
@@ -1223,6 +1224,44 @@ class JDBCSuite extends SharedSparkSession {
     assert(oracle.getTruncateQuery(table, Some(true)) == oracleQuery)
     assert(teradata.getTruncateQuery(table, Some(true)) == teradataQuery)
     assert(db2.getTruncateQuery(table, Some(true)) == db2Query)
+  }
+
+  Seq(
+    ("MySQL",
+      JdbcDialects.get("jdbc:mysql://127.0.0.1/db"),
+      """
+        |INSERT INTO table (`id`, `time`, `value`, `comment`)
+        |VALUES ( ?,?,?,? )
+        |ON DUPLICATE KEY UPDATE `value` = VALUES(`value`), `comment` = VALUES(`comment`)
+        |""".stripMargin),
+    ("Postgres",
+      JdbcDialects.get("jdbc:postgresql://127.0.0.1/db"),
+      """
+        |INSERT INTO table ("id", "time", "value", "comment")
+        |VALUES ( ?,?,?,? )
+        |ON CONFLICT ("id", "time")
+        |DO UPDATE SET "value" = EXCLUDED."value", "comment" = EXCLUDED."comment"
+        |""".stripMargin)
+  ).foreach { case (label, dialect, expected) =>
+    test(s"upsert table query by dialect - ${dialect.getClass.getSimpleName.stripSuffix("$")}") {
+      assert(dialect.supportsUpsert() === true)
+
+      val options = {
+        new JDBCOptions(Map(
+          JDBC_UPSERT_KEY_COLUMNS -> "id, time",
+          JDBCOptions.JDBC_URL -> url,
+          JDBCOptions.JDBC_TABLE_NAME -> "table"
+        ))
+      }
+
+      val table = "table"
+      val columns = Array("id", "time", "value", "comment")
+      val quotedColumns = columns.map(dialect.quoteIdentifier)
+      val isCaseSensitive = false
+      val stmt = dialect.getUpsertStatement(table, quotedColumns, isCaseSensitive, options)
+
+      assert(stmt === expected)
+    }
   }
 
   test("Test DataFrame.where for Date and Timestamp") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is a follow-up on #16685 and #16692.

Implements upsert mode for `SaveMode.Append` of the MySql, MsSql, and Postgres JDBC source.

See #41611 for an alternative using the `MERGE INTO` command (not supported by MySql).

### Why are the changes needed?
The JDBC writer only supports either truncating the existing table or inserting. Duplicates, i.e. rows with identical values in the primary or unique index columns, cause an exception, permitting updating existing and inserting new rows.

Re-evaluating a partition due to executor loss will insert rows that have been inserted in an earlier attempt, which kills the entier Spark job.

### Does this PR introduce _any_ user-facing change?
This adds `upsert` and `upsertKeyColumns` options for `SaveMode.Append` of the JDBC source.

### How was this patch tested?
Tests in `JdbcSuite` and integration suites.

Re-opens #49528.