### PR TITLE
[SPARK-46168][PS] Implementation of idxmin Axis argument

### DIFF
--- a/python/pyspark/pandas/tests/computation/test_idxmax_idxmin.py
+++ b/python/pyspark/pandas/tests/computation/test_idxmax_idxmin.py
@@ -155,6 +155,118 @@ class FrameIdxMaxMinMixin:
         # Verify both raise the same error message
         self.assertEqual(str(pdf_context.exception), str(psdf_context.exception))
 
+    def test_idxmin(self):
+        # Test basic axis=0 (default)
+        pdf = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 2],
+                "b": [4.0, 2.0, 3.0, 1.0],
+                "c": [300, 200, 400, 200],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+
+        self.assert_eq(psdf.idxmin(), pdf.idxmin())
+        self.assert_eq(psdf.idxmin(axis=0), pdf.idxmin(axis=0))
+        self.assert_eq(psdf.idxmin(axis="index"), pdf.idxmin(axis="index"))
+
+        # Test axis=1
+        self.assert_eq(psdf.idxmin(axis=1), pdf.idxmin(axis=1))
+        self.assert_eq(psdf.idxmin(axis="columns"), pdf.idxmin(axis="columns"))
+
+        # Test with NAs
+        pdf = pd.DataFrame(
+            {
+                "a": [1.0, None, 3.0],
+                "b": [None, 2.0, None],
+                "c": [3.0, 4.0, None],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+
+        self.assert_eq(psdf.idxmin(), pdf.idxmin())
+        self.assert_eq(psdf.idxmin(axis=0), pdf.idxmin(axis=0))
+        self.assert_eq(psdf.idxmin(axis=1), pdf.idxmin(axis=1))
+
+        # Test with all-NA row
+        pdf = pd.DataFrame(
+            {
+                "a": [1.0, None],
+                "b": [2.0, None],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+
+        self.assert_eq(psdf.idxmin(axis=1), pdf.idxmin(axis=1))
+
+        # Test with ties (first occurrence should win)
+        pdf = pd.DataFrame(
+            {
+                "a": [3, 2, 1],
+                "b": [3, 5, 1],
+                "c": [1, 5, 1],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+
+        self.assert_eq(psdf.idxmin(axis=1), pdf.idxmin(axis=1))
+
+        # Test with single column
+        pdf = pd.DataFrame({"a": [1, 2, 3]})
+        psdf = ps.from_pandas(pdf)
+
+        self.assert_eq(psdf.idxmin(axis=1), pdf.idxmin(axis=1))
+
+        # Test with empty DataFrame
+        pdf = pd.DataFrame({})
+        psdf = ps.from_pandas(pdf)
+
+        self.assert_eq(psdf.idxmin(axis=1), pdf.idxmin(axis=1))
+
+        # Test with different data types
+        pdf = pd.DataFrame(
+            {
+                "int_col": [1, 2, 3],
+                "float_col": [1.5, 2.5, 0.5],
+                "negative": [-5, -10, -1],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+
+        self.assert_eq(psdf.idxmin(axis=1), pdf.idxmin(axis=1))
+
+        # Test with custom index
+        pdf = pd.DataFrame(
+            {
+                "a": [1, 2, 3],
+                "b": [4, 5, 6],
+                "c": [7, 8, 9],
+            },
+            index=["row1", "row2", "row3"],
+        )
+        psdf = ps.from_pandas(pdf)
+
+        self.assert_eq(psdf.idxmin(axis=1), pdf.idxmin(axis=1))
+
+    def test_idxmin_multiindex_columns(self):
+        # Test that MultiIndex columns raise NotImplementedError for axis=1
+        pdf = pd.DataFrame(
+            {
+                "a": [1, 2, 3],
+                "b": [4, 5, 6],
+                "c": [7, 8, 9],
+            }
+        )
+        pdf.columns = pd.MultiIndex.from_tuples([("x", "a"), ("y", "b"), ("z", "c")])
+        psdf = ps.from_pandas(pdf)
+
+        # axis=0 should work fine (it uses pandas internally)
+        self.assert_eq(psdf.idxmin(axis=0), pdf.idxmin(axis=0))
+
+        # axis=1 should raise NotImplementedError
+        with self.assertRaises(NotImplementedError):
+            psdf.idxmin(axis=1)
+
 
 class FrameIdxMaxMinTests(
     FrameIdxMaxMinMixin,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add axis=1 support for DataFrame.idxmin, matching the existing idxmax axis=1 implementation.

### Why are the changes needed?
Implements missing API parameter

### Does this PR introduce _any_ user-facing change?
Yes, new parameter

### How was this patch tested?
CI

### Was this patch authored or co-authored using generative AI tooling?
Co-authored-by: Claude Opus 4