### PR TITLE
[SPARK-55687][SQL][TEST] Fix ComputeCurrentTimeSuite - No duplicate literals on JDK 25

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ComputeCurrentTimeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ComputeCurrentTimeSuite.scala
@@ -262,11 +262,15 @@ class ComputeCurrentTimeSuite extends PlanTest {
       assert(expected === uniqueLiteralObjectIds.size)
     }
 
-    val numTimezones = ZoneId.SHORT_IDS.size
+    // Use unique ZoneIds count instead of SHORT_IDS.size because some short zone IDs
+    // may map to the same ZoneId (e.g., in Java 25, MST and PNT both map to America/Phoenix)
+    val uniqueZoneIds = ZoneId.SHORT_IDS.asScala.map { case (zoneId, _) =>
+      ZoneId.of(zoneId, ZoneId.SHORT_IDS)
+    }.toSet.size
     checkLiterals({ _: String => CurrentTimestamp() }, 1)
-    checkLiterals({ zoneId: String => LocalTimestamp(Some(zoneId)) }, numTimezones)
+    checkLiterals({ zoneId: String => LocalTimestamp(Some(zoneId)) }, uniqueZoneIds)
     checkLiterals({ _: String => Now() }, 1)
-    checkLiterals({ zoneId: String => CurrentDate(Some(zoneId)) }, numTimezones)
+    checkLiterals({ zoneId: String => CurrentDate(Some(zoneId)) }, uniqueZoneIds)
   }
 
   private def literals[T](plan: LogicalPlan): scala.collection.mutable.ArrayBuffer[T] = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ComputeCurrentTimeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ComputeCurrentTimeSuite.scala
@@ -264,13 +264,13 @@ class ComputeCurrentTimeSuite extends PlanTest {
 
     // Use unique ZoneIds count instead of SHORT_IDS.size because some short zone IDs
     // may map to the same ZoneId (e.g., in Java 25, MST and PNT both map to America/Phoenix)
-    val uniqueZoneIds = ZoneId.SHORT_IDS.asScala.map { case (zoneId, _) =>
+    val numUniqueZoneIds = ZoneId.SHORT_IDS.asScala.map { case (zoneId, _) =>
       ZoneId.of(zoneId, ZoneId.SHORT_IDS)
     }.toSet.size
     checkLiterals({ _: String => CurrentTimestamp() }, 1)
-    checkLiterals({ zoneId: String => LocalTimestamp(Some(zoneId)) }, uniqueZoneIds)
+    checkLiterals({ zoneId: String => LocalTimestamp(Some(zoneId)) }, numUniqueZoneIds)
     checkLiterals({ _: String => Now() }, 1)
-    checkLiterals({ zoneId: String => CurrentDate(Some(zoneId)) }, uniqueZoneIds)
+    checkLiterals({ zoneId: String => CurrentDate(Some(zoneId)) }, numUniqueZoneIds)
   }
 
   private def literals[T](plan: LogicalPlan): scala.collection.mutable.ArrayBuffer[T] = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix a test issue, see details at inline comments.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix a test issue that happens only on JDK 25.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

```
$ export JAVA_HOME=/path/of/openjdk-25
$ build/sbt "catalyst/testOnly *ComputeCurrentTimeSuite"
```

before
```
[info] - No duplicate literals *** FAILED *** (17 milliseconds)
[info]   28 did not equal 27 (ComputeCurrentTimeSuite.scala:262)
[info]   org.scalatest.exceptions.TestFailedException:
[info]   at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
[info]   at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:471)
[info]   at org.scalatest.Assertions$.newAssertionFailedException(Assertions.scala:1231)
[info]   at org.scalatest.Assertions$AssertionsHelper.macroAssert(Assertions.scala:1295)
[info]   at org.apache.spark.sql.catalyst.optimizer.ComputeCurrentTimeSuite.checkLiterals$1(ComputeCurrentTimeSuite.scala:262)
[info]   at org.apache.spark.sql.catalyst.optimizer.ComputeCurrentTimeSuite.$anonfun$new$23(ComputeCurrentTimeSuite.scala:267)
...
[info] Run completed in 1 second, 623 milliseconds.
[info] Total number of tests run: 13
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 12, failed 1, canceled 0, ignored 0, pending 0
[info] *** 1 TEST FAILED ***
[error] Failed tests:
[error] 	org.apache.spark.sql.catalyst.optimizer.ComputeCurrentTimeSuite
[error] (catalyst / Test / testOnly) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 29 s, completed Feb 25, 2026, 10:39:59 PM
```

after
```
...
[info] - No duplicate literals (13 milliseconds)
[info] Run completed in 1 second, 742 milliseconds.
[info] Total number of tests run: 13
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 13, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 16 s, completed Feb 25, 2026, 10:40:31 PM
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.