### PR TITLE
[SPARK-55770][UI] Replace custom .btn-spark with Bootstrap 5 button variant

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/webui.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.css
@@ -42,21 +42,7 @@ a:not([href]):not([class]):hover {
   text-decoration:underline
 }
 
-.btn-spark {
-  color:#333333;
-  background-color:#ffffff;
-  background-image:linear-gradient(to bottom, #ffffff, #e6e6e6);
-  background-repeat:repeat-x;
-  border: 1px solid #ced4da;
-  border-bottom-color: #b3b3b3;
-  box-shadow:inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
-}
 
-.btn-spark:hover {
-  background-color: #e6e6e6;
-  background-position:0 -15px;
-  transition:background-position 0.1s linear;
-}
 
 .form-inline label {
   margin-left: 0.25rem;

--- a/core/src/main/scala/org/apache/spark/ui/PagedTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/PagedTable.scala
@@ -285,7 +285,7 @@ private[spark] trait PagedTable[T] {
                  style="width: 60px;" />
           <label style="white-space: nowrap;">items in a page.</label>
 
-          <button type="submit" class="btn btn-spark btn-sm">Go</button>
+          <button type="submit" class="btn btn-outline-secondary btn-sm">Go</button>
         </form>
       </div>
     </div>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -441,7 +441,7 @@ private[ui] class StagePage(parent: StagesTab, store: AppStatusStore) extends We
                    class="form-control form-control-sm" style="width: 60px;" />
             <label>items in a page.</label>
 
-            <button type="submit" class="btn btn-spark">Go</button>
+            <button type="submit" class="btn btn-outline-secondary">Go</button>
           </form>
         </div>
       </div>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace the custom `.btn-spark` CSS class with Bootstrap 5's built-in `btn-outline-secondary` class.

### Why are the changes needed?

The custom `.btn-spark` class (lines 45-59 in webui.css) defines a legacy gradient background, box-shadow, and hover transition that duplicate what Bootstrap 5 provides natively. Replacing it with `btn-outline-secondary` simplifies the CSS and ensures consistent look with the rest of the BS5-upgraded UI.

Part of SPARK-55760 (Spark Web UI Modernization).

### Does this PR introduce _any_ user-facing change?

Yes — the "Go" buttons in paged tables and stage page now use Bootstrap 5's outline-secondary style instead of the custom gradient style. The visual difference is minimal.

### How was this patch tested?

- Verified no remaining references to `btn-spark` in the codebase
- Visual inspection of paged table "Go" buttons

### Was this patch authored or co-authored using generative AI tooling?

Yes, GitHub Copilot was used.