### PR TITLE
[SPARK-55964] Cache coherence: clear function registry on DROP DATABASE

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -273,10 +273,7 @@ trait SimpleFunctionRegistryBase[T] extends FunctionRegistryBase[T] with Logging
 
   override def dropFunctionsInDatabase(namespace: FunctionIdentifier): Unit = synchronized {
     val toRemove = listFunction().filter { f =>
-      f.database.exists(d => namespace.database.exists(_.equalsIgnoreCase(d))) &&
-        namespace.catalog.isDefined && (
-          f.catalog == namespace.catalog ||
-          (f.catalog.isEmpty && namespace.catalog.contains(CatalogManager.SESSION_CATALOG_NAME)))
+      f.copy(name = "") == namespace
     }
     toRemove.foreach(n => functionBuilders.remove(n))
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -109,10 +109,11 @@ trait FunctionRegistryBase[T] {
   def dropFunction(name: FunctionIdentifier): Boolean
 
   /**
-   * Remove all cached function entries in the given database.
-   * Keeps the cache coherent when a database is dropped.
+   * Remove all cached function entries matching the given namespace.
+   * The namespace is a FunctionIdentifier with empty funcName used as a filter:
+   * matches on database (case-insensitive) and, when specified, catalog.
    */
-  def dropFunctionsInDatabase(db: String): Unit
+  def dropFunctionsInDatabase(namespace: FunctionIdentifier): Unit
 
   /** Checks if a function with a given name exists. */
   def functionExists(name: FunctionIdentifier): Boolean = lookupFunction(name).isDefined
@@ -269,8 +270,11 @@ trait SimpleFunctionRegistryBase[T] extends FunctionRegistryBase[T] with Logging
     functionBuilders.remove(normalizeFuncName(name)).isDefined
   }
 
-  override def dropFunctionsInDatabase(db: String): Unit = synchronized {
-    val toRemove = listFunction().filter(_.database.exists(_.equalsIgnoreCase(db)))
+  override def dropFunctionsInDatabase(namespace: FunctionIdentifier): Unit = synchronized {
+    val toRemove = listFunction().filter { f =>
+      f.database.exists(d => namespace.database.exists(_.equalsIgnoreCase(d))) &&
+        (namespace.catalog.isEmpty || f.catalog == namespace.catalog)
+    }
     toRemove.foreach(n => functionBuilders.remove(n))
   }
 
@@ -306,7 +310,7 @@ trait EmptyFunctionRegistryBase[T] extends FunctionRegistryBase[T] {
     throw SparkUnsupportedOperationException()
   }
 
-  override def dropFunctionsInDatabase(db: String): Unit = {}
+  override def dropFunctionsInDatabase(namespace: FunctionIdentifier): Unit = {}
 
   override def clear(): Unit = {
     throw SparkUnsupportedOperationException()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -273,7 +273,7 @@ trait SimpleFunctionRegistryBase[T] extends FunctionRegistryBase[T] with Logging
 
   override def dropFunctionsInDatabase(namespace: FunctionIdentifier): Unit = synchronized {
     val toRemove = listFunction().filter { f =>
-      f.copy(name = "") == namespace
+      f.copy(funcName = "") == namespace
     }
     toRemove.foreach(n => functionBuilders.remove(n))
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -108,6 +108,12 @@ trait FunctionRegistryBase[T] {
   /** Drop a function and return whether the function existed. */
   def dropFunction(name: FunctionIdentifier): Boolean
 
+  /**
+   * Remove all cached function entries in the given database.
+   * Keeps the cache coherent when a database is dropped.
+   */
+  def dropFunctionsInDatabase(db: String): Unit
+
   /** Checks if a function with a given name exists. */
   def functionExists(name: FunctionIdentifier): Boolean = lookupFunction(name).isDefined
 
@@ -263,6 +269,11 @@ trait SimpleFunctionRegistryBase[T] extends FunctionRegistryBase[T] with Logging
     functionBuilders.remove(normalizeFuncName(name)).isDefined
   }
 
+  override def dropFunctionsInDatabase(db: String): Unit = synchronized {
+    val toRemove = listFunction().filter(_.database.exists(_.equalsIgnoreCase(db)))
+    toRemove.foreach(n => functionBuilders.remove(n))
+  }
+
   override def clear(): Unit = synchronized {
     functionBuilders.clear()
   }
@@ -294,6 +305,8 @@ trait EmptyFunctionRegistryBase[T] extends FunctionRegistryBase[T] {
   override def dropFunction(name: FunctionIdentifier): Boolean = {
     throw SparkUnsupportedOperationException()
   }
+
+  override def dropFunctionsInDatabase(db: String): Unit = {}
 
   override def clear(): Unit = {
     throw SparkUnsupportedOperationException()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -111,7 +111,8 @@ trait FunctionRegistryBase[T] {
   /**
    * Remove all cached function entries matching the given namespace.
    * The namespace is a FunctionIdentifier with empty funcName used as a filter:
-   * matches on database (case-insensitive) and, when specified, catalog.
+   * matches on database (case-insensitive) and catalog. The catalog must be specified
+   * (e.g. when dropping a database, the database belongs to a catalog).
    */
   def dropFunctionsInDatabase(namespace: FunctionIdentifier): Unit
 
@@ -273,7 +274,9 @@ trait SimpleFunctionRegistryBase[T] extends FunctionRegistryBase[T] with Logging
   override def dropFunctionsInDatabase(namespace: FunctionIdentifier): Unit = synchronized {
     val toRemove = listFunction().filter { f =>
       f.database.exists(d => namespace.database.exists(_.equalsIgnoreCase(d))) &&
-        (namespace.catalog.isEmpty || f.catalog == namespace.catalog)
+        namespace.catalog.isDefined && (
+          f.catalog == namespace.catalog ||
+          (f.catalog.isEmpty && namespace.catalog.contains(CatalogManager.SESSION_CATALOG_NAME)))
     }
     toRemove.foreach(n => functionBuilders.remove(n))
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -491,7 +491,8 @@ class SessionCatalog(
         invalidateCachedTable(QualifiedTableName(SESSION_CATALOG_NAME, dbName, t.table))
       }
       // Clear cached functions in this database so the cache stays coherent on drop
-      val namespace = FunctionIdentifier("", Some(dbName), None)
+      val namespace = FunctionIdentifier(
+        "", Some(dbName), Some(CatalogManager.SESSION_CATALOG_NAME))
       functionRegistry.dropFunctionsInDatabase(namespace)
       tableFunctionRegistry.dropFunctionsInDatabase(namespace)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -490,11 +490,10 @@ class SessionCatalog(
       listTables(dbName).foreach { t =>
         invalidateCachedTable(QualifiedTableName(SESSION_CATALOG_NAME, dbName, t.table))
       }
-    }
-    if (databaseExists(dbName)) {
-      // Clear cached functions in this database so cache stays coherent after drop
-      functionRegistry.dropFunctionsInDatabase(dbName)
-      tableFunctionRegistry.dropFunctionsInDatabase(dbName)
+      // Clear cached functions in this database so the cache stays coherent on drop
+      val namespace = FunctionIdentifier("", Some(dbName), None)
+      functionRegistry.dropFunctionsInDatabase(namespace)
+      tableFunctionRegistry.dropFunctionsInDatabase(namespace)
     }
     externalCatalog.dropDatabase(dbName, ignoreIfNotExists, cascade)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -491,6 +491,11 @@ class SessionCatalog(
         invalidateCachedTable(QualifiedTableName(SESSION_CATALOG_NAME, dbName, t.table))
       }
     }
+    if (databaseExists(dbName)) {
+      // Clear cached functions in this database so cache stays coherent after drop
+      functionRegistry.dropFunctionsInDatabase(dbName)
+      tableFunctionRegistry.dropFunctionsInDatabase(dbName)
+    }
     externalCatalog.dropDatabase(dbName, ignoreIfNotExists, cascade)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -490,9 +490,9 @@ class SessionCatalog(
       listTables(dbName).foreach { t =>
         invalidateCachedTable(QualifiedTableName(SESSION_CATALOG_NAME, dbName, t.table))
       }
-      // Clear cached functions in this database so the cache stays coherent on drop
-      val namespace = FunctionIdentifier(
-        "", Some(dbName), Some(CatalogManager.SESSION_CATALOG_NAME))
+      // Clear cached functions in this database so the cache stays coherent on drop.
+      // normalizeFuncName stores entries with catalog=None, so the filter must match that.
+      val namespace = FunctionIdentifier("", Some(dbName), None)
       functionRegistry.dropFunctionsInDatabase(namespace)
       tableFunctionRegistry.dropFunctionsInDatabase(namespace)
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -297,6 +297,69 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
     }
   }
 
+  test("drop database clears function registry cache (cache coherence)") {
+    val extCatalog = newEmptyCatalog()
+    extCatalog.createDatabase(newDb("default"), ignoreIfExists = true)
+    extCatalog.createDatabase(newDb("cache_coherence_db"), ignoreIfExists = false)
+    extCatalog.createFunction(
+      "cache_coherence_db", newFunc("cached_func", Some("cache_coherence_db")))
+    val registry = new SimpleFunctionRegistry()
+    val catalog = new SessionCatalog(extCatalog, registry)
+    try {
+      val ident = FunctionIdentifier("cached_func", Some("cache_coherence_db"))
+      val info = new ExpressionInfo(
+        "test.Example",
+        "cache_coherence_db",
+        "cached_func",
+        "usage",
+        "arguments",
+        "\n    Examples:\n",
+        "\n    \n  ",
+        "misc_funcs",
+        "1.0.0",
+        "",
+        "sql_udf")
+      val builder = (e: Seq[Expression]) => e.head
+      registry.registerFunction(ident, info, builder)
+      assert(registry.functionExists(ident))
+      catalog.dropDatabase("cache_coherence_db", ignoreIfNotExists = false, cascade = true)
+      assert(!registry.functionExists(ident))
+    } finally {
+      catalog.reset()
+    }
+  }
+
+  test("drop database clears table function registry cache (cache coherence)") {
+    val extCatalog = newEmptyCatalog()
+    extCatalog.createDatabase(newDb("default"), ignoreIfExists = true)
+    extCatalog.createDatabase(newDb("cache_coherence_db2"), ignoreIfExists = false)
+    val scalarRegistry = new SimpleFunctionRegistry()
+    val tableRegistry = new SimpleTableFunctionRegistry()
+    val catalog = new SessionCatalog(extCatalog, scalarRegistry, tableRegistry)
+    try {
+      val ident = FunctionIdentifier("cached_table_func", Some("cache_coherence_db2"))
+      val info = new ExpressionInfo(
+        "test.Example",
+        "cache_coherence_db2",
+        "cached_table_func",
+        "usage",
+        "arguments",
+        "\n    Examples:\n",
+        "\n    \n  ",
+        "table_funcs",
+        "1.0.0",
+        "",
+        "sql_udf")
+      val builder = (_: Seq[Expression]) => Range(1, 1, 1, 1)
+      tableRegistry.registerFunction(ident, info, builder)
+      assert(tableRegistry.functionExists(ident))
+      catalog.dropDatabase("cache_coherence_db2", ignoreIfNotExists = false, cascade = true)
+      assert(!tableRegistry.functionExists(ident))
+    } finally {
+      catalog.reset()
+    }
+  }
+
   test("alter database") {
     withBasicCatalog { catalog =>
       val db1 = catalog.getDatabaseMetadata("db1")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -360,6 +360,34 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
     }
   }
 
+  test("drop database preserves functions in other databases (cache coherence)") {
+    val extCatalog = newEmptyCatalog()
+    extCatalog.createDatabase(newDb("default"), ignoreIfExists = true)
+    extCatalog.createDatabase(newDb("drop_me"), ignoreIfExists = false)
+    extCatalog.createDatabase(newDb("keep_me"), ignoreIfExists = false)
+    extCatalog.createFunction("drop_me", newFunc("func_drop", Some("drop_me")))
+    extCatalog.createFunction("keep_me", newFunc("func_keep", Some("keep_me")))
+    val registry = new SimpleFunctionRegistry()
+    val catalog = new SessionCatalog(extCatalog, registry)
+    try {
+      val dropIdent = FunctionIdentifier("func_drop", Some("drop_me"))
+      val keepIdent = FunctionIdentifier("func_keep", Some("keep_me"))
+      val builder = (e: Seq[Expression]) => e.head
+      val makeInfo = (db: String, name: String) => new ExpressionInfo(
+        "test.Example", db, name, "usage", "arguments",
+        "\n    Examples:\n", "\n    \n  ", "misc_funcs", "1.0.0", "", "sql_udf")
+      registry.registerFunction(dropIdent, makeInfo("drop_me", "func_drop"), builder)
+      registry.registerFunction(keepIdent, makeInfo("keep_me", "func_keep"), builder)
+      assert(registry.functionExists(dropIdent))
+      assert(registry.functionExists(keepIdent))
+      catalog.dropDatabase("drop_me", ignoreIfNotExists = false, cascade = true)
+      assert(!registry.functionExists(dropIdent))
+      assert(registry.functionExists(keepIdent))
+    } finally {
+      catalog.reset()
+    }
+  }
+
   test("alter database") {
     withBasicCatalog { catalog =>
       val db1 = catalog.getDatabaseMetadata("db1")


### PR DESCRIPTION
- Add dropFunctionsInDatabase(db) to FunctionRegistryBase and implementations
- SessionCatalog.dropDatabase clears scalar and table function registry cache for the dropped database so resolution does not see stale entries
- Add SessionCatalogSuite tests for cache coherence

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
We now delete functions from a a schema dropped within the session from the sesssion function registry
[design-cache-coherence.md](https://github.com/user-attachments/files/25957395/design-cache-coherence.md)


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Without this change the session coudl keep resolving fucntions from a schema it had dropped.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
It fixes a bug that can be observed.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added new testcases

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Claude Opus4.6