### PR TITLE
[SPARK-55670][BUILD] Add `-Dio.netty.noUnsafe=false` to enable Java 25 support

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/JavaModuleOptions.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/JavaModuleOptions.java
@@ -47,6 +47,7 @@ public class JavaModuleOptions {
       "-Dio.netty.tryReflectionSetAccessible=true",
       "-Dio.netty.allocator.type=pooled",
       "-Dio.netty.handler.ssl.defaultEndpointVerificationAlgorithm=NONE",
+      "-Dio.netty.noUnsafe=false",
       "--enable-native-access=ALL-UNNAMED"};
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,7 @@
       -Dio.netty.tryReflectionSetAccessible=true
       -Dio.netty.allocator.type=pooled
       -Dio.netty.handler.ssl.defaultEndpointVerificationAlgorithm=NONE
+      -Dio.netty.noUnsafe=false
       --enable-native-access=ALL-UNNAMED
     </extraJavaTestArgs>
     <mariadb.java.client.version>3.5.7</mariadb.java.client.version>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1876,6 +1876,7 @@ object TestSettings {
         "-Dio.netty.tryReflectionSetAccessible=true",
         "-Dio.netty.allocator.type=pooled",
         "-Dio.netty.handler.ssl.defaultEndpointVerificationAlgorithm=NONE",
+        "-Dio.netty.noUnsafe=false",
         "--enable-native-access=ALL-UNNAMED").mkString(" ")
       s"-Xmx$heapSize -Xss4m -XX:MaxMetaspaceSize=$metaspaceSize -XX:ReservedCodeCacheSize=128m -Dfile.encoding=UTF-8 $extraTestJavaArgs"
         .split(" ").toSeq

--- a/sql/connect/bin/spark-connect-scala-client
+++ b/sql/connect/bin/spark-connect-scala-client
@@ -73,6 +73,7 @@ JVM_ARGS="-XX:+IgnoreUnrecognizedVMOptions \
   -Dio.netty.tryReflectionSetAccessible=true \
   -Dio.netty.allocator.type=pooled \
   -Dio.netty.handler.ssl.defaultEndpointVerificationAlgorithm=NONE \
+  -Dio.netty.noUnsafe=false \
   --enable-native-access=ALL-UNNAMED \
   $SCJVM_ARGS"
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Arrow requires `-Dio.netty.noUnsafe=false` for Java 24+, see https://github.com/apache/arrow-java/issues/728

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To enable Java 25 support, especially for PySpark, which heavily uses Arrow for JVM/Python data exchange.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Manually verified with JDK 25 (we don't have JDK 25 CI yet), take one Arrow related UT as example.

```
$ export JAVA_HOME=/path/of/openjdk-25
$ build/sbt "sql/testOnly *ArrowConvertersSuite"
```

Before
```
[info] Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.ExceptionInInitializerError [in thread "Executor task launch worker for task 0.0 in stage 0.0 (TID 0)"
[info] 	at org.apache.arrow.memory.netty.DefaultAllocationManagerFactory.<clinit>(DefaultAllocationManagerFactory.java:26)
[info] 	at java.base/java.lang.Class.forName0(Native Method)
[info] 	at java.base/java.lang.Class.forName(Class.java:467)
[info] 	at java.base/java.lang.Class.forName(Class.java:458)
[info] 	at org.apache.arrow.memory.DefaultAllocationManagerOption.getFactory(DefaultAllocationManagerOption.java:105)
[info] 	at org.apache.arrow.memory.DefaultAllocationManagerOption.getDefaultAllocationManagerFactory(DefaultAllocationManagerOption.java:92)
[info] 	at org.apache.arrow.memory.BaseAllocator$Config.getAllocationManagerFactory(BaseAllocator.java:826)
[info] 	at org.apache.arrow.memory.ImmutableConfig.access$001(ImmutableConfig.java:20)
[info] 	at org.apache.arrow.memory.ImmutableConfig$InitShim.getAllocationManagerFactory(ImmutableConfig.java:80)
[info] 	at org.apache.arrow.memory.ImmutableConfig.<init>(ImmutableConfig.java:43)
[info] 	at org.apache.arrow.memory.ImmutableConfig$Builder.build(ImmutableConfig.java:487)
[info] 	at org.apache.arrow.memory.BaseAllocator.<clinit>(BaseAllocator.java:72)
[info] 	at org.apache.spark.sql.util.ArrowUtils$.<clinit>(ArrowUtils.scala:36)
...
[info] Run completed in 6 seconds, 326 milliseconds.
[info] Total number of tests run: 26
[info] Suites: completed 0, aborted 1
[info] Tests: succeeded 0, failed 26, canceled 0, ignored 0, pending 0
[info] *** 1 SUITE ABORTED ***
[info] *** 26 TESTS FAILED ***
[error] Error during tests:
[error] 	org.apache.spark.sql.execution.arrow.ArrowConvertersSuite
[error] (Test / testOnly) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 203 s (0:03:23.0), completed Feb 25, 2026, 10:39:52 AM
```

After
```
[info] Run completed in 7 seconds, 17 milliseconds.
[info] Total number of tests run: 43
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 43, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 29 s, completed Feb 25, 2026, 10:41:46 AM
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.