### PR TITLE
[SPARK-55714][SQL] JDK might throw ArithmeticException without message

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
@@ -302,7 +302,7 @@ class CatalystTypeConvertersSuite extends SparkFunSuite with SQLHelper {
     val errMsg = intercept[ArithmeticException] {
       IntervalUtils.durationToMicros(Duration.ofSeconds(Long.MaxValue, Long.MaxValue))
     }.getMessage
-    assert(errMsg.contains("long overflow"))
+    assert(errMsg == null || errMsg.contains("overflow"))
   }
 
   test("SPARK-35726: Truncate java.time.Duration by fields of day-time interval type") {
@@ -357,7 +357,7 @@ class CatalystTypeConvertersSuite extends SparkFunSuite with SQLHelper {
     val errMsg = intercept[ArithmeticException] {
       IntervalUtils.periodToMonths(Period.of(Int.MaxValue, Int.MaxValue, Int.MaxValue))
     }.getMessage
-    assert(errMsg.contains("integer overflow"))
+    assert(errMsg == null || errMsg.contains("overflow"))
   }
 
   test("SPARK-35769: Truncate java.time.Period by fields of year-month interval type") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
@@ -119,19 +119,19 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
       checkErrorInExpression[SparkArithmeticException](
         UnaryMinus(Literal(Long.MinValue)), "ARITHMETIC_OVERFLOW",
-        Map("message" -> "long overflow", "alternative" -> "",
+        Map("message" -> "overflow", "alternative" -> "",
           "config" -> toSQLConf(SqlApiConf.ANSI_ENABLED_KEY)))
       checkErrorInExpression[SparkArithmeticException](
         UnaryMinus(Literal(Int.MinValue)), "ARITHMETIC_OVERFLOW",
-        Map("message" -> "integer overflow", "alternative" -> "",
+        Map("message" -> "overflow", "alternative" -> "",
           "config" -> toSQLConf(SqlApiConf.ANSI_ENABLED_KEY)))
       checkErrorInExpression[SparkArithmeticException](
         UnaryMinus(Literal(Short.MinValue)), "ARITHMETIC_OVERFLOW",
-        Map("message" -> "short overflow", "alternative" -> "",
+        Map("message" -> "overflow", "alternative" -> "",
           "config" -> toSQLConf(SqlApiConf.ANSI_ENABLED_KEY)))
       checkErrorInExpression[SparkArithmeticException](
         UnaryMinus(Literal(Byte.MinValue)), "ARITHMETIC_OVERFLOW",
-        Map("message" -> "byte overflow", "alternative" -> "",
+        Map("message" -> "overflow", "alternative" -> "",
           "config" -> toSQLConf(SqlApiConf.ANSI_ENABLED_KEY)))
       checkEvaluation(UnaryMinus(positiveShortLit), (- positiveShort).toShort)
       checkEvaluation(UnaryMinus(negativeShortLit), (- negativeShort).toShort)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
@@ -1307,7 +1307,7 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
             timeZoneId = Some(tz)),
           Duration.ZERO)
       }.getMessage
-      assert(errMsg.contains("overflow"))
+      assert(errMsg == null || errMsg.contains("overflow"))
 
       Seq(false, true).foreach { legacy =>
         checkConsistencyBetweenInterpretedAndCodegen(
@@ -1372,7 +1372,7 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
             timeZoneId = Some(tz)),
           Duration.ZERO)
       }.getMessage
-      assert(errMsg.contains("overflow"))
+      assert(errMsg == null || errMsg.contains("overflow"))
 
       Seq(false, true).foreach { legacy =>
         checkConsistencyBetweenInterpretedAndCodegen(
@@ -1822,7 +1822,7 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
             null)
         }.getCause
         assert(e.isInstanceOf[ArithmeticException])
-        assert(e.getMessage.contains("long overflow"))
+        assert(e.getMessage == null || e.getMessage.contains("overflow"))
 
         checkEvaluation(
           TimestampAddInterval(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
@@ -155,7 +155,7 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     check("-100 years -1 millisecond", 0.5, "-50 years -500 microseconds")
     check("2 months 4 seconds", -0.5, "-1 months -2 seconds")
     check("1 month 2 microseconds", 1.5, "1 months 3 microseconds")
-    check("2 months", Int.MaxValue, "integer overflow", Some(true))
+    check("2 months", Int.MaxValue, "overflow", Some(true))
     check("2 months", Int.MaxValue, s"${Int.MaxValue} months", Some(false))
   }
 
@@ -188,7 +188,7 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     check("1 month 3 microsecond", 1.5, "2 microseconds")
     check("1 second", 0, "Division by zero", Some(true))
     check("1 second", 0, null, Some(false))
-    check(s"${Int.MaxValue} months", 0.9, "integer overflow", Some(true))
+    check(s"${Int.MaxValue} months", 0.9, "overflow", Some(true))
     check(s"${Int.MaxValue} months", 0.9, s"${Int.MaxValue} months", Some(false))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -832,7 +832,7 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
       val msg = intercept[ArithmeticException] {
         DateTimeUtils.localDateTimeToMicros(dt)
       }.getMessage
-      assert(msg == "long overflow")
+      assert(msg == null || msg.contains("overflow"))
     }
   }
 
@@ -1445,7 +1445,7 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
       },
       condition = "ARITHMETIC_OVERFLOW",
       parameters = Map(
-        "message" -> "long overflow",
+        "message" -> "overflow",
         "alternative" -> "",
         "config" -> toSQLConf(SqlApiConf.ANSI_ENABLED_KEY))
     )

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
@@ -481,7 +481,7 @@ class IntervalUtilsSuite extends SparkFunSuite with SQLHelper {
     assert(divide(interval, 0.9) === new CalendarInterval(Int.MaxValue, Int.MaxValue,
       ((Int.MaxValue / 9.0) * MICROS_PER_DAY).round))
     val e1 = intercept[ArithmeticException](divideExact(interval, 0.9))
-    assert(e1.getMessage.contains("integer overflow"))
+    assert(e1.getMessage.contains("overflow"))
 
     interval = new CalendarInterval(123, 456, 789)
     assert(divide(interval, 0) === null)

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/int4.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/int4.sql.out
@@ -203,7 +203,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_multiply' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "integer overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -238,7 +238,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_multiply' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "integer overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -273,7 +273,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "integer overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -309,7 +309,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "integer overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -345,7 +345,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_subtract' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "integer overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -381,7 +381,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_subtract' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "integer overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/int8.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/int8.sql.out
@@ -395,7 +395,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_multiply' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -918,7 +918,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_multiply' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -958,7 +958,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_multiply' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -998,7 +998,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_multiply' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/int8.sql.out.java21
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/int8.sql.out.java21
@@ -395,7 +395,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_multiply' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -918,7 +918,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_multiply' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -958,7 +958,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_multiply' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -998,7 +998,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_multiply' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/window_part2.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/window_part2.sql.out
@@ -228,7 +228,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -251,7 +251,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/sql-udf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/sql-udf.sql.out
@@ -1111,7 +1111,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "integer overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/try_aggregates.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/try_aggregates.sql.out
@@ -157,7 +157,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -365,7 +365,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/try_aggregates.sql.out.java21
+++ b/sql/core/src/test/resources/sql-tests/results/try_aggregates.sql.out.java21
@@ -157,7 +157,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -365,7 +365,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/try_arithmetic.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/try_arithmetic.sql.out
@@ -67,7 +67,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "integer overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -91,7 +91,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -307,7 +307,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "integer overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -331,7 +331,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -505,7 +505,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "integer overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -529,7 +529,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -671,7 +671,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "integer overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -695,7 +695,7 @@ org.apache.spark.SparkArithmeticException
   "messageParameters" : {
     "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
     "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
+    "message" : "overflow"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -2656,7 +2656,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
           .select($"date" + $"interval")
           .collect()
       }
-      assert(e.getMessage.contains("integer overflow"))
+      assert(e.getMessage.contains("overflow"))
     }
   }
 
@@ -2685,7 +2685,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
           .select($"date" - $"interval")
           .collect()
       }
-      assert(e.getMessage.contains("integer overflow"))
+      assert(e.getMessage.contains("overflow"))
     }
   }
 
@@ -2723,7 +2723,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
           .collect()
       }.getCause
       assert(e.isInstanceOf[ArithmeticException])
-      assert(e.getMessage.contains("long overflow"))
+      assert(e.getMessage == null || e.getMessage.contains("overflow"))
     }
   }
 
@@ -2760,7 +2760,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
           .collect()
       }.getCause
       assert(e.isInstanceOf[ArithmeticException])
-      assert(e.getMessage.contains("long overflow"))
+      assert(e.getMessage == null || e.getMessage.contains("overflow"))
     }
   }
 
@@ -2807,7 +2807,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
             .collect()
         }.getCause
         assert(e.isInstanceOf[ArithmeticException])
-        assert(e.getMessage.contains("long overflow"))
+        assert(e.getMessage == null || e.getMessage.contains("overflow"))
       }
     }
   }
@@ -3002,7 +3002,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
           .collect()
       }.getCause
       assert(e.isInstanceOf[ArithmeticException])
-      assert(e.getMessage.contains("long overflow"))
+      assert(e.getMessage == null || e.getMessage.contains("overflow"))
     }
   }
 
@@ -3074,7 +3074,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
             .collect()
         }.getCause
         assert(e.isInstanceOf[ArithmeticException])
-        assert(e.getMessage.contains("long overflow"))
+        assert(e.getMessage == null || e.getMessage.contains("overflow"))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -708,7 +708,7 @@ class QueryExecutionErrorsSuite
       ),
       condition = "ARITHMETIC_OVERFLOW",
       parameters = Map(
-        "message" -> "integer overflow",
+        "message" -> "overflow",
         "alternative" -> "",
         "config" -> s""""${SQLConf.ANSI_ENABLED.key}""""))
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Canonicalize the error message of `SparkArithmeticException`:
- null => "overflow"
- "byte overflow", "long overflow", etc., to "overflow".
- leave others as-is.

Update tests to accept null message from `ArithmeticException`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

During test, I found JDK 25 might throw `ArithmeticException` with `null` message, and it varies on different platforms / CPU models, for example, it's different on Apple M1 and x86 Server, and even different on Intel Skylake and AMD Zen4 (both are x86 but with different instructions support)

https://bugs.openjdk.org/browse/JDK-8367990

> This is expected behavior. For "hot throws", the JIT will produce compiled code that does not go through the interpreter via deoptimization to throw an exception but throws a pre-allocated exception object without a stack trace or message. ... this optimization can be disabled with -XX:-OmitStackTraceInFastThrow.

In other words, the error message is not something in the API contract.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Some `ARITHMETIC_OVERFLOW` error condition message changes from "byte overflow", "long overflow", etc., to "overflow".

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass GHA for JDK 17. JDK 25 will be covered by daily tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No, the patch is crafted by hand.