### PR TITLE
[SPARK-55691][CONNECT] GetStatus client

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1975,7 +1975,7 @@ class SparkConnectClient(object):
         try:
             for attempt in self._retrying():
                 with attempt:
-                    resp = self._stub.GetStatus(req, metadata=self.metadata())
+                    resp = self._stub.GetStatus(req, metadata=self._builder.metadata())
                     self._verify_response_integrity(resp)
                     return resp
             raise SparkConnectException("Invalid state during retry exception handling.")
@@ -2221,6 +2221,7 @@ class SparkConnectClient(object):
             pb2.AnalyzePlanResponse,
             pb2.FetchErrorDetailsResponse,
             pb2.ReleaseSessionResponse,
+            pb2.GetStatusResponse,
         ],
     ) -> None:
         """

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
@@ -560,19 +560,15 @@ class SparkConnectClientSuite extends ConnectFunSuite {
       client.getOperationStatuses(Seq("default-op-1", "unknown-op"))
     val statuses = response.getOperationStatusesList.asScala.toSeq
     assert(statuses.size == 2)
-    assert(
-      statuses.map(_.getOperationId).toSet == Set("default-op-1", "unknown-op")
-    )
+    assert(statuses.map(_.getOperationId).toSet == Set("default-op-1", "unknown-op"))
 
     val statusMap = statuses.map(s => s.getOperationId -> s.getState).toMap
     assert(
       statusMap("default-op-1") ==
-        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_SUCCEEDED
-    )
+        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_SUCCEEDED)
     assert(
       statusMap("unknown-op") ==
-        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_UNKNOWN
-    )
+        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_UNKNOWN)
   }
 
   test("getOperationStatuses with no IDs returns all operations from server") {
@@ -585,22 +581,15 @@ class SparkConnectClientSuite extends ConnectFunSuite {
     val response = client.getOperationStatuses()
     val statuses = response.getOperationStatusesList.asScala.toSeq
     assert(statuses.size == 2)
-    assert(
-      statuses.map(_.getOperationId).toSet == Set(
-        "default-op-1",
-        "default-op-2"
-      )
-    )
+    assert(statuses.map(_.getOperationId).toSet == Set("default-op-1", "default-op-2"))
 
     val statusMap = statuses.map(s => s.getOperationId -> s.getState).toMap
     assert(
       statusMap("default-op-1") ==
-        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_SUCCEEDED
-    )
+        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_SUCCEEDED)
     assert(
       statusMap("default-op-2") ==
-        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_RUNNING
-    )
+        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_RUNNING)
   }
 
   test("getOperationStatuses sends extensions and returns them per operation") {
@@ -614,8 +603,7 @@ class SparkConnectClientSuite extends ConnectFunSuite {
 
     val response = client.getOperationStatuses(
       operationIds = Seq("default-op-1", "default-op-2"),
-      operationExtensions = Seq(extension)
-    )
+      operationExtensions = Seq(extension))
 
     // Verify operation statuses are returned
     val statuses = response.getOperationStatusesList.asScala.toSeq
@@ -624,12 +612,10 @@ class SparkConnectClientSuite extends ConnectFunSuite {
     val statusMap = statuses.map(s => s.getOperationId -> s).toMap
     assert(
       statusMap("default-op-1").getState ==
-        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_SUCCEEDED
-    )
+        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_SUCCEEDED)
     assert(
       statusMap("default-op-2").getState ==
-        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_RUNNING
-    )
+        proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_RUNNING)
 
     // Verify that extensions are echoed back per operation
     statuses.foreach { status =>
@@ -639,14 +625,11 @@ class SparkConnectClientSuite extends ConnectFunSuite {
       assert(
         opExtensions.head
           .unpack(classOf[StringValue])
-          .getValue == "custom_extension"
-      )
+          .getValue == "custom_extension")
     }
   }
 
-  test(
-    "getOperationStatuses sends request-level extensions and echoes them in the response"
-  ) {
+  test("getOperationStatuses sends request-level extensions and echoes them in the response") {
     startDummyServer(0)
     client = SparkConnectClient
       .builder()
@@ -657,8 +640,7 @@ class SparkConnectClientSuite extends ConnectFunSuite {
 
     val response = client.getOperationStatuses(
       operationIds = Seq("default-op-1"),
-      requestExtensions = Seq(reqExtension)
-    )
+      requestExtensions = Seq(reqExtension))
 
     // Verify the operation status is returned
     val statuses = response.getOperationStatusesList.asScala.toSeq
@@ -672,8 +654,7 @@ class SparkConnectClientSuite extends ConnectFunSuite {
     assert(
       responseExtensions.head
         .unpack(classOf[StringValue])
-        .getValue == "request_extension"
-    )
+        .getValue == "request_extension")
   }
 
   test("client can set a custom operation id for ExecutePlan requests") {
@@ -1057,18 +1038,15 @@ class DummySparkConnectService() extends SparkConnectServiceGrpc.SparkConnectSer
   }
 
   // Default operations stored in the mock session
-  private val default_operation_statuses = Map(
+  private val defaultOperationStatuses = Map(
     "default-op-1" ->
       proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_SUCCEEDED,
     "default-op-2" ->
-      proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_RUNNING
-  )
+      proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_RUNNING)
 
   override def getStatus(
       request: proto.GetStatusRequest,
-      responseObserver: StreamObserver[proto.GetStatusResponse]
-  ): Unit = {
-    addUserContextExtensions(request.getUserContext)
+      responseObserver: StreamObserver[proto.GetStatusResponse]): Unit = {
     val responseBuilder = proto.GetStatusResponse
       .newBuilder()
       .setSessionId(request.getSessionId)
@@ -1082,7 +1060,7 @@ class DummySparkConnectService() extends SparkConnectServiceGrpc.SparkConnectSer
 
       if (requestedIds.isEmpty) {
         // No specific IDs requested - return all default operations
-        defaultOperations.foreach { case (opId, state) =>
+        defaultOperationStatuses.foreach { case (opId, state) =>
           val statusBuilder = proto.GetStatusResponse.OperationStatus
             .newBuilder()
             .setOperationId(opId)
@@ -1094,10 +1072,9 @@ class DummySparkConnectService() extends SparkConnectServiceGrpc.SparkConnectSer
         // Return status for each requested operation ID
         // Unknown operations return OPERATION_STATE_UNKNOWN
         requestedIds.foreach { opId =>
-          val state = defaultOperations.getOrElse(
+          val state = defaultOperationStatuses.getOrElse(
             opId,
-            proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_UNKNOWN
-          )
+            proto.GetStatusResponse.OperationStatus.OperationState.OPERATION_STATE_UNKNOWN)
           val statusBuilder = proto.GetStatusResponse.OperationStatus
             .newBuilder()
             .setOperationId(opId)

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectBlockingStub.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectBlockingStub.scala
@@ -145,4 +145,17 @@ private[connect] class CustomSparkConnectBlockingStub(
       }
     }
   }
+
+  def getStatus(request: GetStatusRequest): GetStatusResponse = {
+    grpcExceptionConverter.convert(
+      request.getSessionId,
+      request.getUserContext,
+      request.getClientType) {
+      retryHandler.retry {
+        stubState.responseValidator.verifyResponse {
+          stub.getStatus(request)
+        }
+      }
+    }
+  }
 }

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -514,14 +514,14 @@ private[sql] class SparkConnectClient(
       operationIds: Seq[String] = Seq.empty,
       operationExtensions: Seq[protobuf.Any] = Seq.empty,
       requestExtensions: Seq[protobuf.Any] = Seq.empty): proto.GetStatusResponse = {
-    val requestBuilder = proto.GetStatusRequest.newBuilder()
+    val requestBuilder = proto.GetStatusRequest
+      .newBuilder()
       .setUserContext(userContext)
       .setSessionId(sessionId)
       .setClientType(userAgent)
 
     serverSideSessionId.foreach(session =>
-      requestBuilder.setClientObservedServerSideSessionId(session)
-    )
+      requestBuilder.setClientObservedServerSideSessionId(session))
 
     val opStatusRequest = proto.GetStatusRequest.OperationStatusRequest.newBuilder()
     operationIds.foreach(opStatusRequest.addOperationIds)

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/GetStatusHandlerE2ESuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/GetStatusHandlerE2ESuite.scala
@@ -18,6 +18,8 @@ package org.apache.spark.sql.connect.service
 
 import java.util.UUID
 
+import scala.jdk.CollectionConverters._
+
 import org.scalatest.concurrent.Eventually
 
 import org.apache.spark.{SparkException, SparkRuntimeException}
@@ -44,7 +46,8 @@ class GetStatusHandlerE2ESuite extends SparkConnectServerTest {
         )
       }
 
-      val runningStatuses = client.getOperationStatuses(Seq(operationId))
+      val runningStatuses =
+        client.getOperationStatuses(Seq(operationId)).getOperationStatusesList.asScala
       assert(runningStatuses.size == 1)
       assert(
         runningStatuses.head.getState == OperationState.OPERATION_STATE_RUNNING
@@ -55,7 +58,8 @@ class GetStatusHandlerE2ESuite extends SparkConnectServerTest {
 
       // Use eventually to skip the intermediate TERMINATING status
       Eventually.eventually(timeout(eventuallyTimeout)) {
-        val succeededStatuses = client.getOperationStatuses(Seq(operationId))
+        val succeededStatuses =
+          client.getOperationStatuses(Seq(operationId)).getOperationStatusesList.asScala
         assert(succeededStatuses.size == 1)
         assert(
           succeededStatuses.head.getState == OperationState.OPERATION_STATE_SUCCEEDED
@@ -80,7 +84,8 @@ class GetStatusHandlerE2ESuite extends SparkConnectServerTest {
         )
       }
 
-      val runningStatuses = client.getOperationStatuses(Seq(operationId))
+      val runningStatuses =
+        client.getOperationStatuses(Seq(operationId)).getOperationStatusesList.asScala
       assert(runningStatuses.size == 1)
       assert(
         runningStatuses.head.getState == OperationState.OPERATION_STATE_RUNNING
@@ -96,7 +101,8 @@ class GetStatusHandlerE2ESuite extends SparkConnectServerTest {
 
       // Use eventually to skip the intermediate TERMINATING status
       Eventually.eventually(timeout(eventuallyTimeout)) {
-        val cancelledStatuses = client.getOperationStatuses(Seq(operationId))
+        val cancelledStatuses =
+          client.getOperationStatuses(Seq(operationId)).getOperationStatusesList.asScala
         assert(cancelledStatuses.size == 1)
         assert(
           cancelledStatuses.head.getState == OperationState.OPERATION_STATE_CANCELLED
@@ -130,7 +136,8 @@ class GetStatusHandlerE2ESuite extends SparkConnectServerTest {
 
       // Use eventually to skip the intermediate TERMINATING status
       Eventually.eventually(timeout(eventuallyTimeout)) {
-        val statuses = client.getOperationStatuses(Seq(operationId))
+        val statuses =
+          client.getOperationStatuses(Seq(operationId)).getOperationStatusesList.asScala
         assert(statuses.size == 1)
         assert(statuses.head.getOperationId == operationId)
         assert(statuses.head.getState == OperationState.OPERATION_STATE_FAILED)
@@ -147,7 +154,8 @@ class GetStatusHandlerE2ESuite extends SparkConnectServerTest {
 
       // Query for a random operation ID that was never created
       val nonExistentOperationId = UUID.randomUUID().toString
-      val statuses = client.getOperationStatuses(Seq(nonExistentOperationId))
+      val statuses =
+        client.getOperationStatuses(Seq(nonExistentOperationId)).getOperationStatusesList.asScala
       assert(statuses.size == 1)
       assert(statuses.head.getOperationId == nonExistentOperationId)
       assert(statuses.head.getState == OperationState.OPERATION_STATE_UNKNOWN)
@@ -183,7 +191,7 @@ class GetStatusHandlerE2ESuite extends SparkConnectServerTest {
       // the active map and the inactive operations cache being updated with the final
       // Closed status.
       Eventually.eventually(timeout(eventuallyTimeout)) {
-        val statuses = client.getOperationStatuses()
+        val statuses = client.getOperationStatuses().getOperationStatusesList.asScala
         val operationIdToStatus = statuses.map(s => s.getOperationId -> s.getState).toMap
 
         assert(statuses.size == 2)

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/GetStatusHandlerE2ESuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/GetStatusHandlerE2ESuite.scala
@@ -27,31 +27,22 @@ import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.GetStatusResponse.OperationStatus.OperationState
 import org.apache.spark.sql.connect.SparkConnectServerTest
 
-
 class GetStatusHandlerE2ESuite extends SparkConnectServerTest {
 
-  test(
-    "GetStatus tracks operation through lifecycle: RUNNING -> SUCCEEDED"
-  ) {
+  test("GetStatus tracks operation through lifecycle: RUNNING -> SUCCEEDED") {
     withClient { client =>
-      val plan = buildPlan(
-        "SELECT java_method('java.lang.Thread', 'sleep', 2000L) as value"
-      )
+      val plan = buildPlan("SELECT java_method('java.lang.Thread', 'sleep', 2000L) as value")
       val iter = client.execute(plan)
       val operationId = iter.next().getOperationId
 
       Eventually.eventually(timeout(eventuallyTimeout)) {
-        assert(
-          SparkConnectService.executionManager.listExecuteHolders.length == 1
-        )
+        assert(SparkConnectService.executionManager.listExecuteHolders.length == 1)
       }
 
       val runningStatuses =
         client.getOperationStatuses(Seq(operationId)).getOperationStatusesList.asScala
       assert(runningStatuses.size == 1)
-      assert(
-        runningStatuses.head.getState == OperationState.OPERATION_STATE_RUNNING
-      )
+      assert(runningStatuses.head.getState == OperationState.OPERATION_STATE_RUNNING)
 
       while (iter.hasNext) iter.next()
       assertEventuallyExecutionReleased(operationId)
@@ -61,35 +52,25 @@ class GetStatusHandlerE2ESuite extends SparkConnectServerTest {
         val succeededStatuses =
           client.getOperationStatuses(Seq(operationId)).getOperationStatusesList.asScala
         assert(succeededStatuses.size == 1)
-        assert(
-          succeededStatuses.head.getState == OperationState.OPERATION_STATE_SUCCEEDED
-        )
+        assert(succeededStatuses.head.getState == OperationState.OPERATION_STATE_SUCCEEDED)
       }
     }
   }
 
-  test(
-    "GetStatus tracks operation through lifecycle: RUNNING -> CANCELLED"
-  ) {
+  test("GetStatus tracks operation through lifecycle: RUNNING -> CANCELLED") {
     withClient { client =>
-      val plan = buildPlan(
-        "SELECT java_method('java.lang.Thread', 'sleep', 3000L) as value"
-      )
+      val plan = buildPlan("SELECT java_method('java.lang.Thread', 'sleep', 3000L) as value")
       val iter = client.execute(plan)
       val operationId = iter.next().getOperationId
 
       Eventually.eventually(timeout(eventuallyTimeout)) {
-        assert(
-          SparkConnectService.executionManager.listExecuteHolders.length == 1
-        )
+        assert(SparkConnectService.executionManager.listExecuteHolders.length == 1)
       }
 
       val runningStatuses =
         client.getOperationStatuses(Seq(operationId)).getOperationStatusesList.asScala
       assert(runningStatuses.size == 1)
-      assert(
-        runningStatuses.head.getState == OperationState.OPERATION_STATE_RUNNING
-      )
+      assert(runningStatuses.head.getState == OperationState.OPERATION_STATE_RUNNING)
 
       client.interruptOperation(operationId)
 
@@ -104,9 +85,7 @@ class GetStatusHandlerE2ESuite extends SparkConnectServerTest {
         val cancelledStatuses =
           client.getOperationStatuses(Seq(operationId)).getOperationStatusesList.asScala
         assert(cancelledStatuses.size == 1)
-        assert(
-          cancelledStatuses.head.getState == OperationState.OPERATION_STATE_CANCELLED
-        )
+        assert(cancelledStatuses.head.getState == OperationState.OPERATION_STATE_CANCELLED)
       }
     }
   }

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/GetStatusHandlerE2ESuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/GetStatusHandlerE2ESuite.scala
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.connect.service
+
+import java.util.UUID
+
+import org.scalatest.concurrent.Eventually
+
+import org.apache.spark.{SparkException, SparkRuntimeException}
+import org.apache.spark.connect.proto
+import org.apache.spark.connect.proto.GetStatusResponse.OperationStatus.OperationState
+import org.apache.spark.sql.connect.SparkConnectServerTest
+
+
+class GetStatusHandlerE2ESuite extends SparkConnectServerTest {
+
+  test(
+    "GetStatus tracks operation through lifecycle: RUNNING -> SUCCEEDED"
+  ) {
+    withClient { client =>
+      val plan = buildPlan(
+        "SELECT java_method('java.lang.Thread', 'sleep', 2000L) as value"
+      )
+      val iter = client.execute(plan)
+      val operationId = iter.next().getOperationId
+
+      Eventually.eventually(timeout(eventuallyTimeout)) {
+        assert(
+          SparkConnectService.executionManager.listExecuteHolders.length == 1
+        )
+      }
+
+      val runningStatuses = client.getOperationStatuses(Seq(operationId))
+      assert(runningStatuses.size == 1)
+      assert(
+        runningStatuses.head.getState == OperationState.OPERATION_STATE_RUNNING
+      )
+
+      while (iter.hasNext) iter.next()
+      assertEventuallyExecutionReleased(operationId)
+
+      // Use eventually to skip the intermediate TERMINATING status
+      Eventually.eventually(timeout(eventuallyTimeout)) {
+        val succeededStatuses = client.getOperationStatuses(Seq(operationId))
+        assert(succeededStatuses.size == 1)
+        assert(
+          succeededStatuses.head.getState == OperationState.OPERATION_STATE_SUCCEEDED
+        )
+      }
+    }
+  }
+
+  test(
+    "GetStatus tracks operation through lifecycle: RUNNING -> CANCELLED"
+  ) {
+    withClient { client =>
+      val plan = buildPlan(
+        "SELECT java_method('java.lang.Thread', 'sleep', 3000L) as value"
+      )
+      val iter = client.execute(plan)
+      val operationId = iter.next().getOperationId
+
+      Eventually.eventually(timeout(eventuallyTimeout)) {
+        assert(
+          SparkConnectService.executionManager.listExecuteHolders.length == 1
+        )
+      }
+
+      val runningStatuses = client.getOperationStatuses(Seq(operationId))
+      assert(runningStatuses.size == 1)
+      assert(
+        runningStatuses.head.getState == OperationState.OPERATION_STATE_RUNNING
+      )
+
+      client.interruptOperation(operationId)
+
+      intercept[SparkException] {
+        while (iter.hasNext) iter.next()
+      }
+
+      assertEventuallyExecutionReleased(operationId)
+
+      // Use eventually to skip the intermediate TERMINATING status
+      Eventually.eventually(timeout(eventuallyTimeout)) {
+        val cancelledStatuses = client.getOperationStatuses(Seq(operationId))
+        assert(cancelledStatuses.size == 1)
+        assert(
+          cancelledStatuses.head.getState == OperationState.OPERATION_STATE_CANCELLED
+        )
+      }
+    }
+  }
+
+  test("GetStatus returns FAILED for query with error") {
+    withClient { client =>
+      // Use assert_true with a dynamic condition to trigger a runtime failure
+      val plan = buildPlan("SELECT assert_true(id < 0) FROM range(1)")
+      val iter = client.execute(plan)
+      val operationId = iter.next().getOperationId
+
+      // Wait for the execution thread to finish before consuming the error from
+      // the iterator. This prevents a race where consuming the error triggers the
+      // client's ReleaseExecute, and removeExecuteHolder interrupts the execution
+      // thread while it's still in its finally block, which would override the
+      // termination reason from Failed to Canceled.
+      val holder = eventuallyGetExecutionHolderForOperation(operationId)
+      Eventually.eventually(timeout(eventuallyTimeout)) {
+        assert(!holder.isExecuteThreadRunnerAlive())
+      }
+
+      intercept[SparkRuntimeException] {
+        while (iter.hasNext) iter.next()
+      }
+
+      assertEventuallyExecutionReleased(operationId)
+
+      // Use eventually to skip the intermediate TERMINATING status
+      Eventually.eventually(timeout(eventuallyTimeout)) {
+        val statuses = client.getOperationStatuses(Seq(operationId))
+        assert(statuses.size == 1)
+        assert(statuses.head.getOperationId == operationId)
+        assert(statuses.head.getState == OperationState.OPERATION_STATE_FAILED)
+      }
+    }
+  }
+
+  test("GetStatus returns UNKNOWN for non-existent operation") {
+    withClient { client =>
+      // Execute a simple query first to establish the session on the server
+      val plan = buildPlan("SELECT 1")
+      val iter = client.execute(plan)
+      while (iter.hasNext) iter.next()
+
+      // Query for a random operation ID that was never created
+      val nonExistentOperationId = UUID.randomUUID().toString
+      val statuses = client.getOperationStatuses(Seq(nonExistentOperationId))
+      assert(statuses.size == 1)
+      assert(statuses.head.getOperationId == nonExistentOperationId)
+      assert(statuses.head.getState == OperationState.OPERATION_STATE_UNKNOWN)
+    }
+  }
+
+  test("GetStatus returns all operation statuses when no IDs specified") {
+    withClient { client =>
+      val plan1 = buildPlan("SELECT 1 as first_value")
+      val iter1 = client.execute(plan1)
+      val operationId1 = iter1.next().getOperationId
+      while (iter1.hasNext) iter1.next()
+      assertEventuallyExecutionReleased(operationId1)
+
+      val plan2 = buildPlan("SELECT assert_true(id < 0) FROM range(1)")
+      val iter2 = client.execute(plan2)
+      val operationId2 = iter2.next().getOperationId
+
+      // Wait for the execution thread to finish before consuming the error.
+      // Same race condition as in the FAILED test above.
+      val holder2 = eventuallyGetExecutionHolderForOperation(operationId2)
+      Eventually.eventually(timeout(eventuallyTimeout)) {
+        assert(!holder2.isExecuteThreadRunnerAlive())
+      }
+
+      intercept[SparkRuntimeException] {
+        while (iter2.hasNext) iter2.next()
+      }
+
+      assertEventuallyExecutionReleased(operationId2)
+
+      // Use eventually because there is a race between executions being removed from
+      // the active map and the inactive operations cache being updated with the final
+      // Closed status.
+      Eventually.eventually(timeout(eventuallyTimeout)) {
+        val statuses = client.getOperationStatuses()
+        val operationIdToStatus = statuses.map(s => s.getOperationId -> s.getState).toMap
+
+        assert(statuses.size == 2)
+        assert(operationIdToStatus(operationId1) == OperationState.OPERATION_STATE_SUCCEEDED)
+        assert(operationIdToStatus(operationId2) == OperationState.OPERATION_STATE_FAILED)
+      }
+    }
+  }
+
+  test("GetStatus returns session info even when no operation status is requested") {
+    // This test needs raw stub to send a request without operation_status field
+    withRawBlockingStub { stub =>
+      val plan = buildPlan("SELECT 1")
+      val executeRequest = buildExecutePlanRequest(plan)
+      val sessionId = executeRequest.getSessionId
+      val operationId = executeRequest.getOperationId
+
+      val iter = stub.executePlan(executeRequest)
+      while (iter.hasNext) iter.next()
+
+      val releaseRequest = proto.ReleaseExecuteRequest
+        .newBuilder()
+        .setUserContext(userContext)
+        .setSessionId(sessionId)
+        .setOperationId(operationId)
+        .setReleaseAll(proto.ReleaseExecuteRequest.ReleaseAll.newBuilder().build())
+        .build()
+      stub.releaseExecute(releaseRequest)
+      assertEventuallyExecutionReleased(operationId)
+
+      val statusRequest = proto.GetStatusRequest
+        .newBuilder()
+        .setUserContext(userContext)
+        .setSessionId(sessionId)
+        .build()
+
+      val response = stub.getStatus(statusRequest)
+
+      assert(response.getSessionId == sessionId)
+      assert(response.getServerSideSessionId.nonEmpty)
+      assert(response.getOperationStatusesList.isEmpty)
+    }
+  }
+}

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/GetStatusHandlerE2ESuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/GetStatusHandlerE2ESuite.scala
@@ -166,9 +166,7 @@ class GetStatusHandlerE2ESuite extends SparkConnectServerTest {
 
       assertEventuallyExecutionReleased(operationId2)
 
-      // Use eventually because there is a race between executions being removed from
-      // the active map and the inactive operations cache being updated with the final
-      // Closed status.
+      // Use eventually to skip the intermediate TERMINATING status
       Eventually.eventually(timeout(eventuallyTimeout)) {
         val statuses = client.getOperationStatuses().getOperationStatusesList.asScala
         val operationIdToStatus = statuses.map(s => s.getOperationId -> s.getState).toMap
@@ -183,6 +181,7 @@ class GetStatusHandlerE2ESuite extends SparkConnectServerTest {
   test("GetStatus returns session info even when no operation status is requested") {
     // This test needs raw stub to send a request without operation_status field
     withRawBlockingStub { stub =>
+      // Execute a simple query to establish the session on the server.
       val plan = buildPlan("SELECT 1")
       val executeRequest = buildExecutePlanRequest(plan)
       val sessionId = executeRequest.getSessionId


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Client-side implementation of the GetStatus API:
- Add client methods for requesting operation statuses.
  - GetStatus API is designed to support other request types that operation statuses in future. For those types, new methods will have to be created. This is a tradeoff between convenient client methods which encapsulate the most of the request building and flexibility.
- Mark the client methods as Experimental and underscored for now, until enough confidence in the API stability is built.
- Add client tests with mocked service.
- Add E2E tests with real operation lifecycles. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

GetStatus API allows to monitor status of executions in a session, which is particularly useful in multithreaded clients.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. It's a new Spark Connect API.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

- Add client tests with mocked service.
- Add E2E tests with real operation lifecycles, which also test server-side changes. 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Generated-by: Claude 4.6 Opus High