### PR TITLE
[SPARK-55995][SQL] Support TIMESTAMP WITH LOCAL TIME ZONE in SQL syntax

### DIFF
--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -1436,8 +1436,8 @@ nonTrivialPrimitiveType
     | INTERVAL
         (fromYearMonth=(YEAR | MONTH) (TO to=MONTH)? |
          fromDayTime=(DAY | HOUR | MINUTE | SECOND) (TO to=(HOUR | MINUTE | SECOND))?)?
-    | TIMESTAMP (WITHOUT TIME ZONE)?
-    | TIME (LEFT_PAREN precision=integerValue RIGHT_PAREN)? (WITHOUT TIME ZONE)?
+    | TIMESTAMP (withLocalTimeZone | withoutTimeZone)?
+    | TIME (LEFT_PAREN precision=integerValue RIGHT_PAREN)? (withoutTimeZone)?
     | GEOGRAPHY LEFT_PAREN (srid=integerValue | any=ANY) RIGHT_PAREN
     | GEOMETRY LEFT_PAREN (srid=integerValue | any=ANY) RIGHT_PAREN
     ;
@@ -1455,6 +1455,14 @@ trivialPrimitiveType
     | BINARY
     | VOID
     | VARIANT
+    ;
+
+withLocalTimeZone
+    : WITH LOCAL TIME ZONE
+    ;
+
+withoutTimeZone
+    : WITHOUT TIME ZONE
     ;
 
 primitiveType

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/DataTypeAstBuilder.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/DataTypeAstBuilder.scala
@@ -349,10 +349,12 @@ class DataTypeAstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with DataTypeE
           } else {
             CalendarIntervalType
           }
+        case TIMESTAMP if currentCtx.withLocalTimeZone() != null =>
+          TimestampType
+        case TIMESTAMP if currentCtx.withoutTimeZone() != null =>
+          TimestampNTZType
         case TIMESTAMP =>
-          if (currentCtx.WITHOUT() == null) {
-            SqlApiConf.get.timestampType
-          } else TimestampNTZType
+          SqlApiConf.get.timestampType
         case TIME =>
           val precision = if (currentCtx.precision == null) {
             TimeType.DEFAULT_PRECISION

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DataTypeParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DataTypeParserSuite.scala
@@ -64,6 +64,7 @@ class DataTypeParserSuite extends SparkFunSuite with SQLHelper {
   checkDataType("TIME(6)", TimeType(6))
   checkDataType("TIME(6) WITHOUT TIME ZONE", TimeType(6))
   checkDataType("timestamp", TimestampType)
+  checkDataType("TIMESTAMP WITH LOCAL TIME ZONE", TimestampType)
   checkDataType("TIMESTAMP WITHOUT TIME ZONE", TimestampNTZType)
   checkDataType("timestamp_ntz", TimestampNTZType)
   checkDataType("timestamp_ltz", TimestampType)
@@ -158,9 +159,12 @@ class DataTypeParserSuite extends SparkFunSuite with SQLHelper {
   test("Set default timestamp type") {
     withSQLConf(SQLConf.TIMESTAMP_TYPE.key -> TimestampTypes.TIMESTAMP_NTZ.toString) {
       assert(parse("timestamp") === TimestampNTZType)
+      assert(parse("timestamp with local time zone") === TimestampType)
+      assert(parse("timestamp without time zone") === TimestampNTZType)
     }
     withSQLConf(SQLConf.TIMESTAMP_TYPE.key -> TimestampTypes.TIMESTAMP_LTZ.toString) {
       assert(parse("timestamp") === TimestampType)
+      assert(parse("timestamp with local time zone") === TimestampType)
       assert(parse("timestamp without time zone") === TimestampNTZType)
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR proposes to add SQL syntax `TIMESTAMP WITH LOCAL TIME ZONE` for `TimestampType`, as a counterpart of `TIMESTAMP WITHOUT TIME ZONE` for `TimestampNTZType`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Spark SQL supports `TIMESTAMP_LTZ` as a counterpart of `TIMESTAMP_NTZ`, but lacks support 
`TIMESTAMP WITH LOCAL TIME ZONE` as a counterpart of `TIMESTAMP WITHOUT TIME ZONE`.

```
-- fine
CREATE TABLE ts_1(ltz TIMESTAMP, ntz TIMESTAMP_NTZ);

-- fine, equivalent to the above case
CREATE TABLE ts_2(ltz TIMESTAMP, ntz TIMESTAMP WITHOUT TIME ZONE);

-- set TIMESTAMP as alias of TIMESTAMP_NTZ
SET spark.sql.timestampType=TimestampNTZ;

-- fine, both are TimestampNTZ
CREATE TABLE ts_3(ltz TIMESTAMP, ntz TIMESTAMP_NTZ);

-- fine, one Timestamp, and one TimestampNTZ
CREATE TABLE ts_4(ltz TIMESTAMP_LTZ, ntz TIMESTAMP_NTZ);

-- this does not work
CREATE TABLE ts_5(ltz TIMESTAMP WITH LOCAL TIME ZONE, ntz TIMESTAMP WITHOUT TIME ZONE);
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
This introduces new SQL syntax without breaking backward compatibility.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New UTs are added.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.