### PR TITLE
[SPARK-55860][SQL] Use `UNABLE_TO_INFER_SCHEMA` instead of `UNABLE_TO_INFER_SCHEMA_FOR_DATA_SOURCE`

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -6562,12 +6562,6 @@
     ],
     "sqlState" : "42KD9"
   },
-  "UNABLE_TO_INFER_SCHEMA_FOR_DATA_SOURCE" : {
-    "message" : [
-      "Unable to infer schema for <format> at <fileCatalog>. It must be specified manually."
-    ],
-    "sqlState" : "42KD9"
-  },
   "UNBOUND_SQL_PARAMETER" : {
     "message" : [
       "Found the unbound parameter: <name>. Please, fix `args` and provide a mapping of the parameter to either a SQL literal or collection constructor functions such as `map()`, `array()`, `struct()`."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1770,14 +1770,6 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
         "actualSchema" -> actualSchema.toDDL))
   }
 
-  def dataSchemaNotSpecifiedError(format: String, fileCatalog: String): Throwable = {
-    new AnalysisException(
-      errorClass = "UNABLE_TO_INFER_SCHEMA_FOR_DATA_SOURCE",
-      messageParameters = Map(
-        "format" -> format,
-        "fileCatalog" -> fileCatalog))
-  }
-
   def invalidDataSourceError(className: String): Throwable = {
     new AnalysisException(
       errorClass = "_LEGACY_ERROR_TEMP_1135",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -403,8 +403,7 @@ case class DataSource(
             caseInsensitiveOptions - "path",
             fileCatalog.allFiles())
         }.getOrElse {
-          throw QueryCompilationErrors.dataSchemaNotSpecifiedError(
-            format.toString, fileCatalog.allFiles().mkString(","))
+          throw QueryCompilationErrors.dataSchemaNotSpecifiedError(format.toString)
         }
 
         HadoopFsRelation(

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -1113,7 +1113,7 @@ class QueryCompilationErrorsSuite
     )
   }
 
-  test("UNABLE_TO_INFER_SCHEMA_FOR_DATA_SOURCE: empty data source at path") {
+  test("UNABLE_TO_INFER_SCHEMA: empty data source at path") {
     withTempDir { dir =>
       // Create _spark_metadata with a valid empty log entry (version header only, no files)
       val metadataDir = new java.io.File(dir, "_spark_metadata")
@@ -1125,10 +1125,8 @@ class QueryCompilationErrorsSuite
         exception = intercept[AnalysisException] {
           spark.read.format("json").load(dir.getCanonicalPath).collect()
         },
-        condition = "UNABLE_TO_INFER_SCHEMA_FOR_DATA_SOURCE",
-        parameters = Map(
-          "format" -> "JSON",
-          "fileCatalog" -> "")
+        condition = "UNABLE_TO_INFER_SCHEMA",
+        parameters = Map("format" -> "JSON")
       )
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
I propose to use `UNABLE_TO_INFER_SCHEMA` instead of `UNABLE_TO_INFER_SCHEMA_FOR_DATA_SOURCE`. This is because both error messages are used in the same context, and even though `UNABLE_TO_INFER_SCHEMA_FOR_DATA_SOURCE` is more descriptive, we can't go the other way around and use that error class because `UNABLE_TO_INFER_SCHEMA` was introduced long ago, and removing it would be a behavior change. `UNABLE_TO_INFER_SCHEMA_FOR_DATA_SOURCE` was added recently to remove the legacy error.


### Why are the changes needed?
More consistent error messaging.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
