### PR TITLE
[SPARK-55296][PS][FOLLOW-UP] Fix setitem with Series through iloc indexer with pandas 3

### DIFF
--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -621,17 +621,18 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                     psdf[temp_value_col] = value
                 psdf = psdf.sort_values(temp_natural_order).drop(columns=temp_natural_order)
 
-                psser = psdf._psser_for(column_label)
                 if isinstance(key, Series):
-                    key = F.col(
-                        "`{}`".format(psdf[temp_key_col]._internal.data_spark_column_names[0])
-                    )
+                    key = psdf[temp_key_col].spark.column
                 if isinstance(value, Series):
-                    value = F.col(
-                        "`{}`".format(psdf[temp_value_col]._internal.data_spark_column_names[0])
-                    )
+                    value = psdf[temp_value_col].spark.column
 
-                type(self)(psser)[key] = value
+                if isinstance(self, iLocIndexer):
+                    col_sel = psdf._internal.column_labels.index(column_label)
+                else:
+                    col_sel = column_label
+                type(self)(psdf)[key, col_sel] = value
+
+                psser = psdf._psser_for(column_label)
 
                 if self._psdf_or_psser.name is None:
                     psser = psser.rename()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is another follow-up of apache/spark#54375.

Fixes `setitem` with `Series` through `iloc` indexer with pandas 3.

Also fixed some tests with `DataFrame` with `loc` indexer.

### Why are the changes needed?

Setting `Series` through `iloc` indexer causes an analysis exception:

```py
>>> from pyspark import pandas as ps
>>> psdf = ps.DataFrame({"a": [1, 2, 3], "b": [10, 20, 30]})
>>> psser = psdf["a"]
>>>
>>> psser.iloc[[0, 1, 2]] = -ps.DataFrame({"x": [100, 200, 300]})["x"]
Traceback (most recent call last):
...
pyspark.errors.exceptions.captured.AnalysisException: [UNRESOLVED_COLUMN.WITH_SUGGESTION] A column, variable, or function parameter with name `__temp_value_col__` cannot be resolved. Did you mean one of the following? [`__natural_order__`, `__index_level_0__`, `a`, `__distributed_sequence_column__`]. SQLSTATE: 42703;
...
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Updated the related tests and the existing tests should pass.

### Was this patch authored or co-authored using generative AI tooling?

Codex (GPT-5.3-Codex)
