### PR TITLE
[SPARK-55681][SQL] Fix singleton DataType equality after deserialization

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/types/BinaryType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/BinaryType.scala
@@ -31,6 +31,10 @@ class BinaryType private () extends AtomicType {
    */
   override def defaultSize: Int = 100
 
+  override def equals(obj: Any): Boolean = obj.isInstanceOf[BinaryType]
+
+  override def hashCode(): Int = classOf[BinaryType].getSimpleName.hashCode
+
   private[spark] override def asNullable: BinaryType = this
 }
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/BooleanType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/BooleanType.scala
@@ -32,6 +32,10 @@ class BooleanType private () extends AtomicType {
    */
   override def defaultSize: Int = 1
 
+  override def equals(obj: Any): Boolean = obj.isInstanceOf[BooleanType]
+
+  override def hashCode(): Int = classOf[BooleanType].getSimpleName.hashCode
+
   private[spark] override def asNullable: BooleanType = this
 }
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/ByteType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/ByteType.scala
@@ -34,6 +34,10 @@ class ByteType private () extends IntegralType {
 
   override def simpleString: String = "tinyint"
 
+  override def equals(obj: Any): Boolean = obj.isInstanceOf[ByteType]
+
+  override def hashCode(): Int = classOf[ByteType].getSimpleName.hashCode
+
   private[spark] override def asNullable: ByteType = this
 }
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/CalendarIntervalType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/CalendarIntervalType.scala
@@ -39,6 +39,10 @@ class CalendarIntervalType private () extends DataType {
 
   override def typeName: String = "interval"
 
+  override def equals(obj: Any): Boolean = obj.isInstanceOf[CalendarIntervalType]
+
+  override def hashCode(): Int = classOf[CalendarIntervalType].getSimpleName.hashCode
+
   private[spark] override def asNullable: CalendarIntervalType = this
 }
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/DateType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/DateType.scala
@@ -34,6 +34,10 @@ class DateType private () extends DatetimeType {
    */
   override def defaultSize: Int = 4
 
+  override def equals(obj: Any): Boolean = obj.isInstanceOf[DateType]
+
+  override def hashCode(): Int = classOf[DateType].getSimpleName.hashCode
+
   private[spark] override def asNullable: DateType = this
 }
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/DoubleType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/DoubleType.scala
@@ -34,6 +34,10 @@ class DoubleType private () extends FractionalType {
    */
   override def defaultSize: Int = 8
 
+  override def equals(obj: Any): Boolean = obj.isInstanceOf[DoubleType]
+
+  override def hashCode(): Int = classOf[DoubleType].getSimpleName.hashCode
+
   private[spark] override def asNullable: DoubleType = this
 }
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/FloatType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/FloatType.scala
@@ -34,6 +34,10 @@ class FloatType private () extends FractionalType {
    */
   override def defaultSize: Int = 4
 
+  override def equals(obj: Any): Boolean = obj.isInstanceOf[FloatType]
+
+  override def hashCode(): Int = classOf[FloatType].getSimpleName.hashCode
+
   private[spark] override def asNullable: FloatType = this
 }
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/IntegerType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/IntegerType.scala
@@ -34,6 +34,10 @@ class IntegerType private () extends IntegralType {
 
   override def simpleString: String = "int"
 
+  override def equals(obj: Any): Boolean = obj.isInstanceOf[IntegerType]
+
+  override def hashCode(): Int = classOf[IntegerType].getSimpleName.hashCode
+
   private[spark] override def asNullable: IntegerType = this
 }
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/LongType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/LongType.scala
@@ -34,6 +34,10 @@ class LongType private () extends IntegralType {
 
   override def simpleString: String = "bigint"
 
+  override def equals(obj: Any): Boolean = obj.isInstanceOf[LongType]
+
+  override def hashCode(): Int = classOf[LongType].getSimpleName.hashCode
+
   private[spark] override def asNullable: LongType = this
 }
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/NullType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/NullType.scala
@@ -31,6 +31,10 @@ class NullType private () extends DataType {
   // Defined with a private constructor so the companion object is the only possible instantiation.
   override def defaultSize: Int = 1
 
+  override def equals(obj: Any): Boolean = obj.isInstanceOf[NullType]
+
+  override def hashCode(): Int = classOf[NullType].getSimpleName.hashCode
+
   private[spark] override def asNullable: NullType = this
 
   override def typeName: String = "void"

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/ShortType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/ShortType.scala
@@ -34,6 +34,10 @@ class ShortType private () extends IntegralType {
 
   override def simpleString: String = "smallint"
 
+  override def equals(obj: Any): Boolean = obj.isInstanceOf[ShortType]
+
+  override def hashCode(): Int = classOf[ShortType].getSimpleName.hashCode
+
   private[spark] override def asNullable: ShortType = this
 }
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/TimestampNTZType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/TimestampNTZType.scala
@@ -38,6 +38,10 @@ class TimestampNTZType private () extends DatetimeType {
 
   override def typeName: String = "timestamp_ntz"
 
+  override def equals(obj: Any): Boolean = obj.isInstanceOf[TimestampNTZType]
+
+  override def hashCode(): Int = classOf[TimestampNTZType].getSimpleName.hashCode
+
   private[spark] override def asNullable: TimestampNTZType = this
 }
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/TimestampType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/TimestampType.scala
@@ -35,6 +35,10 @@ class TimestampType private () extends DatetimeType {
    */
   override def defaultSize: Int = 8
 
+  override def equals(obj: Any): Boolean = obj.isInstanceOf[TimestampType]
+
+  override def hashCode(): Int = classOf[TimestampType].getSimpleName.hashCode
+
   private[spark] override def asNullable: TimestampType = this
 }
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/VariantType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/VariantType.scala
@@ -32,6 +32,10 @@ class VariantType private () extends AtomicType {
   // picked and we currently don't have any data to support it. This may need revisiting later.
   override def defaultSize: Int = 2048
 
+  override def equals(obj: Any): Boolean = obj.isInstanceOf[VariantType]
+
+  override def hashCode(): Int = classOf[VariantType].getSimpleName.hashCode
+
   /** This is a no-op because values with VARIANT type are always nullable. */
   private[spark] override def asNullable: VariantType = this
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


Override `equals()` and `hashCode()` on 14 singleton `DataType` classes so that non-singleton instances compare equal to the case object singletons:
```
BinaryType, BooleanType, ByteType, ShortType, IntegerType, LongType, FloatType, DoubleType, DateType, TimestampType, TimestampNTZType, NullType, CalendarIntervalType, VariantType
```

For each type:
```
override def equals(obj: Any): Boolean = obj.isInstanceOf[XType]
override def hashCode(): Int = classOf[XType].getSimpleName.hashCode
```
`getSimpleName` is used because Scala's auto-generated hashCode for 0-arity case objects returns `productPrefix.hashCode` (the simple class name). This preserves the exact same hash values, avoiding any change in hash-dependent code paths.

Other DataTypes did not need this change:
- VarcharType, CharType, TimeType, GeometryType, GeographyType — already matched by type (case _: XType
=>) across the codebase
- StringType — has custom equals() comparing collationId
- DecimalType, ArrayType, MapType, StructType — case classes with auto-generated equals()


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Scala case object pattern matching (e.g., `case BinaryType =>`) relies on `equals()`, which for case objects defaults to reference equality. If a non-singleton instance of a DataType class is created at runtime — through any serialization framework that bypasses `readResolve()` — every case `BinaryType` => match in the codebase silently falls through, leading to errors like ([code pointer](https://github.com/apache/spark/blob/3e4df1c1c1e1d9f594a6afcf29b3bae05cc8a348/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala#L241)):
```
IllegalStateException: The data type 'binary' is not supported in generating a writer function...
```

Although the constructors are private, this is a compile-time guard only — serialization frameworks
bypass constructors at runtime, so non-singleton instances can be created.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Before this change, if a non-singleton DataType instance was created through deserialization, pattern matches like `case BinaryType =>` would silently fail, leading to non-deterministic runtime errors. After this change, non-singleton instances are correctly recognized as equal to the singleton, and pattern matching works as expected.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
1. Unit test in DataTypeSuite (singleton DataType equality after deserialization): creates non-singleton instances via reflection for all 14 types, verifies bidirectional equality with singletons, matching hashCode, and correct PhysicalDataType resolution (no fallthrough to UninitializedPhysicalType).
2. Also verified that ExpressionSetSuite passes unchanged (its magic hashCode values are calibrated against IntegerType.hashCode, confirming hash preservation).


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Code (Claude Opus 4.6)