### PR TITLE
[SPARK-55806][DOCS] add section for running `pyspark` with `uv` inline dependencies

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -29,7 +29,7 @@ mypy==1.19.1
 pytest-mypy-plugins==3.2.0
 # See SPARK-38680.
 pandas-stubs>=2.2.0
-scipy-stubs;
+scipy-stubs
 types-PyYAML
 
 # Documentation (SQL)

--- a/python/docs/source/tutorial/python_packaging.rst
+++ b/python/docs/source/tutorial/python_packaging.rst
@@ -270,7 +270,8 @@ To use it, create a wrapper script called ``uv_run``:
 and make it executable with ``chmod +x uv_run``.
 
 You may pass ``--python <version>`` to select a specific Python interpreter
-(see `using different Python versions <https://docs.astral.sh/uv/guides/scripts/#using-different-python-versions>`_):
+(see `using different Python versions <https://docs.astral.sh/uv/guides/scripts/#using-different-python-versions>`_).
+Refer to the :ref:`Installation </getting_started/install.rst>` page for supported Python versions.
 
 Set ``PYSPARK_PYTHON`` to the wrapper script:
 


### PR DESCRIPTION
See [SPARK-55806](https://issues.apache.org/jira/browse/SPARK-55806)

### What changes were proposed in this pull request?
Added a doc section for running pyspark commands with `uv run`. I do think it may be valuable to figure out a way to allow setting `PYSPARK_PYTHON` to a "composite" value (which has an executable + command) maybe, but this way works well.

I have found this approach to be especially valuable in an environment with heterogenous python dependencies across a large organization. We have a "base" set of dependencies ambiently available to pyspark via installation in our docker container, but this allows applying changes or additions for specific use-cases.

I did not include much information about locking dependencies or other information and instead would rely on the `uv run` docs I linked to guide that part.


### Why are the changes needed?
They are not **needed**, but I figured I'd share back to the docs something which has worked well for me.


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
I tried to build the docs with the dependencies in `dev/requirements.txt` but could not. I resorted to using those versions and directly running

```
rst2html.py --halt=severe python/docs/source/tutorial/python_packaging.rst
```

**Note**: I also removed a trailing `;` in `dev/requirements.txt` which caused `uv pip install` to fail.


### Was this patch authored or co-authored using generative AI tooling?
No


cc @HyukjinKwon @asl3 