### PR TITLE
[SPARK-55700][PS] Fix handling integer keys on Series with non-integer index

### DIFF
--- a/python/pyspark/pandas/tests/indexes/test_indexing_adv.py
+++ b/python/pyspark/pandas/tests/indexes/test_indexing_adv.py
@@ -22,6 +22,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
+from pyspark.loose_version import LooseVersion
 from pyspark.pandas.exceptions import SparkPandasNotImplementedError
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
@@ -339,8 +340,12 @@ class IndexingAdvMixin:
         self.assert_eq(psdf[10:3], pdf[10:3], almost=True)
 
         # Index loc search
-        self.assert_eq(psdf.A[4], pdf.A[4])
-        self.assert_eq(psdf.A[3], pdf.A[3])
+        if LooseVersion(pd.__version__) < "3.0.0":
+            self.assert_eq(psdf.A[4], pdf.A[4])
+            self.assert_eq(psdf.A[3], pdf.A[3])
+        else:
+            with self.assertRaises(KeyError):
+                psdf.A[4]
 
         # Positional iloc search
         self.assert_eq(psdf.A[:4], pdf.A[:4], almost=True)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes handling integer keys on Series with non-integer index.

### Why are the changes needed?

Integer keys on Series with non-integer index doesn't handle them as positional index with pandas 3 anymore.

For example:

```py
>>> dates = pd.date_range("20130101", periods=6)
>>> pdf = pd.DataFrame(np.random.randn(6, 4), index=dates, columns=list("ABCD"))
```

- pandas 2

```py
>>> pdf.A[4]
<stdin>:1: FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
np.float64(-1.2836101861392761)
```

- pandas 3

```py
>>> pdf.A[4]
Traceback (most recent call last):
...
KeyError: 4
```

### Does this PR introduce _any_ user-facing change?

Yes, it will behave more like pandas 3.

### How was this patch tested?

Updated the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
