### PR TITLE
[WIP][SPARK-54810] Path

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -139,10 +139,9 @@ object FakeV2SessionCatalog extends TableCatalog with FunctionCatalog with Suppo
  *                              even if a temp view `t` has been created.
  * @param outerPlan The query plan from the outer query that can be used to resolve star
  *                  expressions in a subquery.
- * @param resolutionPathEntries When resolving a view body, the ordered path for unqualified
- *                              relation names. Stays [[None]] in this PR; population from the
- *                              frozen path stored in view metadata is wired in a follow-up.
- *                              Outside views: compute from session
+ * @param resolutionPathEntries When resolving a view or SQL function body, the ordered frozen
+ *                              path for unqualified relation/function names (if persisted in
+ *                              metadata). Outside views/functions, compute from session
  *                              [[CatalogManager.sqlResolutionPathEntries]].
  */
 case class AnalysisContext(
@@ -211,6 +210,8 @@ object AnalysisContext {
     val context = AnalysisContext(
       isDefault = false,
       catalogAndNamespace = viewDesc.viewCatalogAndNamespace,
+      resolutionPathEntries = viewDesc.viewStoredResolutionPath
+        .flatMap(CatalogManager.deserializePathEntries),
       nestedViewDepth = originContext.nestedViewDepth + 1,
       maxNestedViewDepth = maxNestedViewDepth,
       relationCache = originContext.relationCache,
@@ -224,7 +225,10 @@ object AnalysisContext {
 
   def withAnalysisContext[A](function: SQLFunction)(f: => A): A = {
     val originContext = value.get()
-    val context = originContext.copy(collation = function.collation)
+    val context = originContext.copy(
+      resolutionPathEntries = function.functionStoredResolutionPath
+        .flatMap(CatalogManager.deserializePathEntries),
+      collation = function.collation)
     set(context)
     try f finally { set(originContext) }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
@@ -126,8 +126,8 @@ class RelationResolution(
   /**
    * Path entries for unqualified relation resolution.
    *
-   * Inside a view, [[AnalysisContext.resolutionPathEntries]] will be
-   * populated from the frozen path stored in view metadata (follow-up PR).
+   * Inside a view or SQL function, [[AnalysisContext.resolutionPathEntries]] uses the
+   * persisted frozen path from metadata when available.
    * When PATH is disabled, legacy resolution rules apply.
    */
   private def relationResolutionEntries: Seq[Seq[String]] = {
@@ -135,8 +135,6 @@ class RelationResolution(
     if (pinned.isDefined && conf.pathEnabled) {
       pinned.get
     } else {
-      // Keep expanding CurrentSchemaEntry using the live session catalog/namespace until the
-      // follow-up PR wires frozen resolutionPathEntries for view analysis.
       val expandCatalog = catalogManager.currentCatalog.name
       val expandNamespace = catalogManager.currentNamespace.toSeq
       val (pathCatalog, pathNamespace) =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.connector.catalog
 
 import scala.collection.mutable
+import scala.util.Try
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.SQLConfHelper
@@ -348,5 +349,31 @@ private[sql] object CatalogManager {
     import org.json4s.jackson.JsonMethods.compact
     compact(JArray(entries.map(parts =>
       JArray(parts.map(JString(_)).toList)).toList))
+  }
+
+  /**
+   * Parse a stored frozen path string from view/function metadata.
+   * Returns None if the payload is malformed.
+   */
+  def deserializePathEntries(storedPathStr: String): Option[Seq[Seq[String]]] = {
+    import org.json4s.JsonAST.{JArray, JString}
+    import org.json4s.jackson.JsonMethods.parse
+
+    Try(parse(storedPathStr)).toOption match {
+      case Some(JArray(entries)) if entries.nonEmpty =>
+        val converted = entries.foldLeft(Option(Seq.empty[Seq[String]])) { (acc, entry) =>
+          acc.flatMap { collected =>
+            entry match {
+              case JArray(parts) if parts.nonEmpty =>
+                val strings = parts.collect { case JString(s) => s }
+                if (strings.size == parts.size) Some(collected :+ strings)
+                else None
+              case _ => None
+            }
+          }
+        }
+        converted.filter(_.nonEmpty)
+      case _ => None
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLFunctionSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 /**
@@ -109,6 +110,37 @@ class SQLFunctionSuite extends SharedSparkSession {
           stop = 60
         )
       )
+    }
+  }
+
+  test("SPARK-56639: SQL function uses frozen SQL path") {
+    withSQLConf(SQLConf.PATH_ENABLED.key -> "true") {
+      withDatabase("path_func_db_a", "path_func_db_b") {
+        withTable("path_func_db_a.frozen_t", "path_func_db_b.frozen_t") {
+          withUserDefinedFunction("frozen_fn" -> false) {
+            sql("USE default")
+            sql("CREATE DATABASE path_func_db_a")
+            sql("CREATE DATABASE path_func_db_b")
+            sql("CREATE TABLE path_func_db_a.frozen_t USING parquet AS SELECT 10 AS id")
+            sql("CREATE TABLE path_func_db_b.frozen_t USING parquet AS SELECT 20 AS id")
+            try {
+              sql("SET PATH = spark_catalog.path_func_db_a, system.builtin")
+              sql(
+                """
+                  |CREATE FUNCTION frozen_fn()
+                  |RETURNS INT
+                  |RETURN (SELECT MAX(id) FROM frozen_t)
+                  |""".stripMargin)
+              sql("SET PATH = spark_catalog.path_func_db_b, system.builtin")
+
+              checkAnswer(sql("SELECT MAX(id) FROM frozen_t"), Row(20))
+              checkAnswer(sql("SELECT default.frozen_fn()"), Row(10))
+            } finally {
+              sql("SET PATH = DEFAULT_PATH")
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLFunctionSuite.scala
@@ -174,4 +174,55 @@ class SQLFunctionSuite extends SharedSparkSession {
       }
     }
   }
+
+  test("SPARK-56639: current_schema/current_path in SQL functions use invoker context") {
+    withSQLConf(SQLConf.PATH_ENABLED.key -> "true") {
+      withDatabase("path_ctx_fn_a", "path_ctx_fn_b") {
+        withUserDefinedFunction("path_ctx_fn_a.f_scalar_ctx" -> false,
+          "path_ctx_fn_a.f_table_ctx" -> false) {
+          sql("CREATE DATABASE path_ctx_fn_a")
+          sql("CREATE DATABASE path_ctx_fn_b")
+          try {
+            sql("USE path_ctx_fn_a")
+            sql(
+              """
+                |CREATE FUNCTION path_ctx_fn_a.f_scalar_ctx()
+                |RETURNS STRING
+                |RETURN concat(current_schema(), '::', current_path())
+                |""".stripMargin)
+            sql(
+              """
+                |CREATE FUNCTION path_ctx_fn_a.f_table_ctx()
+                |RETURNS TABLE(cs STRING, cp STRING)
+                |RETURN SELECT current_schema() AS cs, current_path() AS cp
+                |""".stripMargin)
+
+            sql("USE path_ctx_fn_b")
+            sql("SET PATH = DEFAULT_PATH")
+
+            val scalar = sql("SELECT path_ctx_fn_a.f_scalar_ctx()").head().getString(0)
+            assert(scalar.startsWith("path_ctx_fn_b::"),
+              s"Expected scalar function to use invoker current_schema, got: $scalar")
+            assert(scalar.contains("path_ctx_fn_b"),
+              s"Expected scalar function to use invoker current_path, got: $scalar")
+            assert(!scalar.contains("path_ctx_fn_a"),
+              s"Did not expect creator schema in scalar function context, got: $scalar")
+
+            val table = sql("SELECT cs, cp FROM path_ctx_fn_a.f_table_ctx()").head()
+            val tableSchema = table.getString(0)
+            val tablePath = table.getString(1)
+            assert(tableSchema == "path_ctx_fn_b",
+              s"Expected table function to use invoker current_schema, got: $tableSchema")
+            assert(tablePath.contains("path_ctx_fn_b"),
+              s"Expected table function to use invoker current_path, got: $tablePath")
+            assert(!tablePath.contains("path_ctx_fn_a"),
+              s"Did not expect creator schema in table function context, got: $tablePath")
+          } finally {
+            sql("SET PATH = DEFAULT_PATH")
+            sql("USE default")
+          }
+        }
+      }
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLFunctionSuite.scala
@@ -143,4 +143,35 @@ class SQLFunctionSuite extends SharedSparkSession {
       }
     }
   }
+
+  test("SPARK-56639: SQL table function uses frozen SQL path") {
+    withSQLConf(SQLConf.PATH_ENABLED.key -> "true") {
+      withDatabase("path_tvf_db_a", "path_tvf_db_b") {
+        withTable("path_tvf_db_a.frozen_t", "path_tvf_db_b.frozen_t") {
+          withUserDefinedFunction("frozen_tvf" -> false) {
+            sql("USE default")
+            sql("CREATE DATABASE path_tvf_db_a")
+            sql("CREATE DATABASE path_tvf_db_b")
+            sql("CREATE TABLE path_tvf_db_a.frozen_t USING parquet AS SELECT 100 AS id")
+            sql("CREATE TABLE path_tvf_db_b.frozen_t USING parquet AS SELECT 200 AS id")
+            try {
+              sql("SET PATH = spark_catalog.path_tvf_db_a, system.builtin")
+              sql(
+                """
+                  |CREATE FUNCTION frozen_tvf()
+                  |RETURNS TABLE(id INT)
+                  |RETURN SELECT MAX(id) AS id FROM frozen_t
+                  |""".stripMargin)
+              sql("SET PATH = spark_catalog.path_tvf_db_b, system.builtin")
+
+              checkAnswer(sql("SELECT MAX(id) FROM frozen_t"), Row(200))
+              checkAnswer(sql("SELECT * FROM default.frozen_tvf()"), Row(100))
+            } finally {
+              sql("SET PATH = DEFAULT_PATH")
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -1435,4 +1435,39 @@ abstract class SQLViewSuite extends QueryTest {
       }
     }
   }
+
+  test("SPARK-56639: current_schema/current_path in persisted view use invoker context") {
+    withSQLConf(PATH_ENABLED.key -> "true") {
+      withDatabase("path_ctx_view_a", "path_ctx_view_b") {
+        withView("path_ctx_view_a.v_ctx") {
+          sql("CREATE DATABASE path_ctx_view_a")
+          sql("CREATE DATABASE path_ctx_view_b")
+          try {
+            sql("USE path_ctx_view_a")
+            sql(
+              """
+                |CREATE VIEW path_ctx_view_a.v_ctx AS
+                |SELECT current_schema() AS cs, current_path() AS cp
+                |""".stripMargin)
+
+            sql("USE path_ctx_view_b")
+            sql("SET PATH = DEFAULT_PATH")
+            val row = sql("SELECT cs, cp FROM path_ctx_view_a.v_ctx").head()
+            val currentSchema = row.getString(0)
+            val currentPath = row.getString(1)
+
+            assert(currentSchema == "path_ctx_view_b",
+              s"Expected invoker current_schema, got: $currentSchema")
+            assert(currentPath.contains("path_ctx_view_b"),
+              s"Expected invoker current_path to include path_ctx_view_b, got: $currentPath")
+            assert(!currentPath.contains("path_ctx_view_a"),
+              s"Did not expect creator schema in current_path, got: $currentPath")
+          } finally {
+            sql("SET PATH = DEFAULT_PATH")
+            sql("USE default")
+          }
+        }
+      }
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -1409,4 +1409,30 @@ abstract class SQLViewSuite extends QueryTest {
       }
     }
   }
+
+  test("SPARK-56639: permanent view uses frozen SQL path") {
+    withSQLConf(PATH_ENABLED.key -> "true") {
+      withDatabase("path_view_db_a", "path_view_db_b") {
+        withTable("path_view_db_a.frozen_t", "path_view_db_b.frozen_t") {
+          withView("default.v_path_frozen") {
+            sql("USE default")
+            sql("CREATE DATABASE path_view_db_a")
+            sql("CREATE DATABASE path_view_db_b")
+            sql("CREATE TABLE path_view_db_a.frozen_t USING parquet AS SELECT 1 AS id")
+            sql("CREATE TABLE path_view_db_b.frozen_t USING parquet AS SELECT 2 AS id")
+            try {
+              sql("SET PATH = spark_catalog.path_view_db_a, system.builtin")
+              sql("CREATE VIEW default.v_path_frozen AS SELECT id FROM frozen_t")
+              sql("SET PATH = spark_catalog.path_view_db_b, system.builtin")
+
+              checkAnswer(sql("SELECT id FROM frozen_t"), Row(2))
+              checkAnswer(sql("SELECT id FROM default.v_path_frozen"), Row(1))
+            } finally {
+              sql("SET PATH = DEFAULT_PATH")
+            }
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Support SQL Standard
* SET PATH
* CURRENT_PATH()

We also introduce the virtual SYSTEM.CURRENT_SCHEMA (for PATH) schema,
SYSTEM_PATH which includes SYSTEM.BUILTIN
and DEFAULT_PATH, which defaults to SYSTEM.SESSION, SYSTEM.BUILTIN, SYSTEM.CURRENT_PATH

Teh path is sued for all DML and queries, but NOT for DDL, such as DROP TABLE.

[SPARK-54810-path-plan.md](https://github.com/user-attachments/files/26061321/SPARK-54810-path-plan.md)

[design-sql-path.md](https://github.com/user-attachments/files/26368223/design-sql-path.md)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Give users control over the order in which to resolve objects in different schemas.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, this is a new feature

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added a new test suite


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes, Claude Opus 4.6 high
