### PR TITLE
[SPARK-55904][PYTHON][CONNECT] Utilize _check_same_session to narrow down types

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -315,20 +315,22 @@ class DataFrame(ParentDataFrame):
         return table[0][0].as_py()
 
     def crossJoin(self, other: ParentDataFrame) -> ParentDataFrame:
-        self._check_same_session(other)
+        other = self._check_same_session(other)
         return DataFrame(
-            plan.Join(
-                left=self._plan, right=other._plan, on=None, how="cross"  # type: ignore[arg-type]
-            ),
+            plan.Join(left=self._plan, right=other._plan, on=None, how="cross"),
             session=self._session,
         )
 
-    def _check_same_session(self, other: ParentDataFrame) -> None:
-        if self._session.session_id != other._session.session_id:  # type: ignore[attr-defined]
+    def _check_same_session(self, other: ParentDataFrame) -> "DataFrame":
+        if (
+            not isinstance(other, DataFrame)
+            or self._session.session_id != other._session.session_id
+        ):
             raise SessionNotSameException(
                 errorClass="SESSION_NOT_SAME",
                 messageParameters={},
             )
+        return other
 
     def coalesce(self, numPartitions: int) -> ParentDataFrame:
         if not numPartitions > 0:
@@ -724,11 +726,11 @@ class DataFrame(ParentDataFrame):
         on: Optional[Union[str, List[str], Column, List[Column]]] = None,
         how: Optional[str] = None,
     ) -> ParentDataFrame:
-        self._check_same_session(other)
+        other = self._check_same_session(other)
         if how is not None and isinstance(how, str):
             how = how.lower().replace("_", "")
         return DataFrame(
-            plan.Join(left=self._plan, right=other._plan, on=on, how=how),  # type: ignore[arg-type]
+            plan.Join(left=self._plan, right=other._plan, on=on, how=how),
             session=self._session,
         )
 
@@ -738,13 +740,11 @@ class DataFrame(ParentDataFrame):
         on: Optional[Column] = None,
         how: Optional[str] = None,
     ) -> ParentDataFrame:
-        self._check_same_session(other)
+        other = self._check_same_session(other)
         if how is not None and isinstance(how, str):
             how = how.lower().replace("_", "")
         return DataFrame(
-            plan.LateralJoin(
-                left=self._plan, right=cast(plan.LogicalPlan, other._plan), on=on, how=how
-            ),
+            plan.LateralJoin(left=self._plan, right=other._plan, on=on, how=how),
             session=self._session,
         )
 
@@ -760,7 +760,7 @@ class DataFrame(ParentDataFrame):
         allowExactMatches: bool = True,
         direction: str = "backward",
     ) -> ParentDataFrame:
-        self._check_same_session(other)
+        other = self._check_same_session(other)
         if how is None:
             how = "inner"
         assert isinstance(how, str), "how should be a string"
@@ -777,7 +777,7 @@ class DataFrame(ParentDataFrame):
         return DataFrame(
             plan.AsOfJoin(
                 left=self._plan,
-                right=other._plan,  # type: ignore[arg-type]
+                right=other._plan,
                 left_as_of=_convert_col(self, leftAsOfColumn),
                 right_as_of=_convert_col(other, rightAsOfColumn),
                 on=on,
@@ -1159,15 +1159,13 @@ class DataFrame(ParentDataFrame):
         return None
 
     def union(self, other: ParentDataFrame) -> ParentDataFrame:
-        self._check_same_session(other)
+        other = self._check_same_session(other)
         return self.unionAll(other)
 
     def unionAll(self, other: ParentDataFrame) -> ParentDataFrame:
-        self._check_same_session(other)
+        other = self._check_same_session(other)
         res = DataFrame(
-            plan.SetOperation(
-                self._plan, other._plan, "union", is_all=True  # type: ignore[arg-type]
-            ),
+            plan.SetOperation(self._plan, other._plan, "union", is_all=True),
             session=self._session,
         )
         res._cached_schema = self._merge_cached_schema(other)
@@ -1176,11 +1174,11 @@ class DataFrame(ParentDataFrame):
     def unionByName(
         self, other: ParentDataFrame, allowMissingColumns: bool = False
     ) -> ParentDataFrame:
-        self._check_same_session(other)
+        other = self._check_same_session(other)
         res = DataFrame(
             plan.SetOperation(
                 self._plan,
-                other._plan,  # type: ignore[arg-type]
+                other._plan,
                 "union",
                 by_name=True,
                 allow_missing_columns=allowMissingColumns,
@@ -1191,22 +1189,18 @@ class DataFrame(ParentDataFrame):
         return res
 
     def subtract(self, other: ParentDataFrame) -> ParentDataFrame:
-        self._check_same_session(other)
+        other = self._check_same_session(other)
         res = DataFrame(
-            plan.SetOperation(
-                self._plan, other._plan, "except", is_all=False  # type: ignore[arg-type]
-            ),
+            plan.SetOperation(self._plan, other._plan, "except", is_all=False),
             session=self._session,
         )
         res._cached_schema = self._merge_cached_schema(other)
         return res
 
     def exceptAll(self, other: ParentDataFrame) -> ParentDataFrame:
-        self._check_same_session(other)
+        other = self._check_same_session(other)
         res = DataFrame(
-            plan.SetOperation(
-                self._plan, other._plan, "except", is_all=True  # type: ignore[arg-type]
-            ),
+            plan.SetOperation(self._plan, other._plan, "except", is_all=True),
             session=self._session,
         )
         res._cached_schema = self._merge_cached_schema(other)
@@ -1218,22 +1212,18 @@ class DataFrame(ParentDataFrame):
         )
 
     def intersect(self, other: ParentDataFrame) -> ParentDataFrame:
-        self._check_same_session(other)
+        other = self._check_same_session(other)
         res = DataFrame(
-            plan.SetOperation(
-                self._plan, other._plan, "intersect", is_all=False  # type: ignore[arg-type]
-            ),
+            plan.SetOperation(self._plan, other._plan, "intersect", is_all=False),
             session=self._session,
         )
         res._cached_schema = self._merge_cached_schema(other)
         return res
 
     def intersectAll(self, other: ParentDataFrame) -> ParentDataFrame:
-        self._check_same_session(other)
+        other = self._check_same_session(other)
         res = DataFrame(
-            plan.SetOperation(
-                self._plan, other._plan, "intersect", is_all=True  # type: ignore[arg-type]
-            ),
+            plan.SetOperation(self._plan, other._plan, "intersect", is_all=True),
             session=self._session,
         )
         res._cached_schema = self._merge_cached_schema(other)
@@ -2226,7 +2216,7 @@ class DataFrame(ParentDataFrame):
                 errorClass="NOT_DATAFRAME",
                 messageParameters={"arg_name": "other", "arg_type": type(other).__name__},
             )
-        self._check_same_session(other)
+        other = self._check_same_session(other)
         return self._session.client.same_semantics(
             plan=self._plan.to_proto(self._session.client),
             other=other._plan.to_proto(other._session.client),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

* Make `_check_same_session` return the input argument if it's on the same session
* Use that value to narrow down types so we can throw away some type: ignore

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When we can narrow down types, we should do it so type hint works better (less exceptions).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

mypy passed.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.