### PR TITLE
[SPARK-55771][UI][FOLLOWUP] Fix progress bar height alignment in BS5 stacked progress

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/webui.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.css
@@ -101,6 +101,10 @@ table.sortable td {
   position: relative;
 }
 
+.progress-stacked > .progress {
+  height: 100%;
+}
+
 .progress-stacked .progress-bar.progress-started {
   background: linear-gradient(to bottom, #A4EDFF, #94DDFF);
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the height mismatch between `.progress-stacked` container (1.42rem) and its inner `.progress` divs (BS5 default 1rem) by adding `height: 100%` to the inner `.progress` elements.

### Why are the changes needed?

After SPARK-55771 introduced BS5 `.progress-stacked`, the inner `.progress` bars use Bootstrap 5's default height (1rem ≈ 14px) which is shorter than the custom stacked container height (1.42rem ≈ 20px). This causes the colored progress bars to not fill the full height of the container, creating a visual misalignment.

**Before (misaligned — bar shorter than container):**
Inner `.progress` = 14px, container = 20px

**After (aligned — bar fills container):**
Inner `.progress` = 100% = 20px, container = 20px

### Does this PR introduce _any_ user-facing change?

Visual fix only — progress bars now properly fill their container height.

### How was this patch tested?

Manual verification with Playwright — confirmed all three elements (`.progress-stacked`, `.progress`, `.progress-bar`) now render at the same height (20px).