### PR TITLE
[SPARK-55962][SQL] Use `getShort` instead of `getInt` casting in `putShortsFromIntsLittleEndian` on Little Endian platforms

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -278,7 +278,7 @@ public final class OffHeapColumnVector extends WritableColumnVector {
       }
     } else {
       for (int i = 0; i < count; ++i, srcOffset += 4, dstOffset += 2) {
-        Platform.putShort(null, dstOffset, (short) Platform.getInt(src, srcOffset));
+        Platform.putShort(null, dstOffset, Platform.getShort(src, srcOffset));
       }
     }
   }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -273,7 +273,7 @@ public final class OnHeapColumnVector extends WritableColumnVector {
       }
     } else {
       for (int i = 0; i < count; ++i, srcOffset += 4) {
-        shortData[rowId + i] = (short) Platform.getInt(src, srcOffset);
+        shortData[rowId + i] = Platform.getShort(src, srcOffset);
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR optimizes the `putShortsFromIntsLittleEndian` method in `OnHeapColumnVector` and `OffHeapColumnVector` specifically for Little Endian platforms.

Instead of reading a full 4-byte `int` and casting it to `short` (which discards the upper bytes), the new implementation directly reads the first 2 bytes using `Platform.getShort()` when the system architecture is Little Endian.


### Why are the changes needed?
To avoid redundant memory access by reading only the necessary 2 bytes instead of 4 bytes per element on Little Endian platforms.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions


### Was this patch authored or co-authored using generative AI tooling?
No