### PR TITLE
[SPARK-55714][SQL][FOLLOWUP] Narrow overflow message canonicalization to only match JDK patterns

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/ExecutionErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/ExecutionErrors.scala
@@ -125,7 +125,10 @@ private[sql] trait ExecutionErrors extends DataTypeErrorsBase {
       // but throws a pre-allocated exception object without a stack trace
       // or message. See https://bugs.openjdk.org/browse/JDK-8367990
       case null => "overflow"
-      case m if m.contains("overflow") => "overflow"
+      // JDK throws messages like "integer overflow", "long overflow", etc.
+      // Only canonicalize these simple "<type> overflow" patterns to avoid
+      // stripping context from richer messages.
+      case m if m.matches("\\w+ overflow") => "overflow"
       case m => m
     }
     val alternative = if (suggestedFunc.nonEmpty) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the overflow message canonicalization in `arithmeticOverflowError` from `m.contains("overflow")` to `m.matches("\\w+ overflow")`, so only simple JDK-style messages like "integer overflow" and "long overflow" are canonicalized to "overflow".

### Why are the changes needed?

The previous `contains("overflow")` check is overly broad — any `ArithmeticException` message that happens to contain the substring "overflow" (e.g., a more descriptive message like "overflow during decimal multiplication") would be incorrectly stripped down to just "overflow", losing useful context. The regex `\w+ overflow` precisely targets the known JDK `ArithmeticException` message format (`"<type> overflow"`) from JDK-8367990's "hot throws" optimization.

### Does this PR introduce _any_ user-facing change?

No. All known JDK overflow messages ("integer overflow", "long overflow", "short overflow", "byte overflow") match both patterns, so this is a purely defensive improvement with zero risk to existing behavior.

### How was this patch tested?

Existing tests already cover the canonicalization behavior. The known JDK messages all match the `\w+ overflow` regex, so test behavior is unchanged.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Sonnet 4.6