### PR TITLE
Revert "[SPARK-54285][PYTHON] Cache timezone info to avoid expensive timestamp conversion"

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -443,12 +443,6 @@ class TimeType(AnyTimeType):
 class TimestampType(DatetimeType, metaclass=DataTypeSingleton):
     """Timestamp (datetime.datetime) data type."""
 
-    # We need to cache the timezone info for datetime.datetime.fromtimestamp
-    # otherwise the forked process will be extremely slow to convert the timestamp.
-    # This is probably a glibc issue - the forked process will have a bad cache/lock
-    # status for the timezone info.
-    tz_info = None
-
     def needConversion(self) -> bool:
         return True
 
@@ -462,12 +456,7 @@ class TimestampType(DatetimeType, metaclass=DataTypeSingleton):
     def fromInternal(self, ts: int) -> datetime.datetime:
         if ts is not None:
             # using int to avoid precision loss in float
-            # If TimestampType.tz_info is not None, we need to use it to convert the timestamp.
-            # Otherwise, we need to use the default timezone.
-            # We need to replace the tzinfo to None to keep backward compatibility
-            return datetime.datetime.fromtimestamp(ts // 1000000, self.tz_info).replace(
-                microsecond=ts % 1000000, tzinfo=None
-            )
+            return datetime.datetime.fromtimestamp(ts // 1000000).replace(microsecond=ts % 1000000)
 
 
 class TimestampNTZType(DatetimeType, metaclass=DataTypeSingleton):

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -18,7 +18,7 @@
 """
 Worker that receives input from Piped RDD.
 """
-import datetime
+import itertools
 import os
 import sys
 import dataclasses
@@ -73,7 +73,7 @@ from pyspark.sql.pandas.serializers import (
     ArrowStreamUDTFSerializer,
     ArrowStreamArrowUDTFSerializer,
 )
-from pyspark.sql.pandas.types import to_arrow_type, TimestampType
+from pyspark.sql.pandas.types import to_arrow_type
 from pyspark.sql.types import (
     ArrayType,
     BinaryType,
@@ -3392,11 +3392,6 @@ def main(infile, outfile):
         if split_index == -1:  # for unit tests
             sys.exit(-1)
         start_faulthandler_periodic_traceback()
-
-        # Use the local timezone to convert the timestamp
-        tz = datetime.datetime.now().astimezone().tzinfo
-        TimestampType.tz_info = tz
-
         check_python_version(infile)
 
         memory_limit_mb = int(os.environ.get("PYSPARK_EXECUTOR_MEMORY_MB", "-1"))

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -18,7 +18,6 @@
 """
 Worker that receives input from Piped RDD.
 """
-import itertools
 import os
 import sys
 import dataclasses


### PR DESCRIPTION

### What changes were proposed in this pull request?
revert https://github.com/apache/spark/pull/52980


### Why are the changes needed?
after winter->summer time swift, the test for timestampe coercion for vanilla python udf `pyspark.sql.tests.coercion.test_python_udf_input_type` starts [failing](https://github.com/apache/spark/actions/runs/22837174577/job/66235976642), it seems the datetime was added 1 additional hour after udf execution.

I found the suspicious commit is the [cached timezone](https://github.com/apache/spark/commit/5fb072e4f25f471e69e2b81ee0155cc24a20725a), the test passes after revert it.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
No
