### PR TITLE
[SPARK-55913][INFRA] Add `.kiro` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 .generated-mima*
 .idea/
 .idea_modules/
+.kiro/
 .metals
 .project
 .pydevproject


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to add `.kiro` to `.gitignore`.

### Why are the changes needed?
Kiro loads/stores its configuration in `.kiro` so this should be ignored.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually confirmed `.kiro` is not listed by `git status`.

### Was this patch authored or co-authored using generative AI tooling?
No.