### PR TITLE
[SPARK-55672][PS][TESTS] Fix error message check due to StringDtype(na_value=nan)

### DIFF
--- a/python/pyspark/pandas/tests/computation/test_compute.py
+++ b/python/pyspark/pandas/tests/computation/test_compute.py
@@ -384,9 +384,13 @@ class FrameComputeMixin:
             pdf.quantile([0.25, 0.5, 0.75], numeric_only=True),
         )
 
-        with self.assertRaisesRegex(TypeError, "Could not convert object \\(string\\) to numeric"):
+        with self.assertRaisesRegex(
+            TypeError, r"Could not convert (object|str) \(string\) to numeric"
+        ):
             psdf.quantile(0.5, numeric_only=False)
-        with self.assertRaisesRegex(TypeError, "Could not convert object \\(string\\) to numeric"):
+        with self.assertRaisesRegex(
+            TypeError, r"Could not convert (object|str) \(string\) to numeric"
+        ):
             psdf.quantile([0.25, 0.5, 0.75], numeric_only=False)
 
     def test_product(self):

--- a/python/pyspark/pandas/tests/computation/test_stats.py
+++ b/python/pyspark/pandas/tests/computation/test_stats.py
@@ -149,11 +149,11 @@ class StatsTestsMixin:
         self.assert_eq(psdf[["E"]].abs(), pdf[["E"]].abs())
 
         with self.assertRaisesRegex(
-            TypeError, "bad operand type for abs\\(\\): object \\(string\\)"
+            TypeError, r"bad operand type for abs\(\): (object|str) \(string\)"
         ):
             psdf.abs()
         with self.assertRaisesRegex(
-            TypeError, "bad operand type for abs\\(\\): object \\(string\\)"
+            TypeError, r"bad operand type for abs\(\): (object|str) \(string\)"
         ):
             psdf.D.abs()
 
@@ -299,10 +299,14 @@ class StatsTestsMixin:
             psdf[["i", "b"]].sum(numeric_only=False), pdf[["i", "b"]].sum(numeric_only=False)
         )
 
-        with self.assertRaisesRegex(TypeError, "Could not convert object \\(string\\) to numeric"):
+        with self.assertRaisesRegex(
+            TypeError, r"Could not convert (object|str) \(string\) to numeric"
+        ):
             psdf.sum(numeric_only=False)
 
-        with self.assertRaisesRegex(TypeError, "Could not convert object \\(string\\) to numeric"):
+        with self.assertRaisesRegex(
+            TypeError, r"Could not convert (object|str) \(string\) to numeric"
+        ):
             psdf.s.sum()
 
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_cov.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_cov.py
@@ -50,9 +50,7 @@ class DiffFramesCovMixin:
         psser1 = ps.from_pandas(pser1)
         with self.assertRaisesRegex(TypeError, "unsupported type: <class 'list'>"):
             psser1.cov([0.12528585, 0.26962463, 0.51111198])
-        with self.assertRaisesRegex(
-            TypeError, "unsupported type: <class 'pandas.core.series.Series'>"
-        ):
+        with self.assertRaisesRegex(TypeError, f"unsupported type: {pd.Series}"):
             psser1.cov(pser2)
 
     def _test_cov(self, pser1, pser2):

--- a/python/pyspark/pandas/tests/series/test_cumulative.py
+++ b/python/pyspark/pandas/tests/series/test_cumulative.py
@@ -68,7 +68,9 @@ class SeriesCumulativeMixin:
         self.assert_eq(pser.cumsum().astype(int), psser.cumsum())
         self.assert_eq(pser.cumsum(skipna=False).astype(int), psser.cumsum(skipna=False))
 
-        with self.assertRaisesRegex(TypeError, r"Could not convert object \(string\) to numeric"):
+        with self.assertRaisesRegex(
+            TypeError, r"Could not convert (object|str) \(string\) to numeric"
+        ):
             ps.Series(["a", "b", "c", "d"]).cumsum()
 
     def test_cumprod(self):
@@ -109,7 +111,9 @@ class SeriesCumulativeMixin:
         self.assert_eq(pser.cumprod(), psser.cumprod())
         self.assert_eq(pser.cumprod(skipna=False).astype(int), psser.cumprod(skipna=False))
 
-        with self.assertRaisesRegex(TypeError, r"Could not convert object \(string\) to numeric"):
+        with self.assertRaisesRegex(
+            TypeError, r"Could not convert (object|str) \(string\) to numeric"
+        ):
             ps.Series(["a", "b", "c", "d"]).cumprod()
 
 

--- a/python/pyspark/pandas/tests/series/test_stat.py
+++ b/python/pyspark/pandas/tests/series/test_stat.py
@@ -382,9 +382,13 @@ class SeriesStatMixin:
         ):
             ps.Series([24.0, 21.0, 25.0, 33.0, 26.0]).quantile(q=1.1)
 
-        with self.assertRaisesRegex(TypeError, "Could not convert object \\(string\\) to numeric"):
+        with self.assertRaisesRegex(
+            TypeError, r"Could not convert (object|str) \(string\) to numeric"
+        ):
             ps.Series(["a", "b", "c"]).quantile()
-        with self.assertRaisesRegex(TypeError, "Could not convert object \\(string\\) to numeric"):
+        with self.assertRaisesRegex(
+            TypeError, r"Could not convert (object|str) \(string\) to numeric"
+        ):
             ps.Series(["a", "b", "c"]).quantile([0.25, 0.5, 0.75])
 
     def test_pct_change(self):
@@ -544,7 +548,9 @@ class SeriesStatMixin:
             ps.Series([]).prod(numeric_only=True)
         with self.assertRaisesRegex(TypeError, "Could not convert object \\(void\\) to numeric"):
             ps.Series([]).prod(min_count=1)
-        with self.assertRaisesRegex(TypeError, "Could not convert object \\(string\\) to numeric"):
+        with self.assertRaisesRegex(
+            TypeError, r"Could not convert (object|str) \(string\) to numeric"
+        ):
             ps.Series(["a", "b", "c"]).prod()
         with self.assertRaisesRegex(
             TypeError, "Could not convert datetime64\\[ns\\] \\(timestamp.*\\) to numeric"
@@ -680,19 +686,19 @@ class SeriesStatMixin:
         )
 
     def test_series_stat_fail(self):
-        with self.assertRaisesRegex(TypeError, "Could not convert object"):
+        with self.assertRaisesRegex(TypeError, "Could not convert (object|str)"):
             ps.Series(["a", "b", "c"]).mean()
-        with self.assertRaisesRegex(TypeError, "Could not convert object"):
+        with self.assertRaisesRegex(TypeError, "Could not convert (object|str)"):
             ps.Series(["a", "b", "c"]).skew()
-        with self.assertRaisesRegex(TypeError, "Could not convert object"):
+        with self.assertRaisesRegex(TypeError, "Could not convert (object|str)"):
             ps.Series(["a", "b", "c"]).kurtosis()
-        with self.assertRaisesRegex(TypeError, "Could not convert object"):
+        with self.assertRaisesRegex(TypeError, "Could not convert (object|str)"):
             ps.Series(["a", "b", "c"]).std()
-        with self.assertRaisesRegex(TypeError, "Could not convert object"):
+        with self.assertRaisesRegex(TypeError, "Could not convert (object|str)"):
             ps.Series(["a", "b", "c"]).var()
-        with self.assertRaisesRegex(TypeError, "Could not convert object"):
+        with self.assertRaisesRegex(TypeError, "Could not convert (object|str)"):
             ps.Series(["a", "b", "c"]).median()
-        with self.assertRaisesRegex(TypeError, "Could not convert object"):
+        with self.assertRaisesRegex(TypeError, "Could not convert (object|str)"):
             ps.Series(["a", "b", "c"]).sem()
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes error message check due to `StringDtype(na_value=nan)`.

### Why are the changes needed?

The dtype for the default string Series is `StringDtype(na_value=nan)` in pandas 3, which causes to change the error messages.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Updated the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
