### PR TITLE
[SPARK-55667][PYTHON][CONNECT] Move check_dependencies to __init__

### DIFF
--- a/python/pyspark/ml/connect/__init__.py
+++ b/python/pyspark/ml/connect/__init__.py
@@ -16,6 +16,11 @@
 #
 
 """Spark Connect Python Client - ML module"""
+
+from pyspark.sql.connect.utils import check_dependencies
+
+check_dependencies()
+
 from pyspark.ml.connect.base import (
     Estimator,
     Transformer,

--- a/python/pyspark/ml/connect/proto.py
+++ b/python/pyspark/ml/connect/proto.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
 from typing import Optional, TYPE_CHECKING, List
 
 import pyspark.sql.connect.proto as pb2

--- a/python/pyspark/ml/connect/readwrite.py
+++ b/python/pyspark/ml/connect/readwrite.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
 from typing import cast, Type, TYPE_CHECKING, Union, Dict, Any
 
 import pyspark.sql.connect.proto as pb2

--- a/python/pyspark/ml/connect/serialize.py
+++ b/python/pyspark/ml/connect/serialize.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
 from typing import Any, List, TYPE_CHECKING, Mapping, Dict
 
 import pyspark.sql.connect.proto as pb2

--- a/python/pyspark/sql/connect/__init__.py
+++ b/python/pyspark/sql/connect/__init__.py
@@ -16,3 +16,7 @@
 #
 
 """Spark Connect client"""
+
+from pyspark.sql.connect.utils import check_dependencies
+
+check_dependencies()

--- a/python/pyspark/sql/connect/avro/functions.py
+++ b/python/pyspark/sql/connect/avro/functions.py
@@ -20,9 +20,6 @@ A collections of builtin avro functions
 """
 
 from pyspark.errors import PySparkTypeError
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
 
 from typing import Dict, Optional, TYPE_CHECKING
 

--- a/python/pyspark/sql/connect/catalog.py
+++ b/python/pyspark/sql/connect/catalog.py
@@ -15,9 +15,6 @@
 # limitations under the License.
 #
 from pyspark.errors import PySparkTypeError
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
 
 from typing import Any, Callable, List, Optional, TYPE_CHECKING
 

--- a/python/pyspark/sql/connect/client/__init__.py
+++ b/python/pyspark/sql/connect/client/__init__.py
@@ -15,9 +15,5 @@
 # limitations under the License.
 #
 
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
 from pyspark.sql.connect.client.core import *  # noqa: F403
 from pyspark.sql.connect.logging import getLogLevel  # noqa: F401

--- a/python/pyspark/sql/connect/client/artifact.py
+++ b/python/pyspark/sql/connect/client/artifact.py
@@ -15,10 +15,7 @@
 # limitations under the License.
 #
 from pyspark.errors import PySparkRuntimeError, PySparkValueError
-from pyspark.sql.connect.utils import check_dependencies
 from pyspark.sql.connect.logging import logger
-
-check_dependencies(__name__)
 
 import hashlib
 import importlib

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -24,9 +24,6 @@ import atexit
 
 import pyspark
 from pyspark.sql.connect.proto.base_pb2 import FetchErrorDetailsResponse
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
 
 import concurrent.futures
 import logging

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -15,9 +15,6 @@
 # limitations under the License.
 #
 from pyspark.sql.connect.client.retries import Retrying, RetryException
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
 
 from threading import RLock
 import uuid

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
 import datetime
 import decimal
 import warnings

--- a/python/pyspark/sql/connect/conf.py
+++ b/python/pyspark/sql/connect/conf.py
@@ -15,9 +15,6 @@
 # limitations under the License.
 #
 from pyspark.errors import PySparkValueError, PySparkTypeError
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
 
 from typing import Any, Dict, Optional, Union, cast
 import warnings

--- a/python/pyspark/sql/connect/conversion.py
+++ b/python/pyspark/sql/connect/conversion.py
@@ -14,11 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
-
 from typing import TYPE_CHECKING
 
 import pyspark.sql.connect.proto as pb2

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -22,9 +22,6 @@ from pyspark.errors.exceptions.base import (
 )
 from pyspark.resource import ResourceProfile
 from pyspark.sql.connect.logging import logger
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
 
 from typing import (
     Any,

--- a/python/pyspark/sql/connect/datasource.py
+++ b/python/pyspark/sql/connect/datasource.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
 from typing import Type, TYPE_CHECKING
 
 from pyspark.sql.datasource import DataSourceRegistration as PySparkDataSourceRegistration

--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
 from typing import (
     cast,
     TYPE_CHECKING,

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
 import decimal
 import inspect
 import warnings

--- a/python/pyspark/sql/connect/functions/partitioning.py
+++ b/python/pyspark/sql/connect/functions/partitioning.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
 from typing import Union, TYPE_CHECKING
 
 from pyspark.errors import PySparkTypeError

--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -15,10 +15,6 @@
 # limitations under the License.
 #
 
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
 import warnings
 from typing import (
     Dict,

--- a/python/pyspark/sql/connect/merge.py
+++ b/python/pyspark/sql/connect/merge.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
 import sys
 from typing import Dict, Optional, TYPE_CHECKING, Callable
 

--- a/python/pyspark/sql/connect/observation.py
+++ b/python/pyspark/sql/connect/observation.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
 from typing import Any, Dict, Optional
 import uuid
 

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -18,9 +18,6 @@
 # mypy: disable-error-code="operator"
 
 from pyspark.resource import ResourceProfile
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
 
 from typing import (
     Any,

--- a/python/pyspark/sql/connect/protobuf/functions.py
+++ b/python/pyspark/sql/connect/protobuf/functions.py
@@ -19,10 +19,6 @@
 A collections of builtin protobuf functions
 """
 
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
 from typing import Dict, Optional, TYPE_CHECKING
 
 from pyspark.sql.protobuf import functions as PyProtobufFunctions

--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
 from typing import Dict
 from typing import Optional, Union, List, overload, Tuple, cast, Callable
 from typing import TYPE_CHECKING

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -15,9 +15,6 @@
 # limitations under the License.
 #
 import uuid
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
 
 import json
 import threading

--- a/python/pyspark/sql/connect/streaming/query.py
+++ b/python/pyspark/sql/connect/streaming/query.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
 import json
 import sys
 import warnings

--- a/python/pyspark/sql/connect/streaming/readwriter.py
+++ b/python/pyspark/sql/connect/streaming/readwriter.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
 import json
 import re
 import sys

--- a/python/pyspark/sql/connect/types.py
+++ b/python/pyspark/sql/connect/types.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
 import json
 
 from typing import Any, Dict, Optional, List

--- a/python/pyspark/sql/connect/udf.py
+++ b/python/pyspark/sql/connect/udf.py
@@ -17,10 +17,6 @@
 """
 User-defined function related classes and functions
 """
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
 import warnings
 import sys
 import functools

--- a/python/pyspark/sql/connect/udtf.py
+++ b/python/pyspark/sql/connect/udtf.py
@@ -17,10 +17,6 @@
 """
 User-defined table function related classes and functions
 """
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
 import warnings
 from typing import List, Type, TYPE_CHECKING, Optional, Union, Any
 

--- a/python/pyspark/sql/connect/utils.py
+++ b/python/pyspark/sql/connect/utils.py
@@ -22,27 +22,24 @@ from pyspark.errors import PySparkImportError
 
 
 def check_dependencies() -> None:
-    try:
-        mod_name = sys.modules["__main__"].__spec__.name
-    except Exception:
-        mod_name = "__main__"
-    if mod_name.startswith("pyspark.sql.connect.") or mod_name.startswith("pyspark.ml.connect."):
-        # If we invoke the module directly, we are doing doctests.
+    main_module = sys.modules["__main__"]
+    if main_module.__spec__ is None and not hasattr(main_module, "__file__"):
+        # The main module is not initialized at all at this point. We must be running doctests.
         from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 
         if not should_test_connect:
             print(
-                f"Skipping {mod_name} doctests: {connect_requirement_message}",
+                f"Skipping doctests: {connect_requirement_message}",
                 file=sys.stderr,
             )
             sys.exit(0)
-    else:
-        require_minimum_pandas_version()
-        require_minimum_pyarrow_version()
-        require_minimum_grpc_version()
-        require_minimum_grpcio_status_version()
-        require_minimum_googleapis_common_protos_version()
-        require_minimum_zstandard_version()
+
+    require_minimum_pandas_version()
+    require_minimum_pyarrow_version()
+    require_minimum_grpc_version()
+    require_minimum_grpcio_status_version()
+    require_minimum_googleapis_common_protos_version()
+    require_minimum_zstandard_version()
 
 
 def require_minimum_grpc_version() -> None:

--- a/python/pyspark/sql/connect/utils.py
+++ b/python/pyspark/sql/connect/utils.py
@@ -21,8 +21,13 @@ from pyspark.sql.pandas.utils import require_minimum_pandas_version, require_min
 from pyspark.errors import PySparkImportError
 
 
-def check_dependencies(mod_name: str) -> None:
-    if mod_name == "__main__" or mod_name == "pyspark.sql.connect.utils":
+def check_dependencies() -> None:
+    try:
+        mod_name = sys.modules["__main__"].__spec__.name
+    except Exception:
+        mod_name = "__main__"
+    if mod_name.startswith("pyspark.sql.connect.") or mod_name.startswith("pyspark.ml.connect."):
+        # If we invoke the module directly, we are doing doctests.
         from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 
         if not should_test_connect:

--- a/python/pyspark/sql/connect/window.py
+++ b/python/pyspark/sql/connect/window.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from pyspark.sql.connect.utils import check_dependencies
-
-check_dependencies(__name__)
-
 from typing import TYPE_CHECKING, Any, Union, Sequence, List, Optional, Tuple, cast, Iterable
 
 from pyspark.sql.column import Column

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -2578,9 +2578,7 @@ class SparkConnectFunctionTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
         )
 
         # Functions in Spark Connect we do not expect to be available in classic PySpark
-        cf_excluded_fn = {
-            "check_dependencies",  # internal helper function
-        }
+        cf_excluded_fn = set()
 
         self.assertEqual(
             cf_fn - sf_fn,

--- a/python/pyspark/sql/tests/test_connect_compatibility.py
+++ b/python/pyspark/sql/tests/test_connect_compatibility.py
@@ -380,7 +380,7 @@ class ConnectCompatibilityTestsMixin:
         expected_missing_connect_properties = set()
         expected_missing_classic_properties = set()
         expected_missing_connect_methods = set()
-        expected_missing_classic_methods = {"check_dependencies"}
+        expected_missing_classic_methods = set()
         self.check_compatibility(
             ClassicFunctions,
             ConnectFunctions,
@@ -418,7 +418,7 @@ class ConnectCompatibilityTestsMixin:
             "cast",
             "get_active_spark_context",
         }
-        expected_missing_classic_methods = {"lit", "check_dependencies"}
+        expected_missing_classic_methods = {"lit"}
         self.check_compatibility(
             ClassicAvro,
             ConnectAvro,
@@ -456,7 +456,7 @@ class ConnectCompatibilityTestsMixin:
             "try_remote_protobuf_functions",
             "get_active_spark_context",
         }
-        expected_missing_classic_methods = {"lit", "check_dependencies"}
+        expected_missing_classic_methods = {"lit"}
         self.check_compatibility(
             ClassicProtobuf,
             ConnectProtobuf,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

* Modified `check_dependencies` so it does not need `__name__` to check whether this is a doctest call. Now it checks whether `sys.modules['__main__']` is initialized to determine if we are running a doctest. If we are running a module under `pyspark.sql.connect` or `pyspark.ml.connect` directly, this function will be executed before the module is initialized. Otherwise the `__main__` module should have a `__spec__` or `__file__` associated to it.
* Removed all the `check_dependencies` usages in different files and moved it to `__init__` file of `pyspark.sql.connect` ad `pyspark.ml.connect`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

There are some downsides to have `check_dependencies` scattered in different files
* People don't really know what's it about. Some files have it and some don't.
* It's against PEP 8 where all the imports should happen before any executable code. We may have some exceptions but we should not do it in too many files.
* When we add a new file in the future, people might forget to do this (or they don't know if they should do it)

With this change, people can still get a decent error message when they don't have the dependencies while they are using connect. doctests are skipped properly. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Did some manual test but still need to check CI.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Only the removing part by Cursor (claude-4.6-opus-high)