### PR TITLE
[SPARK-56013][BUILD] Upgrade `JAXB` to 4.0.7

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -121,8 +121,8 @@ javassist/3.30.2-GA//javassist-3.30.2-GA.jar
 javax.jdo/3.2.0-m3//javax.jdo-3.2.0-m3.jar
 javax.servlet-api/4.0.1//javax.servlet-api-4.0.1.jar
 javolution/5.5.1//javolution-5.5.1.jar
-jaxb-core/4.0.5//jaxb-core-4.0.5.jar
-jaxb-runtime/4.0.5//jaxb-runtime-4.0.5.jar
+jaxb-core/4.0.7//jaxb-core-4.0.7.jar
+jaxb-runtime/4.0.7//jaxb-runtime-4.0.7.jar
 jcl-over-slf4j/2.0.17//jcl-over-slf4j-2.0.17.jar
 jdo-api/3.0.1//jdo-api-3.0.1.jar
 jdom2/2.0.6//jdom2-2.0.6.jar

--- a/pom.xml
+++ b/pom.xml
@@ -663,7 +663,7 @@
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-runtime</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.7</version>
         <scope>compile</scope>
         <exclusions>
           <exclusion>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades `jaxb-runtime` and its transitive dependency `jaxb-core` to 4.0.7.

### Why are the changes needed?

To pick up the latest bug fixes:
- https://github.com/eclipse-ee4j/jaxb-ri/releases/tag/4.0.7-RI
  - https://github.com/eclipse-ee4j/jaxb-ri/pull/1875
  - https://github.com/eclipse-ee4j/jaxb-ri/pull/1862
  - https://github.com/eclipse-ee4j/jaxb-ri/pull/1863
  - https://github.com/eclipse-ee4j/jaxb-ri/pull/1890
  - https://github.com/eclipse-ee4j/jaxb-ri/pull/1883

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the existing tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)