### PR TITLE
[SPARK-55991] Fix unicode related SQL text corruption with parameters

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/SubstituteParamsParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/SubstituteParamsParser.scala
@@ -188,22 +188,25 @@ class SubstituteParamsParser extends Logging {
    * Apply a list of substitutions to the SQL text.
    * Inserts a space separator when a parameter is immediately preceded by a quote
    * to avoid back-to-back quotes after substitution.
+   *
+   * ANTLR's CodePointCharStream reports token positions in Unicode code points, but
+   * Java/Scala String indices are in UTF-16 code units. Supplementary characters
+   * (e.g. emojis) occupy 1 code point but 2 code units, so we must convert.
    */
   private def applySubstitutions(sqlText: String, substitutions: List[Substitution]): String = {
-    // Sort substitutions by start position in reverse order to avoid offset issues
     val sortedSubstitutions = substitutions.sortBy(-_.start)
 
     var result = sqlText
     sortedSubstitutions.foreach { substitution =>
-      val prefix = result.substring(0, substitution.start)
+      val startCU = result.offsetByCodePoints(0, substitution.start)
+      val endCU = result.offsetByCodePoints(0, substitution.end)
+      val prefix = result.substring(0, startCU)
       val replacement = substitution.replacement
-      val suffix = result.substring(substitution.end)
+      val suffix = result.substring(endCU)
 
-      // Check if replacement is immediately preceded by a quote and doesn't already
-      // start with whitespace
-      val needsSpace = substitution.start > 0 &&
-        (result(substitution.start - 1) == '\'' || result(substitution.start - 1) == '"') &&
-        replacement.nonEmpty && !replacement(0).isWhitespace
+      val needsSpace = startCU > 0 &&
+        (result.charAt(startCU - 1) == '\'' || result.charAt(startCU - 1) == '"') &&
+        replacement.nonEmpty && !replacement.charAt(0).isWhitespace
 
       val space = if (needsSpace) " " else ""
       result = s"$prefix$space$replacement$suffix"

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ParameterSubstitutionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ParameterSubstitutionSuite.scala
@@ -137,6 +137,27 @@ class ParameterSubstitutionSuite extends SparkFunSuite {
     assert(result === s"SELECT '${emoji}' AS a FROM T WHERE 'abc' IS NULL")
   }
 
+  test("ParameterHandler - multiple params with emoji in SQL and replacement values") {
+    val flexed = new String(Character.toChars(0x1F4AA))
+    val tada = new String(Character.toChars(0x1F389))
+    val context = NamedParameterContext(Map(
+      "p1" -> Literal(tada),
+      "p2" -> Literal(42)
+    ))
+    val sql = s"SELECT '${flexed}', :p1, '${flexed}', :p2"
+    val (result, _) = ParameterHandler.substituteParameters(sql, context)
+    assert(result === s"SELECT '${flexed}', '${tada}', '${flexed}', 42")
+  }
+
+  test("ParameterHandler - positional params with multiple emojis") {
+    val flexed = new String(Character.toChars(0x1F4AA))
+    val tada = new String(Character.toChars(0x1F389))
+    val context = PositionalParameterContext(Seq(Literal(tada), Literal(99)))
+    val sql = s"SELECT '${flexed}', ?, '${flexed}${flexed}', ?"
+    val (result, _) = ParameterHandler.substituteParameters(sql, context)
+    assert(result === s"SELECT '${flexed}', '${tada}', '${flexed}${flexed}', 99")
+  }
+
   test("Large parameter set") {
 
     val largeParamMap = (1 to 100).map(i => s"param$i" -> Literal(i)).toMap

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ParameterSubstitutionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ParameterSubstitutionSuite.scala
@@ -121,6 +121,22 @@ class ParameterSubstitutionSuite extends SparkFunSuite {
     }
   }
 
+  test("ParameterHandler - named parameter with emoji in SQL") {
+    val emoji = new String(Character.toChars(0x1F4AA)) // supplementary char (2 UTF-16 code units)
+    val context = NamedParameterContext(Map("team" -> Literal("abc")))
+    val sql = s"SELECT '${emoji}' AS a FROM T WHERE :team IS NULL"
+    val (result, _) = ParameterHandler.substituteParameters(sql, context)
+    assert(result === s"SELECT '${emoji}' AS a FROM T WHERE 'abc' IS NULL")
+  }
+
+  test("ParameterHandler - positional parameter with emoji in SQL") {
+    val emoji = new String(Character.toChars(0x1F4AA))
+    val context = PositionalParameterContext(Seq(Literal("abc")))
+    val sql = s"SELECT '${emoji}' AS a FROM T WHERE ? IS NULL"
+    val (result, _) = ParameterHandler.substituteParameters(sql, context)
+    assert(result === s"SELECT '${emoji}' AS a FROM T WHERE 'abc' IS NULL")
+  }
+
   test("Large parameter set") {
 
     val largeParamMap = (1 to 100).map(i => s"param$i" -> Literal(i)).toMap


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix parameter substitution code to be mindful of unicode supplemental characters


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Emojies (and other special characters) cause corruption of the SQL text if parameter markers are substiution due to offset issues. codepoint vs character


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Wrote new testcases

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
YEs Claude Opus 4.6 high
