### PR TITLE
[SPARK-55357][PYTHON] Fix docstring for timestamp_add

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -13070,7 +13070,7 @@ def timestamp_add(unit: str, quantity: "ColumnOrName", ts: "ColumnOrName") -> Co
     """
     Adds the specified number of units to the given timestamp
 
-    versionadded:: 4.0.0
+    ..versionadded:: 4.0.0
 
     Parameters
     ----------

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -13070,7 +13070,7 @@ def timestamp_add(unit: str, quantity: "ColumnOrName", ts: "ColumnOrName") -> Co
     """
     Adds the specified number of units to the given timestamp
 
-    ..versionadded:: 4.0.0
+    .. versionadded:: 4.0.0
 
     Parameters
     ----------

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -13068,7 +13068,7 @@ def timestamp_diff(unit: str, start: "ColumnOrName", end: "ColumnOrName") -> Col
 @_try_remote_functions
 def timestamp_add(unit: str, quantity: "ColumnOrName", ts: "ColumnOrName") -> Column:
     """
-    Adds the specified number of units to the given timestamp.
+    Adds the specified number of units to the given timestamp
 
     .. versionadded:: 4.0.0
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -13070,7 +13070,7 @@ def timestamp_add(unit: str, quantity: "ColumnOrName", ts: "ColumnOrName") -> Co
     """
     Adds the specified number of units to the given timestamp
 
-    .. versionadded:: 4.0.0
+    versionadded:: 4.0.0
 
     Parameters
     ----------

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -13068,15 +13068,14 @@ def timestamp_diff(unit: str, start: "ColumnOrName", end: "ColumnOrName") -> Col
 @_try_remote_functions
 def timestamp_add(unit: str, quantity: "ColumnOrName", ts: "ColumnOrName") -> Column:
     """
-    Gets the difference between the timestamps in the specified units by truncating
-    the fraction part.
+    Adds the specified number of units to the given timestamp.
 
     .. versionadded:: 4.0.0
 
     Parameters
     ----------
     unit : literal string
-        This indicates the units of the difference between the given timestamps.
+        This indicates the units of datetime that you want to add.
         Supported options are (case insensitive): "YEAR", "QUARTER", "MONTH", "WEEK",
         "DAY", "HOUR", "MINUTE", "SECOND", "MILLISECOND" and "MICROSECOND".
     quantity : :class:`~pyspark.sql.Column` or column name
@@ -13087,7 +13086,7 @@ def timestamp_add(unit: str, quantity: "ColumnOrName", ts: "ColumnOrName") -> Co
     Returns
     -------
     :class:`~pyspark.sql.Column`
-        the difference between the timestamps.
+        the resulting timestamp after adding the specified number of units.
 
     See Also
     --------


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix the docstring of the timestamp_add, which was incorrectly copy-pasted from timestamp_diff


### Why are the changes needed?
The current documentation for timestamp_add is misleading

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
No functional changes


### Was this patch authored or co-authored using generative AI tooling?
No
