### PR TITLE
[SPARK-55769][UI] Replace browser alert() with Bootstrap 5 Toast notifications

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-/* global $, Mustache, uiRoot */
+/* global $, Mustache, uiRoot, showToast */
 
 import {
   ConvertDurationString, createRESTEndPointForExecutorsPage, createTemplateURI, errorMessageCell,
@@ -826,8 +826,8 @@ $(document).ready(function () {
             },
             "dataSrc": (jsons) => jsons.aaData,
             "error": function (_ignored_jqXHR, _ignored_textStatus, _ignored_errorThrown) {
-              alert("Unable to connect to the server. Looks like the Spark " +
-                "application must have ended. Please Switch to the history UI.");
+              showToast("Unable to connect to the server. Looks like the Spark " +
+                "application must have ended. Please switch to the history UI.", "warning");
               $("#active-tasks-table_processing").css("display","none");
             }
           },

--- a/core/src/main/resources/org/apache/spark/ui/static/webui.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.js
@@ -29,6 +29,39 @@ function setAppBasePath(path) {
 }
 /* eslint-enable no-unused-vars */
 
+/* eslint-disable no-unused-vars */
+/**
+ * Show a Bootstrap 5 Toast notification (non-blocking replacement for alert()).
+ * @param {string} message - The message to display
+ * @param {string} [type="danger"] - Bootstrap color: "danger", "warning", "success", "info"
+ */
+function showToast(message, type) {
+  type = type || "danger";
+  var container = document.getElementById("spark-toast-container");
+  if (!container) {
+    container = document.createElement("div");
+    container.id = "spark-toast-container";
+    container.className = "toast-container position-fixed top-0 end-0 p-3";
+    container.style.zIndex = "1090";
+    document.body.appendChild(container);
+  }
+  var toastEl = document.createElement("div");
+  toastEl.className = "toast align-items-center text-bg-" + type + " border-0";
+  toastEl.setAttribute("role", "alert");
+  toastEl.innerHTML =
+    '<div class="d-flex">' +
+    '<div class="toast-body">' + message + '</div>' +
+    '<button type="button" class="btn-close btn-close-white me-2 m-auto" ' +
+    'data-bs-dismiss="toast"></button></div>';
+  container.appendChild(toastEl);
+  var toast = new bootstrap.Toast(toastEl, { autohide: false });
+  toast.show();
+  toastEl.addEventListener("hidden.bs.toast", function () {
+    toastEl.remove();
+  });
+}
+/* eslint-enable no-unused-vars */
+
 // Persist BS5 collapse state in localStorage
 $(function() {
   $(document).on("shown.bs.collapse hidden.bs.collapse", ".collapsible-table", function(e) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replaces the blocking browser `alert()` call with a Bootstrap 5 Toast notification.

**Changes (2 files):**
- **webui.js**: Added reusable `showToast(message, type)` function that creates a BS5 Toast in a fixed top-right container. Supports `danger`/`warning`/`success`/`info` types. Toasts auto-remove from DOM after dismissal.
- **stagepage.js**: Replaced server connection error `alert()` with `showToast(..., "warning")` — non-blocking, dismissible, styled.

### Why are the changes needed?

Browser `alert()` is blocking — it freezes the entire page until dismissed. BS5 Toasts are non-blocking, styled consistently with the rest of the UI, and dismissible. Part of SPARK-55760 (Spark Web UI Modernization).

### Does this PR introduce _any_ user-facing change?

Yes — server connection errors on the stage page now show as a top-right Toast notification instead of a browser alert dialog.

### How was this patch tested?

`lint-js` passes.

### Was this patch authored or co-authored using generative AI tooling?

Yes, co-authored with GitHub Copilot.