### PR TITLE
[SPARK-55405][PYTHON][TESTS][FOLLOW-UP] Add macOS ARM overrides for float-to-int unsafe cast golden file mismatches

### DIFF
--- a/.github/workflows/build_python_3.12_macos26.yml
+++ b/.github/workflows/build_python_3.12_macos26.yml
@@ -30,5 +30,6 @@ jobs:
       packages: write
     name: Run
     uses: ./.github/workflows/python_hosted_runner_test.yml
+    if: github.repository == 'apache/spark'
     with:
       os: macos-26

--- a/.github/workflows/build_python_3.12_macos26.yml
+++ b/.github/workflows/build_python_3.12_macos26.yml
@@ -30,6 +30,5 @@ jobs:
       packages: write
     name: Run
     uses: ./.github/workflows/python_hosted_runner_test.yml
-    if: github.repository == 'apache/spark'
     with:
       os: macos-26


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add macOS ARM-specific overrides in `_overrides_unsafe()` for 7 float-to-int unsafe cast cases that differ between Linux ARM and macOS ARM due to LLVM code generation differences. This fixes the `build_python_3.12_macos26` CI workflow which has been failing on every run.

### Why are the changes needed?

Fix macOS 26 CI failures.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested on macOS 26 (Darwin 25.2.0, arm64) with PyArrow 22.0.0. Also tested in CI: https://github.com/Yicong-Huang/spark/actions/runs/22465733224

### Was this patch authored or co-authored using generative AI tooling?

No.