### PR TITLE
[SPARK-56041][PS][TESTS] Normalize ndarray values in apply_batch typed result comparison for pandas 3

### DIFF
--- a/python/pyspark/pandas/tests/computation/test_apply_func.py
+++ b/python/pyspark/pandas/tests/computation/test_apply_func.py
@@ -215,6 +215,19 @@ class FrameApplyFunctionMixin:
             )
 
     def test_apply_batch_with_type(self):
+        using_pandas3 = LooseVersion(pd.__version__) >= "3.0.0"
+
+        def normalize_array_values(pdf: pd.DataFrame) -> pd.DataFrame:
+            if not using_pandas3:
+                return pdf
+
+            pdf = pdf.copy()
+            for column in pdf.columns:
+                pdf[column] = pdf[column].map(
+                    lambda value: list(value) if isinstance(value, np.ndarray) else value
+                )
+            return pdf
+
         pdf = self.pdf
         psdf = ps.from_pandas(pdf)
 
@@ -247,7 +260,7 @@ class FrameApplyFunctionMixin:
 
         actual = psdf.pandas_on_spark.apply_batch(identify3)
         actual.columns = ["a", "b"]
-        self.assert_eq(actual, pdf)
+        self.assert_eq(normalize_array_values(actual._to_pandas()), normalize_array_values(pdf))
 
         # For NumPy typing, NumPy version should be 1.21+
         if LooseVersion(np.__version__) >= LooseVersion("1.21"):
@@ -262,7 +275,7 @@ class FrameApplyFunctionMixin:
 
             actual = psdf.pandas_on_spark.apply_batch(identify4)
             actual.columns = ["a", "b"]
-            self.assert_eq(actual, pdf)
+            self.assert_eq(normalize_array_values(actual._to_pandas()), normalize_array_values(pdf))
 
         arrays = [[1, 2, 3, 4, 5, 6, 7, 8, 9], ["a", "b", "c", "d", "e", "f", "g", "h", "i"]]
         idx = pd.MultiIndex.from_arrays(arrays, names=("number", "color"))
@@ -278,7 +291,7 @@ class FrameApplyFunctionMixin:
         actual = psdf.pandas_on_spark.apply_batch(identify4)
         actual.index.names = ["number", "color"]
         actual.columns = ["a", "b"]
-        self.assert_eq(actual, pdf)
+        self.assert_eq(normalize_array_values(actual._to_pandas()), normalize_array_values(pdf))
 
         def identify5(
             x,
@@ -288,7 +301,7 @@ class FrameApplyFunctionMixin:
             return x
 
         actual = psdf.pandas_on_spark.apply_batch(identify5)
-        self.assert_eq(actual, pdf)
+        self.assert_eq(normalize_array_values(actual._to_pandas()), normalize_array_values(pdf))
 
     def test_transform(self):
         pdf = pd.DataFrame(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the pandas-on-Spark `apply_batch` typed test in `python/pyspark/pandas/tests/computation/test_apply_func.py`.

With pandas 3.x, the typed `apply_batch` cases that return array-like values can produce pandas results whose nested values are `np.ndarray`, while the expected pandas DataFrame still contains Python lists. The values are equivalent, but the comparison is stricter and the test fails.

To make the test compare the intended semantics instead of the container representation, this PR normalizes nested `np.ndarray` values to lists before asserting equality in `test_apply_batch_with_type`. The normalization is scoped to pandas 3.x and only applied in the affected test cases.

### Why are the changes needed?

The failure is caused by stricter comparison behavior in pandas 3.x rather than a functional regression in pandas-on-Spark `apply_batch`.

In the failing cases, the expected and actual results contain the same data, but one side may use Python lists and the other may use `np.ndarray` for nested array values. Relaxing the production code path would broaden behavior beyond the test. Updating the test keeps runtime behavior unchanged and makes the assertion reflect the intended equivalence.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran the related pandas-on-Spark computation test module in both the default Python 3.12 environment and the pandas 3 environment, and both passed.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex GPT-5