### PR TITLE
[SPARK-56050][SQL] Eagerly resolve IDENTIFIER() with string literals at parse time

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -76,13 +76,13 @@ class AstBuilder extends DataTypeAstBuilder
       expression(exprCtx) match {
         case Literal(value, _: StringType) if value != null =>
           val parts = parseMultipartIdentifier(value.toString)
-          withOrigin(ctx) { builder(parts) }
+          builder(parts)
         case expr =>
           PlanWithUnresolvedIdentifier(withOrigin(exprCtx) { expr }, Nil,
             (ident, _) => builder(ident))
       }
     } else {
-      withOrigin(ctx) { builder.apply(visitMultipartIdentifier(ctx.multipartIdentifier)) }
+      builder.apply(visitMultipartIdentifier(ctx.multipartIdentifier))
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -73,10 +73,16 @@ class AstBuilder extends DataTypeAstBuilder
       builder: Seq[String] => LogicalPlan): LogicalPlan = {
     val exprCtx = ctx.expression
     if (exprCtx != null) {
-      PlanWithUnresolvedIdentifier(withOrigin(exprCtx) { expression(exprCtx) }, Nil,
-        (ident, _) => builder(ident))
+      expression(exprCtx) match {
+        case Literal(value, _: StringType) if value != null =>
+          val parts = parseMultipartIdentifier(value.toString)
+          withOrigin(ctx) { builder(parts) }
+        case expr =>
+          PlanWithUnresolvedIdentifier(withOrigin(exprCtx) { expr }, Nil,
+            (ident, _) => builder(ident))
+      }
     } else {
-      builder.apply(visitMultipartIdentifier(ctx.multipartIdentifier))
+      withOrigin(ctx) { builder.apply(visitMultipartIdentifier(ctx.multipartIdentifier)) }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR optimizes `withIdentClause` in `AstBuilder` to eagerly resolve `IDENTIFIER()` calls with string literal arguments at parse time instead of deferring to the analysis phase via `PlanWithUnresolvedIdentifier`.

### Why are the changes needed?

When `IDENTIFIER()` is called with a string literal (e.g., `IDENTIFIER('db.table')`), the value is already known at parse time. The current implementation always defers resolution to analysis by wrapping it in `PlanWithUnresolvedIdentifier`, which is unnecessary overhead for this case.

The optimized `withIdentClause` resolves string literals eagerly and falls back to `PlanWithUnresolvedIdentifier` (deferred resolution) for non-literal expressions.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

Yes, Claude Opus 4.6.