### PR TITLE
[SPARK-55859][PYTHON][TESTS][4.0] Fix udf tests with double

### DIFF
--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -210,7 +210,9 @@ class BaseUDFTestsMixin(object):
         self.spark.catalog.registerFunction("double_int", lambda x: x * 2, IntegerType())
         [row] = self.spark.sql("SELECT double_int(1), double_int(2)").collect()
         self.assertEqual(tuple(row), (2, 4))
-        [row] = self.spark.sql("SELECT double_int(double_int(1)), double_int(double_int(2) + 2)").collect()
+        [row] = self.spark.sql(
+            "SELECT double_int(double_int(1)), double_int(double_int(2) + 2)"
+        ).collect()
         self.assertEqual(tuple(row), (4, 12))
         self.spark.catalog.registerFunction("add", lambda x, y: x + y, IntegerType())
         [row] = self.spark.sql("SELECT double_int(add(1, 2)), add(double_int(2), 1)").collect()

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -192,12 +192,12 @@ class BaseUDFTestsMixin(object):
             df.agg(sum(udf_random_col())).collect()
 
     def test_chained_udf(self):
-        self.spark.catalog.registerFunction("double", lambda x: x + x, IntegerType())
-        [row] = self.spark.sql("SELECT double(1)").collect()
+        self.spark.catalog.registerFunction("double_int", lambda x: x + x, IntegerType())
+        [row] = self.spark.sql("SELECT double_int(1)").collect()
         self.assertEqual(row[0], 2)
-        [row] = self.spark.sql("SELECT double(double(1))").collect()
+        [row] = self.spark.sql("SELECT double_int(double_int(1))").collect()
         self.assertEqual(row[0], 4)
-        [row] = self.spark.sql("SELECT double(double(1) + 1)").collect()
+        [row] = self.spark.sql("SELECT double_int(double_int(1) + 1)").collect()
         self.assertEqual(row[0], 6)
 
     def test_single_udf_with_repeated_argument(self):
@@ -207,13 +207,13 @@ class BaseUDFTestsMixin(object):
         self.assertEqual(tuple(row), (2,))
 
     def test_multiple_udfs(self):
-        self.spark.catalog.registerFunction("double", lambda x: x * 2, IntegerType())
-        [row] = self.spark.sql("SELECT double(1), double(2)").collect()
+        self.spark.catalog.registerFunction("double_int", lambda x: x * 2, IntegerType())
+        [row] = self.spark.sql("SELECT double_int(1), double_int(2)").collect()
         self.assertEqual(tuple(row), (2, 4))
-        [row] = self.spark.sql("SELECT double(double(1)), double(double(2) + 2)").collect()
+        [row] = self.spark.sql("SELECT double_int(double_int(1)), double_int(double_int(2) + 2)").collect()
         self.assertEqual(tuple(row), (4, 12))
         self.spark.catalog.registerFunction("add", lambda x, y: x + y, IntegerType())
-        [row] = self.spark.sql("SELECT double(add(1, 2)), add(double(2), 1)").collect()
+        [row] = self.spark.sql("SELECT double_int(add(1, 2)), add(double_int(2), 1)").collect()
         self.assertEqual(tuple(row), (6, 5))
 
     def test_udf_in_filter_on_top_of_outer_join(self):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Use `double_int` instead of `double` in `branch-4.0` for udf tests (the same as `master`).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

A few days ago some changes were merged into master which probably ignores `double` as an UDF name (because `double` is a builtin function or something?). I did not locate the exact commit but I did confirm that this will fix 4.0 client + master server.

`master` branch already fixes this so we should do it as well.

Failures would look like https://github.com/apache/spark/actions/runs/22734702121/job/65932842420 - double was considered as an identity function.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

I tested this locally with branch-4.0 client + master server. We should be able to see the result on our daily CI. 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.