### PR TITLE
[SPARK-56049][UI] Add search/filter for metrics in SQL plan viz side panel

### DIFF
--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -439,7 +439,18 @@ function updateDetailsPanel(nodeId, nodeDetails) {
   var showStageTask = document.getElementById("stageId-and-taskId-checkbox")
     && document.getElementById("stageId-and-taskId-checkbox").checked;
 
+  var totalMetrics = (details.metrics ? details.metrics.length : 0) +
+    (details.children || []).reduce(function (sum, childId) {
+      var child = nodeDetails[childId];
+      return sum + (child && child.metrics ? child.metrics.length : 0);
+    }, 0);
+
   var html = "";
+  // Add search box when there are many metrics
+  if (totalMetrics > 5) {
+    html += '<input type="text" id="metric-search" class="form-control form-control-sm mb-2" ' +
+      'placeholder="Filter metrics...">';
+  }
   if (details.metrics && details.metrics.length > 0) {
     html += buildMetricsTable(details.metrics, showStageTask, true);
   } else if (!details.children) {
@@ -466,6 +477,18 @@ function updateDetailsPanel(nodeId, nodeDetails) {
   if (typeof sorttable !== "undefined") {
     bodyEl.querySelectorAll("table.sortable").forEach(function (table) {
       sorttable.makeSortable(table);
+    });
+  }
+
+  // Wire up metric search/filter
+  var searchBox = document.getElementById("metric-search");
+  if (searchBox) {
+    searchBox.addEventListener("input", function () {
+      var query = this.value.toLowerCase();
+      bodyEl.querySelectorAll("table tbody tr").forEach(function (row) {
+        var metricName = row.cells[0] ? row.cells[0].textContent.toLowerCase() : "";
+        row.style.display = metricName.indexOf(query) >= 0 ? "" : "none";
+      });
     });
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a search input to the SQL plan visualization side panel that filters metrics by name in real-time.

- Appears when a node has **more than 5 metrics** (e.g., Exchange nodes with 20+ shuffle metrics)
- Typing filters table rows by matching the metric name column
- Instant filtering — no debounce needed for small tables

### Why are the changes needed?

Exchange and WholeStageCodegen nodes can have 20+ metrics. Scrolling through all of them to find a specific metric (e.g., "spill", "duration", "data size") is tedious. The search box lets users type a keyword to instantly filter to relevant metrics.

### Does this PR introduce _any_ user-facing change?

Yes — a "Filter metrics..." search box appears in the side panel when a node has many metrics.

### How was this patch tested?

Manual testing. JS-only change, no Scala changes.

### Was this patch authored or co-authored using generative AI tooling?

Yes, Generated-by: GitHub Copilot(claude-opus-4.6-1m).