### PR TITLE
[SPARK-55958][BUILD][CONNECT] Remove unused `add-scala-test-sources` setting from `pom.xml` in `connect-common`

### DIFF
--- a/sql/connect/common/pom.xml
+++ b/sql/connect/common/pom.xml
@@ -108,24 +108,6 @@
         <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>add-scala-test-sources</id>
-                        <phase>generate-test-sources</phase>
-                        <goals>
-                            <goal>add-test-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>src/test/gen-java</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <!--


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to remove unused `add-scala-test-sources` setting from `pom.xml` in `connect-common`.
`add-scala-test-sources` adds `src/test/gen-java` as a test source directory, but this directory has never existed in the `sql/connect/common`. It appears to have been carried over from `sql/core/pom.xml` when the Connect common module was originally created in SPARK-41369.

### Why are the changes needed?
Cleanup `pom.xml`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA passed.


### Was this patch authored or co-authored using generative AI tooling?
Kiro CLI / Opus 4.6
