### PR TITLE
[SPARK-55709][K8S][TESTS] Fix `ExecutorLifecycleTestUtils.persistentVolumeClaim` to use `ReadWriteOncePod` instead of `ReadWriteOnce`

### DIFF
--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorLifecycleTestUtils.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorLifecycleTestUtils.scala
@@ -260,7 +260,7 @@ object ExecutorLifecycleTestUtils {
         .endMetadata()
       .withNewSpec()
         .withStorageClassName(storageClass)
-        .withAccessModes("ReadWriteOnce")
+        .withAccessModes(DEFAULT_PVC_ACCESS_MODE)
         .withResources(new VolumeResourceRequirementsBuilder()
           .withRequests(Map("storage" -> new Quantity(size)).asJava).build())
         .endSpec()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `ExecutorLifecycleTestUtils.persistentVolumeClaim` to use `ReadWriteOncePod` instead of `ReadWriteOnce`.

### Why are the changes needed?

Since Apache Spark 4.0.0, we used `ReadWriteOncePod` by default. We should test the Apache Spark's behavior consistently.
- #44817
- #44985

### Does this PR introduce _any_ user-facing change?

No, this is a test case change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`