### PR TITLE
[SPARK-55661][CORE] Ensure TaskRunner.run() sends StatusUpdate on setup failures

### DIFF
--- a/core/src/test/scala/org/apache/spark/executor/ExecutorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/ExecutorSuite.scala
@@ -780,7 +780,7 @@ class ExecutorSuite extends SparkFunSuite
       when(env.closureSerializer).thenReturn(mockClosureSerializer)
 
       executor.killMarks.put(taskDescription.taskId,
-        (true, "AQE stage cancellation", System.currentTimeMillis()))
+        (true, "stage cancelled", System.currentTimeMillis()))
 
       executor.launchTask(mockExecutorBackend, taskDescription)
 
@@ -797,7 +797,7 @@ class ExecutorSuite extends SparkFunSuite
       val failureData = statusCaptor.getValue
       val failReason = serializer.newInstance()
         .deserialize[TaskKilled](failureData)
-      assert(failReason.reason === "AQE stage cancellation")
+      assert(failReason.reason === "stage cancelled")
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/executor/ExecutorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/ExecutorSuite.scala
@@ -722,6 +722,85 @@ class ExecutorSuite extends SparkFunSuite
     }
   }
 
+  test("SPARK-55661: TaskRunner.run() setup failure should send StatusUpdate " +
+    "to prevent driver resource leak") {
+    val conf = new SparkConf
+    val serializer = new JavaSerializer(conf)
+    val env = createMockEnv(conf, serializer)
+    val serializedTask = serializer.newInstance().serialize(new FakeTask(0, 0))
+    val taskDescription = createFakeTaskDescription(serializedTask)
+
+    val mockExecutorBackend = mock[ExecutorBackend]
+    val statusCaptor = ArgumentCaptor.forClass(classOf[ByteBuffer])
+
+    withExecutor("id", "localhost", env) { executor =>
+      val mockClosureSerializer = mock[JavaSerializer]
+      when(mockClosureSerializer.newInstance())
+        .thenThrow(new RuntimeException("simulated setup failure in TaskRunner"))
+        .thenReturn(serializer.newInstance())
+      when(env.closureSerializer).thenReturn(mockClosureSerializer)
+
+      executor.launchTask(mockExecutorBackend, taskDescription)
+
+      eventually(timeout(5.seconds), interval(10.milliseconds)) {
+        assert(executor.numRunningTasks === 0)
+      }
+
+      verify(mockExecutorBackend).statusUpdate(
+        meq(0L),
+        meq(TaskState.FAILED),
+        statusCaptor.capture()
+      )
+
+      val failureData = statusCaptor.getValue
+      val failReason = serializer.newInstance()
+        .deserialize[ExceptionFailure](failureData)
+      assert(failReason.exception.isDefined)
+      assert(failReason.exception.get.getMessage ===
+        "simulated setup failure in TaskRunner")
+    }
+  }
+
+  test("SPARK-55661: TaskRunner.run() setup failure on killed task should send " +
+    "StatusUpdate(KILLED) to prevent driver resource leak") {
+    val conf = new SparkConf
+    val serializer = new JavaSerializer(conf)
+    val env = createMockEnv(conf, serializer)
+    val serializedTask = serializer.newInstance().serialize(new FakeTask(0, 0))
+    val taskDescription = createFakeTaskDescription(serializedTask)
+
+    val mockExecutorBackend = mock[ExecutorBackend]
+    val statusCaptor = ArgumentCaptor.forClass(classOf[ByteBuffer])
+
+    withExecutor("id", "localhost", env) { executor =>
+      val mockClosureSerializer = mock[JavaSerializer]
+      when(mockClosureSerializer.newInstance())
+        .thenThrow(new RuntimeException("simulated setup failure in TaskRunner"))
+        .thenReturn(serializer.newInstance())
+      when(env.closureSerializer).thenReturn(mockClosureSerializer)
+
+      executor.killMarks.put(taskDescription.taskId,
+        (true, "AQE stage cancellation", System.currentTimeMillis()))
+
+      executor.launchTask(mockExecutorBackend, taskDescription)
+
+      eventually(timeout(5.seconds), interval(10.milliseconds)) {
+        assert(executor.numRunningTasks === 0)
+      }
+
+      verify(mockExecutorBackend).statusUpdate(
+        meq(0L),
+        meq(TaskState.KILLED),
+        statusCaptor.capture()
+      )
+
+      val failureData = statusCaptor.getValue
+      val failReason = serializer.newInstance()
+        .deserialize[TaskKilled](failureData)
+      assert(failReason.reason === "AQE stage cancellation")
+    }
+  }
+
   private def createMockEnv(conf: SparkConf, serializer: JavaSerializer): SparkEnv = {
     val mockEnv = mock[SparkEnv]
     val mockRpcEnv = mock[RpcEnv]


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Move `TaskRunner.run()` setup code (classloader isolation, thread naming, serializer creation) inside the existing `try/catch/finally` block so that exceptions during setup are caught and reported to the driver via `StatusUpdate`.

- Changed `val isolatedSession` to `var isolatedSession: IsolatedSessionState = defaultSessionState` (declared before `try` with safe default so `finally` can access it for cleanup)
- Changed `val ser` to `var ser: SerializerInstance = null` (declared before `try` so `catch` can check whether setup completed)
- Moved all setup code inside the existing `try` block
- Added a setup-failure branch in the catch-all `case t: Throwable` handler: when `ser == null` (serializer was never created), sends `StatusUpdate(FAILED)` or `StatusUpdate(KILLED)` so the driver releases resources

Closes: https://issues.apache.org/jira/browse/SPARK-55661



### Why are the changes needed?


Previously, setup code (lines 806-833) ran **outside** the try block. If any setup line threw an exception (e.g., `InterruptedException` from a concurrent AQE stage cancellation), execution jumped out of `run()` entirely and no `StatusUpdate` was sent to the driver, `runningTasks` was never cleaned up, and allocated resources (GPU/CPU) were leaked on the driver side.

### Does this PR introduce _any_ user-facing change?
No. This is an internal bug fix


### How was this patch tested?
Two new unit tests added to `ExecutorSuite`:

1. **`SPARK-55661: TaskRunner.run() setup failure should send StatusUpdate to prevent driver resource leak`**  Mocks `env.closureSerializer.newInstance()` to throw during setup, verifies that `StatusUpdate(FAILED)` is sent with the correct `ExceptionFailure` reason, and that `runningTasks` is cleaned up.

2. **`SPARK-55661: TaskRunner.run() setup failure on killed task should send StatusUpdate(KILLED) to prevent driver resource leak`**  Same as above, but pre-sets a `killMark` (simulating an AQE cancellation arriving before `run()` starts)


### Was this patch authored or co-authored using generative AI tooling?
Yes, Generated-by: Cursor 2.5.17 