### PR TITLE
[SPARK-55829][INFRA] Skip PySpark/SparkR/TPC-DS CI for static-resource-only changes

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -104,6 +104,22 @@ jobs:
             sparkr=`./dev/is-changed.py -m sparkr`
             tpcds=`./dev/is-changed.py -m sql`
             docker=`./dev/is-changed.py -m docker-integration-tests`
+            # Skip PySpark, SparkR, TPC-DS when only static UI resources (JS/CSS/HTML) changed.
+            # These tests are unaffected by UI static resource modifications.
+            static_only=true
+            for f in $(git diff --name-only "$APACHE_SPARK_REF" HEAD 2>/dev/null); do
+              case "$f" in
+                */resources/*/static/*|*.css|*.js|*.html) ;;
+                *) static_only=false; break ;;
+              esac
+            done
+            if [ "$static_only" = "true" ]; then
+              pyspark=false
+              pandas=false
+              sparkr=false
+              tpcds=false
+              docker=false
+            fi
             buf=true
             ui=true
             docs=true


### PR DESCRIPTION
### What changes were proposed in this pull request?

When a PR only modifies static UI resources (JS, CSS, HTML files), skip PySpark, SparkR, TPC-DS, and Docker integration tests in CI.

Adds a `static_only` check in the precondition job of `build_and_test.yml`. After `is-changed.py` determines affected modules, it iterates all changed files. If every file matches `*/resources/*/static/*`, `*.css`, `*.js`, or `*.html`, it overrides:
- `pyspark` → `false`
- `pandas` → `false`
- `sparkr` → `false`
- `tpcds` → `false`
- `docker` → `false`

Build and lint jobs still run (needed for compilation check and lint-js).

### Why are the changes needed?

UI modernization PRs (SPARK-55760) change only JS/CSS/HTML files but currently trigger the full CI matrix (~30 jobs). PySpark, SparkR, TPC-DS, and Docker tests are completely unaffected by static resource changes. Skipping them saves ~20 CI jobs per UI-only PR.

### Does this PR introduce _any_ user-facing change?

No. Only affects CI pipeline behavior for static-resource-only PRs.

### How was this patch tested?

Logic verified by inspecting `is-changed.py` module system — `core/` changes trigger all downstream modules because `is-changed.py` does not distinguish source code from static resources within a module.

### Was this patch authored or co-authored using generative AI tooling?

Yes, co-authored with GitHub Copilot.