### PR TITLE
[SPARK-55463][PYTHON][FOLLOW-UP] Delete unnecessary `date_as_object=True` in VariantType conversion

### DIFF
--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -1731,7 +1731,7 @@ class ArrowArrayToPandasConversion:
                 else None
             )
         elif isinstance(spark_type, VariantType):
-            series = arr.to_pandas(date_as_object=True)
+            series = arr.to_pandas()
             series = series.map(
                 lambda v: VariantVal(v["value"], v["metadata"]) if v is not None else None
             )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Delete unnecessary `date_as_object=True`


### Why are the changes needed?
1, VariantType is not supposed to include any date fields;
2, `date_as_object` actually defaults to True, according to the [API reference](https://arrow.apache.org/docs/python/generated/pyarrow.Array.html#pyarrow.Array.to_pandas)

Remove it to be consistent with changes from https://github.com/apache/spark/pull/54303/changes

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
