### PR TITLE
[SPARK-55751][SS] Add metrics on state store loads from DFS

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -244,8 +244,8 @@ class RocksDB(
   // Was snapshot auto repair performed when loading the current version
   @volatile private var performedSnapshotAutoRepair = false
 
-  // Number of DFS (cloud) fetches performed when loading the current version
-  @volatile private var numCloudLoads = 0L
+  // Was state loaded from DFS during the current load operation
+  @volatile private var loadedFromDfs = false
 
   @volatile private var fileManagerMetrics = RocksDBFileManagerMetrics.EMPTY_METRICS
 
@@ -518,7 +518,11 @@ class RocksDB(
           MDC(LogKeys.SNAPSHOT_VERSION, latestSnapshotVersion)}, latestSnapshotUniqueId: ${
           MDC(LogKeys.UUID, latestSnapshotUniqueId)}")
 
-        val metadata = fetchCheckpointFromDfs(latestSnapshotVersion, latestSnapshotUniqueId)
+        val metadata = fileManager.loadCheckpointFromDfs(latestSnapshotVersion,
+          workingDir, rocksDBFileMapping, latestSnapshotUniqueId)
+        // version 0 is the empty initial state; loadCheckpointFromDfs skips DFS for it
+        loadedFromDfs = version > 0
+        loadedVersion = latestSnapshotVersion
 
         // reset the last snapshot version to the latest available snapshot version
         lastSnapshotVersion = latestSnapshotVersion
@@ -601,28 +605,10 @@ class RocksDB(
 
   private def loadEmptyStore(version: Long): Unit = {
     // Use version 0 logic to create empty directory with no SST files
-    val metadata = fetchCheckpointFromDfs(0)
-    // No real snapshot exists at this version; advance loadedVersion to the target
-    // so the next commit produces version + 1 rather than 1.
+    val metadata = fileManager.loadCheckpointFromDfs(0, workingDir, rocksDBFileMapping, None)
     loadedVersion = version
     fileManager.setMaxSeenVersion(version)
     openLocalRocksDB(metadata)
-  }
-
-  /**
-   * Fetches a snapshot from DFS, sets [[loadedVersion]] to the snapshot version,
-   * and increments [[numCloudLoads]]. Returns the checkpoint metadata.
-   * Callers are responsible for calling [[openLocalRocksDB]], setting
-   * [[lastSnapshotVersion]], and any load-path-specific [[loadedVersion]] overrides.
-   */
-  private def fetchCheckpointFromDfs(
-      snapshotVersion: Long,
-      uniqueId: Option[String] = None): RocksDBCheckpointMetadata = {
-    numCloudLoads += 1
-    val metadata = fileManager.loadCheckpointFromDfs(
-      snapshotVersion, workingDir, rocksDBFileMapping, uniqueId)
-    loadedVersion = snapshotVersion
-    metadata
   }
 
   private def loadWithoutCheckpointId(
@@ -640,6 +626,8 @@ class RocksDB(
         } else {
           // load the latest snapshot
           loadSnapshotWithoutCheckpointId(version)
+          // version 0 is the empty initial state; loadCheckpointFromDfs skips DFS for it
+          loadedFromDfs = version > 0
 
           if (loadedVersion != version) {
             val versionsAndUniqueIds: Array[(Long, Option[String])] =
@@ -698,12 +686,14 @@ class RocksDB(
       override protected def beforeLoad(): Unit = closeDB(ignoreException = false)
 
       override protected def loadSnapshotFromCheckpoint(snapshotVersion: Long): Unit = {
-        val metadata = fetchCheckpointFromDfs(snapshotVersion)
+        val remoteMetaData = fileManager.loadCheckpointFromDfs(snapshotVersion,
+          workingDir, rocksDBFileMapping)
 
+        loadedVersion = snapshotVersion
         // Initialize maxVersion upon successful load from DFS
         fileManager.setMaxSeenVersion(snapshotVersion)
 
-        openLocalRocksDB(metadata)
+        openLocalRocksDB(remoteMetaData)
 
         // By setting this to the snapshot version we successfully loaded,
         // if auto snapshot repair is enabled, and we end up skipping the latest snapshot
@@ -798,7 +788,7 @@ class RocksDB(
     assert(version >= 0)
     recordedMetrics = None
     performedSnapshotAutoRepair = false
-    numCloudLoads = 0L
+    loadedFromDfs = false
     // Reset the load metrics before loading
     loadMetrics.clear()
 
@@ -817,8 +807,7 @@ class RocksDB(
     // Record the metrics after loading
     val duration = System.currentTimeMillis() - startTime
     loadMetrics ++= Map(
-      "load" -> duration,
-      "numCloudLoads" -> numCloudLoads
+      "load" -> duration
     )
     // Register with memory manager after successful load
     updateMemoryUsageIfNeeded()
@@ -849,7 +838,8 @@ class RocksDB(
     assert(snapshotVersionStateStoreCkptId.isDefined == endVersionStateStoreCkptId.isDefined)
     assert(snapshotVersion >= 0 && endVersion >= snapshotVersion)
     recordedMetrics = None
-    numCloudLoads = 0L
+    // version 0 is the empty initial state; loadCheckpointFromDfs skips DFS for it
+    loadedFromDfs = endVersion > 0
     loadMetrics.clear()
 
     logInfo(
@@ -875,8 +865,7 @@ class RocksDB(
 
     // Record the metrics after loading
     loadMetrics ++= Map(
-      "loadFromSnapshot" -> (System.currentTimeMillis() - startTime),
-      "numCloudLoads" -> numCloudLoads
+      "loadFromSnapshot" -> (System.currentTimeMillis() - startTime)
     )
 
     this
@@ -900,7 +889,9 @@ class RocksDB(
     assert(snapshotVersionStateStoreCkptId.isDefined == endVersionStateStoreCkptId.isDefined)
 
     closeDB()
-    val metadata = fetchCheckpointFromDfs(snapshotVersion, snapshotVersionStateStoreCkptId)
+    val metadata = fileManager.loadCheckpointFromDfs(snapshotVersion,
+      workingDir, rocksDBFileMapping, snapshotVersionStateStoreCkptId)
+    loadedVersion = snapshotVersion
     lastSnapshotVersion = snapshotVersion
 
     setInitialCFInfo()
@@ -2062,7 +2053,8 @@ class RocksDB(
       lastUploadedSnapshotVersion = lastUploadedSnapshotVersion.get(),
       zipFileBytesUncompressed = fileManagerMetrics.zipFileBytesUncompressed,
       nativeOpsMetrics = nativeOpsMetrics,
-      numSnapshotsAutoRepaired = if (performedSnapshotAutoRepair) 1 else 0)
+      numSnapshotsAutoRepaired = if (performedSnapshotAutoRepair) 1 else 0,
+      loadedFromDfs = if (this.loadedFromDfs) 1 else 0)
   }
 
   /**
@@ -2786,7 +2778,8 @@ case class RocksDBMetrics(
     zipFileBytesUncompressed: Option[Long],
     nativeOpsMetrics: Map[String, Long],
     lastUploadedSnapshotVersion: Long,
-    numSnapshotsAutoRepaired: Long) {
+    numSnapshotsAutoRepaired: Long,
+    loadedFromDfs: Long) {
   def json: String = Serialization.write(this)(RocksDBMetrics.format)
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -838,8 +838,6 @@ class RocksDB(
     assert(snapshotVersionStateStoreCkptId.isDefined == endVersionStateStoreCkptId.isDefined)
     assert(snapshotVersion >= 0 && endVersion >= snapshotVersion)
     recordedMetrics = None
-    // version 0 is the empty initial state; loadCheckpointFromDfs skips DFS for it
-    loadedFromDfs = endVersion > 0
     loadMetrics.clear()
 
     logInfo(
@@ -851,6 +849,9 @@ class RocksDB(
         endVersion,
         snapshotVersionStateStoreCkptId,
         endVersionStateStoreCkptId)
+
+      // version 0 is the empty initial state; loadCheckpointFromDfs skips DFS for it
+      loadedFromDfs = endVersion > 0
 
       logInfo(
         log"Loaded snapshot at version ${MDC(LogKeys.VERSION_NUM, snapshotVersion)} and apply " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -244,8 +244,8 @@ class RocksDB(
   // Was snapshot auto repair performed when loading the current version
   @volatile private var performedSnapshotAutoRepair = false
 
-  // Was a DFS (cloud) fetch performed when loading the current version
-  @volatile private var loadedFromCloud = 0
+  // Number of DFS (cloud) fetches performed when loading the current version
+  @volatile private var numCloudLoads = 0L
 
   @volatile private var fileManagerMetrics = RocksDBFileManagerMetrics.EMPTY_METRICS
 
@@ -611,14 +611,14 @@ class RocksDB(
 
   /**
    * Fetches a snapshot from DFS, sets [[loadedVersion]] to the snapshot version,
-   * and increments [[loadedFromCloud]]. Returns the checkpoint metadata.
+   * and increments [[numCloudLoads]]. Returns the checkpoint metadata.
    * Callers are responsible for calling [[openLocalRocksDB]], setting
    * [[lastSnapshotVersion]], and any load-path-specific [[loadedVersion]] overrides.
    */
   private def fetchCheckpointFromDfs(
       snapshotVersion: Long,
       uniqueId: Option[String] = None): RocksDBCheckpointMetadata = {
-    loadedFromCloud += 1
+    numCloudLoads += 1
     val metadata = fileManager.loadCheckpointFromDfs(
       snapshotVersion, workingDir, rocksDBFileMapping, uniqueId)
     loadedVersion = snapshotVersion
@@ -706,7 +706,7 @@ class RocksDB(
         openLocalRocksDB(metadata)
 
         // By setting this to the snapshot version we successfully loaded,
-        // if auto snapshot repair is enabled and we end up skipping the latest snapshot
+        // if auto snapshot repair is enabled, and we end up skipping the latest snapshot
         // and used an older one, we will create a new snapshot at commit time
         // if the loaded one is old enough.
         lastSnapshotVersion = snapshotVersion
@@ -798,7 +798,7 @@ class RocksDB(
     assert(version >= 0)
     recordedMetrics = None
     performedSnapshotAutoRepair = false
-    loadedFromCloud = 0
+    numCloudLoads = 0L
     // Reset the load metrics before loading
     loadMetrics.clear()
 
@@ -818,7 +818,7 @@ class RocksDB(
     val duration = System.currentTimeMillis() - startTime
     loadMetrics ++= Map(
       "load" -> duration,
-      "loadedFromCloud" -> loadedFromCloud.toLong
+      "numCloudLoads" -> numCloudLoads
     )
     // Register with memory manager after successful load
     updateMemoryUsageIfNeeded()
@@ -849,7 +849,7 @@ class RocksDB(
     assert(snapshotVersionStateStoreCkptId.isDefined == endVersionStateStoreCkptId.isDefined)
     assert(snapshotVersion >= 0 && endVersion >= snapshotVersion)
     recordedMetrics = None
-    loadedFromCloud = 0
+    numCloudLoads = 0L
     loadMetrics.clear()
 
     logInfo(
@@ -876,7 +876,7 @@ class RocksDB(
     // Record the metrics after loading
     loadMetrics ++= Map(
       "loadFromSnapshot" -> (System.currentTimeMillis() - startTime),
-      "loadedFromCloud" -> loadedFromCloud.toLong
+      "numCloudLoads" -> numCloudLoads
     )
 
     this

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -659,6 +659,7 @@ private[sql] class RocksDBStateStoreProvider
           CUSTOM_METRIC_LOAD_TIME -> loadMetrics("load"),
           CUSTOM_METRIC_REPLAY_CHANGE_LOG -> loadMetrics("replayChangelog"),
           CUSTOM_METRIC_NUM_REPLAY_CHANGE_LOG_FILES -> loadMetrics("numReplayChangeLogFiles"),
+          CUSTOM_METRIC_LOADED_FROM_CLOUD -> loadMetrics("loadedFromCloud"),
           CUSTOM_METRIC_BYTES_COPIED -> rocksDBMetrics.bytesCopied,
           CUSTOM_METRIC_FILES_COPIED -> rocksDBMetrics.filesCopied,
           CUSTOM_METRIC_FILES_REUSED -> rocksDBMetrics.filesReused,
@@ -1367,6 +1368,10 @@ object RocksDBStateStoreProvider {
     "rocksdbNumReplayChangelogFiles",
     "RocksDB: load - number of change log files replayed")
 
+  val CUSTOM_METRIC_LOADED_FROM_CLOUD = StateStoreCustomSumMetric(
+    "rocksdbLoadedFromCloud",
+    "RocksDB: load - number of times state was loaded from cloud storage")
+
   val CUSTOM_METRIC_BLOCK_CACHE_MISS = StateStoreCustomSumMetric(
     "rocksdbReadBlockCacheMissCount",
     "RocksDB: read - count of cache misses that required reading from local disk")
@@ -1436,7 +1441,7 @@ object RocksDBStateStoreProvider {
     CUSTOM_METRIC_NUM_EXTERNAL_COL_FAMILIES, CUSTOM_METRIC_NUM_INTERNAL_COL_FAMILIES,
     CUSTOM_METRIC_LOAD_FROM_SNAPSHOT_TIME, CUSTOM_METRIC_LOAD_TIME, CUSTOM_METRIC_REPLAY_CHANGE_LOG,
     CUSTOM_METRIC_NUM_REPLAY_CHANGE_LOG_FILES, CUSTOM_METRIC_NUM_SNAPSHOTS_AUTO_REPAIRED,
-    CUSTOM_METRIC_FORCE_SNAPSHOT)
+    CUSTOM_METRIC_FORCE_SNAPSHOT, CUSTOM_METRIC_LOADED_FROM_CLOUD)
 
   val CUSTOM_INSTANCE_METRIC_SNAPSHOT_LAST_UPLOADED = StateStoreSnapshotLastUploadInstanceMetric()
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -1367,9 +1367,8 @@ object RocksDBStateStoreProvider {
   val CUSTOM_METRIC_NUM_REPLAY_CHANGE_LOG_FILES = StateStoreCustomSizeMetric(
     "rocksdbNumReplayChangelogFiles",
     "RocksDB: load - number of change log files replayed")
-
   val CUSTOM_METRIC_LOADED_FROM_DFS = StateStoreCustomSumMetric(
-    "rocksdbLoadedFromDfs",
+    "rocksdbNumLoadedFromDfs",
     "RocksDB: load - number of state loads from external storage")
 
   val CUSTOM_METRIC_BLOCK_CACHE_MISS = StateStoreCustomSumMetric(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -659,7 +659,6 @@ private[sql] class RocksDBStateStoreProvider
           CUSTOM_METRIC_LOAD_TIME -> loadMetrics("load"),
           CUSTOM_METRIC_REPLAY_CHANGE_LOG -> loadMetrics("replayChangelog"),
           CUSTOM_METRIC_NUM_REPLAY_CHANGE_LOG_FILES -> loadMetrics("numReplayChangeLogFiles"),
-          CUSTOM_METRIC_LOADED_FROM_CLOUD -> loadMetrics("numCloudLoads"),
           CUSTOM_METRIC_BYTES_COPIED -> rocksDBMetrics.bytesCopied,
           CUSTOM_METRIC_FILES_COPIED -> rocksDBMetrics.filesCopied,
           CUSTOM_METRIC_FILES_REUSED -> rocksDBMetrics.filesReused,
@@ -678,6 +677,7 @@ private[sql] class RocksDBStateStoreProvider
           CUSTOM_METRIC_NUM_EXTERNAL_COL_FAMILIES -> internalColFamilyCnt(),
           CUSTOM_METRIC_NUM_INTERNAL_COL_FAMILIES -> externalColFamilyCnt(),
           CUSTOM_METRIC_NUM_SNAPSHOTS_AUTO_REPAIRED -> rocksDBMetrics.numSnapshotsAutoRepaired,
+          CUSTOM_METRIC_LOADED_FROM_DFS -> rocksDBMetrics.loadedFromDfs,
           CUSTOM_METRIC_FORCE_SNAPSHOT -> (if (forceSnapshotOnCommit) 1L else 0L)
         ) ++ rocksDBMetrics.zipFileBytesUncompressed.map(bytes =>
           Map(CUSTOM_METRIC_ZIP_FILE_BYTES_UNCOMPRESSED -> bytes)).getOrElse(Map())
@@ -1368,9 +1368,9 @@ object RocksDBStateStoreProvider {
     "rocksdbNumReplayChangelogFiles",
     "RocksDB: load - number of change log files replayed")
 
-  val CUSTOM_METRIC_LOADED_FROM_CLOUD = StateStoreCustomSumMetric(
-    "rocksdbLoadedFromCloud",
-    "RocksDB: load - number of times state was loaded from cloud storage")
+  val CUSTOM_METRIC_LOADED_FROM_DFS = StateStoreCustomSumMetric(
+    "rocksdbLoadedFromDfs",
+    "RocksDB: load - number of state loads from external storage")
 
   val CUSTOM_METRIC_BLOCK_CACHE_MISS = StateStoreCustomSumMetric(
     "rocksdbReadBlockCacheMissCount",
@@ -1441,7 +1441,7 @@ object RocksDBStateStoreProvider {
     CUSTOM_METRIC_NUM_EXTERNAL_COL_FAMILIES, CUSTOM_METRIC_NUM_INTERNAL_COL_FAMILIES,
     CUSTOM_METRIC_LOAD_FROM_SNAPSHOT_TIME, CUSTOM_METRIC_LOAD_TIME, CUSTOM_METRIC_REPLAY_CHANGE_LOG,
     CUSTOM_METRIC_NUM_REPLAY_CHANGE_LOG_FILES, CUSTOM_METRIC_NUM_SNAPSHOTS_AUTO_REPAIRED,
-    CUSTOM_METRIC_FORCE_SNAPSHOT, CUSTOM_METRIC_LOADED_FROM_CLOUD)
+    CUSTOM_METRIC_FORCE_SNAPSHOT, CUSTOM_METRIC_LOADED_FROM_DFS)
 
   val CUSTOM_INSTANCE_METRIC_SNAPSHOT_LAST_UPLOADED = StateStoreSnapshotLastUploadInstanceMetric()
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -659,7 +659,7 @@ private[sql] class RocksDBStateStoreProvider
           CUSTOM_METRIC_LOAD_TIME -> loadMetrics("load"),
           CUSTOM_METRIC_REPLAY_CHANGE_LOG -> loadMetrics("replayChangelog"),
           CUSTOM_METRIC_NUM_REPLAY_CHANGE_LOG_FILES -> loadMetrics("numReplayChangeLogFiles"),
-          CUSTOM_METRIC_LOADED_FROM_CLOUD -> loadMetrics("loadedFromCloud"),
+          CUSTOM_METRIC_LOADED_FROM_CLOUD -> loadMetrics("numCloudLoads"),
           CUSTOM_METRIC_BYTES_COPIED -> rocksDBMetrics.bytesCopied,
           CUSTOM_METRIC_FILES_COPIED -> rocksDBMetrics.filesCopied,
           CUSTOM_METRIC_FILES_REUSED -> rocksDBMetrics.filesReused,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
@@ -114,7 +114,8 @@ class RocksDBStateStoreIntegrationSuite extends StreamTest
               "SnapshotLastUploaded.partition_0_default", "rocksdbChangeLogWriterCommitLatencyMs",
               "rocksdbSaveZipFilesLatencyMs", "rocksdbLoadFromSnapshotLatencyMs",
               "rocksdbLoadLatencyMs", "rocksdbReplayChangeLogLatencyMs",
-              "rocksdbNumReplayChangelogFiles", "rocksdbForceSnapshotCount"))
+              "rocksdbNumReplayChangelogFiles", "rocksdbForceSnapshotCount",
+              "rocksdbLoadedFromCloud"))
             assert(stateOperatorMetrics.customMetrics.get("rocksdbNumSnapshotsAutoRepaired") == 0,
               "Should be 0 since we didn't repair any snapshot")
           }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
@@ -115,9 +115,11 @@ class RocksDBStateStoreIntegrationSuite extends StreamTest
               "rocksdbSaveZipFilesLatencyMs", "rocksdbLoadFromSnapshotLatencyMs",
               "rocksdbLoadLatencyMs", "rocksdbReplayChangeLogLatencyMs",
               "rocksdbNumReplayChangelogFiles", "rocksdbForceSnapshotCount",
-              "rocksdbLoadedFromCloud"))
+              "rocksdbLoadedFromDfs"))
             assert(stateOperatorMetrics.customMetrics.get("rocksdbNumSnapshotsAutoRepaired") == 0,
               "Should be 0 since we didn't repair any snapshot")
+            assert(stateOperatorMetrics.customMetrics.get("rocksdbLoadedFromDfs") == 0,
+              "Should be 0 since state is served from local cache")
           }
         } finally {
           query.stop()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
@@ -115,10 +115,10 @@ class RocksDBStateStoreIntegrationSuite extends StreamTest
               "rocksdbSaveZipFilesLatencyMs", "rocksdbLoadFromSnapshotLatencyMs",
               "rocksdbLoadLatencyMs", "rocksdbReplayChangeLogLatencyMs",
               "rocksdbNumReplayChangelogFiles", "rocksdbForceSnapshotCount",
-              "rocksdbLoadedFromDfs"))
+              "rocksdbNumLoadedFromDfs"))
             assert(stateOperatorMetrics.customMetrics.get("rocksdbNumSnapshotsAutoRepaired") == 0,
               "Should be 0 since we didn't repair any snapshot")
-            assert(stateOperatorMetrics.customMetrics.get("rocksdbLoadedFromDfs") == 0,
+            assert(stateOperatorMetrics.customMetrics.get("rocksdbNumLoadedFromDfs") == 0,
               "Should be 0 since state is served from local cache")
           }
         } finally {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -2920,6 +2920,7 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
 
         val m1 = db.metricsOpt.get
         assert(m1.loadMetrics("load") > 0)
+        assert(m1.loadMetrics("loadedFromCloud") === 1)
         // since we called load, loadFromSnapshot should not be populated
         assert(!m1.loadMetrics.contains("loadFromSnapshot"))
 
@@ -2956,6 +2957,7 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
         db.refreshRecordedMetricsForTest()
         val m1 = db.metricsOpt.get
         assert(m1.loadMetrics("loadFromSnapshot") > 0)
+        assert(m1.loadMetrics("loadedFromCloud") === 1)
         // since we called loadFromSnapshot, load should not be populated
         assert(!m1.loadMetrics.contains("load"))
         assert(m1.loadMetrics("replayChangelog") > 0)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -2920,10 +2920,10 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
 
         val m1 = db.metricsOpt.get
         assert(m1.loadMetrics("load") > 0)
-        assert(m1.loadMetrics("numCloudLoads") === 1)
         // since we called load, loadFromSnapshot should not be populated
         assert(!m1.loadMetrics.contains("loadFromSnapshot"))
 
+        assert(m1.loadedFromDfs === 1)
         if (conf.enableChangelogCheckpointing) {
           assert(m1.loadMetrics("replayChangelog") > 0)
           assert(m1.loadMetrics("numReplayChangeLogFiles") == 1)
@@ -2931,6 +2931,12 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
           assert(!m1.loadMetrics.contains("replayChangelog"))
           assert(!m1.loadMetrics.contains("numReplayChangeLogFiles"))
         }
+
+        // A reload of the same version is served from local cache - no DFS fetch
+        db.load(2)
+        db.put("c", "1")
+        db.commit()
+        assert(db.metricsOpt.get.loadedFromDfs === 0)
       }
     }
   }
@@ -2957,7 +2963,7 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
         db.refreshRecordedMetricsForTest()
         val m1 = db.metricsOpt.get
         assert(m1.loadMetrics("loadFromSnapshot") > 0)
-        assert(m1.loadMetrics("numCloudLoads") === 1)
+        assert(m1.loadedFromDfs === 1)
         // since we called loadFromSnapshot, load should not be populated
         assert(!m1.loadMetrics.contains("load"))
         assert(m1.loadMetrics("replayChangelog") > 0)
@@ -4139,8 +4145,7 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
             db.put("e", "4")
             db.commit() // a new snapshot (5.zip) will be created since previous one is corrupt
             assert(db.metricsOpt.get.numSnapshotsAutoRepaired == 1)
-            // 4.zip was tried and failed (1 load), then 2.zip succeeded (2 loads)
-            assert(db.metricsOpt.get.loadMetrics("numCloudLoads") === 2)
+            assert(db.metricsOpt.get.loadedFromDfs === 1)
             db.doMaintenance() // upload snapshot 5.zip
           }
 
@@ -4153,8 +4158,8 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
             assert(toStr(db.get("b")) == "1")
             db.commit()
             assert(db.metricsOpt.get.numSnapshotsAutoRepaired == 1)
-            // 5.zip failed (1), 4.zip failed (2), 2.zip failed (3), then version 0 succeeded (4)
-            assert(db.metricsOpt.get.loadMetrics("numCloudLoads") === 4)
+            // All snapshots were corrupt; fallback to version 0 base and replay changelogs from DFS
+            assert(db.metricsOpt.get.loadedFromDfs === 1)
           }
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -4139,6 +4139,8 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
             db.put("e", "4")
             db.commit() // a new snapshot (5.zip) will be created since previous one is corrupt
             assert(db.metricsOpt.get.numSnapshotsAutoRepaired == 1)
+            // 4.zip was tried and failed (1 load), then 2.zip succeeded (2 loads)
+            assert(db.metricsOpt.get.loadMetrics("numCloudLoads") === 2)
             db.doMaintenance() // upload snapshot 5.zip
           }
 
@@ -4151,6 +4153,8 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
             assert(toStr(db.get("b")) == "1")
             db.commit()
             assert(db.metricsOpt.get.numSnapshotsAutoRepaired == 1)
+            // 5.zip failed (1), 4.zip failed (2), 2.zip failed (3), then version 0 succeeded (4)
+            assert(db.metricsOpt.get.loadMetrics("numCloudLoads") === 4)
           }
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -2920,7 +2920,7 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
 
         val m1 = db.metricsOpt.get
         assert(m1.loadMetrics("load") > 0)
-        assert(m1.loadMetrics("loadedFromCloud") === 1)
+        assert(m1.loadMetrics("numCloudLoads") === 1)
         // since we called load, loadFromSnapshot should not be populated
         assert(!m1.loadMetrics.contains("loadFromSnapshot"))
 
@@ -2957,7 +2957,7 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
         db.refreshRecordedMetricsForTest()
         val m1 = db.metricsOpt.get
         assert(m1.loadMetrics("loadFromSnapshot") > 0)
-        assert(m1.loadMetrics("loadedFromCloud") === 1)
+        assert(m1.loadMetrics("numCloudLoads") === 1)
         // since we called loadFromSnapshot, load should not be populated
         assert(!m1.loadMetrics.contains("load"))
         assert(m1.loadMetrics("replayChangelog") > 0)


### PR DESCRIPTION
### What changes were proposed in this pull request?

 This PR adds a new metric, rocksdbNumLoadedFromDfs, that tracks how many load()s of the RocksDB state store fetched a snapshot from remote (cloud/DFS) storage during a single load operation.

### Why are the changes needed?

  Fetching state from cloud storage is significantly more expensive than a local cache hit. Without this metric, there is no way to distinguish a load that was fully served from local disk from one that required one or more round-trips to cloud
  storage. This metric gives operators and developers visibility into cloud load frequency, which is useful for diagnosing performance regressions, tuning snapshot and changelog checkpointing configuration, and understanding cost implications of state store operations.

### Does this PR introduce _any_ user-facing change?

  Yes. A new custom metric rocksdbNumLoadedFromDfs ("RocksDB: load - number of state loads from external storage") is now reported in the Structured Streaming progress reporter under stateOperatorMetrics.customMetrics.


### How was this patch tested?

  - RocksDBSuite: added assertions verifying loadedFromDfs === 1 after a load and after a loadFromSnapshot that each fetch from DFS, and loadedFromDfs === 0 when state is served from local cache.
  - RocksDBStateStoreIntegrationSuite: updated the exhaustive custom-metrics presence check to include rocksdbNumLoadedFromDfs.

### Was this patch authored or co-authored using generative AI tooling?

  Generated-by: Claude Code 2.1.58