### PR TITLE
[SPARK-55682][CORE][SQL] ServiceLoader returned iterator may throw `NoClassDefFoundError` on `hasNext()`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/SparkSession.scala
@@ -1281,15 +1281,18 @@ object SparkSession extends SparkSessionCompanion with Logging {
       Utils.getContextOrSparkClassLoader)
     val loadedExts = loader.iterator()
 
-    while (true) {
+    var keepLoading = true
+    while (keepLoading) {
       try {
-        if (!loadedExts.hasNext) {
-          return
+        if (loadedExts.hasNext) {
+          val ext = loadedExts.next()
+          ext(extensions)
+        } else {
+          keepLoading = false
         }
-        val ext = loadedExts.next()
-        ext(extensions)
       } catch {
-        case e: Throwable => logWarning("Failed to load session extension", e)
+        case e: Throwable =>
+          logWarning("Failed to load session extension", e)
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/SparkSession.scala
@@ -1281,8 +1281,11 @@ object SparkSession extends SparkSessionCompanion with Logging {
       Utils.getContextOrSparkClassLoader)
     val loadedExts = loader.iterator()
 
-    while (loadedExts.hasNext) {
+    while (true) {
       try {
+        if (!loadedExts.hasNext) {
+          return
+        }
         val ext = loadedExts.next()
         ext(extensions)
       } catch {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -734,6 +734,14 @@ object DataSource extends Logging {
         } else {
           throw e
         }
+      case e: NoClassDefFoundError =>
+        // NoClassDefFoundError's class name uses "/" rather than "." for packages
+        val className = e.getMessage.replaceAll("/", ".")
+        if (spark2RemovedClasses.contains(className)) {
+          throw QueryExecutionErrors.incompatibleDataSourceRegisterError(e)
+        } else {
+          throw e
+        }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProvider.scala
@@ -22,8 +22,6 @@ import java.util.ServiceLoader
 import javax.security.auth.login.Configuration
 
 import scala.collection.mutable
-import scala.util.control.Breaks.{break, breakable}
-import scala.util.control.ControlThrowable
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.security.SecurityConfigurationLock
@@ -41,22 +39,20 @@ protected abstract class ConnectionProviderBase extends Logging {
     val providers = mutable.ArrayBuffer[JdbcConnectionProvider]()
 
     val iterator = loader.iterator
-    breakable {
-      while (true) {
-        try {
-          if (!iterator.hasNext) {
-            break()
-          }
-          val provider = iterator.next
+    var keepLoading = true
+    while (keepLoading) {
+      try {
+        if (iterator.hasNext) {
+          val provider = iterator.next()
           logDebug(s"Loaded built-in provider: $provider")
           providers += provider
-        } catch {
-          case ct: ControlThrowable =>
-            throw ct
-          case t: Throwable =>
-            logError("Failed to load built-in provider.")
-            logInfo("Loading of the provider failed with the exception:", t)
+        } else {
+          keepLoading = false
         }
+      } catch {
+        case t: Throwable =>
+          logError("Failed to load built-in provider.")
+          logInfo("Loading of the provider failed with the exception:", t)
       }
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

JDK 24 introduces a behavior change on `ServiceLoader`'s returned iterator, `iterator.hasNext()` might throw
`NoClassDefFoundError`, which previously only happened on `iterator.next()`. See more details at OpenJDK
bug report [JDK-8350481](https://bugs.openjdk.org/browse/JDK-8350481)

Another issue is even the [Javadoc](https://docs.oracle.com/en/java/javase/25/docs/api//java.base/java/util/ServiceLoader.html#iterator()) of `ServiceLoader` say

> Its hasNext and next methods can therefore throw a ServiceConfigurationError for any of the reasons specified
> in the Errors section above. To write robust code it is only necessary to catch ServiceConfigurationError when
> using the iterator. If an error is thrown then subsequent invocations of the iterator will make a best effort
> to locate and instantiate the next available provider, but in general such recovery cannot be guaranteed.

but it actually might throw `NoClassDefFoundError`. See more details at OpenJDK bug report [JDK-8196182](https://bugs.openjdk.org/browse/JDK-8196182)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Enable Java 25 support.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Changes in `HadoopDelegationTokenManager` are covered by UT, other 2 places are not, need to review carefully.

```
$ export JAVA_HOME=/path/of/openjdk-25
$ build/sbt -Phive "hive/testOnly *HiveHadoopDelegationTokenManagerSuite"
```

Before
```
[info]   Cause: java.lang.ClassNotFoundException: org.apache.hadoop.hive.conf.HiveConf
[info]   at org.apache.spark.sql.hive.security.HiveHadoopDelegationTokenManagerSuite$$anon$1.loadClass(HiveHadoopDelegationTokenManagerSuite.scala:51)
[info]   at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490)
[info]   at java.base/java.lang.Class.getDeclaredConstructors0(Native Method)
[info]   at java.base/java.lang.Class.privateGetDeclaredConstructors(Class.java:2985)
[info]   at java.base/java.lang.Class.getConstructor0(Class.java:3180)
[info]   at java.base/java.lang.Class.getConstructor(Class.java:2199)
[info]   at java.base/java.util.ServiceLoader.getConstructor(ServiceLoader.java:623)
[info]   at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:1111)
[info]   at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:1142)
[info]   at java.base/java.util.ServiceLoader$1.hasNext(ServiceLoader.java:1164)
[info]   at java.base/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1246)
[info]   at org.apache.spark.deploy.security.HadoopDelegationTokenManager.loadProviders(HadoopDelegationTokenManager.scala:273)
[info]   at org.apache.spark.deploy.security.HadoopDelegationTokenManager.<init>(HadoopDelegationTokenManager.scala:79)
...
[info] Run completed in 1 second, 186 milliseconds.
[info] Total number of tests run: 3
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 2, failed 1, canceled 0, ignored 0, pending 0
[info] *** 1 TEST FAILED ***
[error] Failed tests:
[error] 	org.apache.spark.sql.hive.security.HiveHadoopDelegationTokenManagerSuite
[error] (hive / Test / testOnly) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 192 s (0:03:12.0), completed Feb 25, 2026, 4:40:21 PM
```

After
```
[info] HiveHadoopDelegationTokenManagerSuite:
[info] - default configuration (44 milliseconds)
16:41:38.695 WARN org.apache.spark.deploy.security.HadoopDelegationTokenManager: spark.yarn.security.credentials.hive.enabled is deprecated. Please use spark.security.credentials.hive.enabled instead.
[info] - using deprecated configurations (6 milliseconds)
[info] - SPARK-23209: obtain tokens when Hive classes are not available (284 milliseconds)
[info] Run completed in 1 second, 200 milliseconds.
[info] Total number of tests run: 3
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 3, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 33 s, completed Feb 25, 2026, 4:41:43 PM
```

A similar issue was fixed in Hadoop too, see HADOOP-19821. I created [a simple project](https://github.com/pan3793/HADOOP-19821) to help reviewers better understand this issue and solution.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.