### PR TITLE
[SPARK-55726][PYTHON][TEST] Add ASV microbenchmark for grouped map pandas UDF

### DIFF
--- a/python/benchmarks/bench_eval_type.py
+++ b/python/benchmarks/bench_eval_type.py
@@ -1,0 +1,319 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Microbenchmarks for PySpark UDF eval types.
+
+Each benchmark class simulates the full worker pipeline for one eval type
+by constructing the complete binary protocol that ``worker.py``'s
+``main(infile, outfile)`` expects.  This avoids depending on internal APIs
+(e.g. ``read_udfs``) whose signatures change across versions.
+
+The protocol is version-aware: at import time we detect whether the current
+PySpark carries the ``RunnerConf`` class (2026+) and build the appropriate
+wire format so that the *same* benchmark file works on both old and new code.
+"""
+
+import io
+import json
+import struct
+import sys
+
+import numpy as np
+import pyarrow as pa
+
+from pyspark.cloudpickle import dumps as cloudpickle_dumps
+from pyspark.serializers import write_int, write_long
+from pyspark.sql.types import (
+    DoubleType,
+    IntegerType,
+    StringType,
+    StructField,
+    StructType,
+)
+from pyspark.util import PythonEvalType
+from pyspark.worker import main as worker_main
+
+# ---------------------------------------------------------------------------
+# Protocol version detection
+# ---------------------------------------------------------------------------
+# RunnerConf exists only in the refactored worker (2026-01+).  When present
+# the wire format uses JSON TaskContext, separate RunnerConf/EvalConf
+# sections, per-arg ``is_kwarg`` flags, and an unconditional ``result_id``.
+try:
+    from pyspark.worker import RunnerConf as _RunnerConf  # noqa: F401
+
+    _NEW_PROTOCOL = True
+except ImportError:
+    _NEW_PROTOCOL = False
+
+
+# ---------------------------------------------------------------------------
+# Wire-format helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_utf8(s, buf):
+    """Write a length-prefixed UTF-8 string (matches ``UTF8Deserializer.loads``)."""
+    encoded = s.encode("utf-8")
+    write_int(len(encoded), buf)
+    buf.write(encoded)
+
+
+def _write_bool(val, buf):
+    buf.write(struct.pack("!?", val))
+
+
+# ---------------------------------------------------------------------------
+# Worker protocol builder
+# ---------------------------------------------------------------------------
+
+
+def _build_preamble(buf):
+    """Write everything ``main()`` reads before ``eval_type``."""
+    write_int(0, buf)  # split_index
+    _write_utf8(f"{sys.version_info[0]}.{sys.version_info[1]}", buf)  # python version
+
+    if _NEW_PROTOCOL:
+        _write_utf8(
+            json.dumps(
+                {
+                    "isBarrier": False,
+                    "stageId": 0,
+                    "partitionId": 0,
+                    "attemptNumber": 0,
+                    "taskAttemptId": 0,
+                    "cpus": 1,
+                    "resources": {},
+                    "localProperties": {},
+                }
+            ),
+            buf,
+        )
+    else:
+        _write_bool(False, buf)  # isBarrier
+        write_int(0, buf)  # stageId
+        write_int(0, buf)  # partitionId
+        write_int(0, buf)  # attemptNumber
+        write_long(0, buf)  # taskAttemptId
+        write_int(1, buf)  # cpus
+        write_int(0, buf)  # num_resources
+        write_int(0, buf)  # num_localProperties
+
+    _write_utf8("/tmp", buf)  # spark_files_dir
+    write_int(0, buf)  # num_python_includes
+    _write_bool(False, buf)  # needs_broadcast_decryption_server
+    write_int(0, buf)  # num_broadcast_variables
+
+
+def _build_udf_payload(udf_func, return_type, arg_offsets, buf):
+    """Write the ``read_single_udf`` portion of the protocol."""
+    write_int(1, buf)  # num_udfs
+    write_int(len(arg_offsets), buf)  # num_arg
+    for offset in arg_offsets:
+        write_int(offset, buf)
+        if _NEW_PROTOCOL:
+            _write_bool(False, buf)  # is_kwarg (new only)
+    write_int(1, buf)  # num_chained
+    command = cloudpickle_dumps((udf_func, return_type))
+    write_int(len(command), buf)
+    buf.write(command)
+    if _NEW_PROTOCOL:
+        write_long(0, buf)  # result_id (unconditional in new protocol)
+
+
+def _build_grouped_arrow_data(arrow_batch, num_groups, buf):
+    """Write grouped-map Arrow data: ``(write_int(1) + IPC) * N + write_int(0)``."""
+    for _ in range(num_groups):
+        write_int(1, buf)
+        writer = pa.RecordBatchStreamWriter(buf, arrow_batch.schema)
+        writer.write_batch(arrow_batch)
+        writer.close()
+    write_int(0, buf)
+
+
+def _build_worker_input(eval_type, udf_func, return_type, arg_offsets, arrow_batch, num_groups):
+    """Assemble the full binary stream consumed by ``worker_main(infile, outfile)``."""
+    buf = io.BytesIO()
+
+    _build_preamble(buf)
+    write_int(eval_type, buf)
+
+    # Runner / eval configuration section
+    if _NEW_PROTOCOL:
+        write_int(0, buf)  # RunnerConf  (0 key-value pairs)
+        write_int(0, buf)  # EvalConf    (0 key-value pairs)
+    else:
+        write_int(0, buf)  # runner_conf (0 key-value pairs, inside read_udfs)
+        _write_bool(False, buf)  # is_profiling
+
+    _build_udf_payload(udf_func, return_type, arg_offsets, buf)
+    _build_grouped_arrow_data(arrow_batch, num_groups, buf)
+    write_int(-4, buf)  # SpecialLengths.END_OF_STREAM
+
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Data helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_grouped_arg_offsets(n_cols, n_keys=0):
+    """``[len, num_keys, key_col_0, …, val_col_0, …]``"""
+    keys = list(range(n_keys))
+    vals = list(range(n_keys, n_cols))
+    offsets = [n_keys] + keys + vals
+    return [len(offsets)] + offsets
+
+
+def _make_grouped_batch(rows_per_group, n_cols):
+    """``group_key (int64)`` + ``(n_cols - 1)`` float32 value columns."""
+    arrays = [pa.array(np.zeros(rows_per_group, dtype=np.int64))] + [
+        pa.array(np.random.rand(rows_per_group).astype(np.float32)) for _ in range(n_cols - 1)
+    ]
+    fields = [StructField("group_key", IntegerType())] + [
+        StructField(f"some_field_{i}", DoubleType()) for i in range(n_cols - 1)
+    ]
+    return (
+        pa.RecordBatch.from_arrays(arrays, names=[f.name for f in fields]),
+        StructType(fields),
+    )
+
+
+def _make_mixed_batch(rows_per_group):
+    """``id``, ``str_col``, ``float_col``, ``double_col``, ``long_col``."""
+    arrays = [
+        pa.array(np.zeros(rows_per_group, dtype=np.int64)),
+        pa.array([f"s{j}" for j in range(rows_per_group)]),
+        pa.array(np.random.rand(rows_per_group).astype(np.float32)),
+        pa.array(np.random.rand(rows_per_group)),
+        pa.array(np.zeros(rows_per_group, dtype=np.int64)),
+    ]
+    fields = [
+        StructField("id", IntegerType()),
+        StructField("str_col", StringType()),
+        StructField("float_col", DoubleType()),
+        StructField("double_col", DoubleType()),
+        StructField("long_col", IntegerType()),
+    ]
+    return (
+        pa.RecordBatch.from_arrays(arrays, names=[f.name for f in fields]),
+        StructType(fields),
+    )
+
+
+# ---------------------------------------------------------------------------
+# SQL_GROUPED_MAP_PANDAS_UDF  (eval type 201)
+# ---------------------------------------------------------------------------
+
+
+class GroupedMapPandasUDFBench:
+    """Full worker round-trip for ``SQL_GROUPED_MAP_PANDAS_UDF`` (201).
+
+    Cases are aligned with the Quicksilver ``PandasFunctionsAPIBenchmarkSuite``.
+    """
+
+    def setup(self):
+        eval_type = PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF
+
+        # ---- varying group size (float data, identity UDF) ----
+        for name, (rows_per_group, n_cols, num_groups) in {
+            "small_few": (1_000, 5, 1_500),
+            "small_many": (1_000, 50, 200),
+            "large_few": (100_000, 5, 350),
+            "large_many": (100_000, 50, 40),
+        }.items():
+            batch, schema = _make_grouped_batch(rows_per_group, n_cols)
+            setattr(
+                self,
+                f"_{name}_input",
+                _build_worker_input(
+                    eval_type,
+                    lambda df: df,
+                    schema,
+                    _build_grouped_arg_offsets(n_cols),
+                    batch,
+                    num_groups=num_groups,
+                ),
+            )
+
+        # ---- mixed types, 1-arg UDF ----
+        mixed_batch, mixed_schema = _make_mixed_batch(3)
+        n_mixed = len(mixed_schema.fields)
+
+        def double_col_add_mean(pdf):
+            return pdf.assign(double_col=pdf["double_col"] + pdf["double_col"].mean())
+
+        self._mixed_input = _build_worker_input(
+            eval_type,
+            double_col_add_mean,
+            mixed_schema,
+            _build_grouped_arg_offsets(n_mixed),
+            mixed_batch,
+            num_groups=1_300,
+        )
+
+        # ---- mixed types, 2-arg UDF with key ----
+        two_arg_schema = StructType(
+            [StructField("group_key", IntegerType()), StructField("double_col_mean", DoubleType())]
+        )
+
+        def double_col_key_add_mean(key, pdf):
+            import pandas as pd
+
+            return pd.DataFrame(
+                [{"group_key": key[0], "double_col_mean": pdf["double_col"].mean()}]
+            )
+
+        self._two_args_input = _build_worker_input(
+            eval_type,
+            double_col_key_add_mean,
+            two_arg_schema,
+            _build_grouped_arg_offsets(n_mixed, n_keys=1),
+            mixed_batch,
+            num_groups=1_600,
+        )
+
+    # -- benchmarks ---------------------------------------------------------
+
+    def _run(self, input_bytes):
+        worker_main(io.BytesIO(input_bytes), io.BytesIO())
+
+    def time_small_groups_few_cols(self):
+        """1k rows/group, 5 cols, 1500 groups."""
+        self._run(self._small_few_input)
+
+    def time_small_groups_many_cols(self):
+        """1k rows/group, 50 cols, 200 groups."""
+        self._run(self._small_many_input)
+
+    def time_large_groups_few_cols(self):
+        """100k rows/group, 5 cols, 350 groups."""
+        self._run(self._large_few_input)
+
+    def time_large_groups_many_cols(self):
+        """100k rows/group, 50 cols, 40 groups."""
+        self._run(self._large_many_input)
+
+    def time_mixed_types(self):
+        """Mixed column types, 1-arg UDF, 3 rows/group, 1300 groups."""
+        self._run(self._mixed_input)
+
+    def time_mixed_types_two_args(self):
+        """Mixed column types, 2-arg UDF with key, 3 rows/group, 1600 groups."""
+        self._run(self._two_args_input)

--- a/python/benchmarks/bench_eval_type.py
+++ b/python/benchmarks/bench_eval_type.py
@@ -217,9 +217,6 @@ class GroupedMapPandasUDFBench:
     mirroring the JVM-side behaviour.  Small groups (1k rows) are unaffected.
     """
 
-    # Run at least 5 times, at most 10, stop if wall time exceeds 10s per benchmark.
-    repeat = (5, 10, 10.0)
-
     # spark.sql.execution.arrow.maxRecordsPerBatch default
     _MAX_RECORDS_PER_BATCH = 10_000
 

--- a/python/benchmarks/bench_eval_type.py
+++ b/python/benchmarks/bench_eval_type.py
@@ -20,8 +20,7 @@ Microbenchmarks for PySpark UDF eval types.
 
 Each benchmark class simulates the full worker pipeline for one eval type
 by constructing the complete binary protocol that ``worker.py``'s
-``main(infile, outfile)`` expects.  This avoids depending on internal APIs
-(e.g. ``read_udfs``) whose signatures change across versions.
+``main(infile, outfile)`` expects.
 
 The protocol is version-aware: at import time we detect whether the current
 PySpark carries the ``RunnerConf`` class (2026+) and build the appropriate

--- a/python/benchmarks/bench_eval_type.py
+++ b/python/benchmarks/bench_eval_type.py
@@ -181,12 +181,12 @@ def _make_mixed_batch(rows_per_group):
 
 
 # ---------------------------------------------------------------------------
-# SQL_GROUPED_MAP_PANDAS_UDF  (eval type 201)
+# SQL_GROUPED_MAP_PANDAS_UDF
 # ---------------------------------------------------------------------------
 
 
 class GroupedMapPandasUDFBench:
-    """Full worker round-trip for ``SQL_GROUPED_MAP_PANDAS_UDF`` (201)."""
+    """Full worker round-trip for ``SQL_GROUPED_MAP_PANDAS_UDF``."""
 
     def setup(self):
         eval_type = PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF

--- a/python/benchmarks/bench_eval_type.py
+++ b/python/benchmarks/bench_eval_type.py
@@ -124,7 +124,12 @@ def _build_grouped_arrow_data(arrow_batch, num_groups, buf, max_records_per_batc
 
 
 def _build_worker_input(
-    eval_type, udf_func, return_type, arg_offsets, arrow_batch, num_groups,
+    eval_type,
+    udf_func,
+    return_type,
+    arg_offsets,
+    arrow_batch,
+    num_groups,
     max_records_per_batch=None,
 ):
     """Assemble the full binary stream consumed by ``worker_main(infile, outfile)``.

--- a/python/benchmarks/bench_eval_type.py
+++ b/python/benchmarks/bench_eval_type.py
@@ -258,7 +258,15 @@ class GroupedMapPandasUDFBench:
         """1k rows/group, 5 cols, 1500 groups."""
         self._run(self._small_few_input)
 
+    def peakmem_small_groups_few_cols(self):
+        """1k rows/group, 5 cols, 1500 groups."""
+        self._run(self._small_few_input)
+
     def time_small_groups_many_cols(self):
+        """1k rows/group, 50 cols, 200 groups."""
+        self._run(self._small_many_input)
+
+    def peakmem_small_groups_many_cols(self):
         """1k rows/group, 50 cols, 200 groups."""
         self._run(self._small_many_input)
 
@@ -266,7 +274,15 @@ class GroupedMapPandasUDFBench:
         """100k rows/group, 5 cols, 350 groups."""
         self._run(self._large_few_input)
 
+    def peakmem_large_groups_few_cols(self):
+        """100k rows/group, 5 cols, 350 groups."""
+        self._run(self._large_few_input)
+
     def time_large_groups_many_cols(self):
+        """100k rows/group, 50 cols, 40 groups."""
+        self._run(self._large_many_input)
+
+    def peakmem_large_groups_many_cols(self):
         """100k rows/group, 50 cols, 40 groups."""
         self._run(self._large_many_input)
 
@@ -274,31 +290,13 @@ class GroupedMapPandasUDFBench:
         """Mixed column types, 1-arg UDF, 3 rows/group, 1300 groups."""
         self._run(self._mixed_input)
 
-    def time_mixed_types_two_args(self):
-        """Mixed column types, 2-arg UDF with key, 3 rows/group, 1600 groups."""
-        self._run(self._two_args_input)
-
-    # -- memory benchmarks ---------------------------------------------------
-
-    def peakmem_small_groups_few_cols(self):
-        """1k rows/group, 5 cols, 1500 groups."""
-        self._run(self._small_few_input)
-
-    def peakmem_small_groups_many_cols(self):
-        """1k rows/group, 50 cols, 200 groups."""
-        self._run(self._small_many_input)
-
-    def peakmem_large_groups_few_cols(self):
-        """100k rows/group, 5 cols, 350 groups."""
-        self._run(self._large_few_input)
-
-    def peakmem_large_groups_many_cols(self):
-        """100k rows/group, 50 cols, 40 groups."""
-        self._run(self._large_many_input)
-
     def peakmem_mixed_types(self):
         """Mixed column types, 1-arg UDF, 3 rows/group, 1300 groups."""
         self._run(self._mixed_input)
+
+    def time_mixed_types_two_args(self):
+        """Mixed column types, 2-arg UDF with key, 3 rows/group, 1600 groups."""
+        self._run(self._two_args_input)
 
     def peakmem_mixed_types_two_args(self):
         """Mixed column types, 2-arg UDF with key, 3 rows/group, 1600 groups."""

--- a/python/benchmarks/bench_eval_type.py
+++ b/python/benchmarks/bench_eval_type.py
@@ -277,3 +277,29 @@ class GroupedMapPandasUDFBench:
     def time_mixed_types_two_args(self):
         """Mixed column types, 2-arg UDF with key, 3 rows/group, 1600 groups."""
         self._run(self._two_args_input)
+
+    # -- memory benchmarks ---------------------------------------------------
+
+    def peakmem_small_groups_few_cols(self):
+        """1k rows/group, 5 cols, 1500 groups."""
+        self._run(self._small_few_input)
+
+    def peakmem_small_groups_many_cols(self):
+        """1k rows/group, 50 cols, 200 groups."""
+        self._run(self._small_many_input)
+
+    def peakmem_large_groups_few_cols(self):
+        """100k rows/group, 5 cols, 350 groups."""
+        self._run(self._large_few_input)
+
+    def peakmem_large_groups_many_cols(self):
+        """100k rows/group, 50 cols, 40 groups."""
+        self._run(self._large_many_input)
+
+    def peakmem_mixed_types(self):
+        """Mixed column types, 1-arg UDF, 3 rows/group, 1300 groups."""
+        self._run(self._mixed_input)
+
+    def peakmem_mixed_types_two_args(self):
+        """Mixed column types, 2-arg UDF with key, 3 rows/group, 1600 groups."""
+        self._run(self._two_args_input)

--- a/python/benchmarks/bench_eval_type.py
+++ b/python/benchmarks/bench_eval_type.py
@@ -104,28 +104,52 @@ def _build_udf_payload(udf_func, return_type, arg_offsets, buf):
     write_long(0, buf)  # result_id
 
 
-def _build_grouped_arrow_data(arrow_batch, num_groups, buf):
-    """Write grouped-map Arrow data: ``(write_int(1) + IPC) * N + write_int(0)``."""
+def _build_grouped_arrow_data(arrow_batch, num_groups, buf, max_records_per_batch=None):
+    """Write grouped-map Arrow data: ``(write_int(1) + IPC) * N + write_int(0)``.
+
+    When *max_records_per_batch* is set and the batch exceeds that limit, each
+    group is split into multiple smaller Arrow batches inside the same IPC stream,
+    mirroring what the JVM does under ``spark.sql.execution.arrow.maxRecordsPerBatch``.
+    """
     for _ in range(num_groups):
         write_int(1, buf)
         writer = pa.RecordBatchStreamWriter(buf, arrow_batch.schema)
-        writer.write_batch(arrow_batch)
+        if max_records_per_batch and arrow_batch.num_rows > max_records_per_batch:
+            for offset in range(0, arrow_batch.num_rows, max_records_per_batch):
+                writer.write_batch(arrow_batch.slice(offset, max_records_per_batch))
+        else:
+            writer.write_batch(arrow_batch)
         writer.close()
     write_int(0, buf)
 
 
-def _build_worker_input(eval_type, udf_func, return_type, arg_offsets, arrow_batch, num_groups):
-    """Assemble the full binary stream consumed by ``worker_main(infile, outfile)``."""
+def _build_worker_input(
+    eval_type, udf_func, return_type, arg_offsets, arrow_batch, num_groups, runner_conf=None
+):
+    """Assemble the full binary stream consumed by ``worker_main(infile, outfile)``.
+
+    Parameters
+    ----------
+    runner_conf : dict, optional
+        Key-value pairs written into the RunnerConf section of the protocol.
+        Use ``{"spark.sql.execution.arrow.maxRecordsPerBatch": N}`` to simulate
+        the JVM-side batch-splitting behaviour for large groups.
+    """
     buf = io.BytesIO()
+    runner_conf = runner_conf or {}
+    max_records_per_batch = runner_conf.get("spark.sql.execution.arrow.maxRecordsPerBatch")
 
     _build_preamble(buf)
     write_int(eval_type, buf)
 
-    write_int(0, buf)  # RunnerConf  (0 key-value pairs)
-    write_int(0, buf)  # EvalConf    (0 key-value pairs)
+    write_int(len(runner_conf), buf)  # RunnerConf
+    for k, v in runner_conf.items():
+        _write_utf8(k, buf)
+        _write_utf8(str(v), buf)
+    write_int(0, buf)  # EvalConf (0 key-value pairs)
 
     _build_udf_payload(udf_func, return_type, arg_offsets, buf)
-    _build_grouped_arrow_data(arrow_batch, num_groups, buf)
+    _build_grouped_arrow_data(arrow_batch, num_groups, buf, max_records_per_batch)
     write_int(-4, buf)  # SpecialLengths.END_OF_STREAM
 
     return buf.getvalue()
@@ -186,10 +210,21 @@ def _make_mixed_batch(rows_per_group):
 
 
 class GroupedMapPandasUDFBench:
-    """Full worker round-trip for ``SQL_GROUPED_MAP_PANDAS_UDF``."""
+    """Full worker round-trip for ``SQL_GROUPED_MAP_PANDAS_UDF``.
+
+    Large groups (100k rows) are split into Arrow sub-batches of at most
+    ``spark.sql.execution.arrow.maxRecordsPerBatch`` rows (default 10 000),
+    mirroring the JVM-side behaviour.  Small groups (1k rows) are unaffected.
+    """
+
+    # spark.sql.execution.arrow.maxRecordsPerBatch default
+    _MAX_RECORDS_PER_BATCH = 10_000
 
     def setup(self):
         eval_type = PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF
+        runner_conf = {
+            "spark.sql.execution.arrow.maxRecordsPerBatch": self._MAX_RECORDS_PER_BATCH
+        }
 
         # ---- varying group size (float data, identity UDF) ----
         for name, (rows_per_group, n_cols, num_groups) in {
@@ -209,6 +244,7 @@ class GroupedMapPandasUDFBench:
                     _build_grouped_arg_offsets(n_cols),
                     batch,
                     num_groups=num_groups,
+                    runner_conf=runner_conf,
                 ),
             )
 
@@ -226,6 +262,7 @@ class GroupedMapPandasUDFBench:
             _build_grouped_arg_offsets(n_mixed),
             mixed_batch,
             num_groups=1_300,
+            runner_conf=runner_conf,
         )
 
         # ---- mixed types, 2-arg UDF with key ----
@@ -247,6 +284,7 @@ class GroupedMapPandasUDFBench:
             _build_grouped_arg_offsets(n_mixed, n_keys=1),
             mixed_batch,
             num_groups=1_600,
+            runner_conf=runner_conf,
         )
 
     # -- benchmarks ---------------------------------------------------------
@@ -271,19 +309,19 @@ class GroupedMapPandasUDFBench:
         self._run(self._small_many_input)
 
     def time_large_groups_few_cols(self):
-        """100k rows/group, 5 cols, 350 groups."""
+        """100k rows/group, 5 cols, 350 groups, split at 10k rows/batch."""
         self._run(self._large_few_input)
 
     def peakmem_large_groups_few_cols(self):
-        """100k rows/group, 5 cols, 350 groups."""
+        """100k rows/group, 5 cols, 350 groups, split at 10k rows/batch."""
         self._run(self._large_few_input)
 
     def time_large_groups_many_cols(self):
-        """100k rows/group, 50 cols, 40 groups."""
+        """100k rows/group, 50 cols, 40 groups, split at 10k rows/batch."""
         self._run(self._large_many_input)
 
     def peakmem_large_groups_many_cols(self):
-        """100k rows/group, 50 cols, 40 groups."""
+        """100k rows/group, 50 cols, 40 groups, split at 10k rows/batch."""
         self._run(self._large_many_input)
 
     def time_mixed_types(self):

--- a/python/benchmarks/bench_eval_type.py
+++ b/python/benchmarks/bench_eval_type.py
@@ -217,6 +217,9 @@ class GroupedMapPandasUDFBench:
     mirroring the JVM-side behaviour.  Small groups (1k rows) are unaffected.
     """
 
+    # Run at least 5 times, at most 10, stop if wall time exceeds 10s per benchmark.
+    repeat = (5, 10, 10.0)
+
     # spark.sql.execution.arrow.maxRecordsPerBatch default
     _MAX_RECORDS_PER_BATCH = 10_000
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add an ASV microbenchmark for `SQL_GROUPED_MAP_PANDAS_UDF` in `python/benchmarks/bench_eval_type.py`.

The benchmark simulates the full `worker.py` pipeline by constructing the complete binary protocol that `main(infile, outfile)` expects.

Large groups (100k rows/group) are split into Arrow sub-batches of 10k rows via `spark.sql.execution.arrow.maxRecordsPerBatch` (default), passed through RunnerConf, mirroring the JVM-side behaviour.

### Why are the changes needed?

This is part of SPARK-55724 to add per-eval-type microbenchmarks for PySpark UDF worker pipelines. These benchmarks help catch performance regressions in the Python-side serialization/deserialization path (e.g., SPARK-55459 fixed a 3x regression in `applyInPandas`).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`asv run --python=same -a repeat='(5,10,10.0)'` on Apple M4 Max:

```
GroupedMapPandasUDFBench:
  time_small_groups_few_cols     (1k rows/group,   5 cols, 1500 groups):  884±3ms
  peakmem_small_groups_few_cols                                         : 1.96 G
  time_small_groups_many_cols    (1k rows/group,  50 cols,  200 groups):  741±5ms
  peakmem_small_groups_many_cols                                        : 1.99 G
  time_large_groups_few_cols     (100k rows/group, 5 cols,  350 groups):  786±60ms
  peakmem_large_groups_few_cols                                         : 3.19 G
  time_large_groups_many_cols    (100k rows/group,50 cols,   40 groups):  681±50ms
  peakmem_large_groups_many_cols                                        : 3.74 G
  time_mixed_types               (mixed cols, 1-arg UDF,   1300 groups):  884±3ms
  peakmem_mixed_types                                                   : 1.90 G
  time_mixed_types_two_args      (mixed cols, 2-arg UDF,   1600 groups):  822±4ms
  peakmem_mixed_types_two_args                                          : 1.91 G
```

### Was this patch authored or co-authored using generative AI tooling?

No.