### PR TITLE
[SPARK-55755][SQL][TESTS] Handle null ArithmeticException message on JDK 25

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/MathUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/MathUtils.scala
@@ -94,7 +94,9 @@ object MathUtils {
       f
     } catch {
       case e: ArithmeticException =>
-        throw ExecutionErrors.arithmeticOverflowError(e.getMessage, hint, context)
+        // On JDK 25+, Math.*Exact may throw ArithmeticException without a message
+        val message = if (e.getMessage != null) e.getMessage else "Overflow"
+        throw ExecutionErrors.arithmeticOverflowError(message, hint, context)
     }
   }
 
@@ -103,7 +105,8 @@ object MathUtils {
        |try {
        |  $evalCode
        |} catch (ArithmeticException e) {
-       |  throw QueryExecutionErrors.arithmeticOverflowError(e.getMessage(), "", $context);
+       |  String msg = e.getMessage() != null ? e.getMessage() : "Overflow";
+       |  throw QueryExecutionErrors.arithmeticOverflowError(msg, "", $context);
        |}
        |""".stripMargin
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystTypeConvertersSuite.scala
@@ -302,7 +302,8 @@ class CatalystTypeConvertersSuite extends SparkFunSuite with SQLHelper {
     val errMsg = intercept[ArithmeticException] {
       IntervalUtils.durationToMicros(Duration.ofSeconds(Long.MaxValue, Long.MaxValue))
     }.getMessage
-    assert(errMsg.contains("long overflow"))
+    // On JDK 25+, Math.multiplyExact may throw ArithmeticException without a message
+    assert(errMsg == null || errMsg.contains("long overflow"))
   }
 
   test("SPARK-35726: Truncate java.time.Duration by fields of day-time interval type") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
@@ -1822,7 +1822,8 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
             null)
         }.getCause
         assert(e.isInstanceOf[ArithmeticException])
-        assert(e.getMessage.contains("long overflow"))
+        // On JDK 25+, Math.multiplyExact may throw ArithmeticException without a message
+        assert(e.getMessage == null || e.getMessage.contains("long overflow"))
 
         checkEvaluation(
           TimestampAddInterval(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -832,7 +832,8 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
       val msg = intercept[ArithmeticException] {
         DateTimeUtils.localDateTimeToMicros(dt)
       }.getMessage
-      assert(msg == "long overflow")
+      // On JDK 25+, Math.multiplyExact may throw ArithmeticException without a message
+      assert(msg == null || msg == "long overflow")
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
@@ -590,7 +590,8 @@ class IntervalUtilsSuite extends SparkFunSuite with SQLHelper {
     val errMsg = intercept[ArithmeticException] {
       durationToMicros(Duration.ofDays(106751991 + 1))
     }.getMessage
-    assert(errMsg.contains("long overflow"))
+    // On JDK 25+, Math.multiplyExact may throw ArithmeticException without a message
+    assert(errMsg == null || errMsg.contains("long overflow"))
   }
 
   test("SPARK-34615: period to months") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/TimestampFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/TimestampFormatterSuite.scala
@@ -448,9 +448,10 @@ class TimestampFormatterSuite extends DatetimeFormatterSuite {
     assert(formatter.parse("294247") === date(294247))
     assert(formatter.parse("-290307") === date(-290307))
     val e1 = intercept[ArithmeticException](formatter.parse("294248"))
-    assert(e1.getMessage === "long overflow")
+    // On JDK 25+, Math.multiplyExact may throw ArithmeticException without a message
+    assert(e1.getMessage == null || e1.getMessage === "long overflow")
     val e2 = intercept[ArithmeticException](formatter.parse("-290308"))
-    assert(e2.getMessage === "long overflow")
+    assert(e2.getMessage == null || e2.getMessage === "long overflow")
   }
 
   test("SPARK-36418: default parsing w/o pattern") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

On JDK 25, `Math.multiplyExact`/`Math.addExact` may throw `ArithmeticException` without a message (null instead of `"long overflow"`). This causes `NullPointerException` in tests that check the raw exception message via `.getMessage.contains(...)`.

This PR:
1. **`MathUtils.withOverflow`**: Provides a fallback message `"Overflow"` when the raw JDK exception message is null, preventing null propagation into Spark error conditions (both interpreted and codegen paths).
2. **Test assertions**: Makes raw `ArithmeticException` message checks null-safe across:
   - `DateExpressionsSuite` (line 1825)
   - `CatalystTypeConvertersSuite` (line 305)
   - `DateTimeUtilsSuite` (line 835)
   - `IntervalUtilsSuite` (line 593)
   - `TimestampFormatterSuite` (lines 451, 453)

### Why are the changes needed?

The JDK 25 scheduled CI build fails with:
```
java.lang.NullPointerException: Cannot invoke "String.contains(java.lang.CharSequence)" because "$org_scalatest_assert_macro_left" is null
  at DateExpressionsSuite.scala:1825
```

See: https://github.com/apache/spark/actions/runs/22513372344/job/65226962993

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests pass on JDK 17. The `MathUtils.withOverflow` fix ensures non-null messages regardless of JDK version.

### Was this patch authored or co-authored using generative AI tooling?

Yes, co-authored with GitHub Copilot.