### PR TITLE
[SPARK-56092][SS][CONNECT] Fix NPE in StreamingQueryException.toString() when cause is null

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryException.scala
+++ b/common/utils/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryException.scala
@@ -99,7 +99,9 @@ class StreamingQueryException private[sql](
     if (queryDebugString.isEmpty) message else s"${message}\n${queryDebugString}"
 
   override def toString(): String =
-    s"""${classOf[StreamingQueryException].getName}: ${if (cause != null) cause.getMessage else message}
+    s"""${classOf[StreamingQueryException].getName}: ${
+          if (cause != null) cause.getMessage else s"$message (no cause)"
+        }
        |$queryDebugString""".stripMargin
 
   override def getCondition: String = errorClass

--- a/common/utils/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryException.scala
+++ b/common/utils/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryException.scala
@@ -99,7 +99,7 @@ class StreamingQueryException private[sql](
     if (queryDebugString.isEmpty) message else s"${message}\n${queryDebugString}"
 
   override def toString(): String =
-    s"""${classOf[StreamingQueryException].getName}: ${cause.getMessage}
+    s"""${classOf[StreamingQueryException].getName}: ${if (cause != null) cause.getMessage else message}
        |$queryDebugString""".stripMargin
 
   override def getCondition: String = errorClass


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix a `NullPointerException` in `StreamingQueryException.toString()` when `cause` is null.

### Why are the changes needed?

When a `StreamingQueryException` is reconstructed on the Spark Connect client side via `GrpcExceptionConverter.errorFactory`, the `cause` field can be null (`params.cause.orNull`). The `toString()` method unconditionally calls `cause.getMessage`, which throws a `NullPointerException`.

This can crash the Scala kernel when it tries to log the exception, masking the actual streaming query failure with an unresponsive kernel error.

### Does this PR introduce _any_ user-facing change?

No. This is a bug fix in error handling — `toString()` will now return a meaningful message instead of throwing an NPE when `cause` is null.

### How was this patch tested?
This should be a simple rewrite.

### Was this patch authored or co-authored using generative AI tooling?

Yes.