### PR TITLE
[SPARK-52687] Fix SPARK_CONNECT_MODE parsing in bin/pyspark

### DIFF
--- a/bin/pyspark
+++ b/bin/pyspark
@@ -83,9 +83,19 @@ export PYTHONPATH="${SPARK_HOME}/python/lib/py4j-0.10.9.9-src.zip:$PYTHONPATH"
 export OLD_PYTHONSTARTUP="$PYTHONSTARTUP"
 export PYTHONSTARTUP="${SPARK_HOME}/python/pyspark/shell.py"
 
-export SPARK_CONNECT_MODE=$($PYSPARK_DRIVER_PYTHON -c "from pyspark.util import spark_connect_mode; print(spark_connect_mode())")
-
-if [[ "$SPARK_CONNECT_MODE" != "0" && "$SPARK_CONNECT_MODE" != "1" ]]; then
+$PYSPARK_DRIVER_PYTHON -c "
+import sys
+try:
+    from pyspark.util import spark_connect_mode
+    m = spark_connect_mode().strip()
+    sys.exit(0 if m == '0' else 1 if m == '1' else 2)
+except Exception:
+    sys.exit(2)
+"
+SPARK_CONNECT_MODE_EC=$?
+if [[ $SPARK_CONNECT_MODE_EC -eq 0 || $SPARK_CONNECT_MODE_EC -eq 1 ]]; then
+  export SPARK_CONNECT_MODE=$SPARK_CONNECT_MODE_EC
+else
   echo "The environment variable SPARK_CONNECT_MODE has unknown value or pyspark.util package is not available: $SPARK_CONNECT_MODE"
   unset SPARK_CONNECT_MODE
 fi


### PR DESCRIPTION
fix https://issues.apache.org/jira/browse/SPARK-52687


### What changes were proposed in this pull request?
Replaced the stdout-based SPARK_CONNECT_MODE detection in bin/pyspark with an exit-code-based approach to avoid invisible characters (e.g. \r, spaces, tabs) causing false "unknown value" errors.

Changes:

Run Python to determine the mode and exit with 0 (classic), 1 (connect), or 2 (error) instead of printing to stdout
Use .strip() in Python to handle whitespace in the env var
Add try/except to handle import failures and invalid values
Update the bash logic to branch on exit code instead of parsing command output


### Why are the changes needed?
https://issues.apache.org/jira/browse/SPARK-52687

The previous implementation used $(python -c "print(spark_connect_mode())") and compared the output to "0" or "1". This could fail when:

Python output included \r (e.g. Windows CRLF)
Any such character made the comparison fail and triggered the "unknown value" message even when the value was logically correct.

### Does this PR introduce _any_ user-facing change?
Yes. Behavior is unchanged for normal cases; the fix only affects previously broken scenarios.

Before: Users could see "The environment variable SPARK_CONNECT_MODE has unknown value or pyspark.util package is not available: 0" even when the value was valid.
After: Valid values (including with surrounding whitespace) are accepted; invalid values still produce an error.


### How was this patch tested?
Manual tests for exit codes 0, 1, and 2
Manual test with SPARK_CONNECT_MODE=" 0 " (whitespace)

### Was this patch authored or co-authored using generative AI tooling?
No
