### PR TITLE
[SPARK-56023][SS] Better load balance in LowLatencyMemoryStream

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/LowLatencyMemoryStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/LowLatencyMemoryStream.scala
@@ -82,10 +82,9 @@ class LowLatencyMemoryStream[A: Encoder](
   override def addData(data: IterableOnce[A]): Offset = synchronized {
     // Distribute data evenly among partition lists.
     val timestamp = clock.getTimeMillis()
-    data.iterator.to(Seq).zipWithIndex.map {
-      case (item, index) =>
-        val partitionId = index % numPartitions
-        records(partitionId) += ((toRow(item).copy().asInstanceOf[UnsafeRow], timestamp))
+    data.iterator.foreach { item =>
+      val partitionId = records.size % numPartitions
+      records(partitionId) += ((toRow(item).copy().asInstanceOf[UnsafeRow], timestamp))
     }
 
     // The new target offset is the offset where all records in all partitions have been processed.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/LowLatencyMemoryStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/LowLatencyMemoryStream.scala
@@ -75,6 +75,9 @@ class LowLatencyMemoryStream[A: Encoder](
   @GuardedBy("this")
   private val records =
     Seq.fill(numPartitions)(new ListBuffer[(UnsafeRow, Long)]())
+  
+  @GuardedBy("this")
+  private var numRecords: Long = 0L
 
   private val recordEndpoint = new LowLatencyMemoryStreamEndpoint(records, this)
   @volatile private var endpointRef: RpcEndpointRef = _
@@ -83,8 +86,9 @@ class LowLatencyMemoryStream[A: Encoder](
     // Distribute data evenly among partition lists.
     val timestamp = clock.getTimeMillis()
     data.iterator.foreach { item =>
-      val partitionId = records.map(_.size).sum % numPartitions
+      val partitionId = numRecords % numPartitions
       records(partitionId) += ((toRow(item).copy().asInstanceOf[UnsafeRow], timestamp))
+      numRecords += 1
     }
 
     // The new target offset is the offset where all records in all partitions have been processed.
@@ -101,6 +105,7 @@ class LowLatencyMemoryStream[A: Encoder](
     val timestamp = clock.getTimeMillis()
     data.iterator.foreach { item =>
       records(partitionId) += ((toRow(item).copy().asInstanceOf[UnsafeRow], timestamp))
+      numRecords += 1
     }
 
     // The new target offset is the offset where all records in all partitions have been processed.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/LowLatencyMemoryStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/LowLatencyMemoryStream.scala
@@ -83,7 +83,7 @@ class LowLatencyMemoryStream[A: Encoder](
     // Distribute data evenly among partition lists.
     val timestamp = clock.getTimeMillis()
     data.iterator.foreach { item =>
-      val partitionId = records.size % numPartitions
+      val partitionId = records.map(_.size).sum % numPartitions
       records(partitionId) += ((toRow(item).copy().asInstanceOf[UnsafeRow], timestamp))
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/LowLatencyMemoryStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/LowLatencyMemoryStream.scala
@@ -75,7 +75,7 @@ class LowLatencyMemoryStream[A: Encoder](
   @GuardedBy("this")
   private val records =
     Seq.fill(numPartitions)(new ListBuffer[(UnsafeRow, Long)]())
-  
+
   @GuardedBy("this")
   private var numRecords: Long = 0L
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/LowLatencyMemoryStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/LowLatencyMemoryStream.scala
@@ -86,7 +86,7 @@ class LowLatencyMemoryStream[A: Encoder](
     // Distribute data evenly among partition lists.
     val timestamp = clock.getTimeMillis()
     data.iterator.foreach { item =>
-      val partitionId = numRecords % numPartitions
+      val partitionId: Int = (numRecords % numPartitions).toInt
       records(partitionId) += ((toRow(item).copy().asInstanceOf[UnsafeRow], timestamp))
       numRecords += 1
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeSuite.scala
@@ -24,10 +24,11 @@ import scala.concurrent.duration.Duration
 
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 
-import org.apache.spark.{SparkIllegalArgumentException, SparkIllegalStateException}
+import org.apache.spark.{SparkIllegalArgumentException, SparkIllegalStateException, TaskContext}
 import org.apache.spark.sql.execution.streaming.{LowLatencyMemoryStream, RealTimeTrigger}
 import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.execution.streaming.sources.ContinuousMemorySink
+import org.apache.spark.sql.functions.udf
 import org.apache.spark.sql.internal.SQLConf
 
 class StreamRealTimeModeSuite extends StreamRealTimeModeSuiteBase {
@@ -202,6 +203,26 @@ class StreamRealTimeModeSuite extends StreamRealTimeModeSuiteBase {
           matchPVals = true
         )
       }
+    )
+  }
+
+  test("LowLatencyMemoryStream load balance among all partitions") {
+    val numPartitions = 3
+    val inputData = LowLatencyMemoryStream[Int](numPartitions)
+
+    val getPartitionId = udf(() => TaskContext.getPartitionId())
+
+    val mapped = inputData.toDS().select($"value", getPartitionId()).as[(Int, Int)]
+
+    testStream(mapped, OutputMode.Update, Map.empty, new ContinuousMemorySink())(
+      StartStream(),
+      // 6 items round-robin across 3 partitions: item i goes to partition (i-1) % 3
+      AddData(inputData, 1, 2, 3),
+      AddData(inputData, 4),
+      AddData(inputData, 5),
+      AddData(inputData, 6),
+      CheckAnswerWithTimeout(10000, (1, 0), (2, 1), (3, 2), (4, 0), (5, 1), (6, 2)),
+      StopStream
     )
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Rewrite `addData` to use `records.size % numPartitions` for better load balance across partitions.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Previously, it will only load balance across partitions when a sequence of data is input altogether. This change enables load balance for one-row-at-a-time input patterns.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. This is a test only source.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
CI.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.