### PR TITLE
[SPARK-55784][UI] Add Bootstrap 5 table-hover class for row highlight on mouseover

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -40,7 +40,7 @@ import org.apache.spark.ui.scope.RDDOperationGraph
 
 /** Utility functions for generating XML pages with spark content. */
 private[spark] object UIUtils extends Logging {
-  val TABLE_CLASS_NOT_STRIPED = "table table-bordered table-sm"
+  val TABLE_CLASS_NOT_STRIPED = "table table-bordered table-hover table-sm"
   val TABLE_CLASS_STRIPED = TABLE_CLASS_NOT_STRIPED + " table-striped"
   val TABLE_CLASS_STRIPED_SORTABLE = TABLE_CLASS_STRIPED + " sortable"
 

--- a/core/src/test/scala/org/apache/spark/ui/UIUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UIUtilsSuite.scala
@@ -161,7 +161,7 @@ class UIUtilsSuite extends SparkFunSuite {
     val generated = listingTable(header, generateDataRowValue, data, tooltipHeaders = tooltip)
 
     val expected: Node =
-      <table class="table table-bordered table-sm table-striped sortable">
+      <table class="table table-bordered table-hover table-sm table-striped sortable">
         <thead>
           <th width="" class="">{header(0)}</th>
           <th width="" class="">
@@ -187,7 +187,7 @@ class UIUtilsSuite extends SparkFunSuite {
     val generated = listingTable(header, generateDataRowValue, data)
 
     val expected =
-      <table class="table table-bordered table-sm table-striped sortable">
+      <table class="table table-bordered table-hover table-sm table-striped sortable">
         <thead>
           <th width="" class="">{header(0)}</th>
           <th width="" class="">{header(1)}</th>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds `table-hover` to the base `TABLE_CLASS_NOT_STRIPED` constant in `UIUtils.scala`:

```
- "table table-bordered table-sm"
+ "table table-bordered table-hover table-sm"
```

This propagates to all table variants (`TABLE_CLASS_STRIPED`, `TABLE_CLASS_STRIPED_SORTABLE`), enabling Bootstrap 5 row highlight on mouseover for all Spark UI tables — Jobs, Stages, Executors, Tasks, Storage, Environment.

### Why are the changes needed?

`table-hover` improves scannability of large tables by highlighting the row under the cursor. This is a standard BS5 feature that Spark UI tables were not using. Part of SPARK-55760 (Spark Web UI Modernization).

### Does this PR introduce _any_ user-facing change?

Yes — table rows now highlight on mouseover. This is a visual enhancement with no functional change.

### How was this patch tested?

`UIUtilsSuite` (8 tests) passes with updated table class assertions.

### Was this patch authored or co-authored using generative AI tooling?

Yes, co-authored with GitHub Copilot.