### PR TITLE
[SPARK-56054][SQL] Fix aliased nested fields ignored for schema evolution in MERGE

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -1115,6 +1115,7 @@ object MergeIntoTable {
     expr match {
       case UnresolvedAttribute(nameParts) if allowUnresolved => nameParts
       case a: AttributeReference => Seq(a.name)
+      case Alias(child, _) => extractFieldPath(child, allowUnresolved)
       case GetStructField(child, ordinal, nameOpt) =>
         extractFieldPath(child, allowUnresolved) :+ nameOpt.getOrElse(s"col$ordinal")
       case _ => Seq.empty

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoSchemaEvolutionTypeWideningAndExtraFieldTests.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoSchemaEvolutionTypeWideningAndExtraFieldTests.scala
@@ -18,6 +18,8 @@
 package org.apache.spark.sql.connector
 
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.connector.catalog.CatalogV2Util
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types._
 
 /**
@@ -1432,4 +1434,64 @@ trait MergeIntoSchemaEvolutionTypeWideningAndExtraFieldTests
     expectErrorWithoutEvolutionContains = "Cannot find data for the output column",
     requiresNestedTypeCoercion = true
   )
+
+  test("schema evolution - aliased assignment value should evolve nested struct fields") {
+    val targetSchema = StructType(Seq(
+      StructField("pk", IntegerType, nullable = false),
+      StructField("info", StructType(Seq(
+        StructField("a", IntegerType)
+      )))
+    ))
+    val sourceSchema = StructType(Seq(
+      StructField("pk", IntegerType, nullable = false),
+      StructField("info", StructType(Seq(
+        StructField("a", IntegerType),
+        StructField("b", IntegerType) // new field
+      )))
+    ))
+
+    def readJson(json: Seq[String], schema: StructType): DataFrame =
+      spark.createDataFrame(spark.read.schema(schema).json(json.toDS()).rdd, schema)
+
+    withTable(tableNameAsString) {
+      withTempView("source") {
+        createTable(CatalogV2Util.structTypeToV2Columns(targetSchema), Seq.empty)
+        readJson(Seq(
+          """{ "pk": 1, "info": { "a": 10 } }""",
+          """{ "pk": 2, "info": { "a": 20 } }"""
+        ), targetSchema).writeTo(tableNameAsString).append()
+
+        readJson(Seq(
+          """{ "pk": 2, "info": { "a": 30, "b": 50 } }""",
+          """{ "pk": 3, "info": { "a": 40, "b": 75 } }"""
+        ), sourceSchema).createOrReplaceTempView("source")
+
+        // Use DataFrame merge API and alias the source. The alias shouldn't prevent schema
+        // evolution.
+        spark.table("source")
+          .mergeInto(tableNameAsString,
+            col(s"$tableNameAsString.pk") === col("source.pk"))
+          .whenMatched().update(Map("info" -> col("source.info").as("info")))
+          .whenNotMatched().insert(Map(
+            "pk" -> col("source.pk").as("pk"),
+            "info" -> col("source.info").as("info")))
+          .withSchemaEvolution()
+          .merge()
+
+        val result = sql(s"SELECT * FROM $tableNameAsString")
+        assert(result.schema === StructType(Seq(
+          StructField("pk", IntegerType, nullable = false),
+          StructField("info", StructType(Seq(
+            StructField("a", IntegerType),
+            // Field `b` is correctly added during schema evolution.
+            StructField("b", IntegerType)
+          )))
+        )))
+        checkAnswer(result, Seq(
+          Row(1, Row(10, null)),
+          Row(2, Row(30, 50)),
+          Row(3, Row(40, 75))))
+      }
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixes a small bug in the [initial implementation of schema evolution in MERGE](https://github.com/apache/spark/pull/51698): when a nested struct fields present in the source is used aliased in a direct assignment clause in MERGE, it is not correctly considered for schema evolution.

Example:
```
source.mergeInto("target", condition)
  .whenMatched()
  update(Map("info" -> col("source.info").as("info")))
  .withSchemaEvolution()
  .merge()
```
where `info` is a struct that contains an extra field in the source compared to the target. Without this fix, the extra field is ignored during schema evolution and isn't added to the target table.
With the fix, it is correctly added to the target schema.

### How was this patch tested?
Added a test that reproduces the issue.
