### PR TITLE
[SPARK-55275] Add InvalidPlanInput sql states for sql/connect

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5938,7 +5938,7 @@
         ]
       }
     },
-    "sqlState" : "XXSC1"
+    "sqlState" : "42000"
   },
   "SPARK_JOB_CANCELLED" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5909,12 +5909,7 @@
       },
       "UNSUPPORTED_LITERAL_TYPE" : {
         "message" : [
-          "Unsupported Literal Type: <kindCase>"
-        ]
-      },
-      "UNSUPPORTED_LITERAL_TYPE_WITH_NUMBER" : {
-        "message" : [
-          "Unsupported Literal Type: <name>(<number>)"
+          "Unsupported Literal Type: <typeInfo>"
         ]
       },
       "UNSUPPORTED_USER_DEFINED_FUNCTION_IMPLEMENTATION" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -936,6 +936,336 @@
           "To disable plan compression, set 'spark.connect.session.planCompression.threshold' to -1."
         ]
       },
+      "AGGREGATE_NEEDS_PLAN_INPUT" : {
+        "message" : [
+          "Aggregate needs a plan input"
+        ]
+      },
+      "AGGREGATE_WITH_PIVOT_REQUIRES_PIVOT" : {
+        "message" : [
+          "Aggregate with GROUP_TYPE_PIVOT requires a Pivot"
+        ]
+      },
+      "ALIAS_WITH_MULTIPLE_IDENTIFIERS_AND_METADATA" : {
+        "message" : [
+          "Alias expressions with more than 1 identifier must not use optional metadata."
+        ]
+      },
+      "ARRAY_LITERAL_MISSING_DATA_TYPE" : {
+        "message" : [
+          "Data type information is missing in the array literal."
+        ]
+      },
+      "ARRAY_LITERAL_NOT_SET" : {
+        "message" : [
+          "Array literal is not set."
+        ]
+      },
+      "ASSERTION_FAILURE" : {
+        "message" : [
+          "<message>"
+        ]
+      },
+      "CANNOT_FIND_CACHED_LOCAL_RELATION" : {
+        "message" : [
+          "Cannot find a cached local relation for hash: <hash>"
+        ]
+      },
+      "CHUNKED_CACHED_LOCAL_RELATION_WITHOUT_DATA" : {
+        "message" : [
+          "ChunkedCachedLocalRelation should contain data."
+        ]
+      },
+      "DATAFRAME_NOT_FOUND" : {
+        "message" : [
+          "No DataFrame with id <dfId> is found in the session <sessionId>"
+        ]
+      },
+      "DATA_TYPE_UNSUPPORTED_CATALYST_TO_PROTO" : {
+        "message" : [
+          "Does not support convert <typeName> to connect proto types."
+        ]
+      },
+      "DATA_TYPE_UNSUPPORTED_PROTO_TO_CATALYST" : {
+        "message" : [
+          "Does not support convert <kindCase> to catalyst types."
+        ]
+      },
+      "DEDUPLICATE_ALL_COLUMNS_AND_SUBSET" : {
+        "message" : [
+          "Cannot deduplicate on both all columns and a subset of columns"
+        ]
+      },
+      "DEDUPLICATE_NEEDS_INPUT" : {
+        "message" : [
+          "Deduplicate needs a plan input"
+        ]
+      },
+      "DEDUPLICATE_REQUIRES_COLUMNS_OR_ALL" : {
+        "message" : [
+          "Deduplicate requires to either deduplicate on all columns or a subset of columns"
+        ]
+      },
+      "EXCEPT_DOES_NOT_SUPPORT_UNION_BY_NAME" : {
+        "message" : [
+          "Except does not support union_by_name"
+        ]
+      },
+      "EXPECTED_NULL_VALUE" : {
+        "message" : [
+          "Expected null value, but got <literalTypeCase>"
+        ]
+      },
+      "EXPECTING_SCALA_UDF" : {
+        "message" : [
+          "Expecting a Scala UDF, but get <exprType>"
+        ]
+      },
+      "FIELD_CANNOT_BE_EMPTY" : {
+        "message" : [
+          "<fieldName> in <fullName> cannot be empty"
+        ]
+      },
+      "FUNCTION_EVAL_TYPE_NOT_SUPPORTED" : {
+        "message" : [
+          "Function with EvalType: <evalType> is not supported"
+        ]
+      },
+      "GROUPING_EXPRESSION_ABSENT" : {
+        "message" : [
+          "The grouping expression cannot be absent for KeyValueGroupedDataset"
+        ]
+      },
+      "INCOMPATIBLE_LITERAL_DATA_TYPE" : {
+        "message" : [
+          "Incompatible data type <dataTypeKindCase> for literal <literalTypeCase>"
+        ]
+      },
+      "INPUT_DATA_NO_SCHEMA" : {
+        "message" : [
+          "Input data for LocalRelation does not produce a schema."
+        ]
+      },
+      "INTERSECT_DOES_NOT_SUPPORT_UNION_BY_NAME" : {
+        "message" : [
+          "Intersect does not support union_by_name"
+        ]
+      },
+      "INVALID_ENUM" : {
+        "message" : [
+          "This enum value of <fullName> is invalid: <name>(<number>)"
+        ]
+      },
+      "INVALID_JDBC_PARAMS" : {
+        "message" : [
+          "Invalid jdbc params, please specify jdbc url and table."
+        ]
+      },
+      "INVALID_ONE_OF_FIELD_NOT_SET" : {
+        "message" : [
+          "This oneOf field in <fullName> is not set: <name>"
+        ]
+      },
+      "INVALID_ONE_OF_FIELD_NOT_SUPPORTED" : {
+        "message" : [
+          "This oneOf field message in <fullName> is not supported: <name>(<number>)"
+        ]
+      },
+      "INVALID_SCHEMA_NON_STRUCT_TYPE" : {
+        "message" : [
+          "The input schema <inputSchema> is not a struct type, but got <dataType>."
+        ]
+      },
+      "INVALID_SQL_WITH_REFERENCES" : {
+        "message" : [
+          "<query> is not a valid relation for SQL with references"
+        ]
+      },
+      "INVALID_WITH_RELATION_REFERENCE" : {
+        "message" : [
+          "Invalid WithRelation reference"
+        ]
+      },
+      "LAMBDA_FUNCTION_ARGUMENT_COUNT_INVALID" : {
+        "message" : [
+          "LambdaFunction requires 1 ~ 3 arguments, but got <got> ones!"
+        ]
+      },
+      "LOCAL_RELATION_CHUNK_SIZE_LIMIT_EXCEEDED" : {
+        "message" : [
+          "One of cached local relation chunks exceeded the limit of <limit> bytes."
+        ]
+      },
+      "LOCAL_RELATION_SIZE_LIMIT_EXCEEDED" : {
+        "message" : [
+          "Cached local relation size (<actualSize> bytes) exceeds the limit (<limit> bytes)."
+        ]
+      },
+      "LOWER_BOUND_REQUIRED_IN_WINDOW_FRAME" : {
+        "message" : [
+          "LowerBound is required in WindowFrame"
+        ]
+      },
+      "MAP_LITERAL_MISSING_DATA_TYPE" : {
+        "message" : [
+          "Data type information is missing in the map literal."
+        ]
+      },
+      "MAP_LITERAL_NOT_SET" : {
+        "message" : [
+          "Map literal is not set."
+        ]
+      },
+      "MULTIPLE_PATHS_NOT_SUPPORTED_FOR_STREAMING_SOURCE" : {
+        "message" : [
+          "Multiple paths are not supported for streaming source"
+        ]
+      },
+      "NA_FILL_VALUES_EMPTY" : {
+        "message" : [
+          "values must contains at least 1 item!"
+        ]
+      },
+      "NA_FILL_VALUES_LENGTH_MISMATCH" : {
+        "message" : [
+          "When values contains more than 1 items, values and cols should have the same length!"
+        ]
+      },
+      "NOT_FOUND_CACHED_LOCAL_RELATION" : {
+        "message" : [
+          "Not found any cached local relation with the hash: <hash> in the session with sessionUUID <sessionUUID>."
+        ]
+      },
+      "NOT_FOUND_CHUNKED_CACHED_LOCAL_RELATION" : {
+        "message" : [
+          "Not found chunked cached local relation block with the hash: <hash> in the session with sessionUUID <sessionUUID>."
+        ]
+      },
+      "NO_HANDLER_FOR_EXTENSION" : {
+        "message" : [
+          "No handler found for extension type: <extensionTypeUrl>"
+        ]
+      },
+      "PREDICATES_NOT_SUPPORTED_FOR_DATA_SOURCE" : {
+        "message" : [
+          "Predicates are not supported for <format> data sources."
+        ]
+      },
+      "PYTHON_UDT_MISSING_FIELDS" : {
+        "message" : [
+          "PythonUserDefinedType requires all the three fields: python_class, serialized_python_class and sql_type."
+        ]
+      },
+      "REDUCE_SHOULD_CARRY_SCALAR_SCALA_UDF" : {
+        "message" : [
+          "reduce should carry a scalar scala udf, but got <got>"
+        ]
+      },
+      "ROW_NOT_SUPPORTED_FOR_UDF" : {
+        "message" : [
+          "Row is not a supported <errorType> type for this UDF."
+        ]
+      },
+      "SCHEMA_REQUIRED_FOR_LOCAL_RELATION" : {
+        "message" : [
+          "Schema for LocalRelation is required when the input data is not provided."
+        ]
+      },
+      "SET_OPERATION_MUST_HAVE_TWO_INPUTS" : {
+        "message" : [
+          "Set operation must have 2 inputs"
+        ]
+      },
+      "SQL_COMMAND_EXPECTS_SQL_OR_WITH_RELATIONS" : {
+        "message" : [
+          "SQL command expects either a SQL or a WithRelations, but got <other>"
+        ]
+      },
+      "STREAMING_QUERY_NOT_FOUND" : {
+        "message" : [
+          "Streaming query <id> is not found"
+        ]
+      },
+      "STREAMING_QUERY_RUN_ID_MISMATCH" : {
+        "message" : [
+          "Run id mismatch for query id <id>. Run id in the request <runId> does not match one on the server <serverRunId>. The query might have restarted."
+        ]
+      },
+      "STRUCT_LITERAL_MISSING_DATA_TYPE" : {
+        "message" : [
+          "Data type information is missing in the struct literal."
+        ]
+      },
+      "STRUCT_LITERAL_NOT_SET" : {
+        "message" : [
+          "Struct literal is not set."
+        ]
+      },
+      "UDT_TYPE_FIELD_INVALID" : {
+        "message" : [
+          "UserDefinedType requires the 'type' field to be 'udt', but got '<udtType>'."
+        ]
+      },
+      "UNION_BY_NAME_ALLOW_MISSING_COL_REQUIRES_BY_NAME" : {
+        "message" : [
+          "UnionByName `allowMissingCol` can be true only if `byName` is true."
+        ]
+      },
+      "UNKNOWN_ANALYZE_METHOD" : {
+        "message" : [
+          "Unknown Analyze Method <other>!"
+        ]
+      },
+      "UNRESOLVED_COLUMN_AMONG_FIELD_NAMES" : {
+        "message" : [
+          "Cannot resolve column name \"<colName>\" among (<fieldNames>)."
+        ]
+      },
+      "UNRESOLVED_NAMED_LAMBDA_VARIABLE_REQUIRES_NAME_PART" : {
+        "message" : [
+          "UnresolvedNamedLambdaVariable requires at least one name part!"
+        ]
+      },
+      "UNRESOLVED_STAR_TARGET_INVALID" : {
+        "message" : [
+          "UnresolvedStar requires a unparsed target ending with '.*', but got <target>."
+        ]
+      },
+      "UNRESOLVED_STAR_WITH_BOTH_TARGET_AND_PLAN_ID" : {
+        "message" : [
+          "UnresolvedStar with both target and plan id is not supported."
+        ]
+      },
+      "UNSUPPORTED_LITERAL_TYPE" : {
+        "message" : [
+          "Unsupported Literal Type: <typeInfo>"
+        ]
+      },
+      "UNSUPPORTED_USER_DEFINED_FUNCTION_IMPLEMENTATION" : {
+        "message" : [
+          "Unsupported UserDefinedFunction implementation: <clazz>"
+        ]
+      },
+      "UPPER_BOUND_REQUIRED_IN_WINDOW_FRAME" : {
+        "message" : [
+          "UpperBound is required in WindowFrame"
+        ]
+      },
+      "USING_COLUMNS_OR_JOIN_CONDITION_SET_IN_JOIN" : {
+        "message" : [
+          "Using columns or join conditions cannot be set at the same time in Join"
+        ]
+      },
+      "WINDOW_FUNCTION_REQUIRED" : {
+        "message" : [
+          "WindowFunction is required in WindowExpression"
+        ]
+      },
+      "WITH_COLUMNS_REQUIRE_SINGLE_NAME_PART" : {
+        "message" : [
+          "WithColumns require column name only contains one name part, but got <got>"
+        ]
+      },
       "PLAN_SIZE_LARGER_THAN_MAX" : {
         "message" : [
           "The plan size is larger than max (<planSize> vs. <maxPlanSize>)",
@@ -5611,334 +5941,6 @@
       }
     },
     "sqlState" : "XXSC0"
-  },
-  "SPARK_CONNECT_INVALID_PLAN_INPUT" : {
-    "message" : [
-      "The Spark Connect plan input is invalid."
-    ],
-    "subClass" : {
-      "AGGREGATE_NEEDS_PLAN_INPUT" : {
-        "message" : [
-          "Aggregate needs a plan input"
-        ]
-      },
-      "AGGREGATE_WITH_PIVOT_REQUIRES_PIVOT" : {
-        "message" : [
-          "Aggregate with GROUP_TYPE_PIVOT requires a Pivot"
-        ]
-      },
-      "ALIAS_WITH_MULTIPLE_IDENTIFIERS_AND_METADATA" : {
-        "message" : [
-          "Alias expressions with more than 1 identifier must not use optional metadata."
-        ]
-      },
-      "ARRAY_LITERAL_MISSING_DATA_TYPE" : {
-        "message" : [
-          "Data type information is missing in the array literal."
-        ]
-      },
-      "ARRAY_LITERAL_NOT_SET" : {
-        "message" : [
-          "Array literal is not set."
-        ]
-      },
-      "ASSERTION_FAILURE" : {
-        "message" : [
-          "<message>"
-        ]
-      },
-      "CANNOT_FIND_CACHED_LOCAL_RELATION" : {
-        "message" : [
-          "Cannot find a cached local relation for hash: <hash>"
-        ]
-      },
-      "CHUNKED_CACHED_LOCAL_RELATION_WITHOUT_DATA" : {
-        "message" : [
-          "ChunkedCachedLocalRelation should contain data."
-        ]
-      },
-      "DATAFRAME_NOT_FOUND" : {
-        "message" : [
-          "No DataFrame with id <dfId> is found in the session <sessionId>"
-        ]
-      },
-      "DATA_TYPE_UNSUPPORTED_CATALYST_TO_PROTO" : {
-        "message" : [
-          "Does not support convert <typeName> to connect proto types."
-        ]
-      },
-      "DATA_TYPE_UNSUPPORTED_PROTO_TO_CATALYST" : {
-        "message" : [
-          "Does not support convert <kindCase> to catalyst types."
-        ]
-      },
-      "DEDUPLICATE_ALL_COLUMNS_AND_SUBSET" : {
-        "message" : [
-          "Cannot deduplicate on both all columns and a subset of columns"
-        ]
-      },
-      "DEDUPLICATE_NEEDS_INPUT" : {
-        "message" : [
-          "Deduplicate needs a plan input"
-        ]
-      },
-      "DEDUPLICATE_REQUIRES_COLUMNS_OR_ALL" : {
-        "message" : [
-          "Deduplicate requires to either deduplicate on all columns or a subset of columns"
-        ]
-      },
-      "EXCEPT_DOES_NOT_SUPPORT_UNION_BY_NAME" : {
-        "message" : [
-          "Except does not support union_by_name"
-        ]
-      },
-      "EXPECTED_NULL_VALUE" : {
-        "message" : [
-          "Expected null value, but got <literalTypeCase>"
-        ]
-      },
-      "EXPECTING_SCALA_UDF" : {
-        "message" : [
-          "Expecting a Scala UDF, but get <exprType>"
-        ]
-      },
-      "FIELD_CANNOT_BE_EMPTY" : {
-        "message" : [
-          "<fieldName> in <fullName> cannot be empty"
-        ]
-      },
-      "FUNCTION_EVAL_TYPE_NOT_SUPPORTED" : {
-        "message" : [
-          "Function with EvalType: <evalType> is not supported"
-        ]
-      },
-      "GROUPING_EXPRESSION_ABSENT" : {
-        "message" : [
-          "The grouping expression cannot be absent for KeyValueGroupedDataset"
-        ]
-      },
-      "INCOMPATIBLE_LITERAL_DATA_TYPE" : {
-        "message" : [
-          "Incompatible data type <dataTypeKindCase> for literal <literalTypeCase>"
-        ]
-      },
-      "INPUT_DATA_NO_SCHEMA" : {
-        "message" : [
-          "Input data for LocalRelation does not produce a schema."
-        ]
-      },
-      "INTERSECT_DOES_NOT_SUPPORT_UNION_BY_NAME" : {
-        "message" : [
-          "Intersect does not support union_by_name"
-        ]
-      },
-      "INVALID_ENUM" : {
-        "message" : [
-          "This enum value of <fullName> is invalid: <name>(<number>)"
-        ]
-      },
-      "INVALID_JDBC_PARAMS" : {
-        "message" : [
-          "Invalid jdbc params, please specify jdbc url and table."
-        ]
-      },
-      "INVALID_ONE_OF_FIELD_NOT_SET" : {
-        "message" : [
-          "This oneOf field in <fullName> is not set: <name>"
-        ]
-      },
-      "INVALID_ONE_OF_FIELD_NOT_SUPPORTED" : {
-        "message" : [
-          "This oneOf field message in <fullName> is not supported: <name>(<number>)"
-        ]
-      },
-      "INVALID_SQL_WITH_REFERENCES" : {
-        "message" : [
-          "<query> is not a valid relation for SQL with references"
-        ]
-      },
-      "INVALID_WITH_RELATION_REFERENCE" : {
-        "message" : [
-          "Invalid WithRelation reference"
-        ]
-      },
-      "LAMBDA_FUNCTION_ARGUMENT_COUNT_INVALID" : {
-        "message" : [
-          "LambdaFunction requires 1 ~ 3 arguments, but got <got> ones!"
-        ]
-      },
-      "LOCAL_RELATION_CHUNK_SIZE_LIMIT_EXCEEDED" : {
-        "message" : [
-          "One of cached local relation chunks exceeded the limit of <limit> bytes."
-        ]
-      },
-      "LOCAL_RELATION_SIZE_LIMIT_EXCEEDED" : {
-        "message" : [
-          "Cached local relation size (<actualSize> bytes) exceeds the limit (<limit> bytes)."
-        ]
-      },
-      "LOWER_BOUND_REQUIRED_IN_WINDOW_FRAME" : {
-        "message" : [
-          "LowerBound is required in WindowFrame"
-        ]
-      },
-      "MAP_LITERAL_MISSING_DATA_TYPE" : {
-        "message" : [
-          "Data type information is missing in the map literal."
-        ]
-      },
-      "MAP_LITERAL_NOT_SET" : {
-        "message" : [
-          "Map literal is not set."
-        ]
-      },
-      "MULTIPLE_PATHS_NOT_SUPPORTED_FOR_STREAMING_SOURCE" : {
-        "message" : [
-          "Multiple paths are not supported for streaming source"
-        ]
-      },
-      "NA_FILL_VALUES_EMPTY" : {
-        "message" : [
-          "values must contains at least 1 item!"
-        ]
-      },
-      "NA_FILL_VALUES_LENGTH_MISMATCH" : {
-        "message" : [
-          "When values contains more than 1 items, values and cols should have the same length!"
-        ]
-      },
-      "NOT_FOUND_CACHED_LOCAL_RELATION" : {
-        "message" : [
-          "Not found any cached local relation with the hash: <hash> in the session with sessionUUID <sessionUUID>."
-        ]
-      },
-      "NOT_FOUND_CHUNKED_CACHED_LOCAL_RELATION" : {
-        "message" : [
-          "Not found chunked cached local relation block with the hash: <hash> in the session with sessionUUID <sessionUUID>."
-        ]
-      },
-      "NO_HANDLER_FOR_EXTENSION" : {
-        "message" : [
-          "No handler found for extension type: <extensionTypeUrl>"
-        ]
-      },
-      "PREDICATES_NOT_SUPPORTED_FOR_DATA_SOURCE" : {
-        "message" : [
-          "Predicates are not supported for <format> data sources."
-        ]
-      },
-      "PYTHON_UDT_MISSING_FIELDS" : {
-        "message" : [
-          "PythonUserDefinedType requires all the three fields: python_class, serialized_python_class and sql_type."
-        ]
-      },
-      "REDUCE_SHOULD_CARRY_SCALAR_SCALA_UDF" : {
-        "message" : [
-          "reduce should carry a scalar scala udf, but got <got>"
-        ]
-      },
-      "ROW_NOT_SUPPORTED_FOR_UDF" : {
-        "message" : [
-          "Row is not a supported <errorType> type for this UDF."
-        ]
-      },
-      "SCHEMA_REQUIRED_FOR_LOCAL_RELATION" : {
-        "message" : [
-          "Schema for LocalRelation is required when the input data is not provided."
-        ]
-      },
-      "SET_OPERATION_MUST_HAVE_TWO_INPUTS" : {
-        "message" : [
-          "Set operation must have 2 inputs"
-        ]
-      },
-      "SQL_COMMAND_EXPECTS_SQL_OR_WITH_RELATIONS" : {
-        "message" : [
-          "SQL command expects either a SQL or a WithRelations, but got <other>"
-        ]
-      },
-      "STREAMING_QUERY_NOT_FOUND" : {
-        "message" : [
-          "Streaming query <id> is not found"
-        ]
-      },
-      "STREAMING_QUERY_RUN_ID_MISMATCH" : {
-        "message" : [
-          "Run id mismatch for query id <id>. Run id in the request <runId> does not match one on the server <serverRunId>. The query might have restarted."
-        ]
-      },
-      "STRUCT_LITERAL_MISSING_DATA_TYPE" : {
-        "message" : [
-          "Data type information is missing in the struct literal."
-        ]
-      },
-      "STRUCT_LITERAL_NOT_SET" : {
-        "message" : [
-          "Struct literal is not set."
-        ]
-      },
-      "UDT_TYPE_FIELD_INVALID" : {
-        "message" : [
-          "UserDefinedType requires the 'type' field to be 'udt', but got '<udtType>'."
-        ]
-      },
-      "UNION_BY_NAME_ALLOW_MISSING_COL_REQUIRES_BY_NAME" : {
-        "message" : [
-          "UnionByName `allowMissingCol` can be true only if `byName` is true."
-        ]
-      },
-      "UNKNOWN_ANALYZE_METHOD" : {
-        "message" : [
-          "Unknown Analyze Method <other>!"
-        ]
-      },
-      "UNRESOLVED_NAMED_LAMBDA_VARIABLE_REQUIRES_NAME_PART" : {
-        "message" : [
-          "UnresolvedNamedLambdaVariable requires at least one name part!"
-        ]
-      },
-      "UNRESOLVED_STAR_TARGET_INVALID" : {
-        "message" : [
-          "UnresolvedStar requires a unparsed target ending with '.*', but got <target>."
-        ]
-      },
-      "UNRESOLVED_STAR_WITH_BOTH_TARGET_AND_PLAN_ID" : {
-        "message" : [
-          "UnresolvedStar with both target and plan id is not supported."
-        ]
-      },
-      "UNSUPPORTED_LITERAL_TYPE" : {
-        "message" : [
-          "Unsupported Literal Type: <typeInfo>"
-        ]
-      },
-      "UNSUPPORTED_USER_DEFINED_FUNCTION_IMPLEMENTATION" : {
-        "message" : [
-          "Unsupported UserDefinedFunction implementation: <clazz>"
-        ]
-      },
-      "UPPER_BOUND_REQUIRED_IN_WINDOW_FRAME" : {
-        "message" : [
-          "UpperBound is required in WindowFrame"
-        ]
-      },
-      "USING_COLUMNS_OR_JOIN_CONDITION_SET_IN_JOIN" : {
-        "message" : [
-          "Using columns or join conditions cannot be set at the same time in Join"
-        ]
-      },
-      "WINDOW_FUNCTION_REQUIRED" : {
-        "message" : [
-          "WindowFunction is required in WindowExpression"
-        ]
-      },
-      "WITH_COLUMNS_REQUIRE_SINGLE_NAME_PART" : {
-        "message" : [
-          "WithColumns require column name only contains one name part, but got <got>"
-        ]
-      }
-    },
-    "sqlState" : "42000"
   },
   "SPARK_JOB_CANCELLED" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -929,13 +929,6 @@
       "The Spark Connect plan is invalid."
     ],
     "subClass" : {
-      "CANNOT_PARSE" : {
-        "message" : [
-          "Cannot decompress or parse the input plan (<errorMsg>)",
-          "This may be caused by a corrupted compressed plan.",
-          "To disable plan compression, set 'spark.connect.session.planCompression.threshold' to -1."
-        ]
-      },
       "AGGREGATE_NEEDS_PLAN_INPUT" : {
         "message" : [
           "Aggregate needs a plan input"
@@ -969,6 +962,13 @@
       "CANNOT_FIND_CACHED_LOCAL_RELATION" : {
         "message" : [
           "Cannot find a cached local relation for hash: <hash>"
+        ]
+      },
+      "CANNOT_PARSE" : {
+        "message" : [
+          "Cannot decompress or parse the input plan (<errorMsg>)",
+          "This may be caused by a corrupted compressed plan.",
+          "To disable plan compression, set 'spark.connect.session.planCompression.threshold' to -1."
         ]
       },
       "CHUNKED_CACHED_LOCAL_RELATION_WITHOUT_DATA" : {
@@ -1146,6 +1146,13 @@
           "No handler found for extension type: <extensionTypeUrl>"
         ]
       },
+      "PLAN_SIZE_LARGER_THAN_MAX" : {
+        "message" : [
+          "The plan size is larger than max (<planSize> vs. <maxPlanSize>)",
+          "This typically occurs when building very complex queries with many operations, large literals, or deeply nested expressions.",
+          "Consider splitting the query into smaller parts using temporary views for intermediate results or reducing the number of operations."
+        ]
+      },
       "PREDICATES_NOT_SUPPORTED_FOR_DATA_SOURCE" : {
         "message" : [
           "Predicates are not supported for <format> data sources."
@@ -1264,13 +1271,6 @@
       "WITH_COLUMNS_REQUIRE_SINGLE_NAME_PART" : {
         "message" : [
           "WithColumns require column name only contains one name part, but got <got>"
-        ]
-      },
-      "PLAN_SIZE_LARGER_THAN_MAX" : {
-        "message" : [
-          "The plan size is larger than max (<planSize> vs. <maxPlanSize>)",
-          "This typically occurs when building very complex queries with many operations, large literals, or deeply nested expressions.",
-          "Consider splitting the query into smaller parts using temporary views for intermediate results or reducing the number of operations."
         ]
       }
     },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5612,6 +5612,339 @@
     },
     "sqlState" : "XXSC0"
   },
+  "SPARK_CONNECT_INVALID_PLAN_INPUT" : {
+    "message" : [
+      "The Spark Connect plan input is invalid."
+    ],
+    "subClass" : {
+      "AGGREGATE_NEEDS_PLAN_INPUT" : {
+        "message" : [
+          "Aggregate needs a plan input"
+        ]
+      },
+      "AGGREGATE_WITH_PIVOT_REQUIRES_PIVOT" : {
+        "message" : [
+          "Aggregate with GROUP_TYPE_PIVOT requires a Pivot"
+        ]
+      },
+      "ALIAS_WITH_MULTIPLE_IDENTIFIERS_AND_METADATA" : {
+        "message" : [
+          "Alias expressions with more than 1 identifier must not use optional metadata."
+        ]
+      },
+      "ARRAY_LITERAL_MISSING_DATA_TYPE" : {
+        "message" : [
+          "Data type information is missing in the array literal."
+        ]
+      },
+      "ARRAY_LITERAL_NOT_SET" : {
+        "message" : [
+          "Array literal is not set."
+        ]
+      },
+      "ASSERTION_FAILURE" : {
+        "message" : [
+          "<message>"
+        ]
+      },
+      "CANNOT_FIND_CACHED_LOCAL_RELATION" : {
+        "message" : [
+          "Cannot find a cached local relation for hash: <hash>"
+        ]
+      },
+      "CHUNKED_CACHED_LOCAL_RELATION_WITHOUT_DATA" : {
+        "message" : [
+          "ChunkedCachedLocalRelation should contain data."
+        ]
+      },
+      "DATAFRAME_NOT_FOUND" : {
+        "message" : [
+          "No DataFrame with id <dfId> is found in the session <sessionId>"
+        ]
+      },
+      "DATA_TYPE_UNSUPPORTED_CATALYST_TO_PROTO" : {
+        "message" : [
+          "Does not support convert <typeName> to connect proto types."
+        ]
+      },
+      "DATA_TYPE_UNSUPPORTED_PROTO_TO_CATALYST" : {
+        "message" : [
+          "Does not support convert <kindCase> to catalyst types."
+        ]
+      },
+      "DEDUPLICATE_ALL_COLUMNS_AND_SUBSET" : {
+        "message" : [
+          "Cannot deduplicate on both all columns and a subset of columns"
+        ]
+      },
+      "DEDUPLICATE_NEEDS_INPUT" : {
+        "message" : [
+          "Deduplicate needs a plan input"
+        ]
+      },
+      "DEDUPLICATE_REQUIRES_COLUMNS_OR_ALL" : {
+        "message" : [
+          "Deduplicate requires to either deduplicate on all columns or a subset of columns"
+        ]
+      },
+      "EXCEPT_DOES_NOT_SUPPORT_UNION_BY_NAME" : {
+        "message" : [
+          "Except does not support union_by_name"
+        ]
+      },
+      "EXPECTED_NULL_VALUE" : {
+        "message" : [
+          "Expected null value, but got <literalTypeCase>"
+        ]
+      },
+      "EXPECTING_SCALA_UDF" : {
+        "message" : [
+          "Expecting a Scala UDF, but get <exprType>"
+        ]
+      },
+      "FIELD_CANNOT_BE_EMPTY" : {
+        "message" : [
+          "<fieldName> in <fullName> cannot be empty"
+        ]
+      },
+      "FUNCTION_EVAL_TYPE_NOT_SUPPORTED" : {
+        "message" : [
+          "Function with EvalType: <evalType> is not supported"
+        ]
+      },
+      "GROUPING_EXPRESSION_ABSENT" : {
+        "message" : [
+          "The grouping expression cannot be absent for KeyValueGroupedDataset"
+        ]
+      },
+      "INCOMPATIBLE_LITERAL_DATA_TYPE" : {
+        "message" : [
+          "Incompatible data type <dataTypeKindCase> for literal <literalTypeCase>"
+        ]
+      },
+      "INPUT_DATA_NO_SCHEMA" : {
+        "message" : [
+          "Input data for LocalRelation does not produce a schema."
+        ]
+      },
+      "INTERSECT_DOES_NOT_SUPPORT_UNION_BY_NAME" : {
+        "message" : [
+          "Intersect does not support union_by_name"
+        ]
+      },
+      "INVALID_ENUM" : {
+        "message" : [
+          "This enum value of <fullName> is invalid: <name>(<number>)"
+        ]
+      },
+      "INVALID_JDBC_PARAMS" : {
+        "message" : [
+          "Invalid jdbc params, please specify jdbc url and table."
+        ]
+      },
+      "INVALID_ONE_OF_FIELD_NOT_SET" : {
+        "message" : [
+          "This oneOf field in <fullName> is not set: <name>"
+        ]
+      },
+      "INVALID_ONE_OF_FIELD_NOT_SUPPORTED" : {
+        "message" : [
+          "This oneOf field message in <fullName> is not supported: <name>(<number>)"
+        ]
+      },
+      "INVALID_SQL_WITH_REFERENCES" : {
+        "message" : [
+          "<query> is not a valid relation for SQL with references"
+        ]
+      },
+      "INVALID_WITH_RELATION_REFERENCE" : {
+        "message" : [
+          "Invalid WithRelation reference"
+        ]
+      },
+      "LAMBDA_FUNCTION_ARGUMENT_COUNT_INVALID" : {
+        "message" : [
+          "LambdaFunction requires 1 ~ 3 arguments, but got <got> ones!"
+        ]
+      },
+      "LOCAL_RELATION_CHUNK_SIZE_LIMIT_EXCEEDED" : {
+        "message" : [
+          "One of cached local relation chunks exceeded the limit of <limit> bytes."
+        ]
+      },
+      "LOCAL_RELATION_SIZE_LIMIT_EXCEEDED" : {
+        "message" : [
+          "Cached local relation size (<actualSize> bytes) exceeds the limit (<limit> bytes)."
+        ]
+      },
+      "LOWER_BOUND_REQUIRED_IN_WINDOW_FRAME" : {
+        "message" : [
+          "LowerBound is required in WindowFrame"
+        ]
+      },
+      "MAP_LITERAL_MISSING_DATA_TYPE" : {
+        "message" : [
+          "Data type information is missing in the map literal."
+        ]
+      },
+      "MAP_LITERAL_NOT_SET" : {
+        "message" : [
+          "Map literal is not set."
+        ]
+      },
+      "MULTIPLE_PATHS_NOT_SUPPORTED_FOR_STREAMING_SOURCE" : {
+        "message" : [
+          "Multiple paths are not supported for streaming source"
+        ]
+      },
+      "NA_FILL_VALUES_EMPTY" : {
+        "message" : [
+          "values must contains at least 1 item!"
+        ]
+      },
+      "NA_FILL_VALUES_LENGTH_MISMATCH" : {
+        "message" : [
+          "When values contains more than 1 items, values and cols should have the same length!"
+        ]
+      },
+      "NOT_FOUND_CACHED_LOCAL_RELATION" : {
+        "message" : [
+          "Not found any cached local relation with the hash: <hash> in the session with sessionUUID <sessionUUID>."
+        ]
+      },
+      "NOT_FOUND_CHUNKED_CACHED_LOCAL_RELATION" : {
+        "message" : [
+          "Not found chunked cached local relation block with the hash: <hash> in the session with sessionUUID <sessionUUID>."
+        ]
+      },
+      "NO_HANDLER_FOR_EXTENSION" : {
+        "message" : [
+          "No handler found for extension type: <extensionTypeUrl>"
+        ]
+      },
+      "PREDICATES_NOT_SUPPORTED_FOR_DATA_SOURCE" : {
+        "message" : [
+          "Predicates are not supported for <format> data sources."
+        ]
+      },
+      "PYTHON_UDT_MISSING_FIELDS" : {
+        "message" : [
+          "PythonUserDefinedType requires all the three fields: python_class, serialized_python_class and sql_type."
+        ]
+      },
+      "REDUCE_SHOULD_CARRY_SCALAR_SCALA_UDF" : {
+        "message" : [
+          "reduce should carry a scalar scala udf, but got <got>"
+        ]
+      },
+      "ROW_NOT_SUPPORTED_FOR_UDF" : {
+        "message" : [
+          "Row is not a supported <errorType> type for this UDF."
+        ]
+      },
+      "SCHEMA_REQUIRED_FOR_LOCAL_RELATION" : {
+        "message" : [
+          "Schema for LocalRelation is required when the input data is not provided."
+        ]
+      },
+      "SET_OPERATION_MUST_HAVE_TWO_INPUTS" : {
+        "message" : [
+          "Set operation must have 2 inputs"
+        ]
+      },
+      "SQL_COMMAND_EXPECTS_SQL_OR_WITH_RELATIONS" : {
+        "message" : [
+          "SQL command expects either a SQL or a WithRelations, but got <other>"
+        ]
+      },
+      "STREAMING_QUERY_NOT_FOUND" : {
+        "message" : [
+          "Streaming query <id> is not found"
+        ]
+      },
+      "STREAMING_QUERY_RUN_ID_MISMATCH" : {
+        "message" : [
+          "Run id mismatch for query id <id>. Run id in the request <runId> does not match one on the server <serverRunId>. The query might have restarted."
+        ]
+      },
+      "STRUCT_LITERAL_MISSING_DATA_TYPE" : {
+        "message" : [
+          "Data type information is missing in the struct literal."
+        ]
+      },
+      "STRUCT_LITERAL_NOT_SET" : {
+        "message" : [
+          "Struct literal is not set."
+        ]
+      },
+      "UDT_TYPE_FIELD_INVALID" : {
+        "message" : [
+          "UserDefinedType requires the 'type' field to be 'udt', but got '<udtType>'."
+        ]
+      },
+      "UNION_BY_NAME_ALLOW_MISSING_COL_REQUIRES_BY_NAME" : {
+        "message" : [
+          "UnionByName `allowMissingCol` can be true only if `byName` is true."
+        ]
+      },
+      "UNKNOWN_ANALYZE_METHOD" : {
+        "message" : [
+          "Unknown Analyze Method <other>!"
+        ]
+      },
+      "UNRESOLVED_NAMED_LAMBDA_VARIABLE_REQUIRES_NAME_PART" : {
+        "message" : [
+          "UnresolvedNamedLambdaVariable requires at least one name part!"
+        ]
+      },
+      "UNRESOLVED_STAR_TARGET_INVALID" : {
+        "message" : [
+          "UnresolvedStar requires a unparsed target ending with '.*', but got <target>."
+        ]
+      },
+      "UNRESOLVED_STAR_WITH_BOTH_TARGET_AND_PLAN_ID" : {
+        "message" : [
+          "UnresolvedStar with both target and plan id is not supported."
+        ]
+      },
+      "UNSUPPORTED_LITERAL_TYPE" : {
+        "message" : [
+          "Unsupported Literal Type: <kindCase>"
+        ]
+      },
+      "UNSUPPORTED_LITERAL_TYPE_WITH_NUMBER" : {
+        "message" : [
+          "Unsupported Literal Type: <name>(<number>)"
+        ]
+      },
+      "UNSUPPORTED_USER_DEFINED_FUNCTION_IMPLEMENTATION" : {
+        "message" : [
+          "Unsupported UserDefinedFunction implementation: <clazz>"
+        ]
+      },
+      "UPPER_BOUND_REQUIRED_IN_WINDOW_FRAME" : {
+        "message" : [
+          "UpperBound is required in WindowFrame"
+        ]
+      },
+      "USING_COLUMNS_OR_JOIN_CONDITION_SET_IN_JOIN" : {
+        "message" : [
+          "Using columns or join conditions cannot be set at the same time in Join"
+        ]
+      },
+      "WINDOW_FUNCTION_REQUIRED" : {
+        "message" : [
+          "WindowFunction is required in WindowExpression"
+        ]
+      },
+      "WITH_COLUMNS_REQUIRE_SINGLE_NAME_PART" : {
+        "message" : [
+          "WithColumns require column name only contains one name part, but got <got>"
+        ]
+      }
+    },
+    "sqlState" : "XXSC1"
+  },
   "SPARK_JOB_CANCELLED" : {
     "message" : [
       "Job <jobId> cancelled <reason>"

--- a/common/utils/src/main/resources/error/error-states.json
+++ b/common/utils/src/main/resources/error/error-states.json
@@ -7536,12 +7536,6 @@
         "standard": "N",
         "usedBy": ["Spark"]
     },
-    "XXSC1": {
-        "description": "Connect Server - Invalid Plan Input",
-        "origin": "Spark",
-        "standard": "N",
-        "usedBy": ["Spark"]
-    },
     "XXKD0": {
         "description": "Analysis - Bad plan",
         "origin": "Databricks",

--- a/common/utils/src/main/resources/error/error-states.json
+++ b/common/utils/src/main/resources/error/error-states.json
@@ -7536,6 +7536,12 @@
         "standard": "N",
         "usedBy": ["Spark"]
     },
+    "XXSC1": {
+        "description": "Connect Server - Invalid Plan Input",
+        "origin": "Spark",
+        "standard": "N",
+        "usedBy": ["Spark"]
+    },
     "XXKD0": {
         "description": "Analysis - Bad plan",
         "origin": "Databricks",

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/DataTypeProtoConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/DataTypeProtoConverter.scala
@@ -160,9 +160,7 @@ object DataTypeProtoConverter {
         .newInstance()
     } else {
       if (!t.hasPythonClass || !t.hasSerializedPythonClass || !t.hasSqlType) {
-        throw InvalidPlanInput(
-          "CONNECT_INVALID_PLAN.PYTHON_UDT_MISSING_FIELDS",
-          Map.empty)
+        throw InvalidPlanInput("CONNECT_INVALID_PLAN.PYTHON_UDT_MISSING_FIELDS", Map.empty)
       }
 
       new PythonUserDefinedType(

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/DataTypeProtoConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/DataTypeProtoConverter.scala
@@ -90,7 +90,7 @@ object DataTypeProtoConverter {
 
       case _ =>
         throw InvalidPlanInput(
-          "SPARK_CONNECT_INVALID_PLAN_INPUT.DATA_TYPE_UNSUPPORTED_PROTO_TO_CATALYST",
+          "CONNECT_INVALID_PLAN.DATA_TYPE_UNSUPPORTED_PROTO_TO_CATALYST",
           Map("kindCase" -> t.getKindCase.toString))
     }
   }
@@ -149,7 +149,7 @@ object DataTypeProtoConverter {
   private def toCatalystUDT(t: proto.DataType.UDT): UserDefinedType[_] = {
     if (t.getType != "udt") {
       throw InvalidPlanInput(
-        "SPARK_CONNECT_INVALID_PLAN_INPUT.UDT_TYPE_FIELD_INVALID",
+        "CONNECT_INVALID_PLAN.UDT_TYPE_FIELD_INVALID",
         Map("udtType" -> t.getType))
     }
 
@@ -161,7 +161,7 @@ object DataTypeProtoConverter {
     } else {
       if (!t.hasPythonClass || !t.hasSerializedPythonClass || !t.hasSqlType) {
         throw InvalidPlanInput(
-          "SPARK_CONNECT_INVALID_PLAN_INPUT.PYTHON_UDT_MISSING_FIELDS",
+          "CONNECT_INVALID_PLAN.PYTHON_UDT_MISSING_FIELDS",
           Map.empty)
       }
 
@@ -393,7 +393,7 @@ object DataTypeProtoConverter {
 
       case _ =>
         throw InvalidPlanInput(
-          "SPARK_CONNECT_INVALID_PLAN_INPUT.DATA_TYPE_UNSUPPORTED_CATALYST_TO_PROTO",
+          "CONNECT_INVALID_PLAN.DATA_TYPE_UNSUPPORTED_CATALYST_TO_PROTO",
           Map("typeName" -> t.typeName))
     }
   }

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/DataTypeProtoConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/DataTypeProtoConverter.scala
@@ -89,7 +89,9 @@ object DataTypeProtoConverter {
       case proto.DataType.KindCase.UDT => toCatalystUDT(t.getUdt)
 
       case _ =>
-        throw InvalidPlanInput(s"Does not support convert ${t.getKindCase} to catalyst types.")
+        throw InvalidPlanInput(
+          "SPARK_CONNECT_INVALID_PLAN_INPUT.DATA_TYPE_UNSUPPORTED_PROTO_TO_CATALYST",
+          Map("kindCase" -> t.getKindCase.toString))
     }
   }
 
@@ -147,7 +149,8 @@ object DataTypeProtoConverter {
   private def toCatalystUDT(t: proto.DataType.UDT): UserDefinedType[_] = {
     if (t.getType != "udt") {
       throw InvalidPlanInput(
-        s"""UserDefinedType requires the 'type' field to be 'udt', but got '${t.getType}'.""")
+        "SPARK_CONNECT_INVALID_PLAN_INPUT.UDT_TYPE_FIELD_INVALID",
+        Map("udtType" -> t.getType))
     }
 
     if (t.hasJvmClass) {
@@ -158,8 +161,8 @@ object DataTypeProtoConverter {
     } else {
       if (!t.hasPythonClass || !t.hasSerializedPythonClass || !t.hasSqlType) {
         throw InvalidPlanInput(
-          "PythonUserDefinedType requires all the three fields: " +
-            "python_class, serialized_python_class and sql_type.")
+          "SPARK_CONNECT_INVALID_PLAN_INPUT.PYTHON_UDT_MISSING_FIELDS",
+          Map.empty)
       }
 
       new PythonUserDefinedType(
@@ -389,7 +392,9 @@ object DataTypeProtoConverter {
         }
 
       case _ =>
-        throw InvalidPlanInput(s"Does not support convert ${t.typeName} to connect proto types.")
+        throw InvalidPlanInput(
+          "SPARK_CONNECT_INVALID_PLAN_INPUT.DATA_TYPE_UNSUPPORTED_CATALYST_TO_PROTO",
+          Map("typeName" -> t.typeName))
     }
   }
 }

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
@@ -387,7 +387,9 @@ object LiteralValueProtoConverter {
   private def getScalaConverter(dataType: proto.DataType): proto.Expression.Literal => Any = {
     val converter: proto.Expression.Literal => Any = dataType.getKindCase match {
       case proto.DataType.KindCase.NULL =>
-        v => throw InvalidPlanInput(s"Expected null value, but got ${v.getLiteralTypeCase}")
+        v => throw InvalidPlanInput(
+          "SPARK_CONNECT_INVALID_PLAN_INPUT.EXPECTED_NULL_VALUE",
+          Map("literalTypeCase" -> v.getLiteralTypeCase.toString))
       case proto.DataType.KindCase.SHORT => v => v.getShort.toShort
       case proto.DataType.KindCase.INTEGER => v => v.getInteger
       case proto.DataType.KindCase.LONG => v => v.getLong
@@ -421,7 +423,9 @@ object LiteralValueProtoConverter {
       case proto.DataType.KindCase.STRUCT =>
         v => toScalaStructInternal(v, dataType.getStruct)
       case _ =>
-        throw InvalidPlanInput(s"Unsupported Literal Type: ${dataType.getKindCase}")
+        throw InvalidPlanInput(
+          "SPARK_CONNECT_INVALID_PLAN_INPUT.UNSUPPORTED_LITERAL_TYPE",
+          Map("kindCase" -> dataType.getKindCase.toString))
     }
     v => if (v.hasNull) null else converter(v)
   }
@@ -558,7 +562,9 @@ object LiteralValueProtoConverter {
                   .setContainsNull(true)
                   .build())
             } else {
-              throw InvalidPlanInput("Data type information is missing in the array literal.")
+              throw InvalidPlanInput(
+                "SPARK_CONNECT_INVALID_PLAN_INPUT.ARRAY_LITERAL_MISSING_DATA_TYPE",
+                Map.empty)
             }
           case proto.Expression.Literal.LiteralTypeCase.MAP =>
             if (literal.getMap.hasKeyType && literal.getMap.hasValueType) {
@@ -570,18 +576,24 @@ object LiteralValueProtoConverter {
                   .setValueContainsNull(true)
                   .build())
             } else {
-              throw InvalidPlanInput("Data type information is missing in the map literal.")
+              throw InvalidPlanInput(
+                "SPARK_CONNECT_INVALID_PLAN_INPUT.MAP_LITERAL_MISSING_DATA_TYPE",
+                Map.empty)
             }
           case proto.Expression.Literal.LiteralTypeCase.STRUCT =>
             if (literal.getStruct.hasStructType) {
               builder.setStruct(literal.getStruct.getStructType.getStruct)
             } else {
-              throw InvalidPlanInput("Data type information is missing in the struct literal.")
+              throw InvalidPlanInput(
+                "SPARK_CONNECT_INVALID_PLAN_INPUT.STRUCT_LITERAL_MISSING_DATA_TYPE",
+                Map.empty)
             }
           case _ =>
             throw InvalidPlanInput(
-              s"Unsupported Literal Type: ${literal.getLiteralTypeCase.name}" +
-                s"(${literal.getLiteralTypeCase.getNumber})")
+              "SPARK_CONNECT_INVALID_PLAN_INPUT.UNSUPPORTED_LITERAL_TYPE_WITH_NUMBER",
+              Map(
+                "name" -> literal.getLiteralTypeCase.name,
+                "number" -> literal.getLiteralTypeCase.getNumber.toString))
         }
         builder.build()
       }
@@ -589,8 +601,10 @@ object LiteralValueProtoConverter {
 
     if (!isCompatible(literal.getLiteralTypeCase, dataType.getKindCase)) {
       throw InvalidPlanInput(
-        s"Incompatible data type ${dataType.getKindCase} " +
-          s"for literal ${literal.getLiteralTypeCase}")
+        "SPARK_CONNECT_INVALID_PLAN_INPUT.INCOMPATIBLE_LITERAL_DATA_TYPE",
+        Map(
+          "dataTypeKindCase" -> dataType.getKindCase.toString,
+          "literalTypeCase" -> literal.getLiteralTypeCase.toString))
     }
 
     dataType
@@ -600,7 +614,9 @@ object LiteralValueProtoConverter {
       literal: proto.Expression.Literal,
       arrayType: proto.DataType.Array): Array[_] = {
     if (!literal.hasArray) {
-      throw InvalidPlanInput("Array literal is not set.")
+      throw InvalidPlanInput(
+        "SPARK_CONNECT_INVALID_PLAN_INPUT.ARRAY_LITERAL_NOT_SET",
+        Map.empty)
     }
     val array = literal.getArray
     def makeArrayData[T](converter: proto.Expression.Literal => T)(implicit
@@ -620,7 +636,9 @@ object LiteralValueProtoConverter {
       literal: proto.Expression.Literal,
       mapType: proto.DataType.Map): mutable.Map[_, _] = {
     if (!literal.hasMap) {
-      throw InvalidPlanInput("Map literal is not set.")
+      throw InvalidPlanInput(
+        "SPARK_CONNECT_INVALID_PLAN_INPUT.MAP_LITERAL_NOT_SET",
+        Map.empty)
     }
     val map = literal.getMap
     def makeMapData[K, V](
@@ -646,7 +664,9 @@ object LiteralValueProtoConverter {
       literal: proto.Expression.Literal,
       structType: proto.DataType.Struct): Any = {
     if (!literal.hasStruct) {
-      throw InvalidPlanInput("Struct literal is not set.")
+      throw InvalidPlanInput(
+        "SPARK_CONNECT_INVALID_PLAN_INPUT.STRUCT_LITERAL_NOT_SET",
+        Map.empty)
     }
     val struct = literal.getStruct
     val structData = Array.tabulate(struct.getElementsCount) { i =>

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
@@ -387,9 +387,10 @@ object LiteralValueProtoConverter {
   private def getScalaConverter(dataType: proto.DataType): proto.Expression.Literal => Any = {
     val converter: proto.Expression.Literal => Any = dataType.getKindCase match {
       case proto.DataType.KindCase.NULL =>
-        v => throw InvalidPlanInput(
-          "CONNECT_INVALID_PLAN.EXPECTED_NULL_VALUE",
-          Map("literalTypeCase" -> v.getLiteralTypeCase.toString))
+        v =>
+          throw InvalidPlanInput(
+            "CONNECT_INVALID_PLAN.EXPECTED_NULL_VALUE",
+            Map("literalTypeCase" -> v.getLiteralTypeCase.toString))
       case proto.DataType.KindCase.SHORT => v => v.getShort.toShort
       case proto.DataType.KindCase.INTEGER => v => v.getInteger
       case proto.DataType.KindCase.LONG => v => v.getLong
@@ -613,9 +614,7 @@ object LiteralValueProtoConverter {
       literal: proto.Expression.Literal,
       arrayType: proto.DataType.Array): Array[_] = {
     if (!literal.hasArray) {
-      throw InvalidPlanInput(
-        "CONNECT_INVALID_PLAN.ARRAY_LITERAL_NOT_SET",
-        Map.empty)
+      throw InvalidPlanInput("CONNECT_INVALID_PLAN.ARRAY_LITERAL_NOT_SET", Map.empty)
     }
     val array = literal.getArray
     def makeArrayData[T](converter: proto.Expression.Literal => T)(implicit
@@ -635,9 +634,7 @@ object LiteralValueProtoConverter {
       literal: proto.Expression.Literal,
       mapType: proto.DataType.Map): mutable.Map[_, _] = {
     if (!literal.hasMap) {
-      throw InvalidPlanInput(
-        "CONNECT_INVALID_PLAN.MAP_LITERAL_NOT_SET",
-        Map.empty)
+      throw InvalidPlanInput("CONNECT_INVALID_PLAN.MAP_LITERAL_NOT_SET", Map.empty)
     }
     val map = literal.getMap
     def makeMapData[K, V](
@@ -663,9 +660,7 @@ object LiteralValueProtoConverter {
       literal: proto.Expression.Literal,
       structType: proto.DataType.Struct): Any = {
     if (!literal.hasStruct) {
-      throw InvalidPlanInput(
-        "CONNECT_INVALID_PLAN.STRUCT_LITERAL_NOT_SET",
-        Map.empty)
+      throw InvalidPlanInput("CONNECT_INVALID_PLAN.STRUCT_LITERAL_NOT_SET", Map.empty)
     }
     val struct = literal.getStruct
     val structData = Array.tabulate(struct.getElementsCount) { i =>

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
@@ -589,9 +589,10 @@ object LiteralValueProtoConverter {
                 Map.empty)
             }
           case _ =>
+            val literalCase = literal.getLiteralTypeCase
             throw InvalidPlanInput(
               "SPARK_CONNECT_INVALID_PLAN_INPUT.UNSUPPORTED_LITERAL_TYPE",
-              Map("typeInfo" -> s"${literal.getLiteralTypeCase.name}(${literal.getLiteralTypeCase.getNumber})"))
+              Map("typeInfo" -> s"${literalCase.name}(${literalCase.getNumber})"))
         }
         builder.build()
       }

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
@@ -425,7 +425,7 @@ object LiteralValueProtoConverter {
       case _ =>
         throw InvalidPlanInput(
           "SPARK_CONNECT_INVALID_PLAN_INPUT.UNSUPPORTED_LITERAL_TYPE",
-          Map("kindCase" -> dataType.getKindCase.toString))
+          Map("typeInfo" -> dataType.getKindCase.toString))
     }
     v => if (v.hasNull) null else converter(v)
   }
@@ -590,10 +590,8 @@ object LiteralValueProtoConverter {
             }
           case _ =>
             throw InvalidPlanInput(
-              "SPARK_CONNECT_INVALID_PLAN_INPUT.UNSUPPORTED_LITERAL_TYPE_WITH_NUMBER",
-              Map(
-                "name" -> literal.getLiteralTypeCase.name,
-                "number" -> literal.getLiteralTypeCase.getNumber.toString))
+              "SPARK_CONNECT_INVALID_PLAN_INPUT.UNSUPPORTED_LITERAL_TYPE",
+              Map("typeInfo" -> s"${literal.getLiteralTypeCase.name}(${literal.getLiteralTypeCase.getNumber})"))
         }
         builder.build()
       }

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
@@ -388,7 +388,7 @@ object LiteralValueProtoConverter {
     val converter: proto.Expression.Literal => Any = dataType.getKindCase match {
       case proto.DataType.KindCase.NULL =>
         v => throw InvalidPlanInput(
-          "SPARK_CONNECT_INVALID_PLAN_INPUT.EXPECTED_NULL_VALUE",
+          "CONNECT_INVALID_PLAN.EXPECTED_NULL_VALUE",
           Map("literalTypeCase" -> v.getLiteralTypeCase.toString))
       case proto.DataType.KindCase.SHORT => v => v.getShort.toShort
       case proto.DataType.KindCase.INTEGER => v => v.getInteger
@@ -424,7 +424,7 @@ object LiteralValueProtoConverter {
         v => toScalaStructInternal(v, dataType.getStruct)
       case _ =>
         throw InvalidPlanInput(
-          "SPARK_CONNECT_INVALID_PLAN_INPUT.UNSUPPORTED_LITERAL_TYPE",
+          "CONNECT_INVALID_PLAN.UNSUPPORTED_LITERAL_TYPE",
           Map("typeInfo" -> dataType.getKindCase.toString))
     }
     v => if (v.hasNull) null else converter(v)
@@ -563,7 +563,7 @@ object LiteralValueProtoConverter {
                   .build())
             } else {
               throw InvalidPlanInput(
-                "SPARK_CONNECT_INVALID_PLAN_INPUT.ARRAY_LITERAL_MISSING_DATA_TYPE",
+                "CONNECT_INVALID_PLAN.ARRAY_LITERAL_MISSING_DATA_TYPE",
                 Map.empty)
             }
           case proto.Expression.Literal.LiteralTypeCase.MAP =>
@@ -577,7 +577,7 @@ object LiteralValueProtoConverter {
                   .build())
             } else {
               throw InvalidPlanInput(
-                "SPARK_CONNECT_INVALID_PLAN_INPUT.MAP_LITERAL_MISSING_DATA_TYPE",
+                "CONNECT_INVALID_PLAN.MAP_LITERAL_MISSING_DATA_TYPE",
                 Map.empty)
             }
           case proto.Expression.Literal.LiteralTypeCase.STRUCT =>
@@ -585,13 +585,13 @@ object LiteralValueProtoConverter {
               builder.setStruct(literal.getStruct.getStructType.getStruct)
             } else {
               throw InvalidPlanInput(
-                "SPARK_CONNECT_INVALID_PLAN_INPUT.STRUCT_LITERAL_MISSING_DATA_TYPE",
+                "CONNECT_INVALID_PLAN.STRUCT_LITERAL_MISSING_DATA_TYPE",
                 Map.empty)
             }
           case _ =>
             val literalCase = literal.getLiteralTypeCase
             throw InvalidPlanInput(
-              "SPARK_CONNECT_INVALID_PLAN_INPUT.UNSUPPORTED_LITERAL_TYPE",
+              "CONNECT_INVALID_PLAN.UNSUPPORTED_LITERAL_TYPE",
               Map("typeInfo" -> s"${literalCase.name}(${literalCase.getNumber})"))
         }
         builder.build()
@@ -600,7 +600,7 @@ object LiteralValueProtoConverter {
 
     if (!isCompatible(literal.getLiteralTypeCase, dataType.getKindCase)) {
       throw InvalidPlanInput(
-        "SPARK_CONNECT_INVALID_PLAN_INPUT.INCOMPATIBLE_LITERAL_DATA_TYPE",
+        "CONNECT_INVALID_PLAN.INCOMPATIBLE_LITERAL_DATA_TYPE",
         Map(
           "dataTypeKindCase" -> dataType.getKindCase.toString,
           "literalTypeCase" -> literal.getLiteralTypeCase.toString))
@@ -614,7 +614,7 @@ object LiteralValueProtoConverter {
       arrayType: proto.DataType.Array): Array[_] = {
     if (!literal.hasArray) {
       throw InvalidPlanInput(
-        "SPARK_CONNECT_INVALID_PLAN_INPUT.ARRAY_LITERAL_NOT_SET",
+        "CONNECT_INVALID_PLAN.ARRAY_LITERAL_NOT_SET",
         Map.empty)
     }
     val array = literal.getArray
@@ -636,7 +636,7 @@ object LiteralValueProtoConverter {
       mapType: proto.DataType.Map): mutable.Map[_, _] = {
     if (!literal.hasMap) {
       throw InvalidPlanInput(
-        "SPARK_CONNECT_INVALID_PLAN_INPUT.MAP_LITERAL_NOT_SET",
+        "CONNECT_INVALID_PLAN.MAP_LITERAL_NOT_SET",
         Map.empty)
     }
     val map = literal.getMap
@@ -664,7 +664,7 @@ object LiteralValueProtoConverter {
       structType: proto.DataType.Struct): Any = {
     if (!literal.hasStruct) {
       throw InvalidPlanInput(
-        "SPARK_CONNECT_INVALID_PLAN_INPUT.STRUCT_LITERAL_NOT_SET",
+        "CONNECT_INVALID_PLAN.STRUCT_LITERAL_NOT_SET",
         Map.empty)
     }
     val struct = literal.getStruct

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/InvalidInputErrors.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/InvalidInputErrors.scala
@@ -32,129 +32,129 @@ object InvalidInputErrors {
 
   def noHandlerFoundForExtension(extensionTypeUrl: String): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.NO_HANDLER_FOR_EXTENSION",
+      "CONNECT_INVALID_PLAN.NO_HANDLER_FOR_EXTENSION",
       Map("extensionTypeUrl" -> extensionTypeUrl))
 
   def invalidSQLWithReferences(query: proto.WithRelations): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.INVALID_SQL_WITH_REFERENCES",
+      "CONNECT_INVALID_PLAN.INVALID_SQL_WITH_REFERENCES",
       Map("query" -> query.toString))
 
   def naFillValuesEmpty(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.NA_FILL_VALUES_EMPTY",
+      "CONNECT_INVALID_PLAN.NA_FILL_VALUES_EMPTY",
       Map.empty)
 
   def naFillValuesLengthMismatch(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.NA_FILL_VALUES_LENGTH_MISMATCH",
+      "CONNECT_INVALID_PLAN.NA_FILL_VALUES_LENGTH_MISMATCH",
       Map.empty)
 
   def deduplicateNeedsInput(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.DEDUPLICATE_NEEDS_INPUT",
+      "CONNECT_INVALID_PLAN.DEDUPLICATE_NEEDS_INPUT",
       Map.empty)
 
   def deduplicateAllColumnsAndSubset(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.DEDUPLICATE_ALL_COLUMNS_AND_SUBSET",
+      "CONNECT_INVALID_PLAN.DEDUPLICATE_ALL_COLUMNS_AND_SUBSET",
       Map.empty)
 
   def deduplicateRequiresColumnsOrAll(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.DEDUPLICATE_REQUIRES_COLUMNS_OR_ALL",
+      "CONNECT_INVALID_PLAN.DEDUPLICATE_REQUIRES_COLUMNS_OR_ALL",
       Map.empty)
 
   def invalidDeduplicateColumn(colName: String, fieldNames: String): InvalidPlanInput =
     InvalidPlanInput(
-      "UNRESOLVED_COLUMN_AMONG_FIELD_NAMES",
+      "CONNECT_INVALID_PLAN.UNRESOLVED_COLUMN_AMONG_FIELD_NAMES",
       Map("colName" -> colName, "fieldNames" -> fieldNames))
 
   def functionEvalTypeNotSupported(evalType: Int): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.FUNCTION_EVAL_TYPE_NOT_SUPPORTED",
+      "CONNECT_INVALID_PLAN.FUNCTION_EVAL_TYPE_NOT_SUPPORTED",
       Map("evalType" -> evalType.toString))
 
   def groupingExpressionAbsentForKeyValueGroupedDataset(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.GROUPING_EXPRESSION_ABSENT",
+      "CONNECT_INVALID_PLAN.GROUPING_EXPRESSION_ABSENT",
       Map.empty)
 
   def expectingScalaUdfButGot(exprType: proto.Expression.ExprTypeCase): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.EXPECTING_SCALA_UDF",
+      "CONNECT_INVALID_PLAN.EXPECTING_SCALA_UDF",
       Map("exprType" -> exprType.toString))
 
   def rowNotSupportedForUdf(errorType: String): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.ROW_NOT_SUPPORTED_FOR_UDF",
+      "CONNECT_INVALID_PLAN.ROW_NOT_SUPPORTED_FOR_UDF",
       Map("errorType" -> errorType))
 
   def notFoundCachedLocalRelation(hash: String, sessionUUID: String): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.NOT_FOUND_CACHED_LOCAL_RELATION",
+      "CONNECT_INVALID_PLAN.NOT_FOUND_CACHED_LOCAL_RELATION",
       Map("hash" -> hash, "sessionUUID" -> sessionUUID))
 
   def notFoundChunkedCachedLocalRelationBlock(
       hash: String,
       sessionUUID: String): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.NOT_FOUND_CHUNKED_CACHED_LOCAL_RELATION",
+      "CONNECT_INVALID_PLAN.NOT_FOUND_CHUNKED_CACHED_LOCAL_RELATION",
       Map("hash" -> hash, "sessionUUID" -> sessionUUID))
 
   def localRelationSizeLimitExceeded(actualSize: Long, limit: Long): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.LOCAL_RELATION_SIZE_LIMIT_EXCEEDED",
+      "CONNECT_INVALID_PLAN.LOCAL_RELATION_SIZE_LIMIT_EXCEEDED",
       Map("actualSize" -> actualSize.toString, "limit" -> limit.toString))
 
   def localRelationChunkSizeLimitExceeded(limit: Long): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.LOCAL_RELATION_CHUNK_SIZE_LIMIT_EXCEEDED",
+      "CONNECT_INVALID_PLAN.LOCAL_RELATION_CHUNK_SIZE_LIMIT_EXCEEDED",
       Map("limit" -> limit.toString))
 
   def withColumnsRequireSingleNamePart(got: String): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.WITH_COLUMNS_REQUIRE_SINGLE_NAME_PART",
+      "CONNECT_INVALID_PLAN.WITH_COLUMNS_REQUIRE_SINGLE_NAME_PART",
       Map("got" -> got))
 
   def inputDataForLocalRelationNoSchema(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.INPUT_DATA_NO_SCHEMA",
+      "CONNECT_INVALID_PLAN.INPUT_DATA_NO_SCHEMA",
       Map.empty)
 
   def chunkedCachedLocalRelationWithoutData(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.CHUNKED_CACHED_LOCAL_RELATION_WITHOUT_DATA",
+      "CONNECT_INVALID_PLAN.CHUNKED_CACHED_LOCAL_RELATION_WITHOUT_DATA",
       Map.empty)
 
   def schemaRequiredForLocalRelation(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.SCHEMA_REQUIRED_FOR_LOCAL_RELATION",
+      "CONNECT_INVALID_PLAN.SCHEMA_REQUIRED_FOR_LOCAL_RELATION",
       Map.empty)
 
   def invalidSchemaStringNonStructType(schema: String, dataType: DataType): InvalidPlanInput =
     InvalidPlanInput(
-      "INVALID_SCHEMA.NON_STRUCT_TYPE",
+      "CONNECT_INVALID_PLAN.INVALID_SCHEMA_NON_STRUCT_TYPE",
       Map("inputSchema" -> quoteByDefault(schema), "dataType" -> toSQLType(dataType)))
 
   def invalidJdbcParams(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.INVALID_JDBC_PARAMS",
+      "CONNECT_INVALID_PLAN.INVALID_JDBC_PARAMS",
       Map.empty)
 
   def predicatesNotSupportedForDataSource(format: String): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.PREDICATES_NOT_SUPPORTED_FOR_DATA_SOURCE",
+      "CONNECT_INVALID_PLAN.PREDICATES_NOT_SUPPORTED_FOR_DATA_SOURCE",
       Map("format" -> format))
 
   def multiplePathsNotSupportedForStreamingSource(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.MULTIPLE_PATHS_NOT_SUPPORTED_FOR_STREAMING_SOURCE",
+      "CONNECT_INVALID_PLAN.MULTIPLE_PATHS_NOT_SUPPORTED_FOR_STREAMING_SOURCE",
       Map.empty)
 
   def invalidEnum(protoEnum: Enum[_] with ProtocolMessageEnum): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.INVALID_ENUM",
+      "CONNECT_INVALID_PLAN.INVALID_ENUM",
       Map(
         "fullName" -> protoEnum.getDescriptorForType.getFullName,
         "name" -> protoEnum.name(),
@@ -166,11 +166,11 @@ object InvalidInputErrors {
     // If the oneOf field is not set, the enum number will be 0.
     if (enumCase.getNumber == 0) {
       InvalidPlanInput(
-        "SPARK_CONNECT_INVALID_PLAN_INPUT.INVALID_ONE_OF_FIELD_NOT_SET",
+        "CONNECT_INVALID_PLAN.INVALID_ONE_OF_FIELD_NOT_SET",
         Map("fullName" -> descriptor.getFullName, "name" -> enumCase.name()))
     } else {
       InvalidPlanInput(
-        "SPARK_CONNECT_INVALID_PLAN_INPUT.INVALID_ONE_OF_FIELD_NOT_SUPPORTED",
+        "CONNECT_INVALID_PLAN.INVALID_ONE_OF_FIELD_NOT_SUPPORTED",
         Map(
           "fullName" -> descriptor.getFullName,
           "name" -> enumCase.name(),
@@ -180,7 +180,7 @@ object InvalidInputErrors {
 
   def cannotBeEmpty(fieldName: String, descriptor: Descriptor): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.FIELD_CANNOT_BE_EMPTY",
+      "CONNECT_INVALID_PLAN.FIELD_CANNOT_BE_EMPTY",
       Map("fieldName" -> fieldName, "fullName" -> descriptor.getFullName))
 
   def invalidSchemaTypeNonStruct(dataType: DataType): InvalidPlanInput =
@@ -188,102 +188,102 @@ object InvalidInputErrors {
 
   def lambdaFunctionArgumentCountInvalid(got: Int): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.LAMBDA_FUNCTION_ARGUMENT_COUNT_INVALID",
+      "CONNECT_INVALID_PLAN.LAMBDA_FUNCTION_ARGUMENT_COUNT_INVALID",
       Map("got" -> got.toString))
 
   def aliasWithMultipleIdentifiersAndMetadata(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.ALIAS_WITH_MULTIPLE_IDENTIFIERS_AND_METADATA",
+      "CONNECT_INVALID_PLAN.ALIAS_WITH_MULTIPLE_IDENTIFIERS_AND_METADATA",
       Map.empty)
 
   def unresolvedStarTargetInvalid(target: String): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.UNRESOLVED_STAR_TARGET_INVALID",
+      "CONNECT_INVALID_PLAN.UNRESOLVED_STAR_TARGET_INVALID",
       Map("target" -> target))
 
   def unresolvedStarWithBothTargetAndPlanId(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.UNRESOLVED_STAR_WITH_BOTH_TARGET_AND_PLAN_ID",
+      "CONNECT_INVALID_PLAN.UNRESOLVED_STAR_WITH_BOTH_TARGET_AND_PLAN_ID",
       Map.empty)
 
   def windowFunctionRequired(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.WINDOW_FUNCTION_REQUIRED",
+      "CONNECT_INVALID_PLAN.WINDOW_FUNCTION_REQUIRED",
       Map.empty)
 
   def lowerBoundRequiredInWindowFrame(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.LOWER_BOUND_REQUIRED_IN_WINDOW_FRAME",
+      "CONNECT_INVALID_PLAN.LOWER_BOUND_REQUIRED_IN_WINDOW_FRAME",
       Map.empty)
 
   def upperBoundRequiredInWindowFrame(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.UPPER_BOUND_REQUIRED_IN_WINDOW_FRAME",
+      "CONNECT_INVALID_PLAN.UPPER_BOUND_REQUIRED_IN_WINDOW_FRAME",
       Map.empty)
 
   def setOperationMustHaveTwoInputs(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.SET_OPERATION_MUST_HAVE_TWO_INPUTS",
+      "CONNECT_INVALID_PLAN.SET_OPERATION_MUST_HAVE_TWO_INPUTS",
       Map.empty)
 
   def exceptDoesNotSupportUnionByName(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.EXCEPT_DOES_NOT_SUPPORT_UNION_BY_NAME",
+      "CONNECT_INVALID_PLAN.EXCEPT_DOES_NOT_SUPPORT_UNION_BY_NAME",
       Map.empty)
 
   def intersectDoesNotSupportUnionByName(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.INTERSECT_DOES_NOT_SUPPORT_UNION_BY_NAME",
+      "CONNECT_INVALID_PLAN.INTERSECT_DOES_NOT_SUPPORT_UNION_BY_NAME",
       Map.empty)
 
   def aggregateNeedsPlanInput(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.AGGREGATE_NEEDS_PLAN_INPUT",
+      "CONNECT_INVALID_PLAN.AGGREGATE_NEEDS_PLAN_INPUT",
       Map.empty)
 
   def aggregateWithPivotRequiresPivot(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.AGGREGATE_WITH_PIVOT_REQUIRES_PIVOT",
+      "CONNECT_INVALID_PLAN.AGGREGATE_WITH_PIVOT_REQUIRES_PIVOT",
       Map.empty)
 
   def invalidWithRelationReference(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.INVALID_WITH_RELATION_REFERENCE",
+      "CONNECT_INVALID_PLAN.INVALID_WITH_RELATION_REFERENCE",
       Map.empty)
 
   def assertionFailure(message: String): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.ASSERTION_FAILURE",
+      "CONNECT_INVALID_PLAN.ASSERTION_FAILURE",
       Map("message" -> message))
 
   def unresolvedNamedLambdaVariableRequiresNamePart(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.UNRESOLVED_NAMED_LAMBDA_VARIABLE_REQUIRES_NAME_PART",
+      "CONNECT_INVALID_PLAN.UNRESOLVED_NAMED_LAMBDA_VARIABLE_REQUIRES_NAME_PART",
       Map.empty)
 
   def usingColumnsOrJoinConditionSetInJoin(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.USING_COLUMNS_OR_JOIN_CONDITION_SET_IN_JOIN",
+      "CONNECT_INVALID_PLAN.USING_COLUMNS_OR_JOIN_CONDITION_SET_IN_JOIN",
       Map.empty)
 
   def sqlCommandExpectsSqlOrWithRelations(other: proto.Relation.RelTypeCase): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.SQL_COMMAND_EXPECTS_SQL_OR_WITH_RELATIONS",
+      "CONNECT_INVALID_PLAN.SQL_COMMAND_EXPECTS_SQL_OR_WITH_RELATIONS",
       Map("other" -> other.toString))
 
   def reduceShouldCarryScalarScalaUdf(got: mutable.Buffer[proto.Expression]): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.REDUCE_SHOULD_CARRY_SCALAR_SCALA_UDF",
+      "CONNECT_INVALID_PLAN.REDUCE_SHOULD_CARRY_SCALAR_SCALA_UDF",
       Map("got" -> got.toString))
 
   def unionByNameAllowMissingColRequiresByName(): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.UNION_BY_NAME_ALLOW_MISSING_COL_REQUIRES_BY_NAME",
+      "CONNECT_INVALID_PLAN.UNION_BY_NAME_ALLOW_MISSING_COL_REQUIRES_BY_NAME",
       Map.empty)
 
   def unsupportedUserDefinedFunctionImplementation(clazz: Class[_]): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.UNSUPPORTED_USER_DEFINED_FUNCTION_IMPLEMENTATION",
+      "CONNECT_INVALID_PLAN.UNSUPPORTED_USER_DEFINED_FUNCTION_IMPLEMENTATION",
       Map("clazz" -> clazz.toString))
 
   def streamingQueryRunIdMismatch(
@@ -291,16 +291,16 @@ object InvalidInputErrors {
       runId: String,
       serverRunId: String): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.STREAMING_QUERY_RUN_ID_MISMATCH",
+      "CONNECT_INVALID_PLAN.STREAMING_QUERY_RUN_ID_MISMATCH",
       Map("id" -> id, "runId" -> runId, "serverRunId" -> serverRunId))
 
   def streamingQueryNotFound(id: String): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.STREAMING_QUERY_NOT_FOUND",
+      "CONNECT_INVALID_PLAN.STREAMING_QUERY_NOT_FOUND",
       Map("id" -> id))
 
   def cannotFindCachedLocalRelation(hash: String): InvalidPlanInput =
     InvalidPlanInput(
-      "SPARK_CONNECT_INVALID_PLAN_INPUT.CANNOT_FIND_CACHED_LOCAL_RELATION",
+      "CONNECT_INVALID_PLAN.CANNOT_FIND_CACHED_LOCAL_RELATION",
       Map("hash" -> hash))
 }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/InvalidInputErrors.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/InvalidInputErrors.scala
@@ -30,29 +30,40 @@ import org.apache.spark.sql.types.DataType
 
 object InvalidInputErrors {
 
-  def noHandlerFoundForExtension(extensionTypeUrl: String): InvalidPlanInput = {
-    InvalidPlanInput(s"No handler found for extension type: $extensionTypeUrl")
-  }
+  def noHandlerFoundForExtension(extensionTypeUrl: String): InvalidPlanInput =
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.NO_HANDLER_FOR_EXTENSION",
+      Map("extensionTypeUrl" -> extensionTypeUrl))
 
   def invalidSQLWithReferences(query: proto.WithRelations): InvalidPlanInput =
-    InvalidPlanInput(s"$query is not a valid relation for SQL with references")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.INVALID_SQL_WITH_REFERENCES",
+      Map("query" -> query.toString))
 
   def naFillValuesEmpty(): InvalidPlanInput =
-    InvalidPlanInput("values must contains at least 1 item!")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.NA_FILL_VALUES_EMPTY",
+      Map.empty)
 
   def naFillValuesLengthMismatch(): InvalidPlanInput =
     InvalidPlanInput(
-      "When values contains more than 1 items, values and cols should have the same length!")
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.NA_FILL_VALUES_LENGTH_MISMATCH",
+      Map.empty)
 
   def deduplicateNeedsInput(): InvalidPlanInput =
-    InvalidPlanInput("Deduplicate needs a plan input")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.DEDUPLICATE_NEEDS_INPUT",
+      Map.empty)
 
   def deduplicateAllColumnsAndSubset(): InvalidPlanInput =
-    InvalidPlanInput("Cannot deduplicate on both all columns and a subset of columns")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.DEDUPLICATE_ALL_COLUMNS_AND_SUBSET",
+      Map.empty)
 
   def deduplicateRequiresColumnsOrAll(): InvalidPlanInput =
     InvalidPlanInput(
-      "Deduplicate requires to either deduplicate on all columns or a subset of columns")
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.DEDUPLICATE_REQUIRES_COLUMNS_OR_ALL",
+      Map.empty)
 
   def invalidDeduplicateColumn(colName: String, fieldNames: String): InvalidPlanInput =
     InvalidPlanInput(
@@ -60,47 +71,66 @@ object InvalidInputErrors {
       Map("colName" -> colName, "fieldNames" -> fieldNames))
 
   def functionEvalTypeNotSupported(evalType: Int): InvalidPlanInput =
-    InvalidPlanInput(s"Function with EvalType: $evalType is not supported")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.FUNCTION_EVAL_TYPE_NOT_SUPPORTED",
+      Map("evalType" -> evalType.toString))
 
   def groupingExpressionAbsentForKeyValueGroupedDataset(): InvalidPlanInput =
-    InvalidPlanInput("The grouping expression cannot be absent for KeyValueGroupedDataset")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.GROUPING_EXPRESSION_ABSENT",
+      Map.empty)
 
   def expectingScalaUdfButGot(exprType: proto.Expression.ExprTypeCase): InvalidPlanInput =
-    InvalidPlanInput(s"Expecting a Scala UDF, but get $exprType")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.EXPECTING_SCALA_UDF",
+      Map("exprType" -> exprType.toString))
 
   def rowNotSupportedForUdf(errorType: String): InvalidPlanInput =
-    InvalidPlanInput(s"Row is not a supported $errorType type for this UDF.")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.ROW_NOT_SUPPORTED_FOR_UDF",
+      Map("errorType" -> errorType))
 
   def notFoundCachedLocalRelation(hash: String, sessionUUID: String): InvalidPlanInput =
     InvalidPlanInput(
-      s"Not found any cached local relation with the hash: " +
-        s"$hash in the session with sessionUUID $sessionUUID.")
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.NOT_FOUND_CACHED_LOCAL_RELATION",
+      Map("hash" -> hash, "sessionUUID" -> sessionUUID))
 
   def notFoundChunkedCachedLocalRelationBlock(
       hash: String,
       sessionUUID: String): InvalidPlanInput =
     InvalidPlanInput(
-      s"Not found chunked cached local relation block with the hash: " +
-        s"$hash in the session with sessionUUID $sessionUUID.")
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.NOT_FOUND_CHUNKED_CACHED_LOCAL_RELATION",
+      Map("hash" -> hash, "sessionUUID" -> sessionUUID))
 
   def localRelationSizeLimitExceeded(actualSize: Long, limit: Long): InvalidPlanInput =
     InvalidPlanInput(
-      s"Cached local relation size ($actualSize bytes) exceeds the limit ($limit bytes).")
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.LOCAL_RELATION_SIZE_LIMIT_EXCEEDED",
+      Map("actualSize" -> actualSize.toString, "limit" -> limit.toString))
 
   def localRelationChunkSizeLimitExceeded(limit: Long): InvalidPlanInput =
-    InvalidPlanInput(s"One of cached local relation chunks exceeded the limit of $limit bytes.")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.LOCAL_RELATION_CHUNK_SIZE_LIMIT_EXCEEDED",
+      Map("limit" -> limit.toString))
 
   def withColumnsRequireSingleNamePart(got: String): InvalidPlanInput =
-    InvalidPlanInput(s"WithColumns require column name only contains one name part, but got $got")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.WITH_COLUMNS_REQUIRE_SINGLE_NAME_PART",
+      Map("got" -> got))
 
   def inputDataForLocalRelationNoSchema(): InvalidPlanInput =
-    InvalidPlanInput("Input data for LocalRelation does not produce a schema.")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.INPUT_DATA_NO_SCHEMA",
+      Map.empty)
 
   def chunkedCachedLocalRelationWithoutData(): InvalidPlanInput =
-    InvalidPlanInput("ChunkedCachedLocalRelation should contain data.")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.CHUNKED_CACHED_LOCAL_RELATION_WITHOUT_DATA",
+      Map.empty)
 
   def schemaRequiredForLocalRelation(): InvalidPlanInput =
-    InvalidPlanInput("Schema for LocalRelation is required when the input data is not provided.")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.SCHEMA_REQUIRED_FOR_LOCAL_RELATION",
+      Map.empty)
 
   def invalidSchemaStringNonStructType(schema: String, dataType: DataType): InvalidPlanInput =
     InvalidPlanInput(
@@ -108,18 +138,27 @@ object InvalidInputErrors {
       Map("inputSchema" -> quoteByDefault(schema), "dataType" -> toSQLType(dataType)))
 
   def invalidJdbcParams(): InvalidPlanInput =
-    InvalidPlanInput("Invalid jdbc params, please specify jdbc url and table.")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.INVALID_JDBC_PARAMS",
+      Map.empty)
 
   def predicatesNotSupportedForDataSource(format: String): InvalidPlanInput =
-    InvalidPlanInput(s"Predicates are not supported for $format data sources.")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.PREDICATES_NOT_SUPPORTED_FOR_DATA_SOURCE",
+      Map("format" -> format))
 
   def multiplePathsNotSupportedForStreamingSource(): InvalidPlanInput =
-    InvalidPlanInput("Multiple paths are not supported for streaming source")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.MULTIPLE_PATHS_NOT_SUPPORTED_FOR_STREAMING_SOURCE",
+      Map.empty)
 
   def invalidEnum(protoEnum: Enum[_] with ProtocolMessageEnum): InvalidPlanInput =
     InvalidPlanInput(
-      s"This enum value of ${protoEnum.getDescriptorForType.getFullName}" +
-        s" is invalid: ${protoEnum.name()}(${protoEnum.getNumber})")
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.INVALID_ENUM",
+      Map(
+        "fullName" -> protoEnum.getDescriptorForType.getFullName,
+        "name" -> protoEnum.name(),
+        "number" -> protoEnum.getNumber.toString))
 
   def invalidOneOfField(
       enumCase: Enum[_] with EnumLite,
@@ -127,90 +166,141 @@ object InvalidInputErrors {
     // If the oneOf field is not set, the enum number will be 0.
     if (enumCase.getNumber == 0) {
       InvalidPlanInput(
-        s"This oneOf field in ${descriptor.getFullName} is not set: ${enumCase.name()}")
+        "SPARK_CONNECT_INVALID_PLAN_INPUT.INVALID_ONE_OF_FIELD_NOT_SET",
+        Map("fullName" -> descriptor.getFullName, "name" -> enumCase.name()))
     } else {
       InvalidPlanInput(
-        s"This oneOf field message in ${descriptor.getFullName} is not supported: " +
-          s"${enumCase.name()}(${enumCase.getNumber})")
+        "SPARK_CONNECT_INVALID_PLAN_INPUT.INVALID_ONE_OF_FIELD_NOT_SUPPORTED",
+        Map(
+          "fullName" -> descriptor.getFullName,
+          "name" -> enumCase.name(),
+          "number" -> enumCase.getNumber.toString))
     }
   }
 
   def cannotBeEmpty(fieldName: String, descriptor: Descriptor): InvalidPlanInput =
-    InvalidPlanInput(s"$fieldName in ${descriptor.getFullName} cannot be empty")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.FIELD_CANNOT_BE_EMPTY",
+      Map("fieldName" -> fieldName, "fullName" -> descriptor.getFullName))
 
   def invalidSchemaTypeNonStruct(dataType: DataType): InvalidPlanInput =
     InvalidPlanInput("INVALID_SCHEMA_TYPE_NON_STRUCT", Map("dataType" -> toSQLType(dataType)))
 
   def lambdaFunctionArgumentCountInvalid(got: Int): InvalidPlanInput =
-    InvalidPlanInput(s"LambdaFunction requires 1 ~ 3 arguments, but got $got ones!")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.LAMBDA_FUNCTION_ARGUMENT_COUNT_INVALID",
+      Map("got" -> got.toString))
 
   def aliasWithMultipleIdentifiersAndMetadata(): InvalidPlanInput =
     InvalidPlanInput(
-      "Alias expressions with more than 1 identifier must not use optional metadata.")
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.ALIAS_WITH_MULTIPLE_IDENTIFIERS_AND_METADATA",
+      Map.empty)
 
   def unresolvedStarTargetInvalid(target: String): InvalidPlanInput =
     InvalidPlanInput(
-      s"UnresolvedStar requires a unparsed target ending with '.*', but got $target.")
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.UNRESOLVED_STAR_TARGET_INVALID",
+      Map("target" -> target))
 
   def unresolvedStarWithBothTargetAndPlanId(): InvalidPlanInput =
-    InvalidPlanInput("UnresolvedStar with both target and plan id is not supported.")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.UNRESOLVED_STAR_WITH_BOTH_TARGET_AND_PLAN_ID",
+      Map.empty)
 
   def windowFunctionRequired(): InvalidPlanInput =
-    InvalidPlanInput("WindowFunction is required in WindowExpression")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.WINDOW_FUNCTION_REQUIRED",
+      Map.empty)
 
   def lowerBoundRequiredInWindowFrame(): InvalidPlanInput =
-    InvalidPlanInput("LowerBound is required in WindowFrame")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.LOWER_BOUND_REQUIRED_IN_WINDOW_FRAME",
+      Map.empty)
 
   def upperBoundRequiredInWindowFrame(): InvalidPlanInput =
-    InvalidPlanInput("UpperBound is required in WindowFrame")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.UPPER_BOUND_REQUIRED_IN_WINDOW_FRAME",
+      Map.empty)
 
   def setOperationMustHaveTwoInputs(): InvalidPlanInput =
-    InvalidPlanInput("Set operation must have 2 inputs")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.SET_OPERATION_MUST_HAVE_TWO_INPUTS",
+      Map.empty)
 
   def exceptDoesNotSupportUnionByName(): InvalidPlanInput =
-    InvalidPlanInput("Except does not support union_by_name")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.EXCEPT_DOES_NOT_SUPPORT_UNION_BY_NAME",
+      Map.empty)
 
   def intersectDoesNotSupportUnionByName(): InvalidPlanInput =
-    InvalidPlanInput("Intersect does not support union_by_name")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.INTERSECT_DOES_NOT_SUPPORT_UNION_BY_NAME",
+      Map.empty)
 
   def aggregateNeedsPlanInput(): InvalidPlanInput =
-    InvalidPlanInput("Aggregate needs a plan input")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.AGGREGATE_NEEDS_PLAN_INPUT",
+      Map.empty)
 
   def aggregateWithPivotRequiresPivot(): InvalidPlanInput =
-    InvalidPlanInput("Aggregate with GROUP_TYPE_PIVOT requires a Pivot")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.AGGREGATE_WITH_PIVOT_REQUIRES_PIVOT",
+      Map.empty)
 
   def invalidWithRelationReference(): InvalidPlanInput =
-    InvalidPlanInput("Invalid WithRelation reference")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.INVALID_WITH_RELATION_REFERENCE",
+      Map.empty)
 
   def assertionFailure(message: String): InvalidPlanInput =
-    InvalidPlanInput(message)
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.ASSERTION_FAILURE",
+      Map("message" -> message))
 
   def unresolvedNamedLambdaVariableRequiresNamePart(): InvalidPlanInput =
-    InvalidPlanInput("UnresolvedNamedLambdaVariable requires at least one name part!")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.UNRESOLVED_NAMED_LAMBDA_VARIABLE_REQUIRES_NAME_PART",
+      Map.empty)
 
   def usingColumnsOrJoinConditionSetInJoin(): InvalidPlanInput =
-    InvalidPlanInput("Using columns or join conditions cannot be set at the same time in Join")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.USING_COLUMNS_OR_JOIN_CONDITION_SET_IN_JOIN",
+      Map.empty)
 
   def sqlCommandExpectsSqlOrWithRelations(other: proto.Relation.RelTypeCase): InvalidPlanInput =
-    InvalidPlanInput(s"SQL command expects either a SQL or a WithRelations, but got $other")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.SQL_COMMAND_EXPECTS_SQL_OR_WITH_RELATIONS",
+      Map("other" -> other.toString))
 
   def reduceShouldCarryScalarScalaUdf(got: mutable.Buffer[proto.Expression]): InvalidPlanInput =
-    InvalidPlanInput(s"reduce should carry a scalar scala udf, but got $got")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.REDUCE_SHOULD_CARRY_SCALAR_SCALA_UDF",
+      Map("got" -> got.toString))
 
   def unionByNameAllowMissingColRequiresByName(): InvalidPlanInput =
-    InvalidPlanInput("UnionByName `allowMissingCol` can be true only if `byName` is true.")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.UNION_BY_NAME_ALLOW_MISSING_COL_REQUIRES_BY_NAME",
+      Map.empty)
 
   def unsupportedUserDefinedFunctionImplementation(clazz: Class[_]): InvalidPlanInput =
-    InvalidPlanInput(s"Unsupported UserDefinedFunction implementation: ${clazz}")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.UNSUPPORTED_USER_DEFINED_FUNCTION_IMPLEMENTATION",
+      Map("clazz" -> clazz.toString))
 
   def streamingQueryRunIdMismatch(
       id: String,
       runId: String,
       serverRunId: String): InvalidPlanInput =
     InvalidPlanInput(
-      s"Run id mismatch for query id $id. Run id in the request $runId " +
-        s"does not match one on the server $serverRunId. The query might have restarted.")
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.STREAMING_QUERY_RUN_ID_MISMATCH",
+      Map("id" -> id, "runId" -> runId, "serverRunId" -> serverRunId))
 
   def streamingQueryNotFound(id: String): InvalidPlanInput =
-    InvalidPlanInput(s"Streaming query $id is not found")
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.STREAMING_QUERY_NOT_FOUND",
+      Map("id" -> id))
+
+  def cannotFindCachedLocalRelation(hash: String): InvalidPlanInput =
+    InvalidPlanInput(
+      "SPARK_CONNECT_INVALID_PLAN_INPUT.CANNOT_FIND_CACHED_LOCAL_RELATION",
+      Map("hash" -> hash))
 }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/InvalidInputErrors.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/InvalidInputErrors.scala
@@ -41,29 +41,19 @@ object InvalidInputErrors {
       Map("query" -> query.toString))
 
   def naFillValuesEmpty(): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.NA_FILL_VALUES_EMPTY",
-      Map.empty)
+    InvalidPlanInput("CONNECT_INVALID_PLAN.NA_FILL_VALUES_EMPTY", Map.empty)
 
   def naFillValuesLengthMismatch(): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.NA_FILL_VALUES_LENGTH_MISMATCH",
-      Map.empty)
+    InvalidPlanInput("CONNECT_INVALID_PLAN.NA_FILL_VALUES_LENGTH_MISMATCH", Map.empty)
 
   def deduplicateNeedsInput(): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.DEDUPLICATE_NEEDS_INPUT",
-      Map.empty)
+    InvalidPlanInput("CONNECT_INVALID_PLAN.DEDUPLICATE_NEEDS_INPUT", Map.empty)
 
   def deduplicateAllColumnsAndSubset(): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.DEDUPLICATE_ALL_COLUMNS_AND_SUBSET",
-      Map.empty)
+    InvalidPlanInput("CONNECT_INVALID_PLAN.DEDUPLICATE_ALL_COLUMNS_AND_SUBSET", Map.empty)
 
   def deduplicateRequiresColumnsOrAll(): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.DEDUPLICATE_REQUIRES_COLUMNS_OR_ALL",
-      Map.empty)
+    InvalidPlanInput("CONNECT_INVALID_PLAN.DEDUPLICATE_REQUIRES_COLUMNS_OR_ALL", Map.empty)
 
   def invalidDeduplicateColumn(colName: String, fieldNames: String): InvalidPlanInput =
     InvalidPlanInput(
@@ -76,9 +66,7 @@ object InvalidInputErrors {
       Map("evalType" -> evalType.toString))
 
   def groupingExpressionAbsentForKeyValueGroupedDataset(): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.GROUPING_EXPRESSION_ABSENT",
-      Map.empty)
+    InvalidPlanInput("CONNECT_INVALID_PLAN.GROUPING_EXPRESSION_ABSENT", Map.empty)
 
   def expectingScalaUdfButGot(exprType: proto.Expression.ExprTypeCase): InvalidPlanInput =
     InvalidPlanInput(
@@ -118,19 +106,13 @@ object InvalidInputErrors {
       Map("got" -> got))
 
   def inputDataForLocalRelationNoSchema(): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.INPUT_DATA_NO_SCHEMA",
-      Map.empty)
+    InvalidPlanInput("CONNECT_INVALID_PLAN.INPUT_DATA_NO_SCHEMA", Map.empty)
 
   def chunkedCachedLocalRelationWithoutData(): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.CHUNKED_CACHED_LOCAL_RELATION_WITHOUT_DATA",
-      Map.empty)
+    InvalidPlanInput("CONNECT_INVALID_PLAN.CHUNKED_CACHED_LOCAL_RELATION_WITHOUT_DATA", Map.empty)
 
   def schemaRequiredForLocalRelation(): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.SCHEMA_REQUIRED_FOR_LOCAL_RELATION",
-      Map.empty)
+    InvalidPlanInput("CONNECT_INVALID_PLAN.SCHEMA_REQUIRED_FOR_LOCAL_RELATION", Map.empty)
 
   def invalidSchemaStringNonStructType(schema: String, dataType: DataType): InvalidPlanInput =
     InvalidPlanInput(
@@ -138,9 +120,7 @@ object InvalidInputErrors {
       Map("inputSchema" -> quoteByDefault(schema), "dataType" -> toSQLType(dataType)))
 
   def invalidJdbcParams(): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.INVALID_JDBC_PARAMS",
-      Map.empty)
+    InvalidPlanInput("CONNECT_INVALID_PLAN.INVALID_JDBC_PARAMS", Map.empty)
 
   def predicatesNotSupportedForDataSource(format: String): InvalidPlanInput =
     InvalidPlanInput(
@@ -207,54 +187,34 @@ object InvalidInputErrors {
       Map.empty)
 
   def windowFunctionRequired(): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.WINDOW_FUNCTION_REQUIRED",
-      Map.empty)
+    InvalidPlanInput("CONNECT_INVALID_PLAN.WINDOW_FUNCTION_REQUIRED", Map.empty)
 
   def lowerBoundRequiredInWindowFrame(): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.LOWER_BOUND_REQUIRED_IN_WINDOW_FRAME",
-      Map.empty)
+    InvalidPlanInput("CONNECT_INVALID_PLAN.LOWER_BOUND_REQUIRED_IN_WINDOW_FRAME", Map.empty)
 
   def upperBoundRequiredInWindowFrame(): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.UPPER_BOUND_REQUIRED_IN_WINDOW_FRAME",
-      Map.empty)
+    InvalidPlanInput("CONNECT_INVALID_PLAN.UPPER_BOUND_REQUIRED_IN_WINDOW_FRAME", Map.empty)
 
   def setOperationMustHaveTwoInputs(): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.SET_OPERATION_MUST_HAVE_TWO_INPUTS",
-      Map.empty)
+    InvalidPlanInput("CONNECT_INVALID_PLAN.SET_OPERATION_MUST_HAVE_TWO_INPUTS", Map.empty)
 
   def exceptDoesNotSupportUnionByName(): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.EXCEPT_DOES_NOT_SUPPORT_UNION_BY_NAME",
-      Map.empty)
+    InvalidPlanInput("CONNECT_INVALID_PLAN.EXCEPT_DOES_NOT_SUPPORT_UNION_BY_NAME", Map.empty)
 
   def intersectDoesNotSupportUnionByName(): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.INTERSECT_DOES_NOT_SUPPORT_UNION_BY_NAME",
-      Map.empty)
+    InvalidPlanInput("CONNECT_INVALID_PLAN.INTERSECT_DOES_NOT_SUPPORT_UNION_BY_NAME", Map.empty)
 
   def aggregateNeedsPlanInput(): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.AGGREGATE_NEEDS_PLAN_INPUT",
-      Map.empty)
+    InvalidPlanInput("CONNECT_INVALID_PLAN.AGGREGATE_NEEDS_PLAN_INPUT", Map.empty)
 
   def aggregateWithPivotRequiresPivot(): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.AGGREGATE_WITH_PIVOT_REQUIRES_PIVOT",
-      Map.empty)
+    InvalidPlanInput("CONNECT_INVALID_PLAN.AGGREGATE_WITH_PIVOT_REQUIRES_PIVOT", Map.empty)
 
   def invalidWithRelationReference(): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.INVALID_WITH_RELATION_REFERENCE",
-      Map.empty)
+    InvalidPlanInput("CONNECT_INVALID_PLAN.INVALID_WITH_RELATION_REFERENCE", Map.empty)
 
   def assertionFailure(message: String): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.ASSERTION_FAILURE",
-      Map("message" -> message))
+    InvalidPlanInput("CONNECT_INVALID_PLAN.ASSERTION_FAILURE", Map("message" -> message))
 
   def unresolvedNamedLambdaVariableRequiresNamePart(): InvalidPlanInput =
     InvalidPlanInput(
@@ -295,9 +255,7 @@ object InvalidInputErrors {
       Map("id" -> id, "runId" -> runId, "serverRunId" -> serverRunId))
 
   def streamingQueryNotFound(id: String): InvalidPlanInput =
-    InvalidPlanInput(
-      "CONNECT_INVALID_PLAN.STREAMING_QUERY_NOT_FOUND",
-      Map("id" -> id))
+    InvalidPlanInput("CONNECT_INVALID_PLAN.STREAMING_QUERY_NOT_FOUND", Map("id" -> id))
 
   def cannotFindCachedLocalRelation(hash: String): InvalidPlanInput =
     InvalidPlanInput(

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -59,7 +59,7 @@ import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, CharVarcharUtils}
 import org.apache.spark.sql.classic.{Catalog, DataFrameWriter, Dataset, MergeIntoWriter, RelationalGroupedDataset, SparkSession, TypedAggUtils, UserDefinedFunctionUtils}
 import org.apache.spark.sql.classic.ClassicConversions._
 import org.apache.spark.sql.connect.client.arrow.ArrowSerializer
-import org.apache.spark.sql.connect.common.{DataTypeProtoConverter, ForeachWriterPacket, InvalidPlanInput, LiteralValueProtoConverter, StorageLevelProtoConverter, StreamingListenerPacket, UdfPacket}
+import org.apache.spark.sql.connect.common.{DataTypeProtoConverter, ForeachWriterPacket, LiteralValueProtoConverter, StorageLevelProtoConverter, StreamingListenerPacket, UdfPacket}
 import org.apache.spark.sql.connect.config.Connect.CONNECT_GRPC_ARROW_MAX_BATCH_SIZE
 import org.apache.spark.sql.connect.ml.MLHandler
 import org.apache.spark.sql.connect.pipelines.PipelinesHandler
@@ -1332,7 +1332,7 @@ class SparkConnectPlanner(
   private def transformCachedLocalRelation(rel: proto.CachedLocalRelation): LogicalPlan = {
     val blockManager = session.sparkContext.env.blockManager
     val blockId = session.artifactManager.getCachedBlockId(rel.getHash).getOrElse {
-      throw InvalidPlanInput(s"Cannot find a cached local relation for hash: ${rel.getHash}")
+      throw InvalidInputErrors.cannotFindCachedLocalRelation(rel.getHash)
     }
     val bytes = blockManager.getLocalBytes(blockId)
     bytes

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -465,7 +465,9 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
   private[connect] def getDataFrameOrThrow(dfId: String): DataFrame = {
     Option(dataFrameCache.get(dfId))
       .getOrElse {
-        throw InvalidPlanInput(s"No DataFrame with id $dfId is found in the session $sessionId")
+        throw InvalidPlanInput(
+          "SPARK_CONNECT_INVALID_PLAN_INPUT.DATAFRAME_NOT_FOUND",
+          Map("dfId" -> dfId, "sessionId" -> sessionId))
       }
   }
 

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -466,7 +466,7 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
     Option(dataFrameCache.get(dfId))
       .getOrElse {
         throw InvalidPlanInput(
-          "SPARK_CONNECT_INVALID_PLAN_INPUT.DATAFRAME_NOT_FOUND",
+          "CONNECT_INVALID_PLAN.DATAFRAME_NOT_FOUND",
           Map("dfId" -> dfId, "sessionId" -> sessionId))
       }
   }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAnalyzeHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAnalyzeHandler.scala
@@ -246,7 +246,7 @@ private[connect] class SparkConnectAnalyzeHandler(
       // for unhandled cases, which will fail tests and block CI if you forget to update it.
       case other =>
         throw InvalidPlanInput(
-          "SPARK_CONNECT_INVALID_PLAN_INPUT.UNKNOWN_ANALYZE_METHOD",
+          "CONNECT_INVALID_PLAN.UNKNOWN_ANALYZE_METHOD",
           Map("other" -> other.toString))
     }
 

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAnalyzeHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAnalyzeHandler.scala
@@ -244,7 +244,10 @@ private[connect] class SparkConnectAnalyzeHandler(
       // RequestDecompressionInterceptor.decompressAnalyzePlanRequest() to handle
       // this case. The interceptor has a default case that throws UnsupportedOperationException
       // for unhandled cases, which will fail tests and block CI if you forget to update it.
-      case other => throw InvalidPlanInput(s"Unknown Analyze Method $other!")
+      case other =>
+        throw InvalidPlanInput(
+          "SPARK_CONNECT_INVALID_PLAN_INPUT.UNKNOWN_ANALYZE_METHOD",
+          Map("other" -> other.toString))
     }
 
     builder

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/InvalidInputErrorsSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/InvalidInputErrorsSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.connect.proto
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.connect.common.{DataTypeProtoConverter, InvalidPlanInput}
-import org.apache.spark.sql.connect.planner.SparkConnectPlanTest
+import org.apache.spark.sql.connect.planner.{InvalidInputErrors, SparkConnectPlanTest}
 import org.apache.spark.sql.types._
 
 class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
@@ -138,6 +138,45 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
         assert(exception.getSqlState == "XXSC1")
       }
     }
+  }
+
+  test("noHandlerFoundForExtension") {
+    val ex = InvalidInputErrors.noHandlerFoundForExtension("foo.bar.Ext")
+    assert(ex.getCondition.contains("NO_HANDLER_FOR_EXTENSION"))
+    assert(ex.getMessage.contains("foo.bar.Ext"))
+    assert(ex.getSqlState == "XXSC1")
+  }
+
+  test("notFoundCachedLocalRelation") {
+    val ex = InvalidInputErrors.notFoundCachedLocalRelation("abc123", "sess-uuid")
+    assert(ex.getCondition.contains("NOT_FOUND_CACHED_LOCAL_RELATION"))
+    assert(ex.getMessage.contains("abc123"))
+    assert(ex.getMessage.contains("sess-uuid"))
+    assert(ex.getSqlState == "XXSC1")
+  }
+
+  test("localRelationSizeLimitExceeded") {
+    val ex = InvalidInputErrors.localRelationSizeLimitExceeded(1000L, 500L)
+    assert(ex.getCondition.contains("LOCAL_RELATION_SIZE_LIMIT_EXCEEDED"))
+    assert(ex.getMessage.contains("1000"))
+    assert(ex.getMessage.contains("500"))
+    assert(ex.getSqlState == "XXSC1")
+  }
+
+  test("functionEvalTypeNotSupported") {
+    val ex = InvalidInputErrors.functionEvalTypeNotSupported(42)
+    assert(ex.getCondition.contains("FUNCTION_EVAL_TYPE_NOT_SUPPORTED"))
+    assert(ex.getMessage.contains("42"))
+    assert(ex.getSqlState == "XXSC1")
+  }
+
+  test("streamingQueryRunIdMismatch") {
+    val ex = InvalidInputErrors.streamingQueryRunIdMismatch("q1", "run1", "run2")
+    assert(ex.getCondition.contains("STREAMING_QUERY_RUN_ID_MISMATCH"))
+    assert(ex.getMessage.contains("q1"))
+    assert(ex.getMessage.contains("run1"))
+    assert(ex.getMessage.contains("run2"))
+    assert(ex.getSqlState == "XXSC1")
   }
 
   // Helper case class to define test cases

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/InvalidInputErrorsSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/InvalidInputErrorsSuite.scala
@@ -97,8 +97,8 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
       }),
     TestCase(
       name = "Deduplicate needs input",
-      expectedErrorCondition = "INTERNAL_ERROR",
-      expectedParameters = Map("message" -> "Deduplicate needs a plan input"),
+      expectedErrorCondition = "SPARK_CONNECT_INVALID_PLAN_INPUT.DEDUPLICATE_NEEDS_INPUT",
+      expectedParameters = Map.empty,
       invalidInput = {
         val deduplicate = proto.Deduplicate
           .newBuilder()
@@ -109,9 +109,10 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
       }),
     TestCase(
       name = "Catalog not set",
-      expectedErrorCondition = "INTERNAL_ERROR",
+      expectedErrorCondition =
+        "SPARK_CONNECT_INVALID_PLAN_INPUT.INVALID_ONE_OF_FIELD_NOT_SET",
       expectedParameters =
-        Map("message" -> "This oneOf field in spark.connect.Catalog is not set: CATTYPE_NOT_SET"),
+        Map("fullName" -> "spark.connect.Catalog", "name" -> "CATTYPE_NOT_SET"),
       invalidInput = {
         val catalog = proto.Catalog
           .newBuilder()
@@ -126,12 +127,16 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
   // Run all test cases
   testCases.foreach { testCase =>
     test(s"${testCase.name}") {
+      val exception = intercept[InvalidPlanInput] {
+        transform(testCase.invalidInput)
+      }
       checkError(
-        exception = intercept[InvalidPlanInput] {
-          transform(testCase.invalidInput)
-        },
+        exception = exception,
         condition = testCase.expectedErrorCondition,
         parameters = testCase.expectedParameters)
+      if (testCase.expectedErrorCondition.startsWith("SPARK_CONNECT_INVALID_PLAN_INPUT")) {
+        assert(exception.getSqlState == "XXSC1")
+      }
     }
   }
 

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/InvalidInputErrorsSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/InvalidInputErrorsSuite.scala
@@ -135,7 +135,7 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
         condition = testCase.expectedErrorCondition,
         parameters = testCase.expectedParameters)
       if (testCase.expectedErrorCondition.startsWith("SPARK_CONNECT_INVALID_PLAN_INPUT")) {
-        assert(exception.getSqlState == "XXSC1")
+        assert(exception.getSqlState == "42000")
       }
     }
   }
@@ -144,7 +144,7 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
     val ex = InvalidInputErrors.noHandlerFoundForExtension("foo.bar.Ext")
     assert(ex.getCondition.contains("NO_HANDLER_FOR_EXTENSION"))
     assert(ex.getMessage.contains("foo.bar.Ext"))
-    assert(ex.getSqlState == "XXSC1")
+    assert(ex.getSqlState == "42000")
   }
 
   test("notFoundCachedLocalRelation") {
@@ -152,7 +152,7 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
     assert(ex.getCondition.contains("NOT_FOUND_CACHED_LOCAL_RELATION"))
     assert(ex.getMessage.contains("abc123"))
     assert(ex.getMessage.contains("sess-uuid"))
-    assert(ex.getSqlState == "XXSC1")
+    assert(ex.getSqlState == "42000")
   }
 
   test("localRelationSizeLimitExceeded") {
@@ -160,14 +160,14 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
     assert(ex.getCondition.contains("LOCAL_RELATION_SIZE_LIMIT_EXCEEDED"))
     assert(ex.getMessage.contains("1000"))
     assert(ex.getMessage.contains("500"))
-    assert(ex.getSqlState == "XXSC1")
+    assert(ex.getSqlState == "42000")
   }
 
   test("functionEvalTypeNotSupported") {
     val ex = InvalidInputErrors.functionEvalTypeNotSupported(42)
     assert(ex.getCondition.contains("FUNCTION_EVAL_TYPE_NOT_SUPPORTED"))
     assert(ex.getMessage.contains("42"))
-    assert(ex.getSqlState == "XXSC1")
+    assert(ex.getSqlState == "42000")
   }
 
   test("streamingQueryRunIdMismatch") {
@@ -176,7 +176,7 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
     assert(ex.getMessage.contains("q1"))
     assert(ex.getMessage.contains("run1"))
     assert(ex.getMessage.contains("run2"))
-    assert(ex.getSqlState == "XXSC1")
+    assert(ex.getSqlState == "42000")
   }
 
   // Helper case class to define test cases

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/InvalidInputErrorsSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/InvalidInputErrorsSuite.scala
@@ -109,8 +109,7 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
       }),
     TestCase(
       name = "Catalog not set",
-      expectedErrorCondition =
-        "CONNECT_INVALID_PLAN.INVALID_ONE_OF_FIELD_NOT_SET",
+      expectedErrorCondition = "CONNECT_INVALID_PLAN.INVALID_ONE_OF_FIELD_NOT_SET",
       expectedParameters =
         Map("fullName" -> "spark.connect.Catalog", "name" -> "CATTYPE_NOT_SET"),
       invalidInput = {

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/InvalidInputErrorsSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/InvalidInputErrorsSuite.scala
@@ -75,7 +75,7 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
       }),
     TestCase(
       name = "Invalid schema string non struct type",
-      expectedErrorCondition = "INVALID_SCHEMA.NON_STRUCT_TYPE",
+      expectedErrorCondition = "CONNECT_INVALID_PLAN.INVALID_SCHEMA_NON_STRUCT_TYPE",
       expectedParameters = Map(
         "inputSchema" -> """"{"type":"array","elementType":"integer","containsNull":false}"""",
         "dataType" -> "\"ARRAY<INT>\""),
@@ -97,7 +97,7 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
       }),
     TestCase(
       name = "Deduplicate needs input",
-      expectedErrorCondition = "SPARK_CONNECT_INVALID_PLAN_INPUT.DEDUPLICATE_NEEDS_INPUT",
+      expectedErrorCondition = "CONNECT_INVALID_PLAN.DEDUPLICATE_NEEDS_INPUT",
       expectedParameters = Map.empty,
       invalidInput = {
         val deduplicate = proto.Deduplicate
@@ -110,7 +110,7 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
     TestCase(
       name = "Catalog not set",
       expectedErrorCondition =
-        "SPARK_CONNECT_INVALID_PLAN_INPUT.INVALID_ONE_OF_FIELD_NOT_SET",
+        "CONNECT_INVALID_PLAN.INVALID_ONE_OF_FIELD_NOT_SET",
       expectedParameters =
         Map("fullName" -> "spark.connect.Catalog", "name" -> "CATTYPE_NOT_SET"),
       invalidInput = {
@@ -134,8 +134,8 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
         exception = exception,
         condition = testCase.expectedErrorCondition,
         parameters = testCase.expectedParameters)
-      if (testCase.expectedErrorCondition.startsWith("SPARK_CONNECT_INVALID_PLAN_INPUT")) {
-        assert(exception.getSqlState == "42000")
+      if (testCase.expectedErrorCondition.startsWith("CONNECT_INVALID_PLAN")) {
+        assert(exception.getSqlState == "56K00")
       }
     }
   }
@@ -144,7 +144,7 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
     val ex = InvalidInputErrors.noHandlerFoundForExtension("foo.bar.Ext")
     assert(ex.getCondition.contains("NO_HANDLER_FOR_EXTENSION"))
     assert(ex.getMessage.contains("foo.bar.Ext"))
-    assert(ex.getSqlState == "42000")
+    assert(ex.getSqlState == "56K00")
   }
 
   test("notFoundCachedLocalRelation") {
@@ -152,7 +152,7 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
     assert(ex.getCondition.contains("NOT_FOUND_CACHED_LOCAL_RELATION"))
     assert(ex.getMessage.contains("abc123"))
     assert(ex.getMessage.contains("sess-uuid"))
-    assert(ex.getSqlState == "42000")
+    assert(ex.getSqlState == "56K00")
   }
 
   test("localRelationSizeLimitExceeded") {
@@ -160,14 +160,14 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
     assert(ex.getCondition.contains("LOCAL_RELATION_SIZE_LIMIT_EXCEEDED"))
     assert(ex.getMessage.contains("1000"))
     assert(ex.getMessage.contains("500"))
-    assert(ex.getSqlState == "42000")
+    assert(ex.getSqlState == "56K00")
   }
 
   test("functionEvalTypeNotSupported") {
     val ex = InvalidInputErrors.functionEvalTypeNotSupported(42)
     assert(ex.getCondition.contains("FUNCTION_EVAL_TYPE_NOT_SUPPORTED"))
     assert(ex.getMessage.contains("42"))
-    assert(ex.getSqlState == "42000")
+    assert(ex.getSqlState == "56K00")
   }
 
   test("streamingQueryRunIdMismatch") {
@@ -176,7 +176,7 @@ class InvalidInputErrorsSuite extends PlanTest with SparkConnectPlanTest {
     assert(ex.getMessage.contains("q1"))
     assert(ex.getMessage.contains("run1"))
     assert(ex.getMessage.contains("run2"))
-    assert(ex.getSqlState == "42000")
+    assert(ex.getSqlState == "56K00")
   }
 
   // Helper case class to define test cases


### PR DESCRIPTION
### What changes were proposed in this pull request?                                                                      
                                                                                                                            
  Add error class `SPARK_CONNECT_INVALID_PLAN_INPUT` with 65 
  subclasses, covering all `InvalidPlanInput` throw sites across the Spark Connect layer (`InvalidInputErrors`,             
  `DataTypeProtoConverter`, `LiteralValueProtoConverter`, `SparkConnectAnalyzeHandler`, `SessionHolder`,                    
  `SparkConnectPlanner`).                                   

  ### Why are the changes needed?

  `InvalidPlanInput` exceptions previously defaulted to `INTERNAL_ERROR` (SQL state `XX000`), making plan-input validation
  failures indistinguishable from genuine internal errors. Use 56K00

  ### Does this PR introduce _any_ user-facing change?

  Yes. `InvalidPlanInput` exceptions now carry SQL state `56K00` and structured error conditions
  (`SPARK_CONNECT_INVALID_PLAN_INPUT.<SUBCLASS>`) instead of `INTERNAL_ERROR` / `XX000`.

  ### How was this patch tested?

  Updated `InvalidInputErrorsSuite` to assert new error conditions and `getSqlState() == "56K00"`. All 5 tests pass.
  `IllegalStateErrorsSuite` (17 tests) unchanged and passing.

  ### Was this patch authored or co-authored using generative AI tooling?

  Generated-by: Claude Sonnet 4.6