### PR TITLE
[SPARK-55725][K8S][DOCS] Make `AbstractPodsAllocator` docs up-to-date

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/AbstractPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/AbstractPodsAllocator.scala
@@ -18,7 +18,7 @@ package org.apache.spark.scheduler.cluster.k8s
 
 import io.fabric8.kubernetes.api.model.Pod
 
-import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.resource.ResourceProfile
 
 
@@ -26,47 +26,72 @@ import org.apache.spark.resource.ResourceProfile
  * :: DeveloperApi ::
  * A abstract interface for allowing different types of pods allocation.
  *
- * The internal Spark implementations are [[StatefulSetPodsAllocator]]
- * and [[ExecutorPodsAllocator]]. This may be useful for folks integrating with custom schedulers.
- *
- * This API may change or be removed at anytime.
+ * The internal Spark implementations are [[StatefulSetPodsAllocator]],
+ * [[DeploymentPodsAllocator]], and [[ExecutorPodsAllocator]].
+ * This may be useful for folks integrating with custom schedulers.
  *
  * @since 3.3.0
  */
 @DeveloperApi
+@Since("3.3.0")
 abstract class AbstractPodsAllocator {
-  /*
+  /**
    * Optional lifecycle manager for tracking executor pod lifecycle events.
    * Set via setExecutorPodsLifecycleManager for backward compatibility.
+   *
+   * @since 4.2.0
    */
+  @Since("4.2.0")
   protected var executorPodsLifecycleManager: Option[ExecutorPodsLifecycleManager] = None
 
-  /*
+  /**
    * Set the lifecycle manager for tracking executor pod lifecycle events.
    * This method is optional and may not exist in custom implementations based on older versions.
+   *
+   * @since 4.2.0
    */
+  @Since("4.2.0")
   def setExecutorPodsLifecycleManager(manager: ExecutorPodsLifecycleManager): Unit = {
     executorPodsLifecycleManager = Some(manager)
   }
 
-  /*
+  /**
    * Set the total expected executors for an application
+   *
+   * @since 3.3.0
    */
+  @Since("3.3.0")
   def setTotalExpectedExecutors(resourceProfileToTotalExecs: Map[ResourceProfile, Int]): Unit
-  /*
+
+  /**
    * Reference to driver pod.
+   *
+   * @since 3.3.0
    */
+  @Since("3.3.0")
   def driverPod: Option[Pod]
-  /*
+
+  /**
    * If the pod for a given exec id is deleted.
+   *
+   * @since 3.3.0
    */
+  @Since("3.3.0")
   def isDeleted(executorId: String): Boolean
-  /*
+
+  /**
    * Start hook.
+   *
+   * @since 3.3.0
    */
+  @Since("3.3.0")
   def start(applicationId: String, schedulerBackend: KubernetesClusterSchedulerBackend): Unit
-  /*
+
+  /**
    * Stop hook
+   *
+   * @since 3.3.0
    */
+  @Since("3.3.0")
   def stop(applicationId: String): Unit
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `AbstractPodsAllocator` documentation up-to-date:
- Use `Javadoc` style instead of `Scaladoc` according to the [Apache Spark Code Style Guide](https://spark.apache.org/contributing.html).
- Add `Since` annotation for the class and methods.
- Update the class documentation with new `DeploymentPodsAllocator`.
- Update the method documentation with `since` tag.

### Why are the changes needed?

`AbstractPodsAllocator` is one of `DeveloperApi` of the Apache Spark.

https://github.com/apache/spark/blob/4da26e4bf9eab119ff2489c5fdf85efe60f6f469/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/AbstractPodsAllocator.scala#L36-L37

Recently, Apache Spark 4.2.0
- Added a new built-in implementation, `DeploymentPodsAllocator`.
  - #52867
- Added new API, `setExecutorPodsLifecycleManager`.
  - #53840

### Does this PR introduce _any_ user-facing change?

No, this changes documentations only.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`