### PR TITLE
[SPARK-55970][CORE] Cap spark.executor.cores to max worker cores when set too large

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -825,6 +825,16 @@ private[deploy] class Master(
     assignedCores
   }
 
+  private def sortUsableWorkersByPolicy(workers: Array[WorkerInfo]): Array[WorkerInfo] = {
+    workerSelectionPolicy match {
+      case CORES_FREE_ASC => workers.sortBy(w => (w.coresFree, w.id))
+      case CORES_FREE_DESC => workers.sortBy(w => (w.coresFree, w.id)).reverse
+      case MEMORY_FREE_ASC => workers.sortBy(w => (w.memoryFree, w.id))
+      case MEMORY_FREE_DESC => workers.sortBy(w => (w.memoryFree, w.id)).reverse
+      case WorkerSelectionPolicy.WORKER_ID => workers.sortBy(_.id)
+    }
+  }
+
   /**
    * Schedule and launch executors on workers
    */
@@ -838,36 +848,54 @@ private[deploy] class Master(
         logInfo(log"Start scheduling for app ${MDC(LogKeys.APP_ID, app.id)} with" +
           log" rpId: ${MDC(LogKeys.RESOURCE_PROFILE_ID, rpId)}")
         val resourceDesc = app.getResourceDescriptionForRpId(rpId)
+        val aliveWorkers = workers.toArray.filter(_.state == WorkerState.ALIVE)
         val coresPerExecutor = resourceDesc.coresPerExecutor.getOrElse(1)
 
         // If the cores left is less than the coresPerExecutor,the cores left will not be allocated
         if (app.coresLeft >= coresPerExecutor) {
           // Filter out workers that don't have enough resources to launch an executor
-          val aliveWorkers = workers.toArray.filter(_.state == WorkerState.ALIVE)
-            .filter(canLaunchExecutor(_, resourceDesc))
-          val usableWorkers = workerSelectionPolicy match {
-            case CORES_FREE_ASC => aliveWorkers.sortBy(w => (w.coresFree, w.id))
-            case CORES_FREE_DESC => aliveWorkers.sortBy(w => (w.coresFree, w.id)).reverse
-            case MEMORY_FREE_ASC => aliveWorkers.sortBy(w => (w.memoryFree, w.id))
-            case MEMORY_FREE_DESC => aliveWorkers.sortBy(w => (w.memoryFree, w.id)).reverse
-            case WorkerSelectionPolicy.WORKER_ID => aliveWorkers.sortBy(_.id)
-          }
+          val usableWorkers = aliveWorkers.filter(canLaunchExecutor(_, resourceDesc))
+          val sortedUsableWorkers = sortUsableWorkersByPolicy(usableWorkers)
           val appMayHang = waitingApps.length == 1 &&
-            waitingApps.head.executors.isEmpty && usableWorkers.isEmpty
-          if (appMayHang) {
+            waitingApps.head.executors.isEmpty && sortedUsableWorkers.isEmpty
+          // If the app would hang, log a warning. Also check whether spark.executor.cores
+          // exceeds the total cores of any worker; if so, cap it to the max worker cores and
+          // recompute the usable workers so the executor can be placed.
+          val (effectiveResourceDesc, effectiveUsableWorkers) = if (appMayHang) {
             logWarning(log"App ${MDC(LogKeys.APP_ID, app.id)} requires more resource " +
               log"than any of Workers could have.")
+            resourceDesc.coresPerExecutor match {
+              case Some(requestedCores)
+                if conf.get(CAP_EXECUTOR_CORES_ENABLED) &&
+                  aliveWorkers.nonEmpty && requestedCores > aliveWorkers.map(_.cores).max =>
+                val maxWorkerCores = aliveWorkers.map(_.cores).max
+                logWarning(log"spark.executor.cores is set to " +
+                  log"${MDC(LogKeys.NUM_EXECUTOR_CORES, requestedCores)}, which exceeds the " +
+                  log"maximum available cores on any worker " +
+                  log"(${MDC(LogKeys.NUM_EXECUTOR_CORES_TOTAL, maxWorkerCores)}). " +
+                  log"Resetting spark.executor.cores to " +
+                  log"${MDC(LogKeys.NUM_EXECUTOR_CORES_TOTAL, maxWorkerCores)} " +
+                  log"to allow executor launch.")
+                val cappedDesc = resourceDesc.copy(coresPerExecutor = Some(maxWorkerCores))
+                val cappedWorkers = sortUsableWorkersByPolicy(
+                  aliveWorkers.filter(canLaunchExecutor(_, cappedDesc)))
+                (cappedDesc, cappedWorkers)
+              case _ => (resourceDesc, sortedUsableWorkers)
+            }
+          } else {
+            (resourceDesc, sortedUsableWorkers)
           }
           val assignedCores =
-            scheduleExecutorsOnWorkers(app, rpId, resourceDesc, usableWorkers, spreadOutApps)
+            scheduleExecutorsOnWorkers(
+              app, rpId, effectiveResourceDesc, effectiveUsableWorkers, spreadOutApps)
 
           // Now that we've decided how many cores to allocate on each worker, let's allocate them
-          for (pos <- usableWorkers.indices if assignedCores(pos) > 0) {
+          for (pos <- effectiveUsableWorkers.indices if assignedCores(pos) > 0) {
             allocateWorkerResourceToExecutors(
               app,
               assignedCores(pos),
-              resourceDesc,
-              usableWorkers(pos),
+              effectiveResourceDesc,
+              effectiveUsableWorkers(pos),
               rpId)
           }
         }

--- a/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
@@ -152,4 +152,13 @@ private[spark] object Deploy {
     .stringConf
     .checkValue(!_.format("20231101000000", 0).exists(_.isWhitespace), "Whitespace is not allowed.")
     .createWithDefault("app-%s-%04d")
+
+  val CAP_EXECUTOR_CORES_ENABLED = ConfigBuilder("spark.deploy.master.capExecutorCoresEnabled")
+    .doc("When enabled, the Master automatically caps spark.executor.cores to the maximum " +
+      "total cores of any alive worker when the app would otherwise hang with no executors " +
+      "launched, and logs a warning to inform the user of the adjustment.")
+    .version("4.2.0")
+    .internal()
+    .booleanConf
+    .createWithDefault(false)
 }

--- a/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
@@ -176,6 +176,42 @@ class MasterSuite extends MasterSuiteBase {
     }
   }
 
+  test("SPARK-55970: executor cores exceeding worker total cores should be capped to worker cores")
+  {
+    val workerCores = 8
+    val requestedCores = 100 // intentionally much larger than worker cores
+    val conf = new SparkConf().set(CAP_EXECUTOR_CORES_ENABLED, true)
+    val master = makeMaster(conf)
+    // maxCores is not set (unlimited), simulating a user who set spark.executor.cores too large
+    // without an explicit spark.cores.max constraint. coresLeft = Int.MaxValue >= requestedCores,
+    // so the scheduler enters the appMayHang path and applies the cap.
+    val appInfo = makeAppInfo(1024, coresPerExecutor = Some(requestedCores))
+    val worker = makeWorkerInfo(2048, workerCores)
+    master.workers += worker
+    master.registerApplication(appInfo)
+    startExecutorsOnWorkers(master)
+    // The executor should be launched with cores capped to the worker's total cores
+    assert(appInfo.executors.size === 1)
+    assert(appInfo.executors.values.head.cores === workerCores)
+  }
+
+  test("SPARK-55970: executor cores within worker total cores should not be capped") {
+    val workerCores = 8
+    val requestedCores = 4 // within worker capacity
+    val conf = new SparkConf().set(CAP_EXECUTOR_CORES_ENABLED, true)
+    val master = makeMaster(conf)
+    val appInfo = makeAppInfo(1024, coresPerExecutor = Some(requestedCores),
+      maxCores = Some(workerCores))
+    val worker = makeWorkerInfo(2048, workerCores)
+    master.workers += worker
+    master.registerApplication(appInfo)
+    startExecutorsOnWorkers(master)
+    // 2 executors should be launched (workerCores / requestedCores = 8 / 4 = 2)
+    // with no capping applied since requestedCores <= workerCores
+    assert(appInfo.executors.size === 2)
+    assert(appInfo.executors.values.forall(_.cores === requestedCores))
+  }
+
   test("SPARK-45753: Support driver id pattern") {
     val master = makeMaster(new SparkConf().set(DRIVER_ID_PATTERN, "my-driver-%2$05d"))
     val submitDate = new Date()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR proposes to cap `spark.executor.cores` to the max cores of any alive workers when user mistakenly set it too large. This behavior is guarded by the newly added conf `spark.deploy.master.capExecutorCoresEnabled` an is disabled by default.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Users could mistakely set `spark.executor.cores` to a too large value that exceeds any of worker could serve and result in no execuor can be launched. This change intends to improve the user-experience by reviving the executor launching automatically if the user does not care about underlying details.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes if the flag is enable. Before the change, users won't see executors being launched with the wrong setting; after the change, users would see the executors launched.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Unit tests


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Yes.