### PR TITLE
[SPARK-55559][SQL] Add optional bits parameter to bit_count for Trino compatibility

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4050,6 +4050,16 @@
           "expects one of binary formats 'base64', 'hex', 'utf-8', but got <invalidFormat>."
         ]
       },
+      "BITS_RANGE" : {
+        "message" : [
+          "expects an integer value in [1, 64], but got <invalidValue>."
+        ]
+      },
+      "BITS_VALUE_OUT_OF_RANGE" : {
+        "message" : [
+          "expects a value in the range of a <bits>-bit signed integer [<lower>, <upper>], but got <invalidValue>."
+        ]
+      },
       "BIT_POSITION_RANGE" : {
         "message" : [
           "expects an integer value in [0, <upper>), but got <invalidValue>."

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -303,8 +303,13 @@ def bitwise_not(col: "ColumnOrName") -> Column:
 bitwise_not.__doc__ = pysparkfuncs.bitwise_not.__doc__
 
 
-def bit_count(col: "ColumnOrName") -> Column:
-    return _invoke_function_over_columns("bit_count", col)
+def bit_count(col: "ColumnOrName", bits: Optional[Union[Column, int]] = None) -> Column:
+    if bits is None:
+        return _invoke_function_over_columns("bit_count", col)
+    else:
+        bits = _enum_to_value(bits)
+        bits = lit(bits) if isinstance(bits, int) else bits
+        return _invoke_function_over_columns("bit_count", col, bits)
 
 
 bit_count.__doc__ = pysparkfuncs.bit_count.__doc__

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -3764,17 +3764,27 @@ def bitwise_not(col: "ColumnOrName") -> Column:
 
 
 @_try_remote_functions
-def bit_count(col: "ColumnOrName") -> Column:
+def bit_count(col: "ColumnOrName", bits: Optional[Union[Column, int]] = None) -> Column:
     """
     Returns the number of bits that are set in the argument expr as an unsigned 64-bit integer,
     or NULL if the argument is NULL.
 
+    If bits is specified, treats expr as a bits-bit signed integer in 2's complement
+    representation before counting set bits.
+
     .. versionadded:: 3.5.0
+
+    .. versionchanged:: 4.2.0
+        Added optional `bits` parameter for Trino-compatible bit width control.
 
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or column name
         target column to compute on.
+    bits : :class:`~pyspark.sql.Column` or int, optional
+        the bit width to use for counting. Must be between 1 and 64.
+
+        .. versionadded:: 4.2.0
 
     Returns
     -------
@@ -3801,8 +3811,21 @@ def bit_count(col: "ColumnOrName") -> Column:
     |    3|               2|
     | NULL|            NULL|
     +-----+----------------+
+
+    >>> from pyspark.sql import functions as sf
+    >>> spark.range(1).select(sf.bit_count(sf.lit(-7), 8)).show()
+    +----------------+
+    |bit_count(-7, 8)|
+    +----------------+
+    |               6|
+    +----------------+
     """
-    return _invoke_function_over_columns("bit_count", col)
+    if bits is None:
+        return _invoke_function_over_columns("bit_count", col)
+    else:
+        bits = _enum_to_value(bits)
+        bits = lit(bits) if isinstance(bits, int) else bits
+        return _invoke_function_over_columns("bit_count", col, bits)
 
 
 @_try_remote_functions

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3219,6 +3219,15 @@ object functions {
   def bit_count(e: Column): Column = Column.fn("bit_count", e)
 
   /**
+   * Returns the number of bits that are set in the argument expr. If bits is specified, treats
+   * expr as a bits-bit signed integer in 2's complement representation before counting set bits.
+   *
+   * @group bitwise_funcs
+   * @since 4.2.0
+   */
+  def bit_count(e: Column, bits: Column): Column = Column.fn("bit_count", e, bits)
+
+  /**
    * Returns the value of the bit (0 or 1) at the specified position. The positions are numbered
    * from right to left, starting at zero. The position argument cannot be negative.
    *

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -946,7 +946,7 @@ object FunctionRegistry {
     expression[ShiftLeft]("<<", true, Some("4.0.0")),
     expression[ShiftRight](">>", true, Some("4.0.0")),
     expression[ShiftRightUnsigned](">>>", true, Some("4.0.0")),
-    expression[BitwiseCount]("bit_count"),
+    expressionBuilder("bit_count", BitCountExpressionBuilder),
     expression[BitAndAgg]("bit_and"),
     expression[BitOrAgg]("bit_or"),
     expression[BitXorAgg]("bit_xor"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
-import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
+import org.apache.spark.sql.catalyst.analysis.{ExpressionBuilder, FunctionRegistry}
 import org.apache.spark.sql.catalyst.expressions.codegen._
-import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.types._
 
 /**
@@ -214,38 +214,144 @@ case class BitwiseNot(child: Expression)
 }
 
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Returns the number of bits that are set in the argument expr as an" +
-    " unsigned 64-bit integer, or NULL if the argument is NULL.",
+  usage = "_FUNC_(expr[, bits]) - Returns the number of bits that are set in the argument expr." +
+    " If bits is specified, treats expr as a bits-bit signed integer in 2's complement." +
+    " If bits is not specified, uses the natural bit width of the input type.",
   examples = """
     Examples:
       > SELECT _FUNC_(0);
        0
+      > SELECT _FUNC_(9, 64);
+       2
+      > SELECT _FUNC_(-7, 8);
+       6
+      > SELECT _FUNC_(-7, 64);
+       62
   """,
   since = "3.0.0",
   group = "bitwise_funcs")
-case class BitwiseCount(child: Expression)
+object BitCountExpressionBuilder extends ExpressionBuilder {
+  override def build(funcName: String, expressions: Seq[Expression]): Expression = {
+    expressions.length match {
+      case 1 => new BitwiseCount(expressions.head)
+      case 2 =>
+        val bitsExpr = expressions(1)
+        if (!bitsExpr.foldable || bitsExpr.dataType != IntegerType) {
+          throw QueryCompilationErrors.nonFoldableArgumentError(funcName, "bits", IntegerType)
+        }
+        val bitsVal = bitsExpr.eval()
+        if (bitsVal == null) {
+          throw QueryCompilationErrors.nonFoldableArgumentError(funcName, "bits", IntegerType)
+        }
+        val bits = bitsVal.asInstanceOf[Int]
+        if (bits < 1 || bits > 64) {
+          throw QueryCompilationErrors.bitsRangeError(funcName, bits)
+        }
+        BitwiseCount(expressions.head, bits)
+      case n =>
+        throw QueryCompilationErrors.wrongNumArgsError(funcName, Seq(1, 2), n)
+    }
+  }
+}
+
+case class BitwiseCount(child: Expression, bits: Int)
   extends UnaryExpression with ExpectsInputTypes {
+  require(bits >= 1 && bits <= 64, s"bits must be in [1, 64], got $bits")
+
+  def this(child: Expression) = this(child, child.dataType match {
+    case BooleanType => 1
+    case ByteType => 8
+    case ShortType => 16
+    case IntegerType => 32
+    case _ => 64 // LongType
+  })
+
   override def nullIntolerant: Boolean = true
 
   override def inputTypes: Seq[AbstractDataType] = Seq(TypeCollection(IntegralType, BooleanType))
 
   override def dataType: DataType = IntegerType
 
-  override def toString: String = s"bit_count($child)"
+  private lazy val isNaturalWidth: Boolean = bits == (child.dataType match {
+    case BooleanType => 1
+    case ByteType => 8
+    case ShortType => 16
+    case IntegerType => 32
+    case _ => 64
+  })
+
+  override def toString: String =
+    if (isNaturalWidth) s"bit_count($child)" else s"bit_count($child, $bits)"
 
   override def prettyName: String = "bit_count"
 
-  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = child.dataType match {
-    case BooleanType => defineCodeGen(ctx, ev, c => s"($c) ? 1 : 0")
-    case _ => defineCodeGen(ctx, ev, c => s"java.lang.Long.bitCount($c)")
+  override def sql: String =
+    if (isNaturalWidth) s"${prettyName}(${child.sql})"
+    else s"${prettyName}(${child.sql}, $bits)"
+
+  private lazy val needsRangeCheck: Boolean = !isNaturalWidth
+
+  private def checkRange(longVal: Long): Unit = {
+    if (needsRangeCheck) {
+      val lower = -(1L << (bits - 1))
+      val upper = (1L << (bits - 1)) - 1
+      if (longVal < lower || longVal > upper) {
+        throw QueryExecutionErrors.bitsValueOutOfRangeError("bit_count", longVal, bits)
+      }
+    }
   }
 
-  protected override def nullSafeEval(input: Any): Any = child.dataType match {
-    case BooleanType => if (input.asInstanceOf[Boolean]) 1 else 0
-    case ByteType => java.lang.Long.bitCount(input.asInstanceOf[Byte])
-    case ShortType => java.lang.Long.bitCount(input.asInstanceOf[Short])
-    case IntegerType => java.lang.Long.bitCount(input.asInstanceOf[Int])
-    case LongType => java.lang.Long.bitCount(input.asInstanceOf[Long])
+  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val maskStr = if (bits == 64) "-1L" else s"((1L << $bits) - 1)"
+    if (needsRangeCheck) {
+      val lower = -(1L << (bits - 1))
+      val upper = (1L << (bits - 1)) - 1
+      val checkClass =
+        "org.apache.spark.sql.errors.QueryExecutionErrors"
+      child.dataType match {
+        case BooleanType => defineCodeGen(ctx, ev, c =>
+          s"""(int) java.lang.Long.bitCount(($c ? 1L : 0L) & $maskStr)""")
+        case ByteType | ShortType | IntegerType => nullSafeCodeGen(ctx, ev, c =>
+          s"""
+             |long ${ev.value}_long = (long) $c;
+             |if (${ev.value}_long < ${lower}L || ${ev.value}_long > ${upper}L) {
+             |  throw (RuntimeException) $checkClass.bitsValueOutOfRangeError(
+             |    "bit_count", ${ev.value}_long, $bits);
+             |}
+             |${ev.value} = (int) java.lang.Long.bitCount(${ev.value}_long & $maskStr);
+           """.stripMargin)
+        case LongType => nullSafeCodeGen(ctx, ev, c =>
+          s"""
+             |if ($c < ${lower}L || $c > ${upper}L) {
+             |  throw (RuntimeException) $checkClass.bitsValueOutOfRangeError(
+             |    "bit_count", $c, $bits);
+             |}
+             |${ev.value} = (int) java.lang.Long.bitCount($c & $maskStr);
+           """.stripMargin)
+      }
+    } else {
+      child.dataType match {
+        case BooleanType => defineCodeGen(ctx, ev,
+          c => s"(int) java.lang.Long.bitCount(($c ? 1L : 0L) & $maskStr)")
+        case ByteType | ShortType | IntegerType => defineCodeGen(ctx, ev,
+          c => s"(int) java.lang.Long.bitCount(((long) $c) & $maskStr)")
+        case LongType => defineCodeGen(ctx, ev,
+          c => s"(int) java.lang.Long.bitCount($c & $maskStr)")
+      }
+    }
+  }
+
+  protected override def nullSafeEval(input: Any): Any = {
+    val mask = if (bits == 64) -1L else (1L << bits) - 1
+    val longVal = child.dataType match {
+      case BooleanType => if (input.asInstanceOf[Boolean]) 1L else 0L
+      case ByteType => input.asInstanceOf[Byte].toLong
+      case ShortType => input.asInstanceOf[Short].toLong
+      case IntegerType => input.asInstanceOf[Int].toLong
+      case LongType => input.asInstanceOf[Long]
+    }
+    checkRange(longVal)
+    java.lang.Long.bitCount(longVal & mask).toInt
   }
 
   override protected def withNewChildInternal(newChild: Expression): BitwiseCount =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1476,6 +1476,15 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
         "paramType" -> toSQLType(paramType)))
   }
 
+  def bitsRangeError(funcName: String, invalidValue: Int): Throwable = {
+    new AnalysisException(
+      errorClass = "INVALID_PARAMETER_VALUE.BITS_RANGE",
+      messageParameters = Map(
+        "parameter" -> toSQLId("bits"),
+        "functionName" -> toSQLId(funcName),
+        "invalidValue" -> invalidValue.toString))
+  }
+
   def literalTypeUnsupportedForSourceTypeError(field: String, source: Expression): Throwable = {
     new AnalysisException(
       errorClass = "INVALID_EXTRACT_FIELD",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2972,6 +2972,21 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
         "invalidValue" -> pos.toString))
   }
 
+  def bitsValueOutOfRangeError(
+      funcName: String, value: Long, bits: Int): Throwable = {
+    val lower = -(1L << (bits - 1))
+    val upper = (1L << (bits - 1)) - 1
+    new SparkIllegalArgumentException(
+      errorClass = "INVALID_PARAMETER_VALUE.BITS_VALUE_OUT_OF_RANGE",
+      messageParameters = Map(
+        "parameter" -> toSQLId("expr"),
+        "functionName" -> toSQLId(funcName),
+        "bits" -> bits.toString,
+        "lower" -> lower.toString,
+        "upper" -> upper.toString,
+        "invalidValue" -> value.toString))
+  }
+
   def variantSizeLimitError(sizeLimit: Int, functionName: String): Throwable = {
     new SparkRuntimeException(
       errorClass = "VARIANT_SIZE_LIMIT",

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/BitwiseExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/BitwiseExpressionsSuite.scala
@@ -17,13 +17,17 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
+import org.scalacheck.Gen
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.types._
 
 
-class BitwiseExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
+class BitwiseExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
+    with ScalaCheckPropertyChecks {
 
   import IntegralLiteralTestUtils._
 
@@ -139,40 +143,198 @@ class BitwiseExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val nullLongLiteral = Literal.create(null, LongType)
     val nullIntLiteral = Literal.create(null, IntegerType)
     val nullBooleanLiteral = Literal.create(null, BooleanType)
-    checkEvaluation(BitwiseCount(nullLongLiteral), null)
-    checkEvaluation(BitwiseCount(nullIntLiteral), null)
-    checkEvaluation(BitwiseCount(nullBooleanLiteral), null)
+    checkEvaluation(new BitwiseCount(nullLongLiteral), null)
+    checkEvaluation(new BitwiseCount(nullIntLiteral), null)
+    checkEvaluation(new BitwiseCount(nullBooleanLiteral), null)
 
     // boolean
-    checkEvaluation(BitwiseCount(Literal(true)), 1)
-    checkEvaluation(BitwiseCount(Literal(false)), 0)
+    checkEvaluation(new BitwiseCount(Literal(true)), 1)
+    checkEvaluation(new BitwiseCount(Literal(false)), 0)
 
     // byte/tinyint
-    checkEvaluation(BitwiseCount(Literal(1.toByte)), 1)
-    checkEvaluation(BitwiseCount(Literal(2.toByte)), 1)
-    checkEvaluation(BitwiseCount(Literal(3.toByte)), 2)
+    checkEvaluation(new BitwiseCount(Literal(1.toByte)), 1)
+    checkEvaluation(new BitwiseCount(Literal(2.toByte)), 1)
+    checkEvaluation(new BitwiseCount(Literal(3.toByte)), 2)
 
     // short/smallint
-    checkEvaluation(BitwiseCount(Literal(1.toShort)), 1)
-    checkEvaluation(BitwiseCount(Literal(2.toShort)), 1)
-    checkEvaluation(BitwiseCount(Literal(3.toShort)), 2)
+    checkEvaluation(new BitwiseCount(Literal(1.toShort)), 1)
+    checkEvaluation(new BitwiseCount(Literal(2.toShort)), 1)
+    checkEvaluation(new BitwiseCount(Literal(3.toShort)), 2)
 
     // int
-    checkEvaluation(BitwiseCount(Literal(1)), 1)
-    checkEvaluation(BitwiseCount(Literal(2)), 1)
-    checkEvaluation(BitwiseCount(Literal(3)), 2)
+    checkEvaluation(new BitwiseCount(Literal(1)), 1)
+    checkEvaluation(new BitwiseCount(Literal(2)), 1)
+    checkEvaluation(new BitwiseCount(Literal(3)), 2)
 
     // long/bigint
-    checkEvaluation(BitwiseCount(Literal(1L)), 1)
-    checkEvaluation(BitwiseCount(Literal(2L)), 1)
-    checkEvaluation(BitwiseCount(Literal(3L)), 2)
+    checkEvaluation(new BitwiseCount(Literal(1L)), 1)
+    checkEvaluation(new BitwiseCount(Literal(2L)), 1)
+    checkEvaluation(new BitwiseCount(Literal(3L)), 2)
 
     // negative num
-    checkEvaluation(BitwiseCount(Literal(-1L)), 64)
+    checkEvaluation(new BitwiseCount(Literal(-1L)), 64)
 
     // edge value
-    checkEvaluation(BitwiseCount(Literal(9223372036854775807L)), 63)
-    checkEvaluation(BitwiseCount(Literal(-9223372036854775808L)), 1)
+    checkEvaluation(new BitwiseCount(Literal(9223372036854775807L)), 63)
+    checkEvaluation(new BitwiseCount(Literal(-9223372036854775808L)), 1)
+  }
+
+  test("BitCount should respect input integer type bit width") {
+    // BIT_COUNT(-1) should return the number of bits in the type, not always 64
+    checkEvaluation(new BitwiseCount(Literal((-1).toByte)), 8)
+    checkEvaluation(new BitwiseCount(Literal((-1).toShort)), 16)
+    checkEvaluation(new BitwiseCount(Literal(-1)), 32)
+    checkEvaluation(new BitwiseCount(Literal(-1L)), 64)
+
+    // Additional cases with specific negative values
+    checkEvaluation(new BitwiseCount(Literal(Int.MinValue)), 1)
+    checkEvaluation(new BitwiseCount(Literal(-65536)), 16)
+    checkEvaluation(new BitwiseCount(Literal(-256)), 24)
+    checkEvaluation(new BitwiseCount(Literal(Byte.MinValue)), 1)
+    checkEvaluation(new BitwiseCount(Literal((-256).toShort)), 8)
+    checkEvaluation(new BitwiseCount(Literal(Short.MinValue)), 1)
+    checkEvaluation(new BitwiseCount(Literal(Long.MinValue)), 1)
+
+    DataTypeTestUtils.integralType.foreach { dt =>
+      checkConsistencyBetweenInterpretedAndCodegen((e: Expression) => new BitwiseCount(e), dt)
+    }
+  }
+
+  test("BitCount with explicit bits parameter") {
+    // Trino-compatible examples
+    checkEvaluation(BitwiseCount(Literal(9), 64), 2)
+    checkEvaluation(BitwiseCount(Literal(9), 8), 2)
+    checkEvaluation(BitwiseCount(Literal(-7), 64), 62)
+    checkEvaluation(BitwiseCount(Literal(-7), 8), 6)
+    checkEvaluation(BitwiseCount(Literal(0), 8), 0)
+    checkEvaluation(BitwiseCount(Literal(-1), 8), 8)
+    checkEvaluation(BitwiseCount(Literal(-1), 64), 64)
+    checkEvaluation(BitwiseCount(Literal(-1), 1), 1)
+    checkEvaluation(BitwiseCount(Literal(0), 1), 0)
+
+    // null first argument
+    checkEvaluation(BitwiseCount(Literal.create(null, IntegerType), 8), null)
+    checkEvaluation(BitwiseCount(Literal.create(null, LongType), 64), null)
+
+    // boolean with bits
+    checkEvaluation(BitwiseCount(Literal(true), 8), 1)
+    checkEvaluation(BitwiseCount(Literal(false), 8), 0)
+
+    // codegen consistency for two-argument form
+    // Use bits=64 for all types to avoid range errors with random values
+    DataTypeTestUtils.integralType.foreach { dt =>
+      checkConsistencyBetweenInterpretedAndCodegen(
+        (e: Expression) => BitwiseCount(e, 64), dt)
+    }
+
+    // range validation: value out of bits-bit signed integer range
+    checkErrorInExpression[SparkIllegalArgumentException](
+      BitwiseCount(Literal(200), 8),
+      "INVALID_PARAMETER_VALUE.BITS_VALUE_OUT_OF_RANGE",
+      Map("parameter" -> "`expr`",
+        "functionName" -> "`bit_count`",
+        "bits" -> "8",
+        "lower" -> "-128",
+        "upper" -> "127",
+        "invalidValue" -> "200"))
+    checkErrorInExpression[SparkIllegalArgumentException](
+      BitwiseCount(Literal(-129), 8),
+      "INVALID_PARAMETER_VALUE.BITS_VALUE_OUT_OF_RANGE",
+      Map("parameter" -> "`expr`",
+        "functionName" -> "`bit_count`",
+        "bits" -> "8",
+        "lower" -> "-128",
+        "upper" -> "127",
+        "invalidValue" -> "-129"))
+    // boundary values should succeed
+    checkEvaluation(BitwiseCount(Literal(127), 8), 7)
+    checkEvaluation(BitwiseCount(Literal(-128), 8), 1)
+  }
+
+  test("BitCount builder validation") {
+    // non-foldable bits
+    val ex1 = intercept[Exception] {
+      BitCountExpressionBuilder.build("bit_count",
+        Seq(Literal(1), $"col".int))
+    }
+    assert(ex1.getMessage.contains("NON_FOLDABLE_ARGUMENT") ||
+      ex1.getMessage.contains("foldable"))
+
+    // null bits
+    val ex2 = intercept[Exception] {
+      BitCountExpressionBuilder.build("bit_count",
+        Seq(Literal(1), Literal.create(null, IntegerType)))
+    }
+    assert(ex2.getMessage.contains("NON_FOLDABLE_ARGUMENT") ||
+      ex2.getMessage.contains("foldable"))
+
+    // bits out of range
+    val ex3 = intercept[Exception] {
+      BitCountExpressionBuilder.build("bit_count",
+        Seq(Literal(1), Literal(0)))
+    }
+    assert(ex3.getMessage.contains("BITS_RANGE") ||
+      ex3.getMessage.contains("[1, 64]"))
+
+    val ex4 = intercept[Exception] {
+      BitCountExpressionBuilder.build("bit_count",
+        Seq(Literal(1), Literal(65)))
+    }
+    assert(ex4.getMessage.contains("BITS_RANGE") ||
+      ex4.getMessage.contains("[1, 64]"))
+
+    // wrong number of arguments
+    val ex5 = intercept[Exception] {
+      BitCountExpressionBuilder.build("bit_count",
+        Seq(Literal(1), Literal(8), Literal(3)))
+    }
+    assert(ex5.getMessage.contains("WRONG_NUM_ARGS") ||
+      ex5.getMessage.contains("number"))
+
+    // direct construction with invalid bits triggers require
+    intercept[IllegalArgumentException] { BitwiseCount(Literal(1), -1) }
+    intercept[IllegalArgumentException] { BitwiseCount(Literal(1), 0) }
+    intercept[IllegalArgumentException] { BitwiseCount(Literal(1), 65) }
+    intercept[IllegalArgumentException] { BitwiseCount(Literal(1), 100) }
+  }
+
+  test("BitCount property: two-argument matches Long.bitCount with mask") {
+    val genBits = Gen.choose(1, 64)
+    forAll(genBits, minSuccessful(200)) { (bits: Int) =>
+      val lower = -(1L << (bits - 1))
+      val upper = (1L << (bits - 1)) - 1
+      val genValue = Gen.choose(lower, upper)
+      forAll(genValue, minSuccessful(10)) { (value: Long) =>
+        val mask = if (bits == 64) -1L else (1L << bits) - 1
+        val expected = java.lang.Long.bitCount(value & mask)
+        val result = BitwiseCount(Literal(value), bits).eval(null)
+        assert(result === expected,
+          s"bit_count($value, $bits): expected $expected but got $result")
+      }
+    }
+  }
+
+  test("BitCount property: single-argument matches natural bit width") {
+    // Long
+    forAll(Gen.choose(Long.MinValue, Long.MaxValue), minSuccessful(100)) { (value: Long) =>
+      val expected = java.lang.Long.bitCount(value)
+      assert(new BitwiseCount(Literal(value)).eval(null) === expected)
+    }
+    // Int
+    forAll(Gen.choose(Int.MinValue, Int.MaxValue), minSuccessful(100)) { (value: Int) =>
+      val expected = java.lang.Integer.bitCount(value)
+      assert(new BitwiseCount(Literal(value)).eval(null) === expected)
+    }
+    // Short
+    forAll(Gen.choose(Short.MinValue, Short.MaxValue), minSuccessful(100)) { (value: Short) =>
+      val expected = java.lang.Integer.bitCount(java.lang.Short.toUnsignedInt(value))
+      assert(new BitwiseCount(Literal(value)).eval(null) === expected)
+    }
+    // Byte
+    forAll(Gen.choose(Byte.MinValue, Byte.MaxValue), minSuccessful(100)) { (value: Byte) =>
+      val expected = java.lang.Integer.bitCount(java.lang.Byte.toUnsignedInt(value))
+      assert(new BitwiseCount(Literal(value)).eval(null) === expected)
+    }
   }
 
   test("BitGet") {

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -47,6 +47,7 @@
 | org.apache.spark.sql.catalyst.expressions.Base64 | base64 | SELECT base64('Spark SQL') | struct<base64(Spark SQL):string> |
 | org.apache.spark.sql.catalyst.expressions.Between | between | SELECT 0.5 between 0.1 AND 1.0 | struct<between(0.5, 0.1, 1.0):boolean> |
 | org.apache.spark.sql.catalyst.expressions.Bin | bin | SELECT bin(13) | struct<bin(13):string> |
+| org.apache.spark.sql.catalyst.expressions.BitCountExpressionBuilder | bit_count | SELECT bit_count(0) | struct<bit_count(0):int> |
 | org.apache.spark.sql.catalyst.expressions.BitLength | bit_length | SELECT bit_length('Spark SQL') | struct<bit_length(Spark SQL):int> |
 | org.apache.spark.sql.catalyst.expressions.BitmapAndAgg | bitmap_and_agg | SELECT substring(hex(bitmap_and_agg(col)), 0, 6) FROM VALUES (X 'F0'), (X '70'), (X '30') AS tab(col) | struct<substring(hex(bitmap_and_agg(col)), 0, 6):string> |
 | org.apache.spark.sql.catalyst.expressions.BitmapBitPosition | bitmap_bit_position | SELECT bitmap_bit_position(1) | struct<bitmap_bit_position(1):bigint> |
@@ -55,7 +56,6 @@
 | org.apache.spark.sql.catalyst.expressions.BitmapCount | bitmap_count | SELECT bitmap_count(X '1010') | struct<bitmap_count(X'1010'):bigint> |
 | org.apache.spark.sql.catalyst.expressions.BitmapOrAgg | bitmap_or_agg | SELECT substring(hex(bitmap_or_agg(col)), 0, 6) FROM VALUES (X '10'), (X '20'), (X '40') AS tab(col) | struct<substring(hex(bitmap_or_agg(col)), 0, 6):string> |
 | org.apache.spark.sql.catalyst.expressions.BitwiseAnd | & | SELECT 3 & 5 | struct<(3 & 5):int> |
-| org.apache.spark.sql.catalyst.expressions.BitwiseCount | bit_count | SELECT bit_count(0) | struct<bit_count(0):int> |
 | org.apache.spark.sql.catalyst.expressions.BitwiseGet | bit_get | SELECT bit_get(11, 0) | struct<bit_get(11, 0):tinyint> |
 | org.apache.spark.sql.catalyst.expressions.BitwiseGet | getbit | SELECT getbit(11, 0) | struct<getbit(11, 0):tinyint> |
 | org.apache.spark.sql.catalyst.expressions.BitwiseNot | ~ | SELECT ~ 0 | struct<~0:int> |

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/bitwise.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/bitwise.sql.out
@@ -2,7 +2,7 @@
 -- !query
 select bit_count(null)
 -- !query analysis
-Project [bit_count(null) AS bit_count(NULL)#x]
+Project [bit_count(null, 64) AS bit_count(NULL, 64)#x]
 +- OneRowRelation
 
 
@@ -112,6 +112,34 @@ Project [bit_count(-1) AS bit_count(-1)#x]
 
 
 -- !query
+select bit_count(cast(-1 as tinyint))
+-- !query analysis
+Project [bit_count(cast(-1 as tinyint)) AS bit_count(CAST(-1 AS TINYINT))#x]
++- OneRowRelation
+
+
+-- !query
+select bit_count(cast(-1 as smallint))
+-- !query analysis
+Project [bit_count(cast(-1 as smallint)) AS bit_count(CAST(-1 AS SMALLINT))#x]
++- OneRowRelation
+
+
+-- !query
+select bit_count(-1)
+-- !query analysis
+Project [bit_count(-1) AS bit_count(-1)#x]
++- OneRowRelation
+
+
+-- !query
+select bit_count(-1L)
+-- !query analysis
+Project [bit_count(-1) AS bit_count(-1)#x]
++- OneRowRelation
+
+
+-- !query
 select bit_count(9223372036854775807L)
 -- !query analysis
 Project [bit_count(9223372036854775807) AS bit_count(9223372036854775807)#x]
@@ -169,6 +197,166 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "startIndex" : 8,
     "stopIndex" : 21,
     "fragment" : "bit_count('a')"
+  } ]
+}
+
+
+-- !query
+select bit_count(9, 64)
+-- !query analysis
+Project [bit_count(9, 64) AS bit_count(9, 64)#x]
++- OneRowRelation
+
+
+-- !query
+select bit_count(9, 8)
+-- !query analysis
+Project [bit_count(9, 8) AS bit_count(9, 8)#x]
++- OneRowRelation
+
+
+-- !query
+select bit_count(-7, 64)
+-- !query analysis
+Project [bit_count(-7, 64) AS bit_count(-7, 64)#x]
++- OneRowRelation
+
+
+-- !query
+select bit_count(-7, 8)
+-- !query analysis
+Project [bit_count(-7, 8) AS bit_count(-7, 8)#x]
++- OneRowRelation
+
+
+-- !query
+select bit_count(0, 8)
+-- !query analysis
+Project [bit_count(0, 8) AS bit_count(0, 8)#x]
++- OneRowRelation
+
+
+-- !query
+select bit_count(-1, 8)
+-- !query analysis
+Project [bit_count(-1, 8) AS bit_count(-1, 8)#x]
++- OneRowRelation
+
+
+-- !query
+select bit_count(-1, 64)
+-- !query analysis
+Project [bit_count(-1, 64) AS bit_count(-1, 64)#x]
++- OneRowRelation
+
+
+-- !query
+select bit_count(9, 0)
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "INVALID_PARAMETER_VALUE.BITS_RANGE",
+  "sqlState" : "22023",
+  "messageParameters" : {
+    "functionName" : "`bit_count`",
+    "invalidValue" : "0",
+    "parameter" : "`bits`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 22,
+    "fragment" : "bit_count(9, 0)"
+  } ]
+}
+
+
+-- !query
+select bit_count(9, 65)
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "INVALID_PARAMETER_VALUE.BITS_RANGE",
+  "sqlState" : "22023",
+  "messageParameters" : {
+    "functionName" : "`bit_count`",
+    "invalidValue" : "65",
+    "parameter" : "`bits`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 23,
+    "fragment" : "bit_count(9, 65)"
+  } ]
+}
+
+
+-- !query
+select bit_count(9, null)
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "NON_FOLDABLE_ARGUMENT",
+  "sqlState" : "42K08",
+  "messageParameters" : {
+    "funcName" : "`bit_count`",
+    "paramName" : "`bits`",
+    "paramType" : "\"INT\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 25,
+    "fragment" : "bit_count(9, null)"
+  } ]
+}
+
+
+-- !query
+select bit_count(9, 'a')
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "NON_FOLDABLE_ARGUMENT",
+  "sqlState" : "42K08",
+  "messageParameters" : {
+    "funcName" : "`bit_count`",
+    "paramName" : "`bits`",
+    "paramType" : "\"INT\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 24,
+    "fragment" : "bit_count(9, 'a')"
+  } ]
+}
+
+
+-- !query
+select bit_count(9, 8, 3)
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "WRONG_NUM_ARGS.WITHOUT_SUGGESTION",
+  "sqlState" : "42605",
+  "messageParameters" : {
+    "actualNum" : "3",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "expectedNum" : "[1, 2]",
+    "functionName" : "`bit_count`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 25,
+    "fragment" : "bit_count(9, 8, 3)"
   } ]
 }
 

--- a/sql/core/src/test/resources/sql-tests/inputs/bitwise.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/bitwise.sql
@@ -30,6 +30,12 @@ select bit_count(3L);
 -- negative num
 select bit_count(-1L);
 
+-- single-argument backward compatibility: negative values respect type bit width
+select bit_count(cast(-1 as tinyint));
+select bit_count(cast(-1 as smallint));
+select bit_count(-1);
+select bit_count(-1L);
+
 -- edge value
 select bit_count(9223372036854775807L);
 select bit_count(-9223372036854775808L);
@@ -37,6 +43,22 @@ select bit_count(-9223372036854775808L);
 -- other illegal arguments
 select bit_count("bit count");
 select bit_count('a');
+
+-- two-argument bit_count (Trino-compatible)
+select bit_count(9, 64);
+select bit_count(9, 8);
+select bit_count(-7, 64);
+select bit_count(-7, 8);
+select bit_count(0, 8);
+select bit_count(-1, 8);
+select bit_count(-1, 64);
+
+-- two-argument bit_count error cases
+select bit_count(9, 0);
+select bit_count(9, 65);
+select bit_count(9, null);
+select bit_count(9, 'a');
+select bit_count(9, 8, 3);
 
 -- test for bit_xor
 --

--- a/sql/core/src/test/resources/sql-tests/results/bitwise.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/bitwise.sql.out
@@ -2,7 +2,7 @@
 -- !query
 select bit_count(null)
 -- !query schema
-struct<bit_count(NULL):int>
+struct<bit_count(NULL, 64):int>
 -- !query output
 NULL
 
@@ -128,6 +128,38 @@ struct<bit_count(-1):int>
 
 
 -- !query
+select bit_count(cast(-1 as tinyint))
+-- !query schema
+struct<bit_count(CAST(-1 AS TINYINT)):int>
+-- !query output
+8
+
+
+-- !query
+select bit_count(cast(-1 as smallint))
+-- !query schema
+struct<bit_count(CAST(-1 AS SMALLINT)):int>
+-- !query output
+16
+
+
+-- !query
+select bit_count(-1)
+-- !query schema
+struct<bit_count(-1):int>
+-- !query output
+32
+
+
+-- !query
+select bit_count(-1L)
+-- !query schema
+struct<bit_count(-1):int>
+-- !query output
+64
+
+
+-- !query
 select bit_count(9223372036854775807L)
 -- !query schema
 struct<bit_count(9223372036854775807):int>
@@ -191,6 +223,183 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "startIndex" : 8,
     "stopIndex" : 21,
     "fragment" : "bit_count('a')"
+  } ]
+}
+
+
+-- !query
+select bit_count(9, 64)
+-- !query schema
+struct<bit_count(9, 64):int>
+-- !query output
+2
+
+
+-- !query
+select bit_count(9, 8)
+-- !query schema
+struct<bit_count(9, 8):int>
+-- !query output
+2
+
+
+-- !query
+select bit_count(-7, 64)
+-- !query schema
+struct<bit_count(-7, 64):int>
+-- !query output
+62
+
+
+-- !query
+select bit_count(-7, 8)
+-- !query schema
+struct<bit_count(-7, 8):int>
+-- !query output
+6
+
+
+-- !query
+select bit_count(0, 8)
+-- !query schema
+struct<bit_count(0, 8):int>
+-- !query output
+0
+
+
+-- !query
+select bit_count(-1, 8)
+-- !query schema
+struct<bit_count(-1, 8):int>
+-- !query output
+8
+
+
+-- !query
+select bit_count(-1, 64)
+-- !query schema
+struct<bit_count(-1, 64):int>
+-- !query output
+64
+
+
+-- !query
+select bit_count(9, 0)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "INVALID_PARAMETER_VALUE.BITS_RANGE",
+  "sqlState" : "22023",
+  "messageParameters" : {
+    "functionName" : "`bit_count`",
+    "invalidValue" : "0",
+    "parameter" : "`bits`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 22,
+    "fragment" : "bit_count(9, 0)"
+  } ]
+}
+
+
+-- !query
+select bit_count(9, 65)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "INVALID_PARAMETER_VALUE.BITS_RANGE",
+  "sqlState" : "22023",
+  "messageParameters" : {
+    "functionName" : "`bit_count`",
+    "invalidValue" : "65",
+    "parameter" : "`bits`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 23,
+    "fragment" : "bit_count(9, 65)"
+  } ]
+}
+
+
+-- !query
+select bit_count(9, null)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "NON_FOLDABLE_ARGUMENT",
+  "sqlState" : "42K08",
+  "messageParameters" : {
+    "funcName" : "`bit_count`",
+    "paramName" : "`bits`",
+    "paramType" : "\"INT\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 25,
+    "fragment" : "bit_count(9, null)"
+  } ]
+}
+
+
+-- !query
+select bit_count(9, 'a')
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "NON_FOLDABLE_ARGUMENT",
+  "sqlState" : "42K08",
+  "messageParameters" : {
+    "funcName" : "`bit_count`",
+    "paramName" : "`bits`",
+    "paramType" : "\"INT\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 24,
+    "fragment" : "bit_count(9, 'a')"
+  } ]
+}
+
+
+-- !query
+select bit_count(9, 8, 3)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "WRONG_NUM_ARGS.WITHOUT_SUGGESTION",
+  "sqlState" : "42605",
+  "messageParameters" : {
+    "actualNum" : "3",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "expectedNum" : "[1, 2]",
+    "functionName" : "`bit_count`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 25,
+    "fragment" : "bit_count(9, 8, 3)"
   } ]
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Fix BitwiseCount (bit_count) to correctly count set bits for negative values of Byte, Short, and Int types by using type-specific unsigned conversion (toUnsignedInt + Integer.bitCount) instead of Long.bitCount with sign extension.
    
2. Add an optional second `bits` parameter to `bit_count(expr[, bits])`, aligning with Trino's `bit_count(x, bits)` semantics. When `bits` is specified, the input is truncated to the lowest `bits` bits (treated as a `bits`-bit signed 2's complement integer) before counting set bits.

### Why are the changes needed?

 1. `bit_count(CAST(-1 AS TINYINT))` incorrectly returned 64 instead of 8 because Long.bitCount sign-extends smaller integer types to 64-bit.
    
 2. Trino supports `bit_count(x, bits)` which allows users to specify the bit width explicitly. Adding this to Spark improves cross-engine compatibility and gives users control over how negative values are interpreted when counting bits.
    
### Does this PR introduce _any_ user-facing change?

 Yes.
    - `bit_count` now returns correct results for negative Byte, Short, and Int values.
    - `bit_count` now accepts an optional second `bits` parameter (integer in [1, 64]).
    - PySpark `bit_count` now accepts an optional `bits` parameter.
 
### How was this patch tested?

 - Unit tests in `BitwiseExpressionsSuite`: single-arg backward compatibility, two-arg concrete examples, builder validation (non-foldable, null, out-of-range, wrong arity), boolean with bits, codegen consistency, and ScalaCheck property tests (200+ iterations).
 - SQL golden tests in `bitwise.sql`: two-argument happy path cases and error cases (out-of-range, null, wrong type, wrong arity).
 - Manual PySpark verification for both single-arg and two-arg calls.

### Was this patch authored or co-authored using generative AI tooling?

Yes.
