### PR TITLE
[SPARK-56014][PS][TESTS] Fix to_numeric ignore test for pandas 3.0

### DIFF
--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -21,6 +21,7 @@ import inspect
 import pandas as pd
 import numpy as np
 
+from pyspark.loose_version import LooseVersion
 from pyspark import pandas as ps
 from pyspark.pandas.exceptions import PandasNotImplementedError
 from pyspark.pandas.namespace import _get_index_map, read_delta
@@ -579,7 +580,13 @@ class NamespaceTestsMixin:
         # "coerce", "ignore" and "raise" with non-Series.
         data = ["1", "2", None, "4", "hello"]
         self.assert_eq(pd.to_numeric(data, errors="coerce"), ps.to_numeric(data, errors="coerce"))
-        self.assert_eq(pd.to_numeric(data, errors="ignore"), ps.to_numeric(data, errors="ignore"))
+        if LooseVersion(pd.__version__) < "3.0.0":
+            self.assert_eq(
+                pd.to_numeric(data, errors="ignore"), ps.to_numeric(data, errors="ignore")
+            )
+        else:
+            with self.assertRaisesRegex(ValueError, "invalid error value specified"):
+                ps.to_numeric(data, errors="ignore")
 
         self.assertRaisesRegex(
             ValueError,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates `pyspark.pandas.tests.test_namespace.NamespaceTests.test_to_numeric` for the pandas 3.0 behavior of `to_numeric(..., errors="ignore")` with non-Series inputs.

In this code path, `ps.to_numeric` delegates to `pd.to_numeric` for non-Series inputs. The existing test assumed that `errors="ignore"` returns the original input, but pandas 3.0 now raises `ValueError("invalid error value specified")` instead.

This patch makes the test follow the pandas version in use:

- for pandas `< 3.0.0`, keep the existing equality check
- for pandas `>= 3.0.0`, assert the `ValueError`

No implementation behavior is changed.

### Why are the changes needed?

The current test fails under the pandas 3.0 test environment because its expectation no longer matches upstream pandas behavior.

Since pandas-on-Spark delegates this non-Series case to pandas, the test should reflect the version-specific pandas behavior rather than hard-coding the pre-3.0 result.

### Does this PR introduce _any_ user-facing change?

Yes, it will behave more like pandas 3.

### How was this patch tested?

Updated the related test.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
