### PR TITLE
[SPARK-55699][SS][FOLLOWUP] Inconsistent reading of LowLatencyClock when used together with ManualClock

### DIFF
--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaBatchPartitionReader.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaBatchPartitionReader.scala
@@ -105,7 +105,7 @@ private case class KafkaBatchPartitionReader(
   }
 
   override def nextWithTimeout(
-      startTime: java.lang.Long, timeoutMs: java.lang.Long): RecordStatus = {
+      startTimeMs: java.lang.Long, timeoutMs: java.lang.Long): RecordStatus = {
     if (!iteratorForRealTimeMode.isDefined) {
       logInfo(s"Getting a new kafka consuming iterator for ${offsetRange.topicPartition} " +
         s"starting from ${nextOffset}, timeoutMs ${timeoutMs}")

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/SupportsRealTimeRead.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/SupportsRealTimeRead.java
@@ -78,12 +78,12 @@ public interface SupportsRealTimeRead<T> extends PartitionReader<T> {
      * Alternative function to be called than next(), that proceed to the next record. The different
      * from next() is that, if there is no more records, the call needs to keep waiting until
      * the timeout.
-     * @param startTime the base time (milliseconds) the was used to calculate the timeout.
+     * @param startTimeMs the base time (milliseconds) the was used to calculate the timeout.
      *                  Sources should use it as the reference time to start waiting for the next
      *                  record instead of getting the latest time from LowLatencyClock.
-     * @param timeout if no result is available after this timeout (milliseconds), return
+     * @param timeoutMs if no result is available after this timeout (milliseconds), return
      * @return {@link RecordStatus} describing whether a record is available and its arrival time
      * @throws IOException
      */
-    RecordStatus nextWithTimeout(Long startTime, Long timeout) throws IOException;
+    RecordStatus nextWithTimeout(Long startTimeMs, Long timeoutMs) throws IOException;
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/LowLatencyMemoryStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/LowLatencyMemoryStream.scala
@@ -286,7 +286,7 @@ class LowLatencyMemoryStreamPartitionReader(
     current = getRecordWithTimestamp
     while (current.isEmpty) {
       val POLL_TIME = 10L
-      if (elapsedTimeMs >= timeout) {
+      if (elapsedTimeMs >= timeoutMs) {
         return RecordStatus.newStatusWithoutArrivalTime(false)
       }
       Thread.sleep(POLL_TIME)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/LowLatencyMemoryStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/LowLatencyMemoryStream.scala
@@ -278,11 +278,10 @@ class LowLatencyMemoryStreamPartitionReader(
     throw new IllegalStateException("Task context was not set!")
   }
   override def nextWithTimeout(
-      startTime: java.lang.Long, timeout: java.lang.Long): RecordStatus = {
+      startTimeMs: java.lang.Long, timeoutMs: java.lang.Long): RecordStatus = {
     // SPARK-55699: Use the reference time passed in by the caller instead of getting the latest
     // time from LowLatencyClock, to avoid inconsistent reading when LowLatencyClock is a
     // manual clock.
-    val startReadTime = startTime
     var elapsedTimeMs = 0L
     current = getRecordWithTimestamp
     while (current.isEmpty) {
@@ -292,7 +291,7 @@ class LowLatencyMemoryStreamPartitionReader(
       }
       Thread.sleep(POLL_TIME)
       current = getRecordWithTimestamp
-      elapsedTimeMs = (clock.nanoTime() - startReadTime) / 1000 / 1000
+      elapsedTimeMs = clock.getTimeMillis() - startTimeMs
     }
     currentOffset += 1
     RecordStatus.newStatusWithArrivalTimeMs(current.get._2)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In the previous [PR](https://github.com/apache/spark/pull/54497), we update the signature of `nextWithTimeout` in `SupportsRealTimeRead`. However, there was a bug introduced in `LowLatencyMemoryStream` where we compared millisecond timestamp and nanosecond timestamp directly without conversion.

This PR fixes this issue, and renamed the parameter to better prevent such issue from happening.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
**Context of the previous PR:** There was an issue that RTM tests that use manual clock might stuck because manual clock advancement may happens right in between `LowLatencyReaderWrap` getting the reference time, and `nextWithTimeout` in each source getting the start time. `nextWithTimeout` may uses the already advanced time to time its wait. When this happens, since the manual clock may only be advanced once by the test, `nextWithTimeout` may never return, causing test timeout. This only affects LowLatencyMemoryStream when using together with manual clocks.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing unit tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.