### PR TITLE
[SPARK-56074][INFRA] Improve AGENTS.md with inline build/test commands, PR workflow, and dev notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ Run a single test case:
 
 ### PR Title
 
-Format: `[SPARK-xxxx][COMPONENT] Title`.
+Format: `[SPARK-xxxx][COMPONENT] Title` where `SPARK-xxxx` is the JIRA ticket ID. Ask the user for the ticket ID if not provided.
 For follow-up fixes: `[SPARK-xxxx][COMPONENT][FOLLOWUP] Title`.
 
 ### PR Description

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Before the first code read, edit, or test in a session, ensure a clean working e
 2. If the latest commit on `<upstream>/master` is more than a day old (check with `git log -1 --format="%ci" <upstream>/master`), run `git fetch <upstream> master`.
 3. If there are uncommitted changes (check with `git status`), ask the user to stash them before proceeding.
 4. Switch to the appropriate branch:
-   - **Existing PR**: look for a local branch matching the PR branch name and confirm with the user. If found, switch to it (if it is checked out in another worktree, work from that worktree). If not found, ask the user whether to fetch the PR to a new local branch or whether there is a local branch under a different name.
+   - **Existing PR**: look for a local branch matching the PR branch name. If found, switch to it and inform the user. If not found, ask whether to fetch it or if there is a local branch under a different name.
    - **New edits**: ask the user to choose: create a new git worktree from `<upstream>/master` and work from there (recommended), or create and switch to a new branch from `<upstream>/master`.
    - **Reading code or running tests**: use `<upstream>/master`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,16 @@
 # Apache Spark
 
-## Before Making Changes
+## Pre-flight Checks
 
-Before the first edit in a session, ensure a clean working environment. DO NOT skip these checks:
+Before the first code read, edit, or test in a session, ensure a clean working environment. DO NOT skip these checks:
 
 1. Run `git remote -v` to identify the personal fork and upstream (`apache/spark`). If unclear, ask the user to configure their remotes following the standard convention (`origin` for the fork, `upstream` for `apache/spark`).
 2. If the latest commit on `<upstream>/master` is more than a day old (check with `git log -1 --format="%ci" <upstream>/master`), run `git fetch <upstream> master`.
 3. If there are uncommitted changes (check with `git status`), ask the user to stash or commit them before proceeding.
-
-Then, depending on the task:
-
-If working on an existing PR:
-- 4a. Find the local branch for the PR by matching branch name and shared commits (one can fast-forward to the other). If not found, ask the user whether to fetch the PR to a new local branch or identify the correct local branch.
-- 4b. Switch to that branch.
-
-If starting new work:
-- 4a. If the current branch has commits not in upstream `master` (check with `git log <upstream>/master..HEAD`), ask the user to pick one:
-   - Create a new git worktree from `<upstream>/master` (recommended) and work from there.
-   - Create and switch to a new branch from `<upstream>/master`.
-- 4b. Otherwise, proceed on the current branch.
+4. Switch to the appropriate branch:
+   - **Existing PR**: find the local branch by matching branch name and shared commits (one can fast-forward to the other). If the branch is checked out in another worktree, work from that worktree. If not found, ask the user whether to fetch the PR to a new local branch or identify the correct local branch.
+   - **New work**: if the current branch has commits not in upstream `master` (check with `git log <upstream>/master..HEAD`), ask the user to choose: create a new git worktree from `<upstream>/master` (recommended), or create and switch to a new branch from `<upstream>/master`.
+   - **Otherwise**: use `<upstream>/master`.
 
 ## Development Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Before the first code read, edit, or test in a session, ensure a clean working e
 2. If the latest commit on `<upstream>/master` is more than a day old (check with `git log -1 --format="%ci" <upstream>/master`), run `git fetch <upstream> master`.
 3. If there are uncommitted changes (check with `git status`), ask the user to stash them before proceeding.
 4. Switch to the appropriate branch:
-   - **Existing PR**: find the local branch by matching branch name and shared commits (one can fast-forward to the other). If the branch is checked out in another worktree, work from that worktree. If not found, ask the user whether to fetch the PR to a new local branch or identify the correct local branch.
+   - **Existing PR**: look for a local branch matching the PR branch name and confirm with the user. If found, switch to it (if it is checked out in another worktree, work from that worktree). If not found, ask the user whether to fetch the PR to a new local branch or whether there is a local branch under a different name.
    - **New edits**: ask the user to choose: create a new git worktree from `<upstream>/master` and work from there (recommended), or create and switch to a new branch from `<upstream>/master`.
    - **Reading code or running tests**: use `<upstream>/master`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Before Making Changes
 
-Before the first edit in a session, ensure a clean working environment:
+Before the first edit in a session, ensure a clean working environment. DO NOT skip these checks:
 
 1. Run `git remote -v` to identify the personal fork and upstream (`apache/spark`). If unclear, ask the user to configure their remotes following the standard convention (`origin` for the fork, `upstream` for `apache/spark`).
 2. If the latest commit on `<upstream>/master` is more than a day old (check with `git log -1 --format="%ci" <upstream>/master`), run `git fetch <upstream> master`.
@@ -11,7 +11,7 @@ Before the first edit in a session, ensure a clean working environment:
 
 ## Development Notes
 
-SQL golden file tests are managed by `SQLQueryTestSuite` and its variants. Read the class documentation before running or updating these tests.
+SQL golden file tests are managed by `SQLQueryTestSuite` and its variants. Read the class documentation before running or updating these tests. DO NOT edit the generated golden files (`.sql.out`) directly. Always regenerate them when needed, and carefully review the diff to make sure it's expected.
 
 Spark Connect protocol is defined in proto files under `sql/connect/common/src/main/protobuf/`. Read the README there before modifying proto definitions.
 
@@ -70,6 +70,6 @@ Run a single test case:
 
 PR title requires a JIRA ticket ID (e.g., `[SPARK-xxxx][SQL] Title`). Ask the user to create a new ticket or provide an existing one if not given. Follow the template in `.github/PULL_REQUEST_TEMPLATE` for the PR description.
 
-Contributors push their feature branch to their personal fork and open PRs against `master` on the upstream Apache Spark repo.
+DO NOT push to the upstream repo. Always push to the personal fork. Open PRs against `master` on the upstream repo.
 
 Always get user approval before external operations such as pushing commits, creating PRs, or posting comments. Use `gh pr create` to open PRs. If `gh` is not installed, generate the GitHub PR URL for the user and recommend installing the GitHub CLI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,8 @@ Spark Connect protocol is defined in proto files under `sql/connect/common/src/m
 
 ## Build and Test
 
+Build and tests can take a long time. Before running tests, ask the user if they have more changes to make.
+
 Prefer SBT over Maven for faster incremental compilation. Module names are defined in `project/SparkBuild.scala`.
 
 Compile a single module:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Apache Spark
 
-Apache Spark is a multi-language engine for large-scale data processing and analytics, primarily written in Scala and Java. It provides SQL and DataFrame APIs for both batch and streaming workloads, with Spark Connect as an optional server-client protocol.
+Apache Spark is a multi-language engine for large-scale data processing and analytics, primarily written in Scala and Java. It supports both batch and streaming workloads, with Spark Connect as an optional server-client protocol.
 
 ## Before Making Changes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,13 @@
 # Apache Spark
 
-Apache Spark is a multi-language engine for large-scale data processing and analytics, primarily written in Scala and Java. It supports both batch and streaming workloads, with Spark Connect as an optional server-client protocol.
-
 ## Before Making Changes
 
-Before the first edit in a session, check the git state:
-1. If there are uncommitted changes, ask the user whether to continue editing or stash/commit first.
-2. If the branch is `master`, or has new commits compared to `master` (check with `git log master..HEAD`), create a new branch from `master` before editing. Inform the user of the new branch name.
-3. Otherwise, proceed on the current branch.
+Before the first edit in a session, ensure a clean working environment:
+
+1. Run `git remote -v` to identify the personal fork and upstream (`apache/spark`). If unclear, ask the user to configure their remotes following the standard convention (`origin` for the fork, `upstream` for `apache/spark`).
+2. If the latest commit on `<upstream>/master` is more than a day old (check with `git log -1 --format="%ci" <upstream>/master`), run `git fetch <upstream> master`.
+3. If the current branch has uncommitted changes or commits not in upstream `master` (check with `git log <upstream>/master..HEAD`), suggest creating a new git worktree from `<upstream>/master` (recommended), or ask the user to clean up by creating a new branch from `<upstream>/master` or stashing changes.
+4. Otherwise, proceed on the current branch.
 
 ## Development Notes
 
@@ -17,29 +17,29 @@ Spark Connect protocol is defined in proto files under `sql/connect/common/src/m
 
 ## Build and Test
 
-Prefer SBT over Maven for day-to-day development (faster incremental compilation). Replace `sql` below with the target module (e.g., `core`, `catalyst`, `connect`).
+Prefer SBT over Maven for faster incremental compilation. Module names are defined in `project/SparkBuild.scala`.
 
 Compile a single module:
 
-    build/sbt sql/compile
+    build/sbt <module>/compile
 
 Compile test code for a single module:
 
-    build/sbt sql/Test/compile
+    build/sbt <module>/Test/compile
 
 Run test suites by wildcard or full class name:
 
-    build/sbt "sql/testOnly *MySuite"
-    build/sbt "sql/testOnly org.apache.spark.sql.MySuite"
+    build/sbt '<module>/testOnly *MySuite'
+    build/sbt '<module>/testOnly org.apache.spark.sql.MySuite'
 
 Run test cases matching a substring:
 
-    build/sbt "sql/testOnly *MySuite -- -z \"test name\""
+    build/sbt '<module>/testOnly *MySuite -- -z "test name"'
 
 For faster iteration, keep SBT open in interactive mode:
 
     build/sbt
-    > project sql
+    > project <module>
     > testOnly *MySuite
 
 ### PySpark Tests
@@ -48,15 +48,15 @@ PySpark tests require building Spark with Hive support first:
 
     build/sbt -Phive package
 
-Set up and activate a virtual environment:
+Activate the virtual environment specified by the user, or default to `~/.virtualenvs/pyspark`:
 
-    if [ ! -d .venv ]; then
-        python3 -m venv .venv
-        source .venv/bin/activate
-        pip install -r dev/requirements.txt
-    else
-        source .venv/bin/activate
-    fi
+    source <venv>/bin/activate
+
+If the default venv does not exist, create it:
+
+    python3 -m venv ~/.virtualenvs/pyspark
+    source ~/.virtualenvs/pyspark/bin/activate
+    pip install -r dev/requirements.txt
 
 Run a single test suite:
 
@@ -68,17 +68,8 @@ Run a single test case:
 
 ## Pull Request Workflow
 
-### PR Title
+PR title requires a JIRA ticket ID (e.g., `[SPARK-xxxx][SQL] Title`). Ask the user to create a new ticket or provide an existing one if not given. Follow the template in `.github/PULL_REQUEST_TEMPLATE` for the PR description.
 
-Format: `[SPARK-xxxx][COMPONENT] Title` where `SPARK-xxxx` is the JIRA ticket ID. Ask the user to create a new ticket or provide an existing one if not given.
-For follow-up fixes: `[SPARK-xxxx][COMPONENT][FOLLOWUP] Title`.
+Contributors push their feature branch to their personal fork and open PRs against `master` on the upstream Apache Spark repo.
 
-### PR Description
-
-Follow the template in `.github/PULL_REQUEST_TEMPLATE`.
-
-### GitHub Workflow
-
-Contributors push their feature branch to their personal fork and open PRs against `master` on the upstream Apache Spark repo. Run `git remote -v` to identify which remote is the fork and which is upstream (`apache/spark`). If the remotes are unclear, ask the user to set them up following the standard convention (`origin` for the fork, `upstream` for `apache/spark`).
-
-Always get user approval before pushing commits or creating PRs. Use `gh pr create` to open PRs. If `gh` is not installed, generate the GitHub PR URL for the user and recommend installing the GitHub CLI.
+Always get user approval before external operations such as pushing commits, creating PRs, or posting comments. Use `gh pr create` to open PRs. If `gh` is not installed, generate the GitHub PR URL for the user and recommend installing the GitHub CLI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,6 @@ PR title requires a JIRA ticket ID (e.g., `[SPARK-xxxx][SQL] Title`). Ask the us
 
 DO NOT push to the upstream repo. Always push to the personal fork. Open PRs against `master` on the upstream repo.
 
-DO NOT force push unless the user explicitly asks. Avoid `--amend` on commits that have been pushed. If the remote branch has new commits, fetch and rebase before pushing.
+DO NOT force push or use `--amend` on pushed commits unless the user explicitly asks. If the remote branch has new commits, fetch and rebase before pushing.
 
 Always get user approval before external operations such as pushing commits, creating PRs, or posting comments. Use `gh pr create` to open PRs. If `gh` is not installed, generate the GitHub PR URL for the user and recommend installing the GitHub CLI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,10 +48,9 @@ PySpark tests require building Spark with Hive support first:
 
     build/sbt -Phive package
 
-Set up and activate a virtual environment (Python 3.10+):
+Set up and activate a virtual environment:
 
     if [ ! -d .venv ]; then
-        python3 -c "import sys; assert sys.version_info >= (3, 10)" || { echo "Python 3.10+ required. Ask the user to install a compatible version."; exit 1; }
         python3 -m venv .venv
         source .venv/bin/activate
         pip install -r dev/requirements.txt
@@ -71,7 +70,7 @@ Run a single test case:
 
 ### PR Title
 
-Format: `[SPARK-xxxx][COMPONENT] Title` or `[MINOR] Title` for trivial changes.
+Format: `[SPARK-xxxx][COMPONENT] Title`.
 For follow-up fixes: `[SPARK-xxxx][COMPONENT][FOLLOWUP] Title`.
 
 ### PR Description

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,85 @@
 # Apache Spark
 
-This file provides context and guidelines for AI coding assistants working with the Apache Spark codebase.
+Apache Spark is a multi-language engine for large-scale data processing and analytics, primarily written in Scala and Java. It provides SQL and DataFrame APIs for both batch and streaming workloads, with Spark Connect as an optional server-client protocol.
+
+## Before Making Changes
+
+Before the first edit in a session, check the git state:
+1. If there are uncommitted changes, ask the user whether to continue editing or stash/commit first.
+2. If the branch is `master`, or has new commits compared to `master` (check with `git log master..HEAD`), create a new branch from `master` before editing. Inform the user of the new branch name.
+3. Otherwise, proceed on the current branch.
+
+## Development Notes
+
+SQL golden file tests are managed by `SQLQueryTestSuite` and its variants. Read the class documentation before running or updating these tests.
+
+Spark Connect protocol is defined in proto files under `sql/connect/common/src/main/protobuf/`. Read the README there before modifying proto definitions.
 
 ## Build and Test
 
-Prefer building in sbt over maven:
+Prefer SBT over Maven for day-to-day development (faster incremental compilation). Replace `sql` below with the target module (e.g., `core`, `catalyst`, `connect`).
 
-- **Building Spark**: [docs/building-spark.md](docs/building-spark.md)
-  - SBT build instructions: See the ["Building with SBT"](docs/building-spark.md#building-with-sbt) section
-  - SBT testing: See the ["Testing with SBT"](docs/building-spark.md#testing-with-sbt) section
-  - Running individual tests: See the ["Running Individual Tests"](docs/building-spark.md#running-individual-tests) section
+Compile a single module:
 
-- **PySpark Testing**: [python/docs/source/development/testing.rst](python/docs/source/development/testing.rst)
+    build/sbt sql/compile
+
+Compile test code for a single module:
+
+    build/sbt sql/Test/compile
+
+Run test suites by wildcard or full class name:
+
+    build/sbt "sql/testOnly *MySuite"
+    build/sbt "sql/testOnly org.apache.spark.sql.MySuite"
+
+Run test cases matching a substring:
+
+    build/sbt "sql/testOnly *MySuite -- -z \"test name\""
+
+For faster iteration, keep SBT open in interactive mode:
+
+    build/sbt
+    > project sql
+    > testOnly *MySuite
+
+### PySpark Tests
+
+PySpark tests require building Spark with Hive support first:
+
+    build/sbt -Phive package
+
+Set up and activate a virtual environment (Python 3.10+):
+
+    if [ ! -d .venv ]; then
+        python3 -c "import sys; assert sys.version_info >= (3, 10)" || { echo "Python 3.10+ required. Ask the user to install a compatible version."; exit 1; }
+        python3 -m venv .venv
+        source .venv/bin/activate
+        pip install -r dev/requirements.txt
+    else
+        source .venv/bin/activate
+    fi
+
+Run a single test suite:
+
+    python/run-tests --testnames pyspark.sql.tests.arrow.test_arrow
+
+Run a single test case:
+
+    python/run-tests --testnames "pyspark.sql.tests.test_catalog CatalogTests.test_current_database"
+
+## Pull Request Workflow
+
+### PR Title
+
+Format: `[SPARK-xxxx][COMPONENT] Title` or `[MINOR] Title` for trivial changes.
+For follow-up fixes: `[SPARK-xxxx][COMPONENT][FOLLOWUP] Title`.
+
+### PR Description
+
+Follow the template in `.github/PULL_REQUEST_TEMPLATE`.
+
+### GitHub Workflow
+
+Contributors push their feature branch to their personal fork and open PRs against `master` on the upstream Apache Spark repo. Run `git remote -v` to identify which remote is the fork and which is upstream (`apache/spark`). If the remotes are unclear, ask the user to set them up following the standard convention (`origin` for the fork, `upstream` for `apache/spark`).
+
+Use `gh pr create` to open PRs. If `gh` is not installed, generate the GitHub PR URL for the user and recommend installing the GitHub CLI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,14 +50,14 @@ PySpark tests require building Spark with Hive support first:
 
     build/sbt -Phive package
 
-Activate the virtual environment specified by the user, or default to `~/.virtualenvs/pyspark`:
+Activate the virtual environment specified by the user, or default to `.venv`:
 
     source <venv>/bin/activate
 
 If the default venv does not exist, create it:
 
-    python3 -m venv ~/.virtualenvs/pyspark
-    source ~/.virtualenvs/pyspark/bin/activate
+    python3 -m venv .venv
+    source .venv/bin/activate
     pip install -r dev/requirements.txt
 
 Run a single test suite:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ Run a single test case:
 
 ### PR Title
 
-Format: `[SPARK-xxxx][COMPONENT] Title` where `SPARK-xxxx` is the JIRA ticket ID. Ask the user for the ticket ID if not provided.
+Format: `[SPARK-xxxx][COMPONENT] Title` where `SPARK-xxxx` is the JIRA ticket ID. Ask the user to create a new ticket or provide an existing one if not given.
 For follow-up fixes: `[SPARK-xxxx][COMPONENT][FOLLOWUP] Title`.
 
 ### PR Description
@@ -81,4 +81,4 @@ Follow the template in `.github/PULL_REQUEST_TEMPLATE`.
 
 Contributors push their feature branch to their personal fork and open PRs against `master` on the upstream Apache Spark repo. Run `git remote -v` to identify which remote is the fork and which is upstream (`apache/spark`). If the remotes are unclear, ask the user to set them up following the standard convention (`origin` for the fork, `upstream` for `apache/spark`).
 
-Use `gh pr create` to open PRs. If `gh` is not installed, generate the GitHub PR URL for the user and recommend installing the GitHub CLI.
+Always get user approval before pushing commits or creating PRs. Use `gh pr create` to open PRs. If `gh` is not installed, generate the GitHub PR URL for the user and recommend installing the GitHub CLI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,9 @@ Before the first edit in a session, ensure a clean working environment. DO NOT s
 
 1. Run `git remote -v` to identify the personal fork and upstream (`apache/spark`). If unclear, ask the user to configure their remotes following the standard convention (`origin` for the fork, `upstream` for `apache/spark`).
 2. If the latest commit on `<upstream>/master` is more than a day old (check with `git log -1 --format="%ci" <upstream>/master`), run `git fetch <upstream> master`.
-3. If the current branch has uncommitted changes or commits not in upstream `master` (check with `git log <upstream>/master..HEAD`), suggest creating a new git worktree from `<upstream>/master` (recommended), or ask the user to clean up by creating a new branch from `<upstream>/master` or stashing changes.
+3. If the current branch has uncommitted changes (check with `git status`) or commits not in upstream `master` (check with `git log <upstream>/master..HEAD`), ask the user to pick one:
+   - Create a new git worktree from `<upstream>/master` (recommended) and work from there.
+   - For uncommitted changes: stash them. For unmerged commits: create and switch to a new branch from `<upstream>/master`.
 4. Otherwise, proceed on the current branch.
 
 ## Development Notes
@@ -71,5 +73,7 @@ Run a single test case:
 PR title requires a JIRA ticket ID (e.g., `[SPARK-xxxx][SQL] Title`). Ask the user to create a new ticket or provide an existing one if not given. Follow the template in `.github/PULL_REQUEST_TEMPLATE` for the PR description.
 
 DO NOT push to the upstream repo. Always push to the personal fork. Open PRs against `master` on the upstream repo.
+
+DO NOT force push unless the user explicitly asks. Avoid `--amend` on commits that have been pushed. If the remote branch has new commits, fetch and rebase before pushing.
 
 Always get user approval before external operations such as pushing commits, creating PRs, or posting comments. Use `gh pr create` to open PRs. If `gh` is not installed, generate the GitHub PR URL for the user and recommend installing the GitHub CLI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,11 @@ Before the first code read, edit, or test in a session, ensure a clean working e
 
 1. Run `git remote -v` to identify the personal fork and upstream (`apache/spark`). If unclear, ask the user to configure their remotes following the standard convention (`origin` for the fork, `upstream` for `apache/spark`).
 2. If the latest commit on `<upstream>/master` is more than a day old (check with `git log -1 --format="%ci" <upstream>/master`), run `git fetch <upstream> master`.
-3. If there are uncommitted changes (check with `git status`), ask the user to stash or commit them before proceeding.
+3. If there are uncommitted changes (check with `git status`), ask the user to stash them before proceeding.
 4. Switch to the appropriate branch:
    - **Existing PR**: find the local branch by matching branch name and shared commits (one can fast-forward to the other). If the branch is checked out in another worktree, work from that worktree. If not found, ask the user whether to fetch the PR to a new local branch or identify the correct local branch.
-   - **New work**: if the current branch has commits not in upstream `master` (check with `git log <upstream>/master..HEAD`), ask the user to choose: create a new git worktree from `<upstream>/master` (recommended), or create and switch to a new branch from `<upstream>/master`.
-   - **Otherwise**: use `<upstream>/master`.
+   - **New edits**: ask the user to choose: create a new git worktree from `<upstream>/master` and work from there (recommended), or create and switch to a new branch from `<upstream>/master`.
+   - **Reading code or running tests**: use `<upstream>/master`.
 
 ## Development Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,19 @@ Before the first edit in a session, ensure a clean working environment. DO NOT s
 
 1. Run `git remote -v` to identify the personal fork and upstream (`apache/spark`). If unclear, ask the user to configure their remotes following the standard convention (`origin` for the fork, `upstream` for `apache/spark`).
 2. If the latest commit on `<upstream>/master` is more than a day old (check with `git log -1 --format="%ci" <upstream>/master`), run `git fetch <upstream> master`.
-3. If the current branch has uncommitted changes (check with `git status`) or commits not in upstream `master` (check with `git log <upstream>/master..HEAD`), ask the user to pick one:
+3. If there are uncommitted changes (check with `git status`), ask the user to stash or commit them before proceeding.
+
+Then, depending on the task:
+
+If working on an existing PR:
+- 4a. Find the local branch for the PR by matching branch name and shared commits (one can fast-forward to the other). If not found, ask the user whether to fetch the PR to a new local branch or identify the correct local branch.
+- 4b. Switch to that branch.
+
+If starting new work:
+- 4a. If the current branch has commits not in upstream `master` (check with `git log <upstream>/master..HEAD`), ask the user to pick one:
    - Create a new git worktree from `<upstream>/master` (recommended) and work from there.
-   - For uncommitted changes: stash them. For unmerged commits: create and switch to a new branch from `<upstream>/master`.
-4. Otherwise, proceed on the current branch.
+   - Create and switch to a new branch from `<upstream>/master`.
+- 4b. Otherwise, proceed on the current branch.
 
 ## Development Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rewrite AGENTS.md to follow industry best practices for AI coding agent instructions:
- Git pre-flight checks (uncommitted changes, branch state) before making edits
- Inline actionable SBT build/test commands instead of links to docs
- PySpark test setup with venv and Python version check
- Development notes for SQLQueryTestSuite golden file tests and Spark Connect proto definitions
- PR workflow guidelines (title format, description template, fork/upstream workflow)
- Add CLAUDE.md as a symlink to AGENTS.md so Claude Code also picks up the instructions

### Why are the changes needed?

The existing AGENTS.md only contained links to build docs, which AI coding agents cannot follow. The rewrite provides inline commands and actionable guidance that agents can directly use. All commands have been verified to work.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

All build and test commands were manually verified:
- `build/sbt sql/compile`, `build/sbt sql/Test/compile`
- `build/sbt "sql/testOnly *MySuite"`, `build/sbt "sql/testOnly *MySuite -- -z \"test name\""`
- PySpark venv setup and `python/run-tests` with both test suite and single test case
- Confirmed `OBJC_DISABLE_INITIALIZE_FORK_SAFETY` is no longer needed on macOS

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.6