### PR TITLE
[SPARK-55685][BUILD] Upgrade ORC to 2.3.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -243,10 +243,10 @@ opencsv/2.3//opencsv-2.3.jar
 opentracing-api/0.33.0//opentracing-api-0.33.0.jar
 opentracing-noop/0.33.0//opentracing-noop-0.33.0.jar
 opentracing-util/0.33.0//opentracing-util-0.33.0.jar
-orc-core/2.2.2/shaded-protobuf/orc-core-2.2.2-shaded-protobuf.jar
+orc-core/2.3.0/shaded-protobuf/orc-core-2.3.0-shaded-protobuf.jar
 orc-format/1.1.1/shaded-protobuf/orc-format-1.1.1-shaded-protobuf.jar
-orc-mapreduce/2.2.2/shaded-protobuf/orc-mapreduce-2.2.2-shaded-protobuf.jar
-orc-shims/2.2.2//orc-shims-2.2.2.jar
+orc-mapreduce/2.3.0/shaded-protobuf/orc-mapreduce-2.3.0-shaded-protobuf.jar
+orc-shims/2.3.0//orc-shims-2.3.0.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8.3//paranamer-2.8.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     <!-- After 10.17.1.0, the minimum required version is JDK19 -->
     <derby.version>10.16.1.1</derby.version>
     <parquet.version>1.17.0</parquet.version>
-    <orc.version>2.2.2</orc.version>
+    <orc.version>2.3.0</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
     <jetty.version>12.1.5</jetty.version>
     <jakartaservlet.version>6.0.0</jakartaservlet.version>
@@ -380,6 +380,10 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
+    </repository>
+    <repository>
+      <id>staging</id>
+      <url>https://repository.apache.org/content/repositories/orgapacheorc-1110/</url>
     </repository>
   </repositories>
   <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -381,10 +381,6 @@
         <enabled>false</enabled>
       </snapshots>
     </repository>
-    <repository>
-      <id>staging</id>
-      <url>https://repository.apache.org/content/repositories/orgapacheorc-1110/</url>
-    </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -307,6 +307,7 @@ object SparkBuild extends PomBuild {
       "gcs-maven-central-mirror" at "https://maven-central.storage-download.googleapis.com/maven2/",
       DefaultMavenRepository,
       Resolver.mavenLocal,
+      "orc" at "https://repository.apache.org/content/repositories/orgapacheorc-1110/",
       Resolver.file("ivyLocal", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns)
     ),
     externalResolvers := resolvers.value,

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -307,7 +307,6 @@ object SparkBuild extends PomBuild {
       "gcs-maven-central-mirror" at "https://maven-central.storage-download.googleapis.com/maven2/",
       DefaultMavenRepository,
       Resolver.mavenLocal,
-      "orc" at "https://repository.apache.org/content/repositories/orgapacheorc-1110/",
       Resolver.file("ivyLocal", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns)
     ),
     externalResolvers := resolvers.value,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade ORC to 2.3.0 for Apache Spark 4.2.0.

### Why are the changes needed?

Apache ORC 2.3.0 is the first release which is tested with Java 25. To bring the latest improved and bug fixed version.
- https://github.com/apache/orc/milestone/50
  - https://github.com/apache/orc/pull/2555
  - https://github.com/apache/orc/pull/2557

Note that there is a known Java 25 issue, [JDK-8377811](https://bugs.openjdk.org/browse/JDK-8377811).
  - ORC-2116 Java 25 G1GC: Optional Evacuations may evacuate pinned objects

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.