### PR TITLE
[SPARK-55997][SS] Set upper bound to prefixScan in RocksDB state store provider

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -1589,18 +1589,28 @@ class RocksDB(
       prefix: Array[Byte],
       cfName: String = StateStore.DEFAULT_COL_FAMILY_NAME): NextIterator[ByteArrayPair] = {
     updateMemoryUsageIfNeeded()
-    val iter = db.newIterator()
     val updatedPrefix = if (useColumnFamilies) {
       encodeStateRowWithPrefix(prefix, cfName)
     } else {
       prefix
     }
 
+    val upperBoundSlice = RocksDB.prefixUpperBound(updatedPrefix).map(new Slice(_))
+    val prefixScanReadOptions = new ReadOptions()
+    upperBoundSlice.foreach(prefixScanReadOptions.setIterateUpperBound)
+
+    val iter = db.newIterator(prefixScanReadOptions)
     iter.seek(updatedPrefix)
+
+    def closeResources(): Unit = {
+      iter.close()
+      prefixScanReadOptions.close()
+      upperBoundSlice.foreach(_.close())
+    }
 
     // Attempt to close this iterator if there is a task failure, or a task interruption.
     Option(TaskContext.get()).foreach { tc =>
-      tc.addTaskCompletionListener[Unit] { _ => iter.close() }
+      tc.addTaskCompletionListener[Unit] { _ => closeResources() }
     }
 
     new NextIterator[ByteArrayPair] {
@@ -1624,12 +1634,12 @@ class RocksDB(
           byteArrayPair
         } else {
           finished = true
-          iter.close()
+          closeResources()
           null
         }
       }
 
-      override protected def close(): Unit = { iter.close() }
+      override protected def close(): Unit = closeResources()
     }
   }
 
@@ -2225,6 +2235,27 @@ class RocksDB(
 }
 
 object RocksDB extends Logging {
+
+  /**
+   * Computes the exclusive upper bound for a prefix byte array by incrementing the prefix.
+   * For example, [0x01, 0x02, 0x03] -> Some([0x01, 0x02, 0x04]).
+   * Returns None if the prefix is all 0xFF bytes (no finite upper bound exists).
+   */
+  def prefixUpperBound(prefix: Array[Byte]): Option[Array[Byte]] = {
+    if (prefix.isEmpty) return None
+
+    var i = prefix.length - 1
+    while (i >= 0) {
+      val incremented = (prefix(i) & 0xFF) + 1
+      if (incremented <= 0xFF) {
+        val upperBound = java.util.Arrays.copyOf(prefix, i + 1)
+        upperBound(i) = incremented.toByte
+        return Some(upperBound)
+      }
+      i -= 1
+    }
+    None
+  }
 
   val mainMemorySources: Seq[String] = Seq(
     "rocksdb.estimate-table-readers-mem",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -4493,6 +4493,82 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
     assert(provider.rocksDB.localRootDir.getParent() == System.getProperty("java.io.tmpdir"))
   }
 
+  test("prefixUpperBound computes correct exclusive upper bound") {
+    def assertBound(input: Array[Byte], expected: Option[Seq[Byte]]): Unit = {
+      assert(RocksDB.prefixUpperBound(input).map(_.toSeq) === expected)
+    }
+
+    // Normal increment
+    assertBound(Array(0x01, 0x02, 0x03), Some(Seq(0x01, 0x02, 0x04)))
+
+    // Single byte
+    assertBound(Array(0x05), Some(Seq(0x06)))
+
+    // Carry: last byte is 0xFF, so it's dropped and previous byte is incremented
+    assertBound(Array(0x01, 0xFF.toByte), Some(Seq(0x02)))
+
+    // Carry: trailing bytes after the incremented position are removed
+    assertBound(Array(0x01, 0x02, 0xFF.toByte), Some(Seq(0x01, 0x03)))
+
+    // Multiple carry
+    assertBound(Array(0x01, 0xFF.toByte, 0xFF.toByte), Some(Seq(0x02)))
+
+    // All 0xFF: no finite upper bound
+    assertBound(Array(0xFF.toByte, 0xFF.toByte), None)
+
+    // Single 0xFF
+    assertBound(Array(0xFF.toByte), None)
+
+    // Empty prefix
+    assertBound(Array.empty[Byte], None)
+
+    // Zero byte
+    assertBound(Array(0x00.toByte), Some(Seq(0x01)))
+  }
+
+  testWithColumnFamilies(
+    "prefixScan returns only keys matching the prefix",
+    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+    val remoteDir = Utils.createTempDir().getAbsolutePath
+
+    withDB(remoteDir, useColumnFamilies = colFamiliesEnabled) { db =>
+      val cfName = if (colFamiliesEnabled) {
+        val cf = "testCF"
+        db.createColFamilyIfAbsent(cf, isInternal = false)
+        cf
+      } else {
+        StateStore.DEFAULT_COL_FAMILY_NAME
+      }
+
+      db.put("aa1", "v1", cfName)
+      db.put("aa2", "v2", cfName)
+      db.put("ab1", "v3", cfName)
+      db.put("bb1", "v4", cfName)
+      db.commit()
+
+      db.load(1)
+
+      val resultAA = db.prefixScan("aa".getBytes, cfName).map(toStr).toSeq
+      assert(resultAA.map(_._1).toSet === Set("aa1", "aa2"))
+      assert(resultAA.size === 2)
+
+      val resultAB = db.prefixScan("ab".getBytes, cfName).map(toStr).toSeq
+      assert(resultAB.map(_._1).toSet === Set("ab1"))
+      assert(resultAB.size === 1)
+
+      val resultBB = db.prefixScan("bb".getBytes, cfName).map(toStr).toSeq
+      assert(resultBB.map(_._1).toSet === Set("bb1"))
+      assert(resultBB.size === 1)
+
+      val resultCC = db.prefixScan("cc".getBytes, cfName).map(toStr).toSeq
+      assert(resultCC.isEmpty)
+
+      val resultA = db.prefixScan("a".getBytes, cfName).map(toStr).toSeq
+      assert(resultA.map(_._1).toSet === Set("aa1", "aa2", "ab1"))
+      assert(resultA.size === 3)
+    }
+  }
+
   private def dbConf = RocksDBConf(StateStoreConf(SQLConf.get.clone()))
 
   class RocksDBCheckpointFormatV2(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to set upper bound to prefixScan (including iterator with column family) in RocksDB state store provider. This is to guide RocksDB to stop finding the next valid key if it already sought the boundary and now figures out the next valid key beyond boundary.

### Why are the changes needed?

For prefix scan (and iterator with column family) in RocksDB state store provider, we create an iterator and seek to the first valid key for the prefix (or vcf), and trigger next till there is no key or the given key is out of bound.

When triggering next, RocksDB has to figure out the next valid key from current position. The issue is "valid" key - let's say there is column family vcf1 which is set to perform prefix scan, and the prefix of the keys are 'a', 'b', 'c' (for simplicity). After we remove all keys for the prefix 'b', prefix scan of the prefix 'a' has to go through all tombstones for 'b' to finally find the valid key from the prefix 'c', which can take a lot of time if the number of keys for prefix 'b' was outstanding.

Since we use virtual column family (vcf) and vcf is identified by prefix, we have the similar problem "across" vcfs. Suppose the case where there are two virtual column families vcf1 and vcf2, where vcf1 is set to perform prefix scan while vcf2 is to perform range scan (and sequentially removed based on watermark/timestamp advancement). If there is prefix scan for vcf1 which is the last prefix of vcf1, it has to go through tombstones for vcf2 to finally find the valid key for vcf2.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New tests for RocksDB class level. Existing tests for prefix scan and iterator with column family should verify e2e.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: claude-4.6-opus