### PR TITLE
[SPARK-54665][PS] Fix boolean vs string comparison to match pandas behavior

### DIFF
--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -364,6 +364,9 @@ class BooleanOpsTestsMixin:
         psser, other_psser = psdf["this"], psdf["that"]
         self.assert_eq(pser == other_pser, psser == other_psser)
         self.assert_eq(pser == pser, psser == psser)
+        # SPARK-54665: boolean vs string comparison should match pandas behavior
+        self.assert_eq(pser == "True", psser == "True")
+        self.assert_eq(pser == "False", psser == "False")
 
     def test_ne(self):
         pdf, psdf = self.bool_pdf, self.bool_psdf
@@ -371,6 +374,9 @@ class BooleanOpsTestsMixin:
         psser, other_psser = psdf["this"], psdf["that"]
         self.assert_eq(pser != other_pser, psser != other_psser)
         self.assert_eq(pser != pser, psser != psser)
+        # SPARK-54665: boolean vs string comparison should match pandas behavior
+        self.assert_eq(pser != "True", psser != "True")
+        self.assert_eq(pser != "False", psser != "False")
 
     def test_lt(self):
         pdf, psdf = self.bool_pdf, self.bool_psdf


### PR DESCRIPTION
### What changes were proposed in this pull request?
Move the `_should_return_all_false` type-mismatch check outside the ANSI mode guard in `DataTypeOps.eq/ne` and `NumericOps.eq/ne` so it runs regardless of `spark.sql.ansi.enabled`.

### Why are the changes needed?
It is a bug, boolean vs string comparison doesn't match pandas behavior when ANSI mode is off.

### Does this PR introduce _any_ user-facing change?
Yes, fix the bug

### How was this patch tested?
CI

### Was this patch authored or co-authored using generative AI tooling?
Co-authored-by: Claude Opus 4