### PR TITLE
Revert "[SPARK-41398][SQL][FOLLOWUP] Update runtime filtering javadocto reflect relaxed partition constraints"

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsRuntimeFiltering.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsRuntimeFiltering.java
@@ -51,10 +51,8 @@ public interface SupportsRuntimeFiltering extends SupportsRuntimeV2Filtering {
    * the originally reported partitioning during runtime filtering. While applying runtime filters,
    * the scan may detect that some {@link InputPartition}s have no matching data. It can omit
    * such partitions entirely only if it does not report a specific partitioning. Otherwise,
-   * the scan can either replace the initially planned {@link InputPartition}s that have no
-   * matching data with empty {@link InputPartition}s, or report only a subset of the original
-   * partition values (omitting those with no data). The scan must not report new partition values
-   * that were not present in the original partitioning.
+   * the scan can replace the initially planned {@link InputPartition}s that have no matching
+   * data with empty {@link InputPartition}s but must preserve the overall number of partitions.
    * <p>
    * Note that Spark will call {@link Scan#toBatch()} again after filtering the scan at runtime.
    *

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsRuntimeV2Filtering.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsRuntimeV2Filtering.java
@@ -55,10 +55,9 @@ public interface SupportsRuntimeV2Filtering extends Scan {
    * the originally reported partitioning during runtime filtering. While applying runtime
    * predicates, the scan may detect that some {@link InputPartition}s have no matching data. It
    * can omit such partitions entirely only if it does not report a specific partitioning.
-   * Otherwise, the scan can either replace the initially planned {@link InputPartition}s that
-   * have no matching data with empty {@link InputPartition}s, or report only a subset of the
-   * original partition values (omitting those with no data). The scan must not report new
-   * partition values that were not present in the original partitioning.
+   * Otherwise, the scan can replace the initially planned {@link InputPartition}s that have no
+   * matching data with empty {@link InputPartition}s but must preserve the overall number of
+   * partitions.
    * <p>
    * Note that Spark will call {@link Scan#toBatch()} again after filtering the scan at runtime.
    *


### PR DESCRIPTION
### What changes were proposed in this pull request?

This reverts commit 38e51eb5e8d49bed5276a2fc71f1709f643d050f.

### Why are the changes needed?

Not only it doesn't make sense to make a follow-up for 3-years old patch, there is a concern about the doc update. We had better get a new JIRA issue for trace-ability.
- https://github.com/apache/spark/pull/54330#discussion_r2851832853

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.