### PR TITLE
[SPARK-54571][CORE] Use LZ4 safeDecompressor

### DIFF
--- a/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
+++ b/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
@@ -152,12 +152,11 @@ class LZ4CompressionCodec(conf: SparkConf) extends CompressionCodec {
   }
 
   override def compressedInputStream(s: InputStream): InputStream = {
-    val disableConcatenationOfByteStream = false
-    new LZ4BlockInputStream(
-      s,
-      lz4Factory.fastDecompressor(),
-      xxHashFactory.newStreamingHash32(defaultSeed).asChecksum,
-      disableConcatenationOfByteStream)
+    LZ4BlockInputStream.newBuilder()
+      .withDecompressor(lz4Factory.safeDecompressor())
+      .withChecksum(xxHashFactory.newStreamingHash32(defaultSeed).asChecksum)
+      .withStopOnEmptyBlock(false)
+      .build(s)
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Switch `LZ4CompressionCodec.compressedInputStream` to use `lz4Factory.safeDecompressor()` instead of `lz4Factory.fastDecompressor()`.

Since Spark upgraded to `at.yawk.lz4:lz4-java:1.10.0` (via #53327), `LZ4BlockInputStream` now has a Builder API that accepts `LZ4SafeDecompressor`. This PR uses that API:

```scala
LZ4BlockInputStream.newBuilder()
  .withDecompressor(lz4Factory.safeDecompressor())
  .withChecksum(xxHashFactory.newStreamingHash32(defaultSeed).asChecksum)
  .withStopOnEmptyBlock(false)
  .build(s)
```

This is a follow-up to #53290, which was blocked because `LZ4BlockInputStream` in lz4-java 1.8.0 did not accept `LZ4SafeDecompressor`. The lz4-java 1.10.0 Builder API unblocks this change.

### Why are the changes needed?

As noted by the lz4-java maintainer (@yawkat) in #53290, as of lz4-java 1.8.1, `safeDecompressor` is **substantially faster** than `fastDecompressor`. The recommended migration path with proper performance is to use `safeDecompressor` via the 1.10.0+ Builder API.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing unit tests.

### Was this patch authored or co-authored using generative AI tooling?

No.