### PR TITLE
[SPARK-55782][UI] Replace CSS float right with Bootstrap 5 float-end utility

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/webui.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.css
@@ -120,7 +120,6 @@ a.kill-link {
   margin-right: 2px;
   margin-left: 20px;
   color: gray;
-  float: right;
 }
 
 a.name-link {
@@ -131,7 +130,6 @@ span.expand-details {
   font-size: 10pt;
   cursor: pointer;
   color: grey;
-  float: right;
 }
 
 span.rest-uri {

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -319,7 +319,7 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
         <input type="hidden" name="terminate" value="true"/>
         <a href="#"
            data-kill-message={s"Are you sure you want to kill application ${app.id} ?"}
-           class="kill-link">(kill)</a>
+           class="kill-link float-end">(kill)</a>
       </form>
     }
     <tr>
@@ -368,7 +368,7 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
         <input type="hidden" name="terminate" value="true"/>
         <a href="#"
            data-kill-message={s"Are you sure you want to kill driver ${driver.id} ?"}
-           class="kill-link">(kill)</a>
+           class="kill-link float-end">(kill)</a>
       </form>
     }
     <tr>

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -722,7 +722,7 @@ private[spark] object UIUtils extends Logging {
     if (isMultiline) {
       // scalastyle:off
       <span data-toggle-details=".stacktrace-details"
-            class="expand-details">
+            class="expand-details float-end">
         +details
       </span> ++
         <div class="stacktrace-details collapsed">

--- a/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/AllJobsPage.scala
@@ -581,7 +581,7 @@ private[ui] class JobPagedTable(
       val killLinkUri = s"$basePath/jobs/job/kill/?id=${job.jobId}"
       <a href={killLinkUri}
          data-kill-message={s"Are you sure you want to kill job ${job.jobId} ?"}
-         class="kill-link">(kill)</a>
+         class="kill-link float-end">(kill)</a>
     } else {
       Seq.empty
     }

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
@@ -225,7 +225,7 @@ private[ui] class StagePagedTable(
       val killLinkUri = s"$basePathUri/stages/stage/kill/?id=${s.stageId}"
       <a href={killLinkUri}
          data-kill-message={s"Are you sure you want to kill stage ${s.stageId} ?"}
-         class="kill-link">(kill)</a>
+         class="kill-link float-end">(kill)</a>
     } else {
       Seq.empty
     }
@@ -236,7 +236,7 @@ private[ui] class StagePagedTable(
     val cachedRddInfos = store.rddList().filter { rdd => s.rddIds.contains(rdd.id) }
     val details = if (s.details != null && s.details.nonEmpty) {
       <span data-toggle-details=".stage-details"
-            class="expand-details">
+            class="expand-details float-end">
         +details
       </span> ++
       <div class="stage-details collapsed">


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replaces 2 `float: right` CSS declarations in `webui.css` with Bootstrap 5 `float-end` utility class on the corresponding HTML elements.

**CSS changes:**
- `a.link`: removed `float: right`
- `span.expand-details`: removed `float: right`

**Scala changes (4 files, 6 elements):**
- `MasterPage.scala`: 2 link anchors added `float-end`
- `AllJobsPage.scala`: 1 link anchor added `float-end`
- `StageTable.scala`: 1 link anchor + 1 expand-details span added `float-end`
- `UIUtils.scala`: 1 expand-details span added `float-end`

### Why are the changes needed?

Aligns with Bootstrap 5 conventions — using utility classes instead of custom CSS for layout. Part of SPARK-55760 (Spark Web UI Modernization).

### Does this PR introduce _any_ user-facing change?

No. Visual appearance is identical.

### How was this patch tested?

Compilation verified. `float-end` produces the same `float: right !important` behavior as the removed CSS rules.

### Was this patch authored or co-authored using generative AI tooling?

Yes, co-authored with GitHub Copilot.
