### PR TITLE
[SPARK-56016][PS] Preserve named Series columns in concat with ignore_index on pandas 3

### DIFF
--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -2655,6 +2655,10 @@ def concat(
             series_names.add(obj.name)
             if not ignore_index and not should_return_series:
                 new_objs.append(obj.to_frame())
+            elif LooseVersion(pd.__version__) >= "3.0.0" and not should_return_series:
+                # pandas 3 preserves a named Series as its own column during
+                # row-wise concat with ignore_index=True instead of renaming it to 0.
+                new_objs.append(obj.to_frame())
             else:
                 new_objs.append(obj.to_frame(DEFAULT_SERIES_NAME))
         else:

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -360,17 +360,21 @@ class NamespaceTestsMixin:
             ([psdf, psdf["C"]], [pdf, pdf["C"]]),
             ([psdf["C"], psdf], [pdf["C"], pdf]),
         ]
-        for psdfs, pdfs in series_objs:
-            for ignore_index, join, sort in itertools.product(ignore_indexes, joins, sorts):
-                self.assert_eq(
-                    ps.concat(psdfs, ignore_index=ignore_index, join=join, sort=sort),
-                    pd.concat(pdfs, ignore_index=ignore_index, join=join, sort=sort),
-                )
+
+        for ignore_index, join, sort in itertools.product(ignore_indexes, joins, sorts):
+            for i, (psdfs, pdfs) in enumerate(series_objs):
+                with self.subTest(
+                    ignore_index=ignore_index, join=join, sort=sort, pair=i, index="single"
+                ):
+                    self.assert_eq(
+                        ps.concat(psdfs, ignore_index=ignore_index, join=join, sort=sort),
+                        pd.concat(pdfs, ignore_index=ignore_index, join=join, sort=sort),
+                    )
 
         for ignore_index, join, sort in itertools.product(ignore_indexes, joins, sorts):
             for i, (psdfs, pdfs) in enumerate(objs):
                 with self.subTest(
-                    ignore_index=ignore_index, join=join, sort=sort, pdfs=pdfs, pair=i
+                    ignore_index=ignore_index, join=join, sort=sort, pair=i, index="single"
                 ):
                     self.assert_eq(
                         ps.concat(psdfs, ignore_index=ignore_index, join=join, sort=sort),
@@ -412,7 +416,7 @@ class NamespaceTestsMixin:
         for ignore_index, sort in itertools.product(ignore_indexes, sorts):
             for i, (psdfs, pdfs) in enumerate(objs):
                 with self.subTest(
-                    ignore_index=ignore_index, join="outer", sort=sort, pdfs=pdfs, pair=i
+                    ignore_index=ignore_index, join="outer", sort=sort, pair=i, index="multi"
                 ):
                     self.assert_eq(
                         ps.concat(psdfs, ignore_index=ignore_index, join="outer", sort=sort),
@@ -423,7 +427,7 @@ class NamespaceTestsMixin:
         for ignore_index in ignore_indexes:
             for i, (psdfs, pdfs) in enumerate(objs):
                 with self.subTest(
-                    ignore_index=ignore_index, join="inner", sort=True, pdfs=pdfs, pair=i
+                    ignore_index=ignore_index, join="inner", sort=True, pair=i, index="multi"
                 ):
                     self.assert_eq(
                         ps.concat(psdfs, ignore_index=ignore_index, join="inner", sort=True),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates pandas-on-Spark `concat` for row-wise concatenation of mixed `DataFrame` and `Series` inputs when `ignore_index=True`.

In pandas 2.x, pandas treats the `Series` input as an anonymous column named `0` in this case. In pandas 3.0+, pandas preserves the `Series` name and aligns it with matching `DataFrame` columns instead. pandas-on-Spark was still always converting mixed `Series` inputs to column `0`, which caused `pyspark.pandas.tests.test_namespace.NamespaceTests.test_concat_index_axis` to fail under pandas 3.

To match pandas behavior, this patch keeps the existing behavior for pandas 2.x, but preserves the `Series` name for mixed `DataFrame`/`Series` concatenation on pandas 3.0+.

This PR also updates the related namespace test to use `subTest(...)` for each concat case so the failing combination is easier to identify.

### Why are the changes needed?

Without this change, pandas-on-Spark produces incorrect columns for mixed `DataFrame`/`Series` concatenation with `ignore_index=True` on pandas 3.0+.

For example, concatenating a `DataFrame` with a named `Series` should reuse the `Series` name as the output column on pandas 3, but pandas-on-Spark instead creates a separate column `0`. That causes behavior differences from pandas and breaks the existing namespace concat test in the pandas 3 environment.

### Does this PR introduce _any_ user-facing change?

Yes, it will behave more like pandas 3.

### How was this patch tested?

The existing tests should pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)