### PR TITLE
[SPARK-55887][CONNECT][FOLLOWUP] Fix flaky SparkConnectServiceSuite limit/tail tests

### DIFF
--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.connect.planner
 import java.io.SequenceInputStream
 import java.util.UUID
 import java.util.concurrent.Semaphore
+import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
@@ -1044,10 +1045,10 @@ class SparkConnectServiceSuite
       .build()
 
     // Capture job execution metrics
-    var numTasks = 0
+    val numTasks = new AtomicInteger(0)
     val listener = new SparkListener {
       override def onTaskEnd(taskEnd: org.apache.spark.scheduler.SparkListenerTaskEnd): Unit = {
-        numTasks += 1
+        numTasks.incrementAndGet()
       }
     }
     spark.sparkContext.addSparkListener(listener)
@@ -1055,7 +1056,7 @@ class SparkConnectServiceSuite
     try {
       val instance = new SparkConnectService(false)
       val responses = mutable.Buffer.empty[proto.ExecutePlanResponse]
-      var done = false
+      @volatile var done = false
       instance.executePlan(
         request,
         new StreamObserver[proto.ExecutePlanResponse] {
@@ -1072,15 +1073,18 @@ class SparkConnectServiceSuite
       // Verify result
       assert(responses.exists(_.hasArrowBatch))
 
+      // Wait for listener bus to process all events
+      spark.sparkContext.listenerBus.waitUntilEmpty()
+
       // Verify optimization:
       // If executeCollect/executeTake is used, it should only scan the first partition (1 task).
       // If execute() is used, it might scan all partitions (100 tasks) for LocalLimit
       // or trigger Shuffle.
       // We expect significantly fewer tasks than numPartitions.
       assert(
-        numTasks < numPartitions,
-        s"Expected fewer tasks than partitions ($numPartitions), but got $numTasks")
-      assert(numTasks >= 1)
+        numTasks.get() < numPartitions,
+        s"Expected fewer tasks than partitions ($numPartitions), but got ${numTasks.get()}")
+      assert(numTasks.get() >= 1)
     } finally {
       spark.sparkContext.removeSparkListener(listener)
     }
@@ -1124,10 +1128,10 @@ class SparkConnectServiceSuite
       .build()
 
     // Capture job execution metrics
-    var numTasks = 0
+    val numTasks = new AtomicInteger(0)
     val listener = new SparkListener {
       override def onTaskEnd(taskEnd: org.apache.spark.scheduler.SparkListenerTaskEnd): Unit = {
-        numTasks += 1
+        numTasks.incrementAndGet()
       }
     }
     spark.sparkContext.addSparkListener(listener)
@@ -1135,7 +1139,7 @@ class SparkConnectServiceSuite
     try {
       val instance = new SparkConnectService(false)
       val responses = mutable.Buffer.empty[proto.ExecutePlanResponse]
-      var done = false
+      @volatile var done = false
       instance.executePlan(
         request,
         new StreamObserver[proto.ExecutePlanResponse] {
@@ -1152,14 +1156,17 @@ class SparkConnectServiceSuite
       // Verify result
       assert(responses.exists(_.hasArrowBatch))
 
+      // Wait for listener bus to process all events
+      spark.sparkContext.listenerBus.waitUntilEmpty()
+
       // Verify optimization:
       // If executeCollect/executeTail is used, it should only scan the last partition (1 task).
       // If execute() is used, it might scan all partitions (100 tasks) or trigger Shuffle.
       // We expect significantly fewer tasks than numPartitions.
       assert(
-        numTasks < numPartitions,
-        s"Expected fewer tasks than partitions ($numPartitions), but got $numTasks")
-      assert(numTasks >= 1)
+        numTasks.get() < numPartitions,
+        s"Expected fewer tasks than partitions ($numPartitions), but got ${numTasks.get()}")
+      assert(numTasks.get() >= 1)
     } finally {
       spark.sparkContext.removeSparkListener(listener)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR is intended to fix the flaky test in `SparkConnectServiceSuite` reported by @zhengruifeng 

hey occasionally (~5%) fails with
```

❯ test 'SPARK-55887: Use executeCollect for tail to avoid full scan'
        org.scalatest.exceptions.TestFailedException: 0 was not greater than or equal to 1
      at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
      at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:471)
      at org.scalatest.Assertions$.newAssertionFailedException(Assertions.scala:1231)
      at org.scalatest.Assertions$AssertionsHelper.macroAssert(Assertions.scala:1295)
      at org.apache.spark.sql.connect.planner.SparkConnectServiceSuite.$anonfun$new$72(SparkConnectServiceSuite.scala:1234)
      at org.scalatest.enablers.Timed$anon$1.timeoutAfter(Timed.scala:127)
      at org.scalatest.concurrent.TimeLimits$.failAfterImpl(TimeLimits.scala:282)
      at org.scalatest.concurrent.TimeLimits.failAfter(TimeLimits.scala:231)
      at org.scalatest.concurrent.TimeLimits.failAfter$(TimeLimits.scala:230)
      at org.apache.spark.SparkFunSuite.failAfter(SparkFunSuite.scala:77)
      at org.apache.spark.SparkFunSuite.testWithTimeout(SparkFunSuite.scala:480)
      at org.apache.spark.SparkFunSuite.$anonfun$test$1(SparkFunSuite.scala:266)
      at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
      at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
      at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
      at org.scalatest.Transformer.apply(Transformer.scala:22)
      at org.scalatest.Transformer.apply(Transformer.scala:20)
      at org.scalatest.funsuite.AnyFunSuiteLike$anon$1.apply(AnyFunSuiteLike.scala:226)
      at org.scalatest.funsuite.AnyFunSuiteLike$anon$1.apply(AnyFunSuiteLike.scala:224)
      at org.apache.spark.SparkFunSuite.runWithCredentials(SparkFunSuite.scala:545)
      at org.apache.spark.SparkFunSuite.withFixture(SparkFunSuite.scala:159)
      at org.scalatest.funsuite.AnyFunSuiteLike.invokeWithFixture$1(AnyFunSuiteLike.scala:224)
      at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$runTest$1(AnyFunSuiteLike.scala:236)
      at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
      at org.scalatest.funsuite.AnyFunSuiteLike.runTest(AnyFunSuiteLike.scala:236)
      at org.scalatest.funsuite.AnyFunSuiteLike.runTest$(AnyFunSuiteLike.scala:218)
      at org.apache.spark.SparkFunSuite.org$scalatest$BeforeAndAfterEach$super$runTest(SparkFunSuite.scala:77)
      at org.scalatest.BeforeAndAfterEach.runTest(BeforeAndAfterEach.scala:234)
      at org.scalatest.BeforeAndAfterEach.runTest$(BeforeAndAfterEach.scala:227)
      at org.apache.spark.SparkFunSuite.runTest(SparkFunSuite.scala:77)
      at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$runTests$1(AnyFunSuiteLike.scala:269)
      at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:413)
      at scala.collection.immutable.List.foreach(List.scala:334)
      at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
      at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:396)
      at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:475)
      at org.scalatest.funsuite.AnyFunSuiteLike.runTests(AnyFunSuiteLike.scala:269)
      at org.scalatest.funsuite.AnyFunSuiteLike.runTests$(AnyFunSuiteLike.scala:268)
      at org.scalatest.funsuite.AnyFunSuite.runTests(AnyFunSuite.scala:1564)
      at org.scalatest.Suite.run(Suite.scala:1114)
      at org.scalatest.Suite.run$(Suite.scala:1096)
      at org.scalatest.funsuite.AnyFunSuite.org$scalatest$funsuite$AnyFunSuiteLike$super$run(AnyFunSuite.scala:1564)
      at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$run$1(AnyFunSuiteLike.scala:273)
      at org.scalatest.SuperEngine.runImpl(Engine.scala:535)
      at org.scalatest.funsuite.AnyFunSuiteLike.run(AnyFunSuiteLike.scala:273)
      at org.scalatest.funsuite.AnyFunSuiteLike.run$(AnyFunSuiteLike.scala:272)
      at org.apache.spark.SparkFunSuite.org$scalatest$BeforeAndAfterAll$super$run(SparkFunSuite.scala:77)
      at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
      at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
      at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
      at org.apache.spark.SparkFunSuite.run(SparkFunSuite.scala:517)
      at org.scalatest.tools.SuiteRunner.run(SuiteRunner.scala:47)
      at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$13(Runner.scala:1321)
      at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$13$adapted(Runner.scala:1315)
      at scala.collection.immutable.List.foreach(List.scala:334)
      at org.scalatest.tools.Runner$.doRunRunRunDaDoRunRun(Runner.scala:1315)
      at org.scalatest.tools.Runner$.$anonfun$runOptionallyWithPassFailReporter$24(Runner.scala:992)
      at org.scalatest.tools.Runner$.$anonfun$runOptionallyWithPassFailReporter$24$adapted(Runner.scala:970)
      at org.scalatest.tools.Runner$.withClassLoaderAndDispatchReporter(Runner.scala:1481)
      at org.scalatest.tools.Runner$.runOptionallyWithPassFailReporter(Runner.scala:970)
      at org.scalatest.tools.Runner$.run(Runner.scala:798)
      at com.databricks.scalatest.ScalaTestRunnerWrapper$.main(ScalaTestRunnerWrapper.scala:56)
      at com.databricks.scalatest.ScalaTestRunnerWrapper.main(ScalaTestRunnerWrapper.scala)
      

```

the main changes as follows:
- Use `AtomicInteger` instead of `var` for thread-safe task counting in `SparkListener.onTaskEnd`, which runs on a different thread
- Add `@volatile` to the `done` flag shared between the main thread and the `StreamObserver` callback
- Call `listenerBus.waitUntilEmpty()` before asserting task counts to ensure all listener events have been processed


### Why are the changes needed?
The tests added in SPARK-55887 have race conditions that can cause flaky failures:
1. `numTasks` is incremented from the listener bus thread but read from the test thread without synchronization — a plain `var` is not thread-safe
2. The `done` flag is written by the `StreamObserver.onCompleted` callback but read by the main thread — without `@volatile`, the main thread may not see the update
3. Task count assertions can execute before the listener bus finishes delivering all `onTaskEnd` events, leading to undercounted tasks



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Opus 4.6
