### PR TITLE
[SPARK-55841][BUILD] Upgrade jackson to 2.21.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -101,12 +101,12 @@ ini4j/0.5.4//ini4j-0.5.4.jar
 istack-commons-runtime/4.1.2//istack-commons-runtime-4.1.2.jar
 ivy/2.5.3//ivy-2.5.3.jar
 jackson-annotations/2.21//jackson-annotations-2.21.jar
-jackson-core/2.21.0//jackson-core-2.21.0.jar
-jackson-databind/2.21.0//jackson-databind-2.21.0.jar
-jackson-dataformat-cbor/2.21.0//jackson-dataformat-cbor-2.21.0.jar
-jackson-dataformat-yaml/2.21.0//jackson-dataformat-yaml-2.21.0.jar
-jackson-datatype-jsr310/2.21.0//jackson-datatype-jsr310-2.21.0.jar
-jackson-module-scala_2.13/2.21.0//jackson-module-scala_2.13-2.21.0.jar
+jackson-core/2.21.1//jackson-core-2.21.1.jar
+jackson-databind/2.21.1//jackson-databind-2.21.1.jar
+jackson-dataformat-cbor/2.21.1//jackson-dataformat-cbor-2.21.1.jar
+jackson-dataformat-yaml/2.21.1//jackson-dataformat-yaml-2.21.1.jar
+jackson-datatype-jsr310/2.21.1//jackson-datatype-jsr310-2.21.1.jar
+jackson-module-scala_2.13/2.21.1//jackson-module-scala_2.13-2.21.1.jar
 jakarta.activation-api/2.1.3//jakarta.activation-api-2.1.3.jar
 jakarta.annotation-api/2.1.1//jakarta.annotation-api-2.1.1.jar
 jakarta.inject-api/2.0.1//jakarta.inject-api-2.0.1.jar
@@ -268,7 +268,7 @@ scala-reflect/2.13.18//scala-reflect-2.13.18.jar
 scala-xml_2.13/2.4.0//scala-xml_2.13-2.4.0.jar
 slf4j-api/2.0.17//slf4j-api-2.0.17.jar
 snakeyaml-engine/2.10//snakeyaml-engine-2.10.jar
-snakeyaml/2.4//snakeyaml-2.4.jar
+snakeyaml/2.5//snakeyaml-2.5.jar
 snappy-java/1.1.10.8//snappy-java-1.1.10.8.jar
 spire-macros_2.13/0.18.0//spire-macros_2.13-0.18.0.jar
 spire-platform_2.13/0.18.0//spire-platform_2.13-0.18.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
     <scalafmt.validateOnly>true</scalafmt.validateOnly>
     <scalafmt.changedOnly>true</scalafmt.changedOnly>
     <!-- Should be consistent with SparkBuild.scala and docs -->
-    <fasterxml.jackson.version>2.21.0</fasterxml.jackson.version>
+    <fasterxml.jackson.version>2.21.1</fasterxml.jackson.version>
     <ws.xmlschema.version>2.3.1</ws.xmlschema.version>
     <snappy.version>1.1.10.8</snappy.version>
     <netlib.ludovic.dev.version>3.1.1</netlib.ludovic.dev.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `jackson` to 2.21.1.

### Why are the changes needed?

- https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.21.1 (2026-02-22)
  - https://github.com/FasterXML/jackson-databind/pull/5674
  - https://github.com/FasterXML/jackson-databind/issues/5616
  - https://github.com/FasterXML/jackson-dataformats-text/pull/610
    - https://bitbucket.org/snakeyaml/snakeyaml/issues/1110/exception-during-parse-of-tab-idented-json

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`.