### PR TITLE
[SPARK-55694][SQL] Block constraints in CTAS/RTAS at parser level

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -5238,6 +5238,11 @@ class AstBuilder extends DataTypeAstBuilder
             "Partition column types may not be specified in Create Table As Select (CTAS)",
             ctx)
 
+        case Some(_) if constraints.nonEmpty =>
+          operationNotAllowed(
+            "Constraints may not be specified in a Create Table As Select (CTAS) statement",
+            ctx)
+
         case Some(query) =>
           CreateTableAsSelect(identifier, partitioning, query, tableSpec, Map.empty, ifNotExists)
 
@@ -5315,6 +5320,11 @@ class AstBuilder extends DataTypeAstBuilder
           // non-reference partition columns are not allowed because schema can't be specified
           operationNotAllowed(
             "Partition column types may not be specified in Replace Table As Select (RTAS)",
+            ctx)
+
+        case Some(_) if constraints.nonEmpty =>
+          operationNotAllowed(
+            "Constraints may not be specified in a Replace Table As Select (RTAS) statement",
             ctx)
 
         case Some(query) =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The grammar accepts constraint specifications (PRIMARY KEY, UNIQUE, CHECK, FOREIGN KEY) in CREATE TABLE AS SELECT and REPLACE TABLE AS SELECT, but the execution layer silently drops them. Neither the ANSI SQL standard nor PostgreSQL supports this syntax - the SQL standard makes table element lists and AS subquery clauses mutually exclusive. Block this at the parser level, consistent with existing CTAS/RTAS checks for schema columns and partition column types.


### Why are the changes needed?
Explicitly throw exception for an unsupported case for clarity

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
unit test

### Was this patch authored or co-authored using generative AI tooling?
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>