### PR TITLE
[SPARK-56081][PS] Align idxmax and idxmin NA handling with pandas 3

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -12576,6 +12576,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             result = F.when(max_value == float("-inf"), F.lit(None)).otherwise(result)
 
+            if LooseVersion(pd.__version__) >= "3.0.0":
+                result = F.when(
+                    result.isNull(), F.raise_error("Encountered all NA values")
+                ).otherwise(result)
+
             internal = self._internal.with_new_columns(
                 [result.alias(SPARK_DEFAULT_SERIES_NAME)],
                 column_labels=[None],
@@ -12705,6 +12710,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 )
 
             result = F.when(min_value == float("inf"), F.lit(None)).otherwise(result)
+
+            if LooseVersion(pd.__version__) >= "3.0.0":
+                result = F.when(
+                    result.isNull(), F.raise_error("Encountered all NA values")
+                ).otherwise(result)
 
             internal = self._internal.with_new_columns(
                 [result.alias(SPARK_DEFAULT_SERIES_NAME)],

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -4538,7 +4538,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 )
                 return np.nan
             else:
-                raise ValueError("Encountered an NA value with skipna=False")
+                if skipna:
+                    raise ValueError("Encountered all NA values")
+                else:
+                    raise ValueError("Encountered an NA value with skipna=False")
         values = list(results[0][1:])
         if len(values) == 1:
             return values[0]
@@ -4654,7 +4657,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 )
                 return np.nan
             else:
-                raise ValueError("Encountered an NA value with skipna=False")
+                if skipna:
+                    raise ValueError("Encountered all NA values")
+                else:
+                    raise ValueError("Encountered an NA value with skipna=False")
         values = list(results[0][1:])
         if len(values) == 1:
             return values[0]

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -4528,14 +4528,17 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if len(results) == 0:
             raise ValueError("attempt to get idxmin of an empty sequence")
         if results[0][0] is None:
-            # This will only happen when skipna is False because we will
-            # place nulls first.
-            warnings.warn(
-                "The behavior of Series.idxmax with all-NA values, or any-NA and skipna=False, "
-                "is deprecated. In a future version this will raise ValueError",
-                FutureWarning,
-            )
-            return np.nan
+            if LooseVersion(pd.__version__) < "3.0.0":
+                # This will only happen when skipna is False because we will
+                # place nulls first.
+                warnings.warn(
+                    "The behavior of Series.idxmax with all-NA values, or any-NA and skipna=False, "
+                    "is deprecated. In a future version this will raise ValueError",
+                    FutureWarning,
+                )
+                return np.nan
+            else:
+                raise ValueError("Encountered an NA value with skipna=False")
         values = list(results[0][1:])
         if len(values) == 1:
             return values[0]
@@ -4641,14 +4644,17 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if len(results) == 0:
             raise ValueError("attempt to get idxmin of an empty sequence")
         if results[0][0] is None:
-            # This will only happen when skipna is False because we will
-            # place nulls first.
-            warnings.warn(
-                "The behavior of Series.idxmin with all-NA values, or any-NA and skipna=False, "
-                "is deprecated. In a future version this will raise ValueError",
-                FutureWarning,
-            )
-            return np.nan
+            if LooseVersion(pd.__version__) < "3.0.0":
+                # This will only happen when skipna is False because we will
+                # place nulls first.
+                warnings.warn(
+                    "The behavior of Series.idxmin with all-NA values, or any-NA and skipna=False, "
+                    "is deprecated. In a future version this will raise ValueError",
+                    FutureWarning,
+                )
+                return np.nan
+            else:
+                raise ValueError("Encountered an NA value with skipna=False")
         values = list(results[0][1:])
         if len(values) == 1:
             return values[0]

--- a/python/pyspark/pandas/tests/computation/test_idxmax_idxmin.py
+++ b/python/pyspark/pandas/tests/computation/test_idxmax_idxmin.py
@@ -17,6 +17,7 @@
 
 import pandas as pd
 
+from pyspark.loose_version import LooseVersion
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
@@ -65,7 +66,11 @@ class FrameIdxMaxMinMixin:
         )
         psdf = ps.from_pandas(pdf)
 
-        self.assert_eq(psdf.idxmax(axis=1), pdf.idxmax(axis=1))
+        if LooseVersion(pd.__version__) < "3.0.0":
+            self.assert_eq(psdf.idxmax(axis=1), pdf.idxmax(axis=1))
+        else:
+            with self.assertRaisesRegex(Exception, "Encountered all NA values"):
+                psdf.idxmax(axis=1).to_pandas()
 
         # Test with ties (first occurrence should win)
         pdf = pd.DataFrame(
@@ -197,7 +202,11 @@ class FrameIdxMaxMinMixin:
         )
         psdf = ps.from_pandas(pdf)
 
-        self.assert_eq(psdf.idxmin(axis=1), pdf.idxmin(axis=1))
+        if LooseVersion(pd.__version__) < "3.0.0":
+            self.assert_eq(psdf.idxmin(axis=1), pdf.idxmin(axis=1))
+        else:
+            with self.assertRaisesRegex(Exception, "Encountered all NA values"):
+                psdf.idxmin(axis=1).to_pandas()
 
         # Test with ties (first occurrence should win)
         pdf = pd.DataFrame(

--- a/python/pyspark/pandas/tests/series/test_index.py
+++ b/python/pyspark/pandas/tests/series/test_index.py
@@ -204,7 +204,11 @@ class SeriesIndexMixin:
         psser = ps.Series(pser)
 
         self.assertEqual(psser.idxmax(), pser.idxmax())
-        self.assertEqual(repr(psser.idxmax(skipna=False)), repr(pser.idxmax(skipna=False)))
+        if LooseVersion(pd.__version__) < "3.0.0":
+            self.assertEqual(repr(psser.idxmax(skipna=False)), repr(pser.idxmax(skipna=False)))
+        else:
+            with self.assertRaisesRegex(ValueError, "Encountered an NA value with skipna=False"):
+                psser.idxmax(skipna=False)
 
     def test_idxmin(self):
         pser = pd.Series(data=[1, 4, 5], index=["A", "B", "C"])
@@ -230,7 +234,11 @@ class SeriesIndexMixin:
         psser = ps.Series(pser)
 
         self.assertEqual(psser.idxmin(), pser.idxmin())
-        self.assertEqual(repr(psser.idxmin(skipna=False)), repr(pser.idxmin(skipna=False)))
+        if LooseVersion(pd.__version__) < "3.0.0":
+            self.assertEqual(repr(psser.idxmin(skipna=False)), repr(pser.idxmin(skipna=False)))
+        else:
+            with self.assertRaisesRegex(ValueError, "Encountered an NA value with skipna=False"):
+                psser.idxmin(skipna=False)
 
     def test_index(self):
         # to check setting name of Index properly.

--- a/python/pyspark/pandas/tests/series/test_index.py
+++ b/python/pyspark/pandas/tests/series/test_index.py
@@ -210,6 +210,13 @@ class SeriesIndexMixin:
             with self.assertRaisesRegex(ValueError, "Encountered an NA value with skipna=False"):
                 psser.idxmax(skipna=False)
 
+        pser = pd.Series([None, None, None], index=[10, 3, 5])
+        psser = ps.Series(pser)
+        with self.assertRaisesRegex(ValueError, "Encountered all NA values$"):
+            psser.idxmax()
+        with self.assertRaisesRegex(ValueError, "Encountered an NA value with skipna=False"):
+            psser.idxmax(skipna=False)
+
     def test_idxmin(self):
         pser = pd.Series(data=[1, 4, 5], index=["A", "B", "C"])
         psser = ps.Series(pser)
@@ -239,6 +246,13 @@ class SeriesIndexMixin:
         else:
             with self.assertRaisesRegex(ValueError, "Encountered an NA value with skipna=False"):
                 psser.idxmin(skipna=False)
+
+        pser = pd.Series([None, None, None], index=[10, 3, 5])
+        psser = ps.Series(pser)
+        with self.assertRaisesRegex(ValueError, "Encountered all NA values$"):
+            psser.idxmin()
+        with self.assertRaisesRegex(ValueError, "Encountered an NA value with skipna=False"):
+            psser.idxmin(skipna=False)
 
     def test_index(self):
         # to check setting name of Index properly.

--- a/python/pyspark/pandas/tests/series/test_index.py
+++ b/python/pyspark/pandas/tests/series/test_index.py
@@ -212,10 +212,14 @@ class SeriesIndexMixin:
 
         pser = pd.Series([None, None, None], index=[10, 3, 5])
         psser = ps.Series(pser)
-        with self.assertRaisesRegex(ValueError, "Encountered all NA values$"):
-            psser.idxmax()
-        with self.assertRaisesRegex(ValueError, "Encountered an NA value with skipna=False"):
-            psser.idxmax(skipna=False)
+        if LooseVersion(pd.__version__) < "3.0.0":
+            self.assertEqual(repr(psser.idxmax()), repr(pser.idxmax()))
+            self.assertEqual(repr(psser.idxmax(skipna=False)), repr(pser.idxmax(skipna=False)))
+        else:
+            with self.assertRaisesRegex(ValueError, "Encountered all NA values$"):
+                psser.idxmax()
+            with self.assertRaisesRegex(ValueError, "Encountered an NA value with skipna=False"):
+                psser.idxmax(skipna=False)
 
     def test_idxmin(self):
         pser = pd.Series(data=[1, 4, 5], index=["A", "B", "C"])
@@ -249,10 +253,14 @@ class SeriesIndexMixin:
 
         pser = pd.Series([None, None, None], index=[10, 3, 5])
         psser = ps.Series(pser)
-        with self.assertRaisesRegex(ValueError, "Encountered all NA values$"):
-            psser.idxmin()
-        with self.assertRaisesRegex(ValueError, "Encountered an NA value with skipna=False"):
-            psser.idxmin(skipna=False)
+        if LooseVersion(pd.__version__) < "3.0.0":
+            self.assertEqual(repr(psser.idxmin()), repr(pser.idxmin()))
+            self.assertEqual(repr(psser.idxmin(skipna=False)), repr(pser.idxmin(skipna=False)))
+        else:
+            with self.assertRaisesRegex(ValueError, "Encountered all NA values$"):
+                psser.idxmin()
+            with self.assertRaisesRegex(ValueError, "Encountered an NA value with skipna=False"):
+                psser.idxmin(skipna=False)
 
     def test_index(self):
         # to check setting name of Index properly.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates pandas-on-Spark `idxmax` and `idxmin` behavior to follow the pandas 3 semantics when NA values are involved.

In `python/pyspark/pandas/series.py`, `Series.idxmax(skipna=False)` and `Series.idxmin(skipna=False)` now raise `ValueError` on pandas 3 instead of returning `np.nan` with a `FutureWarning`, while preserving the existing behavior on pandas versions below 3.0.

In `python/pyspark/pandas/frame.py`, `DataFrame.idxmax(axis=1)` and `DataFrame.idxmin(axis=1)` now raise when pandas 3 would reject rows with all-NA values, instead of silently materializing `None`.

The related pandas-on-Spark tests were updated to assert the version-specific behavior in:
- `python/pyspark/pandas/tests/computation/test_idxmax_idxmin.py`
- `python/pyspark/pandas/tests/series/test_index.py`

### Why are the changes needed?

pandas 3 changed the NA handling for `idxmax` and `idxmin`. The existing pandas-on-Spark implementation still followed the older behavior in these paths, which caused mismatches against pandas 3 expectations.

Aligning these code paths keeps pandas-on-Spark behavior consistent with the pandas version it is running against and makes the failure mode explicit instead of returning a deprecated result.

### Does this PR introduce _any_ user-facing change?

Yes.

When pandas 3 is used:
- `Series.idxmax(skipna=False)` and `Series.idxmin(skipna=False)` now raise `ValueError` when an NA is encountered instead of returning `np.nan`.
- `DataFrame.idxmax(axis=1)` and `DataFrame.idxmin(axis=1)` now raise on rows with all NA values instead of returning a null result.

For pandas versions below 3.0, the existing behavior is preserved.

### How was this patch tested?

Updated the related tests for the pandas-version-specific `idxmax` and `idxmin` behavior.

### Was this patch authored or co-authored using generative AI tooling?

No.
