### PR TITLE
[SPARK-55977][PS] Fix isin() to use strict type matching like pandas

### DIFF
--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -30,14 +30,20 @@ from pandas.api.types import is_list_like, CategoricalDtype
 
 from pyspark.sql import functions as F, Column, Window
 from pyspark.sql.types import (
+    BinaryType,
     BooleanType,
+    CharType,
     DataType,
     DateType,
+    DayTimeIntervalType,
     LongType,
+    NullType,
     NumericType,
     StringType,
     TimestampNTZType,
     TimestampType,
+    TimeType,
+    VarcharType,
 )
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas._typing import Axis, Dtype, IndexOpsLike, Label, SeriesOrIndex
@@ -297,18 +303,27 @@ def _is_value_type_compatible(value: Any, spark_type: DataType) -> bool:
     import datetime
     import decimal
 
-    if value is None:
+    if value is None or isinstance(spark_type, NullType):
         return True
     if isinstance(spark_type, NumericType):
         return isinstance(value, (int, float, bool, decimal.Decimal, np.number))
     if isinstance(spark_type, BooleanType):
         return isinstance(value, (bool, np.bool_, int, float, np.number))
-    if isinstance(spark_type, StringType):
+    if isinstance(spark_type, (StringType, CharType, VarcharType)):
         return isinstance(value, str)
+    if isinstance(spark_type, BinaryType):
+        return isinstance(value, (bytes, bytearray))
     if isinstance(spark_type, (TimestampType, TimestampNTZType)):
         return isinstance(value, (datetime.datetime, pd.Timestamp))
     if isinstance(spark_type, DateType):
         return isinstance(value, (datetime.date, pd.Timestamp))
+    if isinstance(spark_type, TimeType):
+        return isinstance(value, datetime.time)
+    if isinstance(spark_type, DayTimeIntervalType):
+        return isinstance(value, datetime.timedelta)
+    # For complex types (ArrayType, MapType, StructType) and other exotic types
+    # (VariantType, spatial types, YearMonthIntervalType, CalendarIntervalType),
+    # skip filtering and let Spark handle type resolution.
     return True
 
 

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -293,46 +293,38 @@ def _exclude_pd_np_operand(other: Any) -> None:
         )
 
 
-def _isin_compatible_lit(value: Any, spark_type: DataType) -> Optional[Column]:
-    """Return F.lit(value) cast to spark_type if the value is type-compatible, else None.
+def _is_value_type_compatible(value: Any, spark_type: DataType) -> bool:
+    """Check if a Python value's type is compatible with a Spark column type for isin matching.
 
     Pandas isin() uses strict type matching: an integer 1 never matches a string "1".
     However, numeric types (int, float, bool) are cross-compatible, matching Python semantics
     where bool is a subclass of int and int/float compare equal when values match.
-
-    The returned literal is cast to the target Spark type so that Spark's IN expression
-    receives homogeneous types (Spark requires all IN operands to share the same type).
     """
     import datetime
     import decimal
 
     if value is None or isinstance(spark_type, NullType):
-        return F.lit(value).cast(spark_type)
-    compatible: bool
+        return True
     if isinstance(spark_type, NumericType):
-        compatible = isinstance(value, (int, float, bool, decimal.Decimal, np.number))
-    elif isinstance(spark_type, BooleanType):
-        compatible = isinstance(value, (bool, np.bool_, int, float, np.number))
-    elif isinstance(spark_type, (StringType, CharType, VarcharType)):
-        compatible = isinstance(value, str)
-    elif isinstance(spark_type, BinaryType):
-        compatible = isinstance(value, (bytes, bytearray))
-    elif isinstance(spark_type, (TimestampType, TimestampNTZType)):
-        compatible = isinstance(value, (datetime.datetime, pd.Timestamp))
-    elif isinstance(spark_type, DateType):
-        compatible = isinstance(value, (datetime.date, pd.Timestamp))
-    elif isinstance(spark_type, TimeType):
-        compatible = isinstance(value, datetime.time)
-    elif isinstance(spark_type, DayTimeIntervalType):
-        compatible = isinstance(value, datetime.timedelta)
-    else:
-        # For complex types (ArrayType, MapType, StructType) and other exotic types
-        # (VariantType, spatial types, YearMonthIntervalType, CalendarIntervalType),
-        # skip filtering and let Spark handle type resolution.
-        compatible = True
-    if not compatible:
-        return None
-    return F.lit(value).cast(spark_type)
+        return isinstance(value, (int, float, bool, decimal.Decimal, np.number))
+    if isinstance(spark_type, BooleanType):
+        return isinstance(value, (bool, np.bool_, int, float, np.number))
+    if isinstance(spark_type, (StringType, CharType, VarcharType)):
+        return isinstance(value, str)
+    if isinstance(spark_type, BinaryType):
+        return isinstance(value, (bytes, bytearray))
+    if isinstance(spark_type, (TimestampType, TimestampNTZType)):
+        return isinstance(value, (datetime.datetime, pd.Timestamp))
+    if isinstance(spark_type, DateType):
+        return isinstance(value, (datetime.date, pd.Timestamp))
+    if isinstance(spark_type, TimeType):
+        return isinstance(value, datetime.time)
+    if isinstance(spark_type, DayTimeIntervalType):
+        return isinstance(value, datetime.timedelta)
+    # For complex types (ArrayType, MapType, StructType) and other exotic types
+    # (VariantType, spatial types, YearMonthIntervalType, CalendarIntervalType),
+    # skip filtering and let Spark handle type resolution.
+    return True
 
 
 class IndexOpsMixin(object, metaclass=ABCMeta):
@@ -986,7 +978,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
 
         spark_type = self._internal.data_fields[0].spark_type
         compatible = [
-            lit for v in values if (lit := _isin_compatible_lit(v, spark_type)) is not None
+            F.lit(v).cast(spark_type) for v in values if _is_value_type_compatible(v, spark_type)
         ]
         scol = (
             F.coalesce(self.spark.column.isin(compatible), F.lit(False))

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -293,38 +293,46 @@ def _exclude_pd_np_operand(other: Any) -> None:
         )
 
 
-def _is_value_type_compatible(value: Any, spark_type: DataType) -> bool:
-    """Check if a Python value's type is compatible with a Spark column type for isin matching.
+def _isin_compatible_lit(value: Any, spark_type: DataType) -> Optional[Column]:
+    """Return F.lit(value) cast to spark_type if the value is type-compatible, else None.
 
     Pandas isin() uses strict type matching: an integer 1 never matches a string "1".
     However, numeric types (int, float, bool) are cross-compatible, matching Python semantics
     where bool is a subclass of int and int/float compare equal when values match.
+
+    The returned literal is cast to the target Spark type so that Spark's IN expression
+    receives homogeneous types (Spark requires all IN operands to share the same type).
     """
     import datetime
     import decimal
 
     if value is None or isinstance(spark_type, NullType):
-        return True
+        return F.lit(value).cast(spark_type)
+    compatible: bool
     if isinstance(spark_type, NumericType):
-        return isinstance(value, (int, float, bool, decimal.Decimal, np.number))
-    if isinstance(spark_type, BooleanType):
-        return isinstance(value, (bool, np.bool_, int, float, np.number))
-    if isinstance(spark_type, (StringType, CharType, VarcharType)):
-        return isinstance(value, str)
-    if isinstance(spark_type, BinaryType):
-        return isinstance(value, (bytes, bytearray))
-    if isinstance(spark_type, (TimestampType, TimestampNTZType)):
-        return isinstance(value, (datetime.datetime, pd.Timestamp))
-    if isinstance(spark_type, DateType):
-        return isinstance(value, (datetime.date, pd.Timestamp))
-    if isinstance(spark_type, TimeType):
-        return isinstance(value, datetime.time)
-    if isinstance(spark_type, DayTimeIntervalType):
-        return isinstance(value, datetime.timedelta)
-    # For complex types (ArrayType, MapType, StructType) and other exotic types
-    # (VariantType, spatial types, YearMonthIntervalType, CalendarIntervalType),
-    # skip filtering and let Spark handle type resolution.
-    return True
+        compatible = isinstance(value, (int, float, bool, decimal.Decimal, np.number))
+    elif isinstance(spark_type, BooleanType):
+        compatible = isinstance(value, (bool, np.bool_, int, float, np.number))
+    elif isinstance(spark_type, (StringType, CharType, VarcharType)):
+        compatible = isinstance(value, str)
+    elif isinstance(spark_type, BinaryType):
+        compatible = isinstance(value, (bytes, bytearray))
+    elif isinstance(spark_type, (TimestampType, TimestampNTZType)):
+        compatible = isinstance(value, (datetime.datetime, pd.Timestamp))
+    elif isinstance(spark_type, DateType):
+        compatible = isinstance(value, (datetime.date, pd.Timestamp))
+    elif isinstance(spark_type, TimeType):
+        compatible = isinstance(value, datetime.time)
+    elif isinstance(spark_type, DayTimeIntervalType):
+        compatible = isinstance(value, datetime.timedelta)
+    else:
+        # For complex types (ArrayType, MapType, StructType) and other exotic types
+        # (VariantType, spatial types, YearMonthIntervalType, CalendarIntervalType),
+        # skip filtering and let Spark handle type resolution.
+        compatible = True
+    if not compatible:
+        return None
+    return F.lit(value).cast(spark_type)
 
 
 class IndexOpsMixin(object, metaclass=ABCMeta):
@@ -977,7 +985,9 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         )
 
         spark_type = self._internal.data_fields[0].spark_type
-        compatible = [F.lit(v) for v in values if _is_value_type_compatible(v, spark_type)]
+        compatible = [
+            lit for v in values if (lit := _isin_compatible_lit(v, spark_type)) is not None
+        ]
         scol = (
             F.coalesce(self.spark.column.isin(compatible), F.lit(False))
             if compatible

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -29,7 +29,16 @@ import pandas as pd
 from pandas.api.types import is_list_like, CategoricalDtype
 
 from pyspark.sql import functions as F, Column, Window
-from pyspark.sql.types import LongType, BooleanType, NumericType
+from pyspark.sql.types import (
+    BooleanType,
+    DataType,
+    DateType,
+    LongType,
+    NumericType,
+    StringType,
+    TimestampNTZType,
+    TimestampType,
+)
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas._typing import Axis, Dtype, IndexOpsLike, Label, SeriesOrIndex
 from pyspark.pandas.config import get_option, option_context
@@ -276,6 +285,31 @@ def _exclude_pd_np_operand(other: Any) -> None:
             f"Operand of type {type(other).__module__}.{type(other).__qualname__} "
             f"is not supported for this operation. "
         )
+
+
+def _is_value_type_compatible(value: Any, spark_type: DataType) -> bool:
+    """Check if a Python value's type is compatible with a Spark column type for isin matching.
+
+    Pandas isin() uses strict type matching: an integer 1 never matches a string "1".
+    However, numeric types (int, float, bool) are cross-compatible, matching Python semantics
+    where bool is a subclass of int and int/float compare equal when values match.
+    """
+    import datetime
+    import decimal
+
+    if value is None:
+        return True
+    if isinstance(spark_type, NumericType):
+        return isinstance(value, (int, float, bool, decimal.Decimal, np.number))
+    if isinstance(spark_type, BooleanType):
+        return isinstance(value, (bool, np.bool_, int, float, np.number))
+    if isinstance(spark_type, StringType):
+        return isinstance(value, str)
+    if isinstance(spark_type, (TimestampType, TimestampNTZType)):
+        return isinstance(value, (datetime.datetime, pd.Timestamp))
+    if isinstance(spark_type, DateType):
+        return isinstance(value, (datetime.date, pd.Timestamp))
+    return True
 
 
 class IndexOpsMixin(object, metaclass=ABCMeta):
@@ -927,12 +961,17 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
             cast(np.ndarray, values).tolist() if isinstance(values, np.ndarray) else list(values)
         )
 
-        other = [F.lit(v) for v in values]
-        scol = self.spark.column.isin(other)
+        spark_type = self._internal.data_fields[0].spark_type
+        compatible = [F.lit(v) for v in values if _is_value_type_compatible(v, spark_type)]
+        scol = (
+            F.coalesce(self.spark.column.isin(compatible), F.lit(False))
+            if compatible
+            else F.lit(False)
+        )
         field = self._internal.data_fields[0].copy(
             dtype=np.dtype("bool"), spark_type=BooleanType(), nullable=False
         )
-        return self._with_new_scol(scol=F.coalesce(scol, F.lit(False)), field=field)
+        return self._with_new_scol(scol=scol, field=field)
 
     def isnull(self: IndexOpsLike) -> IndexOpsLike:
         """

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -37,7 +37,6 @@ from pyspark.sql.types import (
     DateType,
     DayTimeIntervalType,
     LongType,
-    NullType,
     NumericType,
     StringType,
     TimestampNTZType,
@@ -303,8 +302,6 @@ def _is_value_type_compatible(value: Any, spark_type: DataType) -> bool:
     import datetime
     import decimal
 
-    if value is None or isinstance(spark_type, NullType):
-        return True
     if isinstance(spark_type, NumericType):
         return isinstance(value, (int, float, bool, decimal.Decimal, np.number))
     if isinstance(spark_type, BooleanType):

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -8554,6 +8554,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 % (set(values.keys()).difference(self.columns))
             )
 
+        from pyspark.pandas.base import _is_value_type_compatible
+
         data_spark_columns = []
         if isinstance(values, dict):
             for i, col in enumerate(self.columns):
@@ -8561,10 +8563,16 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     item = values[col]
                     item = item.tolist() if isinstance(item, np.ndarray) else list(item)
 
-                    scol = self._internal.spark_column_for(self._internal.column_labels[i]).isin(
-                        [F.lit(v) for v in item]
+                    label = self._internal.column_labels[i]
+                    col_type = self._internal.spark_type_for(label)
+                    compatible = [F.lit(v) for v in item if _is_value_type_compatible(v, col_type)]
+                    scol = (
+                        F.coalesce(
+                            self._internal.spark_column_for(label).isin(compatible), F.lit(False)
+                        )
+                        if compatible
+                        else F.lit(False)
                     )
-                    scol = F.coalesce(scol, F.lit(False))
                 else:
                     scol = F.lit(False)
                 data_spark_columns.append(scol.alias(self._internal.data_spark_column_names[i]))
@@ -8576,14 +8584,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             )
 
             for label in self._internal.column_labels:
-                if is_ansi_mode_enabled(self._internal.spark_frame.sparkSession):
-                    col_type = self._internal.spark_type_for(label)
-                    scol = self._internal.spark_column_for(label).isin(
-                        [F.lit(v).try_cast(col_type) for v in values]
+                col_type = self._internal.spark_type_for(label)
+                compatible = [F.lit(v) for v in values if _is_value_type_compatible(v, col_type)]
+                scol = (
+                    F.coalesce(
+                        self._internal.spark_column_for(label).isin(compatible), F.lit(False)
                     )
-                else:
-                    scol = self._internal.spark_column_for(label).isin([F.lit(v) for v in values])
-                scol = F.coalesce(scol, F.lit(False))
+                    if compatible
+                    else F.lit(False)
+                )
                 data_spark_columns.append(scol.alias(self._internal.spark_column_name_for(label)))
         else:
             raise TypeError("Values should be iterable, Series, DataFrame or dict.")

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -8554,7 +8554,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 % (set(values.keys()).difference(self.columns))
             )
 
-        from pyspark.pandas.base import _isin_compatible_lit
+        from pyspark.pandas.base import _is_value_type_compatible
 
         data_spark_columns = []
         if isinstance(values, dict):
@@ -8566,7 +8566,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     label = self._internal.column_labels[i]
                     col_type = self._internal.spark_type_for(label)
                     compatible = [
-                        lit for v in item if (lit := _isin_compatible_lit(v, col_type)) is not None
+                        F.lit(v).cast(col_type)
+                        for v in item
+                        if _is_value_type_compatible(v, col_type)
                     ]
                     scol = (
                         F.coalesce(
@@ -8588,7 +8590,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             for label in self._internal.column_labels:
                 col_type = self._internal.spark_type_for(label)
                 compatible = [
-                    lit for v in values if (lit := _isin_compatible_lit(v, col_type)) is not None
+                    F.lit(v).cast(col_type)
+                    for v in values
+                    if _is_value_type_compatible(v, col_type)
                 ]
                 scol = (
                     F.coalesce(

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -8554,7 +8554,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 % (set(values.keys()).difference(self.columns))
             )
 
-        from pyspark.pandas.base import _is_value_type_compatible
+        from pyspark.pandas.base import _isin_compatible_lit
 
         data_spark_columns = []
         if isinstance(values, dict):
@@ -8565,7 +8565,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
                     label = self._internal.column_labels[i]
                     col_type = self._internal.spark_type_for(label)
-                    compatible = [F.lit(v) for v in item if _is_value_type_compatible(v, col_type)]
+                    compatible = [
+                        lit for v in item if (lit := _isin_compatible_lit(v, col_type)) is not None
+                    ]
                     scol = (
                         F.coalesce(
                             self._internal.spark_column_for(label).isin(compatible), F.lit(False)
@@ -8585,7 +8587,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             for label in self._internal.column_labels:
                 col_type = self._internal.spark_type_for(label)
-                compatible = [F.lit(v) for v in values if _is_value_type_compatible(v, col_type)]
+                compatible = [
+                    lit for v in values if (lit := _isin_compatible_lit(v, col_type)) is not None
+                ]
                 scol = (
                     F.coalesce(
                         self._internal.spark_column_for(label).isin(compatible), F.lit(False)

--- a/python/pyspark/pandas/tests/frame/test_reindexing.py
+++ b/python/pyspark/pandas/tests/frame/test_reindexing.py
@@ -788,8 +788,7 @@ class FrameReindexingMixin:
         psdf = ps.from_pandas(pdf)
 
         self.assert_eq(psdf.isin([4, "six"]), pdf.isin([4, "six"]))
-        # Seems like pandas has a bug when passing `np.array` as parameter
-        self.assert_eq(psdf.isin(np.array([4, "six"])), pdf.isin([4, "six"]))
+        self.assert_eq(psdf.isin(np.array([4, "six"])), pdf.isin(np.array([4, "six"])))
         self.assert_eq(
             psdf.isin({"a": [2, 8], "c": ["three", "one"]}),
             pdf.isin({"a": [2, 8], "c": ["three", "one"]}),
@@ -823,6 +822,15 @@ class FrameReindexingMixin:
         self.assert_eq(psdf.isin([4, 3, 1, 1, None]), pdf.isin([4, 3, 1, 1, None]))
 
         self.assert_eq(psdf.isin({"b": [4, 3, 1, 1, None]}), pdf.isin({"b": [4, 3, 1, 1, None]}))
+
+        # Cross-type matching: string values against int columns should not match
+        pdf = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(psdf.isin(["1", "2"]), pdf.isin(["1", "2"]))
+        self.assert_eq(psdf.isin({"a": ["1", "2"]}), pdf.isin({"a": ["1", "2"]}))
+
+        # Numeric cross-type: float values against int columns should match
+        self.assert_eq(psdf.isin([1.0, 2.0]), pdf.isin([1.0, 2.0]))
 
     def test_sample(self):
         psdf = ps.DataFrame({"A": [0, 2, 4]}, index=["x", "y", "z"])

--- a/python/pyspark/pandas/tests/frame/test_reindexing.py
+++ b/python/pyspark/pandas/tests/frame/test_reindexing.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+import datetime
+
 import numpy as np
 import pandas as pd
 from pandas.tseries.offsets import DateOffset
@@ -831,6 +833,35 @@ class FrameReindexingMixin:
 
         # Numeric cross-type: float values against int columns should match
         self.assert_eq(psdf.isin([1.0, 2.0]), pdf.isin([1.0, 2.0]))
+
+        # Bool values are compatible with numeric columns
+        self.assert_eq(psdf.isin([True]), pdf.isin([True]))
+
+        # Bool column: int/float are compatible, string is not
+        pdf = pd.DataFrame({"a": [True, False, True], "b": [1, 2, 3]})
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(psdf.isin([1]), pdf.isin([1]))
+        self.assert_eq(psdf.isin(["True"]), pdf.isin(["True"]))
+
+        # Date column: date is compatible, string/int are not
+        pdf = pd.DataFrame(
+            {
+                "a": [datetime.date(2023, 1, 1), datetime.date(2023, 1, 2)],
+                "b": [1, 2],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(
+            psdf.isin([datetime.date(2023, 1, 1)]),
+            pdf.isin([datetime.date(2023, 1, 1)]),
+        )
+        self.assert_eq(psdf.isin(["2023-01-01"]), pdf.isin(["2023-01-01"]))
+
+        # Binary column: bytes is compatible, string is not
+        pdf = pd.DataFrame({"a": [b"abc", b"def"], "b": [1, 2]})
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(psdf.isin([b"abc"]), pdf.isin([b"abc"]))
+        self.assert_eq(psdf.isin(["abc"]), pdf.isin(["abc"]))
 
     def test_sample(self):
         psdf = ps.DataFrame({"A": [0, 2, 4]}, index=["x", "y", "z"])

--- a/python/pyspark/pandas/tests/series/test_series.py
+++ b/python/pyspark/pandas/tests/series/test_series.py
@@ -377,6 +377,48 @@ class SeriesTestsMixin:
         psser = ps.from_pandas(pser)
         self.assert_eq(psser.isin([1, 2]), pser.isin([1, 2]))
 
+        # Bool column: int/float are compatible, string is not
+        pser = pd.Series([True, False, True], name="a")
+        psser = ps.from_pandas(pser)
+        self.assert_eq(psser.isin([1]), pser.isin([1]))
+        self.assert_eq(psser.isin([1.0]), pser.isin([1.0]))
+        self.assert_eq(psser.isin(["True"]), pser.isin(["True"]))
+
+        # Int column: bool/float are compatible, string is not
+        pser = pd.Series([1, 2, 3], name="a")
+        psser = ps.from_pandas(pser)
+        self.assert_eq(psser.isin([True]), pser.isin([True]))
+        self.assert_eq(psser.isin([1.0, 2.0]), pser.isin([1.0, 2.0]))
+        self.assert_eq(psser.isin(["1"]), pser.isin(["1"]))
+
+        # Date column: date/Timestamp are compatible, string/int are not
+        pser = pd.Series([datetime(2023, 1, 1).date(), datetime(2023, 1, 2).date()], name="a")
+        psser = ps.from_pandas(pser)
+        self.assert_eq(
+            psser.isin([datetime(2023, 1, 1).date()]),
+            pser.isin([datetime(2023, 1, 1).date()]),
+        )
+        self.assert_eq(psser.isin(["2023-01-01"]), pser.isin(["2023-01-01"]))
+        self.assert_eq(psser.isin([1]), pser.isin([1]))
+
+        # Timestamp column: datetime is compatible, int/string are not
+        pser = pd.Series(pd.to_datetime(["2023-01-01", "2023-01-02"]), name="a")
+        psser = ps.from_pandas(pser)
+        self.assert_eq(psser.isin([datetime(2023, 1, 1)]), pser.isin([datetime(2023, 1, 1)]))
+        self.assert_eq(psser.isin([1]), pser.isin([1]))
+
+        # Binary column: bytes is compatible, string is not
+        pser = pd.Series([b"abc", b"def"], name="a")
+        psser = ps.from_pandas(pser)
+        self.assert_eq(psser.isin([b"abc"]), pser.isin([b"abc"]))
+        self.assert_eq(psser.isin(["abc"]), pser.isin(["abc"]))
+
+        # Timedelta column: timedelta is compatible, int/string are not
+        pser = pd.Series([timedelta(days=1), timedelta(days=2)], name="a")
+        psser = ps.from_pandas(pser)
+        self.assert_eq(psser.isin([timedelta(days=1)]), pser.isin([timedelta(days=1)]))
+        self.assert_eq(psser.isin([1]), pser.isin([1]))
+
     def test_notnull(self):
         pser = pd.Series([1, 2, 3, 4, np.nan, 6], name="x")
         psser = ps.from_pandas(pser)

--- a/python/pyspark/pandas/tests/series/test_series.py
+++ b/python/pyspark/pandas/tests/series/test_series.py
@@ -419,6 +419,11 @@ class SeriesTestsMixin:
         self.assert_eq(psser.isin([timedelta(days=1)]), pser.isin([timedelta(days=1)]))
         self.assert_eq(psser.isin([1]), pser.isin([1]))
 
+        # None with incompatible types: None passes type filter but never matches via IN
+        pser = pd.Series([1, 2, 3, None], name="a")
+        psser = ps.from_pandas(pser)
+        self.assert_eq(psser.isin(["a", "b", "c", None]), pser.isin(["a", "b", "c", None]))
+
     def test_notnull(self):
         pser = pd.Series([1, 2, 3, 4, np.nan, 6], name="x")
         psser = ps.from_pandas(pser)

--- a/python/pyspark/pandas/tests/series/test_series.py
+++ b/python/pyspark/pandas/tests/series/test_series.py
@@ -364,6 +364,19 @@ class SeriesTestsMixin:
 
         self.assert_eq(psser.isin([1, 5, 0, None]), pser.isin([1, 5, 0, None]))
 
+        # Cross-type matching: string values against int column should not match
+        pser = pd.Series([1, 2, 3], name="a")
+        psser = ps.from_pandas(pser)
+        self.assert_eq(psser.isin(["1", "2"]), pser.isin(["1", "2"]))
+
+        # Numeric cross-type: float values against int column should match
+        self.assert_eq(psser.isin([1.0, 2.0]), pser.isin([1.0, 2.0]))
+
+        # String column with numeric values should not match
+        pser = pd.Series(["1", "2", "3"], name="a")
+        psser = ps.from_pandas(pser)
+        self.assert_eq(psser.isin([1, 2]), pser.isin([1, 2]))
+
     def test_notnull(self):
         pser = pd.Series([1, 2, 3, 4, np.nan, 6], name="x")
         psser = ps.from_pandas(pser)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Filter isin() values by Python type compatibility and cast literals to the column type.

### Why are the changes needed?
isin() implicitly coerces types, diverging from pandas.

### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
CI

### Was this patch authored or co-authored using generative AI tooling?
Co-authored-by: Claude Opus 4