### PR TITLE
[SPARK-55706][SQL][TESTS] Disable DB2 JDBC Driver tests

### DIFF
--- a/connector/docker-integration-tests/pom.xml
+++ b/connector/docker-integration-tests/pom.xml
@@ -100,11 +100,12 @@
       <artifactId>ojdbc17</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
+    <!-- TODO(SPARK-55707: Re-enable DB2 JDBC Driver tests) -->
+    <!--dependency>
       <groupId>com.ibm.db2</groupId>
       <artifactId>jcc</artifactId>
       <scope>test</scope>
-    </dependency>
+    </dependency-->
     <dependency>
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2IntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2IntegrationSuite.scala
@@ -21,12 +21,13 @@ import java.math.BigDecimal
 import java.sql.{Connection, Date, Timestamp}
 import java.util.Properties
 
+import org.scalatest.Ignore
+
 import org.apache.spark.sql.{Row, SaveMode}
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{ByteType, ShortType, StructType}
-import org.apache.spark.tags.DockerTest
 
 /**
  * To run this test suite for a specific version (e.g., icr.io/db2_community/db2:11.5.9.0):
@@ -36,7 +37,7 @@ import org.apache.spark.tags.DockerTest
  *     "docker-integration-tests/testOnly org.apache.spark.sql.jdbc.DB2IntegrationSuite"
  * }}}
  */
-@DockerTest
+@Ignore // TODO(SPARK-55707): Re-enable DB2 JDBC Driver tests
 class DB2IntegrationSuite extends SharedJDBCIntegrationSuite {
   override val db = new DB2DatabaseOnDocker
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2KrbIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2KrbIntegrationSuite.scala
@@ -24,6 +24,7 @@ import javax.security.auth.login.Configuration
 import com.github.dockerjava.api.model.{AccessMode, Bind, ContainerConfig, HostConfig, Volume}
 import org.apache.hadoop.security.{SecurityUtil, UserGroupInformation}
 import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS
+import org.scalatest.Ignore
 
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 import org.apache.spark.sql.execution.datasources.jdbc.connection.{DB2ConnectionProvider, SecureConnectionProvider}
@@ -37,6 +38,7 @@ import org.apache.spark.tags.DockerTest
  *     "docker-integration-tests/testOnly *DB2KrbIntegrationSuite"
  * }}}
  */
+@Ignore // TODO(SPARK-55707: Re-enable DB2 JDBC Driver tests)
 @DockerTest
 class DB2KrbIntegrationSuite extends DockerKrbJDBCIntegrationSuite {
   override protected val userName = s"db2/$dockerIp"

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2IntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2IntegrationSuite.scala
@@ -20,12 +20,13 @@ package org.apache.spark.sql.jdbc.v2
 import java.sql.Connection
 import java.util.Locale
 
+import org.scalatest.Ignore
+
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
 import org.apache.spark.sql.jdbc.DB2DatabaseOnDocker
 import org.apache.spark.sql.types._
-import org.apache.spark.tags.DockerTest
 
 /**
  * To run this test suite for a specific version (e.g., icr.io/db2_community/db2:11.5.9.0):
@@ -34,7 +35,7 @@ import org.apache.spark.tags.DockerTest
  *     ./build/sbt -Pdocker-integration-tests "testOnly *v2.DB2IntegrationSuite"
  * }}}
  */
-@DockerTest
+@Ignore // TODO(SPARK-55707): Re-enable DB2 JDBC Driver tests
 class DB2IntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest {
 
   // Following tests are disabled for both single and multiple partition read

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2NamespaceSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2NamespaceSuite.scala
@@ -21,6 +21,8 @@ import java.sql.Connection
 
 import scala.jdk.CollectionConverters._
 
+import org.scalatest.Ignore
+
 import org.apache.spark.sql.jdbc.{DB2DatabaseOnDocker, DockerJDBCIntegrationSuite}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.tags.DockerTest
@@ -32,6 +34,7 @@ import org.apache.spark.tags.DockerTest
  *     ./build/sbt -Pdocker-integration-tests "testOnly *v2.DB2NamespaceSuite"
  * }}}
  */
+@Ignore // TODO(SPARK-55707): Re-enable DB2 JDBC Driver tests
 @DockerTest
 class DB2NamespaceSuite extends DockerJDBCIntegrationSuite with V2JDBCNamespaceTest {
   override val db = new DB2DatabaseOnDocker
@@ -39,7 +42,8 @@ class DB2NamespaceSuite extends DockerJDBCIntegrationSuite with V2JDBCNamespaceT
     Map("url" -> db.getJdbcUrl(dockerIp, externalPort),
       "driver" -> "com.ibm.db2.jcc.DB2Driver").asJava)
 
-  catalog.initialize("db2", map)
+  // TODO(SPARK-55707): Re-enable DB2 JDBC Driver tests
+  // catalog.initialize("db2", map)
 
   override def dataPreparation(conn: Connection): Unit = {}
 

--- a/pom.xml
+++ b/pom.xml
@@ -1357,12 +1357,13 @@
         <version>${postgresql.version}</version>
         <scope>test</scope>
       </dependency>
-      <dependency>
+      <!-- TODO(SPARK-55707: Re-enable DB2 JDBC Driver tests) -->
+      <!--dependency>
         <groupId>com.ibm.db2</groupId>
         <artifactId>jcc</artifactId>
         <version>${db2.jcc.version}</version>
         <scope>test</scope>
-      </dependency>
+      </dependency-->
       <dependency>
         <groupId>com.microsoft.sqlserver</groupId>
         <artifactId>mssql-jdbc</artifactId>

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -206,11 +206,12 @@
       <artifactId>postgresql</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
+    <!-- TODO(SPARK-55707: Re-enable DB2 JDBC Driver tests) -->
+    <!--dependency>
       <groupId>com.ibm.db2</groupId>
       <artifactId>jcc</artifactId>
       <scope>test</scope>
-    </dependency>
+    </dependency-->
     <dependency>
       <groupId>com.ibm.icu</groupId>
       <artifactId>icu4j</artifactId>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuite.scala
@@ -185,28 +185,28 @@ class ConnectionProviderSuite
     val postgresDriver = registerDriver(postgresProvider.driverClass)
     val postgresOptions = options("jdbc:postgresql://localhost/postgres")
     val postgresAppEntry = postgresProvider.appEntry(postgresDriver, postgresOptions)
-    val db2Provider = new DB2ConnectionProvider()
-    val db2Driver = registerDriver(db2Provider.driverClass)
-    val db2Options = options("jdbc:db2://localhost/db2")
-    val db2AppEntry = db2Provider.appEntry(db2Driver, db2Options)
+    val mysqlProvider = new MariaDBConnectionProvider()
+    val mysqlDriver = registerDriver(mysqlProvider.driverClass)
+    val mysqlOptions = options("jdbc:mysql://localhost/db")
+    val mysqlAppEntry = mysqlProvider.appEntry(mysqlDriver, mysqlOptions)
 
     // Make sure no authentication for the databases are set
     val rootConfig = Configuration.getConfiguration
     assert(rootConfig.getAppConfigurationEntry(postgresAppEntry) == null)
-    assert(rootConfig.getAppConfigurationEntry(db2AppEntry) == null)
+    assert(rootConfig.getAppConfigurationEntry(mysqlAppEntry) == null)
 
     postgresProvider.setAuthenticationConfig(postgresDriver, postgresOptions)
     val postgresConfig = Configuration.getConfiguration
 
-    db2Provider.setAuthenticationConfig(db2Driver, db2Options)
-    val db2Config = Configuration.getConfiguration
+    mysqlProvider.setAuthenticationConfig(mysqlDriver, mysqlOptions)
+    val mysqlConfig = Configuration.getConfiguration
 
     // Make sure authentication for the databases are set
     assert(rootConfig != postgresConfig)
-    assert(rootConfig != db2Config)
+    assert(rootConfig != mysqlConfig)
     // The topmost config in the chain is linked with all the subsequent entries
-    assert(db2Config.getAppConfigurationEntry(postgresAppEntry) != null)
-    assert(db2Config.getAppConfigurationEntry(db2AppEntry) != null)
+    assert(mysqlConfig.getAppConfigurationEntry(postgresAppEntry) != null)
+    assert(mysqlConfig.getAppConfigurationEntry(mysqlAppEntry) != null)
 
     Configuration.setConfiguration(null)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProviderSuite.scala
@@ -17,6 +17,9 @@
 
 package org.apache.spark.sql.execution.datasources.jdbc.connection
 
+import org.scalatest.Ignore
+
+@Ignore // TODO(SPARK-55707): Re-enable DB2 JDBC Driver tests
 class DB2ConnectionProviderSuite extends ConnectionProviderSuiteBase {
   test("setAuthenticationConfig must set authentication all the time") {
     val provider = new DB2ConnectionProvider()

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1088,7 +1088,8 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       "SELECT TOP (123) a,b FROM test")
   }
 
-  test("SPARK-42534: DB2Dialect Limit query test") {
+  // TODO(SPARK-55707): Re-enable DB2 JDBC Driver tests
+  ignore("SPARK-42534: DB2Dialect Limit query test") {
     // JDBC url is a required option but is not used in this test.
     val options = new JDBCOptions(Map("url" -> "jdbc:db2://host:port", "dbtable" -> "test"))
     assert(
@@ -2261,7 +2262,9 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     }
     // not supported
     Seq(
-      "jdbc:db2://host:port", "jdbc:derby:memory", "jdbc:h2://host:port",
+      // TODO(SPARK-55707): Re-enable DB2 JDBC Driver tests
+      // "jdbc:db2://host:port",
+      "jdbc:derby:memory", "jdbc:h2://host:port",
       "jdbc:sqlserver://host:port", "jdbc:postgresql://host:5432/postgres",
       "jdbc:snowflake://host:443?account=test", "jdbc:teradata://host:port").foreach { url =>
       val options = new JDBCOptions(baseParameters + ("url" -> url))
@@ -2282,7 +2285,8 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       "jdbc:mysql",
       "jdbc:postgresql",
       "jdbc:sqlserver",
-      "jdbc:db2",
+      // TODO(SPARK-55707): Re-enable DB2 JDBC Driver tests
+      // "jdbc:db2",
       "jdbc:h2",
       "jdbc:teradata",
       "jdbc:databricks"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to disable DB2 JDBC driver test coverage until it removes its side-effect.
- `ConnectionProviderSuite` is revised to use another connection provider instead of `DB2`.
- SPARK-55707 is filed to re-enable the disabled tests.

### Why are the changes needed?

To avoid a side-effect on LZ4 test dependency. We had better focus on the non-test dependency first.

**BACKGROUND**
The discussion originally initiated over 2 months ago and we tried many approaches to minimize the gap as much as possible we can. DB2 JDBC was the last hurdle to block `Apache Spark` from upgrading our LZ4 library.
- https://github.com/apache/spark/pull/53290 (Dec 2, 2025)
- https://github.com/apache/spark/pull/53327 (Dec 4, 2025)
- https://github.com/apache/spark/pull/53347 (Dec 5, 2025)
- https://github.com/apache/spark/pull/53453 (Dec 12, 2025)
- https://github.com/apache/spark/pull/53920 (Jan 22, 2026)
- https://github.com/apache/spark/pull/53454 (Dec 12, 2025 ~ Open)

`DB2` is simply just a test dependency (or test coverage), but it causes `java.lang.NoSuchMethodError: 'net.jpountz.lz4.LZ4BlockInputStream$Builder net.jpountz.lz4.LZ4BlockInputStream.newBuilder()'
 	at org.apache.spark.io.LZ4CompressionCodec.compressedInputStream(CompressionCodec.scala:156)` when there is a mismatch between Apache Spark's built-in LZ4 library and DB2's embedded LZ4 library.
 
 Apache Spark distribution has no documentation, assumptions or requirements for JDBC drivers so far. That's the reason [why I suggested to simply disable `Db2` test coverage](https://github.com/apache/spark/pull/53920#pullrequestreview-3858487533) for a while as the alternative #53920 .

https://github.com/apache/spark/blob/1d5681382b9ea2b83bdd7533f59322b7b686145d/pom.xml#L1360-L1365

We don't want to give an extra recommendation like using `12.1.3.0_special_74723` which it may contaminate Spark's classpaths. IBM may want to give a recommendation from their side.

We have still two on-going JIRA issue.
1. #53454 is the main body which @pan3793 has been driving (after @dbtsai )
2. [SPARK-55707](https://issues.apache.org/jira/browse/SPARK-55707) aims to re-enable the disabled tests after #53454 and IBM is able to deliver a normal JDBC driver jar which can work with Apache Spark distributions with different LZ4 versions.

I'm not sure about when (2) is done because it's 3-rd party decision. The bottom line is that the Apache Spark should be able to proceed without being blocked by 3rd-party library packaging issue.

### Does this PR introduce _any_ user-facing change?

No Spark's behavior change because this is only a test dependency and coverage.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.