### PR TITLE
[SPARK-55965][PYTHON] Add warning when pandas >= 3.0.0 is used with PySpark

### DIFF
--- a/python/pyspark/sql/pandas/utils.py
+++ b/python/pyspark/sql/pandas/utils.py
@@ -56,6 +56,16 @@ def require_minimum_pandas_version() -> None:
                 "current_version": str(pandas.__version__),
             },
         )
+    if LooseVersion(pandas.__version__) >= LooseVersion("3.0.0"):
+        import warnings
+
+        warnings.warn(
+            "PySpark does not yet fully support pandas >= 3.0.0. "
+            "Some features may not work correctly. "
+            "It is recommended to use pandas < 3.0.0 for now.",
+            FutureWarning,
+            stacklevel=2,
+        )
 
 
 def require_minimum_pyarrow_version() -> None:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a `FutureWarning` in `require_minimum_pandas_version()` when pandas >= 3.0.0 is detected.

### Why are the changes needed?

PySpark does not yet fully support pandas >= 3.0.0. This adds a warning to inform users.

### Does this PR introduce _any_ user-facing change?

Yes. Users with pandas >= 3.0.0 will see a `FutureWarning` when using PySpark pandas-related features.

### How was this patch tested?

Existing tests.