### PR TITLE
[SPARK-55822][SQL] Rename `_LEGACY_ERROR_TEMP_0052` to `CREATE_VIEW_WITH_IF_NOT_EXISTS_AND_REPLACE`

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1049,6 +1049,12 @@
     },
     "sqlState" : "21S01"
   },
+  "CREATE_VIEW_WITH_IF_NOT_EXISTS_AND_REPLACE" : {
+    "message" : [
+      "CREATE VIEW <viewName> with both IF NOT EXISTS and REPLACE is not allowed."
+    ],
+    "sqlState" : "42601"
+  },
   "CURSOR_ALREADY_EXISTS" : {
     "message" : [
       "Cannot declare cursor <cursorName> because it already exists in the current scope."
@@ -8015,11 +8021,6 @@
   "_LEGACY_ERROR_TEMP_0051" : {
     "message" : [
       "Empty set in <element> grouping sets is not supported."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_0052" : {
-    "message" : [
-      "CREATE VIEW with both IF NOT EXISTS and REPLACE is not allowed."
     ]
   },
   "_LEGACY_ERROR_TEMP_0053" : {

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -618,8 +618,13 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
       ctx)
   }
 
-  def createViewWithBothIfNotExistsAndReplaceError(ctx: ParserRuleContext): Throwable = {
-    new ParseException(errorClass = "_LEGACY_ERROR_TEMP_0052", ctx)
+  def createViewWithBothIfNotExistsAndReplaceError(
+      viewName: String,
+      ctx: ParserRuleContext): Throwable = {
+    new ParseException(
+      errorClass = "CREATE_VIEW_WITH_IF_NOT_EXISTS_AND_REPLACE",
+      messageParameters = Map("viewName" -> viewName),
+      ctx)
   }
 
   def temporaryViewWithSchemaBindingMode(ctx: StatementContext): Throwable = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -685,7 +685,8 @@ class SparkSqlAstBuilder extends AstBuilder {
     }
 
     if (ctx.EXISTS != null && ctx.REPLACE != null) {
-      throw QueryParsingErrors.createViewWithBothIfNotExistsAndReplaceError(ctx)
+      throw QueryParsingErrors.createViewWithBothIfNotExistsAndReplaceError(
+        ctx.identifierReference().getText, ctx)
     }
 
     val properties = ctx.propertyList.asScala.headOption.map(visitPropertyKeyValues)
@@ -778,7 +779,8 @@ class SparkSqlAstBuilder extends AstBuilder {
     }
 
     if (ctx.EXISTS != null && ctx.REPLACE != null) {
-      throw QueryParsingErrors.createViewWithBothIfNotExistsAndReplaceError(ctx)
+      throw QueryParsingErrors.createViewWithBothIfNotExistsAndReplaceError(
+        ctx.identifierReference().getText, ctx)
     }
 
     if (ctx.METRICS(0) == null) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -627,11 +627,18 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
 
       sql("DROP VIEW testView")
 
-      val e = intercept[ParseException] {
-        sql("CREATE OR REPLACE VIEW IF NOT EXISTS testView AS SELECT id FROM jt")
-      }
-      assert(e.message.contains(
-        "CREATE VIEW with both IF NOT EXISTS and REPLACE is not allowed"))
+      val sqlText = "CREATE OR REPLACE VIEW IF NOT EXISTS testView AS SELECT id FROM jt"
+      checkError(
+        exception = intercept[ParseException] {
+          sql(sqlText)
+        },
+        condition = "CREATE_VIEW_WITH_IF_NOT_EXISTS_AND_REPLACE",
+        sqlState = "42601",
+        parameters = Map("viewName" -> "testView"),
+        context = ExpectedContext(
+          fragment = sqlText,
+          start = 0,
+          stop = sqlText.length - 1))
     }
   }
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Rename the legacy error class `_LEGACY_ERROR_TEMP_0052` to a proper descriptive name `CREATE_VIEW_WITH_IF_NOT_EXISTS_AND_REPLACE` and add SQL state 42601 (syntax error - conflicting SQL clauses).

This error is thrown when CREATE VIEW is used with both IF NOT EXISTS and REPLACE simultaneously.

### Why are the changes needed?
Proper error messaging.


### Does this PR introduce _any_ user-facing change?
Yes. The error class name changes from `_LEGACY_ERROR_TEMP_0052` to `CREATE_VIEW_WITH_IF_NOT_EXISTS_AND_REPLACE`, and the SQL state `42601` is now included.


### How was this patch tested?
New unit test.

### Was this patch authored or co-authored using generative AI tooling?
Yes, co-authored with Claude Code