### PR TITLE
[SPARK-55894][BUILD] Upgrade Zookeeper to 3.9.5

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -292,6 +292,6 @@ xbean-asm9-shaded/4.30//xbean-asm9-shaded-4.30.jar
 xmlschema-core/2.3.1//xmlschema-core-2.3.1.jar
 xz/1.10//xz-1.10.jar
 zjsonpatch/7.6.0//zjsonpatch-7.6.0.jar
-zookeeper-jute/3.9.4//zookeeper-jute-3.9.4.jar
-zookeeper/3.9.4//zookeeper-3.9.4.jar
+zookeeper-jute/3.9.5//zookeeper-jute-3.9.5.jar
+zookeeper/3.9.5//zookeeper-3.9.5.jar
 zstd-jni/1.5.7-7//zstd-jni-1.5.7-7.jar

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->
     <protobuf.version>4.33.5</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
-    <zookeeper.version>3.9.4</zookeeper.version>
+    <zookeeper.version>3.9.5</zookeeper.version>
     <curator.version>5.9.0</curator.version>
     <hive.group>org.apache.hive</hive.group>
     <hive.classifier>core</hive.classifier>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades Apache ZooKeeper to 3.9.5 for Apache Spark 4.2.0.

### Why are the changes needed?

ZooKeeper 3.9.5 is the latest release with bug fixes.
- https://zookeeper.apache.org/doc/r3.9.5/releasenotes.html (2026-03-06)

This will close this security report too.
- https://github.com/apache/spark/security/dependabot/171

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)