### PR TITLE
[SPARK-55814][SQL] Add proper error class and SQL state for defineTempViewWithIfNotExistsError

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -6399,7 +6399,7 @@
     "message" : [
       "It is not allowed to define a TEMPORARY view with IF NOT EXISTS."
     ],
-    "sqlState" : "42601"
+    "sqlState" : "0A000"
   },
   "TEMP_VIEW_NAME_TOO_MANY_NAME_PARTS" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -6395,6 +6395,12 @@
     ],
     "sqlState" : "42P07"
   },
+  "TEMP_VIEW_IF_NOT_EXISTS_NOT_ALLOWED" : {
+    "message" : [
+      "It is not allowed to define a TEMPORARY view with IF NOT EXISTS."
+    ],
+    "sqlState" : "42601"
+  },
   "TEMP_VIEW_NAME_TOO_MANY_NAME_PARTS" : {
     "message" : [
       "CREATE TEMPORARY VIEW or the corresponding Dataset APIs only accept single-part view names, but got: <actualName>."
@@ -8020,11 +8026,6 @@
   "_LEGACY_ERROR_TEMP_0052" : {
     "message" : [
       "CREATE VIEW with both IF NOT EXISTS and REPLACE is not allowed."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_0053" : {
-    "message" : [
-      "It is not allowed to define a TEMPORARY view with IF NOT EXISTS."
     ]
   },
   "_LEGACY_ERROR_TEMP_0056" : {

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -638,7 +638,7 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
   }
 
   def defineTempViewWithIfNotExistsError(ctx: CreateViewContext): Throwable = {
-    new ParseException(errorClass = "_LEGACY_ERROR_TEMP_0053", ctx)
+    new ParseException(errorClass = "TEMP_VIEW_IF_NOT_EXISTS_NOT_ALLOWED", ctx)
   }
 
   def notAllowedToAddDBPrefixForTempViewError(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -473,12 +473,14 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
 
   test("error handling: disallow IF NOT EXISTS for CREATE TEMPORARY VIEW") {
     withTempView("myabcdview") {
+      val sqlText = "CREATE TEMPORARY VIEW IF NOT EXISTS myabcdview AS SELECT * FROM jt"
       checkError(
         exception = intercept[ParseException] {
-          sql("CREATE TEMPORARY VIEW IF NOT EXISTS myabcdview AS SELECT * FROM jt")
+          sql(sqlText)
         },
         condition = "TEMP_VIEW_IF_NOT_EXISTS_NOT_ALLOWED",
-        parameters = Map.empty
+        parameters = Map.empty,
+        context = ExpectedContext(sqlText, 0, sqlText.length - 1)
       )
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -473,10 +473,13 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
 
   test("error handling: disallow IF NOT EXISTS for CREATE TEMPORARY VIEW") {
     withTempView("myabcdview") {
-      val e = intercept[ParseException] {
-        sql("CREATE TEMPORARY VIEW IF NOT EXISTS myabcdview AS SELECT * FROM jt")
-      }
-      assert(e.message.contains("It is not allowed to define a TEMPORARY view with IF NOT EXISTS"))
+      checkError(
+        exception = intercept[ParseException] {
+          sql("CREATE TEMPORARY VIEW IF NOT EXISTS myabcdview AS SELECT * FROM jt")
+        },
+        condition = "TEMP_VIEW_IF_NOT_EXISTS_NOT_ALLOWED",
+        parameters = Map.empty
+      )
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds a proper error class and SQL state for the `defineTempViewWithIfNotExistsError` parsing exception.

Changes:
- Added `TEMP_VIEW_IF_NOT_EXISTS_NOT_ALLOWED` error class to `error-conditions.json` with SQL state `0A000 `
- Updated `QueryParsingErrors.defineTempViewWithIfNotExistsError()` to use the new error class
- Removed `_LEGACY_ERROR_TEMP_0053` legacy error class

### Why are the changes needed?
Previously, this error used `_LEGACY_ERROR_TEMP_0053` without a SQL state, making it harder
to identify.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Updated test in `SQLViewSuite.scala`.

### Was this patch authored or co-authored using generative AI tooling?
No.
