### PR TITLE
[SPARK-56029] Optional sub error conditions

### DIFF
--- a/common/utils/src/main/resources/error/README.md
+++ b/common/utils/src/main/resources/error/README.md
@@ -36,6 +36,13 @@ The terms error class, state, and condition come from the SQL standard.
     * Error sub-condition: `TOLERANCE_IS_UNFOLDABLE`
     * Error sub-condition: `UNSUPPORTED_DIRECTION`
 
+### Optional subconditions (SPARK-56029)
+
+Subconditions are **optional**: you may raise or check an error at the main condition level even when the condition has subconditions in `error-conditions.json`.
+
+* **Raising:** You may throw using only the main condition (e.g. `CANNOT_LOAD_STATE_STORE`) when that condition has a `subClass` in the JSON. In that case you do not provide any subcondition name or subcondition-specific message parameters; the main condition's message template is used.
+* **Checking (tests):** In tests, `checkError` (Scala) and `check_error` (PySpark) match by condition by default: passing the main condition matches both the main condition and any of its subconditions, and you do not have to assert subcondition parameters. This allows evolving a condition from having no subconditions to having subconditions without breaking existing tests. When a test must assert the exact subcondition and exact parameters, use the strict option (`matchExactConditionAndParameters` in Scala, `match_exact_condition_and_parameters` in PySpark).
+
 ### Inconsistent Use of the Term "Error Class"
 
 Unfortunately, we have historically used the term "error class" inconsistently to refer both to a proper error class like `42` and also to an error condition like `DATATYPE_MISSING_SIZE`.

--- a/common/utils/src/main/resources/error/README.md
+++ b/common/utils/src/main/resources/error/README.md
@@ -36,7 +36,7 @@ The terms error class, state, and condition come from the SQL standard.
     * Error sub-condition: `TOLERANCE_IS_UNFOLDABLE`
     * Error sub-condition: `UNSUPPORTED_DIRECTION`
 
-### Optional subconditions (SPARK-56029)
+### Optional subconditions
 
 Subconditions are **optional**: you may raise or check an error at the main condition level even when the condition has subconditions in `error-conditions.json`.
 

--- a/common/utils/src/main/scala/org/apache/spark/ErrorClassesJSONReader.scala
+++ b/common/utils/src/main/scala/org/apache/spark/ErrorClassesJSONReader.scala
@@ -111,8 +111,8 @@ class ErrorClassesJsonReader(jsonFileURLs: Seq[URL]) {
     val errorInfo = errorInfoMap.getOrElse(
       mainErrorClass,
       throw SparkException.internalError(s"Cannot find main error class '$errorClass'"))
-    assert(errorInfo.subClass.isDefined == subErrorClass.isDefined)
-
+    // When main-only (no subcondition), use main message template even if the condition has
+    // subconditions in JSON (optional subconditions: SPARK-56029).
     if (subErrorClass.isEmpty) {
       errorInfo.messageTemplate
     } else {

--- a/common/utils/src/main/scala/org/apache/spark/ErrorClassesJSONReader.scala
+++ b/common/utils/src/main/scala/org/apache/spark/ErrorClassesJSONReader.scala
@@ -112,7 +112,7 @@ class ErrorClassesJsonReader(jsonFileURLs: Seq[URL]) {
       mainErrorClass,
       throw SparkException.internalError(s"Cannot find main error class '$errorClass'"))
     // When main-only (no subcondition), use main message template even if the condition has
-    // subconditions in JSON (optional subconditions: SPARK-56029).
+    // subconditions in JSON.
     if (subErrorClass.isEmpty) {
       errorInfo.messageTemplate
     } else {

--- a/core/src/test/scala/org/apache/spark/SparkTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkTestSuite.scala
@@ -276,6 +276,11 @@ trait SparkTestSuite
 
   /**
    * Checks an exception with an error condition against expected results.
+   * By default, condition matches if the exception's condition equals the expected condition
+   * or is a subcondition (e.g. CONDITION.SUBCONDITION when expecting CONDITION). When passing
+   * only the main condition, parameters are not required to be full (subset check). Use
+   * matchExactConditionAndParameters when a test must require the exact condition with no
+   * subcondition and exact parameters.
    * @param exception     The exception to check
    * @param condition     The expected error condition identifying the error
    * @param sqlState      Optional the expected SQLSTATE, not verified if not supplied
@@ -283,6 +288,9 @@ trait SparkTestSuite
    *                      in the error-classes file.
    * @param matchPVals    Optionally treat the parameters value as regular expression pattern.
    *                      false if not supplied.
+   * @param matchExactConditionAndParameters When true, require exact condition match (no prefix
+   *                      match) and full parameter equality. When false (default), condition
+   *                      may be main or subcondition; param check is subset when prefix match.
    */
   protected def checkError(
       exception: SparkThrowable,
@@ -290,24 +298,52 @@ trait SparkTestSuite
       sqlState: Option[String] = None,
       parameters: Map[String, String] = Map.empty,
       matchPVals: Boolean = false,
-      queryContext: Array[ExpectedContext] = Array.empty): Unit = {
-    assert(exception.getCondition === condition)
-    sqlState.foreach(state => assert(exception.getSqlState === state))
-    val expectedParameters = exception.getMessageParameters.asScala
-    if (matchPVals) {
-      assert(expectedParameters.size === parameters.size)
-      expectedParameters.foreach(
-        exp => {
-          val parm = parameters.getOrElse(exp._1,
-            throw new IllegalArgumentException("Missing parameter" + exp._1))
-          if (!exp._2.matches(parm)) {
-            throw new IllegalArgumentException("For parameter '" + exp._1 + "' value '" + exp._2 +
-              "' does not match: " + parm)
-          }
-        }
-      )
+      queryContext: Array[ExpectedContext] = Array.empty,
+      matchExactConditionAndParameters: Boolean = false): Unit = {
+    val actualCondition = exception.getCondition
+    val conditionMatches = if (matchExactConditionAndParameters) {
+      actualCondition === condition
     } else {
-      assert(expectedParameters === parameters)
+      actualCondition === condition || (condition.nonEmpty && actualCondition != null &&
+        actualCondition.startsWith(condition + "."))
+    }
+    assert(conditionMatches,
+      s"Expected condition '$condition' (matchExact=$matchExactConditionAndParameters), " +
+        s"got '$actualCondition'")
+    sqlState.foreach(state => assert(exception.getSqlState === state))
+    val expectedParameters = exception.getMessageParameters.asScala.toMap
+    val isPrefixMatch = !matchExactConditionAndParameters && actualCondition != null &&
+      actualCondition.startsWith(condition + ".")
+    if (isPrefixMatch) {
+      // When matching by main condition only, only require that passed parameters match (subset).
+      parameters.foreach { case (key, value) =>
+        assert(expectedParameters.contains(key),
+          s"Expected parameter '$key' not found in: $expectedParameters")
+        if (matchPVals) {
+          assert(value != null && expectedParameters(key).matches(value),
+            s"For parameter '$key' value '${expectedParameters(key)}' does not match: $value")
+        } else {
+          assert(expectedParameters(key) === value,
+            s"Expected parameter '$key' = '$value', got '${expectedParameters(key)}'")
+        }
+      }
+    } else {
+      // Exact condition match: full parameter equality as before.
+      if (matchPVals) {
+        assert(expectedParameters.size === parameters.size)
+        expectedParameters.foreach(
+          exp => {
+            val parm = parameters.getOrElse(exp._1,
+              throw new IllegalArgumentException("Missing parameter" + exp._1))
+            if (!exp._2.matches(parm)) {
+              throw new IllegalArgumentException("For parameter '" + exp._1 + "' value '" + exp._2 +
+                "' does not match: " + parm)
+            }
+          }
+        )
+      } else {
+        assert(expectedParameters === parameters)
+      }
     }
     val actualQueryContext = exception.getQueryContext()
     assert(actualQueryContext.length === queryContext.length, "Invalid length of the query context")

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -200,6 +200,53 @@ class SparkThrowableSuite extends SparkFunSuite {
     assert(e.getMessageParameters().get("message").contains("Undefined error message parameter"))
   }
 
+  test("SPARK-56029: Optional subconditions - main-only condition when JSON has subClass") {
+    // CANNOT_LOAD_STATE_STORE has subconditions in JSON; we can use main-only (no subcondition).
+    val mainOnlyTemplate = errorReader.getMessageTemplate("CANNOT_LOAD_STATE_STORE")
+    assert(mainOnlyTemplate === "An error occurred during loading state.")
+    val mainOnlyParams = errorReader.getMessageParameters("CANNOT_LOAD_STATE_STORE")
+    assert(mainOnlyParams.isEmpty)
+    // Raising with main-only and empty params should work.
+    val ex = new SparkRuntimeException("CANNOT_LOAD_STATE_STORE", Map.empty[String, String])
+    assert(ex.getCondition === "CANNOT_LOAD_STATE_STORE")
+    assert(ex.getMessage.startsWith(
+      "[CANNOT_LOAD_STATE_STORE] An error occurred during loading state."))
+    assert(ex.getMessageParameters.asScala.isEmpty)
+  }
+
+  test("SPARK-56029: checkError default matches condition or subcondition (prefix match)") {
+    val exWithSubcondition = new SparkRuntimeException(
+      "CANNOT_LOAD_STATE_STORE.UNCATEGORIZED",
+      Map.empty[String, String])
+    checkError(exWithSubcondition, "CANNOT_LOAD_STATE_STORE", parameters = Map.empty)
+    checkError(exWithSubcondition, "CANNOT_LOAD_STATE_STORE.UNCATEGORIZED", parameters = Map.empty)
+  }
+
+  test("SPARK-56029: checkError with matchExactConditionAndParameters requires exact condition") {
+    val exWithSubcondition = new SparkRuntimeException(
+      "CANNOT_LOAD_STATE_STORE.UNCATEGORIZED",
+      Map.empty[String, String])
+    checkError(
+      exWithSubcondition,
+      "CANNOT_LOAD_STATE_STORE.UNCATEGORIZED",
+      parameters = Map.empty,
+      matchExactConditionAndParameters = true)
+    val exMainOnly = new SparkRuntimeException("CANNOT_LOAD_STATE_STORE", Map.empty[String, String])
+    checkError(
+      exMainOnly,
+      "CANNOT_LOAD_STATE_STORE",
+      parameters = Map.empty,
+      matchExactConditionAndParameters = true)
+    val ex = intercept[org.scalatest.exceptions.TestFailedException] {
+      checkError(
+        exWithSubcondition,
+        "CANNOT_LOAD_STATE_STORE",
+        parameters = Map.empty,
+        matchExactConditionAndParameters = true)
+    }
+    assert(ex.getMessage.contains("matchExact"))
+  }
+
   test("Error message is formatted") {
     assert(
       getMessage(

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -1806,9 +1806,7 @@ class UtilsTestsMixin:
             errorClass="SESSION_MUTATION_IN_DECLARATIVE_PIPELINE.SET_RUNTIME_CONF",
             messageParameters=params,
         )
-        self.check_error(
-            ex, "SESSION_MUTATION_IN_DECLARATIVE_PIPELINE", messageParameters=params
-        )
+        self.check_error(ex, "SESSION_MUTATION_IN_DECLARATIVE_PIPELINE", messageParameters=params)
         self.check_error(
             ex,
             "SESSION_MUTATION_IN_DECLARATIVE_PIPELINE.SET_RUNTIME_CONF",

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -1806,7 +1806,9 @@ class UtilsTestsMixin:
         )
         self.check_error(ex, "CANNOT_LOAD_STATE_STORE", messageParameters={})
         self.check_error(
-            ex, "CANNOT_LOAD_STATE_STORE.UNCATEGORIZED", messageParameters={}
+            ex,
+            "CANNOT_LOAD_STATE_STORE.UNCATEGORIZED",
+            messageParameters={},
         )
 
     def test_check_error_match_exact_condition_spark_56029(self):

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -24,6 +24,7 @@ from pyspark.errors import (
     AnalysisException,
     ParseException,
     PySparkAssertionError,
+    PySparkException,
     PySparkValueError,
     IllegalArgumentException,
     SparkUpgradeException,
@@ -1796,6 +1797,47 @@ class UtilsTestsMixin:
         # This should fail
         with self.assertRaises(PySparkAssertionError):
             assertSchemaEqual(s1, s2)
+
+    def test_check_error_optional_subconditions_spark_56029(self):
+        """SPARK-56029: check_error default matches condition or subcondition (prefix match)."""
+        ex = PySparkException(
+            errorClass="CANNOT_LOAD_STATE_STORE.UNCATEGORIZED",
+            messageParameters={},
+        )
+        self.check_error(ex, "CANNOT_LOAD_STATE_STORE", messageParameters={})
+        self.check_error(
+            ex, "CANNOT_LOAD_STATE_STORE.UNCATEGORIZED", messageParameters={}
+        )
+
+    def test_check_error_match_exact_condition_spark_56029(self):
+        """SPARK-56029: check_error with match_exact_condition_and_parameters."""
+        ex_sub = PySparkException(
+            errorClass="CANNOT_LOAD_STATE_STORE.UNCATEGORIZED",
+            messageParameters={},
+        )
+        self.check_error(
+            ex_sub,
+            "CANNOT_LOAD_STATE_STORE.UNCATEGORIZED",
+            messageParameters={},
+            match_exact_condition_and_parameters=True,
+        )
+        ex_main = PySparkException(
+            errorClass="CANNOT_LOAD_STATE_STORE",
+            messageParameters={},
+        )
+        self.check_error(
+            ex_main,
+            "CANNOT_LOAD_STATE_STORE",
+            messageParameters={},
+            match_exact_condition_and_parameters=True,
+        )
+        with self.assertRaises(AssertionError):
+            self.check_error(
+                ex_sub,
+                "CANNOT_LOAD_STATE_STORE",
+                messageParameters={},
+                match_exact_condition_and_parameters=True,
+            )
 
 
 class UtilsTests(ReusedSQLTestCase, UtilsTestsMixin):

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -1800,44 +1800,49 @@ class UtilsTestsMixin:
 
     def test_check_error_optional_subconditions_spark_56029(self):
         """SPARK-56029: check_error default matches condition or subcondition (prefix match)."""
+        # Use an error class that exists in Python error-conditions.json and has sub_class
+        params = {"method": "setRuntimeConf"}
         ex = PySparkException(
-            errorClass="CANNOT_LOAD_STATE_STORE.UNCATEGORIZED",
-            messageParameters={},
+            errorClass="SESSION_MUTATION_IN_DECLARATIVE_PIPELINE.SET_RUNTIME_CONF",
+            messageParameters=params,
         )
-        self.check_error(ex, "CANNOT_LOAD_STATE_STORE", messageParameters={})
+        self.check_error(
+            ex, "SESSION_MUTATION_IN_DECLARATIVE_PIPELINE", messageParameters=params
+        )
         self.check_error(
             ex,
-            "CANNOT_LOAD_STATE_STORE.UNCATEGORIZED",
-            messageParameters={},
+            "SESSION_MUTATION_IN_DECLARATIVE_PIPELINE.SET_RUNTIME_CONF",
+            messageParameters=params,
         )
 
     def test_check_error_match_exact_condition_spark_56029(self):
         """SPARK-56029: check_error with match_exact_condition_and_parameters."""
+        params = {"method": "setRuntimeConf"}
         ex_sub = PySparkException(
-            errorClass="CANNOT_LOAD_STATE_STORE.UNCATEGORIZED",
-            messageParameters={},
+            errorClass="SESSION_MUTATION_IN_DECLARATIVE_PIPELINE.SET_RUNTIME_CONF",
+            messageParameters=params,
         )
         self.check_error(
             ex_sub,
-            "CANNOT_LOAD_STATE_STORE.UNCATEGORIZED",
-            messageParameters={},
+            "SESSION_MUTATION_IN_DECLARATIVE_PIPELINE.SET_RUNTIME_CONF",
+            messageParameters=params,
             match_exact_condition_and_parameters=True,
         )
         ex_main = PySparkException(
-            errorClass="CANNOT_LOAD_STATE_STORE",
-            messageParameters={},
+            errorClass="SESSION_MUTATION_IN_DECLARATIVE_PIPELINE",
+            messageParameters=params,
         )
         self.check_error(
             ex_main,
-            "CANNOT_LOAD_STATE_STORE",
-            messageParameters={},
+            "SESSION_MUTATION_IN_DECLARATIVE_PIPELINE",
+            messageParameters=params,
             match_exact_condition_and_parameters=True,
         )
         with self.assertRaises(AssertionError):
             self.check_error(
                 ex_sub,
-                "CANNOT_LOAD_STATE_STORE",
-                messageParameters={},
+                "SESSION_MUTATION_IN_DECLARATIVE_PIPELINE",
+                messageParameters=params,
                 match_exact_condition_and_parameters=True,
             )
 

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -414,7 +414,17 @@ class PySparkErrorTestUtils:
         query_context_type: Optional[QueryContextType] = None,
         fragment: Optional[str] = None,
         matchPVals: bool = False,
+        match_exact_condition_and_parameters: bool = False,
     ):
+        """
+        Check that the exception has the expected error condition and (optionally) parameters.
+
+        By default, condition matches if the exception's condition equals the expected condition
+        or is a subcondition (e.g. CONDITION.SUBCONDITION when expecting CONDITION). When
+        passing only the main condition, message parameters are not required to be full (subset
+        check). Use match_exact_condition_and_parameters=True when a test must require the
+        exact condition with no subcondition and exact parameters.
+        """
         query_context = exception.getQueryContext()
         assert bool(query_context) == (query_context_type is not None), (
             "`query_context_type` is required when QueryContext exists. "
@@ -427,40 +437,76 @@ class PySparkErrorTestUtils:
             f"checkError requires 'PySparkException', got '{exception.__class__.__name__}'.",
         )
 
-        # Test error class
+        # Test error class (exact or prefix match by default)
         expected = errorClass
-        actual = exception.getCondition()
-        self.assertEqual(
-            expected, actual, f"Expected error class was '{expected}', got '{actual}'."
+        actual_condition = exception.getCondition() or ""
+        if match_exact_condition_and_parameters:
+            condition_matches = actual_condition == expected
+        else:
+            condition_matches = (
+                actual_condition == expected
+                or (expected and actual_condition.startswith(expected + "."))
+            )
+        self.assertTrue(
+            condition_matches,
+            f"Expected error class was '{expected}' (match_exact={match_exact_condition_and_parameters}), "
+            f"got '{actual_condition}'.",
         )
 
         # Test message parameters
-        expected = messageParameters
-        actual = exception.getMessageParameters()
-        if matchPVals:
-            self.assertEqual(
-                len(expected),
-                len(actual),
-                "Expected message parameters count does not match actual message parameters count"
-                f": {len(expected)}, {len(actual)}.",
-            )
-            for key, value in expected.items():
-                self.assertIn(
-                    key,
-                    actual,
-                    f"Expected message parameter key '{key}' was not found "
-                    "in actual message parameters.",
-                )
-                self.assertRegex(
-                    actual[key],
-                    value,
-                    f"Expected message parameter value '{value}' does not match actual message "
-                    f"parameter value '{actual[key]}'.",
-                ),
+        actual_params = exception.getMessageParameters() or {}
+        is_prefix_match = (
+            not match_exact_condition_and_parameters
+            and actual_condition.startswith(expected + ".")
+        )
+        if is_prefix_match:
+            # When matching by main condition only, only require that passed parameters match.
+            if messageParameters:
+                for key, value in messageParameters.items():
+                    self.assertIn(
+                        key,
+                        actual_params,
+                        f"Expected message parameter key '{key}' not found in {actual_params}",
+                    )
+                    if matchPVals:
+                        self.assertRegex(
+                            actual_params[key],
+                            value,
+                            f"Parameter '{key}' value '{actual_params[key]}' does not match pattern '{value}'",
+                        )
+                    else:
+                        self.assertEqual(
+                            actual_params[key],
+                            value,
+                            f"Parameter '{key}': expected '{value}', got '{actual_params[key]}'",
+                        )
         else:
-            self.assertEqual(
-                expected, actual, f"Expected message parameters was '{expected}', got '{actual}'"
-            )
+            expected_params = messageParameters if messageParameters is not None else {}
+            if matchPVals:
+                self.assertEqual(
+                    len(expected_params),
+                    len(actual_params),
+                    "Expected message parameters count does not match actual message parameters count"
+                    f": {len(expected_params)}, {len(actual_params)}.",
+                )
+                for key, value in expected_params.items():
+                    self.assertIn(
+                        key,
+                        actual_params,
+                        f"Expected message parameter key '{key}' was not found "
+                        "in actual message parameters.",
+                    )
+                    self.assertRegex(
+                        actual_params[key],
+                        value,
+                        f"Expected message parameter value '{value}' does not match actual message "
+                        f"parameter value '{actual_params[key]}'.",
+                    )
+            else:
+                self.assertEqual(
+                    expected_params, actual_params,
+                    f"Expected message parameters was '{expected_params}', got '{actual_params}'"
+                )
 
         # Test query context
         if query_context:

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -443,21 +443,19 @@ class PySparkErrorTestUtils:
         if match_exact_condition_and_parameters:
             condition_matches = actual_condition == expected
         else:
-            condition_matches = (
-                actual_condition == expected
-                or (expected and actual_condition.startswith(expected + "."))
+            condition_matches = actual_condition == expected or (
+                expected and actual_condition.startswith(expected + ".")
             )
         self.assertTrue(
             condition_matches,
-            f"Expected error class was '{expected}' (match_exact={match_exact_condition_and_parameters}), "
-            f"got '{actual_condition}'.",
+            f"Expected error class was '{expected}' "
+            f"(match_exact={match_exact_condition_and_parameters}), got '{actual_condition}'.",
         )
 
         # Test message parameters
         actual_params = exception.getMessageParameters() or {}
-        is_prefix_match = (
-            not match_exact_condition_and_parameters
-            and actual_condition.startswith(expected + ".")
+        is_prefix_match = not match_exact_condition_and_parameters and actual_condition.startswith(
+            expected + "."
         )
         if is_prefix_match:
             # When matching by main condition only, only require that passed parameters match.
@@ -472,13 +470,15 @@ class PySparkErrorTestUtils:
                         self.assertRegex(
                             actual_params[key],
                             value,
-                            f"Parameter '{key}' value '{actual_params[key]}' does not match pattern '{value}'",
+                            f"Parameter '{key}' value '{actual_params[key]}' "
+                            f"does not match pattern '{value}'",
                         )
                     else:
                         self.assertEqual(
                             actual_params[key],
                             value,
-                            f"Parameter '{key}': expected '{value}', got '{actual_params[key]}'",
+                            f"Parameter '{key}': expected '{value}', "
+                            f"got '{actual_params[key]}'",
                         )
         else:
             expected_params = messageParameters if messageParameters is not None else {}
@@ -486,8 +486,8 @@ class PySparkErrorTestUtils:
                 self.assertEqual(
                     len(expected_params),
                     len(actual_params),
-                    "Expected message parameters count does not match actual message parameters count"
-                    f": {len(expected_params)}, {len(actual_params)}.",
+                    "Expected message parameters count does not match actual message "
+                    f"parameters count: {len(expected_params)}, {len(actual_params)}.",
                 )
                 for key, value in expected_params.items():
                     self.assertIn(
@@ -499,13 +499,14 @@ class PySparkErrorTestUtils:
                     self.assertRegex(
                         actual_params[key],
                         value,
-                        f"Expected message parameter value '{value}' does not match actual message "
-                        f"parameter value '{actual_params[key]}'.",
+                        f"Expected message parameter value '{value}' does not match "
+                        f"actual message parameter value '{actual_params[key]}'.",
                     )
             else:
                 self.assertEqual(
-                    expected_params, actual_params,
-                    f"Expected message parameters was '{expected_params}', got '{actual_params}'"
+                    expected_params,
+                    actual_params,
+                    f"Expected message parameters was '{expected_params}', got '{actual_params}'",
                 )
 
         # Test query context

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -2619,7 +2619,6 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
       parameters = Map("errorMessage" -> "hello"))
   }
 
-
   test("SPARK-34677: negate/add/subtract year-month and day-time intervals") {
     import testImplicits._
     val df = Seq((Period.ofMonths(10), Duration.ofDays(10), Period.ofMonths(1), Duration.ofDays(1)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -2619,6 +2619,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
       parameters = Map("errorMessage" -> "hello"))
   }
 
+
   test("SPARK-34677: negate/add/subtract year-month and day-time intervals") {
     import testImplicits._
     val df = Seq((Period.ofMonths(10), Duration.ofDays(10), Period.ofMonths(1), Duration.ofDays(1)))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
We make raising of error sub conditions and checking for them optional.
[SPARK-56029-optional-error-subconditions.plan.md](https://github.com/user-attachments/files/26053166/SPARK-56029-optional-error-subconditions.plan.md)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This allows conversion of error conditions without subconditions to ones with possible without churning and causing incompatible changes


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, checkError() is more tolerant

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added error condiiton unit tests


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Claude Opus 4.6 high