### PR TITLE
[SPARK-55686][CORE] SizeEstimator takes care of Compact Object Headers

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/Tests.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Tests.scala
@@ -21,6 +21,8 @@ private[spark] object Tests {
 
   val TEST_USE_COMPRESSED_OOPS_KEY = "spark.test.useCompressedOops"
 
+  val TEST_USE_COMPACT_OBJECT_HEADERS_KEY = "spark.test.useCompactObjectHeaders"
+
   val TEST_MEMORY = ConfigBuilder("spark.testing.memory")
     .version("1.6.0")
     .longConf

--- a/core/src/main/scala/org/apache/spark/util/SizeEstimator.scala
+++ b/core/src/main/scala/org/apache/spark/util/SizeEstimator.scala
@@ -97,8 +97,8 @@ object SizeEstimator extends Logging {
   // Based on https://wikis.oracle.com/display/HotSpotInternals/CompressedOops
   private var isCompressedOops = false
 
-  // Whether compact object headers (JEP 450/519) are enabled.
-  // With compact object headers, the object header is 8 bytes on 64-bit JVMs
+  // Whether Compact Object Headers (JEP 450/519) are enabled.
+  // With Compact Object Headers, the object header is 8 bytes on 64-bit JVMs
   // (the class pointer is encoded inside the mark word), so objectSize = 8
   // and pointerSize = 4 regardless of UseCompressedOops.
   private var isCompactObjectHeaders = false
@@ -133,7 +133,7 @@ object SizeEstimator extends Logging {
   }
 
   private def getIsCompactObjectHeaders: Boolean = {
-    // This is only used by tests to override the detection of compact object headers.
+    // This is only used by tests to override the detection of Compact Object Headers.
     if (System.getProperty(TEST_USE_COMPACT_OBJECT_HEADERS_KEY) != null) {
       return System.getProperty(TEST_USE_COMPACT_OBJECT_HEADERS_KEY).toBoolean
     }

--- a/core/src/main/scala/org/apache/spark/util/SizeEstimator.scala
+++ b/core/src/main/scala/org/apache/spark/util/SizeEstimator.scala
@@ -127,7 +127,7 @@ object SizeEstimator extends Logging {
         12
       }
     }
-    pointerSize = if (is64bit && !isCompressedOops && !isCompactObjectHeaders) 8 else 4
+    pointerSize = if (is64bit && !isCompressedOops) 8 else 4
     classInfos.clear()
     classInfos.put(classOf[Object], new ClassInfo(objectSize, Nil))
   }

--- a/core/src/main/scala/org/apache/spark/util/SizeEstimator.scala
+++ b/core/src/main/scala/org/apache/spark/util/SizeEstimator.scala
@@ -99,8 +99,7 @@ object SizeEstimator extends Logging {
 
   // Whether Compact Object Headers (JEP 450/519) are enabled.
   // With Compact Object Headers, the object header is 8 bytes on 64-bit JVMs
-  // (the class pointer is encoded inside the mark word), so objectSize = 8
-  // and pointerSize = 4 regardless of UseCompressedOops.
+  // (the class pointer is encoded inside the mark word). See https://openjdk.org/jeps/450
   private var isCompactObjectHeaders = false
 
   private var pointerSize = 4

--- a/core/src/main/scala/org/apache/spark/util/SizeEstimator.scala
+++ b/core/src/main/scala/org/apache/spark/util/SizeEstimator.scala
@@ -28,8 +28,7 @@ import com.google.common.collect.MapMaker
 
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.Tests.TEST_USE_COMPRESSED_OOPS_KEY
-import org.apache.spark.util.Utils
+import org.apache.spark.internal.config.Tests.{TEST_USE_COMPACT_OBJECT_HEADERS_KEY, TEST_USE_COMPRESSED_OOPS_KEY}
 import org.apache.spark.util.collection.OpenHashSet
 
 /**
@@ -97,6 +96,13 @@ object SizeEstimator extends Logging {
   // Size of an object reference
   // Based on https://wikis.oracle.com/display/HotSpotInternals/CompressedOops
   private var isCompressedOops = false
+
+  // Whether compact object headers (JEP 450/519) are enabled.
+  // With compact object headers, the object header is 8 bytes on 64-bit JVMs
+  // (the class pointer is encoded inside the mark word), so objectSize = 8
+  // and pointerSize = 4 regardless of UseCompressedOops.
+  private var isCompactObjectHeaders = false
+
   private var pointerSize = 4
 
   // Minimum size of a java.lang.Object
@@ -104,23 +110,40 @@ object SizeEstimator extends Logging {
 
   initialize()
 
-  // Sets object size, pointer size based on architecture and CompressedOops settings
-  // from the JVM.
+  // Sets object size, pointer size based on architecture, CompressedOops
+  // and CompactObjectHeaders settings from the JVM.
   private def initialize(): Unit = {
     val arch = Utils.osArch
     is64bit = arch.contains("64") || arch.contains("s390x")
+    isCompactObjectHeaders = is64bit && getIsCompactObjectHeaders
     isCompressedOops = getIsCompressedOops
 
     objectSize = if (!is64bit) 8 else {
-      if (!isCompressedOops) {
+      if (isCompactObjectHeaders) {
+        8
+      } else if (!isCompressedOops) {
         16
       } else {
         12
       }
     }
-    pointerSize = if (is64bit && !isCompressedOops) 8 else 4
+    pointerSize = if (is64bit && !isCompressedOops && !isCompactObjectHeaders) 8 else 4
     classInfos.clear()
     classInfos.put(classOf[Object], new ClassInfo(objectSize, Nil))
+  }
+
+  private def getIsCompactObjectHeaders: Boolean = {
+    // This is only used by tests to override the detection of compact object headers.
+    if (System.getProperty(TEST_USE_COMPACT_OBJECT_HEADERS_KEY) != null) {
+      return System.getProperty(TEST_USE_COMPACT_OBJECT_HEADERS_KEY).toBoolean
+    }
+
+    // Compact Object Headers is introduced in JEP 450/519, JDK 24/25.
+    if (Runtime.version().feature() < 24) {
+      return false
+    }
+
+    getHotSpotVMOption("UseCompactObjectHeaders").exists(_.contains("true"))
   }
 
   private def getIsCompressedOops: Boolean = {
@@ -136,28 +159,38 @@ object SizeEstimator extends Logging {
       return System.getProperty("java.vm.info").contains("Compressed Ref")
     }
 
-    try {
-      val hotSpotMBeanName = "com.sun.management:type=HotSpotDiagnostic"
-      val server = ManagementFactory.getPlatformMBeanServer()
-
-      // NOTE: This should throw an exception in non-Sun JVMs
-      // scalastyle:off classforname
-      val hotSpotMBeanClass = Class.forName("com.sun.management.HotSpotDiagnosticMXBean")
-      val getVMMethod = hotSpotMBeanClass.getDeclaredMethod("getVMOption",
-          Class.forName("java.lang.String"))
-      // scalastyle:on classforname
-
-      val bean = ManagementFactory.newPlatformMXBeanProxy(server,
-        hotSpotMBeanName, hotSpotMBeanClass)
-      // TODO: We could use reflection on the VMOption returned ?
-      getVMMethod.invoke(bean, "UseCompressedOops").toString.contains("true")
-    } catch {
-      case _: Exception =>
+    getHotSpotVMOption("UseCompressedOops") match {
+      case Some(value) => value.contains("true")
+      case None =>
         // Guess whether they've enabled UseCompressedOops based on whether maxMemory < 32 GB
         val guess = Runtime.getRuntime.maxMemory < (32L*1024*1024*1024)
         logWarning(log"Failed to check whether UseCompressedOops is set; " +
           log"assuming " + (if (guess) log"yes" else log"not"))
         guess
+    }
+  }
+
+  /**
+   * Retrieves the string representation of a HotSpot VM option via the HotSpotDiagnosticMXBean.
+   * Returns [[Some]] with the option's string value on success, or [[None]] if the option cannot
+   * be read (e.g. on non-HotSpot JVMs or when the option does not exist).
+   */
+  private def getHotSpotVMOption(option: String): Option[String] = {
+    try {
+      val hotSpotMBeanName = "com.sun.management:type=HotSpotDiagnostic"
+      val server = ManagementFactory.getPlatformMBeanServer
+
+      // NOTE: This should throw an exception in non-Sun JVMs
+      // scalastyle:off classforname
+      val hotSpotMBeanClass = Class.forName("com.sun.management.HotSpotDiagnosticMXBean")
+      val getVMMethod = hotSpotMBeanClass.getDeclaredMethod("getVMOption", classOf[String])
+      // scalastyle:on classforname
+
+      val bean = ManagementFactory.newPlatformMXBeanProxy(server,
+        hotSpotMBeanName, hotSpotMBeanClass)
+      Some(getVMMethod.invoke(bean, option).toString)
+    } catch {
+      case _: Exception => None
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/util/SizeEstimator.scala
+++ b/core/src/main/scala/org/apache/spark/util/SizeEstimator.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.util
 
-import java.lang.management.ManagementFactory
 import java.lang.reflect.{Field, Modifier}
 import java.util.{IdentityHashMap, Random}
 
@@ -142,7 +141,7 @@ object SizeEstimator extends Logging {
       return false
     }
 
-    getHotSpotVMOption("UseCompactObjectHeaders").exists(_.contains("true"))
+    Utils.getVMOptionValue("UseCompactObjectHeaders").contains("true")
   }
 
   private def getIsCompressedOops: Boolean = {
@@ -158,38 +157,14 @@ object SizeEstimator extends Logging {
       return System.getProperty("java.vm.info").contains("Compressed Ref")
     }
 
-    getHotSpotVMOption("UseCompressedOops") match {
-      case Some(value) => value.contains("true")
+    Utils.getVMOptionValue("UseCompressedOops") match {
+      case Some(value) => value == "true"
       case None =>
         // Guess whether they've enabled UseCompressedOops based on whether maxMemory < 32 GB
         val guess = Runtime.getRuntime.maxMemory < (32L*1024*1024*1024)
         logWarning(log"Failed to check whether UseCompressedOops is set; " +
           log"assuming " + (if (guess) log"yes" else log"not"))
         guess
-    }
-  }
-
-  /**
-   * Retrieves the string representation of a HotSpot VM option via the HotSpotDiagnosticMXBean.
-   * Returns [[Some]] with the option's string value on success, or [[None]] if the option cannot
-   * be read (e.g. on non-HotSpot JVMs or when the option does not exist).
-   */
-  private def getHotSpotVMOption(option: String): Option[String] = {
-    try {
-      val hotSpotMBeanName = "com.sun.management:type=HotSpotDiagnostic"
-      val server = ManagementFactory.getPlatformMBeanServer
-
-      // NOTE: This should throw an exception in non-Sun JVMs
-      // scalastyle:off classforname
-      val hotSpotMBeanClass = Class.forName("com.sun.management.HotSpotDiagnosticMXBean")
-      val getVMMethod = hotSpotMBeanClass.getDeclaredMethod("getVMOption", classOf[String])
-      // scalastyle:on classforname
-
-      val bean = ManagementFactory.newPlatformMXBeanProxy(server,
-        hotSpotMBeanName, hotSpotMBeanClass)
-      Some(getVMMethod.invoke(bean, option).toString)
-    } catch {
-      case _: Exception => None
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/util/SizeEstimator.scala
+++ b/core/src/main/scala/org/apache/spark/util/SizeEstimator.scala
@@ -98,8 +98,8 @@ object SizeEstimator extends Logging {
   private var isCompressedOops = false
 
   // Whether Compact Object Headers (JEP 450/519) are enabled.
-  // With Compact Object Headers, the object header is 8 bytes on 64-bit JVMs
-  // (the class pointer is encoded inside the mark word). See https://openjdk.org/jeps/450
+  // With Compact Object Headers, the object header is 8 bytes on 64-bit JVMs.
+  // See details at https://openjdk.org/jeps/450
   private var isCompactObjectHeaders = false
 
   private var pointerSize = 4

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -3192,19 +3192,25 @@ private[spark] object Utils
   lazy val isShenandoahGC: Boolean = checkUseGC("UseShenandoahGC")
 
   def checkUseGC(useGCObjectStr: String): Boolean = {
-    Try {
-      val clazz = Utils.classForName("com.sun.management.HotSpotDiagnosticMXBean")
-        .asInstanceOf[Class[_ <: PlatformManagedObject]]
-      val vmOptionClazz = Utils.classForName("com.sun.management.VMOption")
-      val hotSpotDiagnosticMXBean = ManagementFactory.getPlatformMXBean(clazz)
-      val vmOptionMethod = clazz.getMethod("getVMOption", classOf[String])
-      val valueMethod = vmOptionClazz.getMethod("getValue")
-
-      val useGCObject = vmOptionMethod.invoke(hotSpotDiagnosticMXBean, useGCObjectStr)
-      val useGC = valueMethod.invoke(useGCObject).asInstanceOf[String]
-      "true".equals(useGC)
-    }.getOrElse(false)
+    getVMOptionValue(useGCObjectStr).contains("true")
   }
+
+  /**
+   * Retrieves the value of a HotSpot VM option via the HotSpotDiagnosticMXBean.
+   * Returns [[Some]] with the option value string on success, or [[None]] if the option cannot
+   * be read (e.g. on non-HotSpot JVMs or when the option does not exist).
+   */
+  def getVMOptionValue(option: String): Option[String] = Try {
+    val clazz = Utils.classForName("com.sun.management.HotSpotDiagnosticMXBean")
+      .asInstanceOf[Class[_ <: PlatformManagedObject]]
+    val vmOptionClazz = Utils.classForName("com.sun.management.VMOption")
+    val hotSpotDiagnosticMXBean = ManagementFactory.getPlatformMXBean(clazz)
+    val vmOptionMethod = clazz.getMethod("getVMOption", classOf[String])
+    val valueMethod = vmOptionClazz.getMethod("getValue")
+
+    val useGCObject = vmOptionMethod.invoke(hotSpotDiagnosticMXBean, option)
+    valueMethod.invoke(useGCObject).asInstanceOf[String]
+  }.toOption
 
   /**
    * Return a string of printStackTrace result.

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -3197,8 +3197,8 @@ private[spark] object Utils
 
   /**
    * Retrieves the value of a HotSpot VM option via the HotSpotDiagnosticMXBean.
-   * Returns [[Some]] with the option value string on success, or [[None]] if the option cannot
-   * be read (e.g. on non-HotSpot JVMs or when the option does not exist).
+   * Returns Some with the option value string on success, or None if the option
+   * cannot be read (e.g. on non-HotSpot JVMs or when the option does not exist).
    */
   def getVMOptionValue(option: String): Option[String] = Try {
     val clazz = Utils.classForName("com.sun.management.HotSpotDiagnosticMXBean")

--- a/core/src/test/scala/org/apache/spark/util/SizeEstimatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/SizeEstimatorSuite.scala
@@ -249,9 +249,9 @@ class SizeEstimatorSuite
   }
 
   // Tests for JEP 450/519: Compact Object Headers
-  // With compact object headers, the object header is 8 bytes (vs. 12 with compressed oops,
+  // With Compact Object Headers, the object header is 8 bytes (vs. 12 with Compressed Oops,
   // or 16 without) because the class pointer is encoded inside the mark word.
-  // Object references are still 4 bytes (like compressed oops).
+  // Object references pointers are 4 bytes with Compressed Oops, or 8 bytes without.
 
   test("64-bit arch with compact object headers: simple classes") {
     reinitializeSizeEstimator("amd64", "true", "true")
@@ -301,7 +301,7 @@ class SizeEstimatorSuite
     // objectSize=8, fields=12 => shellSize=20, aligned to 24
     // DummyString("") => DummyString(24) + Array[Char](0)(16) = 40
     assertResult(40)(SizeEstimator.estimate(DummyString("")))
-    // DummyString("a") => 24 + Array[Char](1): 16 + alignSize(2) = 16 + 8 = 24 => 24+24=48
+    // DummyString("a") => 24 + Array[Char](1): 16 + alignSize(2) = 16+8=24 => 24+24=48
     assertResult(48)(SizeEstimator.estimate(DummyString("a")))
   }
 
@@ -318,5 +318,63 @@ class SizeEstimatorSuite
     //   shellSize = alignSizeUp(13, pointerSize=4) = 16
     //   alignSize(16) = 16
     assertResult(16)(SizeEstimator.estimate(new DummyClass6))
+  }
+
+  test("64-bit arch with compact object headers and no compressed oops") {
+    reinitializeSizeEstimator("amd64", "false", "true")
+    // objectSize = 8, pointerSize = 8
+    // DummyClass1: 8-byte header, no fields => 8 bytes
+    assertResult(8)(SizeEstimator.estimate(new DummyClass1))
+    assertResult(16)(SizeEstimator.estimate(new DummyClass2))
+    // DummyClass3: 8-byte header + Int(4) + Double(8) => 20, aligned to 24
+    assertResult(24)(SizeEstimator.estimate(new DummyClass3))
+    // DummyClass4: 8-byte header + Int(4) + pointer(8) => 20, aligned to 24
+    assertResult(24)(SizeEstimator.estimate(new DummyClass4(null)))
+    // DummyClass4 with DummyClass3: 24 + 24 = 48
+    assertResult(48)(SizeEstimator.estimate(new DummyClass4(new DummyClass3)))
+
+    // Primitive wrapper objects
+    // Boolean/Byte/Char/Short/Int/Float wrappers:
+    // 8-byte header + primitive up to 4 bytes => 12, aligned to 16
+    assertResult(16)(SizeEstimator.estimate(java.lang.Boolean.TRUE))
+    assertResult(16)(SizeEstimator.estimate(java.lang.Byte.valueOf("1")))
+    assertResult(16)(SizeEstimator.estimate(java.lang.Character.valueOf('1')))
+    assertResult(16)(SizeEstimator.estimate(java.lang.Short.valueOf("1")))
+    assertResult(16)(SizeEstimator.estimate(java.lang.Integer.valueOf(1)))
+    assertResult(16)(SizeEstimator.estimate(java.lang.Float.valueOf(1.0f)))
+    // Long/Double wrappers: 8-byte header + 8-byte primitive => 16, aligned to 16
+    assertResult(16)(SizeEstimator.estimate(java.lang.Long.valueOf(1)))
+    assertResult(16)(SizeEstimator.estimate(java.lang.Double.valueOf(1.0)))
+
+    // Primitive arrays
+    // Array header = objectSize(8) + length Int(4) = 12, aligned to 16
+    // Array[Byte](10): 16 + alignSize(10*1=10) = 16 + 16 = 32
+    assertResult(32)(SizeEstimator.estimate(new Array[Byte](10)))
+    // Array[Char](10): 16 + alignSize(10*2=20) = 16 + 24 = 40
+    assertResult(40)(SizeEstimator.estimate(new Array[Char](10)))
+    // Array[Int](10): 16 + alignSize(10*4=40) = 16 + 40 = 56
+    assertResult(56)(SizeEstimator.estimate(new Array[Int](10)))
+    // Array[Long](10): 16 + alignSize(10*8=80) = 16 + 80 = 96
+    assertResult(96)(SizeEstimator.estimate(new Array[Long](10)))
+
+    // Strings (DummyString)
+    // DummyString has: pointer(arr,8) + Int(hashCode,4) + Int(hash32,4) = 16 fields
+    // objectSize=8, fields=16 => shellSize=24, aligned to 24
+    // DummyString("") => DummyString(24) + Array[Char](0)(16) = 40
+    assertResult(40)(SizeEstimator.estimate(DummyString("")))
+    // DummyString("a") => 24 + Array[Char](1): 16 + alignSize(2) = 16+8=24 => 24+24=48
+    assertResult(48)(SizeEstimator.estimate(DummyString("a")))
+
+    // Class field blocks rounding
+    // DummyClass5 extends DummyClass1: parent.shellSize=8, adds Boolean(1)
+    //   alignedSize = max(8, alignSizeUp(8,1)+1) = 9, shellSize=9
+    //   shellSize = alignSizeUp(9, pointerSize=8) = 16
+    //   alignSize(16) = 16
+    assertResult(16)(SizeEstimator.estimate(new DummyClass5))
+    // DummyClass6 extends DummyClass5: parent.shellSize=16, adds Boolean(1)
+    //   alignedSize = max(16, alignSizeUp(16,1)+1) = 17, shellSize=17
+    //   shellSize = alignSizeUp(17, pointerSize=8) = 24
+    //   alignSize(24) = 24
+    assertResult(24)(SizeEstimator.estimate(new DummyClass6))
   }
 }

--- a/core/src/test/scala/org/apache/spark/util/SizeEstimatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/SizeEstimatorSuite.scala
@@ -22,8 +22,7 @@ import scala.collection.mutable.ArrayBuffer
 import org.scalatest.PrivateMethodTester
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.internal.config.Tests.TEST_USE_COMPRESSED_OOPS_KEY
-import org.apache.spark.util.Utils
+import org.apache.spark.internal.config.Tests.{TEST_USE_COMPACT_OBJECT_HEADERS_KEY, TEST_USE_COMPRESSED_OOPS_KEY}
 import org.apache.spark.util.collection.Utils.createArray
 
 class DummyClass1 {}
@@ -77,8 +76,12 @@ class SizeEstimatorSuite
   // Save modified system properties so that we can restore them after tests.
   val originalArch = Utils.osArch
   val originalCompressedOops = System.getProperty(TEST_USE_COMPRESSED_OOPS_KEY)
+  val originalCompactObjectHeaders = System.getProperty(TEST_USE_COMPACT_OBJECT_HEADERS_KEY)
 
-  def reinitializeSizeEstimator(arch: String, useCompressedOops: String): Unit = {
+  def reinitializeSizeEstimator(
+      arch: String,
+      useCompressedOops: String,
+      useCompactObjectHeaders: String): Unit = {
     def set(k: String, v: String): Unit = {
       if (v == null) {
         System.clearProperty(k)
@@ -88,6 +91,7 @@ class SizeEstimatorSuite
     }
     set("os.arch", arch)
     set(TEST_USE_COMPRESSED_OOPS_KEY, useCompressedOops)
+    set(TEST_USE_COMPACT_OBJECT_HEADERS_KEY, useCompactObjectHeaders)
     val initialize = PrivateMethod[Unit](Symbol("initialize"))
     SizeEstimator invokePrivate initialize()
   }
@@ -96,13 +100,13 @@ class SizeEstimatorSuite
     super.beforeEach()
     // Set the arch to 64-bit and compressedOops to true so that SizeEstimator
     // provides identical results across all systems in these tests.
-    reinitializeSizeEstimator("amd64", "true")
+    reinitializeSizeEstimator("amd64", "true", "false")
   }
 
   override def afterEach(): Unit = {
     super.afterEach()
     // Restore system properties and SizeEstimator to their original states.
-    reinitializeSizeEstimator(originalArch, originalCompressedOops)
+    reinitializeSizeEstimator(originalArch, originalCompressedOops, originalCompactObjectHeaders)
   }
 
   test("simple classes") {
@@ -199,7 +203,7 @@ class SizeEstimatorSuite
   }
 
   test("32-bit arch") {
-    reinitializeSizeEstimator("x86", "true")
+    reinitializeSizeEstimator("x86", "true", "false")
     assertResult(40)(SizeEstimator.estimate(DummyString("")))
     assertResult(48)(SizeEstimator.estimate(DummyString("a")))
     assertResult(48)(SizeEstimator.estimate(DummyString("ab")))
@@ -209,7 +213,7 @@ class SizeEstimatorSuite
   // NOTE: The String class definition varies across JDK versions (1.6 vs. 1.7) and vendors
   // (Sun vs IBM). Use a DummyString class to make tests deterministic.
   test("64-bit arch with no compressed oops") {
-    reinitializeSizeEstimator("amd64", "false")
+    reinitializeSizeEstimator("amd64", "false", "false")
     assertResult(56)(SizeEstimator.estimate(DummyString("")))
     assertResult(64)(SizeEstimator.estimate(DummyString("a")))
     assertResult(64)(SizeEstimator.estimate(DummyString("ab")))
@@ -227,13 +231,13 @@ class SizeEstimatorSuite
   }
 
   test("class field blocks rounding on 64-bit VM without useCompressedOops") {
-    reinitializeSizeEstimator("amd64", "false")
+    reinitializeSizeEstimator("amd64", "false", "false")
     assertResult(24)(SizeEstimator.estimate(new DummyClass5))
     assertResult(32)(SizeEstimator.estimate(new DummyClass6))
   }
 
   test("check 64-bit detection for s390x arch") {
-    reinitializeSizeEstimator("s390x", "true")
+    reinitializeSizeEstimator("s390x", "true", "false")
     // Class should be 32 bytes on s390x if recognised as 64 bit platform
     assertResult(32)(SizeEstimator.estimate(new DummyClass7))
   }
@@ -242,5 +246,77 @@ class SizeEstimatorSuite
     // DummyClass8 provides its size estimation.
     assertResult(2015)(SizeEstimator.estimate(new DummyClass8))
     assertResult(20206)(SizeEstimator.estimate(Array.fill(10)(new DummyClass8)))
+  }
+
+  // Tests for JEP 450/519: Compact Object Headers
+  // With compact object headers, the object header is 8 bytes (vs. 12 with compressed oops,
+  // or 16 without) because the class pointer is encoded inside the mark word.
+  // Object references are still 4 bytes (like compressed oops).
+
+  test("64-bit arch with compact object headers: simple classes") {
+    reinitializeSizeEstimator("amd64", "true", "true")
+    // objectSize = 8 (compact header), pointerSize = 4
+    // DummyClass1: 8-byte header, no fields => 8 bytes
+    assertResult(8)(SizeEstimator.estimate(new DummyClass1))
+    // DummyClass2: 8-byte header + Int(4) => 12, aligned to 16
+    assertResult(16)(SizeEstimator.estimate(new DummyClass2))
+    // DummyClass3: 8-byte header + Int(4) + Double(8) => 20, aligned to 24
+    assertResult(24)(SizeEstimator.estimate(new DummyClass3))
+    // DummyClass4: 8-byte header + Int(4) + pointer(4) => 16, aligned to 16
+    assertResult(16)(SizeEstimator.estimate(new DummyClass4(null)))
+    // DummyClass4 with DummyClass3: 16 + 24 = 40
+    assertResult(40)(SizeEstimator.estimate(new DummyClass4(new DummyClass3)))
+  }
+
+  test("64-bit arch with compact object headers: primitive wrapper objects") {
+    reinitializeSizeEstimator("amd64", "true", "true")
+    // Boolean/Byte/Char/Short/Int/Float wrappers: 8-byte header + primitive up to 4 bytes => 16
+    assertResult(16)(SizeEstimator.estimate(java.lang.Boolean.TRUE))
+    assertResult(16)(SizeEstimator.estimate(java.lang.Byte.valueOf("1")))
+    assertResult(16)(SizeEstimator.estimate(java.lang.Character.valueOf('1')))
+    assertResult(16)(SizeEstimator.estimate(java.lang.Short.valueOf("1")))
+    assertResult(16)(SizeEstimator.estimate(java.lang.Integer.valueOf(1)))
+    assertResult(16)(SizeEstimator.estimate(java.lang.Float.valueOf(1.0f)))
+    // Long/Double wrappers: 8-byte header + 8-byte primitive => 16
+    assertResult(16)(SizeEstimator.estimate(java.lang.Long.valueOf(1)))
+    assertResult(16)(SizeEstimator.estimate(java.lang.Double.valueOf(1.0)))
+  }
+
+  test("64-bit arch with compact object headers: primitive arrays") {
+    reinitializeSizeEstimator("amd64", "true", "true")
+    // Array header = objectSize(8) + length Int(4) = 12, aligned to 16
+    // Array[Byte](10): 16 + alignSize(10*1=10) = 16 + 16 = 32
+    assertResult(32)(SizeEstimator.estimate(new Array[Byte](10)))
+    // Array[Char](10): 16 + alignSize(10*2=20) = 16 + 24 = 40
+    assertResult(40)(SizeEstimator.estimate(new Array[Char](10)))
+    // Array[Int](10): 16 + alignSize(10*4=40) = 16 + 40 = 56
+    assertResult(56)(SizeEstimator.estimate(new Array[Int](10)))
+    // Array[Long](10): 16 + alignSize(10*8=80) = 16 + 80 = 96
+    assertResult(96)(SizeEstimator.estimate(new Array[Long](10)))
+  }
+
+  test("64-bit arch with compact object headers: strings") {
+    reinitializeSizeEstimator("amd64", "true", "true")
+    // DummyString has: pointer(arr,4) + Int(hashCode,4) + Int(hash32,4) = 12 fields
+    // objectSize=8, fields=12 => shellSize=20, aligned to 24
+    // DummyString("") => DummyString(24) + Array[Char](0)(16) = 40
+    assertResult(40)(SizeEstimator.estimate(DummyString("")))
+    // DummyString("a") => 24 + Array[Char](1): 16 + alignSize(2) = 16 + 8 = 24 => 24+24=48
+    assertResult(48)(SizeEstimator.estimate(DummyString("a")))
+  }
+
+  test("64-bit arch with compact object headers: class field blocks rounding") {
+    reinitializeSizeEstimator("amd64", "true", "true")
+    // DummyClass1: 8-byte header, no fields => shellSize=8, alignSize(8)=8
+    // DummyClass5 extends DummyClass1: parent.shellSize=8, adds Boolean(1)
+    //   alignedSize = max(8, alignSizeUp(8,1)+1) = 9, shellSize=9
+    //   shellSize = alignSizeUp(9, pointerSize=4) = 12
+    //   alignSize(12) = 16
+    assertResult(16)(SizeEstimator.estimate(new DummyClass5))
+    // DummyClass6 extends DummyClass5: parent.shellSize=12, adds Boolean(1)
+    //   alignedSize = max(12, alignSizeUp(12,1)+1) = 13, shellSize=13
+    //   shellSize = alignSizeUp(13, pointerSize=4) = 16
+    //   alignSize(16) = 16
+    assertResult(16)(SizeEstimator.estimate(new DummyClass6))
   }
 }

--- a/core/src/test/scala/org/apache/spark/util/SizeEstimatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/SizeEstimatorSuite.scala
@@ -251,7 +251,7 @@ class SizeEstimatorSuite
   // Tests for JEP 450/519: Compact Object Headers
   // With Compact Object Headers, the object header is 8 bytes (vs. 12 with Compressed Oops,
   // or 16 without) because the class pointer is encoded inside the mark word.
-  // Object references pointers are 4 bytes with Compressed Oops, or 8 bytes without.
+  // Object reference pointers are 4 bytes with Compressed Oops, or 8 bytes without.
 
   test("64-bit arch with compact object headers: simple classes") {
     reinitializeSizeEstimator("amd64", "true", "true")
@@ -297,7 +297,7 @@ class SizeEstimatorSuite
 
   test("64-bit arch with compact object headers: strings") {
     reinitializeSizeEstimator("amd64", "true", "true")
-    // DummyString has: pointer(arr,4) + Int(hashCode,4) + Int(hash32,4) = 12 fields
+    // DummyString has: pointer(arr,4) + Int(hashCode,4) + Int(hash32,4) = 12 bytes of fields
     // objectSize=8, fields=12 => shellSize=20, aligned to 24
     // DummyString("") => DummyString(24) + Array[Char](0)(16) = 40
     assertResult(40)(SizeEstimator.estimate(DummyString("")))
@@ -358,7 +358,7 @@ class SizeEstimatorSuite
     assertResult(96)(SizeEstimator.estimate(new Array[Long](10)))
 
     // Strings (DummyString)
-    // DummyString has: pointer(arr,8) + Int(hashCode,4) + Int(hash32,4) = 16 fields
+    // DummyString has: pointer(arr,8) + Int(hashCode,4) + Int(hash32,4) = 16 bytes of fields
     // objectSize=8, fields=16 => shellSize=24, aligned to 24
     // DummyString("") => DummyString(24) + Array[Char](0)(16) = 40
     assertResult(40)(SizeEstimator.estimate(DummyString("")))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Modify `SizeEstimator` to take care of Compact Object Headers [JEP 450](https://openjdk.org/jeps/450)/[JEP 519](https://openjdk.org/jeps/519)

With Compact Object Headers, the object header is 8 bytes on 64-bit JVMs.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For better JDK 25 support.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New UTs are added in `SizeEstimatorSuite`.

Also manually tested `SizeEstimator.isCompressedOops` and `SizeEstimator.isCompactObjectHeaders` evaluation.

Remove `private` and run `build/sbt package -Phive,hive-thriftserver`

```patch
  object SizeEstimator extends Logging {
    ...
-   private var isCompressedOops = false
+   var isCompressedOops = false
    ...
-   private var isCompactObjectHeaders = false
+   var isCompactObjectHeaders = false
    ...
  }
```

```
$ export JAVA_HOME=/path/of/openjdk-17
$ SPARK_PREPEND_CLASSES=true bin/spark-shell --driver-java-options="-XX:+UseCompactObjectHeaders"
...
Using Scala version 2.13.18 (OpenJDK 64-Bit Server VM, Java 17.0.13)
...

scala> org.apache.spark.util.SizeEstimator.isCompressedOops
val res0: Boolean = true

scala> org.apache.spark.util.SizeEstimator.isCompactObjectHeaders
val res1: Boolean = false

scala> 
```

```
$ export JAVA_HOME=/path/of/openjdk-25
$ SPARK_PREPEND_CLASSES=true bin/spark-shell --driver-java-options="-XX:+UseCompactObjectHeaders"
...
Using Scala version 2.13.18 (OpenJDK 64-Bit Server VM, Java 25.0.2)
...

scala> org.apache.spark.util.SizeEstimator.isCompressedOops
val res0: Boolean = true

scala> org.apache.spark.util.SizeEstimator.isCompactObjectHeaders
val res1: Boolean = true

scala> 
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes, GitHub Copilot with Claude Sonnet 4.6.