### PR TITLE
[SPARK-55523][SQL] Fix inputMetrics.recordsRead to report rows instead of CachedBatches

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.columnar
 
+import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -167,11 +168,23 @@ case class InMemoryTableScanExec(
         if (enableAccumulatorsForTest && iter.hasNext) {
           readPartitions.add(1)
         }
+        val inputMetrics = TaskContext.get().taskMetrics().inputMetrics
+        var rowCount = 0L
+        // RDD.getOrCompute increments inputMetrics.recordsRead by 1 per CachedBatch on
+        // cache hit, counting batches instead of rows. Register a completion listener that
+        // corrects the final count to the actual number of rows once all batches in this
+        // partition have been consumed. The math works for both cache-hit and cache-miss:
+        // - cache hit:  getOrCompute added numBatches; we add (rowCount - numBatches)
+        // - cache miss: source scan already added rowCount; we add (rowCount - rowCount) = 0
+        TaskContext.get().addTaskCompletionListener[Unit] { _ =>
+          inputMetrics.incRecordsRead(rowCount - inputMetrics.recordsRead)
+        }
         iter.map { batch =>
           if (enableAccumulatorsForTest) {
             readBatches.add(1)
           }
           numOutputRows += batch.numRows
+          rowCount += batch.numRows
           batch
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
@@ -22,6 +22,7 @@ import java.sql.{Date, Timestamp}
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.spark.rdd.RDD
+import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskEnd}
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSet, In}
@@ -619,5 +620,30 @@ class InMemoryColumnarQuerySuite extends QueryTest
     cachedRDDBuilder.clearCache()
 
     assert(exceptionCnt.get == 0)
+  }
+
+  test("SPARK-55523: inputMetrics.recordsRead should count rows not CachedBatches") {
+    val numRows = 1000
+    val df = spark.range(numRows).toDF()
+    df.cache()
+    df.count() // materialize the cache
+
+    var totalRecordsRead = 0L
+    val listener = new SparkListener {
+      override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
+        totalRecordsRead += taskEnd.taskMetrics.inputMetrics.recordsRead
+      }
+    }
+    sparkContext.addSparkListener(listener)
+    try {
+      df.count() // read from cache
+      sparkContext.listenerBus.waitUntilEmpty(5000)
+    } finally {
+      sparkContext.removeSparkListener(listener)
+      df.unpersist()
+    }
+
+    assert(totalRecordsRead == numRows,
+      s"Expected inputMetrics.recordsRead=$numRows (actual rows), but got $totalRecordsRead")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`InMemoryTableScanExec.doExecute()` iterates over `CachedBatch` objects backed by `RDD.getOrCompute`, which increments `inputMetrics.recordsRead` by 1 per `CachedBatch` on a cache hit — counting batches instead of actual rows.

This fix registers a `TaskCompletionListener` inside `mapPartitionsInternal` that corrects the count once all batches in a partition are consumed:
- **Cache hit:** `getOrCompute` added `numBatches`; the listener adds `(rowCount - numBatches)` so the final value equals the actual row count.
- **Cache miss:** the source scan already incremented `recordsRead` by `rowCount`; the listener adds `(rowCount - rowCount) = 0`, leaving the value unchanged.

No changes to `RDD.scala`, so non-SQL RDD caching metrics are unaffected.

### Why are the changes needed?

Users and monitoring tools relying on `TaskMetrics.inputMetrics.recordsRead` (e.g. the Spark UI, external observability systems) see incorrect values when reading from a cached DataFrame. For example, 3,605 rows stored in a single `CachedBatch` would report `recordsRead = 1` instead of `3605`.

### Does this PR introduce _any_ user-facing change?

Yes — `inputMetrics.recordsRead` for queries reading from a cached DataFrame now reports the correct row count instead of the batch count.

### How was this patch tested?

Added a test in `InMemoryColumnarQuerySuite` that caches 1000 rows, materializes the cache, then reads from cache and asserts `inputMetrics.recordsRead == 1000` via a `SparkListener`.

### Notes

`doExecuteColumnar()` has the same underlying issue (batch-level counting via `getOrCompute`) and could be addressed as a follow-up.