### PR TITLE
[SPARK-56048][UI] Add copy plan text and share link buttons to SQL execution page

### DIFF
--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-/* global $, d3, dagreD3, graphlibDot, uiRoot, appBasePath, sorttable */
+/* global $, d3, dagreD3, graphlibDot, uiRoot, appBasePath, sorttable, showToast */
 
 var PlanVizConstants = {
   svgMarginX: 16,
@@ -675,6 +675,32 @@ function rerenderWithDetailedLabels() {
 document.addEventListener("DOMContentLoaded", function () {
   if (shouldRenderPlanViz()) {
     renderPlanViz();
+  }
+
+  // Copy physical plan text to clipboard
+  var copyPlanBtn = document.getElementById("copy-plan-btn");
+  if (copyPlanBtn) {
+    copyPlanBtn.addEventListener("click", function () {
+      var planEl = document.getElementById("physical-plan-details");
+      var text = planEl ? planEl.textContent : "";
+      navigator.clipboard.writeText(text.trim()).then(function () {
+        if (typeof showToast === "function") {
+          showToast("Plan copied to clipboard", "success");
+        }
+      });
+    });
+  }
+
+  // Copy shareable link to clipboard
+  var copyLinkBtn = document.getElementById("copy-link-btn");
+  if (copyLinkBtn) {
+    copyLinkBtn.addEventListener("click", function () {
+      navigator.clipboard.writeText(window.location.href).then(function () {
+        if (typeof showToast === "function") {
+          showToast("Link copied to clipboard", "success");
+        }
+      });
+    });
   }
 });
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
@@ -100,6 +100,12 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
             <label for="plan-viz-format-select">
               <a id="plan-viz-download-btn" class="downloadbutton">Download</a>
             </label>
+            <button id="copy-plan-btn" class="btn btn-sm btn-outline-secondary ms-2"
+                    type="button" title="Copy physical plan to clipboard">
+              &#x1f4cb; Copy Plan</button>
+            <button id="copy-link-btn" class="btn btn-sm btn-outline-secondary ms-1"
+                    type="button" title="Copy shareable link to this execution">
+              &#x1f517; Copy Link</button>
           </div>
         </div>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add two buttons next to the existing Download button on the SQL execution detail page:
- **📋 Copy Plan** — copies the physical plan text to clipboard
- **🔗 Copy Link** — copies the current page URL to clipboard

Both use `navigator.clipboard.writeText` and show a toast notification on success.

### Why are the changes needed?

When debugging query performance, users frequently need to share the physical plan or page link via Slack/JIRA/email. Currently they must manually select text or copy the URL bar. One-click buttons improve this workflow.

### Does this PR introduce _any_ user-facing change?

Yes — two new buttons on the SQL execution detail page.

### How was this patch tested?

Compilation verified. Manual testing.

### Was this patch authored or co-authored using generative AI tooling?

Yes, Generated-by: GitHub Copilot(claude-opus-4.6-1m).
