### PR TITLE
[SPARK-55823][SQL] Rename `_LEGACY_ERROR_TEMP_1134` to `UNABLE_TO_INFER_SCHEMA_FOR_DATA_SOURCE`

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -6544,6 +6544,12 @@
     ],
     "sqlState" : "42KD9"
   },
+  "UNABLE_TO_INFER_SCHEMA_FOR_DATA_SOURCE" : {
+    "message" : [
+      "Unable to infer schema for <format> at <fileCatalog>. It must be specified manually."
+    ],
+    "sqlState" : "42KD9"
+  },
   "UNBOUND_SQL_PARAMETER" : {
     "message" : [
       "Found the unbound parameter: <name>. Please, fix `args` and provide a mapping of the parameter to either a SQL literal or collection constructor functions such as `map()`, `array()`, `struct()`."
@@ -8344,11 +8350,6 @@
   "_LEGACY_ERROR_TEMP_1132" : {
     "message" : [
       "A schema needs to be specified when using <className>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1134" : {
-    "message" : [
-      "Unable to infer schema for <format> at <fileCatalog>. It must be specified manually."
     ]
   },
   "_LEGACY_ERROR_TEMP_1135" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1772,7 +1772,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def dataSchemaNotSpecifiedError(format: String, fileCatalog: String): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1134",
+      errorClass = "UNABLE_TO_INFER_SCHEMA_FOR_DATA_SOURCE",
       messageParameters = Map(
         "format" -> format,
         "fileCatalog" -> fileCatalog))

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -1112,6 +1112,26 @@ class QueryCompilationErrorsSuite
         ExpectedContext(fragment = "aggregate(array(1,2,3), x -> x + 1, 0)", start = 7, stop = 44)
     )
   }
+
+  test("UNABLE_TO_INFER_SCHEMA_FOR_DATA_SOURCE: empty data source at path") {
+    withTempDir { dir =>
+      // Create _spark_metadata with a valid empty log entry (version header only, no files)
+      val metadataDir = new java.io.File(dir, "_spark_metadata")
+      metadataDir.mkdir()
+      java.nio.file.Files.write(
+        new java.io.File(metadataDir, "0").toPath, "v1".getBytes)
+
+      checkError(
+        exception = intercept[AnalysisException] {
+          spark.read.format("json").load(dir.getCanonicalPath).collect()
+        },
+        condition = "UNABLE_TO_INFER_SCHEMA_FOR_DATA_SOURCE",
+        parameters = Map(
+          "format" -> "JSON",
+          "fileCatalog" -> "")
+      )
+    }
+  }
 }
 
 class MyCastToString extends SparkUserDefinedFunction(


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Removing `_LEGACY_ERROR_TEMP_1134` and adding a proper error class `UNABLE_TO_INFER_SCHEMA_FOR_DATA_SOURCE` with a sqlState.


### Why are the changes needed?
Proper error messaging.


### Does this PR introduce _any_ user-facing change?
Yes. The error class name changes from `_LEGACY_ERROR_TEMP_1134` to `UNABLE_TO_INFER_SCHEMA_FOR_DATA_SOURCE`, and the SQL state `42KD9` is now included. The error message text remains identical.


### How was this patch tested?
New unit test.


### Was this patch authored or co-authored using generative AI tooling?
Yes, co-authored with Claude Code.