### PR TITLE
[SPARK-55620][PYTHON][CONNECT] Fix deadlock in test_connect_session d…

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1271,6 +1271,15 @@ class SparkConnectClient(object):
         """
         Close the channel.
         """
+        # Calling channel.close() during Python shutdown can cause a deadlock.
+        # gRPC internally attempts to spawn a new thread, but thread creation
+        # is strictly blocked during interpreter shutdown in Python 3.12+.
+        if self._closed:
+            return
+        if sys.is_finalizing():
+            self._closed = True
+            return
+
         concurrent.futures.wait(self._release_futures, timeout=10)
         ExecutePlanResponseReattachableIterator.shutdown_threadpool_if_idle()
         self._channel.close()

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -48,6 +48,7 @@ import pandas as pd
 import pyarrow as pa
 from pandas.api.types import is_datetime64_dtype, is_timedelta64_dtype
 import urllib
+import sys
 
 from pyspark.sql.connect.dataframe import DataFrame
 from pyspark.sql.dataframe import DataFrame as ParentDataFrame
@@ -872,6 +873,11 @@ class SparkSession:
 
     def __del__(self) -> None:
         try:
+            # Skip cleanup if Python is shutting down.
+            # This prevents a deadlock when closing the gRPC channel.
+            if sys.is_finalizing():
+                return
+
             # StreamingQueryManager has client states that needs to be cleaned up
             if hasattr(self, "_sqm"):
                 self._sqm.close()


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes a deadlock issue during Python 3.12+ shutdown in `test_connect_session`.
It safely skips `self._channel.close()` inside `client.close()` and `__del__()` if the Python interpreter is shutting down (`sys.is_finalizing()`).

### Why are the changes needed?
To prevent flaky CI timeouts (e.g., hanging for 450s). 
The deadlock occurs when `self._channel.close()` is called during `__del__`. gRPC attempts to spawn a new background thread to clean up ongoing RPCs, but Python 3.12+ strictly blocks new thread creation during interpreter shutdown, causing an infinite hang. 
By checking `sys.is_finalizing()`, we can safely skip the gRPC channel closure. The OS will reclaim the network sockets and memory resources upon process exit anyway.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- Tested locally by running `python/run-tests.py --testnames pyspark.sql.tests.connect.test_connect_session` multiple times without any hangs.
- Relying on GitHub Actions CI to verify the flaky test stability.

### Was this patch authored or co-authored using generative AI tooling?
Yes.