### PR TITLE
[SPARK-55988][PS][TESTS] Compare categorical index codes by values in tests

### DIFF
--- a/python/pyspark/pandas/tests/indexes/test_category.py
+++ b/python/pyspark/pandas/tests/indexes/test_category.py
@@ -30,7 +30,7 @@ class CategoricalIndexTestsMixin:
 
         self.assert_eq(psidx, pidx)
         self.assert_eq(psidx.categories, pidx.categories)
-        self.assert_eq(psidx.codes, pd.Index(pidx.codes))
+        self.assert_eq(psidx.codes.to_numpy(), pidx.codes)
         self.assert_eq(psidx.ordered, pidx.ordered)
 
         pidx = pd.Index([1, 2, 3], dtype="category")
@@ -38,7 +38,7 @@ class CategoricalIndexTestsMixin:
 
         self.assert_eq(psidx, pidx)
         self.assert_eq(psidx.categories, pidx.categories)
-        self.assert_eq(psidx.codes, pd.Index(pidx.codes))
+        self.assert_eq(psidx.codes.to_numpy(), pidx.codes)
         self.assert_eq(psidx.ordered, pidx.ordered)
 
         pdf = pd.DataFrame(
@@ -55,7 +55,7 @@ class CategoricalIndexTestsMixin:
 
         self.assert_eq(psidx, pidx)
         self.assert_eq(psidx.categories, pidx.categories)
-        self.assert_eq(psidx.codes, pd.Index(pidx.codes))
+        self.assert_eq(psidx.codes.to_numpy(), pidx.codes)
         self.assert_eq(psidx.ordered, pidx.ordered)
 
         pidx = pdf.set_index(["a", "b"]).index.get_level_values(0)
@@ -63,7 +63,7 @@ class CategoricalIndexTestsMixin:
 
         self.assert_eq(psidx, pidx)
         self.assert_eq(psidx.categories, pidx.categories)
-        self.assert_eq(psidx.codes, pd.Index(pidx.codes))
+        self.assert_eq(psidx.codes.to_numpy(), pidx.codes)
         self.assert_eq(psidx.ordered, pidx.ordered)
 
         with self.assertRaisesRegex(TypeError, "Index.name must be a hashable type"):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates `pyspark.pandas.tests.indexes.test_category` to compare categorical index `codes` by values instead of wrapping pandas `codes` with `pd.Index(...)`.

The test now compares `psidx.codes.to_numpy()` against `pidx.codes`.

### Why are the changes needed?

`CategoricalIndex.codes` on the pandas side is an ndarray-like result. Wrapping it with `pd.Index(...)` makes the test depend on pandas index materialization details rather than the categorical code values themselves.

Comparing the raw codes is a closer match to the pandas API shape and avoids depending on pandas index container behavior that differs in pandas 3.

### Does this PR introduce _any_ user-facing change?

No.

This PR only updates test expectations.

### How was this patch tested?

```bash
./python/run-tests.py --testnames pyspark.pandas.tests.indexes.test_category
```

This test passed locally in both pandas 3.0.0 and pandas 2.3.3 environments.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex GPT-5
