### PR TITLE
[SPARK-55891][SQL] Preserve the SQL scripting context inside EXECUTE IMMEDIATE

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
@@ -45,9 +45,7 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
       // We resolve only UnresolvedIdentifiers, and pass on the other nodes
       val resolved = identifiers.map {
         case UnresolvedIdentifier(nameParts, _) =>
-          // From scripts we can only create local variables, which must be unqualified,
-          // and must not be DECLARE OR REPLACE.
-          if (withinSqlScript) {
+          if (withinLocalVariableScope) {
             if (c.replace) {
               throw new AnalysisException(
                 "INVALID_VARIABLE_DECLARATION.REPLACE_LOCAL_VARIABLE",
@@ -61,7 +59,7 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
                 Map("varName" -> toSQLId(nameParts)))
             }
 
-            SqlScriptingContextManager.get().map(_.getVariableManager)
+            SqlScriptingContextManager.get().flatMap(_.getVariableManager)
               .getOrElse(throw SparkException.internalError(
                 "Scripting local variable manager should be present in SQL script."))
               .qualify(nameParts.last)
@@ -77,7 +75,7 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
       c.copy(names = resolved)
 
     case d @ DropVariable(UnresolvedIdentifier(nameParts, _), _) =>
-      if (withinSqlScript) {
+      if (withinLocalVariableScope) {
         throw new AnalysisException(
           "UNSUPPORTED_FEATURE.SQL_SCRIPTING_DROP_TEMPORARY_VARIABLE", Map.empty)
       }
@@ -203,8 +201,14 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
     }
   }
 
-  private def withinSqlScript: Boolean =
-    SqlScriptingContextManager.get().map(_.getVariableManager).isDefined
+  /**
+   * Whether we are within a local variable scope. This is true when we are directly inside a
+   * SQL script and local variable rules apply (unqualified DECLARE only, no OR REPLACE, no DROP).
+   * EXECUTE IMMEDIATE inside a script is not within a local variable scope, since it works
+   * with session variables as if it were outside the script.
+   */
+  private def withinLocalVariableScope: Boolean =
+    SqlScriptingContextManager.get().flatMap(_.getVariableManager).isDefined
 
   private def assertValidSessionVariableNameParts(
       nameParts: Seq[String],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/VariableResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/VariableResolution.scala
@@ -108,7 +108,7 @@ class VariableResolution(tempVariableManager: TempVariableManager) extends SQLCo
 
     SqlScriptingContextManager
       .get()
-      .map(_.getVariableManager)
+      .flatMap(_.getVariableManager)
       // If variable name is qualified with session.<varName> treat it as a session variable.
       .filterNot(
         _ =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ResolverGuard.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ResolverGuard.scala
@@ -519,7 +519,7 @@ class ResolverGuard(catalogManager: CatalogManager) extends SQLConfHelper {
     catalogManager.tempVariableManager.isEmpty
 
   private def checkScriptingVariables() =
-    SqlScriptingContextManager.get().map(_.getVariableManager).forall(_.isEmpty)
+    SqlScriptingContextManager.get().flatMap(_.getVariableManager).forall(_.isEmpty)
 
   private def tryThrowUnsupportedSinglePassAnalyzerFeature(operator: LogicalPlan): Unit = {
     tryThrowUnsupportedSinglePassAnalyzerFeature(s"${operator.getClass} operator resolution")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SqlScriptingContextManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SqlScriptingContextManager.scala
@@ -27,7 +27,7 @@ trait SqlScriptingContextManager {
   def getContext: SqlScriptingExecutionContextExtension
 
   /**
-   * Get variable manager
+   * Get the variable manager, if available.
    */
-  def getVariableManager: VariableManager
+  def getVariableManager: Option[VariableManager]
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveExecuteImmediate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveExecuteImmediate.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.SqlScriptingContextManager
+import org.apache.spark.sql.catalyst.catalog.{SqlScriptingContextManager => SqlScriptingContextManagerTrait}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, VariableReference}
 import org.apache.spark.sql.catalyst.plans.logical.{Command, CompoundBody, LogicalPlan, SetVariable}
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -96,10 +97,10 @@ case class ResolveExecuteImmediate(sparkSession: SparkSession, catalogManager: C
       stopIndex = Some(sqlString.length - 1)
     )
 
-    // Execute the query recursively with isolated local variable context and EXECUTE IMMEDIATE
-    // origin. The isolation must cover parsing, analysis, and execution phases.
-    // CurrentOrigin.withOrigin ensures expressions created during parsing get the proper context
-    val result = withIsolatedLocalVariableContext {
+    // Execute the query with local variables hidden and EXECUTE IMMEDIATE origin set.
+    // Both must cover parsing, analysis, and execution phases.
+    // CurrentOrigin.withOrigin ensures expressions created during parsing get the proper context.
+    val result = withHiddenLocalVariables {
       CurrentOrigin.withOrigin(executeImmediateOrigin) {
         // Use shared parameterized query execution logic (same as OPEN CURSOR)
         val df = if (args.isEmpty) {
@@ -185,14 +186,32 @@ case class ResolveExecuteImmediate(sparkSession: SparkSession, catalogManager: C
   }
 
   /**
-   * Temporarily isolates the SQL scripting context during EXECUTE IMMEDIATE execution.
-   * This makes withinSqlScript() return false, ensuring that statements within EXECUTE IMMEDIATE
-   * are not affected by the outer SQL script context (e.g., local variables, script-specific
-   * errors).
+   * Temporarily hides the local variable context while executing the `EXECUTE IMMEDIATE` command.
+   * This is expected behavior, as local variables cannot be resolved within the body of this
+   * command. This does not apply to session variables. The rest of the SQL scripting context is
+   * preserved.
+   *
+   * {{{
+   *   DECLARE VARIABLE v1 = 1; -- Session variable.
+   *   BEGIN
+   *     DECLARE v2 = 2; -- Local variable.
+   *     EXECUTE IMMEDIATE 'SELECT v1'; -- Should work.
+   *     EXECUTE IMMEDIATE 'SELECT v2'; -- Should fail.
+   *     EXECUTE IMMEDIATE 'SELECT ?' USING v2; -- Should work.
+   *   END
+   * }}}
    */
-  private def withIsolatedLocalVariableContext[A](f: => A): A = {
-    // Completely clear the SQL scripting context to make withinSqlScript() return false
-    val handle = SqlScriptingContextManager.create(null)
-    handle.runWith(f)
+  private def withHiddenLocalVariables[A](f: => A): A = {
+    val newContextManager = SqlScriptingContextManager.get() match {
+      case Some(contextManager) =>
+        // SqlScriptingContextManagerTrait is catalog.SqlScriptingContextManager, renamed on import
+        // to distinguish from the companion object.
+        new SqlScriptingContextManagerTrait {
+          override def getContext = contextManager.getContext
+          override def getVariableManager = None
+        }
+      case None => null
+    }
+    SqlScriptingContextManager.create(newContextManager).runWith(f)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveExecuteImmediate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveExecuteImmediate.scala
@@ -122,9 +122,9 @@ case class ResolveExecuteImmediate(sparkSession: SparkSession, catalogManager: C
           throw QueryCompilationErrors.sqlScriptInExecuteImmediate(sqlString)
         }
 
-        // Force analysis to happen within the isolated context to ensure local variables
-        // are not accessible. This is critical because DataFrames are lazy and analysis
-        // would otherwise happen outside the isolation context.
+        // Force analysis to happen while local variables are hidden. This is critical  because
+        // DataFrames are lazy and analysis would otherwise happen after withHiddenLocalVariables
+        // has restored the original context.
         df.queryExecution.analyzed
         df
       }
@@ -205,7 +205,7 @@ case class ResolveExecuteImmediate(sparkSession: SparkSession, catalogManager: C
     val newContextManager = SqlScriptingContextManager.get() match {
       case Some(contextManager) =>
         // SqlScriptingContextManagerTrait is catalog.SqlScriptingContextManager, renamed on import
-        // to distinguish from the companion object.
+        // to distinguish from the object of the same name in org.apache.spark.sql.catalyst.
         new SqlScriptingContextManagerTrait {
           override def getContext = contextManager.getContext
           override def getVariableManager = None

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/CreateVariableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/CreateVariableExec.scala
@@ -39,7 +39,7 @@ case class CreateVariableExec(
     replace: Boolean) extends LeafV2CommandExec with ExpressionsEvaluator {
 
   override protected def run(): Seq[InternalRow] = {
-    val scriptingVariableManager = SqlScriptingContextManager.get().map(_.getVariableManager)
+    val scriptingVariableManager = SqlScriptingContextManager.get().flatMap(_.getVariableManager)
     val tempVariableManager = session.sessionState.catalogManager.tempVariableManager
 
     val exprs = prepareExpressions(Seq(defaultExpr.child), subExprEliminationEnabled = false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/FetchCursorExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/FetchCursorExec.scala
@@ -180,7 +180,7 @@ case class FetchCursorExec(
     // Select the appropriate variable manager based on the catalog
     // This logic matches SetVariableExec.setVariable()
     val tempVariableManager = session.sessionState.catalogManager.tempVariableManager
-    val scriptingVariableManager = SqlScriptingContextManager.get().map(_.getVariableManager)
+    val scriptingVariableManager = SqlScriptingContextManager.get().flatMap(_.getVariableManager)
 
     val variableManager = varRef.catalog match {
       case FakeLocalCatalog if scriptingVariableManager.isEmpty =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/SetVariableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/SetVariableExec.scala
@@ -66,7 +66,7 @@ case class SetVariableExec(variables: Seq[VariableReference], query: SparkPlan)
     }
 
     val tempVariableManager = session.sessionState.catalogManager.tempVariableManager
-    val scriptingVariableManager = SqlScriptingContextManager.get().map(_.getVariableManager)
+    val scriptingVariableManager = SqlScriptingContextManager.get().flatMap(_.getVariableManager)
 
     val variableManager = variable.catalog match {
       case FakeLocalCatalog if scriptingVariableManager.isEmpty =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/VariableAssignmentUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/VariableAssignmentUtils.scala
@@ -54,7 +54,7 @@ object VariableAssignmentUtils {
       varRef.originalNameParts.map(_.toLowerCase(Locale.ROOT))
     }
 
-    val scriptingVariableManager = SqlScriptingContextManager.get().map(_.getVariableManager)
+    val scriptingVariableManager = SqlScriptingContextManager.get().flatMap(_.getVariableManager)
 
     val variableManager = varRef.catalog match {
       case FakeLocalCatalog if scriptingVariableManager.isEmpty =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingContextManagerImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingContextManagerImpl.scala
@@ -30,5 +30,5 @@ class SqlScriptingContextManagerImpl(context: SqlScriptingExecutionContext)
 
   override def getContext: SqlScriptingExecutionContextExtension = context
 
-  override def getVariableManager: VariableManager = variableManager
+  override def getVariableManager: Option[VariableManager] = Some(variableManager)
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.test.SharedSparkSession
 
 class ExecuteImmediateEndToEndSuite extends QueryTest with SharedSparkSession {
@@ -45,5 +45,102 @@ class ExecuteImmediateEndToEndSuite extends QueryTest with SharedSparkSession {
       },
       condition = "SQL_SCRIPT_IN_EXECUTE_IMMEDIATE",
       parameters = Map("sqlString" -> "BEGIN SELECT 1; END"))
+  }
+
+  test("EXECUTE IMMEDIATE resolves session variables in body") {
+    withSessionVariable("v1", "v2") {
+      spark.sql("DECLARE v1 = 42")
+      spark.sql("DECLARE v2 = 99")
+      checkAnswer(spark.sql("EXECUTE IMMEDIATE 'SELECT system.session.v1, v2'"), Row(42, 99))
+    }
+  }
+
+  test("EXECUTE IMMEDIATE resolves session variables inside script") {
+    withSessionVariable("v1", "v2") {
+      spark.sql("DECLARE v1 = 10")
+      spark.sql("DECLARE v2 = 20")
+      val result = spark.sql(
+        """
+          |BEGIN
+          |  DECLARE v3 = 1;
+          |  EXECUTE IMMEDIATE 'SELECT system.session.v1, v2';
+          |END
+          |""".stripMargin)
+      checkAnswer(result, Row(10, 20))
+    }
+  }
+
+  test("EXECUTE IMMEDIATE does not resolve local variables") {
+    val result = intercept[AnalysisException] {
+      spark.sql(
+        """
+          |BEGIN
+          |  DECLARE v1 = 5;
+          |  EXECUTE IMMEDIATE 'SELECT v1';
+          |END
+          |""".stripMargin)
+    }
+    checkError(
+      exception = result,
+      condition = "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION",
+      sqlState = "42703",
+      parameters = Map("objectName" -> "`v1`"),
+      context = ExpectedContext(
+        objectType = "EXECUTE IMMEDIATE",
+        objectName = "",
+        startIndex = 7,
+        stopIndex = 8,
+        fragment = "v1"))
+  }
+
+  test("EXECUTE IMMEDIATE resolves local variable in USING clause") {
+    val result = spark.sql(
+      """
+        |BEGIN
+        |  DECLARE v1 = 5;
+        |  EXECUTE IMMEDIATE 'SELECT ?' USING v1;
+        |END
+        |""".stripMargin)
+    checkAnswer(result, Row(5))
+  }
+
+  test("EXECUTE IMMEDIATE resolves session var in body and local var in USING") {
+    withSessionVariable("v1") {
+      spark.sql("DECLARE v1 = 10")
+      val result = spark.sql(
+        """
+          |BEGIN
+          |  DECLARE v2 = 20;
+          |  EXECUTE IMMEDIATE 'SELECT system.session.v1, ?' USING v2;
+          |END
+          |""".stripMargin)
+      checkAnswer(result, Row(10, 20))
+    }
+  }
+
+  test("EXECUTE IMMEDIATE fails when local var referenced in body alongside session var") {
+    withSessionVariable("v1") {
+      spark.sql("DECLARE v1 = 10")
+      val e = intercept[AnalysisException] {
+        spark.sql(
+          """
+            |BEGIN
+            |  DECLARE v2 = 20;
+            |  EXECUTE IMMEDIATE 'SELECT v1, v2';
+            |END
+            |""".stripMargin)
+      }
+      checkError(
+        exception = e,
+        condition = "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION",
+        sqlState = "42703",
+        parameters = Map("objectName" -> "`v2`"),
+        context = ExpectedContext(
+          objectType = "EXECUTE IMMEDIATE",
+          objectName = "",
+          startIndex = 11,
+          stopIndex = 12,
+          fragment = "v2"))
+    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
In this PR, I propose preserving the SQL Scripting context inside `EXECUTE IMMEDIATE`, instead of setting it to `null` while executing the command. I propose persisting everything except the variable manager, since local variables should not be resolvable inside the `EXECUTE IMMEDIATE` body.


### Why are the changes needed?
Improvement.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
New tests.

### Was this patch authored or co-authored using generative AI tooling?
Yes, Claude.
