### PR TITLE
[SPARK-56039][INFRA] Install `remotes` R package for `dev/infra/Dockerfile`

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -24,7 +24,7 @@ LABEL org.opencontainers.image.ref.name="Apache Spark Infra Image"
 # Overwrite this label to avoid exposing the underlying Ubuntu OS version label
 LABEL org.opencontainers.image.version=""
 
-ENV FULL_REFRESH_DATE=20241119
+ENV FULL_REFRESH_DATE=20260317
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
@@ -76,7 +76,7 @@ RUN add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu jammy-c
 # See more in SPARK-39959, roxygen2 < 7.2.1
 RUN Rscript -e "install.packages(c('devtools', 'knitr', 'markdown',  \
     'rmarkdown', 'testthat', 'devtools', 'e1071', 'survival', 'arrow',  \
-    'ggplot2', 'mvtnorm', 'statmod', 'xml2'), repos='https://cloud.r-project.org/')" && \
+    'ggplot2', 'mvtnorm', 'statmod', 'xml2', 'remotes'), repos='https://cloud.r-project.org/')" && \
     Rscript -e "devtools::install_version('roxygen2', version='7.2.0', repos='https://cloud.r-project.org')" && \
     Rscript -e "devtools::install_version('lintr', version='2.0.1', repos='https://cloud.r-project.org')" && \
     Rscript -e "devtools::install_version('pkgdown', version='2.0.1', repos='https://cloud.r-project.org')" && \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to recover the `Cache base image` GitHub Action CI by installing `remotes` R package for `dev/infra/Dockerfile`. Currently, it broke `branch-4.0`.

### Why are the changes needed?

Currently, `Build / Cache base image / main (push)` GitHub Action job has been broken due to the new `devtools` 2.5.0 release. This PR aims to installation `remotes` package explicitly because we cannot pin `devtools` itself.

- https://github.com/r-lib/devtools/releases/tag/v2.5.0 (2026-03-16)
- `branch-4.0`: https://github.com/apache/spark/actions/runs/23209985590/job/67455852567

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Recover the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)