### PR TITLE
[SPARK-53807][CORE][FOLLOW-UP] Fix deadlock between unlock and releaseAllLocksForTask for write lock in BlockInfoManager

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockInfoManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockInfoManager.scala
@@ -196,8 +196,8 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
   }
 
   /**
-   * Unregister a write lock on `blockId` for `taskAttemptId`. This method removes the entry
-   * for the task if no locks are left.
+   * Unregister a write lock on `blockId` for `taskAttemptId`. The entry for the task is
+   * cleaned up later by `releaseAllLocksForTask`.
    */
   private def unregisterWriteLockForTask(taskAttemptId: TaskAttemptId, blockId: BlockId): Unit = {
     writeLocksByTask.computeIfPresent(taskAttemptId, (_, blockIds) => {
@@ -519,8 +519,8 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
     val writeLocks = Option(writeLocksByTask.remove(taskAttemptId)).getOrElse(util.Set.of())
     writeLocks.forEach { blockId =>
       blockInfo(blockId) { (info, condition) =>
-        // Check the existence of `blockId` and also if still be held by this task because `unlock`
-        // may have already released it concurrently. See SPARK-53807 for details.
+        // Check the existence of `blockId` and also if it is still held by this task because
+        // `unlock` may have already released it concurrently. See SPARK-53807 for details.
         if (writeLocks.contains(blockId) && info.writerTask == taskAttemptId) {
           blocksWithReleasedLocks += blockId
           info.writerTask = BlockInfo.NO_WRITER

--- a/core/src/main/scala/org/apache/spark/storage/BlockInfoManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockInfoManager.scala
@@ -180,6 +180,37 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
   private[this] val writeLocksByTask = new ConcurrentHashMap[TaskAttemptId, util.Set[BlockId]]
 
   /**
+   * Register a write lock on `blockId` for `taskAttemptId`. This method creates a new entry
+   * for the task if none exist yet.
+   */
+  private def registerWriteLockForTask(taskAttemptId: TaskAttemptId, blockId: BlockId): Unit = {
+    writeLocksByTask.compute(taskAttemptId, (_, blockIds) => {
+      val newBlockIds = if (blockIds == null) {
+        util.Collections.synchronizedSet(new util.HashSet[BlockId])
+      } else {
+        blockIds
+      }
+      newBlockIds.add(blockId)
+      newBlockIds
+    })
+  }
+
+  /**
+   * Unregister a write lock on `blockId` for `taskAttemptId`. This method removes the entry
+   * for the task if no locks are left.
+   */
+  private def unregisterWriteLockForTask(taskAttemptId: TaskAttemptId, blockId: BlockId): Unit = {
+    writeLocksByTask.computeIfPresent(taskAttemptId, (_, blockIds) => {
+      blockIds.remove(blockId)
+      if (blockIds.isEmpty) {
+        null // Returning null makes the `writeLocksByTask` drop this entry from the map.
+      } else {
+        blockIds
+      }
+    })
+  }
+
+  /**
    * Tracks the set of blocks that each task has locked for reading, along with the number of times
    * that a block has been locked (since our read locks are re-entrant).
    */
@@ -333,7 +364,7 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
       val acquire = info.writerTask == BlockInfo.NO_WRITER && info.readerCount == 0
       if (acquire) {
         info.writerTask = taskAttemptId
-        writeLocksByTask.get(taskAttemptId).add(blockId)
+        registerWriteLockForTask(taskAttemptId, blockId)
         logTrace(s"Task $taskAttemptId acquired write lock for $blockId")
       }
       acquire
@@ -396,10 +427,10 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
     logTrace(s"Task $taskAttemptId releasing lock for $blockId")
     blockInfo(blockId) { (info, condition) =>
       if (info.writerTask != BlockInfo.NO_WRITER) {
-        val blockIds = writeLocksByTask.get(taskAttemptId)
+        val blockIds = writeLocksByTask.get(info.writerTask)
         if (blockIds != null) {
+          unregisterWriteLockForTask(info.writerTask, blockId)
           info.writerTask = BlockInfo.NO_WRITER
-          blockIds.remove(blockId)
         }
       } else {
         // There can be a race between unlock and releaseAllLocksForTask which causes negative
@@ -492,11 +523,10 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
     val writeLocks = Option(writeLocksByTask.remove(taskAttemptId)).getOrElse(util.Set.of())
     writeLocks.forEach { blockId =>
       blockInfo(blockId) { (info, condition) =>
-        // Check the existence of `blockId` because `unlock` may have already removed it
-        // concurrently.
-        if (writeLocks.contains(blockId)) {
+        // Check the existence of `blockId` and also if still be held by this task because `unlock`
+        // may have already released it concurrently. See SPARK-53807 for details.
+        if (writeLocks.contains(blockId) && info.writerTask == taskAttemptId) {
           blocksWithReleasedLocks += blockId
-          assert(info.writerTask == taskAttemptId)
           info.writerTask = BlockInfo.NO_WRITER
           condition.signalAll()
         }
@@ -595,7 +625,7 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
         }
         info.readerCount = 0
         info.writerTask = BlockInfo.NO_WRITER
-        writeLocksByTask.get(taskAttemptId).remove(blockId)
+        unregisterWriteLockForTask(taskAttemptId, blockId)
       }
       condition.signalAll()
     }

--- a/core/src/main/scala/org/apache/spark/storage/BlockInfoManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockInfoManager.scala
@@ -202,11 +202,7 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
   private def unregisterWriteLockForTask(taskAttemptId: TaskAttemptId, blockId: BlockId): Unit = {
     writeLocksByTask.computeIfPresent(taskAttemptId, (_, blockIds) => {
       blockIds.remove(blockId)
-      if (blockIds.isEmpty) {
-        null // Returning null makes the `writeLocksByTask` drop this entry from the map.
-      } else {
-        blockIds
-      }
+      blockIds
     })
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR introduces `registerWriteLockForTask` / `unregisterWriteLockForTask` helpers that use ConcurrentHashMap.compute / computeIfPresent instead of operating directly on the synchronizedSet under a block lock. Especially, with `ConcurrentHashMap.computeIfPresent`, we decouple the lock contention between `blockIds.remove(blockId)` in `unblock` and `writeLocks.forEach` in `releaseAllLocksForTask` (where `blockIds` and `writeLocks` are actually same synchronized Set instance from `writeLocksByTask`). Instead, `ConcurrentHashMap.computeIfPresent` forces `writeLocks.forEach` to wait until `blockIds.remove(blockId)` is completed as guaranteed by `ConcurrentHashMap`'s bin lock.

This PR has two small changes along with:

* Change from `writeLocksByTask.get(taskAttemptId)` to `writeLocksByTask.get(info.writerTask)` in `unlock` for safety in case `unblock` is onvoked out of the task context. This change should be safe as we are holding the block's lock at the point.

* Relax the assertion `assert(info.writerTask == taskAttemptId)` in `releaseAllLocksForTask` and changed to if condition since the concurrent `unlock` could break this assertion after the fix.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The race condition still exists between `unlock` and `releaseAllLocksForTask` for write lock in `BlockInfoManager`. And the race condition results in the deadlock in this way:

Thread 1 (releaseAllLocksForTask): writeLocks.forEach { ... } acquires the set's intrinsic monitor for the entire iteration → then tries blockInfo(blockId) to acquire the block's ReentrantLock
Thread 2 (unlock): holds the block's ReentrantLock (inside blockInfo) → then tries blockIds.remove(blockId) which needs the same set's intrinsic monitor

The example thread stacks:

```
"pool-1-thread-1-ScalaTest-running-BlockInfoManagerSuite" prio=5 Id=17 RUNNABLE
	at java.management@17.0.14/sun.management.ThreadImpl.dumpThreads0(Native Method)
	at java.management@17.0.14/sun.management.ThreadImpl.dumpAllThreads(ThreadImpl.java:528)
	at java.management@17.0.14/sun.management.ThreadImpl.dumpAllThreads(ThreadImpl.java:516)
	at app//org.apache.spark.util.Utils$.getThreadDump(Utils.scala:2141)
	at app//org.apache.spark.storage.BlockInfoManager.$anonfun$releaseAllLocksForTask$2(BlockInfoManager.scala:500)
	at app//org.apache.spark.storage.BlockInfoManager$$Lambda$452/0x00000098012db008.accept(Unknown Source)
	at java.base@17.0.14/java.lang.Iterable.forEach(Iterable.java:75)
	at java.base@17.0.14/java.util.Collections$SynchronizedCollection.forEach(Collections.java:2131)
	-  **locked java.util.Collections$SynchronizedSet@3e7652b2**
	at app//org.apache.spark.storage.BlockInfoManager.releaseAllLocksForTask(BlockInfoManager.scala:495)
	at app//org.apache.spark.storage.BlockInfoManagerSuite.$anonfun$new$99(BlockInfoManagerSuite.scala:461)
	at app//org.apache.spark.storage.BlockInfoManagerSuite$$Lambda$439/0x00000098012c7c28.apply$mcV$sp(Unknown Source)
	at app//scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
	at app//org.apache.spark.storage.BlockInfoManagerSuite.withTaskId(BlockInfoManagerSuite.scala:66)
	at app//org.apache.spark.storage.BlockInfoManagerSuite.$anonfun$new$98(BlockInfoManagerSuite.scala:452)
	...
	at java.base@17.0.14/java.lang.Thread.run(Thread.java:840)

	Number of locked synchronizers = 1
	- java.util.concurrent.ThreadPoolExecutor$Worker@7ee8290b
```

```
"scala-execution-context-global-21" daemon prio=5 Id=21 BLOCKED on java.util.Collections$SynchronizedSet@3e7652b2owned by "pool-1-thread-1-ScalaTest-running-BlockInfoManagerSuite"
	at java.base@17.0.14/java.util.Collections$SynchronizedCollection.remove(Collections.java:2107)
	-  blocked on java.util.Collections$SynchronizedSet@3e7652b2
	at app//org.apache.spark.storage.BlockInfoManager.$anonfun$unlock$3(BlockInfoManager.scala:404)
	at app//org.apache.spark.storage.BlockInfoManager.$anonfun$unlock$3$adapted(BlockInfoManager.scala:399)
	at app//org.apache.spark.storage.BlockInfoManager$$Lambda$437/0x00000098012cc000.apply(Unknown Source)
	at app//org.apache.spark.storage.BlockInfoWrapper.withLock(BlockInfoManager.scala:104)
	at app//org.apache.spark.storage.BlockInfoManager.blockInfo(BlockInfoManager.scala:280)
	at app//org.apache.spark.storage.BlockInfoManager.unlock(BlockInfoManager.scala:399)
	....
	at java.base@17.0.14/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)

	Number of locked synchronizers = 1
	- java.util.concurrent.locks.ReentrantLock$NonfairSync@7c2179cd
```

The deadlock could also be easily reproduce by inserting `Thread.sleep(300)` right before `blockIds.remove(blockId)` in `unlock` and then run unit test SPARK-53807 in `BlockInforManagerSuite`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Manually tested. Before the fix, SPARK-53807 unit test is esaily to fail with the reproduce step. After the fix, the test pass as expected.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.