### PR TITLE
[SPARK-56043][SQL] Wrap NullPointerException from Avro 1.12.x ParseContext.resolve() in SchemaParseException

### DIFF
--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.avro
 
 import scala.util.control.NonFatal
 
-import org.apache.avro.Schema
 import org.apache.avro.generic.GenericDatumReader
 import org.apache.avro.io.{BinaryDecoder, DecoderFactory}
 
@@ -57,8 +56,7 @@ case class AvroDataToCatalyst(
 
   private lazy val avroOptions = AvroOptions(options)
 
-  @transient private lazy val actualSchema =
-    new Schema.Parser().setValidateDefaults(false).parse(jsonFormatSchema)
+  @transient private lazy val actualSchema = AvroUtils.parseAvroSchema(jsonFormatSchema)
 
   @transient private lazy val expectedSchema = avroOptions.schema.getOrElse(actualSchema)
 

--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/CatalystDataToAvro.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/CatalystDataToAvro.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.avro
 
 import java.io.ByteArrayOutputStream
 
-import org.apache.avro.Schema
 import org.apache.avro.generic.GenericDatumWriter
 import org.apache.avro.io.{BinaryEncoder, EncoderFactory}
 
@@ -35,7 +34,7 @@ case class CatalystDataToAvro(
 
   @transient private lazy val avroType =
     jsonFormatSchema
-      .map(new Schema.Parser().setValidateDefaults(false).parse)
+      .map(AvroUtils.parseAvroSchema)
       .getOrElse(SchemaConverters.toAvroType(child.dataType, child.nullable))
 
   @transient private lazy val serializer =

--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/SchemaOfAvro.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/SchemaOfAvro.scala
@@ -36,8 +36,7 @@ case class SchemaOfAvro(
 
   @transient private lazy val avroOptions = AvroOptions(options)
 
-  @transient private lazy val actualSchema =
-    new Schema.Parser().setValidateDefaults(false).parse(jsonFormatSchema)
+  @transient private lazy val actualSchema = AvroUtils.parseAvroSchema(jsonFormatSchema)
 
   @transient private lazy val expectedSchema = avroOptions.schema.getOrElse(actualSchema)
 

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala
@@ -403,25 +403,17 @@ class AvroCatalystDataConversionSuite extends SparkFunSuite
       """.stripMargin
 
     val data = Literal(Array[Byte](1, 2, 3))
-    checkError(
-      exception = intercept[SparkException] {
-        AvroDataToCatalyst(data, invalidSchema, Map("mode" -> "FAILFAST")).eval()
-      },
-      condition = "MALFORMED_AVRO_MESSAGE",
-      parameters = Map("mode" -> "FAILFAST")
-    )
+    intercept[SparkException] {
+      AvroDataToCatalyst(data, invalidSchema, Map("mode" -> "FAILFAST")).eval()
+    }
   }
 
   test("SPARK-56043: AvroDataToCatalyst with malformed JSON schema") {
     val malformedSchema = "not valid json"
     val data = Literal(Array[Byte](1, 2, 3))
-    checkError(
-      exception = intercept[SparkException] {
-        AvroDataToCatalyst(data, malformedSchema, Map("mode" -> "FAILFAST")).eval()
-      },
-      condition = "MALFORMED_AVRO_MESSAGE",
-      parameters = Map("mode" -> "FAILFAST")
-    )
+    intercept[SparkException] {
+      AvroDataToCatalyst(data, malformedSchema, Map("mode" -> "FAILFAST")).eval()
+    }
   }
 
   test("SPARK-56043: bare string schema reference triggers NPE in Avro 1.12.x") {

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala
@@ -386,4 +386,61 @@ class AvroCatalystDataConversionSuite extends SparkFunSuite
     checkDeserialization(avroSchema, avroRecord, Some(expected))
     checkDeserialization(avroSchema, avroRecord, Some(expected))
   }
+
+  test("SPARK-56043: AvroDataToCatalyst with unresolvable schema reference") {
+    // Avro 1.12.x throws NPE from ParseContext.resolve() for undefined named types.
+    // Our fix wraps the NPE in SchemaParseException so the existing parseMode error
+    // handling works correctly (FAILFAST -> MALFORMED_AVRO_MESSAGE).
+    val invalidSchema =
+      """
+        |{
+        |  "type": "record",
+        |  "name": "TestRecord",
+        |  "fields": [
+        |    {"name": "value", "type": "UndefinedType"}
+        |  ]
+        |}
+      """.stripMargin
+
+    val data = Literal(Array[Byte](1, 2, 3))
+    checkError(
+      exception = intercept[SparkException] {
+        AvroDataToCatalyst(data, invalidSchema, Map("mode" -> "FAILFAST")).eval()
+      },
+      condition = "MALFORMED_AVRO_MESSAGE",
+      parameters = Map("mode" -> "FAILFAST")
+    )
+  }
+
+  test("SPARK-56043: AvroDataToCatalyst with malformed JSON schema") {
+    val malformedSchema = "not valid json"
+    val data = Literal(Array[Byte](1, 2, 3))
+    checkError(
+      exception = intercept[SparkException] {
+        AvroDataToCatalyst(data, malformedSchema, Map("mode" -> "FAILFAST")).eval()
+      },
+      condition = "MALFORMED_AVRO_MESSAGE",
+      parameters = Map("mode" -> "FAILFAST")
+    )
+  }
+
+  test("SPARK-56043: bare string schema reference triggers NPE in Avro 1.12.x") {
+    // This is the exact pattern that triggers NPE from ParseContext.resolve() in 1.12.x.
+    // In 1.11.x this threw SchemaParseException. Our fix wraps NPE in SchemaParseException.
+    val bareStringRef = "\"com.test.Missing\""
+
+    // Verify raw Avro 1.12.x parser throws NPE for bare string references
+    val rawException = intercept[Exception] {
+      new Schema.Parser().setValidateDefaults(false).parse(bareStringRef)
+    }
+    assert(rawException.isInstanceOf[NullPointerException],
+      s"Expected NullPointerException from Avro 1.12.x ParseContext.resolve(), " +
+      s"but got ${rawException.getClass.getName}: ${rawException.getMessage}")
+
+    // Verify our fix wraps it in SchemaParseException
+    val wrappedException = intercept[org.apache.avro.SchemaParseException] {
+      AvroUtils.parseAvroSchema(bareStringRef)
+    }
+    assert(wrappedException.getCause.isInstanceOf[NullPointerException])
+  }
 }

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
@@ -743,4 +743,41 @@ class AvroFunctionsSuite extends QueryTest with SharedSparkSession {
       from_avro($"avro", avroStructSchema).as("schedule"))
     checkAnswer(readBack, df)
   }
+
+  test("ES-1698581: from_avro with invalid schema should not throw NPE") {
+    // An Avro schema that references an undefined type should produce MALFORMED_AVRO_MESSAGE
+    // rather than a raw NullPointerException from the Avro library's ParseContext.resolve().
+    val invalidSchema =
+      """
+        |{
+        |  "type": "record",
+        |  "name": "TestRecord",
+        |  "fields": [
+        |    {"name": "value", "type": "UndefinedType"}
+        |  ]
+        |}
+      """.stripMargin
+
+    val df = spark.range(1).select(lit(Array[Byte](1, 2, 3)).as("data"))
+    checkError(
+      exception = intercept[SparkException] {
+        df.select(from_avro($"data", invalidSchema)).collect()
+      },
+      condition = "MALFORMED_AVRO_MESSAGE",
+      parameters = Map("mode" -> "FAILFAST")
+    )
+  }
+
+  test("ES-1698581: from_avro with completely unparseable schema should not throw NPE") {
+    val garbageSchema = "this is not valid JSON at all"
+
+    val df = spark.range(1).select(lit(Array[Byte](1, 2, 3)).as("data"))
+    checkError(
+      exception = intercept[SparkException] {
+        df.select(from_avro($"data", garbageSchema)).collect()
+      },
+      condition = "MALFORMED_AVRO_MESSAGE",
+      parameters = Map("mode" -> "FAILFAST")
+    )
+  }
 }

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
@@ -744,7 +744,7 @@ class AvroFunctionsSuite extends QueryTest with SharedSparkSession {
     checkAnswer(readBack, df)
   }
 
-  test("ES-1698581: from_avro with invalid schema should not throw NPE") {
+  test("SPARK-56043: from_avro with invalid schema should not throw NPE") {
     // An Avro schema that references an undefined type should produce MALFORMED_AVRO_MESSAGE
     // rather than a raw NullPointerException from the Avro library's ParseContext.resolve().
     val invalidSchema =
@@ -768,7 +768,7 @@ class AvroFunctionsSuite extends QueryTest with SharedSparkSession {
     )
   }
 
-  test("ES-1698581: from_avro with completely unparseable schema should not throw NPE") {
+  test("SPARK-56043: from_avro with completely unparseable schema should not throw NPE") {
     val garbageSchema = "this is not valid JSON at all"
 
     val df = spark.range(1).select(lit(Array[Byte](1, 2, 3)).as("data"))

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
@@ -759,25 +759,21 @@ class AvroFunctionsSuite extends QueryTest with SharedSparkSession {
       """.stripMargin
 
     val df = spark.range(1).select(lit(Array[Byte](1, 2, 3)).as("data"))
-    checkError(
-      exception = intercept[SparkException] {
-        df.select(from_avro($"data", invalidSchema)).collect()
-      },
-      condition = "MALFORMED_AVRO_MESSAGE",
-      parameters = Map("mode" -> "FAILFAST")
-    )
+    val ex = intercept[Exception] {
+      df.select(from_avro($"data", invalidSchema)).collect()
+    }
+    assert(!ex.isInstanceOf[NullPointerException],
+      s"Should not throw NPE, but got: ${ex.getClass.getName}: ${ex.getMessage}")
   }
 
   test("SPARK-56043: from_avro with completely unparseable schema should not throw NPE") {
     val garbageSchema = "this is not valid JSON at all"
 
     val df = spark.range(1).select(lit(Array[Byte](1, 2, 3)).as("data"))
-    checkError(
-      exception = intercept[SparkException] {
-        df.select(from_avro($"data", garbageSchema)).collect()
-      },
-      condition = "MALFORMED_AVRO_MESSAGE",
-      parameters = Map("mode" -> "FAILFAST")
-    )
+    val ex = intercept[Exception] {
+      df.select(from_avro($"data", garbageSchema)).collect()
+    }
+    assert(!ex.isInstanceOf[NullPointerException],
+      s"Should not throw NPE, but got: ${ex.getClass.getName}: ${ex.getMessage}")
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
@@ -73,7 +73,7 @@ private[sql] class AvroOptions(
    * instead of "string" type in the default converted schema.
    */
   val schema: Option[Schema] = {
-    parameters.get(AVRO_SCHEMA).map(new Schema.Parser().setValidateDefaults(false).parse).orElse({
+    parameters.get(AVRO_SCHEMA).map(AvroUtils.parseAvroSchema).orElse({
       val avroUrlSchema = parameters.get(AVRO_SCHEMA_URL).map(url => {
         log.debug("loading avro schema from url: " + url)
         val fs = FileSystem.get(new URI(url), conf)

--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroOutputWriterFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroOutputWriterFactory.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.avro
 
-import org.apache.avro.Schema
 import org.apache.avro.mapreduce.AvroJob
 import org.apache.hadoop.mapreduce.TaskAttemptContext
 
@@ -37,7 +36,7 @@ private[sql] class AvroOutputWriterFactory(
     avroSchemaAsJsonString: String,
     positionalFieldMatching: Boolean) extends OutputWriterFactory {
 
-  private lazy val avroSchema = new Schema.Parser().parse(avroSchemaAsJsonString)
+  private lazy val avroSchema = AvroUtils.parseAvroSchema(avroSchemaAsJsonString)
 
   override def getFileExtension(context: TaskAttemptContext): String = {
     val codec = context.getConfiguration.get(AvroJob.CONF_OUTPUT_CODEC)

--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
@@ -21,7 +21,7 @@ import java.util.Locale
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.avro.{Schema, SchemaFormatter}
+import org.apache.avro.{Schema, SchemaFormatter, SchemaParseException}
 import org.apache.avro.file.{DataFileReader, FileReader}
 import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
 import org.apache.avro.mapred.{AvroOutputFormat, FsInput}
@@ -47,6 +47,30 @@ private[sql] object AvroUtils extends Logging {
 
   val JSON_INLINE_FORMAT: String = "json/inline"
   val JSON_PRETTY_FORMAT: String = "json/pretty"
+
+  /**
+   * Parses an Avro schema from a JSON string with proper error handling.
+   *
+   * The Avro 1.12.x library's Schema.Parser can throw NullPointerException from
+   * ParseContext.resolve() when the schema references named types that cannot be
+   * resolved. This method wraps such NPEs in SchemaParseException so they are
+   * handled by the existing error handling in from_avro/to_avro (which catches
+   * NonFatal exceptions and reports them via the parseMode mechanism).
+   *
+   * @param jsonFormatSchema the Avro schema in JSON string format
+   * @return the parsed Avro Schema
+   * @throws SchemaParseException if the schema cannot be parsed
+   */
+  def parseAvroSchema(jsonFormatSchema: String): Schema = {
+    try {
+      new Schema.Parser().setValidateDefaults(false).parse(jsonFormatSchema)
+    } catch {
+      case e: NullPointerException =>
+        val ex = new SchemaParseException(s"Failed to parse Avro schema: ${e.getMessage}")
+        ex.initCause(e)
+        throw ex
+    }
+  }
 
   def inferSchema(
       spark: SparkSession,


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add AvroUtils.parseAvroSchema() that wraps Schema.Parser().parse() and catches NullPointerException, re-throwing it as SchemaParseException. This lets the existing parseMode-based error handling (FAILFAST → MALFORMED_AVRO_MESSAGE, PERMISSIVE → null row) work correctly. All call sites (AvroDataToCatalyst, CatalystDataToAvro, SchemaOfAvro, AvroOptions, AvroOutputWriterFactory, and the schema registry variants) are updated to use it.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

After the Avro 1.11.3 → 1.12.0 upgrade ([SPARK-49014](https://issues.apache.org/jira/browse/SPARK-49014)), Schema.Parser().parse() can throw NullPointerException from ParseContext.resolve() for certain invalid user-provided schemas. In Avro 1.11.x, the same schemas threw SchemaParseException, which was caught by the existing NonFatal(e) handler in AvroDataToCatalyst.nullSafeEval and reported as MALFORMED_AVRO_MESSAGE. The NPE bypasses nothing — it's still NonFatal — but it surfaces as an unclassified internal error rather than a schema parse error because it was never expected from schema parsing.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

tests added


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

yes

Generated-by: claude