### PR TITLE
[SPARK-55721][INFRA] Group sbt build messages in github actions

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -82,11 +82,11 @@ def set_title_and_block(title, err_block):
 @contextmanager
 def group_in_github_actions(title):
     if "GITHUB_ACTIONS" in os.environ:
-        print(f"::group::{title}", flush=True)
+        print(f"\n::group::{title}", flush=True)
         try:
             yield
         finally:
-            print("::endgroup::", flush=True)
+            print("\n::endgroup::", flush=True)
     else:
         yield
 

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -82,11 +82,11 @@ def set_title_and_block(title, err_block):
 @contextmanager
 def group_in_github_actions(title):
     if "GITHUB_ACTIONS" in os.environ:
-        print(f"::group::{title}")
+        print(f"::group::{title}", flush=True)
         try:
             yield
         finally:
-            print("::endgroup::")
+            print("::endgroup::", flush=True)
     else:
         yield
 
@@ -406,6 +406,9 @@ def run_python_tests(test_modules, test_pythons, parallelism, with_coverage=Fals
     command.append("--parallelism=%i" % parallelism)
     command.append("--python-executables=%s" % test_pythons)
     run_cmd(command)
+    print("::group::test", flush=True)
+    print("hello world", flush=True)
+    print("::endgroup::", flush=True)
 
 
 def run_python_packaging_tests():

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -293,7 +293,6 @@ def build_spark_assembly_sbt(extra_profiles, checkstyle=False):
     build_profiles = extra_profiles + modules.root.build_profile_flags
     sbt_goals = ["assembly/package"]
     profiles_and_goals = build_profiles + sbt_goals
-
     print(
         "[info] Building Spark assembly using SBT with these arguments: ",
         " ".join(profiles_and_goals),

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -23,6 +23,7 @@ import os
 import re
 import sys
 import subprocess
+from contextlib import contextmanager
 
 from sparktestsupport import SPARK_HOME, USER_HOME, ERROR_CODES
 from sparktestsupport.shellutils import exit_from_command_with_retcode, run_cmd, rm_r, which
@@ -76,6 +77,18 @@ def set_title_and_block(title, err_block):
     print(line_str)
     print(title)
     print(line_str)
+
+
+@contextmanager
+def group_in_github_actions(title):
+    if "GITHUB_ACTIONS" in os.environ:
+        print(f"::group::{title}")
+        try:
+            yield
+        finally:
+            print("::endgroup::")
+    else:
+        yield
 
 
 def run_apache_rat_checks():
@@ -255,7 +268,8 @@ def build_spark_sbt(extra_profiles):
 
     print("[info] Building Spark using SBT with these arguments: ", " ".join(profiles_and_goals))
 
-    exec_sbt(profiles_and_goals)
+    with group_in_github_actions("sbt build"):
+        exec_sbt(profiles_and_goals)
 
 
 def build_spark_unidoc_sbt(extra_profiles):

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -88,6 +88,7 @@ def group_in_github_actions(title):
         finally:
             print("\n::endgroup::", flush=True)
     else:
+        print(title)
         yield
 
 
@@ -266,9 +267,9 @@ def build_spark_sbt(extra_profiles):
     ]
     profiles_and_goals = build_profiles + sbt_goals
 
-    print("[info] Building Spark using SBT with these arguments: ", " ".join(profiles_and_goals))
-
-    with group_in_github_actions("sbt build"):
+    with group_in_github_actions(
+        "[info] Building Spark using SBT with these arguments: " + " ".join(profiles_and_goals)
+    ):
         exec_sbt(profiles_and_goals)
 
 
@@ -292,11 +293,11 @@ def build_spark_assembly_sbt(extra_profiles, checkstyle=False):
     build_profiles = extra_profiles + modules.root.build_profile_flags
     sbt_goals = ["assembly/package"]
     profiles_and_goals = build_profiles + sbt_goals
-    print(
-        "[info] Building Spark assembly using SBT with these arguments: ",
-        " ".join(profiles_and_goals),
-    )
-    exec_sbt(profiles_and_goals)
+    with group_in_github_actions(
+        "[info] Building Spark assembly using SBT with these arguments: "
+        + " ".join(profiles_and_goals)
+    ):
+        exec_sbt(profiles_and_goals)
 
     if checkstyle:
         run_java_style_checks(build_profiles)
@@ -406,9 +407,6 @@ def run_python_tests(test_modules, test_pythons, parallelism, with_coverage=Fals
     command.append("--parallelism=%i" % parallelism)
     command.append("--python-executables=%s" % test_pythons)
     run_cmd(command)
-    print("::group::test", flush=True)
-    print("hello world", flush=True)
-    print("::endgroup::", flush=True)
 
 
 def run_python_packaging_tests():

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -88,7 +88,6 @@ def group_in_github_actions(title):
         finally:
             print("\n::endgroup::", flush=True)
     else:
-        print(title)
         yield
 
 
@@ -267,9 +266,9 @@ def build_spark_sbt(extra_profiles):
     ]
     profiles_and_goals = build_profiles + sbt_goals
 
-    with group_in_github_actions(
-        "[info] Building Spark using SBT with these arguments: " + " ".join(profiles_and_goals)
-    ):
+    print("[info] Building Spark using SBT with these arguments: ", " ".join(profiles_and_goals))
+
+    with group_in_github_actions("sbt build spark"):
         exec_sbt(profiles_and_goals)
 
 
@@ -293,10 +292,13 @@ def build_spark_assembly_sbt(extra_profiles, checkstyle=False):
     build_profiles = extra_profiles + modules.root.build_profile_flags
     sbt_goals = ["assembly/package"]
     profiles_and_goals = build_profiles + sbt_goals
-    with group_in_github_actions(
-        "[info] Building Spark assembly using SBT with these arguments: "
-        + " ".join(profiles_and_goals)
-    ):
+
+    print(
+        "[info] Building Spark assembly using SBT with these arguments: ",
+        " ".join(profiles_and_goals),
+    )
+
+    with group_in_github_actions("sbt build spark assembly"):
         exec_sbt(profiles_and_goals)
 
     if checkstyle:

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -82,11 +82,11 @@ def set_title_and_block(title, err_block):
 @contextmanager
 def group_in_github_actions(title):
     if "GITHUB_ACTIONS" in os.environ:
-        print(f"\n::group::{title}", flush=True)
+        print(f"::group::{title}", flush=True)
         try:
             yield
         finally:
-            print("\n::endgroup::", flush=True)
+            print("::endgroup::", flush=True)
     else:
         yield
 
@@ -179,6 +179,7 @@ def exec_sbt(sbt_args=()):
     for line in iter(sbt_proc.stdout.readline, b""):
         if not sbt_output_filter.match(line):
             print(line.decode("utf-8"), end="")
+    print()  # print a new line because the code above does not guarantee a new line
     retcode = sbt_proc.wait()
 
     if retcode != 0:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

In github actions, group the sbt build output so it is collapsable.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This PR is made in favor of #54052. The sbt build outputs thousands of lines that many people do not care. It lags the webpage and made it difficult for people to find the part they are interested in.

However, some people are interested in the message so it might not be the best solution to completely make `sbt build` quiet.

By making it collapsable, I think everyone gets what they want. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Check the result of the CI of this PR to see the difference.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.