### PR TITLE
[SPARK-55747][SQL] Fix NPE when accessing elements from an array that is null

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -431,7 +431,7 @@ trait GetArrayItemUtil {
           true
       }
     } else {
-      if (failOnError) arrayElementNullable else true
+      if (failOnError) arrayElementNullable || child.nullable else true
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -1470,4 +1470,19 @@ class StringFunctionsSuite extends QueryTest with SharedSparkSession {
         Seq(Row("abc", "def")))
     }
   }
+
+  test("SPARK-55747: GetArrayItem NPE on null array from split() with ANSI enabled") {
+    // GetArrayItem.nullable was incorrectly computed as false when the array type has
+    // containsNull=false (e.g., from StringSplit) but the array itself can be null.
+    // This caused codegen to skip null checks, leading to NPE when calling
+    // array.numElements() on a null array during bounds checking.
+    withTable("t") {
+      sql("CREATE OR REPLACE TABLE t (s STRING) USING delta")
+      sql("INSERT INTO t VALUES ('a-b'), (null)")
+      checkAnswer(
+        sql("SELECT split(s, '-')[size(split(s, '-')) - 1] FROM t"),
+        Seq(Row("b"), Row(null))
+      )
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -1477,7 +1477,7 @@ class StringFunctionsSuite extends QueryTest with SharedSparkSession {
     // This caused codegen to skip null checks, leading to NPE when calling
     // array.numElements() on a null array during bounds checking.
     withTable("t") {
-      sql("CREATE OR REPLACE TABLE t (s STRING) USING parquet")
+      sql("CREATE TABLE t (s STRING) USING parquet")
       sql("INSERT INTO t VALUES ('a-b'), (null)")
       checkAnswer(
         sql("SELECT split(s, '-')[size(split(s, '-')) - 1] FROM t"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -1477,7 +1477,7 @@ class StringFunctionsSuite extends QueryTest with SharedSparkSession {
     // This caused codegen to skip null checks, leading to NPE when calling
     // array.numElements() on a null array during bounds checking.
     withTable("t") {
-      sql("CREATE OR REPLACE TABLE t (s STRING) USING delta")
+      sql("CREATE OR REPLACE TABLE t (s STRING) USING parquet")
       sql("INSERT INTO t VALUES ('a-b'), (null)")
       checkAnswer(
         sql("SELECT split(s, '-')[size(split(s, '-')) - 1] FROM t"),


### PR DESCRIPTION
### What changes were proposed in this pull request?
The `GetArrayItem` expression incorrectly computed `nullable = false` when indexing into arrays with `containsNull = false` (e.g., from split()), even when the array itself could be null. This caused codegen to skip null checks, leading to NPE on `array.numElements()` during bounds checking.


### Why are the changes needed?
To resolve NPE within spark engine.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Tests in this PR.


### Was this patch authored or co-authored using generative AI tooling?
No