### PR TITLE
[MINOR][CORE][SQL][YARN] Fix various typo errors in comments

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -81,7 +81,7 @@ private[v2] trait V2JDBCTest
     // nullable is true in the expectedSchema because Spark always sets nullable to true
     // regardless of the JDBC metadata https://github.com/apache/spark/pull/18445
     var expectedSchema = new StructType().add("ID", StringType, true, defaultMetadata())
-    // If function is not overriden we don't want to compare external engine types
+    // If function is not overridden we don't want to compare external engine types
     var expectedSchemaWithoutJdbcClientType =
       removeMetadataFromAllFields(expectedSchema, "jdbcClientType")
     var schemaWithoutJdbcClientType =
@@ -91,7 +91,7 @@ private[v2] trait V2JDBCTest
     t = spark.table(s"$catalogName.alt_table")
     expectedSchema = new StructType().add("ID", StringType, true, defaultMetadata())
 
-    // If function is not overriden we don't want to compare external engine types
+    // If function is not overridden we don't want to compare external engine types
     expectedSchemaWithoutJdbcClientType =
       removeMetadataFromAllFields(expectedSchema, "jdbcClientType")
     schemaWithoutJdbcClientType =
@@ -118,7 +118,7 @@ private[v2] trait V2JDBCTest
       .add("ID1", StringType, true, defaultMetadata())
       .add("ID2", StringType, true, defaultMetadata())
 
-    // If function is not overriden we don't want to compare external engine types
+    // If function is not overridden we don't want to compare external engine types
     val expectedSchemaWithoutJdbcClientType =
       removeMetadataFromAllFields(expectedSchema, "jdbcClientType")
     val schemaWithoutJdbcClientType =

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -1486,7 +1486,7 @@ private[scheduler] case class BarrierPendingLaunchTask(
     taskLocality: TaskLocality.TaskLocality,
     assignedResources: Map[String, Map[String, Long]]) {
   // Stored the corresponding index of the WorkerOffer which is responsible to launch the task.
-  // Used to revert the assigned resources (e.g., cores, custome resources) when the barrier
+  // Used to revert the assigned resources (e.g., cores, custom resources) when the barrier
   // task set doesn't launch successfully in a single resourceOffers round.
   var assignedOfferIndex: Int = _
   var assignedCores: Int = 0

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -855,7 +855,7 @@ private[spark] class Client(
    * The archive also contains some Spark configuration. Namely, it saves the contents of
    * SparkConf in a file to be loaded by the AM process.
    *
-   * @param confsToOverride configs that should overriden when creating the final spark conf file
+   * @param confsToOverride configs that should be overridden when creating the final spark conf file
    */
   private def createConfArchive(confsToOverride: Map[String, String]): File = {
     val hadoopConfFiles = new HashMap[String, File]()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/streaming/WriteToStreamStatement.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/streaming/WriteToStreamStatement.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableCatalog}
 import org.apache.spark.sql.streaming.{OutputMode, Trigger}
 
 /**
- * A statement for Stream writing. It contains all neccessary param and will be resolved in the
+ * A statement for Stream writing. It contains all necessary param and will be resolved in the
  * rule [[ResolveStreamWrite]].
  *
  * @param userSpecifiedName  Query name optionally specified by the user.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -3043,7 +3043,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
     val threadId = threadInfo.get.threadRef.get.get.getId
     assert(
       threadId == Thread.currentThread().getId,
-      s"acquired thread should be curent thread ${Thread.currentThread().getId} " +
+      s"acquired thread should be current thread ${Thread.currentThread().getId} " +
         s"after load but was $threadId")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -2209,7 +2209,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
       version = store.commit()
     }
 
-    // Reload the store from the commited version and repeat the above test.
+    // Reload the store from the committed version and repeat the above test.
     tryWithProviderResource(newStoreProvider(storeId, colFamiliesEnabled)) { provider =>
       assert(version > 0)
       val store = provider.getStore(version)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeSuite.scala
@@ -341,7 +341,7 @@ class StreamRealTimeModeWithManualClockSuite extends StreamRealTimeModeManualClo
   }
 
   test("purge offsetLog when it doesn't match with the commit log") {
-    // Simulate when the query fails after commiting the offset log but before the commit log
+    // Simulate when the query fails after committing the offset log but before the commit log
     // by manually deleting the last entry of the commit log.
     val inputData = LowLatencyMemoryStream[Int](1)
     val mapped = inputData.toDS().map(_ + 1)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix several typo errors found in code comments across multiple modules:

| File | Before | After |
|------|--------|-------|
| `WriteToStreamStatement.scala` | `neccessary` | `necessary` |
| `Client.scala` | `overriden` | `overridden` |
| `V2JDBCTest.scala` | `overriden` | `overridden` |
| `TaskSetManager.scala` | `custome` | `custom` |
| `StreamRealTimeModeSuite.scala` | `commiting` | `committing` |
| `RocksDBStateStoreSuite.scala` | `curent` | `current` |
| `StateStoreSuite.scala` | `commited` | `committed` |

### Why are the changes needed?

Typos in code comments can mislead contributors who are unfamiliar with the codebase. Fixing them improves readability and maintains documentation consistency.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only change in code comments.

### How was this patch tested?

No functional changes were made; only comment text was corrected. Existing tests continue to pass.

### Was this patch authored or co-authored using generative AI tooling?

No.

Closes #54674