### PR TITLE
[SPARK-50111][PYTHON] Add subplots support for pie charts in Plotly backend

### DIFF
--- a/python/pyspark/pandas/plot/plotly.py
+++ b/python/pyspark/pandas/plot/plotly.py
@@ -50,24 +50,51 @@ def plot_pandas_on_spark(data: Union["ps.DataFrame", "ps.Series"], kind: str, **
 
 def plot_pie(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
     from plotly import express
+    from plotly.subplots import make_subplots
+    import plotly.graph_objs as go
 
     data = PandasOnSparkPlotAccessor.pandas_plot_data_map["pie"](data)
+    subplots = kwargs.pop("subplots", False) 
+
 
     if isinstance(data, pd.Series):
         pdf = data.to_frame()
         return express.pie(pdf, values=pdf.columns[0], names=pdf.index, **kwargs)
     elif isinstance(data, pd.DataFrame):
-        values = kwargs.pop("y", None)
-        default_names = None
-        if values is not None:
-            default_names = data.index
+        if subplots:
+            import math
+            cols = list(data.columns)
+            layout = kwargs.pop("layout", None)
+            if layout is not None:
+                nrows, ncols = layout
+            else:
+                ncols = min(len(cols), 3)  # default max 3 per row
+                nrows = math.ceil(len(cols) / ncols)
+            fig = make_subplots(
+                rows=nrows,
+                cols=ncols,
+                specs=[[{"type": "pie"}] * ncols for _ in range(nrows)],
+                subplot_titles=[str(c) for c in cols],
+            )
+            for i, col in enumerate(cols):
+                fig.add_trace(
+                    go.Pie(labels=data.index, values=data[col], name=str(col)),
+                    row=i // ncols + 1,
+                    col=i % ncols + 1,
+                )
+            return fig
+        else:
+            values = kwargs.pop("y", None)
+            default_names = None
+            if values is not None:
+                default_names = data.index
 
-        return express.pie(
-            data,
-            values=kwargs.pop("values", values),
-            names=kwargs.pop("names", default_names),
-            **kwargs,
-        )
+            return express.pie(
+                data,
+                values=kwargs.pop("values", values),
+                names=kwargs.pop("names", default_names),
+                **kwargs,
+            )
     else:
         raise RuntimeError("Unexpected type: [%s]" % type(data))
 

--- a/python/pyspark/pandas/plot/plotly.py
+++ b/python/pyspark/pandas/plot/plotly.py
@@ -46,9 +46,7 @@ def plot_pandas_on_spark(data: Union["ps.DataFrame", "ps.Series"], kind: str, **
         return plot_kde(data, **kwargs)
 
     # Other plots.
-    return plotly.plot(
-        PandasOnSparkPlotAccessor.pandas_plot_data_map[kind](data), kind, **kwargs
-    )
+    return plotly.plot(PandasOnSparkPlotAccessor.pandas_plot_data_map[kind](data), kind, **kwargs)
 
 
 def plot_pie(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
@@ -58,7 +56,7 @@ def plot_pie(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
 
     data = PandasOnSparkPlotAccessor.pandas_plot_data_map["pie"](data)
     subplots = kwargs.pop("subplots", False)
-    layout = kwargs.pop("layout", None)
+    col_wrap = kwargs.pop("col_wrap", None)
 
     if isinstance(data, pd.Series):
         pdf = data.to_frame()
@@ -66,16 +64,10 @@ def plot_pie(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
     elif isinstance(data, pd.DataFrame):
         if subplots:
             cols = list(data.columns)
-            if layout is not None:
-                nrows, ncols = layout
-                if nrows * ncols < len(cols):
-                    raise ValueError(
-                        "The provided 'layout' is too small for all columns: "
-                        f"{nrows} rows * {ncols} columns < {len(cols)} columns."
-                    )
-            else:
-                ncols = min(len(cols), 3)  # default max 3 per row
-                nrows = math.ceil(len(cols) / ncols)
+            if col_wrap is not None and col_wrap < 1:
+                raise ValueError("col_wrap must be a positive integer, got %d." % col_wrap)
+            ncols = col_wrap if col_wrap is not None else min(len(cols), 3)
+            nrows = math.ceil(len(cols) / ncols)
             fig = make_subplots(
                 rows=nrows,
                 cols=ncols,
@@ -138,9 +130,7 @@ def plot_histogram(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
                 name=name_like_string(series.name),
                 text=text_bins,
                 hovertemplate=(
-                    "variable="
-                    + name_like_string(series.name)
-                    + "<br>value=%{text}<br>count=%{y}"
+                    "variable=" + name_like_string(series.name) + "<br>value=%{text}<br>count=%{y}"
                 ),
             )
         )
@@ -281,9 +271,7 @@ def plot_kde(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
                     "index": ind,
                 }
             )
-            for label, kde_result in zip(
-                psdf._internal.column_labels, list(kde_results)
-            )
+            for label, kde_result in zip(psdf._internal.column_labels, list(kde_results))
         ]
     )
 

--- a/python/pyspark/pandas/plot/plotly.py
+++ b/python/pyspark/pandas/plot/plotly.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 import inspect
+import math
 from typing import TYPE_CHECKING, Union
 
 import pandas as pd
@@ -54,19 +55,22 @@ def plot_pie(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
     import plotly.graph_objs as go
 
     data = PandasOnSparkPlotAccessor.pandas_plot_data_map["pie"](data)
-    subplots = kwargs.pop("subplots", False) 
-
+    subplots = kwargs.pop("subplots", False)
+    layout = kwargs.pop("layout", None)
 
     if isinstance(data, pd.Series):
         pdf = data.to_frame()
         return express.pie(pdf, values=pdf.columns[0], names=pdf.index, **kwargs)
     elif isinstance(data, pd.DataFrame):
         if subplots:
-            import math
             cols = list(data.columns)
-            layout = kwargs.pop("layout", None)
             if layout is not None:
                 nrows, ncols = layout
+                if nrows * ncols < len(cols):
+                    raise ValueError(
+                        "The provided 'layout' is too small for all columns: "
+                        f"{nrows} rows * {ncols} columns < {len(cols)} columns."
+                    )
             else:
                 ncols = min(len(cols), 3)  # default max 3 per row
                 nrows = math.ceil(len(cols) / ncols)

--- a/python/pyspark/pandas/plot/plotly.py
+++ b/python/pyspark/pandas/plot/plotly.py
@@ -46,7 +46,9 @@ def plot_pandas_on_spark(data: Union["ps.DataFrame", "ps.Series"], kind: str, **
         return plot_kde(data, **kwargs)
 
     # Other plots.
-    return plotly.plot(PandasOnSparkPlotAccessor.pandas_plot_data_map[kind](data), kind, **kwargs)
+    return plotly.plot(
+        PandasOnSparkPlotAccessor.pandas_plot_data_map[kind](data), kind, **kwargs
+    )
 
 
 def plot_pie(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
@@ -136,7 +138,9 @@ def plot_histogram(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
                 name=name_like_string(series.name),
                 text=text_bins,
                 hovertemplate=(
-                    "variable=" + name_like_string(series.name) + "<br>value=%{text}<br>count=%{y}"
+                    "variable="
+                    + name_like_string(series.name)
+                    + "<br>value=%{text}<br>count=%{y}"
                 ),
             )
         )
@@ -277,7 +281,9 @@ def plot_kde(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
                     "index": ind,
                 }
             )
-            for label, kde_result in zip(psdf._internal.column_labels, list(kde_results))
+            for label, kde_result in zip(
+                psdf._internal.column_labels, list(kde_results)
+            )
         ]
     )
 


### PR DESCRIPTION
## Summary

  Adds `subplots` and `layout` kwarg support to `plot_pie` for pandas-on-Spark DataFrames when using the Plotly backend.

  - `subplots=True`: renders each column as a separate pie chart in a multi-subplot figure
  - `layout=(nrows, ncols)`: controls the grid layout; defaults to up to 3 columns per row

  ## How to verify

  import pyspark.pandas as ps

  df = ps.DataFrame({
      "A": [1, 2, 3],
      "B": [4, 5, 6],
      "C": [7, 8, 9],
  }, index=["x", "y", "z"])

  # Auto layout
  fig = df.plot.pie(subplots=True)
  fig.show()

  # Custom layout
  fig = df.plot.pie(subplots=True, layout=(1, 3))
  fig.show()

  Expected: a Plotly figure arranged in the specified grid with pie charts