### PR TITLE
[SPARK-56020][SQL] Improve `GroupPartitions` Spark UI

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/functions/Reducer.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/functions/Reducer.java
@@ -39,4 +39,12 @@ import org.apache.spark.annotation.Evolving;
 @Evolving
 public interface Reducer<I, O> {
   O reduce(I arg);
+
+  /**
+   * Returns a short string representation for plan display (e.g. explain output).
+   * Defaults to the unqualified class name; implementations may override for a richer description.
+   */
+  default String displayName() {
+    return getClass().getSimpleName();
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -192,8 +192,13 @@ case class GroupPartitionsExec(
     }
   }
 
-  /** Summary parts for plan string representation. */
-  private def planSummaryParts(joinKeyMaxFields: Int): Seq[String] = {
+  override def simpleString(maxFields: Int): String = {
+    s"$nodeName${planSummaryParts(maxFields).map(" " + _).mkString("")}"
+  }
+
+  override protected def stringArgs: Iterator[Any] = planSummaryParts(Int.MaxValue)
+
+  private def planSummaryParts(joinKeyMaxFields: Int): Iterator[String] = {
     val joinKeyStr = joinKeyPositions.map { p =>
       s"JoinKeyPositions: ${truncatedString(p, "[", ",", "]", joinKeyMaxFields)}"
     }.getOrElse("")
@@ -204,15 +209,8 @@ case class GroupPartitionsExec(
       s"Reducers: ${truncatedString(names, "[", ", ", "]", joinKeyMaxFields)}"
     }.getOrElse("")
     Seq(joinKeyStr, expectedStr, reducersStr, s"DistributePartitions: $distributePartitions")
-  }
-
-  override def simpleString(maxFields: Int): String = {
-    val parts = planSummaryParts(maxFields)
-    s"$nodeName${parts.filter(_.nonEmpty).map(" " + _).mkString("")}"
-  }
-
-  override protected def stringArgs: Iterator[Any] = {
-    Iterator(child) ++ planSummaryParts(Int.MaxValue).filter(_.nonEmpty).iterator
+      .iterator
+      .filter(_.nonEmpty)
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -201,16 +201,15 @@ case class GroupPartitionsExec(
   private def planSummaryParts(joinKeyMaxFields: Int): Iterator[String] = {
     val joinKeyStr = joinKeyPositions.map { p =>
       s"JoinKeyPositions: ${truncatedString(p, "[", ",", "]", joinKeyMaxFields)}"
-    }.getOrElse("")
-    val expectedStr =
-      expectedPartitionKeys.map(ks => s"ExpectedPartitionKeys: ${ks.size}").getOrElse("")
+    }.iterator
+    val expectedStr = expectedPartitionKeys.map(ks => s"ExpectedPartitionKeys: ${ks.size}")
     val reducersStr = reducers.map { seq =>
-      val names = seq.map(_.map(_.displayName()).getOrElse("identity"))
+      val names = seq.map(_.map(_.toString()).getOrElse("identity"))
       s"Reducers: ${truncatedString(names, "[", ", ", "]", joinKeyMaxFields)}"
-    }.getOrElse("")
-    Seq(joinKeyStr, expectedStr, reducersStr, s"DistributePartitions: $distributePartitions")
-      .iterator
-      .filter(_.nonEmpty)
+    }
+    val distributeStr = Iterator(s"DistributePartitions: $distributePartitions")
+    joinKeyStr ++ expectedStr ++ reducersStr ++ distributeStr
+
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -25,7 +25,7 @@ import org.apache.spark.rdd.{CoalescedRDD, PartitionCoalescer, PartitionGroup, R
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.physical.{KeyedPartitioning, Partitioning}
-import org.apache.spark.sql.catalyst.util.InternalRowComparableWrapper
+import org.apache.spark.sql.catalyst.util.{truncatedString, InternalRowComparableWrapper}
 import org.apache.spark.sql.connector.catalog.functions.Reducer
 import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.types.DataType
@@ -192,14 +192,27 @@ case class GroupPartitionsExec(
     }
   }
 
+  /** Summary parts for plan string representation. */
+  private def planSummaryParts(joinKeyMaxFields: Int): Seq[String] = {
+    val joinKeyStr = joinKeyPositions.map { p =>
+      s"JoinKeyPositions: ${truncatedString(p, "[", ",", "]", joinKeyMaxFields)}"
+    }.getOrElse("")
+    val expectedStr =
+      expectedPartitionKeys.map(ks => s"ExpectedPartitionKeys: ${ks.size}").getOrElse("")
+    val reducersStr = reducers.map { seq =>
+      val names = seq.map(_.map(_.displayName()).getOrElse("identity"))
+      s"Reducers: ${truncatedString(names, "[", ", ", "]", joinKeyMaxFields)}"
+    }.getOrElse("")
+    Seq(joinKeyStr, expectedStr, reducersStr, s"DistributePartitions: $distributePartitions")
+  }
+
   override def simpleString(maxFields: Int): String = {
-    val joinKeyPositionsString =
-      joinKeyPositions.map(p => s" JoinKeyPositions: ${p.mkString("[", ",", "]")}").getOrElse("")
-    val expectedPartitionKeysString =
-      expectedPartitionKeys.map(ks => s" ExpectedPartitionKeys: ${ks.size}").getOrElse("")
-    val reducersString = reducers.map(r => s" Reducers: ${r.count(_.isDefined)}").getOrElse("")
-    s"$nodeName$joinKeyPositionsString$expectedPartitionKeysString$reducersString " +
-      s"DistributePartitions: $distributePartitions"
+    val parts = planSummaryParts(maxFields)
+    s"$nodeName${parts.filter(_.nonEmpty).map(" " + _).mkString("")}"
+  }
+
+  override protected def stringArgs: Iterator[Any] = {
+    Iterator(child) ++ planSummaryParts(Int.MaxValue).filter(_.nonEmpty).iterator
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -3232,7 +3232,8 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase with 
       SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true") {
       val df = sql(
         s"""
-           |SELECT *
+           |${selectWithMergeJoinHint("i", "p")}
+           |*
            |FROM testcat.ns.$items i
            |JOIN testcat.ns.$purchases p ON p.item_id = i.id
            |""".stripMargin)
@@ -3241,7 +3242,7 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase with 
     }
   }
 
-  test("SPARK-55992: GroupPartitions extended explain summary") {
+  test("SPARK-55992: GroupPartitions verbose string (Spark UI)") {
     val items_partitions = Array(bucket(4, "id"), years("arrive_time"))
     createTable(items, itemsColumns, items_partitions)
     sql(s"INSERT INTO testcat.ns.$items VALUES (1, 'aa', 10.0, cast('2021-01-01' as timestamp))")
@@ -3254,14 +3255,26 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase with 
       SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true") {
       val df = sql(
         s"""
-           |SELECT *
+           |${selectWithMergeJoinHint("i", "p")}
+           |*
            |FROM testcat.ns.$items i
            |JOIN testcat.ns.$purchases p ON p.item_id = i.id
            |""".stripMargin)
-      checkKeywordsExistsInExplain(df, ExtendedMode, keywords =
-        "GroupPartitions JoinKeyPositions: [0] ExpectedPartitionKeys: 2 " +
-        "Reducers: [BucketReducer(2)] DistributePartitions: false")
-      checkKeywordsNotExistsInExplain(df, ExtendedMode, "InternalRowComparableWrapper")
+      val groupPartitions = collectAllGroupPartitions(df.queryExecution.executedPlan)
+      assert(groupPartitions.nonEmpty, "plan should contain GroupPartitionsExec")
+      groupPartitions.foreach { node =>
+        val verboseStr = node.verboseStringWithOperatorId()
+        assert(verboseStr.contains("Arguments:"),
+          s"verbose string (Spark UI) should contain Arguments: line: $verboseStr")
+        assert(
+          verboseStr.contains("JoinKeyPositions:") &&
+          verboseStr.contains("ExpectedPartitionKeys:") &&
+          verboseStr.contains("Reducers:") &&
+          verboseStr.contains("DistributePartitions:"),
+          s"verbose string should contain summary fields: $verboseStr")
+        assert(!verboseStr.contains("InternalRowComparableWrapper"),
+          s"verbose string should not dump InternalRow: $verboseStr")
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.connector.catalog.functions._
 import org.apache.spark.sql.connector.distributions.Distributions
 import org.apache.spark.sql.connector.expressions._
 import org.apache.spark.sql.connector.expressions.Expressions._
-import org.apache.spark.sql.execution.{ExtendedMode, SimpleMode, SparkPlan}
+import org.apache.spark.sql.execution.{ExtendedMode, FormattedMode, SimpleMode, SparkPlan}
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2ScanRelation, GroupPartitionsExec}
 import org.apache.spark.sql.execution.exchange.{ShuffleExchangeExec, ShuffleExchangeLike}
 import org.apache.spark.sql.execution.joins.SortMergeJoinExec
@@ -3217,32 +3217,7 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase with 
     }
   }
 
-  test("SPARK-55992: GroupPartitions textual representation in simple and extended explain") {
-    val items_partitions = Array(bucket(4, "id"), years("arrive_time"))
-    createTable(items, itemsColumns, items_partitions)
-    sql(s"INSERT INTO testcat.ns.$items VALUES (1, 'aa', 10.0, cast('2021-01-01' as timestamp))")
-    val purchases_partitions = Array(bucket(6, "item_id"), years("time"))
-    createTable(purchases, purchasesColumns, purchases_partitions)
-    sql(s"INSERT INTO testcat.ns.$purchases VALUES (2, 10.0, cast('2021-01-01' as timestamp))")
-    val keywords = "GroupPartitions JoinKeyPositions: [0] ExpectedPartitionKeys: 2 " +
-      "Reducers: [BucketReducer(2)] DistributePartitions: false"
-    withSQLConf(
-      SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_CO_PARTITION.key -> "false",
-      SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true",
-      SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true") {
-      val df = sql(
-        s"""
-           |${selectWithMergeJoinHint("i", "p")}
-           |*
-           |FROM testcat.ns.$items i
-           |JOIN testcat.ns.$purchases p ON p.item_id = i.id
-           |""".stripMargin)
-      checkKeywordsExistsInExplain(df, SimpleMode, keywords)
-      checkKeywordsExistsInExplain(df, ExtendedMode, keywords)
-    }
-  }
-
-  test("SPARK-55992: GroupPartitions verbose string (Spark UI)") {
+  test("SPARK-55992: GroupPartitions string in simple and extended explain") {
     val items_partitions = Array(bucket(4, "id"), years("arrive_time"))
     createTable(items, itemsColumns, items_partitions)
     sql(s"INSERT INTO testcat.ns.$items VALUES (1, 'aa', 10.0, cast('2021-01-01' as timestamp))")
@@ -3260,21 +3235,15 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase with 
            |FROM testcat.ns.$items i
            |JOIN testcat.ns.$purchases p ON p.item_id = i.id
            |""".stripMargin)
-      val groupPartitions = collectAllGroupPartitions(df.queryExecution.executedPlan)
-      assert(groupPartitions.nonEmpty, "plan should contain GroupPartitionsExec")
-      groupPartitions.foreach { node =>
-        val verboseStr = node.verboseStringWithOperatorId()
-        assert(verboseStr.contains("Arguments:"),
-          s"verbose string (Spark UI) should contain Arguments: line: $verboseStr")
-        assert(
-          verboseStr.contains("JoinKeyPositions:") &&
-          verboseStr.contains("ExpectedPartitionKeys:") &&
-          verboseStr.contains("Reducers:") &&
-          verboseStr.contains("DistributePartitions:"),
-          s"verbose string should contain summary fields: $verboseStr")
-        assert(!verboseStr.contains("InternalRowComparableWrapper"),
-          s"verbose string should not dump InternalRow: $verboseStr")
-      }
+      val simpleAndExtendedKeyword =
+        "GroupPartitions JoinKeyPositions: [0] ExpectedPartitionKeys: 2 " +
+        "Reducers: [BucketReducer(2)] DistributePartitions: false"
+      val formattedKeyword =
+        "Arguments: JoinKeyPositions: [0], ExpectedPartitionKeys: 2, " +
+        "Reducers: [BucketReducer(2)], DistributePartitions: false"
+      checkKeywordsExistsInExplain(df, SimpleMode, simpleAndExtendedKeyword)
+      checkKeywordsExistsInExplain(df, ExtendedMode, simpleAndExtendedKeyword)
+      checkKeywordsExistsInExplain(df, FormattedMode, formattedKeyword)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.connector.catalog.functions._
 import org.apache.spark.sql.connector.distributions.Distributions
 import org.apache.spark.sql.connector.expressions._
 import org.apache.spark.sql.connector.expressions.Expressions._
-import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.{ExtendedMode, SimpleMode, SparkPlan}
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2ScanRelation, GroupPartitionsExec}
 import org.apache.spark.sql.execution.exchange.{ShuffleExchangeExec, ShuffleExchangeLike}
 import org.apache.spark.sql.execution.joins.SortMergeJoinExec
@@ -3217,17 +3217,15 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase with 
     }
   }
 
-  test("SPARK-55992: GroupPartitions textual representatin in plans") {
+  test("SPARK-55992: GroupPartitions textual representation in simple and extended explain") {
     val items_partitions = Array(bucket(4, "id"), years("arrive_time"))
     createTable(items, itemsColumns, items_partitions)
-
     sql(s"INSERT INTO testcat.ns.$items VALUES (1, 'aa', 10.0, cast('2021-01-01' as timestamp))")
-
     val purchases_partitions = Array(bucket(6, "item_id"), years("time"))
     createTable(purchases, purchasesColumns, purchases_partitions)
-
     sql(s"INSERT INTO testcat.ns.$purchases VALUES (2, 10.0, cast('2021-01-01' as timestamp))")
-
+    val keywords = "GroupPartitions JoinKeyPositions: [0] ExpectedPartitionKeys: 2 " +
+      "Reducers: [BucketReducer(2)] DistributePartitions: false"
     withSQLConf(
       SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_CO_PARTITION.key -> "false",
       SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true",
@@ -3238,8 +3236,32 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase with 
            |FROM testcat.ns.$items i
            |JOIN testcat.ns.$purchases p ON p.item_id = i.id
            |""".stripMargin)
-      checkKeywordsExistsInExplain(df, keywords = "GroupPartitions JoinKeyPositions: [0] " +
-        "ExpectedPartitionKeys: 2 Reducers: 1 DistributePartitions: false")
+      checkKeywordsExistsInExplain(df, SimpleMode, keywords)
+      checkKeywordsExistsInExplain(df, ExtendedMode, keywords)
+    }
+  }
+
+  test("SPARK-55992: GroupPartitions extended explain summary") {
+    val items_partitions = Array(bucket(4, "id"), years("arrive_time"))
+    createTable(items, itemsColumns, items_partitions)
+    sql(s"INSERT INTO testcat.ns.$items VALUES (1, 'aa', 10.0, cast('2021-01-01' as timestamp))")
+    val purchases_partitions = Array(bucket(6, "item_id"), years("time"))
+    createTable(purchases, purchasesColumns, purchases_partitions)
+    sql(s"INSERT INTO testcat.ns.$purchases VALUES (2, 10.0, cast('2021-01-01' as timestamp))")
+    withSQLConf(
+      SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_CO_PARTITION.key -> "false",
+      SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true",
+      SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true") {
+      val df = sql(
+        s"""
+           |SELECT *
+           |FROM testcat.ns.$items i
+           |JOIN testcat.ns.$purchases p ON p.item_id = i.id
+           |""".stripMargin)
+      checkKeywordsExistsInExplain(df, ExtendedMode, keywords =
+        "GroupPartitions JoinKeyPositions: [0] ExpectedPartitionKeys: 2 " +
+        "Reducers: [BucketReducer(2)] DistributePartitions: false")
+      checkKeywordsNotExistsInExplain(df, ExtendedMode, "InternalRowComparableWrapper")
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/catalog/functions/transformFunctions.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/catalog/functions/transformFunctions.scala
@@ -114,6 +114,7 @@ object BucketFunction extends ScalarFunction[Int] with ReducibleFunction[Int, In
 
 case class BucketReducer(divisor: Int) extends Reducer[Int, Int] {
   override def reduce(bucket: Int): Int = bucket % divisor
+  override def displayName(): String = toString
 }
 
 object UnboundStringSelfFunction extends UnboundFunction {


### PR DESCRIPTION


### What changes were proposed in this pull request?
Follow up for https://github.com/apache/spark/pull/54801
1. It handled explain but not UI
2. Reducers could be improved a bit
3. Fix a test typo

### Why are the changes needed?
Improve UX for the new SPJ group operator

### Does this PR introduce _any_ user-facing change?
Adds to Explain Extended, and changes unreleased Spark UI for the GroupPartitions node a bit


### How was this patch tested?
Add unit test


### Was this patch authored or co-authored using generative AI tooling?
Yes, cursor
