### PR TITLE
[SPARK-54923][SQL] Add configuration for directory traversal depth before parallel partition discovery

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/HadoopFSUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/HadoopFSUtils.scala
@@ -57,6 +57,10 @@ private[spark] object HadoopFSUtils extends Logging {
    * @param parallelismMax The maximum parallelism for listing. If the number of input paths is
    *                       larger than this value, parallelism will be throttled to this value
    *                       to avoid generating too many tasks.
+   * @param traversalDepth Controls sequential directory pre-traversal on the driver before
+   *                       delegating to parallel workers. A value of 1 (default) means no
+   *                       sequential pre-traversal. A value of N causes the driver to
+   *                       sequentially expand up to N-1 directory levels before parallelizing.
    * @return for each input path, the set of discovered files for the path
    */
   def parallelListLeafFiles(
@@ -67,9 +71,28 @@ private[spark] object HadoopFSUtils extends Logging {
     ignoreMissingFiles: Boolean,
     ignoreLocality: Boolean,
     parallelismThreshold: Int,
-    parallelismMax: Int): Seq[(Path, Seq[FileStatus])] = {
-    parallelListLeafFilesInternal(sc, paths, hadoopConf, filter, isRootLevel = true,
-      ignoreMissingFiles, ignoreLocality, parallelismThreshold, parallelismMax)
+    parallelismMax: Int,
+    traversalDepth: Int = 1): Seq[(Path, Seq[FileStatus])] = {
+    if (traversalDepth > 1) {
+      val expandedPaths =
+        sequentiallyTraverseDirectories(paths, hadoopConf, traversalDepth)
+      // Expanded paths are intermediate directories discovered by sequential traversal,
+      // not user-supplied root paths, so isRootLevel must be false to preserve the
+      // semantics of SPARK-27676 (detect race conditions on non-root paths).
+      // We set tolerateDisappearance = true so that if a directory confirmed during
+      // sequential traversal vanishes before the parallel lister reaches it (e.g.,
+      // concurrent table overwrite or S3 eventual consistency), it is silently skipped
+      // rather than failing the entire query. This flag only applies to the top-level
+      // expanded paths and is NOT propagated to recursive subdirectory listing, keeping
+      // the existing error-detection behavior for deeper levels intact.
+      parallelListLeafFilesInternal(sc, expandedPaths, hadoopConf, filter,
+        isRootLevel = false, ignoreMissingFiles = ignoreMissingFiles,
+        ignoreLocality, parallelismThreshold, parallelismMax,
+        tolerateDisappearance = true)
+    } else {
+      parallelListLeafFilesInternal(sc, paths, hadoopConf, filter, isRootLevel = true,
+        ignoreMissingFiles, ignoreLocality, parallelismThreshold, parallelismMax)
+    }
   }
 
   /**
@@ -106,6 +129,52 @@ private[spark] object HadoopFSUtils extends Logging {
     }
   }
 
+  /**
+   * Sequentially traverses directory hierarchies on the driver up to the specified depth,
+   * collecting all subdirectories found at the target level. For paths that are not directories
+   * or reach a leaf before the target depth, the path itself is returned.
+   *
+   * This is useful for deep-narrow hierarchies (e.g., root/subpath/{year}/{month}/) where
+   * the top levels have very few children and parallelizing at level 1 creates too few tasks.
+   */
+  private def sequentiallyTraverseDirectories(
+      paths: Seq[Path],
+      hadoopConf: Configuration,
+      traversalDepth: Int): Seq[Path] = {
+    var currentPaths = paths
+    var currentDepth = 1
+    while (currentDepth < traversalDepth) {
+      val nextPaths = mutable.ArrayBuffer.empty[Path]
+      for (path <- currentPaths) {
+        try {
+          val fs = path.getFileSystem(hadoopConf)
+          val statuses = fs.listStatus(path)
+          val filtered = statuses.filterNot(s => shouldFilterOutPathName(s.getPath.getName))
+          val (dirs, files) = filtered.partition(_.isDirectory)
+          if (dirs.nonEmpty && files.isEmpty) {
+            // Pure directory level — safe to expand further
+            nextPaths ++= dirs.map(_.getPath)
+          } else {
+            // Leaf (no subdirs) or mixed (files + subdirs) — keep the current path
+            // so the parallel lister can discover all contents including sibling files
+            nextPaths += path
+          }
+        } catch {
+          case _: FileNotFoundException =>
+            logWarning(log"The directory ${MDC(PATH, path)} " +
+              log"was not found during sequential traversal. Skipping.")
+        }
+      }
+      currentPaths = nextPaths.toSeq
+      currentDepth += 1
+    }
+    logInfo(log"Sequential traversal expanded " +
+      log"${MDC(NUM_PATHS, paths.length)} input paths to " +
+      log"${MDC(COUNT, currentPaths.length)} paths at depth " +
+      log"${MDC(RECURSIVE_DEPTH, traversalDepth)}")
+    currentPaths
+  }
+
   private def parallelListLeafFilesInternal(
       sc: SparkContext,
       paths: Seq[Path],
@@ -115,7 +184,8 @@ private[spark] object HadoopFSUtils extends Logging {
       ignoreMissingFiles: Boolean,
       ignoreLocality: Boolean,
       parallelismThreshold: Int,
-      parallelismMax: Int): Seq[(Path, Seq[FileStatus])] = {
+      parallelismMax: Int,
+      tolerateDisappearance: Boolean = false): Seq[(Path, Seq[FileStatus])] = {
 
     // Short-circuits parallel listing when serial listing is likely to be faster.
     if (paths.size <= parallelismThreshold) {
@@ -129,7 +199,8 @@ private[spark] object HadoopFSUtils extends Logging {
           ignoreLocality = ignoreLocality,
           isRootPath = isRootLevel,
           parallelismThreshold = parallelismThreshold,
-          parallelismMax = parallelismMax)
+          parallelismMax = parallelismMax,
+          tolerateDisappearance = tolerateDisappearance)
         (path, leafFiles)
       }
     }
@@ -169,7 +240,8 @@ private[spark] object HadoopFSUtils extends Logging {
               ignoreLocality = ignoreLocality,
               isRootPath = isRootLevel,
               parallelismThreshold = Int.MaxValue,
-              parallelismMax = 0)
+              parallelismMax = 0,
+              tolerateDisappearance = tolerateDisappearance)
             (path, leafFiles)
           }
         }.collect().toImmutableArraySeq
@@ -196,7 +268,8 @@ private[spark] object HadoopFSUtils extends Logging {
       ignoreLocality: Boolean,
       isRootPath: Boolean,
       parallelismThreshold: Int,
-      parallelismMax: Int): Seq[FileStatus] = {
+      parallelismMax: Int,
+      tolerateDisappearance: Boolean = false): Seq[FileStatus] = {
 
     logTrace(s"Listing $path")
     val fs = path.getFileSystem(hadoopConf)
@@ -237,7 +310,13 @@ private[spark] object HadoopFSUtils extends Logging {
       // able to detect race conditions involving root paths being deleted during
       // InMemoryFileIndex construction. However, it's still a net improvement to detect and
       // fail-fast on the non-root cases. For more info see the SPARK-27676 review discussion.
-      case _: FileNotFoundException if isRootPath || ignoreMissingFiles =>
+      //
+      // tolerateDisappearance handles a third case: paths discovered by sequential directory
+      // traversal (SPARK-54923) that may vanish between traversal and parallel listing.
+      // Unlike isRootPath, this flag is not propagated to recursive subdirectory calls,
+      // so deeper-level race conditions are still detected.
+      case _: FileNotFoundException if isRootPath || ignoreMissingFiles
+          || tolerateDisappearance =>
         logWarning(log"The directory ${MDC(PATH, path)} " +
           log"was not found. Was it deleted very recently?")
         Array.empty[FileStatus]

--- a/core/src/test/scala/org/apache/spark/util/HadoopFSUtilsDeepNarrowSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/HadoopFSUtilsDeepNarrowSuite.scala
@@ -1,0 +1,374 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+import java.io.File
+import java.nio.file.Files
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{Path, PathFilter}
+
+import org.apache.spark.{SharedSparkContext, SparkFunSuite}
+
+class HadoopFSUtilsDeepNarrowSuite extends SparkFunSuite with SharedSparkContext {
+
+  private val hadoopConf = new Configuration()
+  private val acceptAllFilter: PathFilter = (_: Path) => true
+
+  private def createDeepHierarchy(
+      baseDir: File,
+      levels: Seq[Seq[String]],
+      numFiles: Int): Unit = {
+    def createLevel(parent: File, remaining: Seq[Seq[String]]): Unit = {
+      if (remaining.isEmpty) {
+        // Create leaf files
+        for (i <- 0 until numFiles) {
+          Files.createFile(new File(parent, s"part-$i.parquet").toPath)
+        }
+      } else {
+        for (dirName <- remaining.head) {
+          val dir = new File(parent, dirName)
+          dir.mkdirs()
+          createLevel(dir, remaining.tail)
+        }
+      }
+    }
+    createLevel(baseDir, levels)
+  }
+
+  test("traversalDepth=1 (default) lists from root level") {
+    withTempDir { baseDir =>
+      // Create: root/year=2023/month=01/files, root/year=2023/month=02/files
+      createDeepHierarchy(
+        baseDir,
+        Seq(Seq("year=2023"), Seq("month=01", "month=02")),
+        numFiles = 3)
+
+      val rootPath = new Path(baseDir.getAbsolutePath)
+      val result = HadoopFSUtils.parallelListLeafFiles(
+        sc = sc,
+        paths = Seq(rootPath),
+        hadoopConf = hadoopConf,
+        filter = acceptAllFilter,
+        ignoreMissingFiles = false,
+        ignoreLocality = true,
+        parallelismThreshold = 32,
+        parallelismMax = 10,
+        traversalDepth = 1)
+
+      val allFiles = result.flatMap(_._2)
+      assert(allFiles.length === 6) // 2 months * 3 files
+      assert(allFiles.forall(_.getPath.getName.endsWith(".parquet")))
+    }
+  }
+
+  test("traversalDepth=2 expands single-child root by one level") {
+    withTempDir { baseDir =>
+      // Deep-narrow: root/subpath/year=2023/files, root/subpath/year=2024/files
+      createDeepHierarchy(
+        baseDir,
+        Seq(Seq("subpath"), Seq("year=2023", "year=2024")),
+        numFiles = 4)
+
+      val rootPath = new Path(baseDir.getAbsolutePath)
+      val result = HadoopFSUtils.parallelListLeafFiles(
+        sc = sc,
+        paths = Seq(rootPath),
+        hadoopConf = hadoopConf,
+        filter = acceptAllFilter,
+        ignoreMissingFiles = false,
+        ignoreLocality = true,
+        parallelismThreshold = 32,
+        parallelismMax = 10,
+        traversalDepth = 2)
+
+      val allFiles = result.flatMap(_._2)
+      assert(allFiles.length === 8) // 2 years * 4 files
+      assert(allFiles.forall(_.getPath.getName.endsWith(".parquet")))
+    }
+  }
+
+  test("traversalDepth=3 expands three levels deep") {
+    withTempDir { baseDir =>
+      // root/region/year=2023/month=01/files
+      createDeepHierarchy(
+        baseDir,
+        Seq(Seq("region-us"), Seq("year=2023"), Seq("month=01", "month=02")),
+        numFiles = 2)
+
+      val rootPath = new Path(baseDir.getAbsolutePath)
+      val result = HadoopFSUtils.parallelListLeafFiles(
+        sc = sc,
+        paths = Seq(rootPath),
+        hadoopConf = hadoopConf,
+        filter = acceptAllFilter,
+        ignoreMissingFiles = false,
+        ignoreLocality = true,
+        parallelismThreshold = 32,
+        parallelismMax = 10,
+        traversalDepth = 3)
+
+      val allFiles = result.flatMap(_._2)
+      assert(allFiles.length === 4) // 2 months * 2 files
+      assert(allFiles.forall(_.getPath.getName.endsWith(".parquet")))
+    }
+  }
+
+  test("traversalDepth handles leaf directories before reaching target depth") {
+    withTempDir { baseDir =>
+      // Create a shallow hierarchy but request deep traversal
+      // root/files (no subdirectories)
+      for (i <- 0 until 5) {
+        Files.createFile(new File(baseDir, s"part-$i.parquet").toPath)
+      }
+
+      val rootPath = new Path(baseDir.getAbsolutePath)
+      val result = HadoopFSUtils.parallelListLeafFiles(
+        sc = sc,
+        paths = Seq(rootPath),
+        hadoopConf = hadoopConf,
+        filter = acceptAllFilter,
+        ignoreMissingFiles = false,
+        ignoreLocality = true,
+        parallelismThreshold = 32,
+        parallelismMax = 10,
+        traversalDepth = 3)
+
+      val allFiles = result.flatMap(_._2)
+      assert(allFiles.length === 5)
+    }
+  }
+
+  test("traversalDepth with wide hierarchy at intermediate level") {
+    withTempDir { baseDir =>
+      // root/subpath/{year=2020..year=2023}/{month=01..month=12}/files
+      val years = (2020 to 2023).map(y => s"year=$y")
+      val months = (1 to 12).map(m => f"month=$m%02d")
+      createDeepHierarchy(
+        baseDir,
+        Seq(Seq("subpath"), years, months),
+        numFiles = 1)
+
+      val rootPath = new Path(baseDir.getAbsolutePath)
+      // traversalDepth=2 should expand root -> subpath -> year=20xx (4 paths)
+      val result = HadoopFSUtils.parallelListLeafFiles(
+        sc = sc,
+        paths = Seq(rootPath),
+        hadoopConf = hadoopConf,
+        filter = acceptAllFilter,
+        ignoreMissingFiles = false,
+        ignoreLocality = true,
+        parallelismThreshold = 32,
+        parallelismMax = 10,
+        traversalDepth = 2)
+
+      val allFiles = result.flatMap(_._2)
+      assert(allFiles.length === 48) // 4 years * 12 months * 1 file
+    }
+  }
+
+  test("traversalDepth with missing intermediate directory") {
+    withTempDir { baseDir =>
+      createDeepHierarchy(
+        baseDir,
+        Seq(Seq("subpath"), Seq("year=2023")),
+        numFiles = 2)
+
+      // Add a non-existent path
+      val missingPath = new Path(new File(baseDir, "nonexistent").getAbsolutePath)
+      val validPath = new Path(baseDir.getAbsolutePath)
+
+      val result = HadoopFSUtils.parallelListLeafFiles(
+        sc = sc,
+        paths = Seq(validPath, missingPath),
+        hadoopConf = hadoopConf,
+        filter = acceptAllFilter,
+        ignoreMissingFiles = true,
+        ignoreLocality = true,
+        parallelismThreshold = 32,
+        parallelismMax = 10,
+        traversalDepth = 2)
+
+      val allFiles = result.flatMap(_._2)
+      assert(allFiles.length === 2)
+    }
+  }
+
+  test("traversalDepth stops expanding when directory contains mixed files and subdirs") {
+    withTempDir { baseDir =>
+      // root/subpath/ contains both a file and a subdirectory
+      val subpath = new File(baseDir, "subpath")
+      subpath.mkdirs()
+      Files.createFile(new File(subpath, "loose-file.parquet").toPath)
+      val nested = new File(subpath, "year=2023")
+      nested.mkdirs()
+      Files.createFile(new File(nested, "part-0.parquet").toPath)
+
+      val rootPath = new Path(baseDir.getAbsolutePath)
+      val result = HadoopFSUtils.parallelListLeafFiles(
+        sc = sc,
+        paths = Seq(rootPath),
+        hadoopConf = hadoopConf,
+        filter = acceptAllFilter,
+        ignoreMissingFiles = false,
+        ignoreLocality = true,
+        parallelismThreshold = 32,
+        parallelismMax = 10,
+        traversalDepth = 3)
+
+      val allFiles = result.flatMap(_._2)
+      // Both the loose file and the nested file should be discovered
+      assert(allFiles.length === 2)
+      assert(allFiles.map(_.getPath.getName).toSet === Set("loose-file.parquet", "part-0.parquet"))
+    }
+  }
+
+  test("traversalDepth filters hidden/underscore directories during sequential traversal") {
+    withTempDir { baseDir =>
+      // root/subpath/ has a normal dir and hidden dirs
+      val subpath = new File(baseDir, "subpath")
+      subpath.mkdirs()
+      val visible = new File(subpath, "year=2023")
+      visible.mkdirs()
+      Files.createFile(new File(visible, "part-0.parquet").toPath)
+      // Hidden directories that should be filtered
+      val hidden = new File(subpath, ".hidden")
+      hidden.mkdirs()
+      Files.createFile(new File(hidden, "part-0.parquet").toPath)
+      val underscore = new File(subpath, "_temporary")
+      underscore.mkdirs()
+      Files.createFile(new File(underscore, "part-0.parquet").toPath)
+
+      val rootPath = new Path(baseDir.getAbsolutePath)
+      val result = HadoopFSUtils.parallelListLeafFiles(
+        sc = sc,
+        paths = Seq(rootPath),
+        hadoopConf = hadoopConf,
+        filter = acceptAllFilter,
+        ignoreMissingFiles = false,
+        ignoreLocality = true,
+        parallelismThreshold = 32,
+        parallelismMax = 10,
+        traversalDepth = 2)
+
+      val allFiles = result.flatMap(_._2)
+      // Only the file under year=2023 should be found
+      assert(allFiles.length === 1)
+      assert(allFiles.head.getPath.getName === "part-0.parquet")
+      assert(allFiles.head.getPath.getParent.getName === "year=2023")
+    }
+  }
+
+  test("traversalDepth preserves _metadata and _common_metadata directories") {
+    withTempDir { baseDir =>
+      // root/subpath/ has _metadata, _common_metadata (should be preserved) and _temporary
+      val subpath = new File(baseDir, "subpath")
+      subpath.mkdirs()
+      val metadata = new File(subpath, "_metadata")
+      metadata.mkdirs()
+      Files.createFile(new File(metadata, "part-0.parquet").toPath)
+      val commonMetadata = new File(subpath, "_common_metadata")
+      commonMetadata.mkdirs()
+      Files.createFile(new File(commonMetadata, "part-0.parquet").toPath)
+      val temporary = new File(subpath, "_temporary")
+      temporary.mkdirs()
+      Files.createFile(new File(temporary, "part-0.parquet").toPath)
+      val normal = new File(subpath, "year=2023")
+      normal.mkdirs()
+      Files.createFile(new File(normal, "part-0.parquet").toPath)
+
+      val rootPath = new Path(baseDir.getAbsolutePath)
+      val result = HadoopFSUtils.parallelListLeafFiles(
+        sc = sc,
+        paths = Seq(rootPath),
+        hadoopConf = hadoopConf,
+        filter = acceptAllFilter,
+        ignoreMissingFiles = false,
+        ignoreLocality = true,
+        parallelismThreshold = 32,
+        parallelismMax = 10,
+        traversalDepth = 2)
+
+      val allFiles = result.flatMap(_._2)
+      val parentNames = allFiles.map(_.getPath.getParent.getName).toSet
+      // _metadata and _common_metadata should be preserved, _temporary should be filtered
+      assert(parentNames.contains("_metadata"))
+      assert(parentNames.contains("_common_metadata"))
+      assert(parentNames.contains("year=2023"))
+      assert(!parentNames.contains("_temporary"))
+    }
+  }
+
+  test("traversalDepth=1 and traversalDepth>1 produce identical file listings") {
+    withTempDir { baseDir =>
+      // root/region/year=2023/month={01,02}/files
+      createDeepHierarchy(
+        baseDir,
+        Seq(Seq("region"), Seq("year=2023"), Seq("month=01", "month=02")),
+        numFiles = 3)
+
+      val rootPath = new Path(baseDir.getAbsolutePath)
+
+      def listWithDepth(depth: Int): Set[String] = {
+        HadoopFSUtils.parallelListLeafFiles(
+          sc = sc,
+          paths = Seq(rootPath),
+          hadoopConf = hadoopConf,
+          filter = acceptAllFilter,
+          ignoreMissingFiles = false,
+          ignoreLocality = true,
+          parallelismThreshold = 32,
+          parallelismMax = 10,
+          traversalDepth = depth
+        ).flatMap(_._2).map(_.getPath.toString).toSet
+      }
+
+      val depth1 = listWithDepth(1)
+      val depth2 = listWithDepth(2)
+      val depth3 = listWithDepth(3)
+
+      assert(depth1.size === 6)
+      assert(depth1 === depth2)
+      assert(depth1 === depth3)
+    }
+  }
+
+  test("traversalDepth with multiple input root paths") {
+    withTempDir { baseDir =>
+      // Two separate root paths, each with a narrow hierarchy
+      val root1 = new File(baseDir, "table1")
+      val root2 = new File(baseDir, "table2")
+      createDeepHierarchy(root1, Seq(Seq("region"), Seq("year=2023")), numFiles = 2)
+      createDeepHierarchy(root2, Seq(Seq("region"), Seq("year=2024")), numFiles = 3)
+
+      val result = HadoopFSUtils.parallelListLeafFiles(
+        sc = sc,
+        paths = Seq(new Path(root1.getAbsolutePath), new Path(root2.getAbsolutePath)),
+        hadoopConf = hadoopConf,
+        filter = acceptAllFilter,
+        ignoreMissingFiles = false,
+        ignoreLocality = true,
+        parallelismThreshold = 32,
+        parallelismMax = 10,
+        traversalDepth = 2)
+
+      val allFiles = result.flatMap(_._2)
+      assert(allFiles.length === 5) // 2 + 3
+    }
+  }
+}

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -130,6 +130,20 @@ Configuration of in-memory caching can be done via `spark.conf.set` or by runnin
     </td>
     <td>2.1.1</td>
   </tr>
+  <tr>
+    <td><code>spark.sql.sources.parallelPartitionDiscovery.traversalDepth</code></td>
+    <td>1</td>
+    <td>
+      Configures sequential directory pre-traversal on the driver before delegating to
+      parallel workers during partition discovery. A value of 1 (default) means no sequential
+      pre-traversal is performed. A value of N causes the driver to sequentially expand up to
+      N-1 directory levels before parallelizing. For deep directory hierarchies with
+      single-child roots (e.g., <code>root/subpath/{year}/{month}/</code>), increasing this
+      value (e.g., to 2 or 3) allows the driver to collect enough paths before parallelizing,
+      improving listing performance.
+    </td>
+    <td>4.2.0</td>
+  </tr>
 </table>
 
 ### Coalesce Hints

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2303,6 +2303,22 @@ object SQLConf {
       .intConf
       .createWithDefault(10000)
 
+  val PARALLEL_PARTITION_DISCOVERY_TRAVERSAL_DEPTH =
+    buildConf("spark.sql.sources.parallelPartitionDiscovery.traversalDepth")
+      .doc("Controls sequential directory pre-traversal on the driver before " +
+        "delegating to parallel workers during partition discovery. " +
+        "A value of 1 (default) means no sequential pre-traversal is performed. " +
+        "A value of N causes the driver to sequentially expand up to N-1 directory " +
+        "levels before parallelizing. For deep directory hierarchies with " +
+        "single-child roots (e.g., root/subpath/{year}/{month}/), increasing this " +
+        "value (e.g., to 2 or 3) allows the driver to collect enough paths before " +
+        "parallelizing, improving listing performance.")
+      .version("4.2.0")
+      .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .intConf
+      .checkValue(depth => depth >= 1, "The traversal depth must be at least 1")
+      .createWithDefault(1)
+
   val IGNORE_DATA_LOCALITY =
     buildConf("spark.sql.sources.ignoreDataLocality")
       .doc("If true, Spark will not fetch the block locations for each file on " +
@@ -7668,6 +7684,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def parallelPartitionDiscoveryParallelism: Int =
     getConf(SQLConf.PARALLEL_PARTITION_DISCOVERY_PARALLELISM)
+
+  def parallelPartitionDiscoveryTraversalDepth: Int =
+    getConf(SQLConf.PARALLEL_PARTITION_DISCOVERY_TRAVERSAL_DEPTH)
 
   def bucketingEnabled: Boolean = getConf(SQLConf.BUCKETING_ENABLED)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -133,10 +133,35 @@ class InMemoryFileIndex(
     val filter = FileInputFormat.getInputPathFilter(new JobConf(hadoopConf, this.getClass))
     val discovered = InMemoryFileIndex.bulkListLeafFiles(
       pathsToFetch.toSeq, hadoopConf, filter, sparkSession, parameters)
-    discovered.foreach { case (path, leafFiles) =>
-      HiveCatalogMetrics.incrementFilesDiscovered(leafFiles.size)
-      fileStatusCache.putLeafFiles(path, leafFiles.toArray)
-      output ++= leafFiles
+    val traversalDepth =
+      sparkSession.sessionState.conf.parallelPartitionDiscoveryTraversalDepth
+    if (traversalDepth > 1 && pathsToFetch.nonEmpty) {
+      // When traversalDepth > 1, bulkListLeafFiles returns results keyed by expanded
+      // intermediate paths rather than the original root paths in pathsToFetch.
+      // Re-group all discovered files under their original root path so that the
+      // FileStatusCache (keyed by root path) can be hit on subsequent lookups.
+      val allDiscoveredFiles = discovered.flatMap(_._2)
+      for (rootPath <- pathsToFetch) {
+        val qualifiedRoot = try {
+          rootPath.getFileSystem(hadoopConf).makeQualified(rootPath).toString
+        } catch {
+          case _: Exception => rootPath.toString
+        }
+        val prefix = if (qualifiedRoot.endsWith("/")) qualifiedRoot else qualifiedRoot + "/"
+        val filesForRoot = allDiscoveredFiles.filter { f =>
+          val fp = f.getPath.toString
+          fp.startsWith(prefix) || fp == qualifiedRoot
+        }
+        HiveCatalogMetrics.incrementFilesDiscovered(filesForRoot.size)
+        fileStatusCache.putLeafFiles(rootPath, filesForRoot.toArray)
+      }
+      output ++= allDiscoveredFiles
+    } else {
+      discovered.foreach { case (path, leafFiles) =>
+        HiveCatalogMetrics.incrementFilesDiscovered(leafFiles.size)
+        fileStatusCache.putLeafFiles(path, leafFiles.toArray)
+        output ++= leafFiles
+      }
     }
     logInfo(log"It took ${MDC(ELAPSED_TIME, (System.nanoTime() - startTime) / (1000 * 1000))} ms" +
       log" to list leaf files for ${MDC(COUNT, paths.length)} paths.")
@@ -176,7 +201,8 @@ object InMemoryFileIndex extends Logging {
         ignoreMissingFiles = ignoreMissingFiles,
         ignoreLocality = sparkSession.sessionState.conf.ignoreDataLocality,
         parallelismThreshold = sparkSession.sessionState.conf.parallelPartitionDiscoveryThreshold,
-        parallelismMax = sparkSession.sessionState.conf.parallelPartitionDiscoveryParallelism)
+        parallelismMax = sparkSession.sessionState.conf.parallelPartitionDiscoveryParallelism,
+        traversalDepth = sparkSession.sessionState.conf.parallelPartitionDiscoveryTraversalDepth)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -680,6 +680,51 @@ class FileIndexSuite extends SharedSparkSession {
       assert(fileIndex2a != fileIndex2b)
     }
   }
+
+  test("SPARK-54923: traversalDepth config is wired through InMemoryFileIndex") {
+    withTempDir { dir =>
+      // Create a deep-narrow hierarchy: root/subpath/year=2023/{month=01,month=02}/files
+      val subpath = new File(dir, "subpath")
+      subpath.mkdir()
+      for (year <- Seq("year=2023")) {
+        val yearDir = new File(subpath, year)
+        yearDir.mkdir()
+        for (month <- Seq("month=01", "month=02")) {
+          val monthDir = new File(yearDir, month)
+          monthDir.mkdir()
+          stringToFile(new File(monthDir, "part-0.parquet"), "data")
+        }
+      }
+
+      val path = new Path(dir.getCanonicalPath)
+
+      def listWithDepth(depth: Int): Set[String] = withSQLConf(
+        SQLConf.PARALLEL_PARTITION_DISCOVERY_TRAVERSAL_DEPTH.key -> depth.toString
+      ) {
+        val idx = new InMemoryFileIndex(spark, Seq(path), Map.empty, None)
+        idx.listLeafFiles(idx.rootPaths).map(_.getPath.toString).toSet
+      }
+
+      val filesDepth1 = listWithDepth(1)
+      val filesDepth2 = listWithDepth(2)
+      val filesDepth3 = listWithDepth(3)
+
+      assert(filesDepth1.size === 2)
+      assert(filesDepth1 === filesDepth2)
+      assert(filesDepth1 === filesDepth3)
+    }
+  }
+
+  test("SPARK-54923: traversalDepth config rejects values less than 1") {
+    val e = intercept[IllegalArgumentException] {
+      withSQLConf(
+        SQLConf.PARALLEL_PARTITION_DISCOVERY_TRAVERSAL_DEPTH.key -> "0"
+      ) {
+        new InMemoryFileIndex(spark, Seq.empty, Map.empty, None)
+      }
+    }
+    assert(e.getMessage.contains("The traversal depth must be at least 1"))
+  }
 }
 
 object DeletionRaceFileSystem {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds a new configuration `spark.sql.sources.parallelPartitionDiscovery.traversalDepth` that controls how many directory levels the driver sequentially expands before delegating to parallel workers during partition discovery.

For deep-narrow directory hierarchies (e.g., `root/subpath/{year}/{month}/`), the top levels have very few children, so parallelizing at level 1 creates too few tasks. This config allows the driver to sequentially traverse N-1 levels first, collecting enough paths to parallelize effectively.

Key design decisions:
- `traversalDepth=1` (default) preserves identical behavior to the original code
- Expanded intermediate paths use `isRootLevel=false` to preserve SPARK-27676 semantics
- A `tolerateDisappearance` flag handles the race condition where directories confirmed during sequential traversal vanish before parallel listing reaches them, without propagating to recursive subdirectory calls
- FileStatusCache keys are re-mapped to original root paths so the cache remains effective when `traversalDepth > 1`
- Sequential traversal filters hidden/underscore directories but preserves `_metadata` and `_common_metadata`
- Mixed directories (containing both files and subdirectories) stop expansion to avoid missing sibling files

### Why are the changes needed?

When tables have deep-narrow directory structures (e.g., a single intermediate path like `root/subpath/` before the partition columns), the parallel partition discovery creates only one task for the single root path. This means the entire directory tree is listed sequentially on a single executor, negating the benefit of parallel listing. By pre-expanding a few levels on the driver, we can distribute the work across multiple tasks.

### Does this PR introduce any user-facing change?

Yes. A new SQL configuration `spark.sql.sources.parallelPartitionDiscovery.traversalDepth` is available. Default value is 1 (no behavior change). Setting it to N causes the driver to sequentially expand up to N-1 directory levels before parallelizing.

### How was this patch tested?

- 11 new tests in HadoopFSUtilsDeepNarrowSuite covering: default behavior, single/multi-level expansion, leaf-before-depth, wide hierarchies, missing directories, mixed files+dirs, hidden directory filtering, _metadata/_common_metadata preservation, consistency across depths, and multiple input roots
- 2 new tests in FileIndexSuite covering: end-to-end traversalDepth with InMemoryFileIndex and config validation (rejects values < 1)

### Was this patch authored or co-authored using generative AI tooling?

Yes