### PR TITLE
[SPARK-55829][INFRA][FOLLOWUP] Fix static-only CI check skipping all jobs on empty diff

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -106,13 +106,18 @@ jobs:
             docker=`./dev/is-changed.py -m docker-integration-tests`
             # Skip PySpark, SparkR, TPC-DS when only static UI resources (JS/CSS/HTML) changed.
             # These tests are unaffected by UI static resource modifications.
-            static_only=true
-            for f in $(git diff --name-only "$APACHE_SPARK_REF" HEAD 2>/dev/null); do
-              case "$f" in
-                */resources/*/static/*|*.css|*.js|*.html) ;;
-                *) static_only=false; break ;;
-              esac
-            done
+            changed_files=$(git diff --name-only "$APACHE_SPARK_REF" HEAD 2>/dev/null)
+            if [ -n "$changed_files" ]; then
+              static_only=true
+              for f in $changed_files; do
+                case "$f" in
+                  */resources/*/static/*) ;;
+                  *) static_only=false; break ;;
+                esac
+              done
+            else
+              static_only=false
+            fi
             if [ "$static_only" = "true" ]; then
               pyspark=false
               pandas=false


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes a bug in #54616 (SPARK-55829) where the static-only CI check incorrectly skips PySpark, SparkR, and TPC-DS jobs on **all** pushes when there are no fork-only changes.

**Root cause**: When `APACHE_SPARK_REF == HEAD` (e.g., syncing fork with upstream), `git diff` returns empty output. The `for` loop runs zero iterations, `static_only` stays `true`, and all jobs are skipped.

**Fix**:
- Default `static_only=false` when diff is empty (no changed files → run everything)
- Only set `static_only=true` when there ARE changed files and ALL match `*/resources/*/static/*`
- Narrowed pattern: removed `*.css|*.js|*.html` (could false-positive on non-static files like Scala test CSS assertions)

### Why are the changes needed?

The bug caused all build/test jobs to be skipped on fork master pushes after merging upstream changes: https://github.com/yaooqinn/spark/actions/runs/22678711938

### Does this PR introduce _any_ user-facing change?

No. CI-only fix.

### How was this patch tested?

Verified logic: empty diff → `static_only=false` → all jobs run as normal.

### Was this patch authored or co-authored using generative AI tooling?

Yes, co-authored with GitHub Copilot.