### PR TITLE
[SPARK-56098][BUILD] Upgrade `mockito-core` to 5.23.0 and use `mockito-5-18`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -441,7 +441,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalatestplus</groupId>
-      <artifactId>mockito-5-12_${scala.binary.version}</artifactId>
+      <artifactId>mockito-5-18_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -1246,7 +1246,7 @@
       </dependency>
       <dependency>
         <groupId>org.scalatestplus</groupId>
-        <artifactId>mockito-5-12_${scala.binary.version}</artifactId>
+        <artifactId>mockito-5-18_${scala.binary.version}</artifactId>
         <version>3.2.19.0</version>
         <scope>test</scope>
       </dependency>
@@ -1265,7 +1265,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>5.12.0</version>
+        <version>5.23.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades `mockito-core` to 5.23.0 and the corresponding `scalatestplus-mockito` to `mockito-5-18` to avoid any future Java 21 and 25 testing issue.

### Why are the changes needed?

Currently, we are using 5.12.0 which was released on 2024-05-11.

We had better keep the test dependency up to date with the latest bug fixes and improvements.
- https://github.com/mockito/mockito/releases/tag/v5.23.0
- https://github.com/mockito/mockito/releases/tag/v5.22.0
  - https://github.com/mockito/mockito/issues/3778
  - https://github.com/mockito/mockito/pull/3785
- https://github.com/mockito/mockito/releases/tag/v5.21.0
  - https://github.com/mockito/mockito/issues/3758
- https://github.com/mockito/mockito/releases/tag/v5.20.0
  - https://github.com/mockito/mockito/pull/3708
- https://github.com/mockito/mockito/releases/tag/v5.19.0
  - https://github.com/mockito/mockito/issues/3659
- https://github.com/mockito/mockito/releases/tag/v5.18.0
- https://github.com/mockito/mockito/releases/tag/v5.17.0
- https://github.com/mockito/mockito/releases/tag/v5.16.0
- https://github.com/mockito/mockito/releases/tag/v5.15.0
  - https://github.com/mockito/mockito/pull/3476
- https://github.com/mockito/mockito/releases/tag/v5.14.0
- https://github.com/mockito/mockito/releases/tag/v5.13.0

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)