### PR TITLE
[SPARK-55868][SQL][Tests] Fix Predicate Pushdown for InMemoryTable for V2Filters

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithV2Filter.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithV2Filter.scala
@@ -155,10 +155,10 @@ object InMemoryTableWithV2Filter {
           } else {
             value == attrVal
           }
-        case p: Predicate if p.name().equals("IS NULL") =>
+        case p: Predicate if p.name().equals("IS_NULL") =>
           val attr = p.children()(0).toString
           null == InMemoryBaseTable.extractValue(attr, partitionNames, partValues)
-        case p: Predicate if p.name().equals("IS NOT NULL") =>
+        case p: Predicate if p.name().equals("IS_NOT_NULL") =>
           val attr = p.children()(0).toString
           null != InMemoryBaseTable.extractValue(attr, partitionNames, partValues)
         case p: Predicate if p.name().equals("ALWAYS_TRUE") => true
@@ -172,8 +172,8 @@ object InMemoryTableWithV2Filter {
     predicates.flatMap(splitAnd).forall {
       case p: Predicate if p.name().equals("=") => true
       case p: Predicate if p.name().equals("<=>") => true
-      case p: Predicate if p.name().equals("IS NULL") => true
-      case p: Predicate if p.name().equals("IS NOT NULL") => true
+      case p: Predicate if p.name().equals("IS_NULL") => true
+      case p: Predicate if p.name().equals("IS_NOT_NULL") => true
       case p: Predicate if p.name().equals("ALWAYS_TRUE") => true
       case _ => false
     }


### PR DESCRIPTION

### What changes were proposed in this pull request?
Fix some Predicate (ie V2 Filter) name match in the filter pushdown code (for the test table supporting V2Filter of InMemoryDataSource for DSV2)

### Why are the changes needed?
These Predicate names are not matching, and no filters are accepted by this test table.  This was found in https://github.com/apache/spark/pull/54459

### Does this PR introduce _any_ user-facing change?
No, tests only


### How was this patch tested?
Running affect tests


### Was this patch authored or co-authored using generative AI tooling?
Yes, cursor