### PR TITLE
[SPARK-55831][YARN] Support `spark.yarn.am.defaultJavaOptions`

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -407,13 +407,28 @@ To use a custom metrics.properties for the application master and executors, upd
   <td>1.2.0</td>
 </tr>
 <tr>
+  <td><code>spark.yarn.am.defaultJavaOptions</code></td>
+  <td>(none)</td>
+  <td>
+  A string of default JVM options to prepend to <code>spark.yarn.am.extraJavaOptions</code>
+  for the YARN Application Master in client mode. Note that it is illegal to set maximum
+  heap size (-Xmx) settings with this option. Maximum heap size settings can be set with
+  <code>spark.yarn.am.memory</code>.
+
+  This is intended to be set by administrators.
+  </td>
+  <td>4.2.0</td>
+</tr>
+<tr>
   <td><code>spark.yarn.am.extraJavaOptions</code></td>
   <td>(none)</td>
   <td>
   A string of extra JVM options to pass to the YARN Application Master in client mode.
   In cluster mode, use <code>spark.driver.extraJavaOptions</code> instead. Note that it is illegal
   to set maximum heap size (-Xmx) settings with this option. Maximum heap size settings can be set
-  with <code>spark.yarn.am.memory</code>
+  with <code>spark.yarn.am.memory</code>.
+
+  <code>spark.yarn.am.defaultJavaOptions</code> will be prepended to this configuration.
   </td>
   <td>1.3.0</td>
 </tr>

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -168,11 +168,6 @@ private[spark] class Client(
 
   private var appId: ApplicationId = null
 
-  // Exposed for testing.
-  private[yarn] def setApplicationId(appId: ApplicationId): Unit = {
-    this.appId = appId
-  }
-
   def getApplicationId(): ApplicationId = {
     appId
   }
@@ -1030,16 +1025,11 @@ private[spark] class Client(
     env
   }
 
-  // Exposed for testing.
-  private[yarn] def setStagingDir(stagingDir: String): Unit = {
-    stagingDirPath = new Path(stagingDir)
-  }
-
   /**
    * Set up a ContainerLaunchContext to launch our ApplicationMaster container.
    * This sets up the launch environment, java options, and the command for launching the AM.
    */
-  private[yarn] def createContainerLaunchContext(): ContainerLaunchContext = {
+  private def createContainerLaunchContext(): ContainerLaunchContext = {
     logInfo("Setting up container launch context for our AM")
     val pySparkArchives =
       if (sparkConf.get(IS_PYTHON_APP)) {

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -168,6 +168,11 @@ private[spark] class Client(
 
   private var appId: ApplicationId = null
 
+  // Exposed for testing.
+  private[yarn] def setApplicationId(appId: ApplicationId): Unit = {
+    this.appId = appId
+  }
+
   def getApplicationId(): ApplicationId = {
     appId
   }
@@ -1025,11 +1030,16 @@ private[spark] class Client(
     env
   }
 
+  // Exposed for testing.
+  private[yarn] def setStagingDir(stagingDir: String): Unit = {
+    stagingDirPath = new Path(stagingDir)
+  }
+
   /**
    * Set up a ContainerLaunchContext to launch our ApplicationMaster container.
    * This sets up the launch environment, java options, and the command for launching the AM.
    */
-  private def createContainerLaunchContext(): ContainerLaunchContext = {
+  private[yarn] def createContainerLaunchContext(): ContainerLaunchContext = {
     logInfo("Setting up container launch context for our AM")
     val pySparkArchives =
       if (sparkConf.get(IS_PYTHON_APP)) {

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config/package.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config/package.scala
@@ -301,8 +301,17 @@ package object config extends Logging {
     .intConf
     .createWithDefault(1)
 
+  private[spark] val AM_DEFAULT_JAVA_OPTIONS = ConfigBuilder("spark.yarn.am.defaultJavaOptions")
+    .doc("Default Java options for the client-mode AM to prepend to " +
+      "`spark.yarn.am.extraJavaOptions`. This is intended to be set by administrators.")
+    .version("4.2.0")
+    .stringConf
+    .createOptional
+
   private[spark] val AM_JAVA_OPTIONS = ConfigBuilder("spark.yarn.am.extraJavaOptions")
-    .doc("Extra Java options for the client-mode AM.")
+    .withPrepended(AM_DEFAULT_JAVA_OPTIONS.key)
+    .doc("Extra Java options for the client-mode AM. " +
+      s"`${AM_DEFAULT_JAVA_OPTIONS.key}` will be prepended to this configuration.")
     .version("1.3.0")
     .stringConf
     .createOptional

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -52,6 +52,7 @@ import org.scalatest.matchers.should.Matchers._
 import org.apache.spark.{SparkConf, SparkException, SparkFunSuite, TestUtils}
 import org.apache.spark.deploy.yarn.config._
 import org.apache.spark.internal.config._
+import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.resource.ResourceID
 import org.apache.spark.resource.ResourceUtils.AMOUNT
 import org.apache.spark.util.{SparkConfWithEnv, Utils}
@@ -753,6 +754,58 @@ class ClientSuite extends SparkFunSuite
     val client = createClient(sparkConf)
     val env = client.setupLaunchEnv(new Path("/staging/dir/path"), Seq())
     env("SPARK_USER") should be ("overrideuser")
+  }
+
+  test("YARN AM JavaOptions") {
+    Seq("client", "cluster").foreach { deployMode =>
+      withTempDir { stagingDir =>
+        val sparkConf = new SparkConfWithEnv(
+          Map("SPARK_HOME" -> System.getProperty("spark.test.home")))
+          .set(SUBMIT_DEPLOY_MODE, deployMode)
+          .set(SparkLauncher.DRIVER_DEFAULT_JAVA_OPTIONS, "-Dx=1 -Dy=2")
+          .set(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS, "-Dz=3")
+          .set(AM_DEFAULT_JAVA_OPTIONS, "-Da=1 -Db=2")
+          .set(AM_JAVA_OPTIONS, "-Dc=3")
+
+        val client = createClient(sparkConf)
+        // A dummy ApplicationId impl, only `toString` method will be called
+        // in Client.createContainerLaunchContext
+        client.setApplicationId(new ApplicationId {
+          override def getId: Int = 1
+          override def setId(i: Int): Unit = {}
+          override def getClusterTimestamp: Long = 1770077136288L
+          override def setClusterTimestamp(l: Long): Unit = {}
+          override def build(): Unit = {}
+          override def toString: String = "application_1770077136288_0001"
+        })
+        client.setStagingDir(stagingDir.getAbsolutePath)
+        val containerLaunchContext = client.createContainerLaunchContext()
+
+        val commands = containerLaunchContext.getCommands.asScala
+        deployMode match {
+          case "client" =>
+            // In client mode, spark.yarn.am.defaultJavaOptions and spark.yarn.am.extraJavaOptions
+            // should be set in AM container command JAVA_OPTIONS
+            commands should contain("'-Da=1'")
+            commands should contain("'-Db=2'")
+            commands should contain("'-Dc=3'")
+            commands should not contain "'-Dx=1'"
+            commands should not contain "'-Dy=2'"
+            commands should not contain "'-Dz=3'"
+          case "cluster" =>
+            // In cluster mode, spark.driver.defaultJavaOptions and spark.driver.extraJavaOptions
+            // should be set in AM container command JAVA_OPTIONS
+            commands should not contain "'-Da=1'"
+            commands should not contain "'-Db=2'"
+            commands should not contain "'-Dc=3'"
+            commands should contain ("'-Dx=1'")
+            commands should contain ("'-Dy=2'")
+            commands should contain ("'-Dz=3'")
+          case m =>
+            fail(s"Unexpected deploy mode: $m")
+        }
+      }
+    }
   }
 
   private val matching = Seq(

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -46,6 +46,7 @@ import org.apache.hadoop.yarn.util.Records
 import org.mockito.ArgumentMatchers.{any, anyBoolean, eq => meq}
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
+import org.scalatest.PrivateMethodTester
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers._
 
@@ -59,7 +60,8 @@ import org.apache.spark.util.{SparkConfWithEnv, Utils}
 
 class ClientSuite extends SparkFunSuite
     with Matchers
-    with ResourceRequestTestHelper {
+    with ResourceRequestTestHelper
+    with PrivateMethodTester {
   private def doReturn(value: Any) = org.mockito.Mockito.doReturn(value, Seq.empty: _*)
 
   import Client._
@@ -768,9 +770,12 @@ class ClientSuite extends SparkFunSuite
           .set(AM_JAVA_OPTIONS, "-Dc=3")
 
         val client = createClient(sparkConf)
+        val appIdField = classOf[Client]
+          .getDeclaredField("org$apache$spark$deploy$yarn$Client$$appId")
+        appIdField.setAccessible(true)
         // A dummy ApplicationId impl, only `toString` method will be called
         // in Client.createContainerLaunchContext
-        client.setApplicationId(new ApplicationId {
+        appIdField.set(client, new ApplicationId {
           override def getId: Int = 1
           override def setId(i: Int): Unit = {}
           override def getClusterTimestamp: Long = 1770077136288L
@@ -778,8 +783,13 @@ class ClientSuite extends SparkFunSuite
           override def build(): Unit = {}
           override def toString: String = "application_1770077136288_0001"
         })
-        client.setStagingDir(stagingDir.getAbsolutePath)
-        val containerLaunchContext = client.createContainerLaunchContext()
+        val stagingDirPathField = classOf[Client]
+          .getDeclaredField("org$apache$spark$deploy$yarn$Client$$stagingDirPath")
+        stagingDirPathField.setAccessible(true)
+        stagingDirPathField.set(client, new Path(stagingDir.getAbsolutePath))
+        val _createContainerLaunchContext =
+          PrivateMethod[ContainerLaunchContext](Symbol("createContainerLaunchContext"))
+        val containerLaunchContext = client invokePrivate _createContainerLaunchContext()
 
         val commands = containerLaunchContext.getCommands.asScala
         deployMode match {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Introduce a new config `spark.yarn.am.defaultJavaOptions`, if set, it will be prepended to the `spark.yarn.am.extraJavaOptions`. Obviously, this only takes effect on YARN client mode.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently, we have both `defaultJavaOptions` and `extraJavaOptions` for driver and executor, but only have `extraJavaOptions` for YARN AM, this is not intuitive. I also found AI sometimes suggests such a non-existent config.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New UT is added.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.