### PR TITLE
[SPARK-55813][SQL] Rename _LEGACY_ERROR_TEMP_2078 to JDBC_TABLE_AND_QUERY_BOTH_SPECIFIED with SQL state 42000

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4373,6 +4373,12 @@
     },
     "sqlState" : "42000"
   },
+  "JDBC_TABLE_AND_QUERY_BOTH_SPECIFIED" : {
+    "message" : [
+      "Both '<jdbcTableName>' and '<jdbcQueryString>' can not be specified at the same time."
+    ],
+    "sqlState" : "42613"
+  },
   "JOIN_CONDITION_IS_NOT_BOOLEAN_TYPE" : {
     "message" : [
       "The join condition <joinCondition> has the invalid type <conditionType>, expected \"BOOLEAN\"."
@@ -9120,11 +9126,6 @@
   "_LEGACY_ERROR_TEMP_2077" : {
     "message" : [
       "Unsupported field name: <fieldName>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2078" : {
-    "message" : [
-      "Both '<jdbcTableName>' and '<jdbcQueryString>' can not be specified at the same time."
     ]
   },
   "_LEGACY_ERROR_TEMP_2079" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1001,7 +1001,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   def cannotSpecifyBothJdbcTableNameAndQueryError(
       jdbcTableName: String, jdbcQueryString: String): SparkIllegalArgumentException = {
     new SparkIllegalArgumentException(
-      errorClass = "_LEGACY_ERROR_TEMP_2078",
+      errorClass = "JDBC_TABLE_AND_QUERY_BOTH_SPECIFIED",
       messageParameters = Map(
         "jdbcTableName" -> jdbcTableName,
         "jdbcQueryString" -> jdbcQueryString))

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1727,33 +1727,42 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
   test("query JDBC option - negative tests") {
     val query = "SELECT * FROM  test.people WHERE theid = 1"
     // load path
-    val e1 = intercept[RuntimeException] {
-      val df = spark.read.format("jdbc")
-        .option("Url", urlWithUserAndPass)
-        .option("query", query)
-        .option("dbtable", "test.people")
-        .load()
-    }.getMessage
-    assert(e1.contains("Both 'dbtable' and 'query' can not be specified at the same time."))
+    checkError(
+      exception = intercept[SparkIllegalArgumentException] {
+        spark.read.format("jdbc")
+          .option("Url", urlWithUserAndPass)
+          .option("query", query)
+          .option("dbtable", "test.people")
+          .load()
+      },
+      condition = "JDBC_TABLE_AND_QUERY_BOTH_SPECIFIED",
+      parameters = Map("jdbcTableName" -> "dbtable", "jdbcQueryString" -> "query")
+    )
 
     // jdbc api path
     val properties = new Properties()
     properties.setProperty(JDBCOptions.JDBC_QUERY_STRING, query)
-    val e2 = intercept[RuntimeException] {
-      spark.read.jdbc(urlWithUserAndPass, "TEST.PEOPLE", properties).collect()
-    }.getMessage
-    assert(e2.contains("Both 'dbtable' and 'query' can not be specified at the same time."))
+    checkError(
+      exception = intercept[SparkIllegalArgumentException] {
+        spark.read.jdbc(urlWithUserAndPass, "TEST.PEOPLE", properties).collect()
+      },
+      condition = "JDBC_TABLE_AND_QUERY_BOTH_SPECIFIED",
+      parameters = Map("jdbcTableName" -> "dbtable", "jdbcQueryString" -> "query")
+    )
 
-    val e3 = intercept[RuntimeException] {
-      sql(
-        s"""
-         |CREATE OR REPLACE TEMPORARY VIEW queryOption
-         |USING org.apache.spark.sql.jdbc
-         |OPTIONS (url '$url', query '$query', dbtable 'TEST.PEOPLE',
-         |         user 'testUser', password 'testPass')
-       """.stripMargin.replaceAll("\n", " "))
-      }.getMessage
-    assert(e3.contains("Both 'dbtable' and 'query' can not be specified at the same time."))
+    checkError(
+      exception = intercept[SparkIllegalArgumentException] {
+        sql(
+          s"""
+           |CREATE OR REPLACE TEMPORARY VIEW queryOption
+           |USING org.apache.spark.sql.jdbc
+           |OPTIONS (url '$url', query '$query', dbtable 'TEST.PEOPLE',
+           |         user 'testUser', password 'testPass')
+         """.stripMargin.replaceAll("\n", " "))
+      },
+      condition = "JDBC_TABLE_AND_QUERY_BOTH_SPECIFIED",
+      parameters = Map("jdbcTableName" -> "dbtable", "jdbcQueryString" -> "query")
+    )
 
     val e4 = intercept[RuntimeException] {
       val df = spark.read.format("jdbc")


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds a proper error class and SQL state for the `cannotSpecifyBothJdbcTableNameAndQueryError` exception.

Changes:

- Added `JDBC_TABLE_AND_QUERY_BOTH_SPECIFIED` error class to error-conditions.json with SQL state `42000`
- Updated `QueryExecutionErrors.cannotSpecifyBothJdbcTableNameAndQueryError()` to use the new error class
- Removed `_LEGACY_ERROR_TEMP_2078` legacy error class

### Why are the changes needed?
Previously, this error used `_LEGACY_ERROR_TEMP_2078` without a SQL state, making it harder to identify and handle programmatically in error monitoring systems.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Updated tests in `JDBCSuite.scala`


### Was this patch authored or co-authored using generative AI tooling?
No.