### PR TITLE
[SPARK-56011][PYTHON][INFRA] Add python/asv wrapper script for running benchmarks from repo root

### DIFF
--- a/dev/asv
+++ b/dev/asv
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Wrapper script to run ASV (Airspeed Velocity) benchmarks from the Spark
+# root directory. All arguments are forwarded to asv.
+#
+# Usage:
+#   ./dev/asv run --python=same --quick
+#   ./dev/asv run --python=same --quick -b 'bench_arrow.LongArrowToPandasBenchmark'
+#   ./dev/asv continuous -f 1.1 upstream/master HEAD
+
+set -euo pipefail
+
+SPARK_HOME="$(cd "$(dirname "$0")/.." && pwd)"
+BENCHMARKS_DIR="$SPARK_HOME/python/benchmarks"
+
+if ! command -v asv &> /dev/null; then
+  echo "Error: asv is not installed. Install it with: pip install asv" >&2
+  exit 1
+fi
+
+cd "$BENCHMARKS_DIR"
+exec asv "$@"

--- a/python/asv
+++ b/python/asv
@@ -16,23 +16,27 @@
 # limitations under the License.
 #
 
-# Wrapper script to run ASV (Airspeed Velocity) benchmarks from the Spark
-# root directory. All arguments are forwarded to asv.
+# Wrapper script to run ASV (Airspeed Velocity) benchmarks for PySpark.
+# All arguments are forwarded to asv.
 #
 # Usage:
-#   ./dev/asv run --python=same --quick
-#   ./dev/asv run --python=same --quick -b 'bench_arrow.LongArrowToPandasBenchmark'
-#   ./dev/asv continuous -f 1.1 upstream/master HEAD
+#   ./python/asv run --python=same --quick
+#   ./python/asv run --python=same --quick -b 'bench_eval_type.GroupedMapPandasUDFTimeBench'
+#   ./python/asv continuous -f 1.1 upstream/master HEAD
 
 set -euo pipefail
 
-SPARK_HOME="$(cd "$(dirname "$0")/.." && pwd)"
-BENCHMARKS_DIR="$SPARK_HOME/python/benchmarks"
+PYTHON_DIR="$(cd "$(dirname "$0")" && pwd)"
+BENCHMARKS_DIR="$PYTHON_DIR/benchmarks"
 
 if ! command -v asv &> /dev/null; then
   echo "Error: asv is not installed. Install it with: pip install asv" >&2
   exit 1
 fi
+
+# Ensure pyspark is importable from source when using --python=same
+PY4J_ZIP="$(ls "$PYTHON_DIR"/lib/py4j-*-src.zip 2>/dev/null | head -1)"
+export PYTHONPATH="${PYTHON_DIR}${PY4J_ZIP:+:$PY4J_ZIP}${PYTHONPATH:+:$PYTHONPATH}"
 
 cd "$BENCHMARKS_DIR"
 exec asv "$@"

--- a/python/benchmarks/README.md
+++ b/python/benchmarks/README.md
@@ -15,7 +15,7 @@ The default configuration uses `virtualenv`, but ASV also supports `conda`, `mam
 
 ## Running Benchmarks
 
-All commands below can be run from the Spark root directory using `./dev/asv`,
+All commands below can be run from the Spark root directory using `./python/asv`,
 which is a wrapper that forwards arguments to `asv` in the benchmarks directory.
 
 ### Quick run (current environment)
@@ -23,13 +23,13 @@ which is a wrapper that forwards arguments to `asv` in the benchmarks directory.
 Run benchmarks using your current Python environment (fastest for development):
 
 ```bash
-./dev/asv run --python=same --quick
+./python/asv run --python=same --quick
 ```
 
 You can also specify the test class to run:
 
 ```bash
-./dev/asv run --python=same --quick -b 'bench_arrow.LongArrowToPandasBenchmark'
+./python/asv run --python=same --quick -b 'bench_arrow.LongArrowToPandasBenchmark'
 ```
 
 ### Full run against a commit
@@ -37,9 +37,9 @@ You can also specify the test class to run:
 Run benchmarks in an isolated virtualenv (builds pyspark from source):
 
 ```bash
-./dev/asv run master^!          # Run on latest master commit
-./dev/asv run v3.5.0^!          # Run on a specific tag
-./dev/asv run abc123^!          # Run on a specific commit
+./python/asv run master^!          # Run on latest master commit
+./python/asv run v3.5.0^!          # Run on a specific tag
+./python/asv run abc123^!          # Run on a specific commit
 ```
 
 ### Compare two commits
@@ -47,13 +47,13 @@ Run benchmarks in an isolated virtualenv (builds pyspark from source):
 Compare current branch against upstream/master with 10% threshold:
 
 ```bash
-./dev/asv continuous -f 1.1 upstream/master HEAD
+./python/asv continuous -f 1.1 upstream/master HEAD
 ```
 
 ### Other useful commands
 
 ```bash
-./dev/asv check          # Validate benchmark syntax
+./python/asv check          # Validate benchmark syntax
 ```
 
 ## Writing Benchmarks

--- a/python/benchmarks/README.md
+++ b/python/benchmarks/README.md
@@ -15,20 +15,21 @@ The default configuration uses `virtualenv`, but ASV also supports `conda`, `mam
 
 ## Running Benchmarks
 
+All commands below can be run from the Spark root directory using `./dev/asv`,
+which is a wrapper that forwards arguments to `asv` in the benchmarks directory.
+
 ### Quick run (current environment)
 
 Run benchmarks using your current Python environment (fastest for development):
 
 ```bash
-cd python/benchmarks
-asv run --python=same --quick
+./dev/asv run --python=same --quick
 ```
 
 You can also specify the test class to run:
 
 ```bash
-cd python/benchmarks
-asv run --python=same --quick -b 'bench_arrow.LongArrowToPandasBenchmark'
+./dev/asv run --python=same --quick -b 'bench_arrow.LongArrowToPandasBenchmark'
 ```
 
 ### Full run against a commit
@@ -36,24 +37,23 @@ asv run --python=same --quick -b 'bench_arrow.LongArrowToPandasBenchmark'
 Run benchmarks in an isolated virtualenv (builds pyspark from source):
 
 ```bash
-cd python/benchmarks
-asv run master^!          # Run on latest master commit
-asv run v3.5.0^!          # Run on a specific tag
-asv run abc123^!          # Run on a specific commit
+./dev/asv run master^!          # Run on latest master commit
+./dev/asv run v3.5.0^!          # Run on a specific tag
+./dev/asv run abc123^!          # Run on a specific commit
 ```
 
 ### Compare two commits
 
-Compare current branch against upstream/main with 10% threshold:
+Compare current branch against upstream/master with 10% threshold:
 
 ```bash
-asv continuous -f 1.1 upstream/main HEAD
+./dev/asv continuous -f 1.1 upstream/master HEAD
 ```
 
 ### Other useful commands
 
 ```bash
-asv check          # Validate benchmark syntax
+./dev/asv check          # Validate benchmark syntax
 ```
 
 ## Writing Benchmarks


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a `python/asv` wrapper script so PySpark ASV benchmarks can be run directly from the Spark root directory, and update the benchmarks README accordingly.

## Why are the changes needed?

Running benchmarks currently requires `cd python/benchmarks` first, which is inconvenient. 

## Does this PR introduce _any_ user-facing change?

No.

## How was this patch tested?

Manually verified the wrapper script runs `asv` correctly from the repo root.

## Was this patch authored or co-authored using generative AI tooling?

No.