### PR TITLE
[SPARK-54374][SQL][UI][FOLLOWUP] Fix SQL plan visualization display issue caused by initial viewBox

### DIFF
--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -29,7 +29,8 @@ function shouldRenderPlanViz() {
 function renderPlanViz() {
   var svg = planVizContainer()
     .append("svg")
-    .attr("viewBox", `${-PlanVizConstants.svgMarginX} ${-PlanVizConstants.svgMarginY} ${window.innerWidth || 1920} 1000`);
+    .attr("width", window.innerWidth || 1920)
+    .attr("height", 1000);
   var metadata = d3.select("#plan-viz-metadata");
   var dot = metadata.select(".dot-file").text().trim();
   var graph = svg.append("g");


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up fix for #53864. Replace the initial `viewBox` attribute with `width` and `height` on the SQL plan SVG element.

### Why are the changes needed?

Setting `viewBox` before dagre-d3 renders the graph changes the SVG coordinate system, which affects how dagre-d3 positions elements. This causes display issues as reported by @pan3793 in https://github.com/apache/spark/pull/53864#issuecomment-3889339344.

Using `width` and `height` instead gives a large initial canvas (preventing the tiny default render — the original intent of #53864) without altering the coordinate system that dagre-d3 depends on. The `resizeSvg()` function still correctly sets the final `viewBox`, `width`, and `height` after rendering completes.

### Does this PR introduce _any_ user-facing change?

Yes, fixes the SQL plan visualization display regression introduced by #53864.

### How was this patch tested?

Tested in Chrome DevTools.

### Was this patch authored or co-authored using generative AI tooling?

Yes, GitHub Copilot was used.