### PR TITLE
[SPARK-48139][CONNECT][TESTS] Re-enable `SparkSessionE2ESuite.interrupt tag`

### DIFF
--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/SparkSessionE2ESuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/SparkSessionE2ESuite.scala
@@ -138,8 +138,7 @@ class SparkSessionE2ESuite extends ConnectFunSuite with RemoteSparkSession {
     assert(interrupted.length == 2, s"Interrupted operations: $interrupted.")
   }
 
-  // TODO(SPARK-48139): Re-enable `SparkSessionE2ESuite.interrupt tag`
-  ignore("interrupt tag") {
+  test("interrupt tag") {
     val session = spark
     import session.implicits._
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to re-enable `SparkSessionE2ESuite.interrupt tag`.
This test was disabled in SPARK-48138 due to its flakiness. Based on my analysis, the flakiness was caused by the following issues.

* SPARK-50889
* SPARK-53673
* SPARK-53339

Now all the issues above have been addressed for `4.2.0` so `SparkSessionE2ESuite.interrupt tag` is ready to be enabled.

### Why are the changes needed?
For better test coverage.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
No.