### PR TITLE
[SPARK-55888][K8S] Parallel pod creation for Kubernetes executor allocation

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -521,17 +521,27 @@ private[spark] object Config extends Logging {
       .checkValue(value => value > 100, "Allocation batch delay must be greater than 0.1s.")
       .createWithDefaultString("1s")
 
+  val KUBERNETES_ALLOCATION_PARALLEL_ENABLED =
+    ConfigBuilder("spark.kubernetes.allocation.batch.parallel.enabled")
+      .doc("When true, executor pods are created in parallel using a thread pool sized by " +
+        "spark.kubernetes.allocation.batch.concurrency. This can significantly speed up " +
+        "executor allocation when K8s API latency is high. " +
+        "When false (default), pods are created serially one by one.")
+      .version("4.2.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val KUBERNETES_ALLOCATION_BATCH_CONCURRENCY =
     ConfigBuilder("spark.kubernetes.allocation.batch.concurrency")
       .doc("Number of concurrent threads to use for creating executor pods in each round of " +
-        "allocation. Setting this to a value greater than 1 enables parallel pod creation, " +
-        "which can significantly speed up executor allocation when K8s API latency is high. " +
-        "Setting this to 1 preserves the original serial behavior.")
+        "allocation. Only takes effect when " +
+        "spark.kubernetes.allocation.batch.parallel.enabled is true. " +
+        "A moderate value like 3-5 is recommended.")
       .version("4.2.0")
       .intConf
       .checkValue(value => value > 0,
         "Allocation batch concurrency should be a positive integer")
-      .createWithDefault(1)
+      .createWithDefault(5)
 
   val KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED =
     ConfigBuilder("spark.kubernetes.allocation.recoveryMode.enabled")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -521,6 +521,18 @@ private[spark] object Config extends Logging {
       .checkValue(value => value > 100, "Allocation batch delay must be greater than 0.1s.")
       .createWithDefaultString("1s")
 
+  val KUBERNETES_ALLOCATION_BATCH_CONCURRENCY =
+    ConfigBuilder("spark.kubernetes.allocation.batch.concurrency")
+      .doc("Number of concurrent threads to use for creating executor pods in each round of " +
+        "allocation. Setting this to a value greater than 1 enables parallel pod creation, " +
+        "which can significantly speed up executor allocation when K8s API latency is high. " +
+        "Setting this to 1 preserves the original serial behavior.")
+      .version("4.2.0")
+      .intConf
+      .checkValue(value => value > 0,
+        "Allocation batch concurrency should be a positive integer")
+      .createWithDefault(1)
+
   val KUBERNETES_ALLOCATION_RECOVERY_MODE_ENABLED =
     ConfigBuilder("spark.kubernetes.allocation.recoveryMode.enabled")
       .doc("When Spark driver detects an executor termination due to OOM, Spark starts to " +

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -542,6 +542,7 @@ class ExecutorPodsAllocator(
         .create())
     } catch {
       case NonFatal(e) =>
+        // Register failure with global tracker if lifecycle manager is available
         val failureCount = registerPodCreationFailure()
         logError(log"Failed to create executor pod ${MDC(LogKeys.EXECUTOR_ID, newExecutorId)}. " +
           log"Total failures: ${MDC(LogKeys.TOTAL, failureCount)}", e)
@@ -572,6 +573,7 @@ class ExecutorPodsAllocator(
         Some(newExecutorId)
       } catch {
         case NonFatal(e) =>
+          // Register failure with global tracker if lifecycle manager is available
           val failureCount = registerPodCreationFailure()
           logError(log"Failed to add owner reference or create PVC for executor pod " +
             log"${MDC(LogKeys.EXECUTOR_ID, newExecutorId)}. " +
@@ -647,26 +649,32 @@ class ExecutorPodsAllocator(
 
     implicit val ec: ExecutionContext = podCreationExecutionContext
 
-    val futures = podSpecs.flatMap { case (newExecutorId, podWithAttachedContainer, resources) =>
-      try {
-        Some(Future {
-          try {
-            val result =
+    var threadPoolShutdown = false
+    val futures = podSpecs.iterator.takeWhile(_ => !threadPoolShutdown).flatMap {
+      case (newExecutorId, podWithAttachedContainer, resources) =>
+        try {
+          Some(Future {
+            // createExecutorPodAndPVCs already logs the error and registers the failure
+            // before rethrowing. We catch here only to prevent a single pod failure
+            // from affecting other concurrent pods.
+            try {
               createExecutorPodAndPVCs(newExecutorId, podWithAttachedContainer, resources)
-            result.map(execId => (execId, resourceProfileId, clock.getTimeMillis()))
-          } catch {
-            case NonFatal(_) => None
-          }
-        })
-      } catch {
-        // If the thread pool has been shut down (e.g., stop() was called while
-        // onNewSnapshots is still running), skip remaining pods gracefully.
-        case _: java.util.concurrent.RejectedExecutionException =>
-          logWarning(log"Thread pool shut down, skipping pod creation for executor " +
-            log"${MDC(LogKeys.EXECUTOR_ID, newExecutorId)}.")
-          None
-      }
-    }
+                .map(execId => (execId, resourceProfileId, clock.getTimeMillis()))
+            } catch {
+              case NonFatal(_) => None
+            }
+          })
+        } catch {
+          // If the thread pool has been shut down (e.g., stop() was called while
+          // onNewSnapshots is still running), stop submitting remaining pods immediately.
+          case _: java.util.concurrent.RejectedExecutionException =>
+            logWarning(log"Thread pool shut down, skipping pod creation for executor " +
+              log"${MDC(LogKeys.EXECUTOR_ID, newExecutorId)}" +
+              log" and all remaining executors.")
+            threadPoolShutdown = true
+            None
+        }
+    }.toSeq
 
     val perPodTimeout = Duration(podCreationTimeout, TimeUnit.MILLISECONDS)
     val results = futures.flatMap { future =>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -21,6 +21,8 @@ import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.Duration
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
@@ -36,7 +38,7 @@ import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.internal.config._
 import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.scheduler.cluster.SchedulerBackendUtils.DEFAULT_NUMBER_EXECUTORS
-import org.apache.spark.util.{Clock, Utils}
+import org.apache.spark.util.{Clock, ThreadUtils, Utils}
 
 class ExecutorPodsAllocator(
     conf: SparkConf,
@@ -68,6 +70,14 @@ class ExecutorPodsAllocator(
   protected val podAllocationSize = conf.get(KUBERNETES_ALLOCATION_BATCH_SIZE)
 
   protected val podAllocationDelay = conf.get(KUBERNETES_ALLOCATION_BATCH_DELAY)
+
+  protected val podAllocationConcurrency = conf.get(KUBERNETES_ALLOCATION_BATCH_CONCURRENCY)
+
+  // Thread pool for parallel pod creation, only created when concurrency > 1
+  protected lazy val podCreationThreadPool =
+    ThreadUtils.newDaemonFixedThreadPool(podAllocationConcurrency, "k8s-pod-creator")
+  protected lazy val podCreationExecutionContext: ExecutionContext =
+    ExecutionContext.fromExecutorService(podCreationThreadPool)
 
   protected val podAllocationMaximum = conf.get(KUBERNETES_ALLOCATION_MAXIMUM)
 
@@ -471,6 +481,116 @@ class ExecutorPodsAllocator(
       applicationId: String,
       resourceProfileId: Int,
       pvcsInUse: Set[String]): Unit = {
+    if (podAllocationConcurrency > 1) {
+      requestNewExecutorsParallel(numExecutorsToAllocate, applicationId,
+        resourceProfileId, pvcsInUse)
+    } else {
+      requestNewExecutorsSerial(numExecutorsToAllocate, applicationId,
+        resourceProfileId, pvcsInUse)
+    }
+  }
+
+  /**
+   * Builds a single executor pod spec, incrementing the executor ID counter.
+   * This is shared by both serial and parallel pod creation paths.
+   *
+   * @return (executorId, pod, associatedResources)
+   */
+  private def buildExecutorPod(
+      applicationId: String,
+      resourceProfileId: Int,
+      reusablePVCs: mutable.Buffer[PersistentVolumeClaim]): (Long, Pod, Seq[HasMetadata]) = {
+    val newExecutorId = EXECUTOR_ID_COUNTER.incrementAndGet()
+    if (newExecutorId >= podAllocationMaximum) {
+      throw new SparkException(s"Exceed the pod creation limit: $podAllocationMaximum")
+    }
+    val executorConf = KubernetesConf.createExecutorConf(
+      conf,
+      newExecutorId.toString,
+      applicationId,
+      driverPod,
+      resourceProfileId)
+    val resolvedExecutorSpec = executorBuilder.buildFromFeatures(executorConf, secMgr,
+      kubernetesClient, rpIdToResourceProfile(resourceProfileId))
+    val executorPod = resolvedExecutorSpec.pod
+    val podWithAttachedContainer = new PodBuilder(executorPod.pod)
+      .editOrNewSpec()
+      .addToContainers(executorPod.container)
+      .endSpec()
+      .build()
+    val resources = replacePVCsIfNeeded(
+      podWithAttachedContainer, resolvedExecutorSpec.executorKubernetesResources, reusablePVCs)
+    (newExecutorId, podWithAttachedContainer, resources)
+  }
+
+  /**
+   * Creates the executor pod via K8s API and sets up owner references and PVCs.
+   * Returns the executor ID on success. Throws on PVC creation failure after cleanup.
+   * Pod creation failures are caught internally and return None.
+   */
+  private def createExecutorPodAndPVCs(
+      newExecutorId: Long,
+      podWithAttachedContainer: Pod,
+      resources: Seq[HasMetadata]): Option[Long] = {
+    val optCreatedExecutorPod = try {
+      Some(kubernetesClient
+        .pods()
+        .inNamespace(namespace)
+        .resource(podWithAttachedContainer)
+        .create())
+    } catch {
+      case NonFatal(e) =>
+        val failureCount = registerPodCreationFailure()
+        logError(log"Failed to create executor pod ${MDC(LogKeys.EXECUTOR_ID, newExecutorId)}. " +
+          log"Total failures: ${MDC(LogKeys.TOTAL, failureCount)}", e)
+        None
+    }
+
+    optCreatedExecutorPod.flatMap { createdExecutorPod =>
+      try {
+        addOwnerReference(createdExecutorPod, resources)
+        resources
+          .filter(_.getKind == "PersistentVolumeClaim")
+          .foreach { resource =>
+            if (conf.get(KUBERNETES_DRIVER_OWN_PVC) && driverPod.nonEmpty) {
+              addOwnerReference(driverPod.get, Seq(resource))
+            }
+            val pvc = resource.asInstanceOf[PersistentVolumeClaim]
+            logInfo(log"Trying to create PersistentVolumeClaim " +
+              log"${MDC(LogKeys.PVC_METADATA_NAME, pvc.getMetadata.getName)} with " +
+              log"StorageClass ${MDC(LogKeys.CLASS_NAME, pvc.getSpec.getStorageClassName)}")
+            kubernetesClient
+              .persistentVolumeClaims()
+              .inNamespace(namespace)
+              .resource(pvc)
+              .create()
+            PVC_COUNTER.incrementAndGet()
+          }
+        logDebug(s"Requested executor with id $newExecutorId from Kubernetes.")
+        Some(newExecutorId)
+      } catch {
+        case NonFatal(e) =>
+          val failureCount = registerPodCreationFailure()
+          logError(log"Failed to add owner reference or create PVC for executor pod " +
+            log"${MDC(LogKeys.EXECUTOR_ID, newExecutorId)}. " +
+            log"Total failures: ${MDC(LogKeys.TOTAL, failureCount)}", e)
+          kubernetesClient.pods()
+            .inNamespace(namespace)
+            .resource(createdExecutorPod)
+            .delete()
+          throw e
+      }
+    }
+  }
+
+  /**
+   * Serial pod creation: builds and creates executor pods one at a time.
+   */
+  private def requestNewExecutorsSerial(
+      numExecutorsToAllocate: Int,
+      applicationId: String,
+      resourceProfileId: Int,
+      pvcsInUse: Set[String]): Unit = {
     // Check reusable PVCs for this executor allocation batch
     val reusablePVCs = getReusablePVCs(applicationId, pvcsInUse)
     for ( _ <- 0 until numExecutorsToAllocate) {
@@ -479,77 +599,94 @@ class ExecutorPodsAllocator(
           log"Wait to reuse one of the existing ${MDC(LogKeys.COUNT, PVC_COUNTER.get())} PVCs.")
         return
       }
-      val newExecutorId = EXECUTOR_ID_COUNTER.incrementAndGet()
-      if (newExecutorId >= podAllocationMaximum) {
-        throw new SparkException(s"Exceed the pod creation limit: $podAllocationMaximum")
+      val (newExecutorId, podWithAttachedContainer, resources) =
+        buildExecutorPod(applicationId, resourceProfileId, reusablePVCs)
+      createExecutorPodAndPVCs(newExecutorId, podWithAttachedContainer, resources).foreach { _ =>
+        newlyCreatedExecutors(newExecutorId) = (resourceProfileId, clock.getTimeMillis())
       }
-      val executorConf = KubernetesConf.createExecutorConf(
-        conf,
-        newExecutorId.toString,
-        applicationId,
-        driverPod,
-        resourceProfileId)
-      val resolvedExecutorSpec = executorBuilder.buildFromFeatures(executorConf, secMgr,
-        kubernetesClient, rpIdToResourceProfile(resourceProfileId))
-      val executorPod = resolvedExecutorSpec.pod
-      val podWithAttachedContainer = new PodBuilder(executorPod.pod)
-        .editOrNewSpec()
-        .addToContainers(executorPod.container)
-        .endSpec()
-        .build()
-      val resources = replacePVCsIfNeeded(
-        podWithAttachedContainer, resolvedExecutorSpec.executorKubernetesResources, reusablePVCs)
-      val optCreatedExecutorPod = try {
-        Some(kubernetesClient
-          .pods()
-          .inNamespace(namespace)
-          .resource(podWithAttachedContainer)
-          .create())
-      } catch {
-        case NonFatal(e) =>
-          // Register failure with global tracker if lifecycle manager is available
-          val failureCount = registerPodCreationFailure()
-          logError(log"Failed to create executor pod ${MDC(LogKeys.EXECUTOR_ID, newExecutorId)}. " +
-            log"Total failures: ${MDC(LogKeys.TOTAL, failureCount)}", e)
-          None
+    }
+  }
+
+  /**
+   * Parallel pod creation: builds pod specs serially (they depend on shared mutable state like
+   * EXECUTOR_ID_COUNTER and reusablePVCs), then creates them via K8s API in parallel using a
+   * thread pool sized by `spark.kubernetes.allocation.batch.concurrency`.
+   */
+  private def requestNewExecutorsParallel(
+      numExecutorsToAllocate: Int,
+      applicationId: String,
+      resourceProfileId: Int,
+      pvcsInUse: Set[String]): Unit = {
+    val batchStartTime = clock.getTimeMillis()
+
+    // Check reusable PVCs for this executor allocation batch
+    val reusablePVCs = getReusablePVCs(applicationId, pvcsInUse)
+
+    // Phase 1: Build all pod specs serially
+    val podSpecs = mutable.ArrayBuffer.empty[(Long, Pod, Seq[HasMetadata])]
+    var i = 0
+    while (i < numExecutorsToAllocate) {
+      if (reusablePVCs.isEmpty && podAllocOnPVC && maxPVCs <= PVC_COUNTER.get()) {
+        logInfo(
+          log"Wait to reuse one of the existing ${MDC(LogKeys.COUNT, PVC_COUNTER.get())} PVCs.")
+        // Stop building more specs; proceed to create whatever we've built so far
+        i = numExecutorsToAllocate
+      } else {
+        podSpecs += buildExecutorPod(applicationId, resourceProfileId, reusablePVCs)
+        i += 1
       }
-      optCreatedExecutorPod.foreach { createdExecutorPod =>
+    }
+    if (podSpecs.isEmpty) return
+
+    val podBuildTotalMs = clock.getTimeMillis() - batchStartTime
+
+    // Phase 2: Create pods via K8s API in parallel
+    val k8sApiStartTime = clock.getTimeMillis()
+
+    implicit val ec: ExecutionContext = podCreationExecutionContext
+
+    val futures = podSpecs.map { case (newExecutorId, podWithAttachedContainer, resources) =>
+      Future {
         try {
-          addOwnerReference(createdExecutorPod, resources)
-          resources
-            .filter(_.getKind == "PersistentVolumeClaim")
-            .foreach { resource =>
-              if (conf.get(KUBERNETES_DRIVER_OWN_PVC) && driverPod.nonEmpty) {
-                addOwnerReference(driverPod.get, Seq(resource))
-              }
-              val pvc = resource.asInstanceOf[PersistentVolumeClaim]
-              logInfo(log"Trying to create PersistentVolumeClaim " +
-                log"${MDC(LogKeys.PVC_METADATA_NAME, pvc.getMetadata.getName)} with " +
-                log"StorageClass ${MDC(LogKeys.CLASS_NAME, pvc.getSpec.getStorageClassName)}")
-              kubernetesClient
-                .persistentVolumeClaims()
-                .inNamespace(namespace)
-                .resource(pvc)
-                .create()
-              PVC_COUNTER.incrementAndGet()
-            }
-          newlyCreatedExecutors(newExecutorId) = (resourceProfileId, clock.getTimeMillis())
-          logDebug(s"Requested executor with id $newExecutorId from Kubernetes.")
+          val result = createExecutorPodAndPVCs(newExecutorId, podWithAttachedContainer, resources)
+          result.map(execId => (execId, resourceProfileId, clock.getTimeMillis()))
         } catch {
-          case NonFatal(e) =>
-            // Register failure with global tracker if lifecycle manager is available
-            val failureCount = registerPodCreationFailure()
-            logError(log"Failed to add owner reference or create PVC for executor pod " +
-              log"${MDC(LogKeys.EXECUTOR_ID, newExecutorId)}. " +
-              log"Total failures: ${MDC(LogKeys.TOTAL, failureCount)}", e)
-            kubernetesClient.pods()
-              .inNamespace(namespace)
-              .resource(createdExecutorPod)
-              .delete()
-            throw e
+          // createExecutorPodAndPVCs already logs the error and registers the failure
+          // before rethrowing. We catch here only to prevent a failed Future from
+          // short-circuiting Future.sequence, so that other concurrent pods can proceed.
+          case NonFatal(_) => None
         }
       }
     }
+
+    val results = try {
+      val allResults = ThreadUtils.awaitResult(
+        Future.sequence(futures), Duration(podCreationTimeout, TimeUnit.MILLISECONDS))
+      allResults.flatten
+    } catch {
+      case NonFatal(e) =>
+        logError(log"Timed out waiting for parallel pod creation to complete " +
+          log"after ${MDC(LogKeys.TIMEOUT, podCreationTimeout)} ms", e)
+        Seq.empty
+    }
+
+    // Phase 3: Register successful creations
+    results.foreach { case (execId, rpId, timestamp) =>
+      newlyCreatedExecutors(execId) = (rpId, timestamp)
+    }
+
+    val succeeded = results.size
+    val failed = podSpecs.size - succeeded
+    val batchTotalMs = clock.getTimeMillis() - batchStartTime
+    val k8sApiWallMs = clock.getTimeMillis() - k8sApiStartTime
+    logDebug(s"[POD-ALLOC-TIMING] Batch creation completed (parallel, " +
+      s"concurrency=$podAllocationConcurrency): " +
+      s"requested=$numExecutorsToAllocate, succeeded=$succeeded, " +
+      s"failed=$failed, " +
+      s"batchTotalMs=$batchTotalMs, " +
+      s"podBuildTotalMs=$podBuildTotalMs, " +
+      s"k8sApiWallClockMs=$k8sApiWallMs, " +
+      s"totalNewlyCreatedUnconfirmed=${newlyCreatedExecutors.size}")
   }
 
   protected def replacePVCsIfNeeded(
@@ -607,6 +744,11 @@ class ExecutorPodsAllocator(
   }
 
   override def stop(applicationId: String): Unit = {
+    if (podAllocationConcurrency > 1) {
+      Utils.tryLogNonFatalError {
+        podCreationThreadPool.shutdownNow()
+      }
+    }
     Utils.tryLogNonFatalError {
       kubernetesClient
         .pods()

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -71,9 +71,11 @@ class ExecutorPodsAllocator(
 
   protected val podAllocationDelay = conf.get(KUBERNETES_ALLOCATION_BATCH_DELAY)
 
+  protected val podAllocationParallelEnabled = conf.get(KUBERNETES_ALLOCATION_PARALLEL_ENABLED)
+
   protected val podAllocationConcurrency = conf.get(KUBERNETES_ALLOCATION_BATCH_CONCURRENCY)
 
-  // Thread pool for parallel pod creation, only created when concurrency > 1
+  // Thread pool for parallel pod creation, only created when parallel is enabled
   protected lazy val podCreationThreadPool =
     ThreadUtils.newDaemonFixedThreadPool(podAllocationConcurrency, "k8s-pod-creator")
   protected lazy val podCreationExecutionContext: ExecutionContext =
@@ -481,7 +483,7 @@ class ExecutorPodsAllocator(
       applicationId: String,
       resourceProfileId: Int,
       pvcsInUse: Set[String]): Unit = {
-    if (podAllocationConcurrency > 1) {
+    if (podAllocationParallelEnabled) {
       requestNewExecutorsParallel(numExecutorsToAllocate, applicationId,
         resourceProfileId, pvcsInUse)
     } else {
@@ -659,15 +661,16 @@ class ExecutorPodsAllocator(
       }
     }
 
-    val results = try {
-      val allResults = ThreadUtils.awaitResult(
-        Future.sequence(futures), Duration(podCreationTimeout, TimeUnit.MILLISECONDS))
-      allResults.flatten
-    } catch {
-      case NonFatal(e) =>
-        logError(log"Timed out waiting for parallel pod creation to complete " +
-          log"after ${MDC(LogKeys.TIMEOUT, podCreationTimeout)} ms", e)
-        Seq.empty
+    val perPodTimeout = Duration(podCreationTimeout, TimeUnit.MILLISECONDS)
+    val results = futures.flatMap { future =>
+      try {
+        ThreadUtils.awaitResult(future, perPodTimeout)
+      } catch {
+        case NonFatal(e) =>
+          logError(log"Timed out or failed waiting for a pod creation future " +
+            log"after ${MDC(LogKeys.TIMEOUT, podCreationTimeout)} ms", e)
+          None
+      }
     }
 
     // Phase 3: Register successful creations
@@ -744,7 +747,7 @@ class ExecutorPodsAllocator(
   }
 
   override def stop(applicationId: String): Unit = {
-    if (podAllocationConcurrency > 1) {
+    if (podAllocationParallelEnabled) {
       Utils.tryLogNonFatalError {
         podCreationThreadPool.shutdownNow()
       }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -647,17 +647,24 @@ class ExecutorPodsAllocator(
 
     implicit val ec: ExecutionContext = podCreationExecutionContext
 
-    val futures = podSpecs.map { case (newExecutorId, podWithAttachedContainer, resources) =>
-      Future {
-        try {
-          val result = createExecutorPodAndPVCs(newExecutorId, podWithAttachedContainer, resources)
-          result.map(execId => (execId, resourceProfileId, clock.getTimeMillis()))
-        } catch {
-          // createExecutorPodAndPVCs already logs the error and registers the failure
-          // before rethrowing. We catch here only to prevent a failed Future from
-          // short-circuiting Future.sequence, so that other concurrent pods can proceed.
-          case NonFatal(_) => None
-        }
+    val futures = podSpecs.flatMap { case (newExecutorId, podWithAttachedContainer, resources) =>
+      try {
+        Some(Future {
+          try {
+            val result =
+              createExecutorPodAndPVCs(newExecutorId, podWithAttachedContainer, resources)
+            result.map(execId => (execId, resourceProfileId, clock.getTimeMillis()))
+          } catch {
+            case NonFatal(_) => None
+          }
+        })
+      } catch {
+        // If the thread pool has been shut down (e.g., stop() was called while
+        // onNewSnapshots is still running), skip remaining pods gracefully.
+        case _: java.util.concurrent.RejectedExecutionException =>
+          logWarning(log"Thread pool shut down, skipping pod creation for executor " +
+            log"${MDC(LogKeys.EXECUTOR_ID, newExecutorId)}.")
+          None
       }
     }
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
@@ -1002,6 +1002,7 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
       .set(s"$prefix.option.claimName", "OnDemand")
       .set(s"$prefix.option.sizeLimit", "200Gi")
       .set(s"$prefix.option.storageClass", "gp3")
+      .set(KUBERNETES_ALLOCATION_BATCH_CONCURRENCY.key, "1")
 
     when(executorBuilder.buildFromFeatures(any(classOf[KubernetesExecutorConf]), meq(secMgr),
       meq(kubernetesClient), any(classOf[ResourceProfile])))
@@ -1028,6 +1029,48 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     intercept[KubernetesClientException] {
       podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 1))
     }
+    assert(podsAllocatorUnderTest.invokePrivate(counter).get() === 0)
+    assert(podsAllocatorUnderTest.invokePrivate(numOutstandingPods).get() == 0)
+  }
+
+  test("SPARK-41410: PVC creation failure in parallel path should not increase PVC counter") {
+    val prefix = "spark.kubernetes.executor.volumes.persistentVolumeClaim.spark-local-dir-1"
+    val confWithPVC = conf.clone
+      .set(KUBERNETES_DRIVER_OWN_PVC.key, "true")
+      .set(KUBERNETES_DRIVER_REUSE_PVC.key, "true")
+      .set(KUBERNETES_DRIVER_WAIT_TO_REUSE_PVC.key, "true")
+      .set(EXECUTOR_INSTANCES.key, "1")
+      .set(s"$prefix.mount.path", "/spark-local-dir")
+      .set(s"$prefix.mount.readOnly", "false")
+      .set(s"$prefix.option.claimName", "OnDemand")
+      .set(s"$prefix.option.sizeLimit", "200Gi")
+      .set(s"$prefix.option.storageClass", "gp3")
+      .set(KUBERNETES_ALLOCATION_BATCH_CONCURRENCY.key, "2")
+
+    when(executorBuilder.buildFromFeatures(any(classOf[KubernetesExecutorConf]), meq(secMgr),
+      meq(kubernetesClient), any(classOf[ResourceProfile])))
+      .thenAnswer((invocation: InvocationOnMock) => {
+        val k8sConf: KubernetesExecutorConf = invocation.getArgument(0)
+        KubernetesExecutorSpec(
+          executorPodWithIdAndVolume(k8sConf.executorId.toInt, k8sConf.resourceProfileId),
+          Seq(persistentVolumeClaim("pvc-0", "gp3", "200Gi")))
+      })
+
+    podsAllocatorUnderTest = new ExecutorPodsAllocator(
+      confWithPVC, secMgr, executorBuilder,
+      kubernetesClient, snapshotsStore, waitForExecutorPodsClock)
+    podsAllocatorUnderTest.setExecutorPodsLifecycleManager(lifecycleManager)
+    podsAllocatorUnderTest.start(TEST_SPARK_APP_ID, schedulerBackend)
+
+    val startTime = Instant.now.toEpochMilli
+    waitForExecutorPodsClock.setTime(startTime)
+
+    val counter = PrivateMethod[AtomicInteger](Symbol("PVC_COUNTER"))()
+    assert(podsAllocatorUnderTest.invokePrivate(counter).get() === 0)
+
+    when(pvcResource.create()).thenThrow(new KubernetesClientException("PVC fails to create"))
+    // In parallel path, exceptions are caught inside Future and do not propagate
+    podsAllocatorUnderTest.setTotalExpectedExecutors(Map(defaultProfile -> 1))
     assert(podsAllocatorUnderTest.invokePrivate(counter).get() === 0)
     assert(podsAllocatorUnderTest.invokePrivate(numOutstandingPods).get() == 0)
   }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
@@ -1002,7 +1002,6 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
       .set(s"$prefix.option.claimName", "OnDemand")
       .set(s"$prefix.option.sizeLimit", "200Gi")
       .set(s"$prefix.option.storageClass", "gp3")
-      .set(KUBERNETES_ALLOCATION_BATCH_CONCURRENCY.key, "1")
 
     when(executorBuilder.buildFromFeatures(any(classOf[KubernetesExecutorConf]), meq(secMgr),
       meq(kubernetesClient), any(classOf[ResourceProfile])))
@@ -1045,7 +1044,7 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
       .set(s"$prefix.option.claimName", "OnDemand")
       .set(s"$prefix.option.sizeLimit", "200Gi")
       .set(s"$prefix.option.storageClass", "gp3")
-      .set(KUBERNETES_ALLOCATION_BATCH_CONCURRENCY.key, "2")
+      .set(KUBERNETES_ALLOCATION_PARALLEL_ENABLED.key, "true")
 
     when(executorBuilder.buildFromFeatures(any(classOf[KubernetesExecutorConf]), meq(secMgr),
       meq(kubernetesClient), any(classOf[ResourceProfile])))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR adds support for creating executor pods in parallel during Kubernetes executor allocation.

Right now, `ExecutorPodsAllocator` creates pods one by one — it sends a create request to the K8s API, waits for the response, then moves on to the next one. This works fine for small jobs, but becomes a real bottleneck when you need thousands of executors.

The idea here is straightforward: pod spec building still happens serially (since it touches shared mutable state like EXECUTOR_ID_COUNTER and reusablePVCs), but the actual K8s API calls to create pods are fired off concurrently using a fixed-size thread pool. After all the futures complete, successful results are registered back on the caller thread.

A new config `spark.kubernetes.allocation.batch.concurrency` controls the parallelism level. It defaults to 1, which keeps the original serial behavior — so this is fully backward-compatible.

### Why are the changes needed?
Each pod creation involves a round-trip to the K8s API server, and depending on cluster load, admission webhooks, etcd, etc., each call can take tens to hundreds of milliseconds. When you're creating 10,000 executors, that adds up fast.

I ran some benchmarks with batchSize=100, maxPending=1000, allocating 10,000 executors.

In production environments, K8s clusters typically have various admission webhooks enabled (security policies, resource quotas, sidecar injection, etc.), and some of them can add significant latency to pod creation calls. In our case, certain webhooks were responding slowly, and the serial allocation became a serious pain point:
| Concurrency | Time (s) | Speedup |
|--------|--------|--------|
| 1 (serial) | 3412 | - |
| 5 | 1171 | 2.91x |
| 10 | 1269 | 2.69x |
| 20 | 1309 | 2.61x | 

Serial allocation took nearly 57 minutes to spin up 10,000 executors. With concurrency=5, that dropped to ~20 minutes — a ~66% reduction.

After disabling those high-latency webhooks, the per-call latency went down, but even then, production K8s clusters still have inherent overhead (API server processing, etcd writes, other controllers reacting to pod events, etc.) that adds up at scale:
| Concurrency | Time (s) | Speedup |
|--------|--------|--------|
| 1 (serial) | 755 | - |
| 3 | 545 | 1.39x |
| 5 | 522 | 1.45x |
| 10 | 588 | 1.28x | 

Even in this lower-latency scenario, concurrency=5 still shaved off ~30% of allocation time. Setting concurrency too high (like 10) can actually hurt a bit, likely due to increased contention on the K8s API server — so a moderate value like 3–5 seems to be the sweet spot.

### Does this PR introduce _any_ user-facing change?
Yes. A new config is added:
- `spark.kubernetes.allocation.batch.concurrency` (default: 1): how many threads to use for creating executor pods concurrently. Set to 1 for the original serial behavior.


### How was this patch tested?
All existing tests in ExecutorPodsAllocatorSuite pass (they run with concurrency=1).
Added a new test for the parallel path: verifies that PVC creation failures don't leak the PVC counter.

### Was this patch authored or co-authored using generative AI tooling?
No.
