### PR TITLE
[SPARK-55711][UI][FOLLOWUP] Fix Job DAG visualization display issue caused by initial viewBox

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/spark-dag-viz.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/spark-dag-viz.js
@@ -160,7 +160,8 @@ function renderDagViz(forJob) {
   const svg = graphContainer()
     .append("svg")
     .attr("class", jobOrStage)
-    .attr("viewBox", `${-VizConstants.svgMarginX} ${-VizConstants.svgMarginY} ${window.innerWidth || 1920} 1000`);
+    .attr("width", window.innerWidth || 1920)
+    .attr("height", 1000);
   if (forJob) {
     renderDagVizForJob(svg);
   } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to SPARK-54373 (#53087). Replace the initial `viewBox` attribute with `width` and `height` on the Job DAG SVG element, consistent with the fix applied to `spark-sql-viz.js` in the SPARK-54374 followup (#54482).

### Why are the changes needed?

Setting `viewBox` before dagre-d3 renders the graph changes the SVG coordinate system, which affects how dagre-d3 positions elements. This causes the same display issue as reported for SQL plan visualization in https://github.com/apache/spark/pull/53864#issuecomment-3889339344.

Using `width` and `height` instead gives a large initial canvas without altering the coordinate system that dagre-d3 depends on. The final `viewBox`, `width`, and `height` are still correctly set after rendering completes.

### Does this PR introduce _any_ user-facing change?

Yes, fixes the Job DAG visualization display regression introduced by SPARK-54373.

### How was this patch tested?

Tested in Chrome DevTools.

### Was this patch authored or co-authored using generative AI tooling?

Yes, GitHub Copilot CLI was used.

cc @pan3793