### PR TITLE
[SPARK-55818][PS] Decimal-float mixed arithmetic should always raise TypeError

### DIFF
--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -461,7 +461,7 @@ class FractionalOps(NumericOps):
             raise TypeError("Multiplication can not be applied to given types.")
 
         is_ansi = is_ansi_mode_enabled(left._internal.spark_frame.sparkSession)
-        if is_ansi and _is_decimal_float_mixed(left, right):
+        if _is_decimal_float_mixed(left, right):
             raise TypeError("Multiplication can not be applied to given types.")
         new_right = transform_boolean_operand_to_numeric(right, spark_type=left.spark.data_type)
 
@@ -474,8 +474,7 @@ class FractionalOps(NumericOps):
         return column_op(wrapped_mul)(left, new_right)
 
     def mod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        is_ansi = is_ansi_mode_enabled(left._internal.spark_frame.sparkSession)
-        if is_ansi and _is_decimal_float_mixed(left, right):
+        if _is_decimal_float_mixed(left, right):
             raise TypeError("Modulo can not be applied to given types.")
 
         return super().mod(left, right)
@@ -485,7 +484,7 @@ class FractionalOps(NumericOps):
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError("True division can not be applied to given types.")
         is_ansi = is_ansi_mode_enabled(left._internal.spark_frame.sparkSession)
-        if is_ansi and _is_decimal_float_mixed(left, right):
+        if _is_decimal_float_mixed(left, right):
             raise TypeError("True division can not be applied to given types.")
         new_right = transform_boolean_operand_to_numeric(right, spark_type=left.spark.data_type)
         left_dtype = left.dtype
@@ -516,7 +515,7 @@ class FractionalOps(NumericOps):
         if not is_valid_operand_for_numeric_arithmetic(right):
             raise TypeError("Floor division can not be applied to given types.")
         is_ansi = is_ansi_mode_enabled(left._internal.spark_frame.sparkSession)
-        if is_ansi and _is_decimal_float_mixed(left, right):
+        if _is_decimal_float_mixed(left, right):
             raise TypeError("Floor division can not be applied to given types.")
         left_dtype = left.dtype
 
@@ -548,8 +547,7 @@ class FractionalOps(NumericOps):
         if not isinstance(right, numbers.Number):
             raise TypeError("True division can not be applied to given types.")
 
-        is_ansi = is_ansi_mode_enabled(left._internal.spark_frame.sparkSession)
-        if is_ansi and _is_decimal_float_mixed(left, right):
+        if _is_decimal_float_mixed(left, right):
             raise TypeError("True division can not be applied to given types.")
 
         def rtruediv(left: PySparkColumn, right: Any) -> PySparkColumn:
@@ -565,8 +563,7 @@ class FractionalOps(NumericOps):
         if not isinstance(right, numbers.Number):
             raise TypeError("Floor division can not be applied to given types.")
 
-        is_ansi = is_ansi_mode_enabled(left._internal.spark_frame.sparkSession)
-        if is_ansi and _is_decimal_float_mixed(left, right):
+        if _is_decimal_float_mixed(left, right):
             raise TypeError("Floor division can not be applied to given types.")
 
         def rfloordiv(left: PySparkColumn, right: Any) -> PySparkColumn:
@@ -578,14 +575,12 @@ class FractionalOps(NumericOps):
         return numpy_column_op(rfloordiv)(left, right)
 
     def rmul(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        is_ansi = is_ansi_mode_enabled(left._internal.spark_frame.sparkSession)
-        if is_ansi and _is_decimal_float_mixed(left, right):
+        if _is_decimal_float_mixed(left, right):
             raise TypeError("Multiplication can not be applied to given types.")
         return super().rmul(left, right)
 
     def rmod(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        is_ansi = is_ansi_mode_enabled(left._internal.spark_frame.sparkSession)
-        if is_ansi and _is_decimal_float_mixed(left, right):
+        if _is_decimal_float_mixed(left, right):
             raise TypeError("Modulo can not be applied to given types.")
 
         return super().rmod(left, right)

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_mul_div.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_mul_div.py
@@ -20,7 +20,6 @@ import pandas as pd
 import numpy as np
 
 from pyspark import pandas as ps
-from pyspark.testing.utils import is_ansi_mode_test
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
 
@@ -62,13 +61,12 @@ class NumMulDivTestsMixin:
             self.assertRaises(TypeError, lambda: psser * psdf["date"])
             self.assertRaises(TypeError, lambda: psser * psdf["categorical"])
 
-        if is_ansi_mode_test:
-            self.assertRaises(TypeError, lambda: psdf["decimal"] * psdf["float"])
-            self.assertRaises(TypeError, lambda: psdf["float"] * psdf["decimal"])
-            self.assertRaises(TypeError, lambda: psdf["decimal"] * psdf["float32"])
-            self.assertRaises(TypeError, lambda: psdf["float32"] * psdf["decimal"])
-            self.assertRaises(TypeError, lambda: psdf["decimal"] * 0.1)
-            self.assertRaises(TypeError, lambda: 0.1 * psdf["decimal"])
+        self.assertRaises(TypeError, lambda: psdf["decimal"] * psdf["float"])
+        self.assertRaises(TypeError, lambda: psdf["float"] * psdf["decimal"])
+        self.assertRaises(TypeError, lambda: psdf["decimal"] * psdf["float32"])
+        self.assertRaises(TypeError, lambda: psdf["float32"] * psdf["decimal"])
+        self.assertRaises(TypeError, lambda: psdf["decimal"] * 0.1)
+        self.assertRaises(TypeError, lambda: 0.1 * psdf["decimal"])
 
     def test_truediv(self):
         pdf, psdf = self.pdf, self.psdf
@@ -86,13 +84,12 @@ class NumMulDivTestsMixin:
                 else:
                     self.assertRaises(TypeError, lambda: psser / psdf[n_col])
 
-        if is_ansi_mode_test:
-            self.assertRaises(TypeError, lambda: psdf["decimal"] / psdf["float"])
-            self.assertRaises(TypeError, lambda: psdf["float"] / psdf["decimal"])
-            self.assertRaises(TypeError, lambda: psdf["decimal"] / psdf["float32"])
-            self.assertRaises(TypeError, lambda: psdf["float32"] / psdf["decimal"])
-            self.assertRaises(TypeError, lambda: psdf["decimal"] / 0.1)
-            self.assertRaises(TypeError, lambda: 0.1 / psdf["decimal"])
+        self.assertRaises(TypeError, lambda: psdf["decimal"] / psdf["float"])
+        self.assertRaises(TypeError, lambda: psdf["float"] / psdf["decimal"])
+        self.assertRaises(TypeError, lambda: psdf["decimal"] / psdf["float32"])
+        self.assertRaises(TypeError, lambda: psdf["float32"] / psdf["decimal"])
+        self.assertRaises(TypeError, lambda: psdf["decimal"] / 0.1)
+        self.assertRaises(TypeError, lambda: 0.1 / psdf["decimal"])
 
     def test_floordiv(self):
         pdf, psdf = self.pdf, self.psdf
@@ -110,13 +107,12 @@ class NumMulDivTestsMixin:
                     psser = psdf[col]
                     self.assertRaises(TypeError, lambda: psser // psdf[n_col])
 
-        if is_ansi_mode_test:
-            self.assertRaises(TypeError, lambda: psdf["decimal"] // psdf["float"])
-            self.assertRaises(TypeError, lambda: psdf["float"] // psdf["decimal"])
-            self.assertRaises(TypeError, lambda: psdf["decimal"] // psdf["float32"])
-            self.assertRaises(TypeError, lambda: psdf["float32"] // psdf["decimal"])
-            self.assertRaises(TypeError, lambda: psdf["decimal"] // 0.1)
-            self.assertRaises(TypeError, lambda: 0.1 // psdf["decimal"])
+        self.assertRaises(TypeError, lambda: psdf["decimal"] // psdf["float"])
+        self.assertRaises(TypeError, lambda: psdf["float"] // psdf["decimal"])
+        self.assertRaises(TypeError, lambda: psdf["decimal"] // psdf["float32"])
+        self.assertRaises(TypeError, lambda: psdf["float32"] // psdf["decimal"])
+        self.assertRaises(TypeError, lambda: psdf["decimal"] // 0.1)
+        self.assertRaises(TypeError, lambda: 0.1 // psdf["decimal"])
 
     def test_mod(self):
         pdf, psdf = self.pdf, self.psdf
@@ -139,13 +135,12 @@ class NumMulDivTestsMixin:
                 else:
                     self.assertRaises(TypeError, lambda: psser % psdf[n_col])
 
-        if is_ansi_mode_test:
-            self.assertRaises(TypeError, lambda: psdf["decimal"] % psdf["float"])
-            self.assertRaises(TypeError, lambda: psdf["float"] % psdf["decimal"])
-            self.assertRaises(TypeError, lambda: psdf["decimal"] % psdf["float32"])
-            self.assertRaises(TypeError, lambda: psdf["float32"] % psdf["decimal"])
-            self.assertRaises(TypeError, lambda: psdf["decimal"] % 0.1)
-            self.assertRaises(TypeError, lambda: 0.1 % psdf["decimal"])
+        self.assertRaises(TypeError, lambda: psdf["decimal"] % psdf["float"])
+        self.assertRaises(TypeError, lambda: psdf["float"] % psdf["decimal"])
+        self.assertRaises(TypeError, lambda: psdf["decimal"] % psdf["float32"])
+        self.assertRaises(TypeError, lambda: psdf["float32"] % psdf["decimal"])
+        self.assertRaises(TypeError, lambda: psdf["decimal"] % 0.1)
+        self.assertRaises(TypeError, lambda: 0.1 % psdf["decimal"])
 
 
 class NumMulDivTests(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove the `is_ansi_mode_enabled` guard from `_is_decimal_float_mixed` checks in `FractionalOps` so that mixing `decimal.Decimal` with float Series always raises `TypeError`, regardless of ANSI mode.

### Why are the changes needed?
It could be considered a bug. With ANSI mode off, `ps.Series([1.0, 2.0, 3.0]) * decimal.Decimal("1.5")` silently computes a result, while pandas raises `TypeError`. The correct behavior (raising `TypeError`) was only triggered when `spark.sql.ansi.enabled=true`.

### Does this PR introduce _any_ user-facing change?
Yes, decimal-float mixed arithmetic now always raises `TypeError` (matching pandas), even with ANSI mode disabled.

### How was this patch tested?
CI

### Was this patch authored or co-authored using generative AI tooling?
Co-authored-by: Claude Opus 4