### PR TITLE
[SPARK-55856][INFRA] Add `.claude` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .bloop
 .bsp/
 .cache
+.claude/
 .classpath
 .ensime
 .ensime_cache/


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to ignore `.claude` directory by adding it to `.gitignore`.

### Why are the changes needed?

`Anthropic` has a promotion for open source projects. I hope we can help the developers.

- https://claude.com/contact-sales/claude-for-oss

> Open-source maintainers and contributors keep the ecosystem running. The Claude for Open Source Program is our way of saying thank you for all your hard work, with 6 months of free Claude Max 20x.
> - Maintainers: You’re a primary maintainer or core team member of a public repo with 5,000+ GitHub stars or 1M+ monthly NPM downloads. You've made‍ commits, releases, or PR reviews within the last 3 months.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Opus 4.6 on Claude Code`.