### PR TITLE
[SPARK-55717][BUILD] Use Google Mirror of Maven Central in MavenUtils

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/MavenUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/MavenUtils.scala
@@ -180,8 +180,9 @@ private[spark] object MavenUtils extends Logging {
     br.setM2compatible(true)
     br.setUsepoms(true)
     val defaultInternalRepo: Option[String] = sys.env.get("DEFAULT_ARTIFACT_REPOSITORY")
-    br.setRoot(defaultInternalRepo.getOrElse("https://repo1.maven.org/maven2/"))
-    br.setName("central")
+    br.setRoot(defaultInternalRepo.getOrElse(
+      "https://maven-central.storage-download.googleapis.com/maven2/"))
+    br.setName("gcs-maven-central-mirror")
     cr.add(br)
 
     val sp: IBiblioResolver = new IBiblioResolver


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the default Maven Central URL in `MavenUtils.scala` from `repo1.maven.org` to Google's Maven Central mirror (`maven-central.storage-download.googleapis.com`).

### Why are the changes needed?

Follow-up of SPARK-55710 / #54508 (suggested by @sarutak). The SBT build already uses the Google mirror as the primary resolver. `MavenUtils` was still defaulting to `repo1.maven.org` for runtime dependency resolution (e.g., `--packages`). This makes it consistent.

The `DEFAULT_ARTIFACT_REPOSITORY` environment variable can still be used to override this.

### Does this PR introduce _any_ user-facing change?

Yes. The default repository URL for `--packages` resolution changes from Maven Central to its Google mirror. Users can override via `DEFAULT_ARTIFACT_REPOSITORY`.

### How was this patch tested?

Existing tests. The change is a URL swap for the same Maven Central content.

### Was this patch authored or co-authored using generative AI tooling?

Yes, GitHub Copilot CLI was used.