### PR TITLE
[SPARK-55677][BUILD] Upgrade `commons-cli` to 1.11.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -35,7 +35,7 @@ bundle/2.35.4//bundle-2.35.4.jar
 cats-kernel_2.13/2.8.0//cats-kernel_2.13-2.8.0.jar
 chill-java/0.10.0//chill-java-0.10.0.jar
 chill_2.13/0.10.0//chill_2.13-0.10.0.jar
-commons-cli/1.10.0//commons-cli-1.10.0.jar
+commons-cli/1.11.0//commons-cli-1.11.0.jar
 commons-codec/1.21.0//commons-codec-1.21.0.jar
 commons-collections4/4.5.0//commons-collections4-4.5.0.jar
 commons-compiler/3.1.9//commons-compiler-3.1.9.jar

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
     <htmlunit3-driver.version>4.32.0</htmlunit3-driver.version>
     <maven-antrun.version>3.1.0</maven-antrun.version>
     <commons-crypto.version>1.1.0</commons-crypto.version>
-    <commons-cli.version>1.10.0</commons-cli.version>
+    <commons-cli.version>1.11.0</commons-cli.version>
     <bouncycastle.version>1.83</bouncycastle.version>
     <tink.version>1.19.0</tink.version>
     <datasketches.version>6.2.0</datasketches.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `commons-cli` to 1.11.0.

### Why are the changes needed?

To bring the latest bug fixes.
- https://commons.apache.org/proper/commons-cli/changes.html#a1.11.0 ( 2025-11-08)
  - https://github.com/apache/commons-cli/pull/396
  - https://github.com/apache/commons-cli/pull/411

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`