### PR TITLE
[SPARK-56027][INFRA] Fix `NoEmptyContinuation` warning of `spark-test-image/lint/Dockerfile`

### DIFF
--- a/dev/spark-test-image/lint/Dockerfile
+++ b/dev/spark-test-image/lint/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get update && apt-get install -y \
 RUN Rscript -e "install.packages(c('devtools', 'knitr', 'markdown', 'rmarkdown', 'testthat', 'remotes'), repos='https://cloud.r-project.org/')" \
     && Rscript -e "devtools::install_version('pkgdown', version='2.0.1', repos='https://cloud.r-project.org')" \
     && Rscript -e "devtools::install_version('preferably', version='0.4', repos='https://cloud.r-project.org')" \
-    && Rscript -e "devtools::install_version('lintr', version='2.0.1', repos='https://cloud.r-project.org')" \
+    && Rscript -e "devtools::install_version('lintr', version='2.0.1', repos='https://cloud.r-project.org')"
 
 # See more in SPARK-39735
 ENV R_LIBS_SITE="/usr/local/lib/R/site-library:${R_LIBS_SITE}:/usr/lib/R/library"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes a trailing backslash (`\`) on an empty continuation line in `dev/spark-test-image/lint/Dockerfile` to fix the `NoEmptyContinuation` warning from Dockerfile linters. This is the only instance of this pattern.

- https://docs.docker.com/reference/build-checks/no-empty-continuation/

### Why are the changes needed?

The trailing `\` at line 69 is followed by an empty line, which triggers the `NoEmptyContinuation` warning. This is a no-op continuation that should be removed for clean lint results.

```
$ cd dev/spark-test-image/lint
$ docker build .
...
 => WARN: NoEmptyContinuation: Empty continuation line (line 72)           0.0s
...
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Verified by searching all Dockerfiles in the repository for the backslash-followed-by-empty-line pattern and confirming this was the only occurrence.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)