### PR TITLE
[SPARK-55824][SQL] Rename `_LEGACY_ERROR_TEMP_1034` to `WINDOW_FUNCTION_NOT_ALLOWED_IN_CLAUSE`

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -7849,6 +7849,12 @@
     ],
     "sqlState" : "42K0E"
   },
+  "WINDOW_FUNCTION_NOT_ALLOWED_IN_CLAUSE" : {
+    "message" : [
+      "It is not allowed to use window functions inside <clauseName> clause."
+    ],
+    "sqlState" : "42601"
+  },
   "WINDOW_FUNCTION_WITHOUT_OVER_CLAUSE" : {
     "message" : [
       "Window function <funcName> requires an OVER clause."
@@ -8112,11 +8118,6 @@
     "message" : [
       "<expr> has multiple Window Specifications (<distinctWindowSpec>).",
       "Please file a bug report with this error message, stack trace, and the query."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1034" : {
-    "message" : [
-      "It is not allowed to use window functions inside <clauseName> clause."
     ]
   },
   "_LEGACY_ERROR_TEMP_1035" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -859,7 +859,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def windowFunctionNotAllowedError(clauseName: String): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1034",
+      errorClass = "WINDOW_FUNCTION_NOT_ALLOWED_IN_CLAUSE",
       messageParameters = Map("clauseName" -> clauseName))
   }
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
@@ -1534,7 +1534,8 @@ table t
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1034",
+  "errorClass" : "WINDOW_FUNCTION_NOT_ALLOWED_IN_CLAUSE",
+  "sqlState" : "42601",
   "messageParameters" : {
     "clauseName" : "WHERE"
   }
@@ -1565,7 +1566,8 @@ select * from t where sum(x) over (partition by y) = 1
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1034",
+  "errorClass" : "WINDOW_FUNCTION_NOT_ALLOWED_IN_CLAUSE",
+  "sqlState" : "42601",
   "messageParameters" : {
     "clauseName" : "WHERE"
   }

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/window_part3.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/window_part3.sql.out
@@ -306,7 +306,8 @@ SELECT * FROM empsalary WHERE row_number() OVER (ORDER BY salary) < 10
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1034",
+  "errorClass" : "WINDOW_FUNCTION_NOT_ALLOWED_IN_CLAUSE",
+  "sqlState" : "42601",
   "messageParameters" : {
     "clauseName" : "WHERE"
   }
@@ -372,7 +373,8 @@ SELECT * FROM empsalary WHERE (rank() OVER (ORDER BY random())) > 10
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1034",
+  "errorClass" : "WINDOW_FUNCTION_NOT_ALLOWED_IN_CLAUSE",
+  "sqlState" : "42601",
   "messageParameters" : {
     "clauseName" : "WHERE"
   }
@@ -384,7 +386,8 @@ SELECT * FROM empsalary WHERE rank() OVER (ORDER BY random())
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1034",
+  "errorClass" : "WINDOW_FUNCTION_NOT_ALLOWED_IN_CLAUSE",
+  "sqlState" : "42601",
   "messageParameters" : {
     "clauseName" : "WHERE"
   }

--- a/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
@@ -1450,7 +1450,8 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1034",
+  "errorClass" : "WINDOW_FUNCTION_NOT_ALLOWED_IN_CLAUSE",
+  "sqlState" : "42601",
   "messageParameters" : {
     "clauseName" : "WHERE"
   }
@@ -1485,7 +1486,8 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1034",
+  "errorClass" : "WINDOW_FUNCTION_NOT_ALLOWED_IN_CLAUSE",
+  "sqlState" : "42601",
   "messageParameters" : {
     "clauseName" : "WHERE"
   }

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/window_part3.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/window_part3.sql.out
@@ -319,7 +319,8 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1034",
+  "errorClass" : "WINDOW_FUNCTION_NOT_ALLOWED_IN_CLAUSE",
+  "sqlState" : "42601",
   "messageParameters" : {
     "clauseName" : "WHERE"
   }
@@ -393,7 +394,8 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1034",
+  "errorClass" : "WINDOW_FUNCTION_NOT_ALLOWED_IN_CLAUSE",
+  "sqlState" : "42601",
   "messageParameters" : {
     "clauseName" : "WHERE"
   }
@@ -407,7 +409,8 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1034",
+  "errorClass" : "WINDOW_FUNCTION_NOT_ALLOWED_IN_CLAUSE",
+  "sqlState" : "42601",
   "messageParameters" : {
     "clauseName" : "WHERE"
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename the legacy error class `_LEGACY_ERROR_TEMP_1034` to `WINDOW_FUNCTION_NOT_ALLOWED_IN_CLAUSE` and add SQL state `42601`.

This error is thrown when a user uses window functions inside a WHERE or HAVING clause, which is not allowed by the SQL standard.

### Why are the changes needed?
Proper error messaging.

### Does this PR introduce _any_ user-facing change?

Yes. The error class name changes from `_LEGACY_ERROR_TEMP_1034` to `WINDOW_FUNCTION_NOT_ALLOWED_IN_CLAUSE`, and the SQL state `42601` is now included. The error message text remains identical.

### How was this patch tested?

Existing golden file tests (`pipe-operators.sql.out`, `window_part3.sql.out`) already cover this error and have been updated with the new error class name and SQL state.

### Was this patch authored or co-authored using generative AI tooling?

Yes, co-authored with Claude Code.