### PR TITLE
[SPARK-55889][BUILD] Upgrade Maven to 3.9.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <java.version>17</java.version>
     <java.minimum.version>17.0.11</java.minimum.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
-    <maven.version>3.9.12</maven.version>
+    <maven.version>3.9.13</maven.version>
     <exec-maven-plugin.version>3.6.1</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.9.1</asm.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates `Apache Maven` to `3.9.13` (the latest Apache Maven release).

### Why are the changes needed?

To keep the Maven version up to date with the latest stable release.

- https://maven.apache.org/docs/3.9.13/release-notes.html (2026-03-06)
- https://github.com/apache/maven/releases/tag/maven-3.9.13

**Maven Core**
- Plugin prerequisites check now properly supports ranges when Java 8 (1.8) is specified
- Fixed Plexus Security Dispatcher JSR330 migration warnings on Java 26+ due to field injection into `final` fields
- Updated plugin versions in default bindings

**Resolver 1.9.27**
- Reverted HTTP PUT parallelization from 1.9.25 due to issues with many Maven Repository Managers struggling with concurrent requests
- HTTP 410 (Gone) status is now treated as 404 (Not Found) in artifact resolution
- Fixed proxy support in Apache HTTP transport
- Fixed locally cached artifacts escaping Remote Repository Filter (RRF)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests should cover this (dependency version bump only).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)