### PR TITLE
[SPARK-55963][K8S] Optimize snapshot traversal in ExecutorPodsAllocator

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -165,18 +165,51 @@ class ExecutorPodsAllocator(
       applicationId: String,
       schedulerBackend: KubernetesClusterSchedulerBackend,
       snapshots: Seq[ExecutorPodsSnapshot]): Unit = {
+    val snapshotProcessStartTime = clock.getTimeMillis()
     logDebug(s"Received ${snapshots.size} snapshots")
-    val k8sKnownExecIds = snapshots.flatMap(_.executorPods.keys).distinct
+
+    // Optimization: Since each snapshot is built incrementally via withUpdate() on top of the
+    // previous one, the last snapshot is always a superset of all prior snapshots in most cases.
+    // However, replaceSnapshot() can cause pods that appeared in earlier snapshots to be absent
+    // in the last one. We merge all snapshots to capture every executor ID that appeared during
+    // this batch, which is the conservative and correct approach.
+    val aggregatedPods: Map[Long, ExecutorPodState] = if (snapshots.size <= 1) {
+      snapshots.headOption.map(_.executorPods).getOrElse(Map.empty)
+    } else {
+      val merged = mutable.HashMap.empty[Long, ExecutorPodState]
+      snapshots.foreach { s => merged ++= s.executorPods }
+      merged.toMap
+    }
+
+    val k8sKnownExecIds = aggregatedPods.keySet
     newlyCreatedExecutors --= k8sKnownExecIds
     schedulerKnownNewlyCreatedExecs --= k8sKnownExecIds
 
     // Although we are going to delete some executors due to timeout in this function,
     // it takes undefined time before the actual deletion. Hence, we should collect all PVCs
     // in use at the beginning. False positive is okay in this context in order to be safe.
-    val k8sKnownPVCNames = snapshots.flatMap(_.executorPods.values.map(_.pod)).flatMap { pod =>
-      pod.getSpec.getVolumes.asScala
-        .flatMap { v => Option(v.getPersistentVolumeClaim).map(_.getClaimName) }
-    }.distinct
+    // Optimization: iterate over the aggregated pod set (already deduplicated by exec ID)
+    // instead of iterating all snapshots which contain massive overlap.
+    val k8sKnownPVCNames: Set[String] = {
+      val pvcNameSet = mutable.HashSet.empty[String]
+      aggregatedPods.valuesIterator.foreach { state =>
+        state.pod.getSpec.getVolumes.asScala.foreach { v =>
+          val pvc = v.getPersistentVolumeClaim
+          if (pvc != null) {
+            pvcNameSet.add(pvc.getClaimName)
+          }
+        }
+      }
+      pvcNameSet.toSet
+    }
+    val snapshotPreprocessMs = clock.getTimeMillis() - snapshotProcessStartTime
+    if (snapshots.size > 1) {
+      logDebug(s"Snapshot preprocessing: " +
+        s"snapshotCount=${snapshots.size}, " +
+        s"aggregatedPodCount=${aggregatedPods.size}, " +
+        s"pvcCount=${k8sKnownPVCNames.size}, " +
+        s"totalPreprocessMs=${snapshotPreprocessMs}")
+    }
 
     // transfer the scheduler backend known executor requests from the newlyCreatedExecutors
     // to the schedulerKnownNewlyCreatedExecs
@@ -399,7 +432,7 @@ class ExecutorPodsAllocator(
     numOutstandingPods.set(totalPendingCount + newlyCreatedExecutors.size)
   }
 
-  protected def getReusablePVCs(applicationId: String, pvcsInUse: Seq[String]) = {
+  protected def getReusablePVCs(applicationId: String, pvcsInUse: Set[String]) = {
     if (conf.get(KUBERNETES_DRIVER_OWN_PVC) && conf.get(KUBERNETES_DRIVER_REUSE_PVC) &&
         driverPod.nonEmpty) {
       try {
@@ -437,7 +470,7 @@ class ExecutorPodsAllocator(
       numExecutorsToAllocate: Int,
       applicationId: String,
       resourceProfileId: Int,
-      pvcsInUse: Seq[String]): Unit = {
+      pvcsInUse: Set[String]): Unit = {
     // Check reusable PVCs for this executor allocation batch
     val reusablePVCs = getReusablePVCs(applicationId, pvcsInUse)
     for ( _ <- 0 until numExecutorsToAllocate) {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocatorSuite.scala
@@ -899,7 +899,7 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     val getReusablePVCs =
       PrivateMethod[mutable.Buffer[PersistentVolumeClaim]](Symbol("getReusablePVCs"))
     when(persistentVolumeClaimList.getItems).thenThrow(new KubernetesClientException("Error"))
-    podsAllocatorUnderTest invokePrivate getReusablePVCs("appId", Seq.empty[String])
+    podsAllocatorUnderTest invokePrivate getReusablePVCs("appId", Set.empty[String])
   }
 
   test("SPARK-41388: getReusablePVCs should ignore recently created PVCs in the previous batch") {
@@ -914,7 +914,8 @@ class ExecutorPodsAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     pvc2.getMetadata.setCreationTimestamp(now.toString)
 
     when(persistentVolumeClaimList.getItems).thenReturn(Seq(pvc1, pvc2).asJava)
-    val reusablePVCs = podsAllocatorUnderTest invokePrivate getReusablePVCs("appId", Seq.empty)
+    val reusablePVCs =
+      podsAllocatorUnderTest invokePrivate getReusablePVCs("appId", Set.empty[String])
     assert(reusablePVCs.size == 1)
     assert(reusablePVCs.head.getMetadata.getName == "pvc-1")
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Optimize the snapshot preprocessing in `ExecutorPodsAllocator.onNewSnapshots()`.

Currently, to collect known executor IDs and PVC names, the code calls `flatMap` + `distinct` across all snapshots. Since each snapshot is built incrementally via `withUpdate()`, they overlap heavily — when requesting 1000 pods, a single batch may contain hundreds of snapshots, each carrying a near-complete copy of the pod map. This leads to a lot of redundant work.

This PR merges all snapshots into a single aggregated map up front, which deduplicates by executor ID naturally. PVC names are then extracted from this deduplicated map. The merge is still correct in the presence of `replaceSnapshot()`, which can drop pods from earlier snapshots. Also changed `pvcsInUse` from `Seq` to `Set` for O(1) `contains()`.

**Note:** This PR is part of a broader effort to improve K8s executor allocation performance. It targets the **snapshot preprocessing** phase of `onNewSnapshots()`. A companion PR #54688 addresses the other major bottleneck — **serial pod creation** — by parallelizing K8s API calls. The two optimizations are independent and complementary.


### Why are the changes needed?
When requesting 1000 executor pods, the average preprocessing time (`totalPreprocessMs`) dropped from **17.6 ms to 1.5 ms** (~11.7x speedup). This overhead is incurred on every snapshot batch and can delay executor allocation at scale.
<img width="1430" height="440" alt="image" src="https://github.com/user-attachments/assets/c095d460-4748-4ac3-b94f-d301a8c44cfc" />



### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Updated existing test


### Was this patch authored or co-authored using generative AI tooling?
No.