### PR TITLE
[SPARK-55741][INFRA] Use `ubuntu-slim` for GitHub Actions `precondition` and `ui` jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1479,7 +1479,7 @@ jobs:
     needs: [precondition]
     if: fromJson(needs.precondition.outputs.required).ui == 'true'
     name: Run Spark UI tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -59,7 +59,7 @@ concurrency:
 jobs:
   precondition:
     name: Check changes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     env:
       GITHUB_PREV_SHA: ${{ github.event.before }}
     outputs:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -59,6 +59,8 @@ concurrency:
 jobs:
   precondition:
     name: Check changes
+    # `ubuntu-slim` is lighter than `ubuntu-latest`.
+    # Please see https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories
     runs-on: ubuntu-slim
     env:
       GITHUB_PREV_SHA: ${{ github.event.before }}
@@ -1479,6 +1481,8 @@ jobs:
     needs: [precondition]
     if: fromJson(needs.precondition.outputs.required).ui == 'true'
     name: Run Spark UI tests
+    # `ubuntu-slim` is lighter than `ubuntu-latest`.
+    # Please see https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories
     runs-on: ubuntu-slim
     timeout-minutes: 120
     steps:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `ubuntu-slim` for GitHub Actions `precondition` and `ui` job.

### Why are the changes needed?

`ubuntu-slim` is a new cost-efficient runner to fit small jobs like `precondition`. We had better use this to save ASF infra usage (if possible)
- https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/
- https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md

| Feature | `ubuntu-slim` | `ubuntu-latest` |
| :--- | :---: | :---: |
| **Cost (per minute)** | **$0.002** | **$0.012** |
| **Cost for 1,000 mins** | **$2.00** | **$12.00** |
| **CPU** | 1 vCPU | 4 vCPU |
| **Memory (RAM)** | 5 GB | 16 GB |
| **Storage (SSD)** | 14 GB | 14 GB |
| **Maximum Runtime** | **15 Minutes** | 6 Hours |
| **Isolation Type** | Container-based (L2) | Dedicated VM |

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

<img width="365" height="212" alt="Screenshot 2026-02-26 at 21 51 06" src="https://github.com/user-attachments/assets/dbcdb852-5e29-4adc-8846-7f260664f62f" />

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`