### PR TITLE
[SPARK-56066][PYTHON] Lazy import numpy to improve import speed

### DIFF
--- a/python/pyspark/statcounter.py
+++ b/python/pyspark/statcounter.py
@@ -21,16 +21,19 @@ import copy
 import math
 from typing import Dict, Iterable, Optional
 
-try:
-    from numpy import maximum, minimum, sqrt
-except ImportError:
-    maximum = max  # type: ignore[assignment]
-    minimum = min  # type: ignore[assignment]
-    sqrt = math.sqrt  # type: ignore[assignment]
-
 
 class StatCounter:
     def __init__(self, values: Optional[Iterable[float]] = None):
+        try:
+            from numpy import maximum, minimum, sqrt
+        except ImportError:
+            maximum = max  # type: ignore[assignment]
+            minimum = min  # type: ignore[assignment]
+            sqrt = math.sqrt  # type: ignore[assignment]
+
+        self.maximum = maximum
+        self.minimum = minimum
+        self.sqrt = sqrt
         if values is None:
             values = list()
         self.n = 0  # Running count of our values
@@ -48,8 +51,8 @@ class StatCounter:
         self.n += 1
         self.mu += delta / self.n
         self.m2 += delta * (value - self.mu)
-        self.maxValue = maximum(self.maxValue, value)
-        self.minValue = minimum(self.minValue, value)
+        self.maxValue = self.maximum(self.maxValue, value)
+        self.minValue = self.minimum(self.minValue, value)
 
         return self
 
@@ -77,8 +80,8 @@ class StatCounter:
                 else:
                     self.mu = (self.mu * self.n + other.mu * other.n) / (self.n + other.n)
 
-                self.maxValue = maximum(self.maxValue, other.maxValue)
-                self.minValue = minimum(self.minValue, other.minValue)
+                self.maxValue = self.maximum(self.maxValue, other.maxValue)
+                self.minValue = self.minimum(self.minValue, other.minValue)
 
                 self.m2 += other.m2 + (delta * delta * self.n * other.n) / (self.n + other.n)
                 self.n += other.n
@@ -122,14 +125,14 @@ class StatCounter:
 
     # Return the standard deviation of the values.
     def stdev(self) -> float:
-        return sqrt(self.variance())
+        return self.sqrt(self.variance())
 
     #
     # Return the sample standard deviation of the values, which corrects for bias in estimating the
     # variance by dividing by N-1 instead of N.
     #
     def sampleStdev(self) -> float:
-        return sqrt(self.sampleVariance())
+        return self.sqrt(self.sampleVariance())
 
     def asDict(self, sample: bool = False) -> Dict[str, float]:
         """Returns the :class:`StatCounter` members as a ``dict``.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

In `StatCounter`, only import `numpy` when needed.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This is the only place that triggers `import numpy` when we `import pyspark`. importing `numpy` takes about 30 ms. We can reduce the bootstrap time significantly.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

CI

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.