### PR TITLE
[SPARK-55673][SQL] Add more tests for nested type encoder

### DIFF
--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/JavaTypeInferenceBeans.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/JavaTypeInferenceBeans.java
@@ -80,7 +80,7 @@ public class JavaTypeInferenceBeans {
   }
 
   // SPARK-46679: Test classes for nested parameterized types with multi-level inheritance
-  static class Foo<T> {
+  public static class Foo<T> {
     private T t;
 
     public T getT() {
@@ -92,7 +92,7 @@ public class JavaTypeInferenceBeans {
     }
   }
 
-  static class FooWrapper<U> {
+  public static class FooWrapper<U> {
     private Foo<U> foo;
 
     public Foo<U> getFoo() {
@@ -104,14 +104,14 @@ public class JavaTypeInferenceBeans {
     }
   }
 
-  static class StringFooWrapper extends FooWrapper<String> {
+  public static class StringFooWrapper extends FooWrapper<String> {
   }
 
   // SPARK-46679: Additional test classes for same type variable names at different levels
-  static class StringBarWrapper extends BarWrapper<String> {
+  public static class StringBarWrapper extends BarWrapper<String> {
   }
 
-  static class BarWrapper<T> {
+  public static class BarWrapper<T> {
     private Bar<T> bar;
 
     public Bar<T> getBar() {
@@ -123,7 +123,7 @@ public class JavaTypeInferenceBeans {
     }
   }
 
-  static class Bar<T> {
+  public static class Bar<T> {
     private T t;
 
     public T getT() {

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -47,6 +47,7 @@ import org.apache.spark.sql.catalyst.encoders.OuterScopes;
 import org.apache.spark.sql.catalyst.expressions.GenericRow;
 import org.apache.spark.sql.test.TestSparkSession;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.catalyst.JavaTypeInferenceBeans;
 import org.apache.spark.util.LongAccumulator;
 
 import static org.apache.spark.sql.functions.*;
@@ -2108,6 +2109,40 @@ public class JavaDatasetSuite implements Serializable {
         .filter(col("a").geq(1));
     final List<Row> expected = Arrays.asList(create(1, "s1"), create(2, "s2"));
     Assertions.assertEquals(expected, df.collectAsList());
+  }
+
+  @Test
+  public void testNestedEncoder() {
+    JavaTypeInferenceBeans.Foo<String> foo = new JavaTypeInferenceBeans.Foo<>();
+    foo.setT("test value");
+
+    JavaTypeInferenceBeans.StringFooWrapper wrapper = new JavaTypeInferenceBeans.StringFooWrapper();
+    wrapper.setFoo(foo);
+
+    List<JavaTypeInferenceBeans.StringFooWrapper> data = Arrays.asList(wrapper);
+    Dataset<JavaTypeInferenceBeans.StringFooWrapper> ds =
+      spark.createDataset(data, Encoders.bean(JavaTypeInferenceBeans.StringFooWrapper.class));
+
+    List<JavaTypeInferenceBeans.StringFooWrapper> result = ds.collectAsList();
+    Assertions.assertEquals(1, result.size());
+    Assertions.assertEquals("test value", result.get(0).getFoo().getT());
+  }
+
+  @Test
+  public void testNestedEncoder2() {
+    JavaTypeInferenceBeans.Bar<String> bar = new JavaTypeInferenceBeans.Bar<>();
+    bar.setT("test value");
+
+    JavaTypeInferenceBeans.StringBarWrapper wrapper = new JavaTypeInferenceBeans.StringBarWrapper();
+    wrapper.setBar(bar);
+
+    List<JavaTypeInferenceBeans.StringBarWrapper> data = Arrays.asList(wrapper);
+    Dataset<JavaTypeInferenceBeans.StringBarWrapper> ds =
+      spark.createDataset(data, Encoders.bean(JavaTypeInferenceBeans.StringBarWrapper.class));
+
+    List<JavaTypeInferenceBeans.StringBarWrapper> result = ds.collectAsList();
+    Assertions.assertEquals(1, result.size());
+    Assertions.assertEquals("test value", result.get(0).getBar().getT());
   }
 
   public static class BeanWithSet implements Serializable {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Small follow up for https://github.com/apache/spark/pull/52444 to add some more tests to reproduce the issue

### Why are the changes needed?
There were tests added in JavaDataSetSuite but they didnt reproduce the issue, I had missed adding these tests

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Ran tests


### Was this patch authored or co-authored using generative AI tooling?
No