### PR TITLE
Spark 54878 support sort keys option inside to json

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -13068,7 +13068,7 @@ def timestamp_diff(unit: str, start: "ColumnOrName", end: "ColumnOrName") -> Col
 @_try_remote_functions
 def timestamp_add(unit: str, quantity: "ColumnOrName", ts: "ColumnOrName") -> Column:
     """
-    Adds the specified number of units to the given timestamp.
+    Adds the specified number of units to the given timestamp
 
     .. versionadded:: 4.0.0
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -13070,7 +13070,7 @@ def timestamp_add(unit: str, quantity: "ColumnOrName", ts: "ColumnOrName") -> Co
     """
     Adds the specified number of units to the given timestamp
 
-    .. versionadded:: 4.0.0
+    versionadded:: 4.0.0
 
     Parameters
     ----------

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -21298,7 +21298,8 @@ def to_json(col: "ColumnOrName", options: Optional[Mapping[str, str]] = None) ->
         See `Data Source Option <https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option>`_
         for the version you use.
         Additionally the function supports the `pretty` option which enables
-        pretty JSON generation.
+        pretty JSON generation, and the ``sortKeys`` option, which sorts
+        map keys lexicographically in the generated JSON.
 
         .. # noqa
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -13068,15 +13068,14 @@ def timestamp_diff(unit: str, start: "ColumnOrName", end: "ColumnOrName") -> Col
 @_try_remote_functions
 def timestamp_add(unit: str, quantity: "ColumnOrName", ts: "ColumnOrName") -> Column:
     """
-    Gets the difference between the timestamps in the specified units by truncating
-    the fraction part.
+    Adds the specified number of units to the given timestamp.
 
     .. versionadded:: 4.0.0
 
     Parameters
     ----------
     unit : literal string
-        This indicates the units of the difference between the given timestamps.
+        This indicates the units of datetime that you want to add.
         Supported options are (case insensitive): "YEAR", "QUARTER", "MONTH", "WEEK",
         "DAY", "HOUR", "MINUTE", "SECOND", "MILLISECOND" and "MICROSECOND".
     quantity : :class:`~pyspark.sql.Column` or column name
@@ -13087,7 +13086,7 @@ def timestamp_add(unit: str, quantity: "ColumnOrName", ts: "ColumnOrName") -> Co
     Returns
     -------
     :class:`~pyspark.sql.Column`
-        the difference between the timestamps.
+        the resulting timestamp after adding the specified number of units.
 
     See Also
     --------

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -3396,6 +3396,13 @@ class FunctionsTestsMixin:
         self.assertEqual("""{"a":1}""", actual["var"])
         self.assertEqual("""{"b":[{"c":"str2"}]}""", actual["var_lit"])
 
+    def test_to_json_sort_keys_option(self):
+        df = self.spark.createDataFrame([({"b": 1, "a": 2},)], ["m"])
+
+        row = df.select(F.to_json("m", {"sortKeys": "true"}).alias("json")).first()
+
+        self.assertEqual("{""a"":2,""b"":1}", row["json"])
+
     def test_variant_expressions(self):
         df = self.spark.createDataFrame(
             [Row(json="""{ "a" : 1 }""", path="$.a"), Row(json="""{ "b" : 2 }""", path="$.b")]

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -9707,8 +9707,9 @@ object functions {
    *   options to control how the struct column is converted into a json string. accepts the same
    *   options and the json data source. See <a href=
    *   "https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option"> Data
-   *   Source Option</a> in the version you use. Additionally the function supports the `pretty`
-   *   option which enables pretty JSON generation.
+  *   Source Option</a> in the version you use. Additionally the function supports the `pretty`
+  *   option which enables pretty JSON generation, and the `sortKeys` option which sorts map
+  *   keys lexicographically in the generated JSON.
    *
    * @group json_funcs
    * @since 2.1.0
@@ -9729,8 +9730,9 @@ object functions {
    *   options to control how the struct column is converted into a json string. accepts the same
    *   options and the json data source. See <a href=
    *   "https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option"> Data
-   *   Source Option</a> in the version you use. Additionally the function supports the `pretty`
-   *   option which enables pretty JSON generation.
+  *   Source Option</a> in the version you use. Additionally the function supports the `pretty`
+  *   option which enables pretty JSON generation, and the `sortKeys` option which sorts map
+  *   keys lexicographically in the generated JSON.
    *
    * @group json_funcs
    * @since 2.1.0

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -100,6 +100,9 @@ class JSONOptions(
   val ignoreNullFields = parameters.get(IGNORE_NULL_FIELDS).map(_.toBoolean)
     .getOrElse(SQLConf.get.jsonGeneratorIgnoreNullFields)
 
+  // Whether to sort keys when generating JSON for map values.
+  val sortKeys = parameters.get(SORT_KEYS).map(_.toBoolean).getOrElse(false)
+
   // If this is true, when writing NULL values to columns of JSON tables with explicit DEFAULT
   // values, never skip writing the NULL values to storage, overriding 'ignoreNullFields' above.
   // This can be useful to enforce that inserted NULL values are present in storage to differentiate
@@ -309,6 +312,7 @@ object JSONOptions extends DataSourceOptions {
   val WRITE_NON_ASCII_CHARACTER_AS_CODEPOINT = newOption("writeNonAsciiCharacterAsCodePoint")
   val SINGLE_VARIANT_COLUMN = newOption(DataSourceOptions.SINGLE_VARIANT_COLUMN)
   val USE_UNSAFE_ROW = newOption("useUnsafeRow")
+  val SORT_KEYS = newOption("sortKeys")
   // Options with alternative
   val ENCODING = "encoding"
   val CHARSET = "charset"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonGenerator.scala
@@ -276,15 +276,39 @@ class JacksonGenerator(
       map: MapData, mapType: MapType, fieldWriter: ValueWriter): Unit = {
     val keyArray = map.keyArray()
     val valueArray = map.valueArray()
-    var i = 0
-    while (i < map.numElements()) {
-      gen.writeFieldName(keyArray.get(i, mapType.keyType).toString)
-      if (!valueArray.isNullAt(i)) {
-        fieldWriter.apply(valueArray, i)
-      } else {
-        gen.writeNull()
+    val numElements = map.numElements()
+    if (!options.sortKeys) {
+      var i = 0
+      while (i < numElements) {
+        gen.writeFieldName(keyArray.get(i, mapType.keyType).toString)
+        if (!valueArray.isNullAt(i)) {
+          fieldWriter.apply(valueArray, i)
+        } else {
+          gen.writeNull()
+        }
+        i += 1
       }
-      i += 1
+    } else {
+      val indices = (0 until numElements).toArray
+      java.util.Arrays.sort(indices, new java.util.Comparator[Int] {
+        override def compare(a: Int, b: Int): Int = {
+          val ka = keyArray.get(a, mapType.keyType).toString
+          val kb = keyArray.get(b, mapType.keyType).toString
+          ka.compareTo(kb)
+        }
+      })
+
+      var j = 0
+      while (j < numElements) {
+        val i = indices(j)
+        gen.writeFieldName(keyArray.get(i, mapType.keyType).toString)
+        if (!valueArray.isNullAt(i)) {
+          fieldWriter.apply(valueArray, i)
+        } else {
+          gen.writeNull()
+        }
+        j += 1
+      }
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
@@ -706,6 +706,26 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     )
   }
 
+  test("to_json with sortKeys - map and nested struct") {
+    val nestedSchema = StructType(Seq(
+      StructField("x", IntegerType),
+      StructField("y", IntegerType)))
+    val schema = MapType(StringType, nestedSchema)
+
+    val mapData = ArrayBasedMapData(Map(
+      UTF8String.fromString("b") -> InternalRow(2, 20),
+      UTF8String.fromString("a") -> InternalRow(1, 10)))
+
+    val input = Literal(mapData, schema)
+
+    // Default behavior should preserve underlying map order (implementation-defined),
+    // so we only assert the sorted behavior here.
+    checkEvaluation(
+      StructsToJson(Map("sortKeys" -> "true"), input),
+      """{"a":{"x":1,"y":10},"b":{"x":2,"y":20}}"""
+    )
+  }
+
   test("to_json - array with maps") {
     val inputSchema = ArrayType(MapType(StringType, IntegerType))
     val input = new GenericArrayData(

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -461,6 +461,22 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
       Row("""{}""") :: Nil)
   }
 
+  test("to_json with option (sortKeys) - map and nested struct") {
+    val df = Seq(
+      (Map("b" -> 1, "a" -> 2), Map("b" -> (1, 2), "a" -> (3, 4)))
+    ).toDF("m", "nested")
+
+    val options = Map("sortKeys" -> "true")
+
+    checkAnswer(
+      df.select(to_json($"m", options)),
+      Row("""{"a":2,"b":1}""") :: Nil)
+
+    checkAnswer(
+      df.select(to_json($"nested", options)),
+      Row("""{"a":{"_1":3,"_2":4},"b":{"_1":1,"_2":2}}""") :: Nil)
+  }
+
   test("to_json - interval support") {
     val baseDf = Seq(Tuple1(Tuple1("-3 month 7 hours"))).toDF("a")
     val df = baseDf.select(struct($"a._1".cast(CalendarIntervalType).as("a")).as("c"))
@@ -857,6 +873,17 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
           from_json($"root", schema_of_json(lit(json))),
           Map("pretty" -> "true"))),
       Seq(Row(expected)))
+  }
+
+  test("to_json with sortKeys and pretty") {
+    val df = Seq(Map("b" -> 1, "a" -> 2)).toDF("m")
+
+    val prettySorted = df.select(
+      to_json($"m", Map("pretty" -> "true", "sortKeys" -> "true"))).as[String].head()
+
+    assert(prettySorted.contains("\"a\" : 2"))
+    assert(prettySorted.contains("\"b\" : 1"))
+    assert(prettySorted.indexOf("\"a\"") < prettySorted.indexOf("\"b\""))
   }
 
   test("from_json invalid json - check modes") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add a `sortKeys` option to the `to_json` function

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently [to_json() function](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.to_json.html) doesn't support the [sort options](https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option). Adding that option would provide ease in comparing JSONs from map object types.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.


If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. if setting as `true`, JSON object keys are sorted alphabetically. If "false", it works in default.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Add unit tests in JsonExpressionsSuite、JsonFunctionsSuite、PySpark test_functions.py.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes, with copilot