### PR TITLE
[SPARK-55855][SQL][DML] DSv2 Transaction API foundations

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TransactionalCatalogPlugin.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TransactionalCatalogPlugin.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.catalog;
+
+import org.apache.spark.sql.connector.catalog.transactions.Transaction;
+import org.apache.spark.sql.connector.catalog.transactions.TransactionInfo;
+
+/**
+ * A {@link CatalogPlugin} that supports transactions.
+ * <p>
+ * Catalogs that implement this interface opt in to transactional query execution. A catalog
+ * implementing this interface is responsible for starting transactions.
+ *
+ * @since 4.2.0
+ */
+public interface TransactionalCatalogPlugin extends CatalogPlugin {
+
+  /**
+   * Begins a new transaction and returns a {@link Transaction} representing it.
+   *
+   * @param info metadata about the transaction being started.
+   */
+  Transaction beginTransaction(TransactionInfo info);
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/transactions/Transaction.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/transactions/Transaction.java
@@ -47,9 +47,8 @@ public interface Transaction extends Closeable {
    * The connector is responsible for detecting and resolving conflicting commits or throwing
    * an exception if resolution is not possible.
    * <p>
-   * This method must be called exactly once. Spark calls {@link #close()} immediately after
-   * this method returns, so implementations should not release resources inside
-   * {@code commit()} itself.
+   * This method will be called exactly once per transaction. Spark calls {@link #close()}
+   * immediately after this method returns.
    */
   void commit();
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/transactions/Transaction.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/transactions/Transaction.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.catalog.transactions;
+
+import org.apache.spark.sql.connector.catalog.CatalogPlugin;
+import org.apache.spark.sql.connector.catalog.TransactionalCatalogPlugin;
+
+import java.io.Closeable;
+
+/**
+ * Represents a transaction.
+ * <p>
+ * Spark begins a transaction with {@link TransactionalCatalogPlugin#beginTransaction} and
+ * executes read/write operations against the transaction's catalog. On success, Spark
+ * calls {@link #commit()}; on failure, Spark calls {@link #abort()}. In both cases Spark
+ * subsequently calls {@link #close()} to release resources.
+ *
+ * @since 4.2.0
+ */
+public interface Transaction extends Closeable {
+
+  /**
+   * Returns the catalog associated with this transaction. This catalog is responsible for tracking
+   * read/write operations that occur within the boundaries of a transaction. This allows
+   * connectors to perform conflict resolution at commit time.
+   */
+  CatalogPlugin catalog();
+
+  /**
+   * Commits the transaction. All writes performed under it become visible to other readers.
+   * <p>
+   * The connector is responsible for detecting and resolving conflicting commits or throwing
+   * an exception if resolution is not possible.
+   * <p>
+   * This method must be called exactly once. Spark calls {@link #close()} immediately after
+   * this method returns, so implementations should not release resources inside
+   * {@code commit()} itself.
+   */
+  void commit();
+
+  /**
+   * Aborts the transaction, discarding any staged changes.
+   * <p>
+   * This method must be idempotent. If the transaction has already been committed or aborted,
+   * invoking it must have no effect.
+   * <p>
+   * Spark calls {@link #close()} immediately after this method returns.
+   */
+  void abort();
+
+  /**
+   * Releases any resources held by this transaction.
+   * <p>
+   * Spark always calls this method after {@link #commit()} or {@link #abort()}, regardless of
+   * whether those methods succeed or not.
+   * <p>
+   * This method must be idempotent. If the transaction has already been closed,
+   * invoking it must have no effect.
+   */
+  @Override
+  void close();
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/transactions/Transaction.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/transactions/Transaction.java
@@ -49,6 +49,8 @@ public interface Transaction extends Closeable {
    * <p>
    * This method will be called exactly once per transaction. Spark calls {@link #close()}
    * immediately after this method returns.
+   *
+   * @throws IllegalStateException if the transaction has already been committed or aborted.
    */
   void commit();
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/transactions/TransactionInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/transactions/TransactionInfo.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.catalog.transactions;
+
+/**
+ * Metadata about a transaction.
+ *
+ * @since 4.2.0
+ */
+public interface TransactionInfo {
+
+  /**
+   * Returns a unique identifier for this transaction.
+   */
+  String id();
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/transactions/TransactionUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/transactions/TransactionUtils.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.transactions
+
+import java.util.UUID
+
+import org.apache.spark.sql.connector.catalog.TransactionalCatalogPlugin
+import org.apache.spark.sql.connector.catalog.transactions.{Transaction, TransactionInfoImpl}
+import org.apache.spark.util.Utils
+
+object TransactionUtils {
+  def commit(transaction: Transaction): Unit = {
+    Utils.tryWithSafeFinally {
+      transaction.commit()
+    } {
+      transaction.close()
+    }
+  }
+
+  def abort(transaction: Transaction): Unit = {
+    Utils.tryWithSafeFinally {
+      transaction.abort()
+    } {
+      transaction.close()
+    }
+  }
+
+  def beginTransaction(catalog: TransactionalCatalogPlugin): Transaction = {
+    val info = TransactionInfoImpl(id = UUID.randomUUID.toString)
+    val transaction = catalog.beginTransaction(info)
+    if (transaction.catalog.name != catalog.name) {
+      abort(transaction)
+      throw new IllegalStateException(
+        s"""Transaction catalog name (${transaction.catalog.name})
+           |must match original catalog name (${catalog.name}).
+           |""".stripMargin)
+    }
+    transaction
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/transactions/TransactionInfoImpl.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/transactions/TransactionInfoImpl.scala
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.catalog.transactions
+
+case class TransactionInfoImpl(id: String) extends TransactionInfo

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/transactions/TransactionUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/transactions/TransactionUtilsSuite.scala
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.transactions
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, TransactionalCatalogPlugin}
+import org.apache.spark.sql.connector.catalog.transactions.{Transaction, TransactionInfo}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+class TransactionUtilsSuite extends SparkFunSuite {
+  val testCatalogName = "test_catalog"
+
+  // --- Helpers ---------------------------------------------------------------
+  private def mockCatalog(catalogName: String): CatalogPlugin = new CatalogPlugin {
+    override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = ()
+    override def name(): String = catalogName
+  }
+
+  private val emptyFunction = () => ()
+  private class TestTransaction(
+      catalogName: String,
+      onCommit: () => Unit = emptyFunction,
+      onAbort: () => Unit = emptyFunction,
+      onClose: () => Unit = emptyFunction) extends Transaction {
+    var committed = false
+    var aborted = false
+    var closed = false
+
+    override def catalog(): CatalogPlugin = mockCatalog(catalogName)
+    override def commit(): Unit = { committed = true; onCommit() }
+    override def abort(): Unit = { aborted = true; onAbort() }
+    override def close(): Unit = { closed = true; onClose() }
+  }
+
+  private def mockTransactionalCatalog(
+      catalogName: String,
+      txnCatalogName: String = null): TransactionalCatalogPlugin = {
+    val resolvedTxnCatalogName = Option(txnCatalogName).getOrElse(catalogName)
+    new TransactionalCatalogPlugin {
+      override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = ()
+      override def name(): String = catalogName
+      override def beginTransaction(info: TransactionInfo): Transaction =
+        new TestTransaction(resolvedTxnCatalogName)
+    }
+  }
+
+  // --- Commit ----------------------------------------------------------------
+  test("commit: calls commit then close") {
+    val txn = new TestTransaction(testCatalogName)
+    TransactionUtils.commit(txn)
+    assert(txn.committed)
+    assert(txn.closed)
+  }
+
+  test("commit: close is called even if commit fails") {
+    val txn = new TestTransaction(
+      testCatalogName, onCommit = () => throw new RuntimeException("commit failed"))
+    intercept[RuntimeException] { TransactionUtils.commit(txn) }
+    assert(txn.closed)
+  }
+
+  // --- Abort -----------------------------------------------------------------
+  test("abort: calls abort then close") {
+    val txn = new TestTransaction(testCatalogName)
+    TransactionUtils.abort(txn)
+    assert(txn.aborted)
+    assert(txn.closed)
+  }
+
+  test("abort: close is called even if abort fails") {
+    val txn = new TestTransaction(testCatalogName,
+      onAbort = () => throw new RuntimeException("abort failed"))
+    intercept[RuntimeException] { TransactionUtils.abort(txn) }
+    assert(txn.closed)
+  }
+
+  // --- Begin Transaction -----------------------------------------------------
+  test("beginTransaction: returns transaction when catalog names match") {
+    val catalog = mockTransactionalCatalog(testCatalogName)
+    val txn = TransactionUtils.beginTransaction(catalog)
+    assert(txn.catalog().name() == testCatalogName)
+  }
+
+  test("beginTransaction: fails when transaction catalog name does not match") {
+    val catalog = mockTransactionalCatalog(catalogName = testCatalogName, txnCatalogName = "other")
+    val e = intercept[IllegalStateException] {
+      TransactionUtils.beginTransaction(catalog)
+    }
+    assert(e.getMessage.contains("other"))
+    assert(e.getMessage.contains(testCatalogName))
+  }
+
+  test("beginTransaction: aborts and closes transaction on catalog name mismatch") {
+    var aborted = false
+    var closed = false
+    val catalog = new TransactionalCatalogPlugin {
+      override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = ()
+      override def name(): String = testCatalogName
+      override def beginTransaction(info: TransactionInfo): Transaction =
+        new TestTransaction(
+          "other",
+          onAbort = () => { aborted = true },
+          onClose = () => { closed = true })
+    }
+    intercept[IllegalStateException] { TransactionUtils.beginTransaction(catalog) }
+    assert(aborted)
+    assert(closed)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently, DSv2 is lacking the required abstractions for allowing transactionality in DML operations. This PR introduces the public Java interfaces that connectors need to implement. In particular, these are the following:

  - `TransactionInfo` — carries the transaction metadata.
  - `Transaction` — represents a transaction. Exposes `catalog`(), `commit`(), `abort`(), and `close`().
  - `TransactionalCatalogPlugin` — extends `CatalogPlugin` with `beginTransaction(TransactionInfo)` method.

This is the first in a series of PRs adding transaction support to DSv2. This PR is based on @aokolnychyi's prototype.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We are currently lacking the required abstractions for DSv2 connectors to implement transactions in write operations.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added a new suite to test `TransactionUtils`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Claude Sonnet 4.6.