### PR TITLE
[SPARK-38719][SQL] Test the error class: CANNOT_CAST_DATATYPE

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -69,6 +69,7 @@ import org.apache.spark.sql.types.{
   IntegerType,
   LongType,
   MetadataBuilder,
+  NullType,
   ObjectType,
   StructField,
   StructType,
@@ -1252,6 +1253,16 @@ class QueryExecutionErrorsSuite
       },
       condition = "_LEGACY_ERROR_TEMP_2249",
       parameters = Map("maxBroadcastTableBytes" -> "1024.0 MiB", "dataSize" -> "2048.0 MiB"))
+  }
+
+  test("SPARK-38719: CANNOT_CAST_DATATYPE") {
+    checkError(
+      exception = intercept[SparkException] {
+        throw QueryExecutionErrors.cannotCastFromNullTypeError(IntegerType)
+      },
+      condition = "CANNOT_CAST_DATATYPE",
+      parameters = Map("sourceType" -> NullType.typeName, "targetType" -> IntegerType.typeName),
+      sqlState = "42846")
   }
 
   test("V1 table don't support time travel") {


### PR DESCRIPTION
## Summary

Adds coverage for the `CANNOT_CAST_DATATYPE` error class in `QueryExecutionErrors`. The test exercises the null-type cast helper and verifies the error class, SQLSTATE, and message parameters.

## Change

- **QueryExecutionErrorsSuite.scala**: Added `SPARK-38719: CANNOT_CAST_DATATYPE`, covering `QueryExecutionErrors.cannotCastFromNullTypeError(IntegerType)` and asserting `sourceType`, `targetType`, and sqlState `42846`.

## Tests

Ran `./build/sbt "sql/testOnly org.apache.spark.sql.errors.QueryExecutionErrorsSuite -- -z SPARK-38719"` - passed.

Fixes SPARK-38719

**JIRA assignee for credit:** deepujain
