### PR TITLE
[MINOR] Add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,9 @@ tpcds-sf-1/
 tpcds-sf-1-text/
 tpcds-kit/
 
+# For Claude Code
+/.claude/
+
 # For GitHub Copilot
 .github/copilot-instructions.md
 .github/agents/


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `/.claude/` to `.gitignore`.

### Why are the changes needed?

Claude Code stores its configuration and session data under `.claude/`. This should be ignored by git to avoid accidental commits of local AI tooling state.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A - `.gitignore` change only.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Sonnet 4.6