### PR TITLE
[SPARK-55841][BUILD][FOLLOWUP] Update `SparkBuild.scala` consistently

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1186,7 +1186,7 @@ object KubernetesIntegrationTests {
  * Overrides to work around sbt's dependency resolution being different from Maven's.
  */
 object DependencyOverrides {
-  lazy val jacksonVersion = sys.props.get("fasterxml.jackson.version").getOrElse("2.20.1")
+  lazy val jacksonVersion = sys.props.get("fasterxml.jackson.version").getOrElse("2.21.1")
   lazy val jacksonDeps = Bom.dependencies("com.fasterxml.jackson" % "jackson-bom" % jacksonVersion)
   lazy val settings = jacksonDeps ++ Seq(
     dependencyOverrides ++= {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update the default value of `fasterxml.jackson.version` in `SparkBuild.scala` consistently.

### Why are the changes needed?

Although we update `Jackson` to 2.21.x already, `Sparkbuild.scala` has outdated value like the following.
- https://github.com/apache/spark/pull/53886
- https://github.com/apache/spark/pull/54626

https://github.com/apache/spark/blob/3126983706e0b18e2f4edd4ced516362c097933a/project/SparkBuild.scala#L1189

**MAVEN**
```
$ mvn dependency:tree | grep jackson-annotations | sort | uniq
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.21:compile
[INFO] |     |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.21:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.21:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.21:compile
[INFO] |  |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.21:compile
[INFO] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.21:compile
[INFO] |  |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.21:compile
[INFO] |  |  |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.21:compile
```

**SBT**
```
$ build/sbt dependencyTree | grep jackson-annotations
Using SPARK_LOCAL_IP=localhost
[info]   | +-com.fasterxml.jackson.core:jackson-annotations:2.20
[info]   | +-com.fasterxml.jackson.core:jackson-annotations:2.20
[info]   | +-com.fasterxml.jackson.core:jackson-annotations:2.20
[info]   | +-com.fasterxml.jackson.core:jackson-annotations:2.20
...
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`.