### PR TITLE
[SPARK-55696][SQL] Add explicit error to Encoders.bean for interface class

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -212,6 +212,12 @@
     ],
     "sqlState" : "22003"
   },
+  "BEAN_ENCODER_INTERFACE_NOT_SUPPORTED" : {
+    "message" : [
+      "Bean encoder does not support interface types: <className>."
+    ],
+    "sqlState" : "0A000"
+  },
   "CALL_ON_STREAMING_DATASET_UNSUPPORTED" : {
     "message" : [
       "The method <methodName> can not be called on streaming Dataset/DataFrame."
@@ -9482,11 +9488,6 @@
   "_LEGACY_ERROR_TEMP_2230" : {
     "message" : [
       "Primitive types are not supported."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2231" : {
-    "message" : [
-      "Bean encoder does not support interface types: <className>."
     ]
   },
   "_LEGACY_ERROR_TEMP_2233" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -206,17 +206,17 @@
     ],
     "sqlState" : "42K03"
   },
-  "BINARY_ARITHMETIC_OVERFLOW" : {
-    "message" : [
-      "<value1> <symbol> <value2> caused overflow. Use <functionName> to ignore overflow problem and return NULL."
-    ],
-    "sqlState" : "22003"
-  },
   "BEAN_ENCODER_INTERFACE_NOT_SUPPORTED" : {
     "message" : [
       "Bean encoder does not support interface type <className>."
     ],
     "sqlState" : "0A000"
+  },
+  "BINARY_ARITHMETIC_OVERFLOW" : {
+    "message" : [
+      "<value1> <symbol> <value2> caused overflow. Use <functionName> to ignore overflow problem and return NULL."
+    ],
+    "sqlState" : "22003"
   },
   "CALL_ON_STREAMING_DATASET_UNSUPPORTED" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -214,7 +214,7 @@
   },
   "BEAN_ENCODER_INTERFACE_NOT_SUPPORTED" : {
     "message" : [
-      "Bean encoder does not support interface types: <className>."
+      "Bean encoder does not support interface type <className>."
     ],
     "sqlState" : "0A000"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -9484,6 +9484,11 @@
       "Primitive types are not supported."
     ]
   },
+  "_LEGACY_ERROR_TEMP_2231" : {
+    "message" : [
+      "Bean encoder does not support interface types: <className>."
+    ]
+  },
   "_LEGACY_ERROR_TEMP_2233" : {
     "message" : [
       "Only Data Sources providing FileFormat are supported: <providingClass>."

--- a/sql/api/src/main/scala/org/apache/spark/sql/Encoders.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Encoders.scala
@@ -195,7 +195,7 @@ object Encoders {
   /**
    * Creates an encoder for Java Bean of type T.
    *
-   * T must be publicly accessible.
+   * T must be a concrete class (not an interface), and must be publicly accessible.
    *
    * supported types for java bean field:
    *   - primitive types: boolean, int, double, etc.

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
@@ -156,7 +156,7 @@ object JavaTypeInference {
       // Deserializer to instantiate the class, which will not work for interfaces.
       if (c.isInterface) {
         throw new SparkUnsupportedOperationException(
-          errorClass = "_LEGACY_ERROR_TEMP_2231",
+          errorClass = "BEAN_ENCODER_INTERFACE_NOT_SUPPORTED",
           messageParameters = Map("className" -> c.getName))
       }
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
@@ -26,6 +26,7 @@ import scala.reflect.ClassTag
 
 import org.apache.commons.lang3.reflect.{TypeUtils => JavaTypeUtils}
 
+import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoder
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders.{ArrayEncoder, BinaryEncoder, BoxedBooleanEncoder, BoxedByteEncoder, BoxedDoubleEncoder, BoxedFloatEncoder, BoxedIntEncoder, BoxedLongEncoder, BoxedShortEncoder, DayTimeIntervalEncoder, DEFAULT_GEOGRAPHY_ENCODER, DEFAULT_GEOMETRY_ENCODER, DEFAULT_JAVA_DECIMAL_ENCODER, EncoderField, IterableEncoder, JavaBeanEncoder, JavaBigIntEncoder, JavaEnumEncoder, LocalDateTimeEncoder, LocalTimeEncoder, MapEncoder, PrimitiveBooleanEncoder, PrimitiveByteEncoder, PrimitiveDoubleEncoder, PrimitiveFloatEncoder, PrimitiveIntEncoder, PrimitiveLongEncoder, PrimitiveShortEncoder, STRICT_DATE_ENCODER, STRICT_INSTANT_ENCODER, STRICT_LOCAL_DATE_ENCODER, STRICT_TIMESTAMP_ENCODER, StringEncoder, UDTEncoder, YearMonthIntervalEncoder}
 import org.apache.spark.sql.errors.ExecutionErrors
@@ -154,7 +155,9 @@ object JavaTypeInference {
       // Encoders for interfaces are not supported because de-serialization uses its
       // Deserializer to instantiate the class, which will not work for interfaces.
       if (c.isInterface) {
-        throw ExecutionErrors.beanEncoderDoesNotSupportInterfaceError(c.getName)
+        throw new SparkUnsupportedOperationException(
+          errorClass = "_LEGACY_ERROR_TEMP_2231",
+          messageParameters = Map("className" -> c.getName))
       }
 
       // TODO: we should only collect properties that have getter and setter. However, some tests

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
@@ -151,6 +151,11 @@ object JavaTypeInference {
       if (seenTypeSet.contains(c)) {
         throw ExecutionErrors.cannotHaveCircularReferencesInBeanClassError(c)
       }
+      // Encoders for interfaces are not supported because de-serialization uses its
+      // Deserializer to instantiate the class, which will not work for interfaces.
+      if (c.isInterface) {
+        throw ExecutionErrors.beanEncoderDoesNotSupportInterfaceError(c.getName)
+      }
 
       // TODO: we should only collect properties that have getter and setter. However, some tests
       //   pass in scala case class as java bean class which doesn't have getter and setter.

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/ExecutionErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/ExecutionErrors.scala
@@ -217,13 +217,6 @@ private[sql] trait ExecutionErrors extends DataTypeErrorsBase {
       messageParameters = Map("name" -> name))
   }
 
-  def beanEncoderDoesNotSupportInterfaceError(className: String):
-  SparkUnsupportedOperationException = {
-    new SparkUnsupportedOperationException(
-      errorClass = "_LEGACY_ERROR_TEMP_2231",
-      messageParameters = Map("className" -> className))
-  }
-
   def primitiveTypesNotSupportedError(): SparkUnsupportedOperationException = {
     new SparkUnsupportedOperationException(errorClass = "_LEGACY_ERROR_TEMP_2230")
   }

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/ExecutionErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/ExecutionErrors.scala
@@ -217,6 +217,13 @@ private[sql] trait ExecutionErrors extends DataTypeErrorsBase {
       messageParameters = Map("name" -> name))
   }
 
+  def beanEncoderDoesNotSupportInterfaceError(className: String):
+  SparkUnsupportedOperationException = {
+    new SparkUnsupportedOperationException(
+      errorClass = "_LEGACY_ERROR_TEMP_2231",
+      messageParameters = Map("className" -> className))
+  }
+
   def primitiveTypesNotSupportedError(): SparkUnsupportedOperationException = {
     new SparkUnsupportedOperationException(errorClass = "_LEGACY_ERROR_TEMP_2230")
   }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -1918,6 +1918,98 @@ public class JavaDatasetSuite implements Serializable {
 
   }
 
+  /**
+   * Interface with JavaBean-style getters/setters for testing encoder with interface type.
+   * Used to verify that Encoders.bean(Interface.class) fails on deserialization (cannot
+   * instantiate interface) while Encoders.kryo(Interface.class) works with concrete implementations.
+   */
+  public interface BeanInterface extends Serializable {
+    String getValue();
+    void setValue(String value);
+    int getId();
+    void setId(int id);
+  }
+
+  public static class BeanImplA implements BeanInterface {
+    private String value;
+    private int id;
+
+    @Override
+    public String getValue() { return value; }
+    @Override
+    public void setValue(String value) { this.value = value; }
+    @Override
+    public int getId() { return id; }
+    @Override
+    public void setId(int id) { this.id = id; }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof BeanImplA)) return false;
+      BeanImplA that = (BeanImplA) o;
+      return id == that.id && Objects.equals(value, that.value);
+    }
+    @Override
+    public int hashCode() { return Objects.hash(value, id); }
+  }
+
+  public static class BeanImplB implements BeanInterface {
+    private String value;
+    private int id;
+
+    @Override
+    public String getValue() { return value; }
+    @Override
+    public void setValue(String value) { this.value = value; }
+    @Override
+    public int getId() { return id; }
+    @Override
+    public void setId(int id) { this.id = id; }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof BeanImplB)) return false;
+      BeanImplB that = (BeanImplB) o;
+      return id == that.id && Objects.equals(value, that.value);
+    }
+    @Override
+    public int hashCode() { return Objects.hash(value, id); }
+  }
+
+  @Test
+  public void testBeanEncoderRejectsInterface() {
+    // Bean encoder does not support interface types (deserialization would fail).
+    // Use Encoders.kryo() or Encoders.javaSerialization() for interface types instead.
+    Exception e = Assertions.assertThrows(Exception.class,
+        () -> Encoders.bean(BeanInterface.class));
+    Assertions.assertTrue(e.getMessage() != null && e.getMessage().contains("interface"),
+        "Expected message about interface not supported: " + e.getMessage());
+  }
+
+  @Test
+  public void testKryoEncoderWithInterfaceAndConcreteImplementations() {
+    BeanImplA a = new BeanImplA();
+    a.setValue("a");
+    a.setId(1);
+    BeanImplB b = new BeanImplB();
+    b.setValue("b");
+    b.setId(2);
+    List<BeanInterface> data = Arrays.asList(a, b);
+
+    Encoder<BeanInterface> kryoEncoder = Encoders.kryo(BeanInterface.class);
+    Dataset<BeanInterface> ds = spark.createDataset(data, kryoEncoder);
+    List<BeanInterface> collected = ds.collectAsList();
+    Assertions.assertEquals(2, collected.size());
+    Assertions.assertEquals("a", collected.get(0).getValue());
+    Assertions.assertEquals(1, collected.get(0).getId());
+    Assertions.assertEquals("b", collected.get(1).getValue());
+    Assertions.assertEquals(2, collected.get(1).getId());
+    Assertions.assertInstanceOf(BeanImplA.class, collected.get(0));
+    Assertions.assertInstanceOf(BeanImplB.class, collected.get(1));
+  }
+
   public class CircularReference1Bean implements Serializable {
     private CircularReference2Bean child;
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -1920,8 +1920,6 @@ public class JavaDatasetSuite implements Serializable {
 
   /**
    * Interface with JavaBean-style getters/setters for testing encoder with interface type.
-   * Used to verify that Encoders.bean(Interface.class) fails on deserialization (cannot
-   * instantiate interface) while Encoders.kryo(Interface.class) works with concrete implementations.
    */
   public interface BeanInterface extends Serializable {
     String getValue();

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.apache.spark.SparkUnsupportedOperationException;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.*;
@@ -1978,11 +1979,14 @@ public class JavaDatasetSuite implements Serializable {
 
   @Test
   public void testBeanEncoderRejectsInterface() {
-    // Bean encoder does not support interface types (deserialization would fail).
-    Exception e = Assertions.assertThrows(Exception.class,
+    SparkUnsupportedOperationException e = Assertions.assertThrows(
+        SparkUnsupportedOperationException.class,
         () -> Encoders.bean(BeanInterface.class));
-    Assertions.assertTrue(e.getMessage() != null && e.getMessage().contains("interface"),
-        "Expected message about interface not supported: " + e.getMessage());
+    Assertions.assertEquals("BEAN_ENCODER_INTERFACE_NOT_SUPPORTED", e.getCondition());
+    Assertions.assertEquals("0A000", e.getSqlState());
+    Assertions.assertEquals(
+        Collections.singletonMap("className", BeanInterface.class.getName()),
+        e.getMessageParameters());
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add explicit error message to Encoders.bean against interfaces


### Why are the changes needed?

For bean Encoders, the de-serializer uses the constructor inferred from the bean Encoder.  ie, we get the bytes back, the Dataset deserialization will use the Encoder's interface class to try to construct  , and fail.

Code ref:
https://github.com/apache/spark/blob/b3703755d80585297367d539de9fa8c5783b1c6b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/DeserializerBuildHelper.scala#L482



### Does this PR introduce _any_ user-facing change?
No, it already fails today with another message:
```
java.lang.IllegalStateException: found an unhandled type: null
      at org.apache.commons.lang3.reflect.TypeUtils.getTypeArguments(TypeUtils.java:915)
      at org.apache.commons.lang3.reflect.TypeUtils.getTypeArguments(TypeUtils.java:791)
      at org.apache.commons.lang3.reflect.TypeUtils.getTypeArguments(TypeUtils.java:886)
      at org.apache.commons.lang3.reflect.TypeUtils.getTypeArguments(TypeUtils.java:873)
      at org.apache.spark.sql.catalyst.JavaTypeInference$.encoderFor(JavaTypeInference.scala:159)
      at org.apache.spark.sql.catalyst.JavaTypeInference$.encoderFor(JavaTypeInference.scala:63)
      at org.apache.spark.sql.catalyst.JavaTypeInference$.encoderFor(JavaTypeInference.scala:56)
      at org.apache.spark.sql.Encoders$.bean(Encoders.scala:211)
      at org.apache.spark.sql.Encoders.bean(Encoders.scala)

```
it will now fail more explicitly.


### How was this patch tested?
Added unit test in JavaDatasetSuite

### Was this patch authored or co-authored using generative AI tooling?
Yes, cursor 
