### PR TITLE
[SPARK-55816][SQL] Rename _LEGACY_ERROR_TEMP_3058 to DUPLICATE_PARTITION_TRANSFORM with SQL state 42711

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1593,6 +1593,12 @@
     ],
     "sqlState" : "23505"
   },
+  "DUPLICATE_PARTITION_TRANSFORM" : {
+    "message" : [
+      "Found duplicate column(s) <checkType>: <duplicateColumns>"
+    ],
+    "sqlState" : "42701"
+  },
   "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT" : {
     "message" : [
       "Call to routine <routineName> is invalid because it includes multiple argument assignments to the same parameter name <parameterName>."
@@ -10007,11 +10013,6 @@
   "_LEGACY_ERROR_TEMP_3057" : {
     "message" : [
       "Cannot retrieve row-level operation from <table>"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3058" : {
-    "message" : [
-      "Found duplicate column(s) <checkType>: <duplicateColumns>"
     ]
   },
   "_LEGACY_ERROR_TEMP_3059" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1597,7 +1597,7 @@
     "message" : [
       "Found duplicate column(s) <checkType>: <duplicateColumns>"
     ],
-    "sqlState" : "42701"
+    "sqlState" : "42711"
   },
   "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT" : {
     "message" : [

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/SchemaUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/SchemaUtils.scala
@@ -231,7 +231,7 @@ private[spark] object SchemaUtils {
         case (x, ys) if ys.length > 1 => s"${x._2.mkString(".")}"
       }
       throw new AnalysisException(
-        errorClass = "_LEGACY_ERROR_TEMP_3058",
+        errorClass = "DUPLICATE_PARTITION_TRANSFORM",
         messageParameters = Map(
           "checkType" -> checkType,
           "duplicateColumns" -> duplicateColumns.mkString(", ")))

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -2109,22 +2109,22 @@ class DataSourceV2SQLSuiteV1Filter
         checkError(
           exception = analysisException(
             s"CREATE TABLE t ($c0 INT) USING $v2Source PARTITIONED BY ($c0, $c1)"),
-          condition = "_LEGACY_ERROR_TEMP_3058",
+          condition = "DUPLICATE_PARTITION_TRANSFORM",
           parameters = Map("checkType" -> "in the partitioning", "duplicateColumns" -> dupCol))
         checkError(
           exception = analysisException(
             s"CREATE TABLE testcat.t ($c0 INT) USING $v2Source PARTITIONED BY ($c0, $c1)"),
-          condition = "_LEGACY_ERROR_TEMP_3058",
+          condition = "DUPLICATE_PARTITION_TRANSFORM",
           parameters = Map("checkType" -> "in the partitioning", "duplicateColumns" -> dupCol))
         checkError(
           exception = analysisException(
             s"CREATE OR REPLACE TABLE t ($c0 INT) USING $v2Source PARTITIONED BY ($c0, $c1)"),
-          condition = "_LEGACY_ERROR_TEMP_3058",
+          condition = "DUPLICATE_PARTITION_TRANSFORM",
           parameters = Map("checkType" -> "in the partitioning", "duplicateColumns" -> dupCol))
         checkError(
           exception = analysisException(s"CREATE OR REPLACE TABLE testcat.t ($c0 INT) " +
             s"USING $v2Source PARTITIONED BY ($c0, $c1)"),
-          condition = "_LEGACY_ERROR_TEMP_3058",
+          condition = "DUPLICATE_PARTITION_TRANSFORM",
           parameters = Map("checkType" -> "in the partitioning", "duplicateColumns" -> dupCol))
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds a proper error class and SQL state for the `checkTransformDuplication` exception in `SchemaUtils`.

Changes:
- Added `DUPLICATE_PARTITION_TRANSFORM` error class to `error-conditions.json` with SQL state `42711`
- Updated `SchemaUtils.checkTransformDuplication()` to use the new error class
- Removed `_LEGACY_ERROR_TEMP_3058` legacy error class


### Why are the changes needed?
Previously, this error used `_LEGACY_ERROR_TEMP_3058` without a SQL state, making it harder
to identify and handle programmatically in error monitoring systems.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Updated `DataSourceV2SQLSuite` tests to check for new error class.


### Was this patch authored or co-authored using generative AI tooling?
No.
