### PR TITLE
[SPARK-55914][TESTS] add `sbt_test_goals` to `sparktestsupport/modules.py` for `sql-api`

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -239,6 +239,9 @@ api = Module(
     source_file_regexes=[
         "sql/api/",
     ],
+    sbt_test_goals=[
+        "sql-api/test",
+    ],
 )
 
 catalyst = Module(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes an issue that tests under `sql/api` don't run through `dev/run-test`.
The cause is that `sbt_test_goals` for `sql-api` is not defined so this PR adds it to `sparktestsupport/modules.py`.

### Why are the changes needed?
For better test coverage.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
All tests including ones under `sql/api` passed on GA.
<img width="707" height="286" alt="tests-under-sql-api" src="https://github.com/user-attachments/assets/09839583-8516-46f4-a04a-00b2267d24d7" />


### Was this patch authored or co-authored using generative AI tooling?
Kiro CLI / Sonnet 4.6