### PR TITLE
[SPARK-55626][SQL][4.1] Don't load metadata columns on Table unless needed in V2TableUtil

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/V2TableUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/V2TableUtil.scala
@@ -95,7 +95,7 @@ private[sql] object V2TableUtil extends SQLConfHelper {
    */
   def extractMetadataColumns(relation: DataSourceV2Relation): Seq[MetadataColumn] = {
     val metaAttrNames = relation.output.filter(_.isMetadataCol).map(_.name)
-    filter(metaAttrNames, metadataColumns(relation.table))
+    if (metaAttrNames.isEmpty) Nil else filter(metaAttrNames, metadataColumns(relation.table))
   }
 
   /**


### PR DESCRIPTION

### What changes were proposed in this pull request?

Rebase of : https://github.com/apache/spark/pull/54433 (by @aokolnychyi )

This PR prevents loading metadata columns on Table unless needed in `V2TableUtil`.

### Why are the changes needed?

These changed are needed to prevent unnecessary load of metadata columns. In some cases, accessing the metadata columns can lead to exceptions on the connector side as detected in Iceberg. Spark should only ask for metadata columns if they were projected.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This patch comes with tests.

### Was this patch authored or co-authored using generative AI tooling?

No.

Closes #54416 from aokolnychyi/spark-55626.

Authored-by: Anton Okolnychyi <aokolnychyi@apache.org>

