### PR TITLE
[SPARK-55694][SQL][FOLLOW-UP] Add test for CREATE OR REPLACE TABLE AS SELECT with constraints

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -3045,7 +3045,8 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
     Seq(
       "CONSTRAINT pk PRIMARY KEY (id)",
       "CONSTRAINT uk UNIQUE (id)",
-      "CONSTRAINT ck CHECK (id > 0)"
+      "CONSTRAINT ck CHECK (id > 0)",
+      "CONSTRAINT fk FOREIGN KEY (id) REFERENCES other_table(id)"
     ).foreach { constraintDef =>
       val sql = s"CREATE TABLE ctas1 ($constraintDef) AS SELECT 1 AS id"
       assertUnsupported(
@@ -3060,9 +3061,26 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
     Seq(
       "CONSTRAINT pk PRIMARY KEY (id)",
       "CONSTRAINT uk UNIQUE (id)",
-      "CONSTRAINT ck CHECK (id > 0)"
+      "CONSTRAINT ck CHECK (id > 0)",
+      "CONSTRAINT fk FOREIGN KEY (id) REFERENCES other_table(id)"
     ).foreach { constraintDef =>
       val sql = s"REPLACE TABLE rtas1 ($constraintDef) AS SELECT 1 AS id"
+      assertUnsupported(
+        sql,
+        Map("message" ->
+          "Constraints may not be specified in a Replace Table As Select (RTAS) statement"),
+        ExpectedContext(fragment = sql, start = 0, stop = sql.length - 1))
+    }
+  }
+
+  test("CREATE OR REPLACE TABLE AS SELECT with constraints") {
+    Seq(
+      "CONSTRAINT pk PRIMARY KEY (id)",
+      "CONSTRAINT uk UNIQUE (id)",
+      "CONSTRAINT ck CHECK (id > 0)",
+      "CONSTRAINT fk FOREIGN KEY (id) REFERENCES other_table(id)"
+    ).foreach { constraintDef =>
+      val sql = s"CREATE OR REPLACE TABLE rtas1 ($constraintDef) AS SELECT 1 AS id"
       assertUnsupported(
         sql,
         Map("message" ->


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add test to verify that constraints (PRIMARY KEY, UNIQUE, CHECK, FOREIGN KEY) are properly rejected in CREATE OR REPLACE TABLE AS SELECT (RTAS) statements at the parser level. Also add FOREIGN KEY coverage to the existing CTAS and RTAS constraint tests. This is to increase test coverage for SPARK-55694. 


### Why are the changes needed?
better test coverage


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
unit test

### Was this patch authored or co-authored using generative AI tooling?
Claude code Opus 4.6
