### PR TITLE
[SPARK-55880][UI] Link SQL plan metric stage IDs to stage detail page

### DIFF
--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-/* global $, d3, dagreD3, graphlibDot */
+/* global $, d3, dagreD3, graphlibDot, uiRoot, appBasePath */
 
 var PlanVizConstants = {
   svgMarginX: 16,
@@ -385,10 +385,19 @@ function buildStatTable(total, min, med, maxVal,
   h += "<td>" + min + "</td><td>" + med +
     "</td><td>" + maxVal + "</td>";
   if (showStageTask) {
-    h += "<td>" + stageId + "</td><td>" + taskId + "</td>";
+    h += "<td>" + stageLink(stageId) + "</td><td>" + taskId + "</td>";
   }
   h += "</tr></tbody></table>";
   return h;
+}
+
+function stageLink(stageId) {
+  if (!stageId) return "";
+  var parts = stageId.split(".");
+  var id = parts[0];
+  var attempt = parts.length > 1 ? parts[1] : "0";
+  var url = uiRoot + appBasePath + "/stages/stage/?id=" + id + "&attempt=" + attempt;
+  return '<a href="' + url + '">' + stageId + '</a>';
 }
 
 /*


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make stage IDs in the SQL plan visualization metric detail panel clickable links to the corresponding stage detail page.

When the "Show Stage ID and Task ID" checkbox is enabled on the SQL execution page, each metric row in the side panel shows a Stage column. Previously this was plain text like `3.0`. Now it renders as a hyperlink to `/stages/stage/?id=3&attempt=0`.

### Why are the changes needed?

Navigating from a SQL plan node metric to the corresponding stage requires manually copying the stage ID and navigating to the Stages tab. A direct link improves workflow efficiency.

### Does this PR introduce _any_ user-facing change?

Yes — Stage IDs in the SQL plan metric detail panel are now clickable links.

### How was this patch tested?

Manual testing. The change is JS-only (no Scala changes).

### Was this patch authored or co-authored using generative AI tooling?

Yes, co-authored with GitHub Copilot.