### PR TITLE
[SPARK-53675][PYTHON] Add str support in withColumn and withColumns in PySpark

### DIFF
--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1659,7 +1659,7 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         """
         return self.columns
 
-    def withColumns(self, *colsMap: Dict[str, Column]) -> ParentDataFrame:
+    def withColumns(self, *colsMap: Dict[str, "ColumnOrName"]) -> ParentDataFrame:
         # Below code is to help enable kwargs in future.
         assert len(colsMap) == 1
         colsMap = colsMap[0]  # type: ignore[assignment]
@@ -1678,13 +1678,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             self.sparkSession,
         )
 
-    def withColumn(self, colName: str, col: Column) -> ParentDataFrame:
-        if not isinstance(col, Column):
-            raise PySparkTypeError(
-                errorClass="NOT_COLUMN",
-                messageParameters={"arg_name": "col", "arg_type": type(col).__name__},
-            )
-        return DataFrame(self._jdf.withColumn(colName, col._jc), self.sparkSession)
+    def withColumn(self, colName: str, col: "ColumnOrName") -> ParentDataFrame:
+        return DataFrame(self._jdf.withColumn(colName, _to_java_column(col)), self.sparkSession)
 
     def withColumnRenamed(self, existing: str, new: str) -> ParentDataFrame:
         return DataFrame(self._jdf.withColumnRenamed(existing, new), self.sparkSession)

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -905,7 +905,7 @@ class DataFrame(ParentDataFrame):
         )._to_table()
         return table[0][0].as_py()
 
-    def withColumns(self, *colsMap: Dict[str, Column]) -> ParentDataFrame:
+    def withColumns(self, *colsMap: Dict[str, "ColumnOrName"]) -> ParentDataFrame:
         # Below code is to help enable kwargs in future.
         assert len(colsMap) == 1
         colsMap = colsMap[0]  # type: ignore[assignment]
@@ -920,7 +920,7 @@ class DataFrame(ParentDataFrame):
         columns: List[Column] = []
         for columnName, column in colsMap.items():
             names.append(columnName)
-            columns.append(column)
+            columns.append(F._to_col(column))
 
         return DataFrame(
             plan.WithColumns(
@@ -931,17 +931,12 @@ class DataFrame(ParentDataFrame):
             session=self._session,
         )
 
-    def withColumn(self, colName: str, col: Column) -> ParentDataFrame:
-        if not isinstance(col, Column):
-            raise PySparkTypeError(
-                errorClass="NOT_COLUMN",
-                messageParameters={"arg_name": "col", "arg_type": type(col).__name__},
-            )
+    def withColumn(self, colName: str, col: "ColumnOrName") -> ParentDataFrame:
         return DataFrame(
             plan.WithColumns(
                 self._plan,
                 columnNames=[colName],
-                columns=[col],
+                columns=[F._to_col(col)],
             ),
             session=self._session,
         )

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -5677,7 +5677,7 @@ class DataFrame:
         ...
 
     @dispatch_df_method
-    def withColumns(self, *colsMap: Dict[str, Column]) -> "DataFrame":
+    def withColumns(self, *colsMap: Dict[str, "ColumnOrName"]) -> "DataFrame":
         """
         Returns a new :class:`DataFrame` by adding multiple columns or replacing the
         existing columns that have the same names.
@@ -5694,7 +5694,8 @@ class DataFrame:
         Parameters
         ----------
         colsMap : dict
-            a dict of column name and :class:`Column`. Currently, only a single map is supported.
+            a dict of column name and :class:`Column` or str. Currently, only a single map is
+            supported.
 
         Returns
         -------
@@ -5711,11 +5712,19 @@ class DataFrame:
         |  2|Alice|   4|   5|
         |  5|  Bob|   7|   8|
         +---+-----+----+----+
+
+        >>> df.withColumns({'age_copy': 'age', 'name_copy': 'name'}).show()
+        +---+-----+--------+---------+
+        |age| name|age_copy|name_copy|
+        +---+-----+--------+---------+
+        |  2|Alice|       2|    Alice|
+        |  5|  Bob|       5|      Bob|
+        +---+-----+--------+---------+
         """
         ...
 
     @dispatch_df_method
-    def withColumn(self, colName: str, col: Column) -> "DataFrame":
+    def withColumn(self, colName: str, col: "ColumnOrName") -> "DataFrame":
         """
         Returns a new :class:`DataFrame` by adding a column or replacing the
         existing column that has the same name.
@@ -5732,8 +5741,8 @@ class DataFrame:
         ----------
         colName : str
             string, name of the new column.
-        col : :class:`Column`
-            a :class:`Column` expression for the new column.
+        col : :class:`Column` or str
+            a :class:`Column` expression for the new column, or a column name as a string.
 
         Returns
         -------
@@ -5757,6 +5766,14 @@ class DataFrame:
         |  2|Alice|   4|
         |  5|  Bob|   7|
         +---+-----+----+
+
+        >>> df.withColumn('age_copy', 'age').show()
+        +---+-----+--------+
+        |age| name|age_copy|
+        +---+-----+--------+
+        |  2|Alice|       2|
+        |  5|  Bob|       5|
+        +---+-----+--------+
         """
         ...
 

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -422,6 +422,30 @@ class DataFrameTestsMixin:
         keys = self.df.withColumn("key", self.df.key).select("key").collect()
         self.assertEqual([r.key for r in keys], list(range(100)))
 
+    def test_with_column_with_column_name_str(self):
+        # SPARK-53675: withColumn should accept a string column name
+        df = self.spark.createDataFrame([(2, "Alice"), (5, "Bob")], schema=["age", "name"])
+
+        # String column name should produce the same result as col("age")
+        result_str = df.withColumn("age_copy", "age").select("age_copy").collect()
+        result_col = df.withColumn("age_copy", col("age")).select("age_copy").collect()
+        self.assertEqual(result_str, result_col)
+
+        # Non-Column, non-str should raise PySparkTypeError
+        with self.assertRaises(PySparkTypeError) as pe:
+            df.withColumn("age2", 123)
+
+        self.check_error(
+            exception=pe.exception,
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "col", "arg_type": "int"},
+        )
+
+        # A string is treated as a column name, not a SQL expression.
+        # "age + 2" is interpreted as a column literally named "age + 2", which doesn't exist.
+        with self.assertRaises(AnalysisException):
+            df.withColumn("age2", "age + 2").collect()
+
     # regression test for SPARK-10417
     def test_column_iterator(self):
         def foo():
@@ -456,6 +480,29 @@ class DataFrameTestsMixin:
         # Type check
         self.assertRaises(TypeError, self.df.withColumns, ["key"])
         self.assertRaises(Exception, self.df.withColumns)
+
+    def test_with_columns_with_column_name_str(self):
+        # SPARK-53675: withColumns should accept string column names as values
+        df = self.spark.createDataFrame([(2, "Alice"), (5, "Bob")], schema=["age", "name"])
+
+        # String column names should produce the same result as Column objects
+        result_str = df.withColumns({"age_copy": "age", "name_copy": "name"}).collect()
+        result_col = df.withColumns({"age_copy": col("age"), "name_copy": col("name")}).collect()
+        self.assertEqual(result_str, result_col)
+
+        # Mix of Column objects and string column names
+        result_mix = df.withColumns({"age_copy": col("age"), "name_copy": "name"}).collect()
+        self.assertEqual(result_mix, result_col)
+
+        # Non-Column, non-str value should raise PySparkTypeError
+        with self.assertRaises(PySparkTypeError) as pe:
+            df.withColumns({"age_copy": 123})
+
+        self.check_error(
+            exception=pe.exception,
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "col", "arg_type": "int"},
+        )
 
     def test_generic_hints(self):
         df1 = self.spark.range(10e10).toDF("id")


### PR DESCRIPTION
Switch from Column to ColumnOrName, and reuse builtin function, which also have type check


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Add support for https://issues.apache.org/jira/browse/SPARK-53675
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
User will be able to use str and column for withColumn and withColumns. And we does change the error message from `NOT_COLUMN` to `NOT_COLUMN_OR_STR`
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Test `python/run-tests  --testnames pyspark.sql.tests.test_dataframe`
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
Claude help me to understand the behaviors 
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
