### PR TITLE
[SPARK-38743][SQL] Test the error class: MISSING_STATIC_PARTITION_COLUMN

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5920,6 +5920,12 @@
     ],
     "sqlState" : "42803"
   },
+  "MISSING_STATIC_PARTITION_COLUMN" : {
+    "message" : [
+      "Static partition column <staticName> is not found in the table."
+    ],
+    "sqlState" : "42703"
+  },
   "MISSING_TIMEOUT_CONFIGURATION" : {
     "message" : [
       "The operation has timed out, but no timeout duration is configured. To set a processing time-based timeout, use 'GroupState.setTimeoutDuration()' in your 'mapGroupsWithState' or 'flatMapGroupsWithState' operation. For event-time-based timeout, use 'GroupState.setTimeoutTimestamp()' and define a watermark using 'Dataset.withWatermark()'."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -442,7 +442,9 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
   }
 
   def missingStaticPartitionColumn(staticName: String): Throwable = {
-    SparkException.internalError(s"Unknown static partition column: $staticName.")
+    new AnalysisException(
+      errorClass = "MISSING_STATIC_PARTITION_COLUMN",
+      messageParameters = Map("staticName" -> toSQLId(staticName)))
   }
 
   def staticPartitionInUserSpecifiedColumnsError(staticName: String): Throwable = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -231,6 +231,17 @@ class QueryCompilationErrorsSuite
     }
   }
 
+  test("SPARK-38743: MISSING_STATIC_PARTITION_COLUMN") {
+    val e = intercept[AnalysisException] {
+      throw QueryCompilationErrors.missingStaticPartitionColumn("p")
+    }
+    checkError(
+      exception = e,
+      condition = "MISSING_STATIC_PARTITION_COLUMN",
+      parameters = Map("staticName" -> "`p`"),
+      sqlState = Some("42703"))
+  }
+
   test("UNTYPED_SCALA_UDF: use untyped Scala UDF should fail by default") {
     checkError(
       exception = intercept[AnalysisException](udf((x: Int) => x, IntegerType)),


### PR DESCRIPTION
## Summary

Adds test coverage and standard error class for the `MISSING_STATIC_PARTITION_COLUMN` case in QueryCompilationErrors. When an INSERT or DELETE specifies a static partition column name that is not found in the target table's output, Spark now throws an `AnalysisException` with error class `MISSING_STATIC_PARTITION_COLUMN` and sqlState `42703`, instead of a generic internal error.

## Change

- **error-conditions.json**: Added `MISSING_STATIC_PARTITION_COLUMN` with message "Static partition column <staticName> is not found in the table." and sqlState `42703`.
- **QueryCompilationErrors.scala**: Updated `missingStaticPartitionColumn(staticName)` to throw `AnalysisException` with error class `MISSING_STATIC_PARTITION_COLUMN` and `messageParameters = Map("staticName" -> toSQLId(staticName))` instead of `SparkException.internalError`.
- **QueryCompilationErrorsSuite.scala**: Added test `SPARK-38743: MISSING_STATIC_PARTITION_COLUMN` that asserts error class, sqlState, and message parameters for the exception from `QueryCompilationErrors.missingStaticPartitionColumn("p")`.

## Tests

New test in `QueryCompilationErrorsSuite` covers the error class, sqlState, and message parameters as required by the JIRA.

Fixes SPARK-38743

**JIRA assignee for credit:** deepujain
