### PR TITLE
[SPARK-55730][PYTHON] Not make timezone lower case

### DIFF
--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -158,7 +158,7 @@ class RunnerConf(Conf):
 
     @property
     def timezone(self) -> Optional[str]:
-        return self.get("spark.sql.session.timeZone", None)
+        return self.get("spark.sql.session.timeZone", None, lower_str=False)
 
     @property
     def arrow_max_records_per_batch(self) -> int:

--- a/python/pyspark/worker_util.py
+++ b/python/pyspark/worker_util.py
@@ -246,8 +246,8 @@ class Conf:
             v = utf8_deserializer.loads(infile)
             self._conf[k] = v
 
-    def get(self, key: str, default: Any = "") -> Any:
+    def get(self, key: str, default: Any = "", *, lower_str: bool = True) -> Any:
         val = self._conf.get(key, default)
-        if isinstance(val, str):
+        if isinstance(val, str) and lower_str:
             return val.lower()
         return val


### PR DESCRIPTION
### What changes were proposed in this pull request?

Not make timezone lower case.

### Why are the changes needed?

The resolution of timezone has been changed in pandas 3:

- https://pandas.pydata.org/pandas-docs/version/3.0/whatsnew/v3.0.0.html#pytz-now-an-optional-dependency

which caused the issue that a lowercase timezone is not recognized by pandas' search in some environment.

```
...
  File "/.../pandas/_libs/tslibs/timezones.pyx", line 133, in pandas._libs.tslibs.timezones.maybe_get_tz
  File "/.../pandas/_libs/tslibs/timezones.pyx", line 158, in pandas._libs.tslibs.timezones.maybe_get_tz
  File "/.../zoneinfo/_common.py", line 24, in load_tzdata
    raise ZoneInfoNotFoundError(f"No time zone found with key {key}")
zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key etc/utc'
```

If it's `Etc/UTC`, it works.

### Does this PR introduce _any_ user-facing change?

Yes, it will behave more like pandas 3.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.
