### PR TITLE
[SPARK-54878][SQL] Support sort_keys option inside to_json

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -21299,7 +21299,8 @@ def to_json(col: "ColumnOrName", options: Optional[Mapping[str, str]] = None) ->
         See `Data Source Option <https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option>`_
         for the version you use.
         Additionally the function supports the `pretty` option which enables
-        pretty JSON generation.
+        pretty JSON generation, and the `sortKeys` option which sorts map keys
+        in JSON objects for deterministic output.
 
         .. # noqa
 

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -3396,6 +3396,23 @@ class FunctionsTestsMixin:
         self.assertEqual("""{"a":1}""", actual["var"])
         self.assertEqual("""{"b":[{"c":"str2"}]}""", actual["var_lit"])
 
+    def test_to_json_sort_keys_option(self):
+        df = self.spark.createDataFrame([({"b": 1, "a": 2},)], ["m"])
+        res = df.select(F.to_json("m", {"sortKeys": "true"}).alias("j")).collect()
+        self.assertEqual("""{"a":2,"b":1}""", res[0]["j"])
+
+        nested = self.spark.createDataFrame(
+            [({"outerB": {"y": 2, "x": 1}, "outerA": {"d": 4, "c": 3}},)],
+            ["m"],
+        )
+        res_nested = nested.select(
+            F.to_json("m", {"sortKeys": "true"}).alias("j")
+        ).collect()
+        self.assertEqual(
+            """{"outerA":{"c":3,"d":4},"outerB":{"x":1,"y":2}}""",
+            res_nested[0]["j"],
+        )
+
     def test_variant_expressions(self):
         df = self.spark.createDataFrame(
             [Row(json="""{ "a" : 1 }""", path="$.a"), Row(json="""{ "b" : 2 }""", path="$.b")]

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -3405,9 +3405,7 @@ class FunctionsTestsMixin:
             [({"outerB": {"y": 2, "x": 1}, "outerA": {"d": 4, "c": 3}},)],
             ["m"],
         )
-        res_nested = nested.select(
-            F.to_json("m", {"sortKeys": "true"}).alias("j")
-        ).collect()
+        res_nested = nested.select(F.to_json("m", {"sortKeys": "true"}).alias("j")).collect()
         self.assertEqual(
             """{"outerA":{"c":3,"d":4},"outerB":{"x":1,"y":2}}""",
             res_nested[0]["j"],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -192,6 +192,13 @@ class JSONOptions(
   val pretty: Boolean = parameters.get(PRETTY).map(_.toBoolean).getOrElse(false)
 
   /**
+   * Sorting map keys in JSON objects if the parameter is enabled.
+   * This is mainly useful for deterministic JSON output, for example
+   * when comparing JSON strings generated from map-typed columns.
+   */
+  val sortKeys: Boolean = parameters.get(SORT_KEYS).map(_.toBoolean).getOrElse(false)
+
+  /**
    * Enables inferring of TimestampType and TimestampNTZType from strings matched to the
    * corresponding timestamp pattern defined by the timestampFormat and timestampNTZFormat options
    * respectively.
@@ -304,6 +311,7 @@ object JSONOptions extends DataSourceOptions {
   val LINE_SEP = newOption("lineSep")
   val PRETTY = newOption("pretty")
   val INFER_TIMESTAMP = newOption("inferTimestamp")
+  val SORT_KEYS = newOption("sortKeys")
   val COLUMN_NAME_OF_CORRUPT_RECORD = newOption(DataSourceOptions.COLUMN_NAME_OF_CORRUPT_RECORD)
   val TIME_ZONE = newOption("timeZone")
   val WRITE_NON_ASCII_CHARACTER_AS_CODEPOINT = newOption("writeNonAsciiCharacterAsCodePoint")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonGenerator.scala
@@ -22,6 +22,8 @@ import java.io.Writer
 import com.fasterxml.jackson.core._
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
 
+import scala.util.Sorting
+
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.SpecializedGetters
 import org.apache.spark.sql.catalyst.util._
@@ -276,15 +278,42 @@ class JacksonGenerator(
       map: MapData, mapType: MapType, fieldWriter: ValueWriter): Unit = {
     val keyArray = map.keyArray()
     val valueArray = map.valueArray()
-    var i = 0
-    while (i < map.numElements()) {
-      gen.writeFieldName(keyArray.get(i, mapType.keyType).toString)
-      if (!valueArray.isNullAt(i)) {
-        fieldWriter.apply(valueArray, i)
-      } else {
-        gen.writeNull()
+    val numElements = map.numElements()
+
+    if (!options.sortKeys) {
+      var i = 0
+      while (i < numElements) {
+        gen.writeFieldName(keyArray.get(i, mapType.keyType).toString)
+        if (!valueArray.isNullAt(i)) {
+          fieldWriter.apply(valueArray, i)
+        } else {
+          gen.writeNull()
+        }
+        i += 1
       }
-      i += 1
+    } else {
+      val keyType = mapType.keyType
+      val indices = Array.tabulate(numElements)(identity)
+      val ordering = new Ordering[Int] {
+        override def compare(x: Int, y: Int): Int = {
+          val sx = keyArray.get(x, keyType).toString
+          val sy = keyArray.get(y, keyType).toString
+          sx.compareTo(sy)
+        }
+      }
+      Sorting.quickSort(indices)(ordering)
+
+      var pos = 0
+      while (pos < numElements) {
+        val i = indices(pos)
+        gen.writeFieldName(keyArray.get(i, keyType).toString)
+        if (!valueArray.isNullAt(i)) {
+          fieldWriter.apply(valueArray, i)
+        } else {
+          gen.writeNull()
+        }
+        pos += 1
+      }
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonGenerator.scala
@@ -22,8 +22,6 @@ import java.io.Writer
 import com.fasterxml.jackson.core._
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
 
-import scala.util.Sorting
-
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.SpecializedGetters
 import org.apache.spark.sql.catalyst.util._
@@ -294,18 +292,11 @@ class JacksonGenerator(
     } else {
       val keyType = mapType.keyType
       val indices = Array.tabulate(numElements)(identity)
-      val ordering = new Ordering[Int] {
-        override def compare(x: Int, y: Int): Int = {
-          val sx = keyArray.get(x, keyType).toString
-          val sy = keyArray.get(y, keyType).toString
-          sx.compareTo(sy)
-        }
-      }
-      Sorting.quickSort(indices)(ordering)
+      val sortedIndices = indices.sortBy(i => keyArray.get(i, keyType).toString)
 
       var pos = 0
       while (pos < numElements) {
-        val i = indices(pos)
+        val i = sortedIndices(pos)
         gen.writeFieldName(keyArray.get(i, keyType).toString)
         if (!valueArray.isNullAt(i)) {
           fieldWriter.apply(valueArray, i)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/json/JacksonGeneratorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/json/JacksonGeneratorSuite.scala
@@ -106,6 +106,18 @@ class JacksonGeneratorSuite extends SparkFunSuite {
     assert(writer.toString === """{"a":1}""")
   }
 
+  test("initial with Map and write out a map data with sortKeys=true") {
+    val dataType = MapType(StringType, IntegerType)
+    // Intentionally construct map data with keys in non-sorted order.
+    val input = ArrayBasedMapData(Array("b", "a"), Array(1, 2))
+    val writer = new CharArrayWriter()
+    val sortOption = new JSONOptions(Map("sortKeys" -> "true"), utcId)
+    val gen = new JacksonGenerator(dataType, writer, sortOption)
+    gen.write(input)
+    gen.flush()
+    assert(writer.toString === """{"a":2,"b":1}""")
+  }
+
   test("initial with Map and write out an array of maps") {
     val dataType = MapType(StringType, IntegerType)
     val input = new GenericArrayData(

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -423,6 +423,22 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
       Row("""{"a":1}""") :: Nil)
   }
 
+  test("to_json with option (sortKeys)") {
+    val df = Seq(Map("b" -> 1, "a" -> 2)).toDF("a")
+    val options = Map("sortKeys" -> "true")
+
+    checkAnswer(
+      df.select(to_json($"a", options)),
+      Row("""{"a":2,"b":1}""") :: Nil)
+
+    val nested = Seq(Map("outerB" -> Map("y" -> 2, "x" -> 1),
+      "outerA" -> Map("d" -> 4, "c" -> 3))).toDF("m")
+
+    checkAnswer(
+      nested.select(to_json($"m", options)),
+      Row("""{"outerA":{"c":3,"d":4},"outerB":{"x":1,"y":2}}""") :: Nil)
+  }
+
   test("to_json with option (timestampFormat)") {
     val df = Seq(Tuple1(Tuple1(java.sql.Timestamp.valueOf("2015-08-26 18:00:00.0")))).toDF("a")
     val options = Map("timestampFormat" -> "dd/MM/yyyy HH:mm")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add a new JSON write option sortKeys. When enabled, map keys are shown in lexicographical order. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently to_json() doesn't support the sort options, which makes comparing JSON strings from MapType  inconvenient.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. if setting as true, JSON object keys are sorted alphabetically. If "false", it works in default.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Add unit tests in JacksonGeneratorSuite, JsonFunctionsSuite, PySpark tests in test_functions.py. 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Cooperate with GPT-5.1