### PR TITLE
[SPARK-48942][SQL][TESTS] Add regression tests for Array of Structs with UDT fields in Parquet

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
@@ -867,6 +867,32 @@ abstract class ParquetQuerySuite extends QueryTest with ParquetTest with SharedS
     }
   }
 
+  test("SPARK-48942: Array of Structs with UDT fields in Parquet") {
+    val schema = StructType(
+      StructField("arr", ArrayType(
+        StructType(Seq(
+          StructField("col1", new TestPrimitiveUDT())
+        ))
+      )) :: Nil)
+
+    withTempPath { dir =>
+      val rows = sparkContext.parallelize(0 until 2).map { i =>
+        Row(Seq(Row(TestPrimitive(i + 1))))
+      }
+      val df = spark.createDataFrame(rows, schema)
+      df.write.parquet(dir.getCanonicalPath)
+
+      for (offHeapEnabled <- Seq(true, false)) {
+        withSQLConf(SQLConf.COLUMN_VECTOR_OFFHEAP_ENABLED.key -> offHeapEnabled.toString) {
+          withAllParquetReaders {
+            val res = spark.read.parquet(dir.getCanonicalPath)
+            checkAnswer(res, df)
+          }
+        }
+      }
+    }
+  }
+
   test("expand UDT in StructType") {
     val schema = new StructType().add("n", new TestNestedStructUDT, nullable = true)
     val expected = new StructType().add("n", new TestNestedStructUDT().sqlType, nullable = true)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnVectorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnVectorSuite.scala
@@ -988,6 +988,12 @@ class ColumnVectorSuite extends SparkFunSuite with SQLHelper {
     assert(testVector.dataType() === StructType(Seq(StructField("year", IntegerType))))
   }
 
+  testVectors("user defined type in array of struct type",
+    10, ArrayType(StructType(Seq(StructField("year", yearUDT))))) { testVector =>
+    assert(testVector.dataType() ===
+      ArrayType(StructType(Seq(StructField("year", IntegerType)))))
+  }
+
   testVectors("SPARK-53434: ColumnarRow.get() should handle null", 1, structType) { testVector =>
     val c1 = testVector.getChild(0)
     val c2 = testVector.getChild(1)


### PR DESCRIPTION
### What changes were proposed in this pull request?
No functional changes. The bug was fixed in SPARK-52651, but no regression test covered the exact scenario from the original report (SPARK-48942). These tests ensure the fix continues to work for the ArrayType(StructType(UDT field)) nesting pattern.


### Why are the changes needed?
These tests ensure the fix continues to work for the ArrayType(StructType(UDT field)) nesting pattern.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
ran the new unit tests


### Was this patch authored or co-authored using generative AI tooling?
Generated By: Claude Opus 4.6