### PR TITLE
[SPARK-56013][SPARK-56024][BUILD] Upgrade `jaxb-runtime` to 4.0.6 and `jakarta.xml.bind-api` to 4.0.5

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -110,13 +110,13 @@ jackson-dataformat-cbor/2.21.2//jackson-dataformat-cbor-2.21.2.jar
 jackson-dataformat-yaml/2.21.2//jackson-dataformat-yaml-2.21.2.jar
 jackson-datatype-jsr310/2.21.2//jackson-datatype-jsr310-2.21.2.jar
 jackson-module-scala_2.13/2.21.2//jackson-module-scala_2.13-2.21.2.jar
-jakarta.activation-api/2.1.4//jakarta.activation-api-2.1.4.jar
+jakarta.activation-api/2.1.3//jakarta.activation-api-2.1.3.jar
 jakarta.annotation-api/2.1.1//jakarta.annotation-api-2.1.1.jar
 jakarta.inject-api/2.0.1//jakarta.inject-api-2.0.1.jar
 jakarta.servlet-api/6.0.0//jakarta.servlet-api-6.0.0.jar
 jakarta.validation-api/3.0.2//jakarta.validation-api-3.0.2.jar
 jakarta.ws.rs-api/3.1.0//jakarta.ws.rs-api-3.1.0.jar
-jakarta.xml.bind-api/4.0.5//jakarta.xml.bind-api-4.0.5.jar
+jakarta.xml.bind-api/4.0.2//jakarta.xml.bind-api-4.0.2.jar
 janino/3.1.9//janino-3.1.9.jar
 java-diff-utils/4.16//java-diff-utils-4.16.jar
 java-trace-api/0.2.11-beta//java-trace-api-0.2.11-beta.jar
@@ -125,8 +125,8 @@ javassist/3.30.2-GA//javassist-3.30.2-GA.jar
 javax.jdo/3.2.0-m3//javax.jdo-3.2.0-m3.jar
 javax.servlet-api/4.0.1//javax.servlet-api-4.0.1.jar
 javolution/5.5.1//javolution-5.5.1.jar
-jaxb-core/4.0.6//jaxb-core-4.0.6.jar
-jaxb-runtime/4.0.6//jaxb-runtime-4.0.6.jar
+jaxb-core/4.0.5//jaxb-core-4.0.5.jar
+jaxb-runtime/4.0.5//jaxb-runtime-4.0.5.jar
 jcl-over-slf4j/2.0.17//jcl-over-slf4j-2.0.17.jar
 jdo-api/3.0.1//jdo-api-3.0.1.jar
 jdom2/2.0.6.1//jdom2-2.0.6.1.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -110,13 +110,13 @@ jackson-dataformat-cbor/2.21.2//jackson-dataformat-cbor-2.21.2.jar
 jackson-dataformat-yaml/2.21.2//jackson-dataformat-yaml-2.21.2.jar
 jackson-datatype-jsr310/2.21.2//jackson-datatype-jsr310-2.21.2.jar
 jackson-module-scala_2.13/2.21.2//jackson-module-scala_2.13-2.21.2.jar
-jakarta.activation-api/2.1.3//jakarta.activation-api-2.1.3.jar
+jakarta.activation-api/2.1.4//jakarta.activation-api-2.1.4.jar
 jakarta.annotation-api/2.1.1//jakarta.annotation-api-2.1.1.jar
 jakarta.inject-api/2.0.1//jakarta.inject-api-2.0.1.jar
 jakarta.servlet-api/6.0.0//jakarta.servlet-api-6.0.0.jar
 jakarta.validation-api/3.0.2//jakarta.validation-api-3.0.2.jar
 jakarta.ws.rs-api/3.1.0//jakarta.ws.rs-api-3.1.0.jar
-jakarta.xml.bind-api/4.0.2//jakarta.xml.bind-api-4.0.2.jar
+jakarta.xml.bind-api/4.0.5//jakarta.xml.bind-api-4.0.5.jar
 janino/3.1.9//janino-3.1.9.jar
 java-diff-utils/4.16//java-diff-utils-4.16.jar
 java-trace-api/0.2.11-beta//java-trace-api-0.2.11-beta.jar
@@ -125,8 +125,8 @@ javassist/3.30.2-GA//javassist-3.30.2-GA.jar
 javax.jdo/3.2.0-m3//javax.jdo-3.2.0-m3.jar
 javax.servlet-api/4.0.1//javax.servlet-api-4.0.1.jar
 javolution/5.5.1//javolution-5.5.1.jar
-jaxb-core/4.0.5//jaxb-core-4.0.5.jar
-jaxb-runtime/4.0.5//jaxb-runtime-4.0.5.jar
+jaxb-core/4.0.6//jaxb-core-4.0.6.jar
+jaxb-runtime/4.0.6//jaxb-runtime-4.0.6.jar
 jcl-over-slf4j/2.0.17//jcl-over-slf4j-2.0.17.jar
 jdo-api/3.0.1//jdo-api-3.0.1.jar
 jdom2/2.0.6.1//jdom2-2.0.6.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -663,7 +663,7 @@
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-runtime</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.6</version>
         <scope>compile</scope>
         <exclusions>
           <exclusion>
@@ -679,7 +679,7 @@
       <dependency>
         <groupId>jakarta.xml.bind</groupId>
         <artifactId>jakarta.xml.bind-api</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.5</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -663,7 +663,7 @@
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-runtime</artifactId>
-        <version>4.0.6</version>
+        <version>4.0.5</version>
         <scope>compile</scope>
         <exclusions>
           <exclusion>
@@ -679,7 +679,7 @@
       <dependency>
         <groupId>jakarta.xml.bind</groupId>
         <artifactId>jakarta.xml.bind-api</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR Upgrade jaxb-runtime from 4.0.5 to 4.0.6 and jakarta.xml.bind-api from 4.0.2 to 4.0.5.

### Why are the changes needed?
https://github.com/eclipse-ee4j/jaxb-ri/releases

https://github.com/jakartaee/jaxb-api/releases

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
GHA


### Was this patch authored or co-authored using generative AI tooling?
No