### PR TITLE
[SPARK-55940][BUILD] Upgrade Kafka to 3.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <!-- Version used in Maven Hive dependency -->
     <hive.version>2.3.10</hive.version>
     <!-- note that this should be compatible with Kafka brokers version 0.10 and up -->
-    <kafka.version>3.9.1</kafka.version>
+    <kafka.version>3.9.2</kafka.version>
     <!-- After 10.17.1.0, the minimum required version is JDK19 -->
     <derby.version>10.16.1.1</derby.version>
     <parquet.version>1.17.0</parquet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to Upgrade Kafka to 3.9.2.

### Why are the changes needed?

Apache Kafka 3.9.2 is the first 3.9.x version which is officially tested under Java 25.

https://downloads.apache.org/kafka/3.9.2/RELEASE_NOTES.html
- https://github.com/apache/kafka/pull/21026
- https://github.com/apache/kafka/pull/21104

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`.