### PR TITLE
[SPARK-53970][PYTHON] Remove incorrect 'optional' tag for messageName…

### DIFF
--- a/python/pyspark/sql/protobuf/functions.py
+++ b/python/pyspark/sql/protobuf/functions.py
@@ -63,7 +63,7 @@ def from_protobuf(
     ----------
     data : :class:`~pyspark.sql.Column` or str
         the binary column.
-    messageName: str, optional
+    messageName: str
         the protobuf message name to look for in descriptor file, or
         The Protobuf class name when descFilePath parameter is not set.
         E.g. `com.example.protos.ExampleEvent`.
@@ -196,7 +196,7 @@ def to_protobuf(
     ----------
     data : :class:`~pyspark.sql.Column` or str
         the data column.
-    messageName: str, optional
+    messageName: str
         the protobuf message name to look for in descriptor file, or
         The Protobuf class name when descFilePath parameter is not set.
         E.g. `com.example.protos.ExampleEvent`.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes a minor documentation inconsistency in `pyspark/sql/protobuf/functions.py`. It removes the `optional` tag from the `messageName` parameter in the docstrings of both the `from_protobuf` and `to_protobuf` functions.

### Why are the changes needed?

As reported in [SPARK-53970](https://issues.apache.org/jira/browse/SPARK-53970), the function signatures define `messageName` as a required positional argument (it has no default value). However, the docstrings incorrectly labeled it as `optional`. This mismatch could mislead developers into thinking they can omit the argument, which would result in a `TypeError`. Updating the docstring ensures it accurately reflects the code's behavior.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only fix.

### How was this patch tested?

Manual review of the docstring changes. Passed local Python linter checks (`./dev/lint-python`) to ensure no style regressions.

### Was this patch authored or co-authored using generative AI tooling?

No.