### PR TITLE
[SPARK-55918][SQL][CONNECT] Rewrite spark.catalog getDatabase / databaseExists in SQL DDL

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/DDLBasedCatalog.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/DDLBasedCatalog.scala
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.internal
+
+import scala.util.control.NonFatal
+
+import org.apache.spark.sql.{AnalysisException, DataFrame}
+import org.apache.spark.sql.catalog.{Catalog, Database}
+
+/**
+ * Trait that provides DDL-based implementations of selected [[Catalog]] methods (e.g. via SQL DDL
+ * such as DESCRIBE NAMESPACE EXTENDED, SHOW NAMESPACES). Core and Connect Catalog classes mix in
+ * this trait and call `super` for those methods when `spark.sql.catalog.useDDLBasedAPI` is true.
+ * Methods not implemented here are provided by the concrete class.
+ */
+private[sql] trait DDLBasedCatalog extends Catalog {
+
+  /** Used for legacy single-part resolution. */
+  private val defaultCatalogName: String = "spark_catalog"
+
+  private def sql(str: String): DataFrame = sql(str, Map.empty)
+  private[sql] def sql(str: String, args: Map[String, Any]): DataFrame
+  private[sql] def parseMultipartIdentifier(identifier: String): Seq[String]
+  private[sql] def quoteIdentifier(identifier: String): String
+
+  @throws[AnalysisException]("database does not exist")
+  override def getDatabase(dbName: String): Database = {
+    val idents = parseMultipartIdentifier(dbName)
+    // Legacy behavior: for a single-part name, prefer default catalog if it has that database.
+    val identsToDescribe = if (idents.length == 1) {
+      val qualified = s"${quoteIdentifier(defaultCatalogName)}.${quoteIdentifier(idents.head)}"
+      if (databaseExists(qualified)) {
+        Seq(defaultCatalogName, idents.head)
+      } else {
+        currentCatalog() +: idents
+      }
+    } else {
+      idents
+    }
+    // Use parameterized SQL with identifier(:ns) so the namespace is bound as a value, not
+    // concatenated into the SQL string (prevents SQL injection).
+    val nsParam = identsToDescribe.mkString(".")
+    val rows = sql("DESCRIBE NAMESPACE EXTENDED identifier(:ns)", Map("ns" -> nsParam)).collect()
+    val info = rows.map(row => (row.getString(0), Option(row.getString(1)).getOrElse(""))).toMap
+    val name = info.getOrElse("Namespace Name", identsToDescribe.last)
+    val catalog = info.getOrElse(
+      "Catalog Name",
+      if (identsToDescribe.length > 1) identsToDescribe.head else "")
+    new Database(
+      name = name,
+      catalog = catalog,
+      description = info.get("Comment").orNull,
+      locationUri = info.get("Location").orNull)
+  }
+
+  override def databaseExists(dbName: String): Boolean = {
+    try {
+      val parts =
+        try parseMultipartIdentifier(dbName)
+        catch { case NonFatal(_) => Seq(dbName) }
+      if (parts.length == 1) {
+        val name = parts.head
+        // Legacy: resolve using existence (default first, else current); we do two explicit checks.
+        def inCatalog(catalogParam: Option[String]): Boolean = {
+          try {
+            val (sqlStr, args) = catalogParam match {
+              case Some(catalog) =>
+                ("SHOW NAMESPACES IN identifier(:catalog)", Map("catalog" -> catalog))
+              case None =>
+                ("SHOW NAMESPACES", Map.empty[String, Any])
+            }
+            val rows = sql(sqlStr, args).collect()
+            rows.exists(row => row.getString(0).equalsIgnoreCase(name))
+          } catch {
+            case _: AnalysisException => false
+            case NonFatal(_) => false
+          }
+        }
+        inCatalog(Some(defaultCatalogName)) || inCatalog(None)
+      } else {
+        // Multi-part: namespace can be nested (e.g. cat.ns.db). One existence check via DESCRIBE.
+        try {
+          val ns = parts.mkString(".")
+          sql("DESCRIBE NAMESPACE EXTENDED identifier(:ns)", Map("ns" -> ns)).collect()
+          true
+        } catch {
+          case _: AnalysisException => false
+          case NonFatal(_) => false
+        }
+      }
+    } catch {
+      case _: AnalysisException => false
+      case NonFatal(_) => false
+    }
+  }
+}

--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
@@ -54,6 +54,7 @@ private[sql] trait SqlApiConf {
   def legacyParameterSubstitutionConstantsOnly: Boolean
   def legacyIdentifierClauseOnly: Boolean
   def typesFrameworkEnabled: Boolean
+  def useDDLBasedCatalogAPI: Boolean
 }
 
 private[sql] object SqlApiConf {
@@ -77,6 +78,8 @@ private[sql] object SqlApiConf {
   val PARSER_DFA_CACHE_FLUSH_RATIO_KEY: String =
     SqlApiConfHelper.PARSER_DFA_CACHE_FLUSH_RATIO_KEY
   val MANAGE_PARSER_CACHES_KEY: String = SqlApiConfHelper.MANAGE_PARSER_CACHES_KEY
+  val USE_DDL_BASED_CATALOG_API_KEY: String =
+    SqlApiConfHelper.USE_DDL_BASED_CATALOG_API_KEY
 
   def get: SqlApiConf = SqlApiConfHelper.getConfGetter.get()()
 
@@ -112,4 +115,5 @@ private[sql] object DefaultSqlApiConf extends SqlApiConf {
   override def legacyParameterSubstitutionConstantsOnly: Boolean = false
   override def legacyIdentifierClauseOnly: Boolean = false
   override def typesFrameworkEnabled: Boolean = false
+  override def useDDLBasedCatalogAPI: Boolean = true
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConfHelper.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConfHelper.scala
@@ -42,6 +42,7 @@ private[sql] object SqlApiConfHelper {
     "spark.sql.parser.parserDfaCacheFlushThreshold"
   val PARSER_DFA_CACHE_FLUSH_RATIO_KEY: String = "spark.sql.parser.parserDfaCacheFlushRatio"
   val MANAGE_PARSER_CACHES_KEY: String = "spark.sql.parser.manageParserCaches"
+  val USE_DDL_BASED_CATALOG_API_KEY: String = "spark.sql.catalog.useDDLBasedAPI"
 
   val confGetter: AtomicReference[() => SqlApiConf] = {
     new AtomicReference[() => SqlApiConf](() => DefaultSqlApiConf)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5537,6 +5537,14 @@ object SQLConf {
     .stringConf
     .createWithDefault(SESSION_CATALOG_NAME)
 
+  val USE_DDL_BASED_CATALOG_API = buildConf(SqlApiConfHelper.USE_DDL_BASED_CATALOG_API_KEY)
+    .doc("When true, spark.catalog uses SQL DDL (e.g. DESCRIBE NAMESPACE EXTENDED, SHOW " +
+      "NAMESPACES) instead of the internal catalog resolver for catalog APIs that support it. " +
+      "Set to false to use the original implementation for those APIs.")
+    .version("4.2.0")
+    .booleanConf
+    .createWithDefault(true)
+
   val V2_SESSION_CATALOG_IMPLEMENTATION =
     buildConf(s"spark.sql.catalog.$SESSION_CATALOG_NAME")
       .doc("A catalog implementation that will be used as the v2 interface to Spark's built-in " +
@@ -7157,6 +7165,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def geospatialEnabled: Boolean = getConf(GEOSPATIAL_ENABLED)
 
   def typesFrameworkEnabled: Boolean = getConf(TYPES_FRAMEWORK_ENABLED)
+
+  override def useDDLBasedCatalogAPI: Boolean = getConf(USE_DDL_BASED_CATALOG_API)
 
   def dataSourceV2JoinPushdown: Boolean = getConf(DATA_SOURCE_V2_JOIN_PUSHDOWN)
 

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/CatalogSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/CatalogSuite.scala
@@ -365,4 +365,36 @@ class CatalogSuite extends ConnectFunSuite with RemoteSparkSession with SQLHelpe
       assert(freshColumns.contains("c3"))
     }
   }
+
+  test("parseMultipartIdentifier matches expected behavior for valid identifiers") {
+    // Duplicated in sql/core CatalogSuite; change both together when adding cases.
+    val testCases: Seq[(String, Seq[String])] = Seq(
+      ("a", Seq("a")),
+      ("a.b", Seq("a", "b")),
+      ("a.b.c", Seq("a", "b", "c")),
+      ("  a  .  b  ", Seq("a", "b")),
+      ("`a`", Seq("a")),
+      ("`a`.`b`", Seq("a", "b")),
+      ("a.`b.c`", Seq("a", "b.c")),
+      ("`a.b`.c", Seq("a.b", "c")),
+      ("`a``b`", Seq("a`b")),
+      ("cat.`db.schema`.tbl", Seq("cat", "db.schema", "tbl")),
+      (
+        "`org.apache.spark.sql.json`.`s3://buck/tmp/abc.json`",
+        Seq("org.apache.spark.sql.json", "s3://buck/tmp/abc.json")),
+      ("default.tab1", Seq("default", "tab1")),
+      ("`default`.`tab1`", Seq("default", "tab1")))
+    testCases.foreach { case (input, expected) =>
+      val actual = spark.catalog.parseMultipartIdentifier(input)
+      assert(
+        actual === expected,
+        s"parseMultipartIdentifier(${input.replace("`", "\\`")}) should match: " +
+          s"expected $expected, got $actual")
+    }
+  }
+
+  test("parseMultipartIdentifier returns empty for null and empty string") {
+    assert(spark.catalog.parseMultipartIdentifier(null) === Seq.empty)
+    assert(spark.catalog.parseMultipartIdentifier("") === Seq.empty)
+  }
 }

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/Catalog.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/Catalog.scala
@@ -23,11 +23,73 @@ import org.apache.spark.sql.catalog.{CatalogMetadata, Column, Database, Function
 import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoder
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders.{PrimitiveBooleanEncoder, StringEncoder}
+import org.apache.spark.sql.catalyst.util.QuotingUtils
 import org.apache.spark.sql.connect.common.{DataTypeProtoConverter, StorageLevelProtoConverter}
+import org.apache.spark.sql.internal.{DDLBasedCatalog, SqlApiConf}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.storage.StorageLevel
 
-class Catalog(sparkSession: SparkSession) extends catalog.Catalog {
+class Catalog(sparkSession: SparkSession) extends catalog.Catalog with DDLBasedCatalog {
+
+  private def useDDLBasedCatalogAPI: Boolean =
+    SqlApiConf.get.useDDLBasedCatalogAPI
+
+  override def sql(str: String, args: Map[String, Any]): org.apache.spark.sql.DataFrame =
+    sparkSession.sql(str, args)
+
+  /**
+   * Parse a multipart identifier (no catalyst dependency). Split by '.' only when not inside
+   * backtick-quoted segments; unquote and unescape (`` -> `).
+   */
+  override def parseMultipartIdentifier(identifier: String): Seq[String] = {
+    if (identifier == null || identifier.isEmpty) return Seq.empty
+    val parts = scala.collection.mutable.ArrayBuffer.empty[String]
+    var i = 0
+    val n = identifier.length
+    while (i < n) {
+      while (i < n && identifier(i) == ' ') i += 1
+      if (i >= n) return parts.toSeq
+      val partStart = i
+      if (identifier(i) == '`') {
+        i += 1
+        val sb = new StringBuilder
+        var done = false
+        while (i < n && !done) {
+          identifier(i) match {
+            case '`' =>
+              i += 1
+              if (i < n && identifier(i) == '`') {
+                sb.append('`')
+                i += 1
+              } else {
+                parts += sb.toString
+                while (i < n && identifier(i) == ' ') i += 1
+                if (i < n && identifier(i) == '.') i += 1
+                else if (i < n) {
+                  val rest = identifier.substring(i).trim
+                  if (rest.nonEmpty) parts += rest
+                  return parts.toSeq
+                }
+                done = true
+              }
+            case c =>
+              sb.append(c)
+              i += 1
+          }
+        }
+        if (!done) parts += sb.toString
+      } else {
+        while (i < n && identifier(i) != '.') i += 1
+        val part = identifier.substring(partStart, i).trim
+        if (part.nonEmpty) parts += part
+        if (i < n && identifier(i) == '.') i += 1
+      }
+    }
+    parts.toSeq
+  }
+
+  override def quoteIdentifier(identifier: String): String =
+    QuotingUtils.quoteIdentifier(identifier)
 
   /**
    * Returns the current default database in this session.
@@ -197,11 +259,15 @@ class Catalog(sparkSession: SparkSession) extends catalog.Catalog {
    * @since 3.5.0
    */
   override def getDatabase(dbName: String): Database = {
-    sparkSession
-      .newDataset(Catalog.databaseEncoder) { builder =>
-        builder.getCatalogBuilder.getGetDatabaseBuilder.setDbName(dbName)
-      }
-      .head()
+    if (useDDLBasedCatalogAPI) {
+      super.getDatabase(dbName)
+    } else {
+      sparkSession
+        .newDataset(Catalog.databaseEncoder) { builder =>
+          builder.getCatalogBuilder.getGetDatabaseBuilder.setDbName(dbName)
+        }
+        .head()
+    }
   }
 
   /**
@@ -289,11 +355,15 @@ class Catalog(sparkSession: SparkSession) extends catalog.Catalog {
    * @since 3.5.0
    */
   override def databaseExists(dbName: String): Boolean = {
-    sparkSession
-      .newDataset(PrimitiveBooleanEncoder) { builder =>
-        builder.getCatalogBuilder.getDatabaseExistsBuilder.setDbName(dbName)
-      }
-      .head()
+    if (useDDLBasedCatalogAPI) {
+      super.databaseExists(dbName)
+    } else {
+      sparkSession
+        .newDataset(PrimitiveBooleanEncoder) { builder =>
+          builder.getCatalogBuilder.getDatabaseExistsBuilder.setDbName(dbName)
+        }
+        .head()
+    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/Catalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/Catalog.scala
@@ -42,6 +42,7 @@ import org.apache.spark.sql.execution.command.{ShowNamespacesCommand, ShowTables
 import org.apache.spark.sql.execution.command.CommandUtils
 import org.apache.spark.sql.execution.datasources.{DataSource, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.internal.{DDLBasedCatalog, SqlApiConf}
 import org.apache.spark.sql.internal.connector.V1Function
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.storage.StorageLevel
@@ -51,9 +52,16 @@ import org.apache.spark.util.ArrayImplicits._
 /**
  * Internal implementation of the user-facing `Catalog`.
  */
-class Catalog(sparkSession: SparkSession) extends catalog.Catalog {
+class Catalog(sparkSession: SparkSession) extends catalog.Catalog with DDLBasedCatalog {
 
   private def sessionCatalog: SessionCatalog = sparkSession.sessionState.catalog
+
+  override def sql(str: String, args: Map[String, Any]): org.apache.spark.sql.DataFrame =
+    sparkSession.sql(str, args)
+  override def parseMultipartIdentifier(identifier: String): Seq[String] =
+    sparkSession.sessionState.sqlParser.parseMultipartIdentifier(identifier)
+  override def quoteIdentifier(identifier: String): String =
+    org.apache.spark.sql.catalyst.util.QuotingUtils.quoteIdentifier(identifier)
 
   /**
    * Helper function for parsing identifiers.
@@ -452,7 +460,11 @@ class Catalog(sparkSession: SparkSession) extends catalog.Catalog {
    * `Database` can be found.
    */
   override def getDatabase(dbName: String): Database = {
-    makeDatabase(None, dbName)
+    if (SqlApiConf.get.useDDLBasedCatalogAPI) {
+      super.getDatabase(dbName)
+    } else {
+      makeDatabase(None, dbName)
+    }
   }
 
   // when catalogName is specified, dbName should be a valid quoted multi-part identifier, or a
@@ -543,11 +555,15 @@ class Catalog(sparkSession: SparkSession) extends catalog.Catalog {
    * Checks if the database with the specified name exists.
    */
   override def databaseExists(dbName: String): Boolean = {
-    try {
-      getDatabase(dbName)
-      true
-    } catch {
-      case _: NoSuchNamespaceException => false
+    if (SqlApiConf.get.useDDLBasedCatalogAPI) {
+      super.databaseExists(dbName)
+    } else {
+      try {
+        getDatabase(dbName)
+        true
+      } catch {
+        case _: NoSuchNamespaceException => false
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

- When `spark.sql.catalog.useDDLBasedAPI` is enabled, both Classic and Connect use the shared DDL-based implementation in `DDLBasedCatalog` for `getDatabase` and `databaseExists`, removing separate legacy code paths in Classic (e.g. `makeDatabase`/`resolveNamespace` for these methods). Behavior is implemented via SQL (DESCRIBE NAMESPACE, SHOW NAMESPACES) with parameterized args.
- Rely on the shared DDL-based implementation and remove redundant protobuf type definitions that were only needed for the previous Connect-specific catalog handling.

### Why are the changes needed?

- Single implementation for catalog lookups when the DDL-based API is on, reducing duplication and drift between Classic and Connect.
- Parameterized SQL in `DDLBasedCatalog` avoids string concatenation and reduces injection risk.
- Dropping extra Connect protobuf definitions simplifies the Connect catalog stack.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests should cover them.

### Was this patch authored or co-authored using generative AI tooling?

No.