### PR TITLE
[SPARK-55887][CONNECT][TESTS][FOLLOW-UP] Make new tests more stable

### DIFF
--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
@@ -1069,6 +1069,9 @@ class SparkConnectServiceSuite
         assert(done)
       }
 
+      // Wait for listener bus to process all events
+      spark.sparkContext.listenerBus.waitUntilEmpty()
+
       // Verify result
       assert(responses.exists(_.hasArrowBatch))
 
@@ -1148,6 +1151,9 @@ class SparkConnectServiceSuite
       Eventually.eventually(timeout(10.seconds)) {
         assert(done)
       }
+
+      // Wait for listener bus to process all events
+      spark.sparkContext.listenerBus.waitUntilEmpty()
 
       // Verify result
       assert(responses.exists(_.hasArrowBatch))


### PR DESCRIPTION

### What changes were proposed in this pull request?
Make new tests more stable


### Why are the changes needed?
they occasionally (~5%) fails with
```

❯ test 'SPARK-55887: Use executeCollect for tail to avoid full scan'
        org.scalatest.exceptions.TestFailedException: 0 was not greater than or equal to 1
      at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
      at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:471)
      at org.scalatest.Assertions$.newAssertionFailedException(Assertions.scala:1231)
      at org.scalatest.Assertions$AssertionsHelper.macroAssert(Assertions.scala:1295)
      at org.apache.spark.sql.connect.planner.SparkConnectServiceSuite.$anonfun$new$72(SparkConnectServiceSuite.scala:1234)
      at org.scalatest.enablers.Timed$anon$1.timeoutAfter(Timed.scala:127)
      at org.scalatest.concurrent.TimeLimits$.failAfterImpl(TimeLimits.scala:282)
      at org.scalatest.concurrent.TimeLimits.failAfter(TimeLimits.scala:231)
      at org.scalatest.concurrent.TimeLimits.failAfter$(TimeLimits.scala:230)
      at org.apache.spark.SparkFunSuite.failAfter(SparkFunSuite.scala:77)
      at org.apache.spark.SparkFunSuite.testWithTimeout(SparkFunSuite.scala:480)
      at org.apache.spark.SparkFunSuite.$anonfun$test$1(SparkFunSuite.scala:266)
      at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
      at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
      at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
      at org.scalatest.Transformer.apply(Transformer.scala:22)
      at org.scalatest.Transformer.apply(Transformer.scala:20)
      at org.scalatest.funsuite.AnyFunSuiteLike$anon$1.apply(AnyFunSuiteLike.scala:226)
      at org.scalatest.funsuite.AnyFunSuiteLike$anon$1.apply(AnyFunSuiteLike.scala:224)
      at org.apache.spark.SparkFunSuite.runWithCredentials(SparkFunSuite.scala:545)
      at org.apache.spark.SparkFunSuite.withFixture(SparkFunSuite.scala:159)
      at org.scalatest.funsuite.AnyFunSuiteLike.invokeWithFixture$1(AnyFunSuiteLike.scala:224)
      at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$runTest$1(AnyFunSuiteLike.scala:236)
      at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
      at org.scalatest.funsuite.AnyFunSuiteLike.runTest(AnyFunSuiteLike.scala:236)
      at org.scalatest.funsuite.AnyFunSuiteLike.runTest$(AnyFunSuiteLike.scala:218)
      at org.apache.spark.SparkFunSuite.org$scalatest$BeforeAndAfterEach$super$runTest(SparkFunSuite.scala:77)
      at org.scalatest.BeforeAndAfterEach.runTest(BeforeAndAfterEach.scala:234)
      at org.scalatest.BeforeAndAfterEach.runTest$(BeforeAndAfterEach.scala:227)
      at org.apache.spark.SparkFunSuite.runTest(SparkFunSuite.scala:77)
      at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$runTests$1(AnyFunSuiteLike.scala:269)
      at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:413)
      at scala.collection.immutable.List.foreach(List.scala:334)
      at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
      at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:396)
      at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:475)
      at org.scalatest.funsuite.AnyFunSuiteLike.runTests(AnyFunSuiteLike.scala:269)
      at org.scalatest.funsuite.AnyFunSuiteLike.runTests$(AnyFunSuiteLike.scala:268)
      at org.scalatest.funsuite.AnyFunSuite.runTests(AnyFunSuite.scala:1564)
      at org.scalatest.Suite.run(Suite.scala:1114)
      at org.scalatest.Suite.run$(Suite.scala:1096)
      at org.scalatest.funsuite.AnyFunSuite.org$scalatest$funsuite$AnyFunSuiteLike$super$run(AnyFunSuite.scala:1564)
      at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$run$1(AnyFunSuiteLike.scala:273)
      at org.scalatest.SuperEngine.runImpl(Engine.scala:535)
      at org.scalatest.funsuite.AnyFunSuiteLike.run(AnyFunSuiteLike.scala:273)
      at org.scalatest.funsuite.AnyFunSuiteLike.run$(AnyFunSuiteLike.scala:272)
      at org.apache.spark.SparkFunSuite.org$scalatest$BeforeAndAfterAll$super$run(SparkFunSuite.scala:77)
      at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
      at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
      at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
      at org.apache.spark.SparkFunSuite.run(SparkFunSuite.scala:517)
      at org.scalatest.tools.SuiteRunner.run(SuiteRunner.scala:47)
      at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$13(Runner.scala:1321)
      at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$13$adapted(Runner.scala:1315)
      at scala.collection.immutable.List.foreach(List.scala:334)
      at org.scalatest.tools.Runner$.doRunRunRunDaDoRunRun(Runner.scala:1315)
      at org.scalatest.tools.Runner$.$anonfun$runOptionallyWithPassFailReporter$24(Runner.scala:992)
      at org.scalatest.tools.Runner$.$anonfun$runOptionallyWithPassFailReporter$24$adapted(Runner.scala:970)
      at org.scalatest.tools.Runner$.withClassLoaderAndDispatchReporter(Runner.scala:1481)
      at org.scalatest.tools.Runner$.runOptionallyWithPassFailReporter(Runner.scala:970)
      at org.scalatest.tools.Runner$.run(Runner.scala:798)
      at com.databricks.scalatest.ScalaTestRunnerWrapper$.main(ScalaTestRunnerWrapper.scala:56)
      at com.databricks.scalatest.ScalaTestRunnerWrapper.main(ScalaTestRunnerWrapper.scala)
      

```


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
manually check


### Was this patch authored or co-authored using generative AI tooling?
Opus 4.6 is used
