### PR TITLE
[SPARK-55848][SQL][4.1][FOLLOW-UP] Restore deleted comments

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -392,11 +392,16 @@ case class KeyGroupedPartitioning(
         if (isPartiallyClustered) {
           false
         } else if (requireAllClusterKeys) {
+          // Checks whether this partitioning is partitioned on exactly same clustering keys of
+          // `ClusteredDistribution`.
           c.areAllClusterKeysMatched(expressions)
         } else {
+          // We'll need to find leaf attributes from the partition expressions first.
           val attributes = expressions.flatMap(_.collectLeaves())
 
           if (SQLConf.get.v2BucketingAllowJoinKeysSubsetOfPartitionKeys) {
+            // check that join keys (required clustering keys)
+            // overlap with partition keys (KeyGroupedPartitioning attributes)
             requiredClustering.exists(x => attributes.exists(_.semanticEquals(x))) &&
                 expressions.forall(_.collectLeaves().size == 1)
           } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to #54751. Restores 3 comments in `satisfies0()` that were accidentally deleted during the restructuring. Comments only, no logic changes.

### Why are the changes needed?

Per @peter-toth's review in #54851, the original comments should be preserved.

### Does this PR introduce any user-facing change?

No. Comments only.

### How was this patch tested?

Compilation verified. No logic changes.

### Was this patch authored or co-authored using generative AI tooling?

No.