### PR TITLE
[SPARK-56047][SQL] Propagate `distinctCount` through Union in CBO statistics estimation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/UnionEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/UnionEstimation.scala
@@ -24,8 +24,9 @@ import org.apache.spark.sql.types._
 
 /**
  * Estimate the number of output rows by doing the sum of output rows for each child of union,
- * and estimate min and max stats for each column by finding the overall min and max of that
- * column coming from its children.
+ * and estimate column stats (min, max, nullCount, distinctCount) for each column from its
+ * children. Min and max are computed as the overall min/max across children, nullCount is summed,
+ * and distinctCount is estimated as the max across children (capped by total row count).
  */
 object UnionEstimation {
   import EstimationUtils._
@@ -51,14 +52,23 @@ object UnionEstimation {
 
     val newMinMaxStats = computeMinMaxStats(union)
     val newNullCountStats = computeNullCountStats(union)
+    val newDistinctCountStats = computeDistinctCountStats(union, outputRows)
     val newAttrStats = {
       val baseStats = AttributeMap(newMinMaxStats)
-      val overwriteStats = newNullCountStats.map { case attrStat@(attr, stat) =>
+      // Layer nullCount on top of min/max
+      val withNullCount = newNullCountStats.map { case attrStat @ (attr, stat) =>
         baseStats.get(attr).map { baseStat =>
           attr -> baseStat.copy(nullCount = stat.nullCount)
         }.getOrElse(attrStat)
       }
-      AttributeMap(newMinMaxStats ++ overwriteStats)
+      val merged = AttributeMap(newMinMaxStats ++ withNullCount)
+      // Layer distinctCount on top of min/max + nullCount
+      val withDistinctCount = newDistinctCountStats.map { case attrStat @ (attr, stat) =>
+        merged.get(attr).map { baseStat =>
+          attr -> baseStat.copy(distinctCount = stat.distinctCount)
+        }.getOrElse(attrStat)
+      }
+      AttributeMap(newMinMaxStats ++ withNullCount ++ withDistinctCount)
     }
 
     Some(
@@ -122,6 +132,45 @@ object UnionEstimation {
             totalNullCount + colStat.nullCount.get
         }
         val newStat = ColumnStat(nullCount = Some(colWithNullStatValues))
+        unionOutput(outputIndex) -> newStat
+    }
+  }
+
+  /**
+   * For each column, if all children have distinctCount, propagate the max distinctCount
+   * across children. The result is capped by outputRows when available.
+   *
+   * For UNION ALL, true distinctCount satisfies:
+   *   max(dc_i) <= true_dc <= min(sum(dc_i), rowCount)
+   * We use max as a lower-bound estimate. This may underestimate when branches have
+   * disjoint values, but UNION ALL branches typically share overlapping values
+   * (e.g. web_sales and catalog_sales reference the same date keys),
+   * so max is a reasonable approximation in the common case.
+   */
+  private def computeDistinctCountStats(
+      union: Union,
+      outputRows: Option[BigInt]): Seq[(Attribute, ColumnStat)] = {
+    val unionOutput = union.output
+    val attrToComputeDistinctCount = union.children.map(_.output).transpose.zipWithIndex.filter {
+      case (attrs, _) => attrs.zipWithIndex.forall {
+        case (attr, childIndex) =>
+          val attrStats = union.children(childIndex).stats.attributeStats
+          attrStats.get(attr).isDefined && attrStats(attr).distinctCount.isDefined
+      }
+    }
+    attrToComputeDistinctCount.map {
+      case (attrs, outputIndex) =>
+        val maxDistinctCount = attrs.zipWithIndex.foldLeft[BigInt](0) {
+          case (currentMax, (attr, childIndex)) =>
+            val colStat = union.children(childIndex).stats.attributeStats(attr)
+            currentMax.max(colStat.distinctCount.get)
+        }
+        // Cap distinctCount by outputRows if available
+        val cappedDistinctCount = outputRows match {
+          case Some(rows) => maxDistinctCount.min(rows)
+          case None => maxDistinctCount
+        }
+        val newStat = ColumnStat(distinctCount = Some(cappedDistinctCount))
         unionOutput(outputIndex) -> newStat
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/BasicStatsEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/BasicStatsEstimationSuite.scala
@@ -318,7 +318,8 @@ test("range with invalid long value") {
     val rowCount = Some(plan.rowCount * childrenSize)
     val attributeStats = AttributeMap(
       Seq(
-        attribute -> ColumnStat(min = Some(1), max = Some(10), nullCount = Some(0))))
+        attribute -> ColumnStat(
+          distinctCount = Some(10), min = Some(1), max = Some(10), nullCount = Some(0))))
     checkStats(
       union,
       expectedStatsCboOn = Statistics(sizeInBytes = sizeInBytes,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/UnionAggregateEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/UnionAggregateEstimationSuite.scala
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.statsEstimation
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.{AttributeMap, AttributeReference}
+import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, Union}
+import org.apache.spark.sql.types.IntegerType
+
+/**
+ * Verifies that UnionEstimation propagates distinctCount, enabling
+ * AggregateEstimation to produce accurate CBO estimates for
+ * `SELECT ... GROUP BY ... FROM (... UNION ALL ...)` queries.
+ */
+class UnionAggregateEstimationSuite extends StatsEstimationTestBase {
+
+  private val colKey = AttributeReference("key", IntegerType)()
+  private val colVal = AttributeReference("val", IntegerType)()
+
+  private def makeChild(
+      keyAttr: AttributeReference,
+      valAttr: AttributeReference,
+      rows: Int,
+      distinctKeys: Int): StatsTestPlan = {
+    StatsTestPlan(
+      outputList = Seq(keyAttr, valAttr),
+      rowCount = rows,
+      attributeStats = AttributeMap(Seq(
+        keyAttr -> ColumnStat(
+          distinctCount = Some(distinctKeys),
+          min = Some(1),
+          max = Some(distinctKeys),
+          nullCount = Some(0),
+          avgLen = Some(4),
+          maxLen = Some(4)),
+        valAttr -> ColumnStat(
+          distinctCount = Some(rows),
+          min = Some(1),
+          max = Some(rows),
+          nullCount = Some(0),
+          avgLen = Some(4),
+          maxLen = Some(4))
+      )),
+      size = Some(rows.toLong * 8)
+    )
+  }
+
+  test("Aggregate directly on a single child retains CBO distinctCount") {
+    // Aggregate(child) -- no Union involved, CBO should work fine
+    val child = makeChild(colKey, colVal, rows = 1000000, distinctKeys = 100)
+    val agg = child.groupBy(child.output.head)(count(child.output(1)).as("cnt"))
+    val aggStats = agg.stats
+
+    // AggregateEstimation should succeed: rowCount = distinctKeys = 100
+    assert(aggStats.rowCount.isDefined, "rowCount should be defined (CBO succeeded)")
+    assert(aggStats.rowCount.get == 100,
+      s"Expected rowCount=100, got ${aggStats.rowCount.get}")
+  }
+
+  test("Union propagates distinctCount, enabling AggregateEstimation CBO") {
+    val key1 = AttributeReference("key1", IntegerType)()
+    val val1 = AttributeReference("val1", IntegerType)()
+    val key2 = AttributeReference("key2", IntegerType)()
+    val val2 = AttributeReference("val2", IntegerType)()
+
+    val child1 = makeChild(key1, val1, rows = 500000, distinctKeys = 100)
+    val child2 = makeChild(key2, val2, rows = 500000, distinctKeys = 100)
+
+    val union = Union(Seq(child1, child2))
+
+    // Verify: Union stats should have rowCount AND distinctCount
+    val unionStats = union.stats
+    assert(unionStats.rowCount.isDefined, "Union rowCount should be defined")
+    assert(unionStats.rowCount.get == 1000000,
+      s"Union rowCount should be 1M, got ${unionStats.rowCount.get}")
+
+    val unionKeyAttr = union.output.head
+    val unionKeyStat = unionStats.attributeStats.get(unionKeyAttr)
+    assert(unionKeyStat.isDefined, "Union should have attributeStats for key column")
+    assert(unionKeyStat.get.distinctCount.isDefined,
+      "Union should have distinctCount (propagated as max across children)")
+    assert(unionKeyStat.get.distinctCount.get == 100,
+      s"distinctCount should be max(100, 100) = 100, got ${unionKeyStat.get.distinctCount.get}")
+    assert(unionKeyStat.get.hasCountStats,
+      "hasCountStats should be true since both distinctCount and nullCount are defined")
+
+    // Now: Aggregate on top of Union -- CBO should work
+    val agg = union.groupBy(unionKeyAttr)(count(union.output(1)).as("cnt"))
+    val aggStats = agg.stats
+
+    assert(aggStats.rowCount.isDefined,
+      "AggregateEstimation CBO should succeed (rowCount defined)")
+    assert(aggStats.rowCount.get == 100,
+      s"Expected rowCount=100, got ${aggStats.rowCount.get}")
+    // With CBO, sizeInBytes should be small (100 rows), not millions of rows
+    assert(aggStats.sizeInBytes < 10000,
+      s"With CBO, aggregate sizeInBytes should be small, got ${aggStats.sizeInBytes}")
+  }
+
+  test("Same Aggregate without Union retains accurate CBO estimate") {
+    // Control group: same data volume but as a single child, no Union
+    val child = makeChild(colKey, colVal, rows = 1000000, distinctKeys = 100)
+    val agg = child.groupBy(child.output.head)(count(child.output(1)).as("cnt"))
+    val aggStats = agg.stats
+
+    // CBO works: rowCount = 100, sizeInBytes is small
+    assert(aggStats.rowCount.isDefined && aggStats.rowCount.get == 100)
+    assert(aggStats.sizeInBytes < 10000,
+      s"With CBO, aggregate sizeInBytes should be small, got ${aggStats.sizeInBytes}")
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/UnionAggregateEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/UnionAggregateEstimationSuite.scala
@@ -61,7 +61,7 @@ class UnionAggregateEstimationSuite extends StatsEstimationTestBase {
     )
   }
 
-  test("Aggregate directly on a single child retains CBO distinctCount") {
+  test("SPARK-56047: Aggregate directly on a single child retains CBO distinctCount") {
     // Aggregate(child) -- no Union involved, CBO should work fine
     val child = makeChild(colKey, colVal, rows = 1000000, distinctKeys = 100)
     val agg = child.groupBy(child.output.head)(count(child.output(1)).as("cnt"))
@@ -73,7 +73,7 @@ class UnionAggregateEstimationSuite extends StatsEstimationTestBase {
       s"Expected rowCount=100, got ${aggStats.rowCount.get}")
   }
 
-  test("Union propagates distinctCount, enabling AggregateEstimation CBO") {
+  test("SPARK-56047: Union propagates distinctCount, enabling AggregateEstimation CBO") {
     val key1 = AttributeReference("key1", IntegerType)()
     val val1 = AttributeReference("val1", IntegerType)()
     val key2 = AttributeReference("key2", IntegerType)()
@@ -113,7 +113,7 @@ class UnionAggregateEstimationSuite extends StatsEstimationTestBase {
       s"With CBO, aggregate sizeInBytes should be small, got ${aggStats.sizeInBytes}")
   }
 
-  test("Same Aggregate without Union retains accurate CBO estimate") {
+  test("SPARK-56047: Same Aggregate without Union retains accurate CBO estimate") {
     // Control group: same data volume but as a single child, no Union
     val child = makeChild(colKey, colVal, rows = 1000000, distinctKeys = 100)
     val agg = child.groupBy(child.output.head)(count(child.output(1)).as("cnt"))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/UnionEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/UnionEstimationSuite.scala
@@ -154,8 +154,10 @@ class UnionEstimationSuite extends StatsEstimationTestBase {
       rowCount = Some(4),
       attributeStats = AttributeMap(
         Seq(
-          attrInt -> ColumnStat(min = Some(1), max = Some(6), nullCount = Some(2)),
-          attrDouble -> ColumnStat(min = Some(2.0), max = Some(7.0), nullCount = Some(4)),
+          attrInt -> ColumnStat(
+            distinctCount = Some(2), min = Some(1), max = Some(6), nullCount = Some(2)),
+          attrDouble -> ColumnStat(
+            distinctCount = Some(2), min = Some(2.0), max = Some(7.0), nullCount = Some(4)),
           attrShort -> ColumnStat(min = Some(s1), max = Some(s4)),
           attrLong -> ColumnStat(min = Some(1L), max = Some(6L)),
           attrByte -> ColumnStat(min = Some(b1), max = Some(b4)),
@@ -206,12 +208,12 @@ class UnionEstimationSuite extends StatsEstimationTestBase {
 
     val union = Union(Seq(child1, child2))
 
-    // Only null count is present in the attribute stats
+    // Only nullCount and distinctCount are present (no min/max since child2 lacks them)
     val expectedStats = logical.Statistics(
       sizeInBytes = 2 * 1024,
       rowCount = Some(4),
       attributeStats = AttributeMap(
-        Seq(attrInt -> ColumnStat(nullCount = Some(0)))))
+        Seq(attrInt -> ColumnStat(distinctCount = Some(2), nullCount = Some(0)))))
     assert(union.stats === expectedStats)
   }
 
@@ -252,12 +254,114 @@ class UnionEstimationSuite extends StatsEstimationTestBase {
 
     val union = Union(Seq(child1, child2))
 
-    // Null count should not present in the stats.
+    // nullCount should not be present (child2 lacks it), but distinctCount and min/max should.
     val expectedStats = logical.Statistics(
       sizeInBytes = 2 * 1024,
       rowCount = Some(4),
       attributeStats = AttributeMap(
-        Seq(attrInt -> ColumnStat(min = Some(1), max = Some(4), nullCount = None))))
+        Seq(attrInt -> ColumnStat(
+          distinctCount = Some(2), min = Some(1), max = Some(4), nullCount = None))))
     assert(union.stats === expectedStats)
+  }
+
+  test("distinctCount propagated as max across children") {
+    val sz = Some(BigInt(1024))
+    val attrInt = AttributeReference("cint", IntegerType)()
+    val columnInfo = AttributeMap(Seq(
+      attrInt -> ColumnStat(distinctCount = Some(100), min = Some(1), max = Some(200),
+        nullCount = Some(0))))
+    val columnInfo1 = AttributeMap(Seq(
+      AttributeReference("cint1", IntegerType)() -> ColumnStat(
+        distinctCount = Some(200), min = Some(1), max = Some(300), nullCount = Some(0))))
+
+    val child1 = StatsTestPlan(
+      outputList = columnInfo.keys.toSeq, rowCount = 500,
+      attributeStats = columnInfo, size = sz)
+    val child2 = StatsTestPlan(
+      outputList = columnInfo1.keys.toSeq, rowCount = 500,
+      attributeStats = columnInfo1, size = sz)
+
+    val union = Union(Seq(child1, child2))
+    val unionStats = union.stats
+    val keyStat = unionStats.attributeStats(union.output.head)
+    assert(keyStat.distinctCount === Some(200),
+      "distinctCount should be max(100, 200) = 200")
+  }
+
+  test("distinctCount omitted when one child lacks it") {
+    val sz = Some(BigInt(1024))
+    val attrInt = AttributeReference("cint", IntegerType)()
+    val columnInfo = AttributeMap(Seq(
+      attrInt -> ColumnStat(distinctCount = Some(100), min = Some(1), max = Some(200),
+        nullCount = Some(0))))
+    // No distinctCount
+    val columnInfo1 = AttributeMap(Seq(
+      AttributeReference("cint1", IntegerType)() -> ColumnStat(
+        min = Some(1), max = Some(300), nullCount = Some(0))))
+
+    val child1 = StatsTestPlan(
+      outputList = columnInfo.keys.toSeq, rowCount = 500,
+      attributeStats = columnInfo, size = sz)
+    val child2 = StatsTestPlan(
+      outputList = columnInfo1.keys.toSeq, rowCount = 500,
+      attributeStats = columnInfo1, size = sz)
+
+    val union = Union(Seq(child1, child2))
+    val unionStats = union.stats
+    val keyStat = unionStats.attributeStats(union.output.head)
+    assert(keyStat.distinctCount.isEmpty,
+      "distinctCount should be None when one child lacks it")
+  }
+
+  test("distinctCount capped by rowCount") {
+    val sz = Some(BigInt(1024))
+    val attrInt = AttributeReference("cint", IntegerType)()
+    // distinctCount (500) > rowCount of union (6)
+    val columnInfo = AttributeMap(Seq(
+      attrInt -> ColumnStat(distinctCount = Some(500), min = Some(1), max = Some(1000),
+        nullCount = Some(0))))
+    val columnInfo1 = AttributeMap(Seq(
+      AttributeReference("cint1", IntegerType)() -> ColumnStat(
+        distinctCount = Some(300), min = Some(1), max = Some(1000), nullCount = Some(0))))
+
+    val child1 = StatsTestPlan(
+      outputList = columnInfo.keys.toSeq, rowCount = 3,
+      attributeStats = columnInfo, size = sz)
+    val child2 = StatsTestPlan(
+      outputList = columnInfo1.keys.toSeq, rowCount = 3,
+      attributeStats = columnInfo1, size = sz)
+
+    val union = Union(Seq(child1, child2))
+    val unionStats = union.stats
+    assert(unionStats.rowCount === Some(6))
+    val keyStat = unionStats.attributeStats(union.output.head)
+    assert(keyStat.distinctCount === Some(6),
+      "distinctCount should be capped at rowCount=6, not max(500,300)=500")
+  }
+
+  test("hasCountStats is true when both distinctCount and nullCount propagated") {
+    val sz = Some(BigInt(1024))
+    val attrInt = AttributeReference("cint", IntegerType)()
+    val columnInfo = AttributeMap(Seq(
+      attrInt -> ColumnStat(distinctCount = Some(10), min = Some(1), max = Some(20),
+        nullCount = Some(1))))
+    val columnInfo1 = AttributeMap(Seq(
+      AttributeReference("cint1", IntegerType)() -> ColumnStat(
+        distinctCount = Some(15), min = Some(1), max = Some(30), nullCount = Some(2))))
+
+    val child1 = StatsTestPlan(
+      outputList = columnInfo.keys.toSeq, rowCount = 100,
+      attributeStats = columnInfo, size = sz)
+    val child2 = StatsTestPlan(
+      outputList = columnInfo1.keys.toSeq, rowCount = 100,
+      attributeStats = columnInfo1, size = sz)
+
+    val union = Union(Seq(child1, child2))
+    val unionStats = union.stats
+    val keyStat = unionStats.attributeStats(union.output.head)
+    assert(keyStat.hasCountStats,
+      "hasCountStats should be true when both distinctCount and nullCount are defined")
+    assert(keyStat.distinctCount === Some(15))
+    assert(keyStat.nullCount === Some(3))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/UnionEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/UnionEstimationSuite.scala
@@ -264,7 +264,7 @@ class UnionEstimationSuite extends StatsEstimationTestBase {
     assert(union.stats === expectedStats)
   }
 
-  test("distinctCount propagated as max across children") {
+  test("SPARK-56047: distinctCount propagated as max across children") {
     val sz = Some(BigInt(1024))
     val attrInt = AttributeReference("cint", IntegerType)()
     val columnInfo = AttributeMap(Seq(
@@ -288,7 +288,7 @@ class UnionEstimationSuite extends StatsEstimationTestBase {
       "distinctCount should be max(100, 200) = 200")
   }
 
-  test("distinctCount omitted when one child lacks it") {
+  test("SPARK-56047: distinctCount omitted when one child lacks it") {
     val sz = Some(BigInt(1024))
     val attrInt = AttributeReference("cint", IntegerType)()
     val columnInfo = AttributeMap(Seq(
@@ -313,7 +313,7 @@ class UnionEstimationSuite extends StatsEstimationTestBase {
       "distinctCount should be None when one child lacks it")
   }
 
-  test("distinctCount capped by rowCount") {
+  test("SPARK-56047: distinctCount capped by rowCount") {
     val sz = Some(BigInt(1024))
     val attrInt = AttributeReference("cint", IntegerType)()
     // distinctCount (500) > rowCount of union (6)
@@ -339,7 +339,7 @@ class UnionEstimationSuite extends StatsEstimationTestBase {
       "distinctCount should be capped at rowCount=6, not max(500,300)=500")
   }
 
-  test("hasCountStats is true when both distinctCount and nullCount propagated") {
+  test("SPARK-56047: hasCountStats is true when both distinctCount and nullCount propagated") {
     val sz = Some(BigInt(1024))
     val attrInt = AttributeReference("cint", IntegerType)()
     val columnInfo = AttributeMap(Seq(

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5.sf100/explain.txt
@@ -10,8 +10,8 @@ TakeOrderedAndProject (77)
                :     +- * HashAggregate (19)
                :        +- * Project (18)
                :           +- * BroadcastHashJoin Inner BuildRight (17)
-               :              :- * Project (15)
-               :              :  +- * BroadcastHashJoin Inner BuildRight (14)
+               :              :- * Project (12)
+               :              :  +- * BroadcastHashJoin Inner BuildRight (11)
                :              :     :- Union (9)
                :              :     :  :- * Project (4)
                :              :     :  :  +- * Filter (3)
@@ -21,18 +21,18 @@ TakeOrderedAndProject (77)
                :              :     :     +- * Filter (7)
                :              :     :        +- * ColumnarToRow (6)
                :              :     :           +- Scan parquet spark_catalog.default.store_returns (5)
-               :              :     +- BroadcastExchange (13)
-               :              :        +- * Filter (12)
-               :              :           +- * ColumnarToRow (11)
-               :              :              +- Scan parquet spark_catalog.default.store (10)
-               :              +- ReusedExchange (16)
+               :              :     +- ReusedExchange (10)
+               :              +- BroadcastExchange (16)
+               :                 +- * Filter (15)
+               :                    +- * ColumnarToRow (14)
+               :                       +- Scan parquet spark_catalog.default.store (13)
                :- * HashAggregate (42)
                :  +- Exchange (41)
                :     +- * HashAggregate (40)
                :        +- * Project (39)
                :           +- * BroadcastHashJoin Inner BuildRight (38)
-               :              :- * Project (36)
-               :              :  +- * BroadcastHashJoin Inner BuildRight (35)
+               :              :- * Project (33)
+               :              :  +- * BroadcastHashJoin Inner BuildRight (32)
                :              :     :- Union (30)
                :              :     :  :- * Project (25)
                :              :     :  :  +- * Filter (24)
@@ -42,18 +42,18 @@ TakeOrderedAndProject (77)
                :              :     :     +- * Filter (28)
                :              :     :        +- * ColumnarToRow (27)
                :              :     :           +- Scan parquet spark_catalog.default.catalog_returns (26)
-               :              :     +- BroadcastExchange (34)
-               :              :        +- * Filter (33)
-               :              :           +- * ColumnarToRow (32)
-               :              :              +- Scan parquet spark_catalog.default.catalog_page (31)
-               :              +- ReusedExchange (37)
+               :              :     +- ReusedExchange (31)
+               :              +- BroadcastExchange (37)
+               :                 +- * Filter (36)
+               :                    +- * ColumnarToRow (35)
+               :                       +- Scan parquet spark_catalog.default.catalog_page (34)
                +- * HashAggregate (71)
                   +- Exchange (70)
                      +- * HashAggregate (69)
                         +- * Project (68)
                            +- * BroadcastHashJoin Inner BuildRight (67)
-                              :- * Project (65)
-                              :  +- * BroadcastHashJoin Inner BuildRight (64)
+                              :- * Project (62)
+                              :  +- * BroadcastHashJoin Inner BuildRight (61)
                               :     :- Union (59)
                               :     :  :- * Project (46)
                               :     :  :  +- * Filter (45)
@@ -71,11 +71,11 @@ TakeOrderedAndProject (77)
                               :     :                 +- * Filter (53)
                               :     :                    +- * ColumnarToRow (52)
                               :     :                       +- Scan parquet spark_catalog.default.web_sales (51)
-                              :     +- BroadcastExchange (63)
-                              :        +- * Filter (62)
-                              :           +- * ColumnarToRow (61)
-                              :              +- Scan parquet spark_catalog.default.web_site (60)
-                              +- ReusedExchange (66)
+                              :     +- ReusedExchange (60)
+                              +- BroadcastExchange (66)
+                                 +- * Filter (65)
+                                    +- * ColumnarToRow (64)
+                                       +- Scan parquet spark_catalog.default.web_site (63)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -118,64 +118,64 @@ Input [4]: [sr_store_sk#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_s
 
 (9) Union
 
-(10) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#22, s_store_id#23]
+(10) ReusedExchange [Reuses operator id: 82]
+Output [1]: [d_date_sk#22]
+
+(11) BroadcastHashJoin [codegen id : 5]
+Left keys [1]: [date_sk#7]
+Right keys [1]: [d_date_sk#22]
+Join type: Inner
+Join condition: None
+
+(12) Project [codegen id : 5]
+Output [5]: [store_sk#6, sales_price#8, profit#9, return_amt#10, net_loss#11]
+Input [7]: [store_sk#6, date_sk#7, sales_price#8, profit#9, return_amt#10, net_loss#11, d_date_sk#22]
+
+(13) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#23, s_store_id#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string>
 
-(11) ColumnarToRow [codegen id : 3]
-Input [2]: [s_store_sk#22, s_store_id#23]
+(14) ColumnarToRow [codegen id : 4]
+Input [2]: [s_store_sk#23, s_store_id#24]
 
-(12) Filter [codegen id : 3]
-Input [2]: [s_store_sk#22, s_store_id#23]
-Condition : isnotnull(s_store_sk#22)
+(15) Filter [codegen id : 4]
+Input [2]: [s_store_sk#23, s_store_id#24]
+Condition : isnotnull(s_store_sk#23)
 
-(13) BroadcastExchange
-Input [2]: [s_store_sk#22, s_store_id#23]
+(16) BroadcastExchange
+Input [2]: [s_store_sk#23, s_store_id#24]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
-(14) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [store_sk#6]
-Right keys [1]: [s_store_sk#22]
-Join type: Inner
-Join condition: None
-
-(15) Project [codegen id : 5]
-Output [6]: [date_sk#7, sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_id#23]
-Input [8]: [store_sk#6, date_sk#7, sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_sk#22, s_store_id#23]
-
-(16) ReusedExchange [Reuses operator id: 82]
-Output [1]: [d_date_sk#24]
-
 (17) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [date_sk#7]
-Right keys [1]: [d_date_sk#24]
+Left keys [1]: [store_sk#6]
+Right keys [1]: [s_store_sk#23]
 Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 5]
-Output [5]: [sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_id#23]
-Input [7]: [date_sk#7, sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_id#23, d_date_sk#24]
+Output [5]: [sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_id#24]
+Input [7]: [store_sk#6, sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_sk#23, s_store_id#24]
 
 (19) HashAggregate [codegen id : 5]
-Input [5]: [sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_id#23]
-Keys [1]: [s_store_id#23]
+Input [5]: [sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_id#24]
+Keys [1]: [s_store_id#24]
 Functions [4]: [partial_sum(UnscaledValue(sales_price#8)), partial_sum(UnscaledValue(return_amt#10)), partial_sum(UnscaledValue(profit#9)), partial_sum(UnscaledValue(net_loss#11))]
 Aggregate Attributes [4]: [sum#25, sum#26, sum#27, sum#28]
-Results [5]: [s_store_id#23, sum#29, sum#30, sum#31, sum#32]
+Results [5]: [s_store_id#24, sum#29, sum#30, sum#31, sum#32]
 
 (20) Exchange
-Input [5]: [s_store_id#23, sum#29, sum#30, sum#31, sum#32]
-Arguments: hashpartitioning(s_store_id#23, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [5]: [s_store_id#24, sum#29, sum#30, sum#31, sum#32]
+Arguments: hashpartitioning(s_store_id#24, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (21) HashAggregate [codegen id : 6]
-Input [5]: [s_store_id#23, sum#29, sum#30, sum#31, sum#32]
-Keys [1]: [s_store_id#23]
+Input [5]: [s_store_id#24, sum#29, sum#30, sum#31, sum#32]
+Keys [1]: [s_store_id#24]
 Functions [4]: [sum(UnscaledValue(sales_price#8)), sum(UnscaledValue(return_amt#10)), sum(UnscaledValue(profit#9)), sum(UnscaledValue(net_loss#11))]
 Aggregate Attributes [4]: [sum(UnscaledValue(sales_price#8))#33, sum(UnscaledValue(return_amt#10))#34, sum(UnscaledValue(profit#9))#35, sum(UnscaledValue(net_loss#11))#36]
-Results [5]: [MakeDecimal(sum(UnscaledValue(sales_price#8))#33,17,2) AS sales#37, MakeDecimal(sum(UnscaledValue(return_amt#10))#34,17,2) AS returns#38, (MakeDecimal(sum(UnscaledValue(profit#9))#35,17,2) - MakeDecimal(sum(UnscaledValue(net_loss#11))#36,17,2)) AS profit#39, store channel AS channel#40, concat(store, s_store_id#23) AS id#41]
+Results [5]: [MakeDecimal(sum(UnscaledValue(sales_price#8))#33,17,2) AS sales#37, MakeDecimal(sum(UnscaledValue(return_amt#10))#34,17,2) AS returns#38, (MakeDecimal(sum(UnscaledValue(profit#9))#35,17,2) - MakeDecimal(sum(UnscaledValue(net_loss#11))#36,17,2)) AS profit#39, store channel AS channel#40, concat(store, s_store_id#24) AS id#41]
 
 (22) Scan parquet spark_catalog.default.catalog_sales
 Output [4]: [cs_catalog_page_sk#42, cs_ext_sales_price#43, cs_net_profit#44, cs_sold_date_sk#45]
@@ -217,64 +217,64 @@ Input [4]: [cr_catalog_page_sk#52, cr_return_amount#53, cr_net_loss#54, cr_retur
 
 (30) Union
 
-(31) Scan parquet spark_catalog.default.catalog_page
-Output [2]: [cp_catalog_page_sk#62, cp_catalog_page_id#63]
+(31) ReusedExchange [Reuses operator id: 82]
+Output [1]: [d_date_sk#62]
+
+(32) BroadcastHashJoin [codegen id : 11]
+Left keys [1]: [date_sk#47]
+Right keys [1]: [d_date_sk#62]
+Join type: Inner
+Join condition: None
+
+(33) Project [codegen id : 11]
+Output [5]: [page_sk#46, sales_price#48, profit#49, return_amt#50, net_loss#51]
+Input [7]: [page_sk#46, date_sk#47, sales_price#48, profit#49, return_amt#50, net_loss#51, d_date_sk#62]
+
+(34) Scan parquet spark_catalog.default.catalog_page
+Output [2]: [cp_catalog_page_sk#63, cp_catalog_page_id#64]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_page]
 PushedFilters: [IsNotNull(cp_catalog_page_sk)]
 ReadSchema: struct<cp_catalog_page_sk:int,cp_catalog_page_id:string>
 
-(32) ColumnarToRow [codegen id : 9]
-Input [2]: [cp_catalog_page_sk#62, cp_catalog_page_id#63]
+(35) ColumnarToRow [codegen id : 10]
+Input [2]: [cp_catalog_page_sk#63, cp_catalog_page_id#64]
 
-(33) Filter [codegen id : 9]
-Input [2]: [cp_catalog_page_sk#62, cp_catalog_page_id#63]
-Condition : isnotnull(cp_catalog_page_sk#62)
+(36) Filter [codegen id : 10]
+Input [2]: [cp_catalog_page_sk#63, cp_catalog_page_id#64]
+Condition : isnotnull(cp_catalog_page_sk#63)
 
-(34) BroadcastExchange
-Input [2]: [cp_catalog_page_sk#62, cp_catalog_page_id#63]
+(37) BroadcastExchange
+Input [2]: [cp_catalog_page_sk#63, cp_catalog_page_id#64]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
 
-(35) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [page_sk#46]
-Right keys [1]: [cp_catalog_page_sk#62]
-Join type: Inner
-Join condition: None
-
-(36) Project [codegen id : 11]
-Output [6]: [date_sk#47, sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_id#63]
-Input [8]: [page_sk#46, date_sk#47, sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_sk#62, cp_catalog_page_id#63]
-
-(37) ReusedExchange [Reuses operator id: 82]
-Output [1]: [d_date_sk#64]
-
 (38) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [date_sk#47]
-Right keys [1]: [d_date_sk#64]
+Left keys [1]: [page_sk#46]
+Right keys [1]: [cp_catalog_page_sk#63]
 Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 11]
-Output [5]: [sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_id#63]
-Input [7]: [date_sk#47, sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_id#63, d_date_sk#64]
+Output [5]: [sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_id#64]
+Input [7]: [page_sk#46, sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_sk#63, cp_catalog_page_id#64]
 
 (40) HashAggregate [codegen id : 11]
-Input [5]: [sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_id#63]
-Keys [1]: [cp_catalog_page_id#63]
+Input [5]: [sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_id#64]
+Keys [1]: [cp_catalog_page_id#64]
 Functions [4]: [partial_sum(UnscaledValue(sales_price#48)), partial_sum(UnscaledValue(return_amt#50)), partial_sum(UnscaledValue(profit#49)), partial_sum(UnscaledValue(net_loss#51))]
 Aggregate Attributes [4]: [sum#65, sum#66, sum#67, sum#68]
-Results [5]: [cp_catalog_page_id#63, sum#69, sum#70, sum#71, sum#72]
+Results [5]: [cp_catalog_page_id#64, sum#69, sum#70, sum#71, sum#72]
 
 (41) Exchange
-Input [5]: [cp_catalog_page_id#63, sum#69, sum#70, sum#71, sum#72]
-Arguments: hashpartitioning(cp_catalog_page_id#63, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [5]: [cp_catalog_page_id#64, sum#69, sum#70, sum#71, sum#72]
+Arguments: hashpartitioning(cp_catalog_page_id#64, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (42) HashAggregate [codegen id : 12]
-Input [5]: [cp_catalog_page_id#63, sum#69, sum#70, sum#71, sum#72]
-Keys [1]: [cp_catalog_page_id#63]
+Input [5]: [cp_catalog_page_id#64, sum#69, sum#70, sum#71, sum#72]
+Keys [1]: [cp_catalog_page_id#64]
 Functions [4]: [sum(UnscaledValue(sales_price#48)), sum(UnscaledValue(return_amt#50)), sum(UnscaledValue(profit#49)), sum(UnscaledValue(net_loss#51))]
 Aggregate Attributes [4]: [sum(UnscaledValue(sales_price#48))#73, sum(UnscaledValue(return_amt#50))#74, sum(UnscaledValue(profit#49))#75, sum(UnscaledValue(net_loss#51))#76]
-Results [5]: [MakeDecimal(sum(UnscaledValue(sales_price#48))#73,17,2) AS sales#77, MakeDecimal(sum(UnscaledValue(return_amt#50))#74,17,2) AS returns#78, (MakeDecimal(sum(UnscaledValue(profit#49))#75,17,2) - MakeDecimal(sum(UnscaledValue(net_loss#51))#76,17,2)) AS profit#79, catalog channel AS channel#80, concat(catalog_page, cp_catalog_page_id#63) AS id#81]
+Results [5]: [MakeDecimal(sum(UnscaledValue(sales_price#48))#73,17,2) AS sales#77, MakeDecimal(sum(UnscaledValue(return_amt#50))#74,17,2) AS returns#78, (MakeDecimal(sum(UnscaledValue(profit#49))#75,17,2) - MakeDecimal(sum(UnscaledValue(net_loss#51))#76,17,2)) AS profit#79, catalog channel AS channel#80, concat(catalog_page, cp_catalog_page_id#64) AS id#81]
 
 (43) Scan parquet spark_catalog.default.web_sales
 Output [4]: [ws_web_site_sk#82, ws_ext_sales_price#83, ws_net_profit#84, ws_sold_date_sk#85]
@@ -351,64 +351,64 @@ Input [8]: [wr_item_sk#92, wr_order_number#93, wr_return_amt#94, wr_net_loss#95,
 
 (59) Union
 
-(60) Scan parquet spark_catalog.default.web_site
-Output [2]: [web_site_sk#107, web_site_id#108]
+(60) ReusedExchange [Reuses operator id: 82]
+Output [1]: [d_date_sk#107]
+
+(61) BroadcastHashJoin [codegen id : 21]
+Left keys [1]: [date_sk#87]
+Right keys [1]: [d_date_sk#107]
+Join type: Inner
+Join condition: None
+
+(62) Project [codegen id : 21]
+Output [5]: [wsr_web_site_sk#86, sales_price#88, profit#89, return_amt#90, net_loss#91]
+Input [7]: [wsr_web_site_sk#86, date_sk#87, sales_price#88, profit#89, return_amt#90, net_loss#91, d_date_sk#107]
+
+(63) Scan parquet spark_catalog.default.web_site
+Output [2]: [web_site_sk#108, web_site_id#109]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_site]
 PushedFilters: [IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_site_id:string>
 
-(61) ColumnarToRow [codegen id : 19]
-Input [2]: [web_site_sk#107, web_site_id#108]
+(64) ColumnarToRow [codegen id : 20]
+Input [2]: [web_site_sk#108, web_site_id#109]
 
-(62) Filter [codegen id : 19]
-Input [2]: [web_site_sk#107, web_site_id#108]
-Condition : isnotnull(web_site_sk#107)
+(65) Filter [codegen id : 20]
+Input [2]: [web_site_sk#108, web_site_id#109]
+Condition : isnotnull(web_site_sk#108)
 
-(63) BroadcastExchange
-Input [2]: [web_site_sk#107, web_site_id#108]
+(66) BroadcastExchange
+Input [2]: [web_site_sk#108, web_site_id#109]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
-(64) BroadcastHashJoin [codegen id : 21]
-Left keys [1]: [wsr_web_site_sk#86]
-Right keys [1]: [web_site_sk#107]
-Join type: Inner
-Join condition: None
-
-(65) Project [codegen id : 21]
-Output [6]: [date_sk#87, sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_id#108]
-Input [8]: [wsr_web_site_sk#86, date_sk#87, sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_sk#107, web_site_id#108]
-
-(66) ReusedExchange [Reuses operator id: 82]
-Output [1]: [d_date_sk#109]
-
 (67) BroadcastHashJoin [codegen id : 21]
-Left keys [1]: [date_sk#87]
-Right keys [1]: [d_date_sk#109]
+Left keys [1]: [wsr_web_site_sk#86]
+Right keys [1]: [web_site_sk#108]
 Join type: Inner
 Join condition: None
 
 (68) Project [codegen id : 21]
-Output [5]: [sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_id#108]
-Input [7]: [date_sk#87, sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_id#108, d_date_sk#109]
+Output [5]: [sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_id#109]
+Input [7]: [wsr_web_site_sk#86, sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_sk#108, web_site_id#109]
 
 (69) HashAggregate [codegen id : 21]
-Input [5]: [sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_id#108]
-Keys [1]: [web_site_id#108]
+Input [5]: [sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_id#109]
+Keys [1]: [web_site_id#109]
 Functions [4]: [partial_sum(UnscaledValue(sales_price#88)), partial_sum(UnscaledValue(return_amt#90)), partial_sum(UnscaledValue(profit#89)), partial_sum(UnscaledValue(net_loss#91))]
 Aggregate Attributes [4]: [sum#110, sum#111, sum#112, sum#113]
-Results [5]: [web_site_id#108, sum#114, sum#115, sum#116, sum#117]
+Results [5]: [web_site_id#109, sum#114, sum#115, sum#116, sum#117]
 
 (70) Exchange
-Input [5]: [web_site_id#108, sum#114, sum#115, sum#116, sum#117]
-Arguments: hashpartitioning(web_site_id#108, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [5]: [web_site_id#109, sum#114, sum#115, sum#116, sum#117]
+Arguments: hashpartitioning(web_site_id#109, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (71) HashAggregate [codegen id : 22]
-Input [5]: [web_site_id#108, sum#114, sum#115, sum#116, sum#117]
-Keys [1]: [web_site_id#108]
+Input [5]: [web_site_id#109, sum#114, sum#115, sum#116, sum#117]
+Keys [1]: [web_site_id#109]
 Functions [4]: [sum(UnscaledValue(sales_price#88)), sum(UnscaledValue(return_amt#90)), sum(UnscaledValue(profit#89)), sum(UnscaledValue(net_loss#91))]
 Aggregate Attributes [4]: [sum(UnscaledValue(sales_price#88))#118, sum(UnscaledValue(return_amt#90))#119, sum(UnscaledValue(profit#89))#120, sum(UnscaledValue(net_loss#91))#121]
-Results [5]: [MakeDecimal(sum(UnscaledValue(sales_price#88))#118,17,2) AS sales#122, MakeDecimal(sum(UnscaledValue(return_amt#90))#119,17,2) AS returns#123, (MakeDecimal(sum(UnscaledValue(profit#89))#120,17,2) - MakeDecimal(sum(UnscaledValue(net_loss#91))#121,17,2)) AS profit#124, web channel AS channel#125, concat(web_site, web_site_id#108) AS id#126]
+Results [5]: [MakeDecimal(sum(UnscaledValue(sales_price#88))#118,17,2) AS sales#122, MakeDecimal(sum(UnscaledValue(return_amt#90))#119,17,2) AS returns#123, (MakeDecimal(sum(UnscaledValue(profit#89))#120,17,2) - MakeDecimal(sum(UnscaledValue(net_loss#91))#121,17,2)) AS profit#124, web channel AS channel#125, concat(web_site, web_site_id#109) AS id#126]
 
 (72) Union
 
@@ -449,25 +449,25 @@ BroadcastExchange (82)
 
 
 (78) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#24, d_date#148]
+Output [2]: [d_date_sk#22, d_date#148]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-08-23), LessThanOrEqual(d_date,2000-09-06), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (79) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#24, d_date#148]
+Input [2]: [d_date_sk#22, d_date#148]
 
 (80) Filter [codegen id : 1]
-Input [2]: [d_date_sk#24, d_date#148]
-Condition : (((isnotnull(d_date#148) AND (d_date#148 >= 2000-08-23)) AND (d_date#148 <= 2000-09-06)) AND isnotnull(d_date_sk#24))
+Input [2]: [d_date_sk#22, d_date#148]
+Condition : (((isnotnull(d_date#148) AND (d_date#148 >= 2000-08-23)) AND (d_date#148 <= 2000-09-06)) AND isnotnull(d_date_sk#22))
 
 (81) Project [codegen id : 1]
-Output [1]: [d_date_sk#24]
-Input [2]: [d_date_sk#24, d_date#148]
+Output [1]: [d_date_sk#22]
+Input [2]: [d_date_sk#22, d_date#148]
 
 (82) BroadcastExchange
-Input [1]: [d_date_sk#24]
+Input [1]: [d_date_sk#22]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
 Subquery:2 Hosting operator id = 5 Hosting Expression = sr_returned_date_sk#15 IN dynamicpruning#5

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5.sf100/simplified.txt
@@ -15,9 +15,9 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                             WholeStageCodegen (5)
                               HashAggregate [s_store_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
                                 Project [sales_price,profit,return_amt,net_loss,s_store_id]
-                                  BroadcastHashJoin [date_sk,d_date_sk]
-                                    Project [date_sk,sales_price,profit,return_amt,net_loss,s_store_id]
-                                      BroadcastHashJoin [store_sk,s_store_sk]
+                                  BroadcastHashJoin [store_sk,s_store_sk]
+                                    Project [store_sk,sales_price,profit,return_amt,net_loss]
+                                      BroadcastHashJoin [date_sk,d_date_sk]
                                         InputAdapter
                                           Union
                                             WholeStageCodegen (1)
@@ -42,14 +42,14 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                       Scan parquet spark_catalog.default.store_returns [sr_store_sk,sr_return_amt,sr_net_loss,sr_returned_date_sk]
                                                         ReusedSubquery [d_date_sk] #1
                                         InputAdapter
-                                          BroadcastExchange #4
-                                            WholeStageCodegen (3)
-                                              Filter [s_store_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
+                                          ReusedExchange [d_date_sk] #3
                                     InputAdapter
-                                      ReusedExchange [d_date_sk] #3
+                                      BroadcastExchange #4
+                                        WholeStageCodegen (4)
+                                          Filter [s_store_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
                     WholeStageCodegen (12)
                       HashAggregate [cp_catalog_page_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),sales,returns,profit,channel,id,sum,sum,sum,sum]
                         InputAdapter
@@ -57,9 +57,9 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                             WholeStageCodegen (11)
                               HashAggregate [cp_catalog_page_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
                                 Project [sales_price,profit,return_amt,net_loss,cp_catalog_page_id]
-                                  BroadcastHashJoin [date_sk,d_date_sk]
-                                    Project [date_sk,sales_price,profit,return_amt,net_loss,cp_catalog_page_id]
-                                      BroadcastHashJoin [page_sk,cp_catalog_page_sk]
+                                  BroadcastHashJoin [page_sk,cp_catalog_page_sk]
+                                    Project [page_sk,sales_price,profit,return_amt,net_loss]
+                                      BroadcastHashJoin [date_sk,d_date_sk]
                                         InputAdapter
                                           Union
                                             WholeStageCodegen (7)
@@ -77,14 +77,14 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                       Scan parquet spark_catalog.default.catalog_returns [cr_catalog_page_sk,cr_return_amount,cr_net_loss,cr_returned_date_sk]
                                                         ReusedSubquery [d_date_sk] #1
                                         InputAdapter
-                                          BroadcastExchange #6
-                                            WholeStageCodegen (9)
-                                              Filter [cp_catalog_page_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.catalog_page [cp_catalog_page_sk,cp_catalog_page_id]
+                                          ReusedExchange [d_date_sk] #3
                                     InputAdapter
-                                      ReusedExchange [d_date_sk] #3
+                                      BroadcastExchange #6
+                                        WholeStageCodegen (10)
+                                          Filter [cp_catalog_page_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.catalog_page [cp_catalog_page_sk,cp_catalog_page_id]
                     WholeStageCodegen (22)
                       HashAggregate [web_site_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),sales,returns,profit,channel,id,sum,sum,sum,sum]
                         InputAdapter
@@ -92,9 +92,9 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                             WholeStageCodegen (21)
                               HashAggregate [web_site_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
                                 Project [sales_price,profit,return_amt,net_loss,web_site_id]
-                                  BroadcastHashJoin [date_sk,d_date_sk]
-                                    Project [date_sk,sales_price,profit,return_amt,net_loss,web_site_id]
-                                      BroadcastHashJoin [wsr_web_site_sk,web_site_sk]
+                                  BroadcastHashJoin [wsr_web_site_sk,web_site_sk]
+                                    Project [wsr_web_site_sk,sales_price,profit,return_amt,net_loss]
+                                      BroadcastHashJoin [date_sk,d_date_sk]
                                         InputAdapter
                                           Union
                                             WholeStageCodegen (13)
@@ -129,11 +129,11 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_web_site_sk,ws_order_number,ws_sold_date_sk]
                                         InputAdapter
-                                          BroadcastExchange #10
-                                            WholeStageCodegen (19)
-                                              Filter [web_site_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.web_site [web_site_sk,web_site_id]
+                                          ReusedExchange [d_date_sk] #3
                                     InputAdapter
-                                      ReusedExchange [d_date_sk] #3
+                                      BroadcastExchange #10
+                                        WholeStageCodegen (20)
+                                          Filter [web_site_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.web_site [web_site_sk,web_site_id]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/explain.txt
@@ -1,63 +1,60 @@
 == Physical Plan ==
-TakeOrderedAndProject (59)
-+- * HashAggregate (58)
-   +- Exchange (57)
-      +- * HashAggregate (56)
-         +- * HashAggregate (55)
-            +- * HashAggregate (54)
-               +- * Project (53)
-                  +- * SortMergeJoin Inner (52)
-                     :- * Sort (43)
-                     :  +- * Project (42)
-                     :     +- * BroadcastHashJoin Inner BuildLeft (41)
-                     :        :- BroadcastExchange (10)
-                     :        :  +- * Project (9)
-                     :        :     +- * BroadcastHashJoin Inner BuildRight (8)
-                     :        :        :- * Filter (3)
-                     :        :        :  +- * ColumnarToRow (2)
-                     :        :        :     +- Scan parquet spark_catalog.default.customer_address (1)
-                     :        :        +- BroadcastExchange (7)
-                     :        :           +- * Filter (6)
-                     :        :              +- * ColumnarToRow (5)
-                     :        :                 +- Scan parquet spark_catalog.default.store (4)
-                     :        +- * HashAggregate (40)
-                     :           +- * HashAggregate (39)
-                     :              +- * Project (38)
-                     :                 +- * SortMergeJoin Inner (37)
-                     :                    :- * Sort (31)
-                     :                    :  +- Exchange (30)
-                     :                    :     +- * Project (29)
-                     :                    :        +- * BroadcastHashJoin Inner BuildRight (28)
-                     :                    :           :- * Project (22)
-                     :                    :           :  +- * BroadcastHashJoin Inner BuildRight (21)
-                     :                    :           :     :- Union (19)
-                     :                    :           :     :  :- * Project (14)
-                     :                    :           :     :  :  +- * Filter (13)
-                     :                    :           :     :  :     +- * ColumnarToRow (12)
-                     :                    :           :     :  :        +- Scan parquet spark_catalog.default.catalog_sales (11)
-                     :                    :           :     :  +- * Project (18)
-                     :                    :           :     :     +- * Filter (17)
-                     :                    :           :     :        +- * ColumnarToRow (16)
-                     :                    :           :     :           +- Scan parquet spark_catalog.default.web_sales (15)
-                     :                    :           :     +- ReusedExchange (20)
-                     :                    :           +- BroadcastExchange (27)
-                     :                    :              +- * Project (26)
-                     :                    :                 +- * Filter (25)
-                     :                    :                    +- * ColumnarToRow (24)
-                     :                    :                       +- Scan parquet spark_catalog.default.item (23)
-                     :                    +- * Sort (36)
-                     :                       +- Exchange (35)
-                     :                          +- * Filter (34)
-                     :                             +- * ColumnarToRow (33)
-                     :                                +- Scan parquet spark_catalog.default.customer (32)
-                     +- * Sort (51)
-                        +- Exchange (50)
-                           +- * Project (49)
-                              +- * BroadcastHashJoin Inner BuildRight (48)
-                                 :- * Filter (46)
-                                 :  +- * ColumnarToRow (45)
-                                 :     +- Scan parquet spark_catalog.default.store_sales (44)
-                                 +- ReusedExchange (47)
+TakeOrderedAndProject (56)
++- * HashAggregate (55)
+   +- Exchange (54)
+      +- * HashAggregate (53)
+         +- * HashAggregate (52)
+            +- Exchange (51)
+               +- * HashAggregate (50)
+                  +- * Project (49)
+                     +- * BroadcastHashJoin Inner BuildRight (48)
+                        :- * Project (46)
+                        :  +- * BroadcastHashJoin Inner BuildLeft (45)
+                        :     :- BroadcastExchange (41)
+                        :     :  +- * Project (40)
+                        :     :     +- * BroadcastHashJoin Inner BuildLeft (39)
+                        :     :        :- BroadcastExchange (10)
+                        :     :        :  +- * Project (9)
+                        :     :        :     +- * BroadcastHashJoin Inner BuildRight (8)
+                        :     :        :        :- * Filter (3)
+                        :     :        :        :  +- * ColumnarToRow (2)
+                        :     :        :        :     +- Scan parquet spark_catalog.default.customer_address (1)
+                        :     :        :        +- BroadcastExchange (7)
+                        :     :        :           +- * Filter (6)
+                        :     :        :              +- * ColumnarToRow (5)
+                        :     :        :                 +- Scan parquet spark_catalog.default.store (4)
+                        :     :        +- * HashAggregate (38)
+                        :     :           +- Exchange (37)
+                        :     :              +- * HashAggregate (36)
+                        :     :                 +- * Project (35)
+                        :     :                    +- * BroadcastHashJoin Inner BuildLeft (34)
+                        :     :                       :- BroadcastExchange (30)
+                        :     :                       :  +- * Project (29)
+                        :     :                       :     +- * BroadcastHashJoin Inner BuildRight (28)
+                        :     :                       :        :- * Project (26)
+                        :     :                       :        :  +- * BroadcastHashJoin Inner BuildRight (25)
+                        :     :                       :        :     :- Union (19)
+                        :     :                       :        :     :  :- * Project (14)
+                        :     :                       :        :     :  :  +- * Filter (13)
+                        :     :                       :        :     :  :     +- * ColumnarToRow (12)
+                        :     :                       :        :     :  :        +- Scan parquet spark_catalog.default.catalog_sales (11)
+                        :     :                       :        :     :  +- * Project (18)
+                        :     :                       :        :     :     +- * Filter (17)
+                        :     :                       :        :     :        +- * ColumnarToRow (16)
+                        :     :                       :        :     :           +- Scan parquet spark_catalog.default.web_sales (15)
+                        :     :                       :        :     +- BroadcastExchange (24)
+                        :     :                       :        :        +- * Project (23)
+                        :     :                       :        :           +- * Filter (22)
+                        :     :                       :        :              +- * ColumnarToRow (21)
+                        :     :                       :        :                 +- Scan parquet spark_catalog.default.item (20)
+                        :     :                       :        +- ReusedExchange (27)
+                        :     :                       +- * Filter (33)
+                        :     :                          +- * ColumnarToRow (32)
+                        :     :                             +- Scan parquet spark_catalog.default.customer (31)
+                        :     +- * Filter (44)
+                        :        +- * ColumnarToRow (43)
+                        :           +- Scan parquet spark_catalog.default.store_sales (42)
+                        +- ReusedExchange (47)
 
 
 (1) Scan parquet spark_catalog.default.customer_address
@@ -146,120 +143,112 @@ Input [3]: [ws_item_sk#13, ws_bill_customer_sk#14, ws_sold_date_sk#15]
 
 (19) Union
 
-(20) ReusedExchange [Reuses operator id: 64]
-Output [1]: [d_date_sk#19]
-
-(21) BroadcastHashJoin [codegen id : 7]
-Left keys [1]: [sold_date_sk#10]
-Right keys [1]: [d_date_sk#19]
-Join type: Inner
-Join condition: None
-
-(22) Project [codegen id : 7]
-Output [2]: [customer_sk#11, item_sk#12]
-Input [4]: [sold_date_sk#10, customer_sk#11, item_sk#12, d_date_sk#19]
-
-(23) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#20, i_class#21, i_category#22]
+(20) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#19, i_class#20, i_category#21]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_category), IsNotNull(i_class), EqualTo(i_category,Women                                             ), EqualTo(i_class,maternity                                         ), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_class:string,i_category:string>
 
-(24) ColumnarToRow [codegen id : 6]
-Input [3]: [i_item_sk#20, i_class#21, i_category#22]
+(21) ColumnarToRow [codegen id : 5]
+Input [3]: [i_item_sk#19, i_class#20, i_category#21]
 
-(25) Filter [codegen id : 6]
-Input [3]: [i_item_sk#20, i_class#21, i_category#22]
-Condition : ((((isnotnull(i_category#22) AND isnotnull(i_class#21)) AND (i_category#22 = Women                                             )) AND (i_class#21 = maternity                                         )) AND isnotnull(i_item_sk#20))
+(22) Filter [codegen id : 5]
+Input [3]: [i_item_sk#19, i_class#20, i_category#21]
+Condition : ((((isnotnull(i_category#21) AND isnotnull(i_class#20)) AND (i_category#21 = Women                                             )) AND (i_class#20 = maternity                                         )) AND isnotnull(i_item_sk#19))
 
-(26) Project [codegen id : 6]
-Output [1]: [i_item_sk#20]
-Input [3]: [i_item_sk#20, i_class#21, i_category#22]
+(23) Project [codegen id : 5]
+Output [1]: [i_item_sk#19]
+Input [3]: [i_item_sk#19, i_class#20, i_category#21]
 
-(27) BroadcastExchange
-Input [1]: [i_item_sk#20]
+(24) BroadcastExchange
+Input [1]: [i_item_sk#19]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
 
-(28) BroadcastHashJoin [codegen id : 7]
+(25) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [item_sk#12]
-Right keys [1]: [i_item_sk#20]
+Right keys [1]: [i_item_sk#19]
+Join type: Inner
+Join condition: None
+
+(26) Project [codegen id : 7]
+Output [2]: [sold_date_sk#10, customer_sk#11]
+Input [4]: [sold_date_sk#10, customer_sk#11, item_sk#12, i_item_sk#19]
+
+(27) ReusedExchange [Reuses operator id: 61]
+Output [1]: [d_date_sk#22]
+
+(28) BroadcastHashJoin [codegen id : 7]
+Left keys [1]: [sold_date_sk#10]
+Right keys [1]: [d_date_sk#22]
 Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 7]
 Output [1]: [customer_sk#11]
-Input [3]: [customer_sk#11, item_sk#12, i_item_sk#20]
+Input [3]: [sold_date_sk#10, customer_sk#11, d_date_sk#22]
 
-(30) Exchange
+(30) BroadcastExchange
 Input [1]: [customer_sk#11]
-Arguments: hashpartitioning(customer_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
-(31) Sort [codegen id : 8]
-Input [1]: [customer_sk#11]
-Arguments: [customer_sk#11 ASC NULLS FIRST], false, 0
-
-(32) Scan parquet spark_catalog.default.customer
+(31) Scan parquet spark_catalog.default.customer
 Output [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
 
-(33) ColumnarToRow [codegen id : 9]
+(32) ColumnarToRow
 Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
 
-(34) Filter [codegen id : 9]
+(33) Filter
 Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Condition : (isnotnull(c_customer_sk#23) AND isnotnull(c_current_addr_sk#24))
 
-(35) Exchange
-Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
-Arguments: hashpartitioning(c_customer_sk#23, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(36) Sort [codegen id : 10]
-Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
-Arguments: [c_customer_sk#23 ASC NULLS FIRST], false, 0
-
-(37) SortMergeJoin
+(34) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [customer_sk#11]
 Right keys [1]: [c_customer_sk#23]
 Join type: Inner
 Join condition: None
 
-(38) Project
+(35) Project [codegen id : 8]
 Output [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Input [3]: [customer_sk#11, c_customer_sk#23, c_current_addr_sk#24]
 
-(39) HashAggregate
+(36) HashAggregate [codegen id : 8]
 Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Keys [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Functions: []
 Aggregate Attributes: []
 Results [2]: [c_customer_sk#23, c_current_addr_sk#24]
 
-(40) HashAggregate
+(37) Exchange
+Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
+Arguments: hashpartitioning(c_customer_sk#23, c_current_addr_sk#24, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(38) HashAggregate
 Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Keys [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Functions: []
 Aggregate Attributes: []
 Results [2]: [c_customer_sk#23, c_current_addr_sk#24]
 
-(41) BroadcastHashJoin [codegen id : 11]
+(39) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ca_address_sk#1]
 Right keys [1]: [c_current_addr_sk#24]
 Join type: Inner
 Join condition: None
 
-(42) Project [codegen id : 11]
+(40) Project [codegen id : 9]
 Output [1]: [c_customer_sk#23]
 Input [3]: [ca_address_sk#1, c_customer_sk#23, c_current_addr_sk#24]
 
-(43) Sort [codegen id : 11]
+(41) BroadcastExchange
 Input [1]: [c_customer_sk#23]
-Arguments: [c_customer_sk#23 ASC NULLS FIRST], false, 0
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
-(44) Scan parquet spark_catalog.default.store_sales
+(42) Scan parquet spark_catalog.default.store_sales
 Output [3]: [ss_customer_sk#25, ss_ext_sales_price#26, ss_sold_date_sk#27]
 Batched: true
 Location: InMemoryFileIndex []
@@ -267,234 +256,230 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#27), dynamicpruningexpression(ss_so
 PushedFilters: [IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_customer_sk:int,ss_ext_sales_price:decimal(7,2)>
 
-(45) ColumnarToRow [codegen id : 13]
+(43) ColumnarToRow
 Input [3]: [ss_customer_sk#25, ss_ext_sales_price#26, ss_sold_date_sk#27]
 
-(46) Filter [codegen id : 13]
+(44) Filter
 Input [3]: [ss_customer_sk#25, ss_ext_sales_price#26, ss_sold_date_sk#27]
 Condition : isnotnull(ss_customer_sk#25)
 
-(47) ReusedExchange [Reuses operator id: 69]
-Output [1]: [d_date_sk#29]
-
-(48) BroadcastHashJoin [codegen id : 13]
-Left keys [1]: [ss_sold_date_sk#27]
-Right keys [1]: [d_date_sk#29]
-Join type: Inner
-Join condition: None
-
-(49) Project [codegen id : 13]
-Output [2]: [ss_customer_sk#25, ss_ext_sales_price#26]
-Input [4]: [ss_customer_sk#25, ss_ext_sales_price#26, ss_sold_date_sk#27, d_date_sk#29]
-
-(50) Exchange
-Input [2]: [ss_customer_sk#25, ss_ext_sales_price#26]
-Arguments: hashpartitioning(ss_customer_sk#25, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(51) Sort [codegen id : 14]
-Input [2]: [ss_customer_sk#25, ss_ext_sales_price#26]
-Arguments: [ss_customer_sk#25 ASC NULLS FIRST], false, 0
-
-(52) SortMergeJoin [codegen id : 15]
+(45) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [c_customer_sk#23]
 Right keys [1]: [ss_customer_sk#25]
 Join type: Inner
 Join condition: None
 
-(53) Project [codegen id : 15]
-Output [2]: [c_customer_sk#23, ss_ext_sales_price#26]
-Input [3]: [c_customer_sk#23, ss_customer_sk#25, ss_ext_sales_price#26]
+(46) Project [codegen id : 11]
+Output [3]: [c_customer_sk#23, ss_ext_sales_price#26, ss_sold_date_sk#27]
+Input [4]: [c_customer_sk#23, ss_customer_sk#25, ss_ext_sales_price#26, ss_sold_date_sk#27]
 
-(54) HashAggregate [codegen id : 15]
+(47) ReusedExchange [Reuses operator id: 66]
+Output [1]: [d_date_sk#29]
+
+(48) BroadcastHashJoin [codegen id : 11]
+Left keys [1]: [ss_sold_date_sk#27]
+Right keys [1]: [d_date_sk#29]
+Join type: Inner
+Join condition: None
+
+(49) Project [codegen id : 11]
+Output [2]: [c_customer_sk#23, ss_ext_sales_price#26]
+Input [4]: [c_customer_sk#23, ss_ext_sales_price#26, ss_sold_date_sk#27, d_date_sk#29]
+
+(50) HashAggregate [codegen id : 11]
 Input [2]: [c_customer_sk#23, ss_ext_sales_price#26]
 Keys [1]: [c_customer_sk#23]
 Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#26))]
 Aggregate Attributes [1]: [sum#30]
 Results [2]: [c_customer_sk#23, sum#31]
 
-(55) HashAggregate [codegen id : 15]
+(51) Exchange
+Input [2]: [c_customer_sk#23, sum#31]
+Arguments: hashpartitioning(c_customer_sk#23, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(52) HashAggregate [codegen id : 12]
 Input [2]: [c_customer_sk#23, sum#31]
 Keys [1]: [c_customer_sk#23]
 Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#26))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#26))#32]
 Results [1]: [cast((MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#26))#32,17,2) / 50) as int) AS segment#33]
 
-(56) HashAggregate [codegen id : 15]
+(53) HashAggregate [codegen id : 12]
 Input [1]: [segment#33]
 Keys [1]: [segment#33]
 Functions [1]: [partial_count(1)]
 Aggregate Attributes [1]: [count#34]
 Results [2]: [segment#33, count#35]
 
-(57) Exchange
+(54) Exchange
 Input [2]: [segment#33, count#35]
-Arguments: hashpartitioning(segment#33, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Arguments: hashpartitioning(segment#33, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(58) HashAggregate [codegen id : 16]
+(55) HashAggregate [codegen id : 13]
 Input [2]: [segment#33, count#35]
 Keys [1]: [segment#33]
 Functions [1]: [count(1)]
 Aggregate Attributes [1]: [count(1)#36]
 Results [3]: [segment#33, count(1)#36 AS num_customers#37, (segment#33 * 50) AS segment_base#38]
 
-(59) TakeOrderedAndProject
+(56) TakeOrderedAndProject
 Input [3]: [segment#33, num_customers#37, segment_base#38]
 Arguments: 100, [segment#33 ASC NULLS FIRST, num_customers#37 ASC NULLS FIRST], [segment#33, num_customers#37, segment_base#38]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 11 Hosting Expression = cs_sold_date_sk#8 IN dynamicpruning#9
-BroadcastExchange (64)
-+- * Project (63)
-   +- * Filter (62)
-      +- * ColumnarToRow (61)
-         +- Scan parquet spark_catalog.default.date_dim (60)
+BroadcastExchange (61)
++- * Project (60)
+   +- * Filter (59)
+      +- * ColumnarToRow (58)
+         +- Scan parquet spark_catalog.default.date_dim (57)
 
 
-(60) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#19, d_year#39, d_moy#40]
+(57) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#22, d_year#39, d_moy#40]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), EqualTo(d_moy,12), EqualTo(d_year,1998), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(61) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#19, d_year#39, d_moy#40]
+(58) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#22, d_year#39, d_moy#40]
 
-(62) Filter [codegen id : 1]
-Input [3]: [d_date_sk#19, d_year#39, d_moy#40]
-Condition : ((((isnotnull(d_moy#40) AND isnotnull(d_year#39)) AND (d_moy#40 = 12)) AND (d_year#39 = 1998)) AND isnotnull(d_date_sk#19))
+(59) Filter [codegen id : 1]
+Input [3]: [d_date_sk#22, d_year#39, d_moy#40]
+Condition : ((((isnotnull(d_moy#40) AND isnotnull(d_year#39)) AND (d_moy#40 = 12)) AND (d_year#39 = 1998)) AND isnotnull(d_date_sk#22))
 
-(63) Project [codegen id : 1]
-Output [1]: [d_date_sk#19]
-Input [3]: [d_date_sk#19, d_year#39, d_moy#40]
+(60) Project [codegen id : 1]
+Output [1]: [d_date_sk#22]
+Input [3]: [d_date_sk#22, d_year#39, d_moy#40]
 
-(64) BroadcastExchange
-Input [1]: [d_date_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+(61) BroadcastExchange
+Input [1]: [d_date_sk#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
 Subquery:2 Hosting operator id = 15 Hosting Expression = ws_sold_date_sk#15 IN dynamicpruning#9
 
-Subquery:3 Hosting operator id = 44 Hosting Expression = ss_sold_date_sk#27 IN dynamicpruning#28
-BroadcastExchange (69)
-+- * Project (68)
-   +- * Filter (67)
-      +- * ColumnarToRow (66)
-         +- Scan parquet spark_catalog.default.date_dim (65)
+Subquery:3 Hosting operator id = 42 Hosting Expression = ss_sold_date_sk#27 IN dynamicpruning#28
+BroadcastExchange (66)
++- * Project (65)
+   +- * Filter (64)
+      +- * ColumnarToRow (63)
+         +- Scan parquet spark_catalog.default.date_dim (62)
 
 
-(65) Scan parquet spark_catalog.default.date_dim
+(62) Scan parquet spark_catalog.default.date_dim
 Output [2]: [d_date_sk#29, d_month_seq#41]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,ScalarSubquery#42), LessThanOrEqual(d_month_seq,ScalarSubquery#43), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int>
 
-(66) ColumnarToRow [codegen id : 1]
+(63) ColumnarToRow [codegen id : 1]
 Input [2]: [d_date_sk#29, d_month_seq#41]
 
-(67) Filter [codegen id : 1]
+(64) Filter [codegen id : 1]
 Input [2]: [d_date_sk#29, d_month_seq#41]
-Condition : (((isnotnull(d_month_seq#41) AND (d_month_seq#41 >= ReusedSubquery Subquery scalar-subquery#42, [id=#9])) AND (d_month_seq#41 <= ReusedSubquery Subquery scalar-subquery#43, [id=#10])) AND isnotnull(d_date_sk#29))
+Condition : (((isnotnull(d_month_seq#41) AND (d_month_seq#41 >= ReusedSubquery Subquery scalar-subquery#42, [id=#10])) AND (d_month_seq#41 <= ReusedSubquery Subquery scalar-subquery#43, [id=#11])) AND isnotnull(d_date_sk#29))
 
-(68) Project [codegen id : 1]
+(65) Project [codegen id : 1]
 Output [1]: [d_date_sk#29]
 Input [2]: [d_date_sk#29, d_month_seq#41]
 
-(69) BroadcastExchange
+(66) BroadcastExchange
 Input [1]: [d_date_sk#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=12]
 
-Subquery:4 Hosting operator id = 67 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#9]
+Subquery:4 Hosting operator id = 64 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#10]
 
-Subquery:5 Hosting operator id = 67 Hosting Expression = ReusedSubquery Subquery scalar-subquery#43, [id=#10]
+Subquery:5 Hosting operator id = 64 Hosting Expression = ReusedSubquery Subquery scalar-subquery#43, [id=#11]
 
-Subquery:6 Hosting operator id = 65 Hosting Expression = Subquery scalar-subquery#42, [id=#9]
-* HashAggregate (76)
-+- Exchange (75)
-   +- * HashAggregate (74)
-      +- * Project (73)
-         +- * Filter (72)
-            +- * ColumnarToRow (71)
-               +- Scan parquet spark_catalog.default.date_dim (70)
+Subquery:6 Hosting operator id = 62 Hosting Expression = Subquery scalar-subquery#42, [id=#10]
+* HashAggregate (73)
++- Exchange (72)
+   +- * HashAggregate (71)
+      +- * Project (70)
+         +- * Filter (69)
+            +- * ColumnarToRow (68)
+               +- Scan parquet spark_catalog.default.date_dim (67)
 
 
-(70) Scan parquet spark_catalog.default.date_dim
+(67) Scan parquet spark_catalog.default.date_dim
 Output [3]: [d_month_seq#44, d_year#45, d_moy#46]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,1998), EqualTo(d_moy,12)]
 ReadSchema: struct<d_month_seq:int,d_year:int,d_moy:int>
 
-(71) ColumnarToRow [codegen id : 1]
+(68) ColumnarToRow [codegen id : 1]
 Input [3]: [d_month_seq#44, d_year#45, d_moy#46]
 
-(72) Filter [codegen id : 1]
+(69) Filter [codegen id : 1]
 Input [3]: [d_month_seq#44, d_year#45, d_moy#46]
 Condition : (((isnotnull(d_year#45) AND isnotnull(d_moy#46)) AND (d_year#45 = 1998)) AND (d_moy#46 = 12))
 
-(73) Project [codegen id : 1]
+(70) Project [codegen id : 1]
 Output [1]: [(d_month_seq#44 + 1) AS (d_month_seq + 1)#47]
 Input [3]: [d_month_seq#44, d_year#45, d_moy#46]
 
-(74) HashAggregate [codegen id : 1]
+(71) HashAggregate [codegen id : 1]
 Input [1]: [(d_month_seq + 1)#47]
 Keys [1]: [(d_month_seq + 1)#47]
 Functions: []
 Aggregate Attributes: []
 Results [1]: [(d_month_seq + 1)#47]
 
-(75) Exchange
+(72) Exchange
 Input [1]: [(d_month_seq + 1)#47]
-Arguments: hashpartitioning((d_month_seq + 1)#47, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Arguments: hashpartitioning((d_month_seq + 1)#47, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(76) HashAggregate [codegen id : 2]
+(73) HashAggregate [codegen id : 2]
 Input [1]: [(d_month_seq + 1)#47]
 Keys [1]: [(d_month_seq + 1)#47]
 Functions: []
 Aggregate Attributes: []
 Results [1]: [(d_month_seq + 1)#47]
 
-Subquery:7 Hosting operator id = 65 Hosting Expression = Subquery scalar-subquery#43, [id=#10]
-* HashAggregate (83)
-+- Exchange (82)
-   +- * HashAggregate (81)
-      +- * Project (80)
-         +- * Filter (79)
-            +- * ColumnarToRow (78)
-               +- Scan parquet spark_catalog.default.date_dim (77)
+Subquery:7 Hosting operator id = 62 Hosting Expression = Subquery scalar-subquery#43, [id=#11]
+* HashAggregate (80)
++- Exchange (79)
+   +- * HashAggregate (78)
+      +- * Project (77)
+         +- * Filter (76)
+            +- * ColumnarToRow (75)
+               +- Scan parquet spark_catalog.default.date_dim (74)
 
 
-(77) Scan parquet spark_catalog.default.date_dim
+(74) Scan parquet spark_catalog.default.date_dim
 Output [3]: [d_month_seq#48, d_year#49, d_moy#50]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,1998), EqualTo(d_moy,12)]
 ReadSchema: struct<d_month_seq:int,d_year:int,d_moy:int>
 
-(78) ColumnarToRow [codegen id : 1]
+(75) ColumnarToRow [codegen id : 1]
 Input [3]: [d_month_seq#48, d_year#49, d_moy#50]
 
-(79) Filter [codegen id : 1]
+(76) Filter [codegen id : 1]
 Input [3]: [d_month_seq#48, d_year#49, d_moy#50]
 Condition : (((isnotnull(d_year#49) AND isnotnull(d_moy#50)) AND (d_year#49 = 1998)) AND (d_moy#50 = 12))
 
-(80) Project [codegen id : 1]
+(77) Project [codegen id : 1]
 Output [1]: [(d_month_seq#48 + 3) AS (d_month_seq + 3)#51]
 Input [3]: [d_month_seq#48, d_year#49, d_moy#50]
 
-(81) HashAggregate [codegen id : 1]
+(78) HashAggregate [codegen id : 1]
 Input [1]: [(d_month_seq + 3)#51]
 Keys [1]: [(d_month_seq + 3)#51]
 Functions: []
 Aggregate Attributes: []
 Results [1]: [(d_month_seq + 3)#51]
 
-(82) Exchange
+(79) Exchange
 Input [1]: [(d_month_seq + 3)#51]
-Arguments: hashpartitioning((d_month_seq + 3)#51, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+Arguments: hashpartitioning((d_month_seq + 3)#51, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(83) HashAggregate [codegen id : 2]
+(80) HashAggregate [codegen id : 2]
 Input [1]: [(d_month_seq + 3)#51]
 Keys [1]: [(d_month_seq + 3)#51]
 Functions: []

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/simplified.txt
@@ -1,137 +1,128 @@
 TakeOrderedAndProject [segment,num_customers,segment_base]
-  WholeStageCodegen (16)
+  WholeStageCodegen (13)
     HashAggregate [segment,count] [count(1),num_customers,segment_base,count]
       InputAdapter
         Exchange [segment] #1
-          WholeStageCodegen (15)
+          WholeStageCodegen (12)
             HashAggregate [segment] [count,count]
               HashAggregate [c_customer_sk,sum] [sum(UnscaledValue(ss_ext_sales_price)),segment,sum]
-                HashAggregate [c_customer_sk,ss_ext_sales_price] [sum,sum]
-                  Project [c_customer_sk,ss_ext_sales_price]
-                    SortMergeJoin [c_customer_sk,ss_customer_sk]
-                      InputAdapter
-                        WholeStageCodegen (11)
-                          Sort [c_customer_sk]
-                            Project [c_customer_sk]
-                              BroadcastHashJoin [ca_address_sk,c_current_addr_sk]
+                InputAdapter
+                  Exchange [c_customer_sk] #2
+                    WholeStageCodegen (11)
+                      HashAggregate [c_customer_sk,ss_ext_sales_price] [sum,sum]
+                        Project [c_customer_sk,ss_ext_sales_price]
+                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                            Project [c_customer_sk,ss_ext_sales_price,ss_sold_date_sk]
+                              BroadcastHashJoin [c_customer_sk,ss_customer_sk]
                                 InputAdapter
-                                  BroadcastExchange #2
-                                    WholeStageCodegen (2)
-                                      Project [ca_address_sk]
-                                        BroadcastHashJoin [ca_county,ca_state,s_county,s_state]
-                                          Filter [ca_address_sk,ca_county,ca_state]
-                                            ColumnarToRow
-                                              InputAdapter
-                                                Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county,ca_state]
+                                  BroadcastExchange #3
+                                    WholeStageCodegen (9)
+                                      Project [c_customer_sk]
+                                        BroadcastHashJoin [ca_address_sk,c_current_addr_sk]
                                           InputAdapter
-                                            BroadcastExchange #3
-                                              WholeStageCodegen (1)
-                                                Filter [s_county,s_state]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.store [s_county,s_state]
-                                HashAggregate [c_customer_sk,c_current_addr_sk]
-                                  HashAggregate [c_customer_sk,c_current_addr_sk]
-                                    Project [c_customer_sk,c_current_addr_sk]
-                                      SortMergeJoin [customer_sk,c_customer_sk]
-                                        InputAdapter
-                                          WholeStageCodegen (8)
-                                            Sort [customer_sk]
-                                              InputAdapter
-                                                Exchange [customer_sk] #4
-                                                  WholeStageCodegen (7)
-                                                    Project [customer_sk]
-                                                      BroadcastHashJoin [item_sk,i_item_sk]
-                                                        Project [customer_sk,item_sk]
-                                                          BroadcastHashJoin [sold_date_sk,d_date_sk]
-                                                            InputAdapter
-                                                              Union
-                                                                WholeStageCodegen (3)
-                                                                  Project [cs_sold_date_sk,cs_bill_customer_sk,cs_item_sk]
-                                                                    Filter [cs_item_sk,cs_bill_customer_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_sold_date_sk]
-                                                                            SubqueryBroadcast [d_date_sk] #1
-                                                                              BroadcastExchange #5
-                                                                                WholeStageCodegen (1)
-                                                                                  Project [d_date_sk]
-                                                                                    Filter [d_moy,d_year,d_date_sk]
-                                                                                      ColumnarToRow
-                                                                                        InputAdapter
-                                                                                          Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
-                                                                WholeStageCodegen (4)
-                                                                  Project [ws_sold_date_sk,ws_bill_customer_sk,ws_item_sk]
-                                                                    Filter [ws_item_sk,ws_bill_customer_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_bill_customer_sk,ws_sold_date_sk]
-                                                                            ReusedSubquery [d_date_sk] #1
-                                                            InputAdapter
-                                                              ReusedExchange [d_date_sk] #5
-                                                        InputAdapter
-                                                          BroadcastExchange #6
-                                                            WholeStageCodegen (6)
-                                                              Project [i_item_sk]
-                                                                Filter [i_category,i_class,i_item_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_class,i_category]
-                                        InputAdapter
-                                          WholeStageCodegen (10)
-                                            Sort [c_customer_sk]
-                                              InputAdapter
-                                                Exchange [c_customer_sk] #7
-                                                  WholeStageCodegen (9)
-                                                    Filter [c_customer_sk,c_current_addr_sk]
+                                            BroadcastExchange #4
+                                              WholeStageCodegen (2)
+                                                Project [ca_address_sk]
+                                                  BroadcastHashJoin [ca_county,ca_state,s_county,s_state]
+                                                    Filter [ca_address_sk,ca_county,ca_state]
                                                       ColumnarToRow
                                                         InputAdapter
-                                                          Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
-                      InputAdapter
-                        WholeStageCodegen (14)
-                          Sort [ss_customer_sk]
+                                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county,ca_state]
+                                                    InputAdapter
+                                                      BroadcastExchange #5
+                                                        WholeStageCodegen (1)
+                                                          Filter [s_county,s_state]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.store [s_county,s_state]
+                                          HashAggregate [c_customer_sk,c_current_addr_sk]
+                                            InputAdapter
+                                              Exchange [c_customer_sk,c_current_addr_sk] #6
+                                                WholeStageCodegen (8)
+                                                  HashAggregate [c_customer_sk,c_current_addr_sk]
+                                                    Project [c_customer_sk,c_current_addr_sk]
+                                                      BroadcastHashJoin [customer_sk,c_customer_sk]
+                                                        InputAdapter
+                                                          BroadcastExchange #7
+                                                            WholeStageCodegen (7)
+                                                              Project [customer_sk]
+                                                                BroadcastHashJoin [sold_date_sk,d_date_sk]
+                                                                  Project [sold_date_sk,customer_sk]
+                                                                    BroadcastHashJoin [item_sk,i_item_sk]
+                                                                      InputAdapter
+                                                                        Union
+                                                                          WholeStageCodegen (3)
+                                                                            Project [cs_sold_date_sk,cs_bill_customer_sk,cs_item_sk]
+                                                                              Filter [cs_item_sk,cs_bill_customer_sk]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_sold_date_sk]
+                                                                                      SubqueryBroadcast [d_date_sk] #1
+                                                                                        BroadcastExchange #8
+                                                                                          WholeStageCodegen (1)
+                                                                                            Project [d_date_sk]
+                                                                                              Filter [d_moy,d_year,d_date_sk]
+                                                                                                ColumnarToRow
+                                                                                                  InputAdapter
+                                                                                                    Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                                                          WholeStageCodegen (4)
+                                                                            Project [ws_sold_date_sk,ws_bill_customer_sk,ws_item_sk]
+                                                                              Filter [ws_item_sk,ws_bill_customer_sk]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_bill_customer_sk,ws_sold_date_sk]
+                                                                                      ReusedSubquery [d_date_sk] #1
+                                                                      InputAdapter
+                                                                        BroadcastExchange #9
+                                                                          WholeStageCodegen (5)
+                                                                            Project [i_item_sk]
+                                                                              Filter [i_category,i_class,i_item_sk]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_class,i_category]
+                                                                  InputAdapter
+                                                                    ReusedExchange [d_date_sk] #8
+                                                        Filter [c_customer_sk,c_current_addr_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
+                                Filter [ss_customer_sk]
+                                  ColumnarToRow
+                                    InputAdapter
+                                      Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_ext_sales_price,ss_sold_date_sk]
+                                        SubqueryBroadcast [d_date_sk] #2
+                                          BroadcastExchange #10
+                                            WholeStageCodegen (1)
+                                              Project [d_date_sk]
+                                                Filter [d_month_seq,d_date_sk]
+                                                  ReusedSubquery [(d_month_seq + 1)] #3
+                                                  ReusedSubquery [(d_month_seq + 3)] #4
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet spark_catalog.default.date_dim [d_date_sk,d_month_seq]
+                                                        Subquery #3
+                                                          WholeStageCodegen (2)
+                                                            HashAggregate [(d_month_seq + 1)]
+                                                              InputAdapter
+                                                                Exchange [(d_month_seq + 1)] #11
+                                                                  WholeStageCodegen (1)
+                                                                    HashAggregate [(d_month_seq + 1)]
+                                                                      Project [d_month_seq]
+                                                                        Filter [d_year,d_moy]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.date_dim [d_month_seq,d_year,d_moy]
+                                                        Subquery #4
+                                                          WholeStageCodegen (2)
+                                                            HashAggregate [(d_month_seq + 3)]
+                                                              InputAdapter
+                                                                Exchange [(d_month_seq + 3)] #12
+                                                                  WholeStageCodegen (1)
+                                                                    HashAggregate [(d_month_seq + 3)]
+                                                                      Project [d_month_seq]
+                                                                        Filter [d_year,d_moy]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.date_dim [d_month_seq,d_year,d_moy]
                             InputAdapter
-                              Exchange [ss_customer_sk] #8
-                                WholeStageCodegen (13)
-                                  Project [ss_customer_sk,ss_ext_sales_price]
-                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                      Filter [ss_customer_sk]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_ext_sales_price,ss_sold_date_sk]
-                                              SubqueryBroadcast [d_date_sk] #2
-                                                BroadcastExchange #9
-                                                  WholeStageCodegen (1)
-                                                    Project [d_date_sk]
-                                                      Filter [d_month_seq,d_date_sk]
-                                                        ReusedSubquery [(d_month_seq + 1)] #3
-                                                        ReusedSubquery [(d_month_seq + 3)] #4
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_month_seq]
-                                                              Subquery #3
-                                                                WholeStageCodegen (2)
-                                                                  HashAggregate [(d_month_seq + 1)]
-                                                                    InputAdapter
-                                                                      Exchange [(d_month_seq + 1)] #10
-                                                                        WholeStageCodegen (1)
-                                                                          HashAggregate [(d_month_seq + 1)]
-                                                                            Project [d_month_seq]
-                                                                              Filter [d_year,d_moy]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet spark_catalog.default.date_dim [d_month_seq,d_year,d_moy]
-                                                              Subquery #4
-                                                                WholeStageCodegen (2)
-                                                                  HashAggregate [(d_month_seq + 3)]
-                                                                    InputAdapter
-                                                                      Exchange [(d_month_seq + 3)] #11
-                                                                        WholeStageCodegen (1)
-                                                                          HashAggregate [(d_month_seq + 3)]
-                                                                            Project [d_month_seq]
-                                                                              Filter [d_year,d_moy]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet spark_catalog.default.date_dim [d_month_seq,d_year,d_moy]
-                                      InputAdapter
-                                        ReusedExchange [d_date_sk] #9
+                              ReusedExchange [d_date_sk] #10

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a.sf100/explain.txt
@@ -13,8 +13,8 @@ TakeOrderedAndProject (90)
             :           :     +- * HashAggregate (19)
             :           :        +- * Project (18)
             :           :           +- * BroadcastHashJoin Inner BuildRight (17)
-            :           :              :- * Project (15)
-            :           :              :  +- * BroadcastHashJoin Inner BuildRight (14)
+            :           :              :- * Project (12)
+            :           :              :  +- * BroadcastHashJoin Inner BuildRight (11)
             :           :              :     :- Union (9)
             :           :              :     :  :- * Project (4)
             :           :              :     :  :  +- * Filter (3)
@@ -24,18 +24,18 @@ TakeOrderedAndProject (90)
             :           :              :     :     +- * Filter (7)
             :           :              :     :        +- * ColumnarToRow (6)
             :           :              :     :           +- Scan parquet spark_catalog.default.store_returns (5)
-            :           :              :     +- BroadcastExchange (13)
-            :           :              :        +- * Filter (12)
-            :           :              :           +- * ColumnarToRow (11)
-            :           :              :              +- Scan parquet spark_catalog.default.store (10)
-            :           :              +- ReusedExchange (16)
+            :           :              :     +- ReusedExchange (10)
+            :           :              +- BroadcastExchange (16)
+            :           :                 +- * Filter (15)
+            :           :                    +- * ColumnarToRow (14)
+            :           :                       +- Scan parquet spark_catalog.default.store (13)
             :           :- * HashAggregate (42)
             :           :  +- Exchange (41)
             :           :     +- * HashAggregate (40)
             :           :        +- * Project (39)
             :           :           +- * BroadcastHashJoin Inner BuildRight (38)
-            :           :              :- * Project (36)
-            :           :              :  +- * BroadcastHashJoin Inner BuildRight (35)
+            :           :              :- * Project (33)
+            :           :              :  +- * BroadcastHashJoin Inner BuildRight (32)
             :           :              :     :- Union (30)
             :           :              :     :  :- * Project (25)
             :           :              :     :  :  +- * Filter (24)
@@ -45,18 +45,18 @@ TakeOrderedAndProject (90)
             :           :              :     :     +- * Filter (28)
             :           :              :     :        +- * ColumnarToRow (27)
             :           :              :     :           +- Scan parquet spark_catalog.default.catalog_returns (26)
-            :           :              :     +- BroadcastExchange (34)
-            :           :              :        +- * Filter (33)
-            :           :              :           +- * ColumnarToRow (32)
-            :           :              :              +- Scan parquet spark_catalog.default.catalog_page (31)
-            :           :              +- ReusedExchange (37)
+            :           :              :     +- ReusedExchange (31)
+            :           :              +- BroadcastExchange (37)
+            :           :                 +- * Filter (36)
+            :           :                    +- * ColumnarToRow (35)
+            :           :                       +- Scan parquet spark_catalog.default.catalog_page (34)
             :           +- * HashAggregate (71)
             :              +- Exchange (70)
             :                 +- * HashAggregate (69)
             :                    +- * Project (68)
             :                       +- * BroadcastHashJoin Inner BuildRight (67)
-            :                          :- * Project (65)
-            :                          :  +- * BroadcastHashJoin Inner BuildRight (64)
+            :                          :- * Project (62)
+            :                          :  +- * BroadcastHashJoin Inner BuildRight (61)
             :                          :     :- Union (59)
             :                          :     :  :- * Project (46)
             :                          :     :  :  +- * Filter (45)
@@ -74,11 +74,11 @@ TakeOrderedAndProject (90)
             :                          :     :                 +- * Filter (53)
             :                          :     :                    +- * ColumnarToRow (52)
             :                          :     :                       +- Scan parquet spark_catalog.default.web_sales (51)
-            :                          :     +- BroadcastExchange (63)
-            :                          :        +- * Filter (62)
-            :                          :           +- * ColumnarToRow (61)
-            :                          :              +- Scan parquet spark_catalog.default.web_site (60)
-            :                          +- ReusedExchange (66)
+            :                          :     +- ReusedExchange (60)
+            :                          +- BroadcastExchange (66)
+            :                             +- * Filter (65)
+            :                                +- * ColumnarToRow (64)
+            :                                   +- Scan parquet spark_catalog.default.web_site (63)
             :- * HashAggregate (80)
             :  +- Exchange (79)
             :     +- * HashAggregate (78)
@@ -131,64 +131,64 @@ Input [4]: [sr_store_sk#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_s
 
 (9) Union
 
-(10) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#22, s_store_id#23]
+(10) ReusedExchange [Reuses operator id: 95]
+Output [1]: [d_date_sk#22]
+
+(11) BroadcastHashJoin [codegen id : 5]
+Left keys [1]: [date_sk#7]
+Right keys [1]: [d_date_sk#22]
+Join type: Inner
+Join condition: None
+
+(12) Project [codegen id : 5]
+Output [5]: [store_sk#6, sales_price#8, profit#9, return_amt#10, net_loss#11]
+Input [7]: [store_sk#6, date_sk#7, sales_price#8, profit#9, return_amt#10, net_loss#11, d_date_sk#22]
+
+(13) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#23, s_store_id#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string>
 
-(11) ColumnarToRow [codegen id : 3]
-Input [2]: [s_store_sk#22, s_store_id#23]
+(14) ColumnarToRow [codegen id : 4]
+Input [2]: [s_store_sk#23, s_store_id#24]
 
-(12) Filter [codegen id : 3]
-Input [2]: [s_store_sk#22, s_store_id#23]
-Condition : isnotnull(s_store_sk#22)
+(15) Filter [codegen id : 4]
+Input [2]: [s_store_sk#23, s_store_id#24]
+Condition : isnotnull(s_store_sk#23)
 
-(13) BroadcastExchange
-Input [2]: [s_store_sk#22, s_store_id#23]
+(16) BroadcastExchange
+Input [2]: [s_store_sk#23, s_store_id#24]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
-(14) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [store_sk#6]
-Right keys [1]: [s_store_sk#22]
-Join type: Inner
-Join condition: None
-
-(15) Project [codegen id : 5]
-Output [6]: [date_sk#7, sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_id#23]
-Input [8]: [store_sk#6, date_sk#7, sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_sk#22, s_store_id#23]
-
-(16) ReusedExchange [Reuses operator id: 95]
-Output [1]: [d_date_sk#24]
-
 (17) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [date_sk#7]
-Right keys [1]: [d_date_sk#24]
+Left keys [1]: [store_sk#6]
+Right keys [1]: [s_store_sk#23]
 Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 5]
-Output [5]: [sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_id#23]
-Input [7]: [date_sk#7, sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_id#23, d_date_sk#24]
+Output [5]: [sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_id#24]
+Input [7]: [store_sk#6, sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_sk#23, s_store_id#24]
 
 (19) HashAggregate [codegen id : 5]
-Input [5]: [sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_id#23]
-Keys [1]: [s_store_id#23]
+Input [5]: [sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_id#24]
+Keys [1]: [s_store_id#24]
 Functions [4]: [partial_sum(UnscaledValue(sales_price#8)), partial_sum(UnscaledValue(return_amt#10)), partial_sum(UnscaledValue(profit#9)), partial_sum(UnscaledValue(net_loss#11))]
 Aggregate Attributes [4]: [sum#25, sum#26, sum#27, sum#28]
-Results [5]: [s_store_id#23, sum#29, sum#30, sum#31, sum#32]
+Results [5]: [s_store_id#24, sum#29, sum#30, sum#31, sum#32]
 
 (20) Exchange
-Input [5]: [s_store_id#23, sum#29, sum#30, sum#31, sum#32]
-Arguments: hashpartitioning(s_store_id#23, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [5]: [s_store_id#24, sum#29, sum#30, sum#31, sum#32]
+Arguments: hashpartitioning(s_store_id#24, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (21) HashAggregate [codegen id : 6]
-Input [5]: [s_store_id#23, sum#29, sum#30, sum#31, sum#32]
-Keys [1]: [s_store_id#23]
+Input [5]: [s_store_id#24, sum#29, sum#30, sum#31, sum#32]
+Keys [1]: [s_store_id#24]
 Functions [4]: [sum(UnscaledValue(sales_price#8)), sum(UnscaledValue(return_amt#10)), sum(UnscaledValue(profit#9)), sum(UnscaledValue(net_loss#11))]
 Aggregate Attributes [4]: [sum(UnscaledValue(sales_price#8))#33, sum(UnscaledValue(return_amt#10))#34, sum(UnscaledValue(profit#9))#35, sum(UnscaledValue(net_loss#11))#36]
-Results [5]: [store channel AS channel#37, concat(store, s_store_id#23) AS id#38, MakeDecimal(sum(UnscaledValue(sales_price#8))#33,17,2) AS sales#39, MakeDecimal(sum(UnscaledValue(return_amt#10))#34,17,2) AS returns#40, (MakeDecimal(sum(UnscaledValue(profit#9))#35,17,2) - MakeDecimal(sum(UnscaledValue(net_loss#11))#36,17,2)) AS profit#41]
+Results [5]: [store channel AS channel#37, concat(store, s_store_id#24) AS id#38, MakeDecimal(sum(UnscaledValue(sales_price#8))#33,17,2) AS sales#39, MakeDecimal(sum(UnscaledValue(return_amt#10))#34,17,2) AS returns#40, (MakeDecimal(sum(UnscaledValue(profit#9))#35,17,2) - MakeDecimal(sum(UnscaledValue(net_loss#11))#36,17,2)) AS profit#41]
 
 (22) Scan parquet spark_catalog.default.catalog_sales
 Output [4]: [cs_catalog_page_sk#42, cs_ext_sales_price#43, cs_net_profit#44, cs_sold_date_sk#45]
@@ -230,64 +230,64 @@ Input [4]: [cr_catalog_page_sk#52, cr_return_amount#53, cr_net_loss#54, cr_retur
 
 (30) Union
 
-(31) Scan parquet spark_catalog.default.catalog_page
-Output [2]: [cp_catalog_page_sk#62, cp_catalog_page_id#63]
+(31) ReusedExchange [Reuses operator id: 95]
+Output [1]: [d_date_sk#62]
+
+(32) BroadcastHashJoin [codegen id : 11]
+Left keys [1]: [date_sk#47]
+Right keys [1]: [d_date_sk#62]
+Join type: Inner
+Join condition: None
+
+(33) Project [codegen id : 11]
+Output [5]: [page_sk#46, sales_price#48, profit#49, return_amt#50, net_loss#51]
+Input [7]: [page_sk#46, date_sk#47, sales_price#48, profit#49, return_amt#50, net_loss#51, d_date_sk#62]
+
+(34) Scan parquet spark_catalog.default.catalog_page
+Output [2]: [cp_catalog_page_sk#63, cp_catalog_page_id#64]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_page]
 PushedFilters: [IsNotNull(cp_catalog_page_sk)]
 ReadSchema: struct<cp_catalog_page_sk:int,cp_catalog_page_id:string>
 
-(32) ColumnarToRow [codegen id : 9]
-Input [2]: [cp_catalog_page_sk#62, cp_catalog_page_id#63]
+(35) ColumnarToRow [codegen id : 10]
+Input [2]: [cp_catalog_page_sk#63, cp_catalog_page_id#64]
 
-(33) Filter [codegen id : 9]
-Input [2]: [cp_catalog_page_sk#62, cp_catalog_page_id#63]
-Condition : isnotnull(cp_catalog_page_sk#62)
+(36) Filter [codegen id : 10]
+Input [2]: [cp_catalog_page_sk#63, cp_catalog_page_id#64]
+Condition : isnotnull(cp_catalog_page_sk#63)
 
-(34) BroadcastExchange
-Input [2]: [cp_catalog_page_sk#62, cp_catalog_page_id#63]
+(37) BroadcastExchange
+Input [2]: [cp_catalog_page_sk#63, cp_catalog_page_id#64]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
 
-(35) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [page_sk#46]
-Right keys [1]: [cp_catalog_page_sk#62]
-Join type: Inner
-Join condition: None
-
-(36) Project [codegen id : 11]
-Output [6]: [date_sk#47, sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_id#63]
-Input [8]: [page_sk#46, date_sk#47, sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_sk#62, cp_catalog_page_id#63]
-
-(37) ReusedExchange [Reuses operator id: 95]
-Output [1]: [d_date_sk#64]
-
 (38) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [date_sk#47]
-Right keys [1]: [d_date_sk#64]
+Left keys [1]: [page_sk#46]
+Right keys [1]: [cp_catalog_page_sk#63]
 Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 11]
-Output [5]: [sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_id#63]
-Input [7]: [date_sk#47, sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_id#63, d_date_sk#64]
+Output [5]: [sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_id#64]
+Input [7]: [page_sk#46, sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_sk#63, cp_catalog_page_id#64]
 
 (40) HashAggregate [codegen id : 11]
-Input [5]: [sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_id#63]
-Keys [1]: [cp_catalog_page_id#63]
+Input [5]: [sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_id#64]
+Keys [1]: [cp_catalog_page_id#64]
 Functions [4]: [partial_sum(UnscaledValue(sales_price#48)), partial_sum(UnscaledValue(return_amt#50)), partial_sum(UnscaledValue(profit#49)), partial_sum(UnscaledValue(net_loss#51))]
 Aggregate Attributes [4]: [sum#65, sum#66, sum#67, sum#68]
-Results [5]: [cp_catalog_page_id#63, sum#69, sum#70, sum#71, sum#72]
+Results [5]: [cp_catalog_page_id#64, sum#69, sum#70, sum#71, sum#72]
 
 (41) Exchange
-Input [5]: [cp_catalog_page_id#63, sum#69, sum#70, sum#71, sum#72]
-Arguments: hashpartitioning(cp_catalog_page_id#63, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [5]: [cp_catalog_page_id#64, sum#69, sum#70, sum#71, sum#72]
+Arguments: hashpartitioning(cp_catalog_page_id#64, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (42) HashAggregate [codegen id : 12]
-Input [5]: [cp_catalog_page_id#63, sum#69, sum#70, sum#71, sum#72]
-Keys [1]: [cp_catalog_page_id#63]
+Input [5]: [cp_catalog_page_id#64, sum#69, sum#70, sum#71, sum#72]
+Keys [1]: [cp_catalog_page_id#64]
 Functions [4]: [sum(UnscaledValue(sales_price#48)), sum(UnscaledValue(return_amt#50)), sum(UnscaledValue(profit#49)), sum(UnscaledValue(net_loss#51))]
 Aggregate Attributes [4]: [sum(UnscaledValue(sales_price#48))#73, sum(UnscaledValue(return_amt#50))#74, sum(UnscaledValue(profit#49))#75, sum(UnscaledValue(net_loss#51))#76]
-Results [5]: [catalog channel AS channel#77, concat(catalog_page, cp_catalog_page_id#63) AS id#78, MakeDecimal(sum(UnscaledValue(sales_price#48))#73,17,2) AS sales#79, MakeDecimal(sum(UnscaledValue(return_amt#50))#74,17,2) AS returns#80, (MakeDecimal(sum(UnscaledValue(profit#49))#75,17,2) - MakeDecimal(sum(UnscaledValue(net_loss#51))#76,17,2)) AS profit#81]
+Results [5]: [catalog channel AS channel#77, concat(catalog_page, cp_catalog_page_id#64) AS id#78, MakeDecimal(sum(UnscaledValue(sales_price#48))#73,17,2) AS sales#79, MakeDecimal(sum(UnscaledValue(return_amt#50))#74,17,2) AS returns#80, (MakeDecimal(sum(UnscaledValue(profit#49))#75,17,2) - MakeDecimal(sum(UnscaledValue(net_loss#51))#76,17,2)) AS profit#81]
 
 (43) Scan parquet spark_catalog.default.web_sales
 Output [4]: [ws_web_site_sk#82, ws_ext_sales_price#83, ws_net_profit#84, ws_sold_date_sk#85]
@@ -364,64 +364,64 @@ Input [8]: [wr_item_sk#92, wr_order_number#93, wr_return_amt#94, wr_net_loss#95,
 
 (59) Union
 
-(60) Scan parquet spark_catalog.default.web_site
-Output [2]: [web_site_sk#107, web_site_id#108]
+(60) ReusedExchange [Reuses operator id: 95]
+Output [1]: [d_date_sk#107]
+
+(61) BroadcastHashJoin [codegen id : 21]
+Left keys [1]: [date_sk#87]
+Right keys [1]: [d_date_sk#107]
+Join type: Inner
+Join condition: None
+
+(62) Project [codegen id : 21]
+Output [5]: [wsr_web_site_sk#86, sales_price#88, profit#89, return_amt#90, net_loss#91]
+Input [7]: [wsr_web_site_sk#86, date_sk#87, sales_price#88, profit#89, return_amt#90, net_loss#91, d_date_sk#107]
+
+(63) Scan parquet spark_catalog.default.web_site
+Output [2]: [web_site_sk#108, web_site_id#109]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_site]
 PushedFilters: [IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_site_id:string>
 
-(61) ColumnarToRow [codegen id : 19]
-Input [2]: [web_site_sk#107, web_site_id#108]
+(64) ColumnarToRow [codegen id : 20]
+Input [2]: [web_site_sk#108, web_site_id#109]
 
-(62) Filter [codegen id : 19]
-Input [2]: [web_site_sk#107, web_site_id#108]
-Condition : isnotnull(web_site_sk#107)
+(65) Filter [codegen id : 20]
+Input [2]: [web_site_sk#108, web_site_id#109]
+Condition : isnotnull(web_site_sk#108)
 
-(63) BroadcastExchange
-Input [2]: [web_site_sk#107, web_site_id#108]
+(66) BroadcastExchange
+Input [2]: [web_site_sk#108, web_site_id#109]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
-(64) BroadcastHashJoin [codegen id : 21]
-Left keys [1]: [wsr_web_site_sk#86]
-Right keys [1]: [web_site_sk#107]
-Join type: Inner
-Join condition: None
-
-(65) Project [codegen id : 21]
-Output [6]: [date_sk#87, sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_id#108]
-Input [8]: [wsr_web_site_sk#86, date_sk#87, sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_sk#107, web_site_id#108]
-
-(66) ReusedExchange [Reuses operator id: 95]
-Output [1]: [d_date_sk#109]
-
 (67) BroadcastHashJoin [codegen id : 21]
-Left keys [1]: [date_sk#87]
-Right keys [1]: [d_date_sk#109]
+Left keys [1]: [wsr_web_site_sk#86]
+Right keys [1]: [web_site_sk#108]
 Join type: Inner
 Join condition: None
 
 (68) Project [codegen id : 21]
-Output [5]: [sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_id#108]
-Input [7]: [date_sk#87, sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_id#108, d_date_sk#109]
+Output [5]: [sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_id#109]
+Input [7]: [wsr_web_site_sk#86, sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_sk#108, web_site_id#109]
 
 (69) HashAggregate [codegen id : 21]
-Input [5]: [sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_id#108]
-Keys [1]: [web_site_id#108]
+Input [5]: [sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_id#109]
+Keys [1]: [web_site_id#109]
 Functions [4]: [partial_sum(UnscaledValue(sales_price#88)), partial_sum(UnscaledValue(return_amt#90)), partial_sum(UnscaledValue(profit#89)), partial_sum(UnscaledValue(net_loss#91))]
 Aggregate Attributes [4]: [sum#110, sum#111, sum#112, sum#113]
-Results [5]: [web_site_id#108, sum#114, sum#115, sum#116, sum#117]
+Results [5]: [web_site_id#109, sum#114, sum#115, sum#116, sum#117]
 
 (70) Exchange
-Input [5]: [web_site_id#108, sum#114, sum#115, sum#116, sum#117]
-Arguments: hashpartitioning(web_site_id#108, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [5]: [web_site_id#109, sum#114, sum#115, sum#116, sum#117]
+Arguments: hashpartitioning(web_site_id#109, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (71) HashAggregate [codegen id : 22]
-Input [5]: [web_site_id#108, sum#114, sum#115, sum#116, sum#117]
-Keys [1]: [web_site_id#108]
+Input [5]: [web_site_id#109, sum#114, sum#115, sum#116, sum#117]
+Keys [1]: [web_site_id#109]
 Functions [4]: [sum(UnscaledValue(sales_price#88)), sum(UnscaledValue(return_amt#90)), sum(UnscaledValue(profit#89)), sum(UnscaledValue(net_loss#91))]
 Aggregate Attributes [4]: [sum(UnscaledValue(sales_price#88))#118, sum(UnscaledValue(return_amt#90))#119, sum(UnscaledValue(profit#89))#120, sum(UnscaledValue(net_loss#91))#121]
-Results [5]: [web channel AS channel#122, concat(web_site, web_site_id#108) AS id#123, MakeDecimal(sum(UnscaledValue(sales_price#88))#118,17,2) AS sales#124, MakeDecimal(sum(UnscaledValue(return_amt#90))#119,17,2) AS returns#125, (MakeDecimal(sum(UnscaledValue(profit#89))#120,17,2) - MakeDecimal(sum(UnscaledValue(net_loss#91))#121,17,2)) AS profit#126]
+Results [5]: [web channel AS channel#122, concat(web_site, web_site_id#109) AS id#123, MakeDecimal(sum(UnscaledValue(sales_price#88))#118,17,2) AS sales#124, MakeDecimal(sum(UnscaledValue(return_amt#90))#119,17,2) AS returns#125, (MakeDecimal(sum(UnscaledValue(profit#89))#120,17,2) - MakeDecimal(sum(UnscaledValue(net_loss#91))#121,17,2)) AS profit#126]
 
 (72) Union
 
@@ -534,25 +534,25 @@ BroadcastExchange (95)
 
 
 (91) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#24, d_date#212]
+Output [2]: [d_date_sk#22, d_date#212]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1998-08-04), LessThanOrEqual(d_date,1998-08-18), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (92) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#24, d_date#212]
+Input [2]: [d_date_sk#22, d_date#212]
 
 (93) Filter [codegen id : 1]
-Input [2]: [d_date_sk#24, d_date#212]
-Condition : (((isnotnull(d_date#212) AND (d_date#212 >= 1998-08-04)) AND (d_date#212 <= 1998-08-18)) AND isnotnull(d_date_sk#24))
+Input [2]: [d_date_sk#22, d_date#212]
+Condition : (((isnotnull(d_date#212) AND (d_date#212 >= 1998-08-04)) AND (d_date#212 <= 1998-08-18)) AND isnotnull(d_date_sk#22))
 
 (94) Project [codegen id : 1]
-Output [1]: [d_date_sk#24]
-Input [2]: [d_date_sk#24, d_date#212]
+Output [1]: [d_date_sk#22]
+Input [2]: [d_date_sk#22, d_date#212]
 
 (95) BroadcastExchange
-Input [1]: [d_date_sk#24]
+Input [1]: [d_date_sk#22]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=13]
 
 Subquery:2 Hosting operator id = 5 Hosting Expression = sr_returned_date_sk#15 IN dynamicpruning#5

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a.sf100/simplified.txt
@@ -22,9 +22,9 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                           WholeStageCodegen (5)
                                             HashAggregate [s_store_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
                                               Project [sales_price,profit,return_amt,net_loss,s_store_id]
-                                                BroadcastHashJoin [date_sk,d_date_sk]
-                                                  Project [date_sk,sales_price,profit,return_amt,net_loss,s_store_id]
-                                                    BroadcastHashJoin [store_sk,s_store_sk]
+                                                BroadcastHashJoin [store_sk,s_store_sk]
+                                                  Project [store_sk,sales_price,profit,return_amt,net_loss]
+                                                    BroadcastHashJoin [date_sk,d_date_sk]
                                                       InputAdapter
                                                         Union
                                                           WholeStageCodegen (1)
@@ -49,14 +49,14 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                     Scan parquet spark_catalog.default.store_returns [sr_store_sk,sr_return_amt,sr_net_loss,sr_returned_date_sk]
                                                                       ReusedSubquery [d_date_sk] #1
                                                       InputAdapter
-                                                        BroadcastExchange #5
-                                                          WholeStageCodegen (3)
-                                                            Filter [s_store_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
+                                                        ReusedExchange [d_date_sk] #4
                                                   InputAdapter
-                                                    ReusedExchange [d_date_sk] #4
+                                                    BroadcastExchange #5
+                                                      WholeStageCodegen (4)
+                                                        Filter [s_store_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
                                   WholeStageCodegen (12)
                                     HashAggregate [cp_catalog_page_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),channel,id,sales,returns,profit,sum,sum,sum,sum]
                                       InputAdapter
@@ -64,9 +64,9 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                           WholeStageCodegen (11)
                                             HashAggregate [cp_catalog_page_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
                                               Project [sales_price,profit,return_amt,net_loss,cp_catalog_page_id]
-                                                BroadcastHashJoin [date_sk,d_date_sk]
-                                                  Project [date_sk,sales_price,profit,return_amt,net_loss,cp_catalog_page_id]
-                                                    BroadcastHashJoin [page_sk,cp_catalog_page_sk]
+                                                BroadcastHashJoin [page_sk,cp_catalog_page_sk]
+                                                  Project [page_sk,sales_price,profit,return_amt,net_loss]
+                                                    BroadcastHashJoin [date_sk,d_date_sk]
                                                       InputAdapter
                                                         Union
                                                           WholeStageCodegen (7)
@@ -84,14 +84,14 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                     Scan parquet spark_catalog.default.catalog_returns [cr_catalog_page_sk,cr_return_amount,cr_net_loss,cr_returned_date_sk]
                                                                       ReusedSubquery [d_date_sk] #1
                                                       InputAdapter
-                                                        BroadcastExchange #7
-                                                          WholeStageCodegen (9)
-                                                            Filter [cp_catalog_page_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.catalog_page [cp_catalog_page_sk,cp_catalog_page_id]
+                                                        ReusedExchange [d_date_sk] #4
                                                   InputAdapter
-                                                    ReusedExchange [d_date_sk] #4
+                                                    BroadcastExchange #7
+                                                      WholeStageCodegen (10)
+                                                        Filter [cp_catalog_page_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.catalog_page [cp_catalog_page_sk,cp_catalog_page_id]
                                   WholeStageCodegen (22)
                                     HashAggregate [web_site_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),channel,id,sales,returns,profit,sum,sum,sum,sum]
                                       InputAdapter
@@ -99,9 +99,9 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                           WholeStageCodegen (21)
                                             HashAggregate [web_site_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
                                               Project [sales_price,profit,return_amt,net_loss,web_site_id]
-                                                BroadcastHashJoin [date_sk,d_date_sk]
-                                                  Project [date_sk,sales_price,profit,return_amt,net_loss,web_site_id]
-                                                    BroadcastHashJoin [wsr_web_site_sk,web_site_sk]
+                                                BroadcastHashJoin [wsr_web_site_sk,web_site_sk]
+                                                  Project [wsr_web_site_sk,sales_price,profit,return_amt,net_loss]
+                                                    BroadcastHashJoin [date_sk,d_date_sk]
                                                       InputAdapter
                                                         Union
                                                           WholeStageCodegen (13)
@@ -136,14 +136,14 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                                   InputAdapter
                                                                                     Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_web_site_sk,ws_order_number,ws_sold_date_sk]
                                                       InputAdapter
-                                                        BroadcastExchange #11
-                                                          WholeStageCodegen (19)
-                                                            Filter [web_site_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.web_site [web_site_sk,web_site_id]
+                                                        ReusedExchange [d_date_sk] #4
                                                   InputAdapter
-                                                    ReusedExchange [d_date_sk] #4
+                                                    BroadcastExchange #11
+                                                      WholeStageCodegen (20)
+                                                        Filter [web_site_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.web_site [web_site_sk,web_site_id]
                   WholeStageCodegen (49)
                     HashAggregate [channel,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),id,sum(sales),sum(returns),sum(profit),sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter


### PR DESCRIPTION
### What changes were proposed in this pull request?

`UnionEstimation` currently propagates `min`, `max`, and `nullCount` column statistics, but does not propagate `distinctCount`. This means `ColumnStat.hasCountStats` (which requires both `distinctCount.isDefined` and `nullCount.isDefined`) always returns `false` for Union output columns, so downstream operators like `AggregateEstimation` cannot leverage CBO and fall back to `SizeInBytesOnlyStatsPlanVisitor`.

This PR extends `UnionEstimation` to also propagate `distinctCount`, enabling downstream operators (`AggregateEstimation`, `JoinEstimation`, etc.) that depend on `hasCountStats` to produce accurate CBO estimates for queries over `UNION ALL`, improving physical plan selection (join ordering, join strategy, etc.).

**Main changes of (`UnionEstimation.scala`)**:

- Added `computeDistinctCountStats(union, outputRows)` method that follows the same structure as the existing `computeNullCountStats`: it iterates transposed children output attributes, only computes when all children have `distinctCount` for a given column, takes `max(distinctCount)` across children, and caps the result by `outputRows` when available.
- Modified `estimate()` to call `computeDistinctCountStats` and layer distinctCount on top of the merged min/max + nullCount stats (three-layer merge).

For UNION ALL, the true `distinctCount` satisfies: `max(dc_i) <= true_dc <= min(sum(dc_i), rowCount)`. We use `max` as the estimate because UNION ALL branches typically share overlapping values (e.g., `web_sales` and `catalog_sales` reference the same date dimension keys), making `max` a reasonable approximation. Even in the worst case of completely disjoint values, `max` underestimates by at most N× (N = number of branches, typically 2–3), which is far better than losing CBO entirely.

### Why are the changes needed?

For queries over `UNION ALL` with CBO enabled, the missing `distinctCount` on Union output causes downstream estimators (e.g., `AggregateEstimation`, `JoinEstimation`) that check `hasCountStats` to fall back to `SizeInBytesOnlyStatsPlanVisitor`, producing inflated `sizeInBytes` estimates. This can lead the optimizer to choose suboptimal join ordering and join strategies.

For example, in TPC-DS sf100:
- **q5/q5a**: More accurate cardinality estimates cause the optimizer to reorder the date_dim join and the dimension table join (store/catalog_page/web_site).
- **q54**: More accurate estimates allow the optimizer to recognize that a Union-derived subquery result is small enough to broadcast, converting 2 SortMergeJoins to BroadcastHashJoins and eliminating 4 Sort + 2 Exchange operators (16→13 codegen stages).

### Does this PR introduce _any_ user-facing change?

No. This is an internal improvement to the CBO statistics estimation. Query results are unchanged; only physical plan selection (join ordering, join strategy, etc.) may differ due to more accurate cardinality estimates.

### How was this patch tested?

1. 1. **Updated 4 existing tests** in `UnionEstimationSuite` (3 tests) and `BasicStatsEstimationSuite` (1 test) to include the now-propagated `distinctCount` in expected `ColumnStat` values.
2. **Added 4 new unit tests** in `UnionEstimationSuite`:
   - `SPARK-56047: distinctCount propagated as max across children`: verifies max(100, 200) = 200.
   - `SPARK-56047: distinctCount omitted when one child lacks it`: verifies distinctCount is None when not all children have it.
   - `SPARK-56047: distinctCount capped by rowCount`: verifies min(max(500, 300), 6) = 6.
   - `SPARK-56047: hasCountStats is true when both distinctCount and nullCount propagated`: verifies end-to-end `hasCountStats` correctness.
3. **Added `UnionAggregateEstimationSuite`** (3 tests) verifying that `AggregateEstimation` produces accurate CBO estimates (correct `rowCount`, small `sizeInBytes`) when operating on Union output, compared against a control group without Union.
4. **Regenerated 3 TPC-DS plan stability golden files** (q5.sf100, q54.sf100, q5a.sf100) that reflect improved physical plan selection (join reordering in q5/q5a, SortMergeJoin→BroadcastHashJoin in q54) due to more accurate cardinality estimates after Union. 
5. Pass Github Actions.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Sonnet 4.6.
