### PR TITLE
[SPARK-56008][BUILD] Upgrade `tink` to 1.20.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -265,7 +265,7 @@ stax-api/1.0.1//stax-api-1.0.1.jar
 stream/2.9.8//stream-2.9.8.jar
 super-csv/2.2.0//super-csv-2.2.0.jar
 threeten-extra/1.8.0//threeten-extra-1.8.0.jar
-tink/1.19.0//tink-1.19.0.jar
+tink/1.20.0//tink-1.20.0.jar
 transaction-api/1.1//transaction-api-1.1.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar
 vertx-auth-common/4.5.24//vertx-auth-common-4.5.24.jar

--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.11.0</commons-cli.version>
     <bouncycastle.version>1.83</bouncycastle.version>
-    <tink.version>1.19.0</tink.version>
+    <tink.version>1.20.0</tink.version>
     <datasketches.version>6.2.0</datasketches.version>
     <netty.version>4.2.10.Final</netty.version>
     <netty-tcnative.version>2.0.74.Final</netty-tcnative.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades the `Tink` dependency to 1.20.0.

### Why are the changes needed?

To pick up the latest bug fixes and improvements:
- https://github.com/tink-crypto/tink-java/releases/tag/v1.20.0
    - https://github.com/tink-crypto/tink-java/issues/63
    - Protobuf dependency updated to 4.33.0
    - Faster JWT signature primitive creation
    - AES-SIV primitive now accepts 32-byte keys

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the existing tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)