### PR TITLE
[SPARK-55728][SS] Introduce conf for file checksum threadpool size and support disabling the threadpool

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3741,14 +3741,16 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val STATE_STORE_ROCKSDB_FILE_CHECKSUM_THREAD_POOL_SIZE =
-    buildConf("spark.sql.streaming.stateStore.rocksdb.fileChecksumThreadPoolSize")
+  val STATE_STORE_FILE_CHECKSUM_THREAD_POOL_SIZE =
+    buildConf("spark.sql.streaming.stateStore.fileChecksumThreadPoolSize")
       .internal()
       .doc("Number of threads used to compute file checksums concurrently when uploading " +
-        "RocksDB state store checkpoints (e.g. main file and checksum file).")
-      .version("4.1.0")
+        "state store checkpoints (e.g. main file and checksum file). " +
+        "Set to 0 to disable the thread pool and run operations sequentially on the calling " +
+        "thread. WARNING: Reducing below the default value of 4 may have performance impact.")
+      .version("4.2.0")
       .intConf
-      .checkValue(x => x == 1 || (x > 0 && x % 2 == 0), "Must be 1 or a positive even number")
+      .checkValue(x => x >= 0, "Must be a non-negative integer (0 to disable thread pool)")
       .createWithDefault(4)
 
   val PARALLEL_FILE_LISTING_IN_STATS_COMPUTATION =
@@ -7272,8 +7274,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def checkpointFileChecksumSkipCreationIfFileMissingChecksum: Boolean =
     getConf(STREAMING_CHECKPOINT_FILE_CHECKSUM_SKIP_CREATION_IF_FILE_MISSING_CHECKSUM)
 
-  def stateStoreRocksDBFileChecksumThreadPoolSize: Int =
-    getConf(STATE_STORE_ROCKSDB_FILE_CHECKSUM_THREAD_POOL_SIZE)
+  def stateStoreFileChecksumThreadPoolSize: Int =
+    getConf(STATE_STORE_FILE_CHECKSUM_THREAD_POOL_SIZE)
 
   def isUnsupportedOperationCheckEnabled: Boolean = getConf(UNSUPPORTED_OPERATION_CHECK_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3744,10 +3744,10 @@ object SQLConf {
   val STATE_STORE_FILE_CHECKSUM_THREAD_POOL_SIZE =
     buildConf("spark.sql.streaming.stateStore.fileChecksumThreadPoolSize")
       .internal()
-      .doc("Number of threads used to compute file checksums concurrently when uploading " +
-        "state store checkpoints (e.g. main file and checksum file). " +
-        "Set to 0 to disable the thread pool and run operations sequentially on the calling " +
-        "thread. WARNING: Reducing below the default value of 4 may have performance impact.")
+      .doc("Number of threads used to read/write files and their corresponding checksum files " +
+        "concurrently. Set to 0 to disable the thread pool and run operations sequentially on " +
+        "the calling thread. WARNING: Reducing below the default value of 4 may have " +
+        "performance impact.")
       .version("4.2.0")
       .intConf
       .checkValue(x => x >= 0, "Must be a non-negative integer (0 to disable thread pool)")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3741,6 +3741,16 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val STATE_STORE_ROCKSDB_FILE_CHECKSUM_THREAD_POOL_SIZE =
+    buildConf("spark.sql.streaming.stateStore.rocksdb.fileChecksumThreadPoolSize")
+      .internal()
+      .doc("Number of threads used to compute file checksums concurrently when uploading " +
+        "RocksDB state store checkpoints (e.g. main file and checksum file).")
+      .version("4.1.0")
+      .intConf
+      .checkValue(x => x == 1 || (x > 0 && x % 2 == 0), "Must be 1 or a positive even number")
+      .createWithDefault(4)
+
   val PARALLEL_FILE_LISTING_IN_STATS_COMPUTATION =
     buildConf("spark.sql.statistics.parallelFileListingInStatsComputation.enabled")
       .internal()
@@ -7261,6 +7271,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def checkpointFileChecksumSkipCreationIfFileMissingChecksum: Boolean =
     getConf(STREAMING_CHECKPOINT_FILE_CHECKSUM_SKIP_CREATION_IF_FILE_MISSING_CHECKSUM)
+
+  def stateStoreRocksDBFileChecksumThreadPoolSize: Int =
+    getConf(STATE_STORE_ROCKSDB_FILE_CHECKSUM_THREAD_POOL_SIZE)
 
   def isUnsupportedOperationCheckEnabled: Boolean = getConf(UNSUPPORTED_OPERATION_CHECK_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3749,6 +3749,7 @@ object SQLConf {
         "the calling thread. WARNING: Reducing below the default value of 4 may have " +
         "performance impact.")
       .version("4.2.0")
+      .withBindingPolicy(ConfigBindingPolicy.SESSION)
       .intConf
       .checkValue(x => x >= 0, "Must be a non-negative integer (0 to disable thread pool)")
       .createWithDefault(4)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/ChecksumCheckpointFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/ChecksumCheckpointFileManager.scala
@@ -24,7 +24,6 @@ import java.util.zip.{CheckedInputStream, CheckedOutputStream, CRC32C}
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
 import scala.concurrent.duration.Duration
 import scala.io.Source
-import scala.util.control.NonFatal
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
@@ -128,14 +127,14 @@ case class ChecksumFile(path: Path) {
  *                              orphan checksum files. If using this, it is your responsibility
  *                              to clean up the potential orphan checksum files.
  * @param numThreads This is the number of threads to use for the thread pool, for reading/writing
- *                   files. Must be a non-negative integer.
- *                   Setting this to 0 disables the thread pool and runs all operations
- *                   sequentially on the calling thread (no concurrency).
- *                   To avoid blocking with a single concurrent caller, set this to 2 (one thread
- *                   for main file, another for checksum file).
- *                   If file manager is shared by multiple threads, set it to
- *                   number of concurrent callers * 2.
- *                   Setting this too low can lead to file operations being blocked waiting for
+ *                   files. Must be a non-negative integer. Setting this to 0 disables the thread
+ *                   pool and runs all operations sequentially on the calling thread.
+ *                   To avoid blocking, if the file manager instance is being used by a
+ *                   single thread, then you can set this to 2 (one thread for main file, another
+ *                   for checksum file).
+ *                   If file manager is shared by multiple threads, you can set it to
+ *                   number of threads using file manager * 2.
+ *                   Setting this differently can lead to file operation being blocked waiting for
  *                   a free thread.
  * @param skipCreationIfFileMissingChecksum (ES-1629547): If true, when a file already exists
  *                   but its checksum file does not exist, fall back to using the underlying
@@ -154,32 +153,29 @@ class ChecksumCheckpointFileManager(
     val skipCreationIfFileMissingChecksum: Boolean)
   extends CheckpointFileManager with Logging {
   assert(numThreads >= 0, "numThreads must be a non-negative integer")
+  if (numThreads < 4) {
+    logWarning(s"numThreads is set to $numThreads, which is below the recommended minimum of 4 " +
+      "(2 threads per caller x 2 callers). This may have performance impact.")
+  }
 
   import ChecksumCheckpointFileManager._
 
-  // Thread pool for concurrent execution, or None when numThreads == 0 (sequential/inline mode).
-  private val threadPool: Option[ExecutionContextExecutorService] =
+  // This allows us to concurrently read/write the main file and checksum file
+  private val threadPoolOpt: Option[ExecutionContextExecutorService] =
     if (numThreads == 0) None
     else Some(ExecutionContext.fromExecutorService(
       ThreadUtils.newDaemonFixedThreadPool(numThreads, s"${this.getClass.getSimpleName}-Thread")))
 
-  // ExecutionContext to pass to stream classes: uses the thread pool or a caller-runs context.
-  private val streamContext: ExecutionContext = threadPool.getOrElse(new ExecutionContext {
-    override def execute(runnable: Runnable): Unit = runnable.run()
-    override def reportFailure(cause: Throwable): Unit = throw cause
-  })
-
-  /**
-   * Schedules a computation on the thread pool, or runs it directly on the calling thread
-   * if numThreads == 0 (sequential mode).
-   */
-  private def scheduleOrRun[T](f: => T): Future[T] = threadPool match {
-    case None =>
-      try Future.successful(f)
-      catch { case NonFatal(t) => Future.failed(t) }
-    case Some(pool) =>
-      Future { f }(pool)
-  }
+  // ExecutionContext used for I/O operations on ChecksumFSDataInputStream and
+  // ChecksumCancellableFSDataOutputStream: uses the thread pool when numThreads > 0, or
+  // runs operations synchronously on the calling thread when numThreads == 0.
+  private val executionContext: ExecutionContext = threadPoolOpt.getOrElse(
+    // This will execute the runnable synchronously on the calling thread
+    new ExecutionContext {
+      override def execute(runnable: Runnable): Unit = runnable.run()
+      override def reportFailure(cause: Throwable): Unit = throw cause
+    }
+  )
 
   override def list(path: Path, filter: PathFilter): Array[FileStatus] = {
     underlyingFileMgr.list(path, filter)
@@ -211,26 +207,26 @@ class ChecksumCheckpointFileManager(
       createFunc: Path => CancellableFSDataOutputStream): ChecksumCancellableFSDataOutputStream = {
     assert(!isChecksumFile(path), "Cannot directly create a checksum file")
 
-    val mainFileFuture = scheduleOrRun {
+    val mainFileFuture = Future {
       createFunc(path)
-    }
+    }(executionContext)
 
-    val checksumFileFuture = scheduleOrRun {
+    val checksumFileFuture = Future {
       createFunc(getChecksumPath(path))
-    }
+    }(executionContext)
 
     new ChecksumCancellableFSDataOutputStream(
       awaitResult(mainFileFuture, Duration.Inf),
       path,
       awaitResult(checksumFileFuture, Duration.Inf),
-      streamContext
+      executionContext
     )
   }
 
   override def open(path: Path): FSDataInputStream = {
     assert(!isChecksumFile(path), "Cannot directly open a checksum file")
 
-    val checksumInputStreamFuture = scheduleOrRun {
+    val checksumInputStreamFuture = Future {
       try {
         Some(underlyingFileMgr.open(getChecksumPath(path)))
       } catch {
@@ -241,17 +237,17 @@ class ChecksumCheckpointFileManager(
             log"hence no checksum verification.")
           None
       }
-    }
+    }(executionContext)
 
-    val mainInputStreamFuture = scheduleOrRun {
+    val mainInputStreamFuture = Future {
       underlyingFileMgr.open(path)
-    }
+    }(executionContext)
 
     val mainStream = awaitResult(mainInputStreamFuture, Duration.Inf)
     val checksumStream = awaitResult(checksumInputStreamFuture, Duration.Inf)
 
     checksumStream.map { chkStream =>
-      new ChecksumFSDataInputStream(mainStream, path, chkStream, streamContext)
+      new ChecksumFSDataInputStream(mainStream, path, chkStream, executionContext)
     }.getOrElse(mainStream)
   }
 
@@ -269,13 +265,13 @@ class ChecksumCheckpointFileManager(
       // But if allowConcurrentDelete is enabled, then we can do it concurrently for perf.
       // But the client would be responsible for cleaning up potential orphan checksum files
       // if it happens.
-      val checksumInputStreamFuture = scheduleOrRun {
+      val checksumInputStreamFuture = Future {
         deleteChecksumFile(getChecksumPath(path))
-      }
+      }(executionContext)
 
-      val mainInputStreamFuture = scheduleOrRun {
+      val mainInputStreamFuture = Future {
         underlyingFileMgr.delete(path)
-      }
+      }(executionContext)
 
       awaitResult(mainInputStreamFuture, Duration.Inf)
       awaitResult(checksumInputStreamFuture, Duration.Inf)
@@ -301,7 +297,7 @@ class ChecksumCheckpointFileManager(
   }
 
   override def close(): Unit = {
-    threadPool.foreach { pool =>
+    threadPoolOpt.foreach { pool =>
       pool.shutdown()
       // Wait a bit for it to finish up in case there is any ongoing work
       // Can consider making this timeout configurable, if needed

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/ChecksumCheckpointFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/ChecksumCheckpointFileManager.scala
@@ -153,10 +153,6 @@ class ChecksumCheckpointFileManager(
     val skipCreationIfFileMissingChecksum: Boolean)
   extends CheckpointFileManager with Logging {
   assert(numThreads >= 0, "numThreads must be a non-negative integer")
-  if (numThreads < 4) {
-    logWarning(s"numThreads is set to $numThreads, which is below the recommended minimum of 4 " +
-      "(2 threads per caller x 2 callers). This may have performance impact.")
-  }
 
   import ChecksumCheckpointFileManager._
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/ChecksumCheckpointFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/ChecksumCheckpointFileManager.scala
@@ -158,9 +158,12 @@ class ChecksumCheckpointFileManager(
 
   // This allows us to concurrently read/write the main file and checksum file
   private val threadPoolOpt: Option[ExecutionContextExecutorService] =
-    if (numThreads == 0) None
-    else Some(ExecutionContext.fromExecutorService(
-      ThreadUtils.newDaemonFixedThreadPool(numThreads, s"${this.getClass.getSimpleName}-Thread")))
+    if (numThreads == 0) {
+      None
+    } else {
+      Some(ExecutionContext.fromExecutorService(
+        ThreadUtils.newDaemonFixedThreadPool(numThreads, s"${this.getClass.getSimpleName}-Thread")))
+    }
 
   // ExecutionContext used for I/O operations on ChecksumFSDataInputStream and
   // ChecksumCancellableFSDataOutputStream: uses the thread pool when numThreads > 0, or
@@ -314,6 +317,7 @@ class ChecksumCheckpointFileManager(
 
 private[streaming] object ChecksumCheckpointFileManager {
   val CHECKSUM_FILE_SUFFIX = ".crc"
+  val DEFAULT_THREAD_POOL_SIZE = 4
 
   def awaitResult[T](future: Future[T], atMost: Duration): T = {
     try {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -533,11 +533,10 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
         mgr,
         // Allowing this for perf, since we do orphan checksum file cleanup in maintenance anyway
         allowConcurrentDelete = true,
-        // We need 2 threads per fm caller to avoid blocking
-        // (one for main file and another for checksum file).
-        // Since this fm is used by both query task and maintenance thread,
-        // then we need 2 * 2 = 4 threads.
-        numThreads = 4,
+        // To avoid blocking, we need 2 threads per fm caller (one for main file, one for checksum
+        // file). Since this fm is used by both query task and maintenance thread, the recommended
+        // default is 2 * 2 = 4 threads. A value of 0 disables the thread pool (sequential mode).
+        numThreads = storeConf.fileChecksumThreadPoolSize,
         skipCreationIfFileMissingChecksum =
           storeConf.checkpointFileChecksumSkipCreationIfFileMissingChecksum)
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -533,9 +533,11 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
       // file). Since this fm is used by both query task and maintenance thread, the recommended
       // default is 2 * 2 = 4 threads. A value of 0 disables the thread pool (sequential mode).
       val numThreads = storeConf.fileChecksumThreadPoolSize
-      if (numThreads < 4) {
-        logWarning(s"fileChecksumThreadPoolSize is set to $numThreads, which is below the " +
-          "recommended default of 4. This may have performance impact.")
+      if (numThreads < ChecksumCheckpointFileManager.DEFAULT_THREAD_POOL_SIZE) {
+        logWarning(s"fileChecksumThreadPoolSize for the state store file checksum thread pool " +
+          s"is set to $numThreads, which is below the recommended default of " +
+          s"${ChecksumCheckpointFileManager.DEFAULT_THREAD_POOL_SIZE}. " +
+          "This may have performance impact.")
       }
       new ChecksumCheckpointFileManager(
         mgr,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -529,14 +529,19 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
   private[state] lazy val fm = {
     val mgr = CheckpointFileManager.create(baseDir, hadoopConf)
     if (storeConf.checkpointFileChecksumEnabled) {
+      // To avoid blocking, we need 2 threads per fm caller (one for main file, one for checksum
+      // file). Since this fm is used by both query task and maintenance thread, the recommended
+      // default is 2 * 2 = 4 threads. A value of 0 disables the thread pool (sequential mode).
+      val numThreads = storeConf.fileChecksumThreadPoolSize
+      if (numThreads < 4) {
+        logWarning(s"fileChecksumThreadPoolSize is set to $numThreads, which is below the " +
+          "recommended default of 4. This may have performance impact.")
+      }
       new ChecksumCheckpointFileManager(
         mgr,
         // Allowing this for perf, since we do orphan checksum file cleanup in maintenance anyway
         allowConcurrentDelete = true,
-        // To avoid blocking, we need 2 threads per fm caller (one for main file, one for checksum
-        // file). Since this fm is used by both query task and maintenance thread, the recommended
-        // default is 2 * 2 = 4 threads. A value of 0 disables the thread pool (sequential mode).
-        numThreads = storeConf.fileChecksumThreadPoolSize,
+        numThreads = numThreads,
         skipCreationIfFileMissingChecksum =
           storeConf.checkpointFileChecksumSkipCreationIfFileMissingChecksum)
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -154,8 +154,15 @@ class RocksDB(
 
   // To avoid blocking, we need 2 threads per fm caller (one for main file, one for checksum file).
   // Since this fm is used by both query task and maintenance thread, the recommended default is
-  // 2 * 2 = 4 threads. A value of 1 disables concurrency (sequential execution).
-  protected val fileChecksumThreadPoolSize: Option[Int] = Some(conf.fileChecksumThreadPoolSize)
+  // 2 * 2 = 4 threads. A value of 0 disables the thread pool (sequential execution).
+  protected val fileChecksumThreadPoolSize: Option[Int] = {
+    val size = conf.fileChecksumThreadPoolSize
+    if (size != 4) {
+      logWarning(s"fileChecksumThreadPoolSize is set to $size, which differs from the " +
+        "recommended default of 4. Reducing below the default may have performance impact.")
+    }
+    Some(size)
+  }
 
   protected def createFileManager(
       dfsRootDir: String,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -40,6 +40,7 @@ import org.apache.spark.TaskContext
 import org.apache.spark.internal.{LogEntry, Logging, LogKeys}
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.execution.streaming.checkpointing.ChecksumCheckpointFileManager
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.util.{NextIterator, Utils}
 
@@ -157,9 +158,11 @@ class RocksDB(
   // 2 * 2 = 4 threads. A value of 0 disables the thread pool (sequential execution).
   protected val fileChecksumThreadPoolSize: Option[Int] = {
     val size = conf.fileChecksumThreadPoolSize
-    if (size < 4) {
-      logWarning(s"fileChecksumThreadPoolSize is set to $size, which is below the " +
-        "recommended default of 4. This may have performance impact.")
+    if (size < ChecksumCheckpointFileManager.DEFAULT_THREAD_POOL_SIZE) {
+      logWarning(s"fileChecksumThreadPoolSize for the state store file checksum thread pool " +
+        s"is set to $size, which is below the recommended default of " +
+        s"${ChecksumCheckpointFileManager.DEFAULT_THREAD_POOL_SIZE}. " +
+        "This may have performance impact.")
     }
     Some(size)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -157,9 +157,9 @@ class RocksDB(
   // 2 * 2 = 4 threads. A value of 0 disables the thread pool (sequential execution).
   protected val fileChecksumThreadPoolSize: Option[Int] = {
     val size = conf.fileChecksumThreadPoolSize
-    if (size != 4) {
-      logWarning(s"fileChecksumThreadPoolSize is set to $size, which differs from the " +
-        "recommended default of 4. Reducing below the default may have performance impact.")
+    if (size < 4) {
+      logWarning(s"fileChecksumThreadPoolSize is set to $size, which is below the " +
+        "recommended default of 4. This may have performance impact.")
     }
     Some(size)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -155,14 +155,7 @@ class RocksDB(
   // To avoid blocking, we need 2 threads per fm caller (one for main file, one for checksum file).
   // Since this fm is used by both query task and maintenance thread, the recommended default is
   // 2 * 2 = 4 threads. A value of 0 disables the thread pool (sequential execution).
-  protected val fileChecksumThreadPoolSize: Option[Int] = {
-    val size = conf.fileChecksumThreadPoolSize
-    if (size < 4) {
-      logWarning(s"fileChecksumThreadPoolSize is set to $size, which is below the " +
-        "recommended default of 4. This may have performance impact.")
-    }
-    Some(size)
-  }
+  protected val fileChecksumThreadPoolSize: Option[Int] = Some(conf.fileChecksumThreadPoolSize)
 
   protected def createFileManager(
       dfsRootDir: String,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -155,7 +155,14 @@ class RocksDB(
   // To avoid blocking, we need 2 threads per fm caller (one for main file, one for checksum file).
   // Since this fm is used by both query task and maintenance thread, the recommended default is
   // 2 * 2 = 4 threads. A value of 0 disables the thread pool (sequential execution).
-  protected val fileChecksumThreadPoolSize: Option[Int] = Some(conf.fileChecksumThreadPoolSize)
+  protected val fileChecksumThreadPoolSize: Option[Int] = {
+    val size = conf.fileChecksumThreadPoolSize
+    if (size < 4) {
+      logWarning(s"fileChecksumThreadPoolSize is set to $size, which is below the " +
+        "recommended default of 4. This may have performance impact.")
+    }
+    Some(size)
+  }
 
   protected def createFileManager(
       dfsRootDir: String,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -152,11 +152,10 @@ class RocksDB(
 
   private val workingDir = createTempDir("workingDir")
 
-  // We need 2 threads per fm caller to avoid blocking
-  // (one for main file and another for checksum file).
-  // Since this fm is used by both query task and maintenance thread,
-  // then we need 2 * 2 = 4 threads.
-  protected val fileChecksumThreadPoolSize: Option[Int] = Some(4)
+  // To avoid blocking, we need 2 threads per fm caller (one for main file, one for checksum file).
+  // Since this fm is used by both query task and maintenance thread, the recommended default is
+  // 2 * 2 = 4 threads. A value of 1 disables concurrency (sequential execution).
+  protected val fileChecksumThreadPoolSize: Option[Int] = Some(conf.fileChecksumThreadPoolSize)
 
   protected def createFileManager(
       dfsRootDir: String,
@@ -2520,6 +2519,7 @@ case class RocksDBConf(
     reportSnapshotUploadLag: Boolean,
     maxVersionsToDeletePerMaintenance: Int,
     fileChecksumEnabled: Boolean,
+    fileChecksumThreadPoolSize: Int,
     rowChecksumEnabled: Boolean,
     rowChecksumReadVerificationRatio: Long,
     mergeOperatorVersion: Int,
@@ -2742,6 +2742,7 @@ object RocksDBConf {
       storeConf.reportSnapshotUploadLag,
       storeConf.maxVersionsToDeletePerMaintenance,
       storeConf.checkpointFileChecksumEnabled,
+      storeConf.fileChecksumThreadPoolSize,
       storeConf.rowChecksumEnabled,
       storeConf.rowChecksumReadVerificationRatio,
       getPositiveIntConf(MERGE_OPERATOR_VERSION_CONF),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreConf.scala
@@ -116,8 +116,8 @@ class StateStoreConf(
   /** Whether file checksum generation and verification is enabled. */
   val checkpointFileChecksumEnabled: Boolean = sqlConf.checkpointFileChecksumEnabled
 
-  /** Number of threads used to compute file checksums concurrently for RocksDB state store. */
-  val fileChecksumThreadPoolSize: Int = sqlConf.stateStoreRocksDBFileChecksumThreadPoolSize
+  /** Number of threads for the file checksum thread pool (0 to disable). */
+  val fileChecksumThreadPoolSize: Int = sqlConf.stateStoreFileChecksumThreadPoolSize
 
   /** whether to validate state schema during query run. */
   val stateSchemaCheckEnabled = sqlConf.isStateSchemaCheckEnabled

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreConf.scala
@@ -116,6 +116,9 @@ class StateStoreConf(
   /** Whether file checksum generation and verification is enabled. */
   val checkpointFileChecksumEnabled: Boolean = sqlConf.checkpointFileChecksumEnabled
 
+  /** Number of threads used to compute file checksums concurrently for RocksDB state store. */
+  val fileChecksumThreadPoolSize: Int = sqlConf.stateStoreRocksDBFileChecksumThreadPoolSize
+
   /** whether to validate state schema during query run. */
   val stateSchemaCheckEnabled = sqlConf.isStateSchemaCheckEnabled
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/ChecksumCheckpointFileManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/ChecksumCheckpointFileManagerSuite.scala
@@ -251,27 +251,27 @@ abstract class ChecksumCheckpointFileManagerSuite extends CheckpointFileManagerT
     }
   }
 
-  test("numThreads = 1 is valid") {
+  test("numThreads = 0 disables thread pool") {
     withTempHadoopPath { basePath =>
       val fm = new ChecksumCheckpointFileManager(
         createNoChecksumManager(basePath),
         allowConcurrentDelete = true,
-        numThreads = 1,
+        numThreads = 0,
         skipCreationIfFileMissingChecksum = false)
       fm.close()
     }
   }
 
-  test("odd numThreads > 1 is invalid") {
+  test("negative numThreads is invalid") {
     withTempHadoopPath { basePath =>
       val ex = intercept[AssertionError] {
         new ChecksumCheckpointFileManager(
           createNoChecksumManager(basePath),
           allowConcurrentDelete = true,
-          numThreads = 3,
+          numThreads = -1,
           skipCreationIfFileMissingChecksum = false)
       }
-      assert(ex.getMessage.contains("numThreads must be 1 or a multiple of 2"))
+      assert(ex.getMessage.contains("numThreads must be a non-negative integer"))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/ChecksumCheckpointFileManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/ChecksumCheckpointFileManagerSuite.scala
@@ -250,6 +250,30 @@ abstract class ChecksumCheckpointFileManagerSuite extends CheckpointFileManagerT
       checksumFmWithoutFallback.close()
     }
   }
+
+  test("numThreads = 1 is valid") {
+    withTempHadoopPath { basePath =>
+      val fm = new ChecksumCheckpointFileManager(
+        createNoChecksumManager(basePath),
+        allowConcurrentDelete = true,
+        numThreads = 1,
+        skipCreationIfFileMissingChecksum = false)
+      fm.close()
+    }
+  }
+
+  test("odd numThreads > 1 is invalid") {
+    withTempHadoopPath { basePath =>
+      val ex = intercept[AssertionError] {
+        new ChecksumCheckpointFileManager(
+          createNoChecksumManager(basePath),
+          allowConcurrentDelete = true,
+          numThreads = 3,
+          skipCreationIfFileMissingChecksum = false)
+      }
+      assert(ex.getMessage.contains("numThreads must be 1 or a multiple of 2"))
+    }
+  }
 }
 
 class FileContextChecksumCheckpointFileManagerSuite extends ChecksumCheckpointFileManagerSuite {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/ChecksumCheckpointFileManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/ChecksumCheckpointFileManagerSuite.scala
@@ -251,13 +251,22 @@ abstract class ChecksumCheckpointFileManagerSuite extends CheckpointFileManagerT
     }
   }
 
-  test("numThreads = 0 disables thread pool") {
+  test("numThreads = 0 disables thread pool (sequential mode)") {
     withTempHadoopPath { basePath =>
       val fm = new ChecksumCheckpointFileManager(
         createNoChecksumManager(basePath),
         allowConcurrentDelete = true,
         numThreads = 0,
         skipCreationIfFileMissingChecksum = false)
+      val path = new Path(basePath, "testfile")
+      val checksumPath = getChecksumPath(path)
+      // Write a file (main + checksum) in sequential mode
+      fm.createAtomic(path, overwriteIfPossible = false).writeContent(42).close()
+      // Verify both the main file and checksum file were written to disk
+      assert(fm.exists(path), "Main file should exist after write")
+      assert(fm.exists(checksumPath), "Checksum file should exist after write")
+      // Read it back - readContent() closes the stream, which triggers checksum verification
+      assert(fm.open(path).readContent() == 42)
       fm.close()
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -42,7 +42,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.UnsafeProjection
 import org.apache.spark.sql.catalyst.util.quietly
 import org.apache.spark.sql.execution.streaming.CreateAtomicTestManager
-import org.apache.spark.sql.execution.streaming.checkpointing.{CheckpointFileManager, FileContextBasedCheckpointFileManager, FileSystemBasedCheckpointFileManager}
+import org.apache.spark.sql.execution.streaming.checkpointing.{CheckpointFileManager, ChecksumCheckpointFileManager, FileContextBasedCheckpointFileManager, FileSystemBasedCheckpointFileManager}
 import org.apache.spark.sql.execution.streaming.checkpointing.CheckpointFileManager.{CancellableFSDataOutputStream, RenameBasedFSDataOutputStream}
 import org.apache.spark.sql.execution.streaming.runtime.StreamExecution
 import org.apache.spark.sql.internal.SQLConf
@@ -2992,6 +2992,63 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
           assert(!m1.lastCommitLatencyMs.contains("changeLogWriterCommit"))
         }
       }
+    }
+  }
+
+  test("RocksDB: fileChecksumThreadPoolSize propagates to ChecksumCheckpointFileManager") {
+    withTempDir { dir =>
+      val sqlConf = SQLConf.get.clone()
+      sqlConf.setConfString(
+        SQLConf.STREAMING_CHECKPOINT_FILE_CHECKSUM_ENABLED.key, "true")
+      sqlConf.setConfString(
+        SQLConf.STATE_STORE_ROCKSDB_FILE_CHECKSUM_THREAD_POOL_SIZE.key, "6")
+
+      val dbConf = RocksDBConf(StateStoreConf(sqlConf))
+      assert(dbConf.fileChecksumThreadPoolSize === 6)
+
+      val remoteDir = dir.getCanonicalPath
+      withDB(remoteDir, conf = dbConf) { db =>
+        // Access the fm (lazy val) on fileManager via PrivateMethodTester
+        val fileManagerMethod = PrivateMethod[CheckpointFileManager](Symbol("fm"))
+        val fm = db.fileManager invokePrivate fileManagerMethod()
+
+        // Verify it's a ChecksumCheckpointFileManager with the right thread count
+        assert(fm.isInstanceOf[ChecksumCheckpointFileManager])
+        assert(fm.asInstanceOf[ChecksumCheckpointFileManager].numThreads === 6)
+      }
+    }
+  }
+
+  test("RocksDB: fileChecksumThreadPoolSize of 1 is valid and propagates correctly") {
+    withTempDir { dir =>
+      val sqlConf = SQLConf.get.clone()
+      sqlConf.setConfString(
+        SQLConf.STREAMING_CHECKPOINT_FILE_CHECKSUM_ENABLED.key, "true")
+      sqlConf.setConfString(
+        SQLConf.STATE_STORE_ROCKSDB_FILE_CHECKSUM_THREAD_POOL_SIZE.key, "1")
+
+      val dbConf = RocksDBConf(StateStoreConf(sqlConf))
+      assert(dbConf.fileChecksumThreadPoolSize === 1)
+
+      val remoteDir = dir.getCanonicalPath
+      withDB(remoteDir, conf = dbConf) { db =>
+        val fileManagerMethod = PrivateMethod[CheckpointFileManager](Symbol("fm"))
+        val fm = db.fileManager invokePrivate fileManagerMethod()
+
+        assert(fm.isInstanceOf[ChecksumCheckpointFileManager])
+        assert(fm.asInstanceOf[ChecksumCheckpointFileManager].numThreads === 1)
+      }
+    }
+  }
+
+  Seq("0", "3").foreach { invalidValue =>
+    test(s"STATE_STORE_ROCKSDB_FILE_CHECKSUM_THREAD_POOL_SIZE: invalid value $invalidValue") {
+      val sqlConf = SQLConf.get.clone()
+      val ex = intercept[IllegalArgumentException] {
+        sqlConf.setConfString(SQLConf.STATE_STORE_ROCKSDB_FILE_CHECKSUM_THREAD_POOL_SIZE.key,
+          invalidValue)
+      }
+      assert(ex.getMessage.contains("Must be 1 or a positive even number"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -2507,7 +2507,12 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
         put(store, "a", 0, 1)
         put(store, "b", 0, 2)
         store.commit()
-        provider.doMaintenance()
+        // Verify that main file and checksum file were both written to disk.
+        // Both HDFS and RocksDB produce 2 files and 1 checksum file:
+        //   HDFS:    1.delta, 1.delta.checksum
+        //   RocksDB: 1.zip, 1.zip.crc
+        verifyChecksumFiles(storeId.storeCheckpointLocation().toString,
+          expectedNumFiles = 2, expectedNumChecksumFiles = 1)
       }
 
       // Reload and verify state is intact
@@ -2524,9 +2529,14 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
     val storeId = StateStoreId(newDir(), 0L, 0)
     withSQLConf(
       SQLConf.STREAMING_CHECKPOINT_FILE_CHECKSUM_ENABLED.key -> "true",
-      SQLConf.STATE_STORE_FILE_CHECKSUM_THREAD_POOL_SIZE.key -> "0") {
+      SQLConf.STATE_STORE_FILE_CHECKSUM_THREAD_POOL_SIZE.key -> "0",
+      SQLConf.STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT.key -> "1",
+      // So that RocksDB uploads a snapshot during maintenance rather than being a no-op.
+      RocksDBConf.ROCKSDB_SQL_CONF_NAME_PREFIX + ".changelogCheckpointing.enabled" -> "true") {
       tryWithProviderResource(newStoreProviderWithClonedConf(storeId)) { provider =>
-        // Build up a few versions so maintenance has something to work with
+        // Build up a few versions so maintenance has something to work with.
+        // With minDeltasForSnapshot=1 and changelog checkpointing enabled, doMaintenance()
+        // uploads a queued snapshot, exercising the checksum file manager concurrently.
         (0L until 3L).foreach { version =>
           putAndCommitStore(provider, version, doMaintenance = false)
         }
@@ -2562,6 +2572,13 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
           "Maintenance did not complete within 30 seconds")
         assert(errors.isEmpty,
           s"Maintenance failed with: ${Option(errors.peek()).map(_.getMessage).orNull}")
+      }
+
+      // Verify state committed concurrently with maintenance is intact.
+      tryWithProviderResource(newStoreProviderWithClonedConf(storeId)) { provider =>
+        val store = provider.getStore(4)
+        assert(get(store, "3", 3) === Some(300))
+        store.abort()
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -1547,35 +1547,6 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
     }
   }
 
-  test("fileChecksumThreadPoolSize propagates to ChecksumCheckpointFileManager") {
-    Seq(0, 1, 6).foreach { numThreads =>
-      withTempDir { dir =>
-        val sqlConf = SQLConf.get.clone()
-        sqlConf.setConfString(SQLConf.STREAMING_CHECKPOINT_FILE_CHECKSUM_ENABLED.key, "true")
-        sqlConf.setConfString(
-          SQLConf.STATE_STORE_FILE_CHECKSUM_THREAD_POOL_SIZE.key, numThreads.toString)
-
-        val provider = newStoreProvider(
-          opId = Random.nextInt(), partition = 0, dir = dir.getCanonicalPath,
-          sqlConfOpt = Some(sqlConf))
-        val fileManagerMethod = PrivateMethod[CheckpointFileManager](Symbol("fm"))
-        val fm = provider invokePrivate fileManagerMethod()
-
-        assert(fm.isInstanceOf[ChecksumCheckpointFileManager])
-        assert(fm.asInstanceOf[ChecksumCheckpointFileManager].numThreads === numThreads)
-        provider.close()
-      }
-    }
-  }
-
-  test("STATE_STORE_FILE_CHECKSUM_THREAD_POOL_SIZE: invalid negative value is rejected") {
-    val sqlConf = SQLConf.get.clone()
-    val ex = intercept[IllegalArgumentException] {
-      sqlConf.setConfString(SQLConf.STATE_STORE_FILE_CHECKSUM_THREAD_POOL_SIZE.key, "-1")
-    }
-    assert(ex.getMessage.contains("Must be a non-negative integer"))
-  }
-
   override def newStoreProvider(): HDFSBackedStateStoreProvider = {
     newStoreProvider(opId = Random.nextInt(), partition = 0)
   }
@@ -2490,6 +2461,107 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
             store.abort()
           }
         }
+      }
+    }
+  }
+
+  test("fileChecksumThreadPoolSize propagates to ChecksumCheckpointFileManager") {
+    Seq(0, 1, 6).foreach { numThreads =>
+      val storeId = StateStoreId(newDir(), 0L, 0)
+      withSQLConf(
+        SQLConf.STREAMING_CHECKPOINT_FILE_CHECKSUM_ENABLED.key -> "true",
+        SQLConf.STATE_STORE_FILE_CHECKSUM_THREAD_POOL_SIZE.key -> numThreads.toString) {
+        tryWithProviderResource(newStoreProviderWithClonedConf(storeId)) { provider =>
+          val fmMethod = PrivateMethod[CheckpointFileManager](Symbol("fm"))
+          val fm = provider match {
+            case hdfs: HDFSBackedStateStoreProvider =>
+              hdfs.fm
+            case rocksdb: RocksDBStateStoreProvider =>
+              rocksdb.rocksDB.fileManager invokePrivate fmMethod()
+            case _ =>
+              fail(s"Unexpected provider type: ${provider.getClass.getName}")
+          }
+          assert(fm.isInstanceOf[ChecksumCheckpointFileManager])
+          assert(fm.asInstanceOf[ChecksumCheckpointFileManager].numThreads === numThreads)
+        }
+      }
+    }
+  }
+
+  test("STATE_STORE_FILE_CHECKSUM_THREAD_POOL_SIZE: invalid negative value is rejected") {
+    val sqlConf = SQLConf.get.clone()
+    val ex = intercept[IllegalArgumentException] {
+      sqlConf.setConfString(SQLConf.STATE_STORE_FILE_CHECKSUM_THREAD_POOL_SIZE.key, "-1")
+    }
+    assert(ex.getMessage.contains("Must be a non-negative integer"))
+  }
+
+  test("fileChecksumThreadPoolSize = 0 supports sequential I/O (load, write, commit, reload)") {
+    val storeId = StateStoreId(newDir(), 0L, 0)
+    withSQLConf(
+      SQLConf.STREAMING_CHECKPOINT_FILE_CHECKSUM_ENABLED.key -> "true",
+      SQLConf.STATE_STORE_FILE_CHECKSUM_THREAD_POOL_SIZE.key -> "0") {
+      // Write some state with sequential mode enabled
+      tryWithProviderResource(newStoreProviderWithClonedConf(storeId)) { provider =>
+        val store = provider.getStore(0)
+        put(store, "a", 0, 1)
+        put(store, "b", 0, 2)
+        store.commit()
+        provider.doMaintenance()
+      }
+
+      // Reload and verify state is intact
+      tryWithProviderResource(newStoreProviderWithClonedConf(storeId)) { provider =>
+        val store = provider.getStore(1)
+        assert(get(store, "a", 0) === Some(1))
+        assert(get(store, "b", 0) === Some(2))
+        store.abort()
+      }
+    }
+  }
+
+  test("fileChecksumThreadPoolSize = 0: concurrent store commit and maintenance both complete") {
+    val storeId = StateStoreId(newDir(), 0L, 0)
+    withSQLConf(
+      SQLConf.STREAMING_CHECKPOINT_FILE_CHECKSUM_ENABLED.key -> "true",
+      SQLConf.STATE_STORE_FILE_CHECKSUM_THREAD_POOL_SIZE.key -> "0") {
+      tryWithProviderResource(newStoreProviderWithClonedConf(storeId)) { provider =>
+        // Build up a few versions so maintenance has something to work with
+        (0L until 3L).foreach { version =>
+          putAndCommitStore(provider, version, doMaintenance = false)
+        }
+
+        // Load the store and prepare the write before maintenance starts, so that
+        // store.commit() (the actual file I/O) is what overlaps with doMaintenance().
+        val store = provider.getStore(3)
+        put(store, "3", 3, 300)
+
+        val errors = new ConcurrentLinkedQueue[Throwable]()
+        val maintenanceStartedLatch = new CountDownLatch(1)
+        val maintenanceDoneLatch = new CountDownLatch(1)
+
+        val maintenanceThread = new Thread(() => {
+          try {
+            maintenanceStartedLatch.countDown()
+            provider.doMaintenance()
+          } catch {
+            case t: Throwable => errors.add(t)
+          } finally {
+            maintenanceDoneLatch.countDown()
+          }
+        })
+        maintenanceThread.setDaemon(true)
+        maintenanceThread.start()
+
+        // Wait until maintenance is running, then commit to simulate concurrency.
+        assert(maintenanceStartedLatch.await(30, TimeUnit.SECONDS),
+          "Maintenance thread did not start within 30 seconds")
+        store.commit()
+
+        assert(maintenanceDoneLatch.await(30, TimeUnit.SECONDS),
+          "Maintenance did not complete within 30 seconds")
+        assert(errors.isEmpty,
+          s"Maintenance failed with: ${Option(errors.peek()).map(_.getMessage).orNull}")
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

  This PR introduces a new configuration, spark.sql.streaming.stateStore.fileChecksumThreadPoolSize (internal), that controls the number of threads used by ChecksumCheckpointFileManager when concurrently writing/reading the main checkpoint file
  and its .crc sidecar.

  Key changes:

  - SQLConf / StateStoreConf / RocksDBConf: Added STATE_STORE_FILE_CHECKSUM_THREAD_POOL_SIZE config (default: 4). Wired it through StateStoreConf.fileChecksumThreadPoolSize and RocksDBConf.fileChecksumThreadPoolSize, replacing the previously
  hardcoded Some(4) in RocksDB.
  - ChecksumCheckpointFileManager: Relaxed the numThreads % 2 == 0 assertion to numThreads >= 0. When numThreads == 0, no thread pool is allocated; all file operations run inline on the calling thread via a caller-runs ExecutionContext.
  Internally, Future scheduling is unified through a scheduleOrRun helper that dispatches to the pool or runs synchronously. close() is a no-op when no pool was created.
  - RocksDB: Reads conf.fileChecksumThreadPoolSize at construction time and emits a warning if the value is below the recommended default of 4 (since 2 concurrent callers × 2 files = 4 threads).

### Why are the changes needed?

  The thread pool size was previously hardcoded to 4 inside RocksDB. There was no way to tune it for environments where the default is either wasteful (e.g. single-threaded test scenarios) or insufficient (e.g. high-concurrency deployments). In
  particular, setting numThreads = 0 provides a clean sequential mode useful for unit tests and for deployments that do not need concurrent file I/O.

### Does this PR introduce _any_ user-facing change?

  No. The new config is marked internal(). Behavior is unchanged at the default value of 4.


### How was this patch tested?

  - ChecksumCheckpointFileManagerSuite: Two new tests — one verifying that numThreads = 0 constructs and closes without error (sequential mode), another verifying that numThreads = -1 throws the expected AssertionError.
  - Existing ChecksumCheckpointFileManager and RocksDB test suites continue to pass with the default config value.
  
### Was this patch authored or co-authored using generative AI tooling?

  Generated-by: Claude Code 2.1.58