### PR TITLE
[SPARK-43253][SQL] Assign a name to the error class _LEGACY_ERROR_TEMP_2017

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -7004,6 +7004,12 @@
     ],
     "sqlState" : "42803"
   },
+  "UNRESOLVED_COLLECTION_CLS" : {
+    "message" : [
+      "Custom collection class is not resolved. Ensure the class is accessible and properly defined before analysis."
+    ],
+    "sqlState" : "0A000"
+  },
   "UNRESOLVED_COLUMN" : {
     "message" : [
       "A column, variable, or function parameter with name <objectName> cannot be resolved."
@@ -9274,11 +9280,6 @@
   "_LEGACY_ERROR_TEMP_2003" : {
     "message" : [
       "Unsuccessful try to zip maps with <size> unique keys due to exceeding the array size limit <maxRoundedArrayLength>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2017" : {
-    "message" : [
-      "not resolved."
     ]
   },
   "_LEGACY_ERROR_TEMP_2026" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -458,7 +458,9 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def customCollectionClsNotResolvedError(): SparkUnsupportedOperationException = {
-    new SparkUnsupportedOperationException("_LEGACY_ERROR_TEMP_2017")
+    new SparkUnsupportedOperationException(
+      errorClass = "UNRESOLVED_COLLECTION_CLS",
+      messageParameters = Map.empty[String, String])
   }
 
   def classUnsupportedByMapObjectsError(cls: Class[_]): SparkRuntimeException = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
@@ -26,7 +26,7 @@ import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.Random
 
-import org.apache.spark.{SparkConf, SparkException, SparkFunSuite, SparkRuntimeException}
+import org.apache.spark.{SparkConf, SparkException, SparkFunSuite, SparkRuntimeException, SparkUnsupportedOperationException}
 import org.apache.spark.serializer.{JavaSerializer, KryoSerializer}
 import org.apache.spark.sql.{RandomDataGenerator, Row}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, ScalaReflection, ScroogeLikeExample}
@@ -103,6 +103,17 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
         ("Couldn't find method oneArgNotExistMethod with arguments " +
           "(class org.apache.spark.unsafe.types.UTF8String) on class java.lang.Object.")
       )
+    )
+  }
+
+  test("SPARK-43253: UNRESOLVED_COLLECTION_CLS error class") {
+    checkError(
+      exception = intercept[SparkUnsupportedOperationException] {
+        val unresolved = UnresolvedMapObjects(identity, Literal(1), None)
+        unresolved.dataType
+      },
+      condition = "UNRESOLVED_COLLECTION_CLS",
+      parameters = Map.empty
     )
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Assigned a proper name to the legacy error class `_LEGACY_ERROR_TEMP_2017` 
in `error-conditions.json`. The error is now named `UNRESOLVED_COLLECTION_CLS` 
with an improved error message and sqlState `0A000`.

### Why are the changes needed?
`_LEGACY_ERROR_TEMP_2017` was a temporary placeholder name from the error 
class migration project. This PR gives it a meaningful name that clearly 
describes the error condition.

### Does this PR introduce any user-facing change?
Yes, the error message has been improved from the vague "not resolved." to 
"Custom collection class is not resolved. Ensure the class is accessible 
and properly defined before analysis."

### How was this patch tested?
Added a new test in `ObjectExpressionsSuite` that verifies the error class, 
condition name, and parameters using `checkError()`.

### Was this patch authored or co-authored using generative AI tooling?
No.