### PR TITLE
[SPARK-55998][SHS] Synchronize more places on accessing SHS listing.db

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -1345,10 +1345,14 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
 
     // Delete driver log file entries that exceed the configured max age and
     // may have been deleted on filesystem externally.
-    val stale = KVUtils.viewToSeq(listing.view(classOf[LogInfo])
-      .index("lastProcessed")
-      .reverse()
-      .first(maxTime), Int.MaxValue) { l => l.logType != null && l.logType == LogType.DriverLogs }
+    val stale = listing.synchronized {
+      KVUtils.viewToSeq(listing.view(classOf[LogInfo])
+        .index("lastProcessed")
+        .reverse()
+        .first(maxTime), Int.MaxValue) { l =>
+          l.logType != null && l.logType == LogType.DriverLogs
+        }
+    }
     stale.filterNot(isProcessing).foreach { log =>
       logInfo(log"Deleting invalid driver log ${MDC(PATH, log.logPath)}")
       listing.synchronized {

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -584,7 +584,9 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
       .foreach { log =>
         log.appId.foreach { appId =>
           cleanAppData(appId, log.attemptId, log.logPath)
-          listing.delete(classOf[LogInfo], log.logPath)
+          listing.synchronized {
+            listing.delete(classOf[LogInfo], log.logPath)
+          }
         }
       }
 
@@ -698,7 +700,9 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
                   // If the LogInfo read had succeeded, but the ApplicationInafoWrapper
                   // read failure and throw the exception, we should also cleanup the log
                   // info from listing db.
-                  listing.delete(classOf[LogInfo], reader.rootPath.toString)
+                  listing.synchronized {
+                    listing.delete(classOf[LogInfo], reader.rootPath.toString)
+                  }
                   false
                 } else if (count < conf.get(UPDATE_BATCHSIZE)) {
                   listing.write(LogInfo(reader.rootPath.toString(), newLastScanTime,
@@ -1194,7 +1198,9 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
       logInfo(log"Deleting invalid / corrupt event log ${MDC(PATH, log.logPath)}")
       val logPath = new Path(log.logPath)
       deleteLog(fsForPath(logPath), logPath)
-      listing.delete(classOf[LogInfo], log.logPath)
+      listing.synchronized {
+        listing.delete(classOf[LogInfo], log.logPath)
+      }
     }
 
     log.appId.foreach { appId =>
@@ -1228,22 +1234,28 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     }
 
     // Delete log files that don't have a valid application and exceed the configured max age.
-    val stale = KVUtils.viewToSeq(listing.view(classOf[LogInfo])
-      .index("lastProcessed")
-      .reverse()
-      .first(maxTime), Int.MaxValue) { l => l.logType == null || l.logType == LogType.EventLogs }
+    val stale = listing.synchronized {
+      KVUtils.viewToSeq(listing.view(classOf[LogInfo])
+        .index("lastProcessed")
+        .reverse()
+        .first(maxTime), Int.MaxValue) { l => l.logType == null || l.logType == LogType.EventLogs }
+    }
     stale.filterNot(isProcessing).foreach { log =>
       if (log.appId.isEmpty) {
         logInfo(log"Deleting invalid / corrupt event log ${MDC(PATH, log.logPath)}")
         val logPath = new Path(log.logPath)
         deleteLog(fsForPath(logPath), logPath)
-        listing.delete(classOf[LogInfo], log.logPath)
+        listing.synchronized {
+          listing.delete(classOf[LogInfo], log.logPath)
+        }
       }
     }
 
     // If the number of files is bigger than MAX_LOG_NUM,
     // clean up all completed attempts per application one by one.
-    val num = KVUtils.size(listing.view(classOf[LogInfo]).index("lastProcessed"))
+    val num = listing.synchronized {
+      KVUtils.size(listing.view(classOf[LogInfo]).index("lastProcessed"))
+    }
     var count = num - maxNum
     if (count > 0) {
       logInfo(log"Try to delete ${MDC(NUM_FILES, count)} old event logs" +
@@ -1324,7 +1336,9 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         }
       if (deleteFile) {
         logInfo(log"Deleting expired driver log for: ${MDC(PATH, logFileStr)}")
-        listing.delete(classOf[LogInfo], logFileStr)
+        listing.synchronized {
+          listing.delete(classOf[LogInfo], logFileStr)
+        }
         deleteLog(driverLogFs, f.getPath())
       }
     }
@@ -1337,7 +1351,9 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
       .first(maxTime), Int.MaxValue) { l => l.logType != null && l.logType == LogType.DriverLogs }
     stale.filterNot(isProcessing).foreach { log =>
       logInfo(log"Deleting invalid driver log ${MDC(PATH, log.logPath)}")
-      listing.delete(classOf[LogInfo], log.logPath)
+      listing.synchronized {
+        listing.delete(classOf[LogInfo], log.logPath)
+      }
       deleteLog(driverLogFs, new Path(log.logPath))
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Wrap all 

- `listing.delete(classOf[LogInfo], <path>)` and
- `listing.view(classOf[LogInfo])`

operations in SHS's `FsHistoryProvider` with `listing.synchronized { ... }`, this is similar to SPARK-37659.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
```
spark.history.fs.cleaner.enabled true
spark.history.fs.cleaner.interval 2h
spark.history.fs.cleaner.maxNum 650000
spark.history.provider org.apache.spark.deploy.history.FsHistoryProvider
spark.history.store.hybridStore.enabled true
spark.history.store.hybridStore.diskBackend ROCKSDB
```

With the above configs, we found that the real preserved number of eventlogs sometimes can exceed 1 million, which reaches the number of files limitation of the HDFS single folder, and then causes the inability to submit new Spark apps (fails due to being unable to create event log file).

After digging the SHS's logs (it's an internal version based on OSS Spark 3.3.4, after taking a look, the master code should have the same issue), we found that in most cases, the scheduled cleanLogs task will fail with

```
2026-02-14 01:05:34 [ERROR] [spark-history-task-0] Utils#302 - Uncaught exception in thread spark-history-task-0
java.util.NoSuchElementException: 1^@__main__^@+hdfs://namenode/spark2-history/application_1770077136288_1231234_1.lz4.inprogress
        at org.apache.spark.util.kvstore.RocksDB.get(RocksDB.java:167) ~[spark-kvstore_2.12-3.3.4.113.jar:3.3.4.113]
        at org.apache.spark.util.kvstore.RocksDBIterator.next(RocksDBIterator.java:128) ~[spark-kvstore_2.12-3.3.4.113.jar:3.3.4.113]
        at scala.collection.convert.Wrappers$JIteratorWrapper.next(Wrappers.scala:46) ~[scala-library-2.12.20.jar:?]
        at scala.collection.Iterator.foreach(Iterator.scala:943) ~[scala-library-2.12.20.jar:?]
        at scala.collection.Iterator.foreach$(Iterator.scala:943) ~[scala-library-2.12.20.jar:?]
        at scala.collection.AbstractIterator.foreach(Iterator.scala:1431) ~[scala-library-2.12.20.jar:?]
        at scala.collection.IterableLike.foreach(IterableLike.scala:74) ~[scala-library-2.12.20.jar:?]
        at scala.collection.IterableLike.foreach$(IterableLike.scala:73) ~[scala-library-2.12.20.jar:?]
        at scala.collection.AbstractIterable.foreach(Iterable.scala:56) ~[scala-library-2.12.20.jar:?]
        at scala.collection.TraversableOnce.size(TraversableOnce.scala:139) ~[scala-library-2.12.20.jar:?]
        at scala.collection.TraversableOnce.size$(TraversableOnce.scala:129) ~[scala-library-2.12.20.jar:?]
        at scala.collection.AbstractTraversable.size(Traversable.scala:108) ~[scala-library-2.12.20.jar:?]
        at org.apache.spark.deploy.history.FsHistoryProvider.$anonfun$cleanLogs$1(FsHistoryProvider.scala:1020) ~[spark-core_2.12-3.3.4.113.jar:3.3.4.113]
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23) ~[scala-library-2.12.20.jar:?]
        at org.apache.spark.util.Utils$.tryLog(Utils.scala:2091) [spark-core_2.12-3.3.4.113.jar:3.3.4.113]
        at org.apache.spark.deploy.history.FsHistoryProvider.cleanLogs(FsHistoryProvider.scala:984) [spark-core_2.12-3.3.4.113.jar:3.3.4.113]
        at org.apache.spark.deploy.history.FsHistoryProvider.$anonfun$startPolling$4(FsHistoryProvider.scala:326) [spark-core_2.12-3.3.4.113.jar:3.3.4.113]
        at org.apache.spark.util.Utils$.tryOrExit(Utils.scala:1436) [spark-core_2.12-3.3.4.113.jar:3.3.4.113]
        at org.apache.spark.deploy.history.FsHistoryProvider.$anonfun$getRunner$1(FsHistoryProvider.scala:228) [spark-core_2.12-3.3.4.113.jar:3.3.4.113]
        ...
```

and the failure causes a significant backlog in the event log folders
```
$ zgrep 'Uncaught exception\|Try to delete' spark-history-server.log.20260214.gz
2026-02-14 01:05:34 [ERROR] [spark-history-task-0] Utils#302 - Uncaught exception in thread spark-history-task-0
2026-02-14 03:05:40 [ERROR] [spark-history-task-0] Utils#302 - Uncaught exception in thread spark-history-task-0
2026-02-14 05:07:04 [ERROR] [spark-history-task-0] Utils#302 - Uncaught exception in thread spark-history-task-0
2026-02-14 07:08:12 [ERROR] [spark-history-task-0] Utils#302 - Uncaught exception in thread spark-history-task-0
2026-02-14 09:10:02 [ERROR] [spark-history-task-0] Utils#302 - Uncaught exception in thread spark-history-task-0
2026-02-14 11:11:20 [ERROR] [spark-history-task-0] Utils#302 - Uncaught exception in thread spark-history-task-0
2026-02-14 13:11:51 [ERROR] [spark-history-task-0] Utils#302 - Uncaught exception in thread spark-history-task-0
2026-02-14 15:12:33 [ERROR] [spark-history-task-0] Utils#302 - Uncaught exception in thread spark-history-task-0
2026-02-14 17:13:37 [ERROR] [spark-history-task-0] Utils#302 - Uncaught exception in thread spark-history-task-0
2026-02-14 19:14:55 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 55271 old event logs to keep 650000 logs in total.
2026-02-14 21:18:59 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 3566 old event logs to keep 650000 logs in total.
2026-02-14 23:19:35 [ERROR] [spark-history-task-0] Utils#302 - Uncaught exception in thread spark-history-task-0
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, this fixes a bug that SHS may not clean up expired event logs in time.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
I have rolled out the patched SHS online for a few days, and am monitoring logs, it has no failures in the cleaning up phase anymore.

```
$ zgrep 'Uncaught exception\|Try to delete' spark-history-server.log.20260314.gz
2026-03-14 01:58:20 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 5886 old event logs to keep 650000 logs in total.
2026-03-14 03:59:49 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 5792 old event logs to keep 650000 logs in total.
2026-03-14 06:00:33 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 6467 old event logs to keep 650000 logs in total.
2026-03-14 08:02:41 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 7531 old event logs to keep 650000 logs in total.
2026-03-14 10:03:39 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 7831 old event logs to keep 650000 logs in total.
2026-03-14 12:06:07 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 5662 old event logs to keep 650000 logs in total.
2026-03-14 14:07:55 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 4894 old event logs to keep 650000 logs in total.
2026-03-14 16:09:04 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 4476 old event logs to keep 650000 logs in total.
2026-03-14 18:11:17 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 3757 old event logs to keep 650000 logs in total.
2026-03-14 20:12:05 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 3477 old event logs to keep 650000 logs in total.
2026-03-14 22:13:34 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 3350 old event logs to keep 650000 logs in total.

$ zgrep 'Uncaught exception\|Try to delete' spark-history-server.log.20260315.gz
2026-03-15 00:15:34 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 3480 old event logs to keep 650000 logs in total.
2026-03-15 02:16:24 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 5805 old event logs to keep 650000 logs in total.
2026-03-15 04:17:56 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 6003 old event logs to keep 650000 logs in total.
2026-03-15 06:20:06 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 6576 old event logs to keep 650000 logs in total.
2026-03-15 08:20:52 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 7348 old event logs to keep 650000 logs in total.
2026-03-15 10:24:21 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 7358 old event logs to keep 650000 logs in total.
2026-03-15 12:27:48 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 5537 old event logs to keep 650000 logs in total.
2026-03-15 14:28:35 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 4922 old event logs to keep 650000 logs in total.
2026-03-15 16:29:19 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 4014 old event logs to keep 650000 logs in total.
2026-03-15 18:31:08 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 3510 old event logs to keep 650000 logs in total.
2026-03-15 20:33:05 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 3351 old event logs to keep 650000 logs in total.
2026-03-15 22:34:55 [INFO] [spark-history-task-0] FsHistoryProvider#185 - Try to delete 3653 old event logs to keep 650000 logs in total.
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.