### PR TITLE
[SPARK-55815][SQL] Add proper error class and SQL state for _LEGACY_ERROR_TEMP_1310

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -643,6 +643,12 @@
     ],
     "sqlState" : "42P08"
   },
+  "CATALOG_NOT_FOUND_FOR_IDENTIFIER" : {
+    "message" : [
+      "Couldn't find a catalog to handle the identifier <quote>."
+    ],
+    "sqlState" : "42P08"
+  },
   "CHECKPOINT_FILE_CHECKSUM_VERIFICATION_FAILED" : {
     "message" : [
       "Checksum verification failed, the file may be corrupted. File: <fileName>",
@@ -8848,11 +8854,6 @@
   "_LEGACY_ERROR_TEMP_1309" : {
     "message" : [
       "insertInto() can't be used together with partitionBy(). Partition columns have already been defined for the table. It is not necessary to use partitionBy()."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1310" : {
-    "message" : [
-      "Couldn't find a catalog to handle the identifier <quote>."
     ]
   },
   "_LEGACY_ERROR_TEMP_1312" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -643,12 +643,6 @@
     ],
     "sqlState" : "42P08"
   },
-  "CATALOG_NOT_FOUND_FOR_IDENTIFIER" : {
-    "message" : [
-      "Couldn't find a catalog to handle the identifier <quote>."
-    ],
-    "sqlState" : "42P08"
-  },
   "CHECKPOINT_FILE_CHECKSUM_VERIFICATION_FAILED" : {
     "message" : [
       "Checksum verification failed, the file may be corrupted. File: <fileName>",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3565,12 +3565,6 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map.empty)
   }
 
-  def cannotFindCatalogToHandleIdentifierError(quote: String): Throwable = {
-    new AnalysisException(
-      errorClass = "CATALOG_NOT_FOUND_FOR_IDENTIFIER",
-      messageParameters = Map("quote" -> quote))
-  }
-
   def tableAlreadyExistsError(tableIdent: TableIdentifier): Throwable = {
     new TableAlreadyExistsException(tableIdent.nameParts)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3567,7 +3567,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def cannotFindCatalogToHandleIdentifierError(quote: String): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1310",
+      errorClass = "CATALOG_NOT_FOUND_FOR_IDENTIFIER",
       messageParameters = Map("quote" -> quote))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/DataFrameWriter.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.catalog.TableWritePrivilege._
 import org.apache.spark.sql.connector.expressions.{ClusterByTransform, FieldReference, IdentityTransform, Transform}
-import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.command.{DDLUtils, SaveAsV1TableCommand}
 import org.apache.spark.sql.execution.datasources.{DataSource, DataSourceUtils}
@@ -331,7 +331,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) extends sql.DataFram
       case AsTableIdentifier(tableIdentifier) =>
         insertIntoCommand(tableIdentifier)
       case other =>
-        throw QueryCompilationErrors.cannotFindCatalogToHandleIdentifierError(other.quoted)
+        throw QueryExecutionErrors.catalogNotFoundError(other.head)
     }
   }
 
@@ -455,7 +455,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) extends sql.DataFram
         saveAsV1TableCommand(tableIdentifier)
 
       case other =>
-        throw QueryCompilationErrors.cannotFindCatalogToHandleIdentifierError(other.quoted)
+        throw QueryExecutionErrors.catalogNotFoundError(other.head)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -38,6 +38,7 @@ import org.apache.spark.internal.io.HadoopMapReduceCommitProtocol
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.connector.catalog.CatalogNotFoundException
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, LogicalPlan, OverwriteByExpression}
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.command.DataWritingCommandExec
@@ -923,18 +924,22 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSparkSession with 
   test("insertInto/saveAsTable with unresolvable multi-part identifier") {
     val df = spark.range(1)
     checkError(
-      exception = intercept[AnalysisException] {
+      exception = intercept[CatalogNotFoundException] {
         df.write.insertInto("a.b.c.d")
       },
-      condition = "CATALOG_NOT_FOUND_FOR_IDENTIFIER",
-      parameters = Map("quote" -> "`a`.`b`.`c`.`d`")
+      condition = "CATALOG_NOT_FOUND",
+      parameters = Map(
+        "catalogName" -> "`a`",
+        "config" -> "\"spark.sql.catalog.a\"")
     )
     checkError(
-      exception = intercept[AnalysisException] {
+      exception = intercept[CatalogNotFoundException] {
         df.write.saveAsTable("a.b.c.d")
       },
-      condition = "CATALOG_NOT_FOUND_FOR_IDENTIFIER",
-      parameters = Map("quote" -> "`a`.`b`.`c`.`d`")
+      condition = "CATALOG_NOT_FOUND",
+      parameters = Map(
+        "catalogName" -> "`a`",
+        "config" -> "\"spark.sql.catalog.a\"")
     )
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -920,6 +920,24 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSparkSession with 
     }
   }
 
+  test("insertInto/saveAsTable with unresolvable multi-part identifier") {
+    val df = spark.range(1)
+    checkError(
+      exception = intercept[AnalysisException] {
+        df.write.insertInto("a.b.c.d")
+      },
+      condition = "CATALOG_NOT_FOUND_FOR_IDENTIFIER",
+      parameters = Map("quote" -> "`a`.`b`.`c`.`d`")
+    )
+    checkError(
+      exception = intercept[AnalysisException] {
+        df.write.saveAsTable("a.b.c.d")
+      },
+      condition = "CATALOG_NOT_FOUND_FOR_IDENTIFIER",
+      parameters = Map("quote" -> "`a`.`b`.`c`.`d`")
+    )
+  }
+
   test("saveAsTable with mode Append should not fail if the table not exists " +
     "but a same-name temp view exist") {
     withTable("same_name") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR uses a proper error class and SQL state for the `cannotFindCatalogToHandleIdentifierError` exception.

Changes:
- Use `CATALOG_NOT_FOUND` error class instead of `_LEGACY_ERROR_TEMP_1310`
- Updated `QueryCompilationErrors.cannotFindCatalogToHandleIdentifierError()` to use the existing method
- Removed `_LEGACY_ERROR_TEMP_1310` legacy error class


### Why are the changes needed?
Previously, this error used `_LEGACY_ERROR_TEMP_1310` without a SQL state, making it harder
to identify.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
New tests in `DataFrameWriterSuite.scala`.


### Was this patch authored or co-authored using generative AI tooling?
No.
