### PR TITLE
[SPARK-49825][SQL] Fix the default warehouse dir for case with white spaces.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -17,11 +17,11 @@
 
 package org.apache.spark.sql.internal
 
+import java.io.File
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
-import org.apache.spark.util.Utils
 
 
 /**
@@ -36,7 +36,7 @@ object StaticSQLConf {
     .doc("The default location for managed databases and tables.")
     .version("2.0.0")
     .stringConf
-    .createWithDefault(Utils.resolveURI("spark-warehouse").toString)
+    .createWithDefault(new File("spark-warehouse").getCanonicalFile.toString)
 
   val CATALOG_DEFAULT_DATABASE =
     buildStaticConf(s"spark.sql.catalog.$SESSION_CATALOG_NAME.defaultDatabase")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The default warehouse directory, the value of `spark.sql.warehouse.sql` conf, is always `spark-warehouse/` under the current directory. The reported issue is for the case when the current directory path contains white spaces. Current behavior of the default conf for warehouse path is to resolve the URI of the current path, which causes the URL encoded string. Because we know that the default warehouse is always the local filesystem directory, this PR proposes to use directly the `File` object instead of `Utils.resolveURI` to avoid unnecessary URL encoded string.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Without this PR, when saving dataframe as table like `df.saveAsTable("my_table")`, the files for the table is not created under expected `$PWD/spark-warehouse/my_table`, but it creates a brand new directory that with URL encoded string.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, when the spark process runs at the path with white spaces, the destination of `df.saveAsTable` changes.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
It was tricky to add a test case since this is related with the process path. Instead I did perform manual testing, making the directory with white spaces, reproduce the issue with the existing code, and then verify the fix. Followed through the reproduce path that the original jira ticket proposed.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.