### PR TITLE
[SPARK-55639][K8S] Support Recovery-mode K8s Executors

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -523,10 +523,14 @@ private[spark] object Config extends Logging {
 
   val KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED =
     ConfigBuilder("spark.kubernetes.allocation.recoveryMode.enabled")
-      .doc("If true, enables the recovery mode during executor allocation.")
+      .doc("When Spark driver detects an executor termination due to OOM, Spark starts to " +
+        "allocate the recovery-mode executors which accept only a single task per executor JVM. " +
+        "In other words, the recovery-mode executors replace the OOM-terminated executors to " +
+        "survive from the resource-hungry tasks for the remaining tasks and stages. " +
+        "If set to `false`, Spark will not use the recovery-mode executors.")
       .version("4.2.0")
       .booleanConf
-      .createWithDefault(false)
+      .createOptional
 
   val KUBERNETES_ALLOCATION_MAXIMUM =
     ConfigBuilder("spark.kubernetes.allocation.maximum")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -521,6 +521,13 @@ private[spark] object Config extends Logging {
       .checkValue(value => value > 100, "Allocation batch delay must be greater than 0.1s.")
       .createWithDefaultString("1s")
 
+  val KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED =
+    ConfigBuilder("spark.kubernetes.allocation.recoveryMode.enabled")
+      .doc("If true, enables the recovery mode during executor allocation.")
+      .version("4.2.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val KUBERNETES_ALLOCATION_MAXIMUM =
     ConfigBuilder("spark.kubernetes.allocation.maximum")
       .doc("The maximum number of executor pods to try to create during the whole job lifecycle.")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -164,7 +164,13 @@ private[spark] class BasicExecutorFeatureStep(
       KubernetesUtils.buildEnvVars(
         Seq(
           ENV_DRIVER_URL -> driverUrl,
-          ENV_EXECUTOR_CORES -> execResources.cores.get.toString,
+          ENV_EXECUTOR_CORES -> {
+            if (kubernetesConf.get(KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED)) {
+              "1"
+            } else {
+              execResources.cores.get.toString
+            }
+          },
           ENV_EXECUTOR_MEMORY -> executorMemoryString,
           ENV_APPLICATION_ID -> kubernetesConf.appId,
           // This is to set the SPARK_CONF_DIR to be /opt/spark/conf

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -165,7 +165,7 @@ private[spark] class BasicExecutorFeatureStep(
         Seq(
           ENV_DRIVER_URL -> driverUrl,
           ENV_EXECUTOR_CORES -> {
-            if (kubernetesConf.get(KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED)) {
+            if (kubernetesConf.get(KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED).getOrElse(false)) {
               kubernetesConf.get("spark.task.cpus")
             } else {
               execResources.cores.get.toString

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -166,7 +166,7 @@ private[spark] class BasicExecutorFeatureStep(
           ENV_DRIVER_URL -> driverUrl,
           ENV_EXECUTOR_CORES -> {
             if (kubernetesConf.get(KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED).getOrElse(false)) {
-              kubernetesConf.get("spark.task.cpus")
+              kubernetesConf.get("spark.task.cpus", "1")
             } else {
               execResources.cores.get.toString
             }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -166,7 +166,7 @@ private[spark] class BasicExecutorFeatureStep(
           ENV_DRIVER_URL -> driverUrl,
           ENV_EXECUTOR_CORES -> {
             if (kubernetesConf.get(KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED)) {
-              "1"
+              kubernetesConf.get("spark.task.cpus")
             } else {
               execResources.cores.get.toString
             }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -430,6 +430,9 @@ class ExecutorPodsAllocator(
   }
 
   def setRecoveryMode(): Unit = {
+    if (conf.getInt("spark.task.cpus", 1) > 1) {
+      return
+    }
     conf.set(KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED, true)
   }
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -430,10 +430,7 @@ class ExecutorPodsAllocator(
   }
 
   def setRecoveryMode(): Unit = {
-    if (conf.getInt("spark.task.cpus", 1) > 1) {
-      return
-    }
-    conf.set(KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED, true)
+    conf.setIfMissing(KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED, true)
   }
 
   protected def requestNewExecutors(

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -429,6 +429,10 @@ class ExecutorPodsAllocator(
     }
   }
 
+  def setRecoveryMode(): Unit = {
+    conf.set(KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED, true)
+  }
+
   protected def requestNewExecutors(
       numExecutorsToAllocate: Int,
       applicationId: String,

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -668,6 +668,27 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     assert(memoryPolicy.get.getRestartPolicy === "NotRequired")
   }
 
+  test("SPARK-55639: ENV_EXECUTOR_CORES is always 1 when recoveryMode is enabled") {
+    val rpb = new ResourceProfileBuilder()
+    val ereq = new ExecutorResourceRequests()
+    val treq = new TaskResourceRequests()
+    ereq.cores(4)
+    treq.cpus(2)
+    rpb.require(ereq).require(treq)
+    val rp = rpb.build()
+
+    var step = new BasicExecutorFeatureStep(newExecutorConf(), new SecurityManager(baseConf), rp)
+    var executor = step.configurePod(SparkPod.initialPod())
+    var cores = executor.container.getEnv.asScala.find(_.getName == ENV_EXECUTOR_CORES).get.getValue
+    assert(cores === "4")
+
+    baseConf.set(KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED, true)
+    step = new BasicExecutorFeatureStep(newExecutorConf(), new SecurityManager(baseConf), rp)
+    executor = step.configurePod(SparkPod.initialPod())
+    cores = executor.container.getEnv.asScala.find(_.getName == ENV_EXECUTOR_CORES).get.getValue
+    assert(cores === "1")
+  }
+
   // There is always exactly one controller reference, and it points to the driver pod.
   private def checkOwnerReferences(executor: Pod, driverPodUid: String): Unit = {
     assert(executor.getMetadata.getOwnerReferences.size() === 1)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -668,7 +668,7 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     assert(memoryPolicy.get.getRestartPolicy === "NotRequired")
   }
 
-  test("SPARK-55639: ENV_EXECUTOR_CORES is always 1 when recoveryMode is enabled") {
+  test("SPARK-55639: ENV_EXECUTOR_CORES is spark.task.cpus when recoveryMode is enabled") {
     val rpb = new ResourceProfileBuilder()
     val ereq = new ExecutorResourceRequests()
     val treq = new TaskResourceRequests()
@@ -683,10 +683,11 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     assert(cores === "4")
 
     baseConf.set(KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED, true)
+    baseConf.set("spark.task.cpus", "2")
     step = new BasicExecutorFeatureStep(newExecutorConf(), new SecurityManager(baseConf), rp)
     executor = step.configurePod(SparkPod.initialPod())
     cores = executor.container.getEnv.asScala.find(_.getName == ENV_EXECUTOR_CORES).get.getValue
-    assert(cores === "1")
+    assert(cores === "2")
   }
 
   // There is always exactly one controller reference, and it points to the driver pod.

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
@@ -1086,6 +1086,6 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     val podsAllocator = new ExecutorPodsAllocator(newConf, secMgr, executorBuilder,
       kubernetesClient, snapshotsStore, waitForExecutorPodsClock)
     podsAllocator.setRecoveryMode()
-    assert(!newConf.get(KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED))
+    assert(!newConf.get(KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED).get)
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
@@ -1081,19 +1081,11 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     assert(podsAllocatorUnderTest.invokePrivate(numOutstandingPods).get() == 0)
   }
 
-  test("SPARK-55639: setRecoveryMode should set recovery mode if spark.task.cpus <= 1") {
-    val confWithCpus1 = conf.clone.set("spark.task.cpus", "1")
-    val podsAllocator = new ExecutorPodsAllocator(confWithCpus1, secMgr,
-      executorBuilder, kubernetesClient, snapshotsStore, waitForExecutorPodsClock)
+  test("SPARK-55639: setRecoveryMode should not change recovery mode if it is already false") {
+    val newConf = conf.clone.set(KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED, false)
+    val podsAllocator = new ExecutorPodsAllocator(newConf, secMgr, executorBuilder,
+      kubernetesClient, snapshotsStore, waitForExecutorPodsClock)
     podsAllocator.setRecoveryMode()
-    assert(confWithCpus1.get(KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED))
-  }
-
-  test("SPARK-55639: setRecoveryMode should not set recovery mode if spark.task.cpus > 1") {
-    val confWithCpus2 = conf.clone.set("spark.task.cpus", "2")
-    val podsAllocator = new ExecutorPodsAllocator(confWithCpus2, secMgr,
-      executorBuilder, kubernetesClient, snapshotsStore, waitForExecutorPodsClock)
-    podsAllocator.setRecoveryMode()
-    assert(!confWithCpus2.get(KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED))
+    assert(!newConf.get(KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED))
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
@@ -1080,4 +1080,20 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     // Verify no pods were created since all attempts failed
     assert(podsAllocatorUnderTest.invokePrivate(numOutstandingPods).get() == 0)
   }
+
+  test("SPARK-55639: setRecoveryMode should set recovery mode if spark.task.cpus <= 1") {
+    val confWithCpus1 = conf.clone.set("spark.task.cpus", "1")
+    val podsAllocator = new ExecutorPodsAllocator(confWithCpus1, secMgr,
+      executorBuilder, kubernetesClient, snapshotsStore, waitForExecutorPodsClock)
+    podsAllocator.setRecoveryMode()
+    assert(confWithCpus1.get(KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED))
+  }
+
+  test("SPARK-55639: setRecoveryMode should not set recovery mode if spark.task.cpus > 1") {
+    val confWithCpus2 = conf.clone.set("spark.task.cpus", "2")
+    val podsAllocator = new ExecutorPodsAllocator(confWithCpus2, secMgr,
+      executorBuilder, kubernetesClient, snapshotsStore, waitForExecutorPodsClock)
+    podsAllocator.setRecoveryMode()
+    assert(!confWithCpus2.get(KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `Recovery-mode` K8s Executors.

### Why are the changes needed?

Frequently, Spark jobs have skewed data and corresponding tasks. In the worst case, a single resource-hungry task becomes a serial killer of executors. The homogeneous executors are unable to handle this kind of situation.

So, this PR introduces a **recovery-mode executor** when Spark driver detects `OOM` situation from the failed executors. A recovery-mode executor aims to provide an executor serving only a single task. In other words, after OOM, new executor will be created with the same pod spec (memory and core) except `ENV_EXECUTOR_CORES=spark.task.cpus` environment variable setting to allow a single task per executor JVM.

**EXAMPLE: OOM happens at `Executor 1` and `Executor 3` is created as the recover mode**

<img width="1838" height="526" alt="Screenshot 2026-02-28 at 06 38 39" src="https://github.com/user-attachments/assets/66854654-790e-4aa3-9eae-d0fd7456f100" />


### Does this PR introduce _any_ user-facing change?

- There is no behavior change for a healthy job with no executor loss.
- There is no behavior change for jobs with non-OOM executor loss.
- For the failed job due to OOM, this PR only tries to mitigate the situation by trying to make the job to finish.
  - If the OOM happens even on the recovery-mode executor (a single task per executor JVM). The job will fail again.
  - If the recovery-mode executor can handle those skewed tasks, this job will succeed which is good.
- For the faulty job with one or two OOM-driven executor loss, this PR only affects newly created pods (which are one or two as we assumed). So, technically, the job will succeed in the very similar way because the most of executors are the same.
  - `spark.kubernetes.allocation.recoveryMode.enabled=false` will disable the whole feature.

### How was this patch tested?

Pass the CIs with newly added test cases.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`