### PR TITLE
[SPARK-55710][BUILD] Use Google Mirror of Maven Central for SBT bootstrap

### DIFF
--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -43,7 +43,7 @@ acquire_sbt_jar () {
   # artifacts from internal repos only.
   # Ex:
   #   DEFAULT_ARTIFACT_REPOSITORY=https://artifacts.internal.com/libs-release/
-  URL1=${DEFAULT_ARTIFACT_REPOSITORY:-https://repo1.maven.org/maven2/}org/scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch-${SBT_VERSION}.jar
+  URL1=${DEFAULT_ARTIFACT_REPOSITORY:-https://maven-central.storage-download.googleapis.com/maven2/}org/scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch-${SBT_VERSION}.jar
   JAR=build/sbt-launch-${SBT_VERSION}.jar
 
   sbt_jar=$JAR


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the default SBT bootstrap repository from Maven Central (`repo1.maven.org`) to Google's Maven Central mirror (`maven-central.storage-download.googleapis.com`) for downloading the `sbt-launch` jar.

### Why are the changes needed?

The rest of the SBT build already uses the Google mirror as the primary resolver, as `project/SparkBuild.scala`. The bootstrap script (`build/sbt-launch-lib.bash`) was the only place still defaulting to Maven Central. This makes it consistent and avoids flaky Maven Central connections during the initial `sbt-launch` jar download.

The `DEFAULT_ARTIFACT_REPOSITORY` environment variable can still be used to override this.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually tested by removing the cached `sbt-launch-1.12.4.jar` and verifying the bootstrap successfully downloads from the Google mirror with matching checksum.

### Was this patch authored or co-authored using generative AI tooling?

Yes, GitHub Copilot CLI was used.