### PR TITLE
[SPARK-55659][CORE] Improve `EventLogFileWriter` to log `stop` operation

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala
@@ -250,6 +250,7 @@ class SingleEventLogFileWriter(
    * ".inprogress" suffix.
    */
   override def stop(): Unit = {
+    logInfo(log"Stopping event writer for ${MDC(PATH, logPath)}")
     closeWriter()
     renameFile(new Path(inProgressPath), new Path(logPath), shouldOverwrite)
   }
@@ -367,6 +368,7 @@ class RollingEventLogFilesWriter(
   }
 
   override def stop(): Unit = {
+    logInfo(log"Stopping event writer for ${MDC(PATH, logPath)}")
     closeWriter()
     val appStatusPathIncomplete = getAppStatusFilePath(logDirForAppPath, appId, appAttemptId,
       inProgress = true)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `EventLogFileWriter` to log `stop` operation.

### Why are the changes needed?

Apache Spark has been logging the start of event log processing. We had better log the end of event log processing as a pair.

**BEFORE**

```
$ bin/run-example -c spark.eventLog.enabled=true -c spark.eventLog.dir=/tmp SparkPi 2>&1 | grep RollingEventLogFilesWriter
26/02/24 08:24:27 INFO RollingEventLogFilesWriter: Logging events to file:/private/tmp/eventlog_v2_local-1771950267185/events_1_local-1771950267185.zstd
```

**AFTER**

```
$ bin/run-example -c spark.eventLog.enabled=true -c spark.eventLog.dir=/tmp SparkPi 2>&1 | grep RollingEventLogFilesWriter
26/02/24 08:24:41 INFO RollingEventLogFilesWriter: Logging events to file:/private/tmp/eventlog_v2_local-1771950279197/events_1_local-1771950279197.zstd
26/02/24 08:24:42 INFO RollingEventLogFilesWriter: Stopping event writer for file:/private/tmp/eventlog_v2_local-1771950279197
```

### Does this PR introduce _any_ user-facing change?

No behavior change because this is a log.

### How was this patch tested?

Manual test.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`