### PR TITLE
[SPARK-54680][SQL] Rename TABLESAMPLE-related legacy error conditions to descriptive names

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3077,6 +3077,12 @@
     ],
     "sqlState" : "58030"
   },
+  "INVALID_BYTE_LENGTH_LITERAL" : {
+    "message" : [
+      "<bytesStr> is not a valid byte length literal, expected syntax: DIGIT+ ('B' | 'K' | 'M' | 'G')."
+    ],
+    "sqlState" : "42604"
+  },
   "INVALID_BYTE_STRING" : {
     "message" : [
       "The expected format is ByteString, but was <unsupported> (<class>)."
@@ -6730,6 +6736,12 @@
     ],
     "sqlState" : "54023"
   },
+  "TABLESAMPLE_EMPTY_INPUT" : {
+    "message" : [
+      "TABLESAMPLE does not accept empty inputs."
+    ],
+    "sqlState" : "42601"
+  },
   "TASK_WRITE_FAILED" : {
     "message" : [
       "Task failed while writing rows to <path>."
@@ -8006,6 +8018,12 @@
     },
     "sqlState" : "0A000"
   },
+  "UNSUPPORTED_TABLESAMPLE_METHOD" : {
+    "message" : [
+      "TABLESAMPLE(<msg>) is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
   "UNSUPPORTED_TABLE_CHANGE_IN_JDBC_CATALOG" : {
     "message" : [
       "The table change <change> is not supported for the JDBC catalog on table <tableName>. Supported changes include: AddColumn, RenameColumn, DeleteColumn, UpdateColumnType, UpdateColumnNullability."
@@ -8276,21 +8294,6 @@
   "_LEGACY_ERROR_TEMP_0012" : {
     "message" : [
       "DISTRIBUTE BY is not supported."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_0014" : {
-    "message" : [
-      "TABLESAMPLE does not accept empty inputs."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_0015" : {
-    "message" : [
-      "TABLESAMPLE(<msg>) is not supported."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_0016" : {
-    "message" : [
-      "<bytesStr> is not a valid byte length literal, expected syntax: DIGIT+ ('B' | 'K' | 'M' | 'G')."
     ]
   },
   "_LEGACY_ERROR_TEMP_0018" : {

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -209,19 +209,19 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
   }
 
   def emptyInputForTableSampleError(ctx: ParserRuleContext): Throwable = {
-    new ParseException(errorClass = "_LEGACY_ERROR_TEMP_0014", ctx)
+    new ParseException(errorClass = "TABLESAMPLE_EMPTY_INPUT", ctx)
   }
 
   def tableSampleByBytesUnsupportedError(msg: String, ctx: SampleMethodContext): Throwable = {
     new ParseException(
-      errorClass = "_LEGACY_ERROR_TEMP_0015",
+      errorClass = "UNSUPPORTED_TABLESAMPLE_METHOD",
       messageParameters = Map("msg" -> msg),
       ctx)
   }
 
   def invalidByteLengthLiteralError(bytesStr: String, ctx: SampleByBytesContext): Throwable = {
     new ParseException(
-      errorClass = "_LEGACY_ERROR_TEMP_0016",
+      errorClass = "INVALID_BYTE_LENGTH_LITERAL",
       messageParameters = Map("bytesStr" -> bytesStr),
       ctx)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -827,7 +827,7 @@ class PlanParserSuite extends AnalysisTest {
     val fragment1 = "tablesample(bucket 4 out of 10 on x)"
     checkError(
       exception = parseException(sql1),
-      condition = "_LEGACY_ERROR_TEMP_0015",
+      condition = "UNSUPPORTED_TABLESAMPLE_METHOD",
       parameters = Map("msg" -> "BUCKET x OUT OF y ON colname"),
       context = ExpectedContext(
         fragment = fragment1,
@@ -849,7 +849,7 @@ class PlanParserSuite extends AnalysisTest {
     val fragment3 = "TABLESAMPLE(300M)"
     checkError(
       exception = parseException(sql3),
-      condition = "_LEGACY_ERROR_TEMP_0015",
+      condition = "UNSUPPORTED_TABLESAMPLE_METHOD",
       parameters = Map("msg" -> "byteLengthLiteral"),
       context = ExpectedContext(
         fragment = fragment3,
@@ -860,7 +860,7 @@ class PlanParserSuite extends AnalysisTest {
     val fragment4 = "TABLESAMPLE(BUCKET 3 OUT OF 32 ON rand())"
     checkError(
       exception = parseException(sql4),
-      condition = "_LEGACY_ERROR_TEMP_0015",
+      condition = "UNSUPPORTED_TABLESAMPLE_METHOD",
       parameters = Map("msg" -> "BUCKET x OUT OF y ON function"),
       context = ExpectedContext(
         fragment = fragment4,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename the following legacy error conditions in the SQL parser to proper descriptive names and add SQL states:

| Legacy Name | New Name | sqlState | Description |
|---|---|---|---|
| `_LEGACY_ERROR_TEMP_0014` | `TABLESAMPLE_EMPTY_INPUT` | `42601` | TABLESAMPLE clause with empty inputs |
| `_LEGACY_ERROR_TEMP_0015` | `UNSUPPORTED_TABLESAMPLE_METHOD` | `0A000` | Unsupported TABLESAMPLE method (e.g., BUCKET x OUT OF y ON colname) |
| `_LEGACY_ERROR_TEMP_0016` | `INVALID_BYTE_LENGTH_LITERAL` | `42604` | Invalid byte length literal in TABLESAMPLE |

### Why are the changes needed?

This is part of the ongoing effort to replace legacy temporary error condition names with proper, descriptive names (tracked across SPARK-55822, SPARK-55823, SPARK-55824, SPARK-55825, SPARK-55826, etc.). Proper error condition names improve error readability and debugging experience for users.

SQL states are assigned following the existing conventions:
- `42601` - Syntax error (invalid syntax usage)
- `0A000` - Feature not supported
- `42604` - Invalid literal value

### Does this PR introduce _any_ user-facing change?

Yes. The error class names change from temporary legacy names to descriptive names, and SQL states are now included in the error responses. The error messages themselves remain unchanged.

### How was this patch tested?

Existing unit tests in `PlanParserSuite` updated to reference the new error condition names. All 3 test cases for `_LEGACY_ERROR_TEMP_0015` (`UNSUPPORTED_TABLESAMPLE_METHOD`) are updated.

### Was this patch authored or co-authored using generative AI tooling?

No

Closes #54680