### PR TITLE
[SPARK-55723][PYTHON] Generalize enforce_schema error to PySparkTypeError

### DIFF
--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -1052,11 +1052,6 @@
       "Column names of the returned pyarrow.Table do not match specified schema.<missing><extra>"
     ]
   },
-  "RESULT_COLUMNS_MISMATCH_FOR_ARROW_UDTF": {
-    "message": [
-      "Column names of the returned pyarrow.Table or pyarrow.RecordBatch do not match specified schema. Expected: <expected> Actual: <actual>"
-    ]
-  },
   "RESULT_COLUMNS_MISMATCH_FOR_PANDAS_UDF": {
     "message": [
       "Column names of the returned pandas.DataFrame do not match specified schema.<missing><extra>"

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -21,7 +21,7 @@ import decimal
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, Union, overload
 
 import pyspark
-from pyspark.errors import PySparkRuntimeError, PySparkValueError
+from pyspark.errors import PySparkTypeError, PySparkValueError
 from pyspark.sql.pandas.types import (
     _dedup_names,
     _deduplicate_field_names,
@@ -117,10 +117,6 @@ class ArrowBatchTransformer:
         """
         Enforce target schema on a RecordBatch by reordering columns and coercing types.
 
-        .. note::
-            Currently this function is only used by UDTF. The error messages
-            are UDTF-specific (see SPARK-55723).
-
         Parameters
         ----------
         batch : pa.RecordBatch
@@ -157,16 +153,11 @@ class ArrowBatchTransformer:
             if arr.type != field.type:
                 try:
                     arr = arr.cast(target_type=field.type, safe=safecheck)
-                except (pa.ArrowInvalid, pa.ArrowTypeError):
-                    # TODO(SPARK-55723): Unify error messages for all UDF types,
-                    #  not just UDTF.
-                    raise PySparkRuntimeError(
-                        errorClass="RESULT_COLUMNS_MISMATCH_FOR_ARROW_UDTF",
-                        messageParameters={
-                            "expected": str(field.type),
-                            "actual": str(arr.type),
-                        },
-                    )
+                except (pa.ArrowInvalid, pa.ArrowTypeError) as e:
+                    raise PySparkTypeError(
+                        f"Result type of column '{field.name}' does not match "
+                        f"the expected type. Expected: {field.type}, got: {arr.type}."
+                    ) from e
             coerced_arrays.append(arr)
 
         return pa.RecordBatch.from_arrays(coerced_arrays, names=target_names)

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -322,14 +322,12 @@ class ArrowStreamArrowUDTFSerializer(ArrowStreamUDTFSerializer):
                                     safecheck=True,
                                 )
                             )
-                        except (pa.ArrowInvalid, pa.ArrowTypeError):
-                            raise PySparkRuntimeError(
-                                errorClass="RESULT_COLUMNS_MISMATCH_FOR_ARROW_UDTF",
-                                messageParameters={
-                                    "expected": str(field.type),
-                                    "actual": str(batch.column(i).type),
-                                },
-                            )
+                        except (pa.ArrowInvalid, pa.ArrowTypeError) as e:
+                            raise PySparkTypeError(
+                                f"Result type of column '{field.name}' does not "
+                                f"match the expected type. Expected: {field.type}, "
+                                f"got: {batch.column(i).type}."
+                            ) from e
                     coerced_batch = pa.RecordBatch.from_arrays(
                         coerced_arrays, names=expected_field_names
                     )

--- a/python/pyspark/sql/tests/arrow/test_arrow_udtf.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udtf.py
@@ -373,9 +373,8 @@ class ArrowUDTFTestsMixin:
         # Should fail with Arrow cast exception since string cannot be cast to int
         with self.assertRaisesRegex(
             PythonException,
-            "PySparkRuntimeError: \\[RESULT_COLUMNS_MISMATCH_FOR_ARROW_UDTF\\] "
-            "Column names of the returned pyarrow.Table or pyarrow.RecordBatch do not match "
-            "specified schema. Expected: int32 Actual: string",
+            "PySparkTypeError: Result type of column 'id' does not match the expected type. "
+            "Expected: int32, got: string.",
         ):
             result_df = StringToIntUDTF()
             result_df.collect()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace `PySparkRuntimeError` with `RESULT_COLUMNS_MISMATCH_FOR_ARROW_UDTF` error class in `enforce_schema` and `ArrowStreamArrowUDTFSerializer` with a general `PySparkTypeError` that reports column name, expected type, and actual type without being specific to any UDF type.

### Why are the changes needed?

The `RESULT_COLUMNS_MISMATCH_FOR_ARROW_UDTF` error class was UDTF-specific, but `enforce_schema` is a general utility used across UDF types. The error message ("Column names ... do not match specified schema") was also misleading -- the actual failure is a type cast error, not a column name mismatch.


### Does this PR introduce _any_ user-facing change?

Yes. The error type changes from `PySparkRuntimeError` to `PySparkTypeError`, and the message now accurately describes the type mismatch:

**Before:**
```
PySparkRuntimeError: [RESULT_COLUMNS_MISMATCH_FOR_ARROW_UDTF] Column names of the returned pyarrow.Table or pyarrow.RecordBatch do not match specified schema. Expected: int32 Actual: string
```

**After:**
```
PySparkTypeError: Result type of column 'id' does not match the expected type. Expected: int32, got: string.
```

### How was this patch tested?

Updated existing test in `test_arrow_udtf.py`.

### Was this patch authored or co-authored using generative AI tooling?

No