### PR TITLE
[SPARK-55812][SQL] Consolidate dataSchemaNotSpecifiedError to use UNABLE_TO_INFER_SCHEMA

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -8346,11 +8346,6 @@
       "A schema needs to be specified when using <className>."
     ]
   },
-  "_LEGACY_ERROR_TEMP_1134" : {
-    "message" : [
-      "Unable to infer schema for <format> at <fileCatalog>. It must be specified manually."
-    ]
-  },
   "_LEGACY_ERROR_TEMP_1135" : {
     "message" : [
       "<className> is not a valid Spark SQL Data Source."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1771,11 +1771,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
   }
 
   def dataSchemaNotSpecifiedError(format: String, fileCatalog: String): Throwable = {
-    new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1134",
-      messageParameters = Map(
-        "format" -> format,
-        "fileCatalog" -> fileCatalog))
+    dataSchemaNotSpecifiedError(format)
   }
 
   def invalidDataSourceError(className: String): Throwable = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR consolidates the 2-parameter overload of `dataSchemaNotSpecifiedError` to use the existing `UNABLE_TO_INFER_SCHEMA` error class (SQL state `42KD9`).

Changes:
- Updated the 2-parameter `dataSchemaNotSpecifiedError()` method to delegate to the 1-parameter version
- Removed `_LEGACY_ERROR_TEMP_1134` from `error-conditions.json`

Previously, the 2-parameter overload used `_LEGACY_ERROR_TEMP_1134` with no SQL state, while the 1-parameter version already used `UNABLE_TO_INFER_SCHEMA` with SQL state `42KD9`.

### Why are the changes needed?
This is needed to ensure reliable error reporting.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
The 1-parameter version already has comprehensive test coverage via `UNABLE_TO_INFER_SCHEMA`.


### Was this patch authored or co-authored using generative AI tooling?
No.
