### PR TITLE
[SPARK-56044][CORE] HistoryServerDiskManager does not delete app store on release when app is not in active map

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServerDiskManager.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServerDiskManager.scala
@@ -171,18 +171,28 @@ private class HistoryServerDiskManager(
     }
 
     oldSizeOpt.foreach { oldSize =>
-      val path = appStorePath(appId, attemptId)
       updateUsage(-oldSize, committed = true)
-      if (path.isDirectory()) {
-        if (delete) {
-          deleteStore(path)
-        } else {
-          val newSize = sizeOf(path)
-          val newInfo = listing.read(classOf[ApplicationStoreInfo], path.getAbsolutePath())
-            .copy(size = newSize)
-          listing.write(newInfo)
-          updateUsage(newSize, committed = true)
+    }
+
+    // Apply the store operation regardless of whether the app was in the active map, since
+    // the store directory may still exist on disk (e.g., when the app was never opened after
+    // a restart).
+    val path = appStorePath(appId, attemptId)
+    if (path.isDirectory()) {
+      if (delete) {
+        // If the app was not actively tracked, its size was not deducted above; do it now.
+        if (oldSizeOpt.isEmpty) {
+          val size = sizeOf(path)
+          updateUsage(-size, committed = true)
         }
+        deleteStore(path)
+      } else if (oldSizeOpt.isDefined) {
+        // Re-measure the size since the store may have changed while it was open.
+        val newSize = sizeOf(path)
+        val newInfo = listing.read(classOf[ApplicationStoreInfo], path.getAbsolutePath())
+          .copy(size = newSize)
+        listing.write(newInfo)
+        updateUsage(newSize, committed = true)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerDiskManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerDiskManagerSuite.scala
@@ -220,6 +220,38 @@ abstract class HistoryServerDiskManagerSuite extends SparkFunSuite with BeforeAn
     assert(store.read(classOf[ApplicationStoreInfo], dstC.getAbsolutePath).size === 2)
   }
 
+  test("SPARK-56044: release with delete cleans up store when app is not in active map") {
+    val manager = mockManager()
+    val leaseA = manager.lease(2)
+    doReturn(2L).when(manager).sizeOf(meq(leaseA.tmpPath))
+    val dstPathA = manager.appStorePath("app1", None)
+    doReturn(2L).when(manager).sizeOf(meq(dstPathA))
+    val dst = leaseA.commit("app1", None)
+    assert(dst.exists())
+    assert(manager.committed() === 2)
+
+    // Release without deleting; the store remains on disk and in the listing.
+    doReturn(2L).when(manager).sizeOf(meq(dst))
+    manager.release("app1", None)
+    assert(dst.exists())
+    assert(manager.committed() === 2)
+
+    // Simulate: service restarts, new disk manager is initialized with an empty active map.
+    val manager2 = mockManager()
+    doReturn(2L).when(manager2).sizeOf(meq(dst))
+    doReturn(2L).when(manager2).sizeOf(meq(new File(testDir, "apps")))
+    manager2.initialize()
+    assert(dst.exists())
+    assert(store.read(classOf[ApplicationStoreInfo], dst.getAbsolutePath).size === 2)
+
+    // Delete via release; the app was never opened in manager2 so it is not in the active map.
+    manager2.release("app1", None, delete = true)
+    assert(!dst.exists())
+    assert(!store.view(classOf[ApplicationStoreInfo]).iterator().hasNext)
+    assert(manager2.committed() === 0)
+    assert(manager2.free() === MAX_USAGE)
+  }
+
   test("SPARK-38095: appStorePath should use backend extensions") {
     val conf = new SparkConf().set(HYBRID_STORE_DISK_BACKEND, backend.toString)
     val manager = new HistoryServerDiskManager(conf, testDir, store, new ManualClock())


### PR DESCRIPTION
### What changes were proposed in this pull request?

`HistoryServerDiskManager.release()` skips the store directory deletion when the application is not present in the in-memory `active` map. This happens because the directory operation is nested inside an `oldSizeOpt.foreach` block, which only executes when the app was actively tracked.

The `active` map is in-memory only and is empty after a History Server restart. When log expiration triggers `release(delete=true)` for an app that was never reopened after a restart, the on-disk store directory (`.ldb` / `.rdb`) is never deleted, causing orphaned store directories to accumulate indefinitely.

This PR separates the `updateUsage` deduction (which applies only to actively tracked apps) from the directory operation (which should apply whenever the directory exists on disk). When deleting an app not in the active map, its size is derived directly from disk before deduction to keep usage accounting accurate.

### Why are the changes needed?

Without this fix, orphaned `.ldb`/`.rdb` store directories are never cleaned up after a History Server restart, causing unbounded disk usage growth.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added a new test `SPARK-56044: release with delete cleans up store when app is not in active map` in `HistoryServerDiskManagerSuite` that simulates a History Server restart and verifies that `release(delete=true)` correctly deletes the store directory, removes the listing entry, and zeroes out usage accounting when the app is not in the active map.