### PR TITLE
[SPARK-56080][PS] Align Series.argmax/argmin with pandas 3.0 NA handling

### DIFF
--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -6535,13 +6535,16 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             max_value = results[0]
             # If the maximum is achieved in multiple locations, the first row position is returned.
             if max_value[0] is None:
-                warnings.warn(
-                    "The behavior of Series.argmax/argmin "
-                    "with skipna=False and NAs, or with all-NAs is deprecated. "
-                    "In a future version this will raise ValueError.",
-                    FutureWarning,
-                )
-                return -1
+                if LooseVersion(pd.__version__) < "3.0.0":
+                    warnings.warn(
+                        "The behavior of Series.argmax/argmin "
+                        "with skipna=False and NAs, or with all-NAs is deprecated. "
+                        "In a future version this will raise ValueError.",
+                        FutureWarning,
+                    )
+                    return -1
+                else:
+                    raise ValueError("Encountered an NA value with skipna=False")
             else:
                 return max_value[1]
 
@@ -6604,13 +6607,16 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             min_value = results[0]
             # If the maximum is achieved in multiple locations, the first row position is returned.
             if min_value[0] is None:
-                warnings.warn(
-                    "The behavior of Series.argmax/argmin "
-                    "with skipna=False and NAs, or with all-NAs is deprecated. "
-                    "In a future version this will raise ValueError.",
-                    FutureWarning,
-                )
-                return -1
+                if LooseVersion(pd.__version__) < "3.0.0":
+                    warnings.warn(
+                        "The behavior of Series.argmax/argmin "
+                        "with skipna=False and NAs, or with all-NAs is deprecated. "
+                        "In a future version this will raise ValueError.",
+                        FutureWarning,
+                    )
+                    return -1
+                else:
+                    raise ValueError("Encountered an NA value with skipna=False")
             else:
                 return min_value[1]
 

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -6544,7 +6544,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                     )
                     return -1
                 else:
-                    raise ValueError("Encountered an NA value with skipna=False")
+                    if skipna:
+                        raise ValueError("Encountered all NA values")
+                    else:
+                        raise ValueError("Encountered an NA value with skipna=False")
             else:
                 return max_value[1]
 
@@ -6616,7 +6619,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                     )
                     return -1
                 else:
-                    raise ValueError("Encountered an NA value with skipna=False")
+                    if skipna:
+                        raise ValueError("Encountered all NA values")
+                    else:
+                        raise ValueError("Encountered an NA value with skipna=False")
             else:
                 return min_value[1]
 

--- a/python/pyspark/pandas/tests/series/test_arg_ops.py
+++ b/python/pyspark/pandas/tests/series/test_arg_ops.py
@@ -18,6 +18,7 @@
 import numpy as np
 import pandas as pd
 
+from pyspark.loose_version import LooseVersion
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
@@ -152,15 +153,29 @@ class SeriesArgOpsMixin:
         psser2 = ps.from_pandas(pser2)
         self.assert_eq(pser2.argmin(), psser2.argmin())
         self.assert_eq(pser2.argmax(), psser2.argmax())
-        self.assert_eq(pser2.argmin(skipna=False), psser2.argmin(skipna=False))
-        self.assert_eq(pser2.argmax(skipna=False), psser2.argmax(skipna=False))
+        if LooseVersion(pd.__version__) < "3.0.0":
+            self.assert_eq(pser2.argmin(skipna=False), psser2.argmin(skipna=False))
+            self.assert_eq(pser2.argmax(skipna=False), psser2.argmax(skipna=False))
 
-        # Null Series
-        self.assert_eq(pd.Series([np.nan]).argmin(), ps.Series([np.nan]).argmin())
-        self.assert_eq(pd.Series([np.nan]).argmax(), ps.Series([np.nan]).argmax())
-        self.assert_eq(
-            pd.Series([np.nan]).argmax(skipna=False), ps.Series([np.nan]).argmax(skipna=False)
-        )
+            # Null Series
+            self.assert_eq(pd.Series([np.nan]).argmin(), ps.Series([np.nan]).argmin())
+            self.assert_eq(pd.Series([np.nan]).argmax(), ps.Series([np.nan]).argmax())
+            self.assert_eq(
+                pd.Series([np.nan]).argmax(skipna=False), ps.Series([np.nan]).argmax(skipna=False)
+            )
+        else:
+            with self.assertRaisesRegex(ValueError, "Encountered an NA value with skipna=False"):
+                psser2.argmin(skipna=False)
+            with self.assertRaisesRegex(ValueError, "Encountered an NA value with skipna=False"):
+                psser2.argmax(skipna=False)
+
+            # Null Series
+            with self.assertRaisesRegex(ValueError, "Encountered an NA value with skipna=False"):
+                ps.Series([np.nan]).argmin()
+            with self.assertRaisesRegex(ValueError, "Encountered an NA value with skipna=False"):
+                ps.Series([np.nan]).argmax()
+            with self.assertRaisesRegex(ValueError, "Encountered an NA value with skipna=False"):
+                ps.Series([np.nan]).argmax(skipna=False)
 
         with self.assertRaisesRegex(ValueError, "attempt to get argmin of an empty sequence"):
             ps.Series([]).argmin()

--- a/python/pyspark/pandas/tests/series/test_arg_ops.py
+++ b/python/pyspark/pandas/tests/series/test_arg_ops.py
@@ -161,6 +161,9 @@ class SeriesArgOpsMixin:
             self.assert_eq(pd.Series([np.nan]).argmin(), ps.Series([np.nan]).argmin())
             self.assert_eq(pd.Series([np.nan]).argmax(), ps.Series([np.nan]).argmax())
             self.assert_eq(
+                pd.Series([np.nan]).argmin(skipna=False), ps.Series([np.nan]).argmin(skipna=False)
+            )
+            self.assert_eq(
                 pd.Series([np.nan]).argmax(skipna=False), ps.Series([np.nan]).argmax(skipna=False)
             )
         else:
@@ -170,12 +173,16 @@ class SeriesArgOpsMixin:
                 psser2.argmax(skipna=False)
 
             # Null Series
-            with self.assertRaisesRegex(ValueError, "Encountered an NA value with skipna=False"):
+            with self.assertRaisesRegex(ValueError, "Encountered all NA values$"):
                 ps.Series([np.nan]).argmin()
-            with self.assertRaisesRegex(ValueError, "Encountered an NA value with skipna=False"):
+            with self.assertRaisesRegex(ValueError, "Encountered all NA values$"):
                 ps.Series([np.nan]).argmax()
             with self.assertRaisesRegex(ValueError, "Encountered an NA value with skipna=False"):
-                ps.Series([np.nan]).argmax(skipna=False)
+                ps.Series([np.nan]).argmin(skipna=False)
+                with self.assertRaisesRegex(
+                    ValueError, "Encountered an NA value with skipna=False"
+                ):
+                    ps.Series([np.nan]).argmax(skipna=False)
 
         with self.assertRaisesRegex(ValueError, "attempt to get argmin of an empty sequence"):
             ps.Series([]).argmin()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates pandas-on-Spark `Series.argmax` and `Series.argmin` to match pandas 3.0 behavior for NA handling.

In `python/pyspark/pandas/series.py`, when an NA value is encountered with `skipna=False` or the Series is all-NA, pandas-on-Spark now raises `ValueError("Encountered an NA value with skipna=False")` for pandas 3.0 and later. For pandas versions earlier than 3.0, the existing deprecated behavior is preserved and still returns `-1` with a `FutureWarning`.

The related tests in `python/pyspark/pandas/tests/series/test_arg_ops.py` were updated so the expected behavior depends on the pandas version in use.

### Why are the changes needed?

pandas-on-Spark should remain consistent with pandas behavior.

pandas 3.0 changed `Series.argmax` and `Series.argmin` so NA cases with `skipna=False`, as well as all-NA cases, raise `ValueError` instead of following the previous deprecated return path. Without this change, pandas-on-Spark behaves differently from pandas 3.0+ in these cases.

### Does this PR introduce _any_ user-facing change?

Yes.

For pandas 3.0 and later, `pyspark.pandas.Series.argmax` and `pyspark.pandas.Series.argmin` now raise `ValueError("Encountered an NA value with skipna=False")` when NA values are present with `skipna=False`, or when the Series is all-NA.

For pandas versions earlier than 3.0, the existing behavior is unchanged.

### How was this patch tested?

Updated the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No
