### PR TITLE
[SPARK-54665][PS] Fix comparison between boolean Series and string literals 

### DIFF
--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -360,6 +360,10 @@ class BooleanOps(DataTypeOps):
         return operand
 
     def eq(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        _sanitize_list_like(right)
+        if isinstance(right, str):
+            return column_op(lambda c: F.lit(False))(left)
+
         if is_ansi_mode_enabled(left._internal.spark_frame.sparkSession):
             # Handle bool vs. non-bool numeric comparisons
             left_is_bool = _is_boolean_type(left)
@@ -376,6 +380,12 @@ class BooleanOps(DataTypeOps):
                     )
 
         return super().eq(left, right)
+
+    def ne(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        _sanitize_list_like(right)
+        if isinstance(right, str):
+            return column_op(lambda c: F.lit(True))(left)
+        return super(BooleanOps, self).ne(left, right)
 
     def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -364,6 +364,10 @@ class BooleanOpsTestsMixin:
         psser, other_psser = psdf["this"], psdf["that"]
         self.assert_eq(pser == other_pser, psser == other_psser)
         self.assert_eq(pser == pser, psser == psser)
+        # SPARK-54665: Comparison between boolean Series and string literals
+        self.assert_eq(pser == "True", psser == "True")
+        self.assert_eq(pser == "False", psser == "False")
+        self.assert_eq(pser == "any string", psser == "any string")
 
     def test_ne(self):
         pdf, psdf = self.bool_pdf, self.bool_psdf
@@ -371,6 +375,10 @@ class BooleanOpsTestsMixin:
         psser, other_psser = psdf["this"], psdf["that"]
         self.assert_eq(pser != other_pser, psser != other_psser)
         self.assert_eq(pser != pser, psser != psser)
+        # SPARK-54665: Comparison between boolean Series and string literals
+        self.assert_eq(pser != "True", psser != "True")
+        self.assert_eq(pser != "False", psser != "False")
+        self.assert_eq(pser != "any string", psser != "any string")
 
     def test_lt(self):
         pdf, psdf = self.bool_pdf, self.bool_psdf
@@ -794,6 +802,10 @@ class BooleanExtensionOpsTestsMixin:
         other_pser, other_psser = pdf["that"], psdf["that"]
         self.check_extension(pser == other_pser, psser == other_psser)
         self.check_extension(pser == pser, psser == psser)
+        # SPARK-54665: Comparison between boolean Series and string literals
+        self.check_extension(pser == "True", psser == "True")
+        self.check_extension(pser == "False", psser == "False")
+        self.check_extension(pser == "any string", psser == "any string")
 
     def test_ne(self):
         pdf, psdf = self.boolean_pdf, self.boolean_psdf
@@ -801,6 +813,10 @@ class BooleanExtensionOpsTestsMixin:
         other_pser, other_psser = pdf["that"], psdf["that"]
         self.check_extension(pser != other_pser, psser != other_psser)
         self.check_extension(pser != pser, psser != psser)
+        # SPARK-54665: Comparison between boolean Series and string literals
+        self.check_extension(pser != "True", psser != "True")
+        self.check_extension(pser != "False", psser != "False")
+        self.check_extension(pser != "any string", psser != "any string")
 
     def test_lt(self):
         pdf, psdf = self.boolean_pdf, self.boolean_psdf


### PR DESCRIPTION
### What changes were proposed in this pull request?
This resolves the open issue:
https://issues.apache.org/jira/browse/SPARK-54665 (https://issues.apache.org/jira/browse/SPARK-54665)

This PR resolves an inconsistency in pandas-on-Spark (`pyspark.pandas`) where comparing a boolean `Series` to a string literal returns `True` for equality (`==`) and `False` for inequality (`!=`). 

This PR explicitly overrides the `eq` and `ne` methods in `BooleanOps` (`python/pyspark/pandas/data_type_ops/boolean_ops.py`) to correctly handle string comparisons by returning a boolean series filled with `False` (for `eq`) and `True` (for `ne`), aligning the behavior with native pandas semantics.

### Why are the changes needed?
This change is needed to maintain strict API and behavioral parity with native pandas. 

Currently, in `pyspark.pandas` 4.0.1:
`ps.Series([True, False]) == 'True'` incorrectly yields `[True, True]`.
In native `pandas`:
`pd.Series([True, False]) == 'True'` correctly yields `[False, False]`.

This divergence causes silent logical errors when migrating existing pandas workloads to Spark. By fixing this, we ensure predictable and correct comparison logic for end-users.

### Does this PR introduce _any_ user-facing change?
Yes, this fixes a bug in behavioral semantics.

**Previous Behavior (pandas-on-Spark):**
```python
import pyspark.pandas as ps
s = ps.Series([True, False])
s == "True"
# 0    True
# 1    True
```

**New Behavior (Matching native pandas):**
```python
import pyspark.pandas as ps
s = ps.Series([True, False])
s == "True"
# 0    False
# 1    False
```

### How was this patch tested?
This patch was tested by adding explicit unit tests verifying equality (`==`) and inequality (`!=`) comparisons between boolean series and string literals.

Added tests in `python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py`:
- `BooleanOpsTests.test_eq_ne_with_string` (indirectly via `test_eq` and `test_ne` updates)
- `BooleanExtensionOpsTestsMixin` updates to ensure extension types are also covered.

Tests can be run locally via:
```bash
./python/run-tests --modules pyspark-pandas-slow --testnames "pyspark.pandas.tests.data_type_ops.test_boolean_ops"
```

### Was this patch authored or co-authored using generative AI tooling?
co-authored using: Gemini CLI (Model: Gemini 2.5 Pro)
