### PR TITLE
[SPARK-55851][PYTHON] Clarify types of datasource partition and read

### DIFF
--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -818,7 +818,7 @@ class DataSourceStreamReader(ABC):
 
         Returns
         -------
-        sequence of :class:`InputPartition`\\s or None
+        sequence of :class:`InputPartition`\\s
             A sequence of partitions for this data source. Each partition value
             must be an instance of `InputPartition` or a subclass of it.
         """

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -578,7 +578,7 @@ class DataSourceReader(ABC):
         """
         return filters
 
-    def partitions(self) -> Sequence[InputPartition]:
+    def partitions(self) -> Sequence[Union[InputPartition, None]]:
         """
         Returns an iterator of partitions for this data source.
 
@@ -626,13 +626,12 @@ class DataSourceReader(ABC):
         >>> def partitions(self):
         ...     return [RangeInputPartition(1, 3), RangeInputPartition(5, 10)]
         """
-        raise PySparkNotImplementedError(
-            errorClass="NOT_IMPLEMENTED",
-            messageParameters={"feature": "partitions"},
-        )
+        return [None]
 
     @abstractmethod
-    def read(self, partition: InputPartition) -> Union[Iterator[Tuple], Iterator["RecordBatch"]]:
+    def read(
+        self, partition: Union[InputPartition, None]
+    ) -> Union[Iterator[Tuple], Iterator["RecordBatch"]]:
         """
         Generates data for a given partition and returns an iterator of tuples or rows.
 
@@ -643,7 +642,7 @@ class DataSourceReader(ABC):
 
         Parameters
         ----------
-        partition : object
+        partition : InputPartition or None
             The partition to read. It must be one of the partition values returned by
             :meth:`DataSourceReader.partitions`.
 
@@ -805,7 +804,7 @@ class DataSourceStreamReader(ABC):
         """
         return None
 
-    def partitions(self, start: dict, end: dict) -> Sequence[InputPartition]:
+    def partitions(self, start: dict, end: dict) -> Sequence[Union[InputPartition, None]]:
         """
         Returns a list of InputPartition given the start and end offsets. Each InputPartition
         represents a data split that can be processed by one Spark task. This may be called with
@@ -821,17 +820,16 @@ class DataSourceStreamReader(ABC):
 
         Returns
         -------
-        sequence of :class:`InputPartition`\\s
+        sequence of :class:`InputPartition`\\s or None
             A sequence of partitions for this data source. Each partition value
-            must be an instance of `InputPartition` or a subclass of it.
+            must be either None, or an instance of `InputPartition` or a subclass of it.
         """
-        raise PySparkNotImplementedError(
-            errorClass="NOT_IMPLEMENTED",
-            messageParameters={"feature": "partitions"},
-        )
+        return [None]
 
     @abstractmethod
-    def read(self, partition: InputPartition) -> Union[Iterator[Tuple], Iterator["RecordBatch"]]:
+    def read(
+        self, partition: Union[InputPartition, None]
+    ) -> Union[Iterator[Tuple], Iterator["RecordBatch"]]:
         """
         Generates data for a given partition and returns an iterator of tuples or rows.
 
@@ -847,7 +845,7 @@ class DataSourceStreamReader(ABC):
 
         Parameters
         ----------
-        partition : :class:`InputPartition`
+        partition : :class:`InputPartition` or None
             The partition to read. It must be one of the partition values returned by
             :meth:`DataSourceStreamReader.partitions`.
 

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -578,7 +578,7 @@ class DataSourceReader(ABC):
         """
         return filters
 
-    def partitions(self) -> Sequence[Union[InputPartition, None]]:
+    def partitions(self) -> Sequence[InputPartition]:
         """
         Returns an iterator of partitions for this data source.
 
@@ -588,8 +588,8 @@ class DataSourceReader(ABC):
         partition value to read the data.
 
         This method is called once during query planning. By default, it returns a
-        single partition with the value ``None``. Subclasses can override this method
-        to return multiple partitions.
+        single partition with the value `InputPartition(None)`. Subclasses can override
+        this method to return multiple partitions.
 
         It's recommended to override this method for better performance when reading
         large datasets.
@@ -626,12 +626,10 @@ class DataSourceReader(ABC):
         >>> def partitions(self):
         ...     return [RangeInputPartition(1, 3), RangeInputPartition(5, 10)]
         """
-        return [None]
+        return [InputPartition(None)]
 
     @abstractmethod
-    def read(
-        self, partition: Union[InputPartition, None]
-    ) -> Union[Iterator[Tuple], Iterator["RecordBatch"]]:
+    def read(self, partition: InputPartition) -> Union[Iterator[Tuple], Iterator["RecordBatch"]]:
         """
         Generates data for a given partition and returns an iterator of tuples or rows.
 
@@ -642,7 +640,7 @@ class DataSourceReader(ABC):
 
         Parameters
         ----------
-        partition : InputPartition or None
+        partition : InputPartition
             The partition to read. It must be one of the partition values returned by
             :meth:`DataSourceReader.partitions`.
 
@@ -804,7 +802,7 @@ class DataSourceStreamReader(ABC):
         """
         return None
 
-    def partitions(self, start: dict, end: dict) -> Sequence[Union[InputPartition, None]]:
+    def partitions(self, start: dict, end: dict) -> Sequence[InputPartition]:
         """
         Returns a list of InputPartition given the start and end offsets. Each InputPartition
         represents a data split that can be processed by one Spark task. This may be called with
@@ -822,14 +820,15 @@ class DataSourceStreamReader(ABC):
         -------
         sequence of :class:`InputPartition`\\s or None
             A sequence of partitions for this data source. Each partition value
-            must be either None, or an instance of `InputPartition` or a subclass of it.
+            must be an instance of `InputPartition` or a subclass of it.
         """
-        return [None]
+        raise PySparkNotImplementedError(
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "partitions"},
+        )
 
     @abstractmethod
-    def read(
-        self, partition: Union[InputPartition, None]
-    ) -> Union[Iterator[Tuple], Iterator["RecordBatch"]]:
+    def read(self, partition: InputPartition) -> Union[Iterator[Tuple], Iterator["RecordBatch"]]:
         """
         Generates data for a given partition and returns an iterator of tuples or rows.
 
@@ -845,7 +844,7 @@ class DataSourceStreamReader(ABC):
 
         Parameters
         ----------
-        partition : :class:`InputPartition` or None
+        partition : :class:`InputPartition`
             The partition to read. It must be one of the partition values returned by
             :meth:`DataSourceStreamReader.partitions`.
 

--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -1151,7 +1151,7 @@ class BasePythonDataSourceTestsMixin:
                             {"class_name": "TestJsonReader", "func_name": "partitions"},
                         ),
                         (
-                            "TestJsonReader.read: None",
+                            "TestJsonReader.read: InputPartition(value=None)",
                             {"class_name": "TestJsonReader", "func_name": "read"},
                         ),
                     ]

--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -1040,7 +1040,7 @@ class BasePythonDataSourceTestsMixin:
                             {"class_name": "TestJsonReader", "func_name": "partitions"},
                         ),
                         (
-                            "TestJsonReader.read: InputPartition(None)",
+                            "TestJsonReader.read: InputPartition(value=None)",
                             {"class_name": "TestJsonReader", "func_name": "read"},
                         ),
                     ]

--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -162,7 +162,7 @@ class BasePythonDataSourceTestsMixin:
                 if partition_func is not None:
                     return partition_func()
                 else:
-                    return [None]
+                    return [InputPartition(None)]
 
             def read(self, partition):
                 return read_func(self.schema, partition)

--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -1040,7 +1040,7 @@ class BasePythonDataSourceTestsMixin:
                             {"class_name": "TestJsonReader", "func_name": "partitions"},
                         ),
                         (
-                            "TestJsonReader.read: None",
+                            "TestJsonReader.read: InputPartition(None)",
                             {"class_name": "TestJsonReader", "func_name": "read"},
                         ),
                     ]

--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -162,7 +162,7 @@ class BasePythonDataSourceTestsMixin:
                 if partition_func is not None:
                     return partition_func()
                 else:
-                    raise NotImplementedError
+                    return [None]
 
             def read(self, partition):
                 return read_func(self.schema, partition)

--- a/python/pyspark/sql/worker/plan_data_source_read.py
+++ b/python/pyspark/sql/worker/plan_data_source_read.py
@@ -18,7 +18,6 @@
 import functools
 import pyarrow as pa
 from itertools import islice, chain
-from types import NoneType
 from typing import IO, List, Iterator, Iterable, Tuple, Union
 
 from pyspark.errors import PySparkAssertionError, PySparkRuntimeError
@@ -250,7 +249,7 @@ def write_read_func_and_partitions(
                     "actual": f"'{type(partitions).__name__}'",
                 },
             )
-        if not all(isinstance(p, (InputPartition, NoneType)) for p in partitions):
+        if not all(isinstance(p, InputPartition) for p in partitions):
             partition_types = ", ".join([f"'{type(p).__name__}'" for p in partitions])
             raise PySparkRuntimeError(
                 errorClass="DATA_SOURCE_TYPE_MISMATCH",
@@ -260,7 +259,7 @@ def write_read_func_and_partitions(
                 },
             )
         if len(partitions) == 0:
-            partitions = [None]
+            partitions = [InputPartition(None)]
 
         # Return the serialized partition values.
         write_int(len(partitions), outfile)

--- a/python/pyspark/sql/worker/plan_data_source_read.py
+++ b/python/pyspark/sql/worker/plan_data_source_read.py
@@ -18,6 +18,7 @@
 import functools
 import pyarrow as pa
 from itertools import islice, chain
+from types import NoneType
 from typing import IO, List, Iterator, Iterable, Tuple, Union
 
 from pyspark.errors import PySparkAssertionError, PySparkRuntimeError
@@ -215,7 +216,7 @@ def write_read_func_and_partitions(
             f"but found '{type(partition).__name__}'."
         )
 
-        output_iter = reader.read(partition)  # type: ignore[arg-type]
+        output_iter = reader.read(partition)
 
         # Validate the output iterator.
         if not isinstance(output_iter, Iterator):
@@ -240,29 +241,26 @@ def write_read_func_and_partitions(
 
     if not is_streaming:
         # The partitioning of python batch source read is determined before query execution.
-        try:
-            partitions = reader.partitions()  # type: ignore[call-arg]
-            if not isinstance(partitions, list):
-                raise PySparkRuntimeError(
-                    errorClass="DATA_SOURCE_TYPE_MISMATCH",
-                    messageParameters={
-                        "expected": "'partitions' to return a list",
-                        "actual": f"'{type(partitions).__name__}'",
-                    },
-                )
-            if not all(isinstance(p, InputPartition) for p in partitions):
-                partition_types = ", ".join([f"'{type(p).__name__}'" for p in partitions])
-                raise PySparkRuntimeError(
-                    errorClass="DATA_SOURCE_TYPE_MISMATCH",
-                    messageParameters={
-                        "expected": "elements in 'partitions' to be of type 'InputPartition'",
-                        "actual": partition_types,
-                    },
-                )
-            if len(partitions) == 0:
-                partitions = [None]  # type: ignore[list-item]
-        except NotImplementedError:
-            partitions = [None]  # type: ignore[list-item]
+        partitions = reader.partitions()  # type: ignore[call-arg]
+        if not isinstance(partitions, list):
+            raise PySparkRuntimeError(
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
+                    "expected": "'partitions' to return a list",
+                    "actual": f"'{type(partitions).__name__}'",
+                },
+            )
+        if not all(isinstance(p, (InputPartition, NoneType)) for p in partitions):
+            partition_types = ", ".join([f"'{type(p).__name__}'" for p in partitions])
+            raise PySparkRuntimeError(
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
+                    "expected": "elements in 'partitions' to be of type 'InputPartition'",
+                    "actual": partition_types,
+                },
+            )
+        if len(partitions) == 0:
+            partitions = [None]
 
         # Return the serialized partition values.
         write_int(len(partitions), outfile)

--- a/python/pyspark/sql/worker/plan_data_source_read.py
+++ b/python/pyspark/sql/worker/plan_data_source_read.py
@@ -210,7 +210,7 @@ def write_read_func_and_partitions(
         # Deserialize the partition value.
         partition = pickleSer.loads(partition_bytes)
 
-        assert partition is None or isinstance(partition, InputPartition), (
+        assert isinstance(partition, InputPartition), (
             "Expected the partition value to be of type 'InputPartition', "
             f"but found '{type(partition).__name__}'."
         )

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
@@ -533,7 +533,7 @@ class PythonDataSourceSuite extends PythonDataSourceSuiteBase {
          |        return []
          |
          |    def read(self, partition):
-         |        if partition is None:
+         |        if partition.value is None:
          |            yield ("success", )
          |        else:
          |            yield ("failed", )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Clarify and unify the types of datasource partition/read function.
* Correct type annotation 
* Change the default behavior of `partition` to make it match the documentation.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Our current type hint for `partition` and `read` is wrong. We do accept `None` as a partition in our code but we did not mention it. This will confuse users as this is documented and user facing.

We also says the default behavior for `partition` is to return a list with `None` - but we didn't do that. Instead, we used a very convoluted approach - raise an exception, catch that in the worker and convert that to `[None]`. That's super unnecessary.

This change should not affect users if they already overwrite their `partition` and `read` method. (unless they overwrite with a function that raises `NotImplementedError`).

Overall this gives us a more consistent interface with correct typing.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Basically no. Unless user does something crazy.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

CI

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.