### PR TITLE
[SPARK-55713][PYTHON][TESTS] Add `LongArrowToPandasBenchmark` for long type conversions

### DIFF
--- a/python/benchmarks/bench_arrow.py
+++ b/python/benchmarks/bench_arrow.py
@@ -51,3 +51,68 @@ class ArrowToPandasBenchmark:
 
     def peakmem_int_with_nulls_to_pandas(self, n_rows, types_mapper):
         self.int_array_with_nulls.to_pandas(types_mapper=self.types_mapper)
+
+
+class LongArrowToPandasBenchmark:
+    """Benchmark for Arrow long array -> Pandas conversions."""
+
+    params = [
+        [10000, 100000, 1000000],
+        ["simple", "arrow_types_mapper", "pd.Series"],
+    ]
+    param_names = ["n_rows", "method"]
+
+    def setup(self, n_rows, method):
+        self.long_array = pa.array(list(range(n_rows - 1)) + [9223372036854775707], type=pa.int64())
+
+    # check 3 different ways to convert non-nullable longs to numpy int64
+    def run_long_to_pandas(self, n_rows, method):
+        if method == "simple":
+            ser = self.long_array.to_pandas()
+        elif method == "arrow_types_mapper":
+            ser = self.long_array.to_pandas(types_mapper=pd.ArrowDtype).astype(np.int64)
+        else:
+            ser = pd.Series(self.long_array, dtype=np.int64)
+        assert ser.dtype == np.int64
+
+    def time_long_to_pandas(self, n_rows, method):
+        self.run_long_to_pandas(n_rows, method)
+
+    def peakmem_long_to_pandas(self, n_rows, method):
+        self.run_long_to_pandas(n_rows, method)
+
+
+class NullableLongArrowToPandasBenchmark:
+    """Benchmark for Arrow long array with nulls -> Pandas conversions."""
+
+    params = [
+        [10000, 100000, 1000000],
+        ["integer_object_nulls", "arrow_types_mapper", "pd.Series"],
+    ]
+    param_names = ["n_rows", "method"]
+
+    def setup(self, n_rows, method):
+        self.long_array_with_nulls = pa.array(
+            [i if i % 10 != 0 else None for i in range(n_rows - 1)] + [9223372036854775707],
+            type=pa.int64(),
+            )
+
+    # check 3 different ways to convert nullable longs to nullable extension type
+    def run_long_with_nulls_to_pandas_ext(self, n_rows, method):
+        if method == "integer_object_nulls":
+            ser = self.long_array_with_nulls.to_pandas(integer_object_nulls=True).astype(
+                pd.Int64Dtype()
+            )
+        elif method == "arrow_types_mapper":
+            ser = self.long_array_with_nulls.to_pandas(types_mapper=pd.ArrowDtype).astype(
+                pd.Int64Dtype()
+            )
+        else:
+            ser = pd.Series(self.long_array_with_nulls.to_pylist(), dtype=pd.Int64Dtype())
+        assert ser.dtype == pd.Int64Dtype()
+
+    def time_long_with_nulls_to_pandas_ext(self, n_rows, method):
+        self.run_long_with_nulls_to_pandas_ext(n_rows, method)
+
+    def peakmem_long_with_nulls_to_pandas_ext(self, n_rows, method):
+        self.run_long_with_nulls_to_pandas_ext(n_rows, method)

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -1654,33 +1654,7 @@ class ArrowArrayToPandasConversion:
 
         series: pd.Series
 
-        # TODO(SPARK-55332): Create benchmark for pa.array -> pd.series integer conversion
-        # 1, benchmark a nullable integral array
-        # a = pa.array(list(range(10000000)) + [9223372036854775707, None], type=pa.int64())
-        # %timeit a.to_pandas(types_mapper=pd.ArrowDtype)
-        # 11.9 μs ± 407 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
-        # %timeit a.to_pandas(types_mapper=pd.ArrowDtype).astype(pd.Int64Dtype())
-        # 589 ms ± 9.35 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
-        # %timeit pd.Series(a.to_pylist(), dtype=pd.Int64Dtype())
-        # 2.94 s ± 19.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
-        # %timeit a.to_pandas(integer_object_nulls=True).astype(pd.Int64Dtype())
-        # 2.05 s ± 22.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
-        # pd.Series(a, dtype=pd.Int64Dtype())
-        # fails due to internal np.float64 coercion
-        # OverflowError: Python int too large to convert to C long
-        #
-        # 2, benchmark a nullable integral array
-        # b = pa.array(list(range(10000000)) + [9223372036854775707, 1], type=pa.int64())
-        # %timeit b.to_pandas(types_mapper=pd.ArrowDtype).astype(np.int64)
-        # 30.2 μs ± 831 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
-        # %timeit pd.Series(b.to_pandas(types_mapper=pd.ArrowDtype), dtype=np.int64)
-        # 33.3 μs ± 928 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
-        # %timeit pd.Series(b, dtype=np.int64) <- lose the name
-        # 11.9 μs ± 125 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
-        # %timeit b.to_pandas()
-        # 7.56 μs ± 96.5 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
-        # %timeit b.to_pandas().astype(np.int64) <- astype is non-trivial
-        # 19.1 μs ± 242 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
+        # conversion methods are selected based on benchmark python/benchmarks/bench_arrow.py
         if isinstance(spark_type, ByteType):
             if arr.null_count > 0:
                 series = arr.to_pandas(types_mapper=pd.ArrowDtype).astype(pd.Int8Dtype())


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add benchmark for long type conversions


### Why are the changes needed?
to check the performance of critical code path


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
manually check for now, the ASV is not yet set up in CI

```sh
(spark-dev-313) ➜  benchmarks git:(update_benchmark_null_int) asv run --python=same --quick -b 'bench_arrow.LongArrowToPandasBenchmark'
· Discovering benchmarks
· Running 2 total benchmarks (1 commits * 1 environments * 2 benchmarks)
[ 0.00%] ·· Benchmarking existing-py_Users_ruifeng.zheng_.dev_miniconda3_envs_spark-dev-313_bin_python3.13
[25.00%] ··· bench_arrow.LongArrowToPandasBenchmark.peakmem_long_to_pandas                                                 ok
[25.00%] ··· ========= ======== ==================== ===========
             --                          method                 
             --------- -----------------------------------------
               n_rows   simple   arrow_types_mapper   pd.Series 
             ========= ======== ==================== ===========
               10000     109M           110M             111M   
               100000    117M           115M             110M   
              1000000    164M           165M             165M   
             ========= ======== ==================== ===========

[50.00%] ··· bench_arrow.LongArrowToPandasBenchmark.time_long_to_pandas                                                    ok
[50.00%] ··· ========= ========= ==================== ===========
             --                          method                  
             --------- ------------------------------------------
               n_rows    simple   arrow_types_mapper   pd.Series 
             ========= ========= ==================== ===========
               10000    131±0μs        310±0μs          162±0μs  
               100000   134±0μs        482±0μs          173±0μs  
              1000000   155±0μs        1.35±0ms         273±0μs  
             ========= ========= ==================== ===========

(spark-dev-313) ➜  benchmarks git:(update_benchmark_null_int) asv run --python=same --quick -b 'bench_arrow.NullableLongArrowToPandasBenchmark'
· Discovering benchmarks
· Running 2 total benchmarks (1 commits * 1 environments * 2 benchmarks)
[ 0.00%] ·· Benchmarking existing-py_Users_ruifeng.zheng_.dev_miniconda3_envs_spark-dev-313_bin_python3.13
[25.00%] ··· bench_arrow.NullableLongArrowToPandasBenchmark.peakmem_long_with_nulls_to_pandas_ext                          ok
[25.00%] ··· ========= ====================== ==================== ===========
             --                                 method                        
             --------- -------------------------------------------------------
               n_rows   integer_object_nulls   arrow_types_mapper   pd.Series 
             ========= ====================== ==================== ===========
               10000            110M                  110M             108M   
               100000           132M                  115M             113M   
              1000000           246M                  201M             201M   
             ========= ====================== ==================== ===========

[50.00%] ··· bench_arrow.NullableLongArrowToPandasBenchmark.time_long_with_nulls_to_pandas_ext                             ok
[50.00%] ··· ========= ====================== ==================== ===========
             --                                 method                        
             --------- -------------------------------------------------------
               n_rows   integer_object_nulls   arrow_types_mapper   pd.Series 
             ========= ====================== ==================== ===========
               10000          1.49±0ms              1.81±0ms         3.19±0ms 
               100000         13.2±0ms              12.2±0ms         30.0±0ms 
              1000000         158±0ms               123±0ms          296±0ms  
             ========= ====================== ==================== ===========
```


### Was this patch authored or co-authored using generative AI tooling?
no