### PR TITLE
[SPARK-55882][SQL] Rename `_LEGACY_ERROR_TEMP_1048` to `INVALID_COALESCE_HINT_PARAMETER`

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2776,6 +2776,12 @@
     },
     "sqlState" : "42K04"
   },
+  "INVALID_COALESCE_HINT_PARAMETER" : {
+    "message" : [
+      "<hintName> Hint expects a partition number as a parameter."
+    ],
+    "sqlState" : "42601"
+  },
   "INVALID_COLUMN_NAME_AS_PATH" : {
     "message" : [
       "The datasource <datasource> cannot save the column <columnName> because its name contains some characters that are not allowed in file paths. Please, use an alias to rename it."
@@ -8166,11 +8172,6 @@
   "_LEGACY_ERROR_TEMP_1047" : {
     "message" : [
       "<hintName> Hint parameters should include an optional integral partitionNum and/or columns, but <invalidParams> can not be recognized as either partitionNum or columns."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1048" : {
-    "message" : [
-      "<hintName> Hint expects a partition number as a parameter."
     ]
   },
   "_LEGACY_ERROR_TEMP_1050" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1021,7 +1021,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def invalidCoalesceHintParameterError(hintName: String): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1048",
+      errorClass = "INVALID_COALESCE_HINT_PARAMETER",
       messageParameters = Map("hintName" -> hintName))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
@@ -151,17 +151,27 @@ class ResolveHintsSuite extends AnalysisTest {
       UnresolvedHint("REPARTITION", Seq(Literal(100.toShort)), table("TaBlE")),
       Repartition(numPartitions = 100, shuffle = true, child = testRelation))
 
-    val errMsg = "COALESCE Hint expects a partition number as a parameter"
+    checkError(
+      exception = intercept[AnalysisException] {
+        getAnalyzer.execute(UnresolvedHint("COALESCE", Seq.empty, table("TaBlE")))
+      },
+      condition = "INVALID_COALESCE_HINT_PARAMETER",
+      parameters = Map("hintName" -> "COALESCE"))
 
-    assertAnalysisError(
-      UnresolvedHint("COALESCE", Seq.empty, table("TaBlE")),
-      Seq(errMsg))
-    assertAnalysisError(
-      UnresolvedHint("COALESCE", Seq(Literal(10), Literal(false)), table("TaBlE")),
-      Seq(errMsg))
-    assertAnalysisError(
-      UnresolvedHint("COALESCE", Seq(Literal(1.0)), table("TaBlE")),
-      Seq(errMsg))
+    checkError(
+      exception = intercept[AnalysisException] {
+        getAnalyzer.execute(
+          UnresolvedHint("COALESCE", Seq(Literal(10), Literal(false)), table("TaBlE")))
+      },
+      condition = "INVALID_COALESCE_HINT_PARAMETER",
+      parameters = Map("hintName" -> "COALESCE"))
+
+    checkError(
+      exception = intercept[AnalysisException] {
+        getAnalyzer.execute(UnresolvedHint("COALESCE", Seq(Literal(1.0)), table("TaBlE")))
+      },
+      condition = "INVALID_COALESCE_HINT_PARAMETER",
+      parameters = Map("hintName" -> "COALESCE"))
 
     checkAnalysisWithoutViewWrapper(
       UnresolvedHint("RePartition", Seq(Literal(10), UnresolvedAttribute("a")), table("TaBlE")),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Rename the legacy error class `_LEGACY_ERROR_TEMP_1048` to `INVALID_COALESCE_HINT_PARAMETER` and add SQL state `42601`.

This error is thrown when a COALESCE or REPARTITION hint is used with invalid parameters (missing, wrong type, or too many).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Proper error messaging.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. The error class name changes from `_LEGACY_ERROR_TEMP_1048` to `INVALID_COALESCE_HINT_PARAMETER`, and the SQL state `42601` is now included. The error message text remains identical.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests in `ResolveHintsSuite` have been updated to use structured `checkError()` validation.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.