### PR TITLE
[SPARK-56102][SQL] `UnionEstimation` code cleanup

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/UnionEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/UnionEstimation.scala
@@ -97,14 +97,16 @@ object UnionEstimation {
           val maybeDistinctCount = maybeColStats.foldLeft(Option(BigInt(0))) {
             case (Some(currentMax), Some(s)) => s.distinctCount.map(currentMax.max)
             case _ => None
-          }.map(max => outputRows.fold(max)(max.min))
+          }
+          // Cap distinctCount by outputRows if available
+          val cappedDistinctCount = maybeDistinctCount.map(max => outputRows.fold(max)(max.min))
 
-          if (maybeMinMax.isDefined || maybeNullCount.isDefined || maybeDistinctCount.isDefined) {
+          if (maybeMinMax.isDefined || maybeNullCount.isDefined || cappedDistinctCount.isDefined) {
             Some(outputAttr -> ColumnStat(
               min = maybeMinMax.map(_._1),
               max = maybeMinMax.map(_._2),
               nullCount = maybeNullCount,
-              distinctCount = maybeDistinctCount
+              distinctCount = cappedDistinctCount
             ))
           } else None
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/UnionEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/UnionEstimation.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.plans.logical.statsEstimation
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeSet}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap}
 import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, Statistics, Union}
 import org.apache.spark.sql.catalyst.types.PhysicalDataType
 import org.apache.spark.sql.types._
@@ -46,77 +46,18 @@ object UnionEstimation {
     val sizeInBytes = union.children.map(_.stats.sizeInBytes).sum
     val outputRows = if (rowCountsExist(union.children: _*)) {
       Some(union.children.map(_.stats.rowCount.get).sum)
-    } else {
-      None
-    }
-
-    val newMinMaxStats = computeMinMaxStats(union)
-    val newNullCountStats = computeNullCountStats(union)
-    val newDistinctCountStats = computeDistinctCountStats(union, outputRows)
-
-    val minMaxMap = AttributeMap(newMinMaxStats)
-    val nullCountMap = AttributeMap(newNullCountStats)
-    val distinctCountMap = AttributeMap(newDistinctCountStats)
-
-    val allAttrs = AttributeSet(newMinMaxStats.map(_._1) ++ newNullCountStats.map(_._1) ++
-      newDistinctCountStats.map(_._1))
-    val newAttrStats = AttributeMap(allAttrs.map { attr =>
-      val base = minMaxMap.getOrElse(attr, ColumnStat())
-      val withNull = nullCountMap.get(attr).fold(base)(s => base.copy(nullCount = s.nullCount))
-      val withDistinctCount = distinctCountMap.get(attr)
-        .fold(withNull)(s => withNull.copy(distinctCount = s.distinctCount))
-      attr -> withDistinctCount
-    })
-
-    Some(
-      Statistics(
-        sizeInBytes = sizeInBytes,
-        rowCount = outputRows,
-        attributeStats = newAttrStats))
-  }
-
-  private def computeMinMaxStats(union: Union): Seq[(Attribute, ColumnStat)] = {
-    union.children.map(_.output).transpose.zip(union.output).flatMap {
-      case (attrs, outputAttr) if isTypeSupported(outputAttr.dataType) =>
-        val statComparator = createStatComparator(outputAttr.dataType)
-        val zipped = attrs.zip(union.children)
-        val (firstAttr, firstChild) = zipped.head
-        val initialMinMax = firstChild.stats.attributeStats.get(firstAttr)
-          .collect { case s if s.hasMinMaxStats => (s.min.get, s.max.get) }
-        val maybeMinMax = zipped.tail.foldLeft(initialMinMax) {
-          case (Some((minVal, maxVal)), (attr, child)) =>
-            child.stats.attributeStats.get(attr).collect {
-              case s if s.hasMinMaxStats =>
-                val min = if (statComparator(s.min.get, minVal)) s.min.get else minVal
-                val max = if (statComparator(maxVal, s.max.get)) s.max.get else maxVal
-                (min, max)
-            }
-          case _ => None
-        }
-        maybeMinMax.map { case (min, max) =>
-          outputAttr -> ColumnStat(min = Some(min), max = Some(max))
-        }
-      case _ => None
-    }
-  }
-
-  private def computeNullCountStats(union: Union): Seq[(Attribute, ColumnStat)] = {
-    union.children.map(_.output).transpose.zip(union.output).flatMap {
-      case (attrs, outputAttr) =>
-        val maybeTotalNullCount = attrs.zip(union.children).foldLeft(Option(BigInt(0))) {
-          case (Some(total), (attr, child)) =>
-            child.stats.attributeStats.get(attr).flatMap(_.nullCount).map(total + _)
-          case _ => None
-        }
-        maybeTotalNullCount.map { totalNullCount =>
-          outputAttr -> ColumnStat(nullCount = Some(totalNullCount))
-        }
-    }
+    } else None
+    Some(Statistics(
+      sizeInBytes = sizeInBytes,
+      rowCount = outputRows,
+      attributeStats = AttributeMap(computeColumnStats(union, outputRows))))
   }
 
   /**
-   * For each column, if all children have distinctCount, propagate the max distinctCount
-   * across children. The result is capped by outputRows when available.
+   * For each output column, compute min/max, nullCount, and distinctCount in a single pass.
+   * Min and max are computed as the overall min/max across children (only for supported types),
+   * nullCount is summed, and distinctCount is estimated as the max across children (capped by
+   * outputRows).
    *
    * For UNION ALL, true distinctCount satisfies:
    *   max(dc_i) <= true_dc <= min(sum(dc_i), rowCount)
@@ -125,21 +66,47 @@ object UnionEstimation {
    * (e.g. web_sales and catalog_sales reference the same date keys),
    * so max is a reasonable approximation in the common case.
    */
-  private def computeDistinctCountStats(
+  private def computeColumnStats(
       union: Union,
       outputRows: Option[BigInt]): Seq[(Attribute, ColumnStat)] = {
-    union.children.map(_.output).transpose.zip(union.output).flatMap {
-      case (attrs, outputAttr) =>
-        val maybeMaxDistinctCount = attrs.zip(union.children).foldLeft(Option(BigInt(0))) {
-          case (Some(currentMax), (attr, child)) =>
-            child.stats.attributeStats.get(attr).flatMap(_.distinctCount).map(currentMax.max)
-          case _ => None
-        }
-        maybeMaxDistinctCount.map { maxDistinctCount =>
-          // Cap distinctCount by outputRows if available
-          val cappedDistinctCount = outputRows.fold(maxDistinctCount)(maxDistinctCount.min)
-          outputAttr -> ColumnStat(distinctCount = Some(cappedDistinctCount))
-        }
-    }
+    // For each child, look up the ColumnStat for each of its output attributes.
+    // After transposing, maybeColStats(i) holds the ColumnStat (if available) contributed
+    // by the i-th child for the current output column.
+    union.children.map(c => c.output.map(c.stats.attributeStats.get))
+      .transpose.zip(union.output).flatMap {
+        case (maybeColStats, outputAttr) =>
+          val maybeMinMax: Option[(Any, Any)] = if (isTypeSupported(outputAttr.dataType)) {
+            val statComparator = createStatComparator(outputAttr.dataType)
+            val initial = maybeColStats.head
+              .collect { case s if s.hasMinMaxStats => (s.min.get, s.max.get) }
+            maybeColStats.tail.foldLeft(initial) {
+              case (Some((minVal, maxVal)), Some(s)) if s.hasMinMaxStats =>
+                Some((
+                  if (statComparator(s.min.get, minVal)) s.min.get else minVal,
+                  if (statComparator(maxVal, s.max.get)) s.max.get else maxVal
+                ))
+              case _ => None
+            }
+          } else None
+
+          val maybeNullCount = maybeColStats.foldLeft(Option(BigInt(0))) {
+            case (Some(total), Some(s)) => s.nullCount.map(total + _)
+            case _ => None
+          }
+
+          val maybeDistinctCount = maybeColStats.foldLeft(Option(BigInt(0))) {
+            case (Some(currentMax), Some(s)) => s.distinctCount.map(currentMax.max)
+            case _ => None
+          }.map(max => outputRows.fold(max)(max.min))
+
+          if (maybeMinMax.isDefined || maybeNullCount.isDefined || maybeDistinctCount.isDefined) {
+            Some(outputAttr -> ColumnStat(
+              min = maybeMinMax.map(_._1),
+              max = maybeMinMax.map(_._2),
+              nullCount = maybeNullCount,
+              distinctCount = maybeDistinctCount
+            ))
+          } else None
+      }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/UnionEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/UnionEstimation.scala
@@ -72,9 +72,9 @@ object UnionEstimation {
     // For each child, look up the ColumnStat for each of its output attributes.
     // After transposing, maybeColStats(i) holds the ColumnStat (if available) contributed
     // by the i-th child for the current output column.
-    union.children.map(c => c.output.map(c.stats.attributeStats.get))
-      .transpose.zip(union.output).flatMap {
-        case (maybeColStats, outputAttr) =>
+    union.output.zip(union.children.map(c => c.output.map(c.stats.attributeStats.get)).transpose)
+      .flatMap {
+        case (outputAttr, maybeColStats) =>
           val maybeMinMax: Option[(Any, Any)] = if (isTypeSupported(outputAttr.dataType)) {
             val statComparator = createStatComparator(outputAttr.dataType)
             val initial = maybeColStats.head

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/UnionEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/UnionEstimation.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.plans.logical.statsEstimation
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeSet}
 import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, Statistics, Union}
 import org.apache.spark.sql.catalyst.types.PhysicalDataType
 import org.apache.spark.sql.types._
@@ -53,23 +53,20 @@ object UnionEstimation {
     val newMinMaxStats = computeMinMaxStats(union)
     val newNullCountStats = computeNullCountStats(union)
     val newDistinctCountStats = computeDistinctCountStats(union, outputRows)
-    val newAttrStats = {
-      val baseStats = AttributeMap(newMinMaxStats)
-      // Layer nullCount on top of min/max
-      val withNullCount = newNullCountStats.map { case attrStat @ (attr, stat) =>
-        baseStats.get(attr).map { baseStat =>
-          attr -> baseStat.copy(nullCount = stat.nullCount)
-        }.getOrElse(attrStat)
-      }
-      val merged = AttributeMap(newMinMaxStats ++ withNullCount)
-      // Layer distinctCount on top of min/max + nullCount
-      val withDistinctCount = newDistinctCountStats.map { case attrStat @ (attr, stat) =>
-        merged.get(attr).map { baseStat =>
-          attr -> baseStat.copy(distinctCount = stat.distinctCount)
-        }.getOrElse(attrStat)
-      }
-      AttributeMap(newMinMaxStats ++ withNullCount ++ withDistinctCount)
-    }
+
+    val minMaxMap = AttributeMap(newMinMaxStats)
+    val nullCountMap = AttributeMap(newNullCountStats)
+    val distinctCountMap = AttributeMap(newDistinctCountStats)
+
+    val allAttrs = AttributeSet(newMinMaxStats.map(_._1) ++ newNullCountStats.map(_._1) ++
+      newDistinctCountStats.map(_._1))
+    val newAttrStats = AttributeMap(allAttrs.map { attr =>
+      val base = minMaxMap.getOrElse(attr, ColumnStat())
+      val withNull = nullCountMap.get(attr).fold(base)(s => base.copy(nullCount = s.nullCount))
+      val withDistinctCount = distinctCountMap.get(attr)
+        .fold(withNull)(s => withNull.copy(distinctCount = s.distinctCount))
+      attr -> withDistinctCount
+    })
 
     Some(
       Statistics(
@@ -79,60 +76,41 @@ object UnionEstimation {
   }
 
   private def computeMinMaxStats(union: Union): Seq[(Attribute, ColumnStat)] = {
-    val unionOutput = union.output
-    val attrToComputeMinMaxStats = union.children.map(_.output).transpose.zipWithIndex.filter {
-      case (attrs, outputIndex) => isTypeSupported(unionOutput(outputIndex).dataType) &&
-        // checks if all the children has min/max stats for an attribute
-        attrs.zipWithIndex.forall {
-          case (attr, childIndex) =>
-            val attrStats = union.children(childIndex).stats.attributeStats
-            attrStats.get(attr).isDefined && attrStats(attr).hasMinMaxStats
-        }
-    }
-    attrToComputeMinMaxStats.map {
-      case (attrs, outputIndex) =>
-        val dataType = unionOutput(outputIndex).dataType
-        val statComparator = createStatComparator(dataType)
-        val minMaxValue = attrs.zipWithIndex.foldLeft[(Option[Any], Option[Any])]((None, None)) {
-          case ((minVal, maxVal), (attr, childIndex)) =>
-            val colStat = union.children(childIndex).stats.attributeStats(attr)
-            val min = if (minVal.isEmpty || statComparator(colStat.min.get, minVal.get)) {
-              colStat.min
-            } else {
-              minVal
+    union.children.map(_.output).transpose.zip(union.output).flatMap {
+      case (attrs, outputAttr) if isTypeSupported(outputAttr.dataType) =>
+        val statComparator = createStatComparator(outputAttr.dataType)
+        val zipped = attrs.zip(union.children)
+        val (firstAttr, firstChild) = zipped.head
+        val initialMinMax = firstChild.stats.attributeStats.get(firstAttr)
+          .collect { case s if s.hasMinMaxStats => (s.min.get, s.max.get) }
+        val maybeMinMax = zipped.tail.foldLeft(initialMinMax) {
+          case (Some((minVal, maxVal)), (attr, child)) =>
+            child.stats.attributeStats.get(attr).collect {
+              case s if s.hasMinMaxStats =>
+                val min = if (statComparator(s.min.get, minVal)) s.min.get else minVal
+                val max = if (statComparator(maxVal, s.max.get)) s.max.get else maxVal
+                (min, max)
             }
-            val max = if (maxVal.isEmpty || statComparator(maxVal.get, colStat.max.get)) {
-              colStat.max
-            } else {
-              maxVal
-            }
-            (min, max)
+          case _ => None
         }
-        val newStat = ColumnStat(min = minMaxValue._1, max = minMaxValue._2)
-        unionOutput(outputIndex) -> newStat
+        maybeMinMax.map { case (min, max) =>
+          outputAttr -> ColumnStat(min = Some(min), max = Some(max))
+        }
+      case _ => None
     }
   }
 
   private def computeNullCountStats(union: Union): Seq[(Attribute, ColumnStat)] = {
-    val unionOutput = union.output
-    val attrToComputeNullCount = union.children.map(_.output).transpose.zipWithIndex.filter {
-      case (attrs, _) => attrs.zipWithIndex.forall {
-        case (attr, childIndex) =>
-          val attrStats = union.children(childIndex).stats.attributeStats
-          attrStats.get(attr).isDefined && attrStats(attr).nullCount.isDefined
-      }
-    }
-    attrToComputeNullCount.map {
-      case (attrs, outputIndex) =>
-        val firstStat = union.children.head.stats.attributeStats(attrs.head)
-        val firstNullCount = firstStat.nullCount.get
-        val colWithNullStatValues = attrs.zipWithIndex.tail.foldLeft[BigInt](firstNullCount) {
-          case (totalNullCount, (attr, childIndex)) =>
-            val colStat = union.children(childIndex).stats.attributeStats(attr)
-            totalNullCount + colStat.nullCount.get
+    union.children.map(_.output).transpose.zip(union.output).flatMap {
+      case (attrs, outputAttr) =>
+        val maybeTotalNullCount = attrs.zip(union.children).foldLeft(Option(BigInt(0))) {
+          case (Some(total), (attr, child)) =>
+            child.stats.attributeStats.get(attr).flatMap(_.nullCount).map(total + _)
+          case _ => None
         }
-        val newStat = ColumnStat(nullCount = Some(colWithNullStatValues))
-        unionOutput(outputIndex) -> newStat
+        maybeTotalNullCount.map { totalNullCount =>
+          outputAttr -> ColumnStat(nullCount = Some(totalNullCount))
+        }
     }
   }
 
@@ -150,28 +128,18 @@ object UnionEstimation {
   private def computeDistinctCountStats(
       union: Union,
       outputRows: Option[BigInt]): Seq[(Attribute, ColumnStat)] = {
-    val unionOutput = union.output
-    val attrToComputeDistinctCount = union.children.map(_.output).transpose.zipWithIndex.filter {
-      case (attrs, _) => attrs.zipWithIndex.forall {
-        case (attr, childIndex) =>
-          val attrStats = union.children(childIndex).stats.attributeStats
-          attrStats.get(attr).isDefined && attrStats(attr).distinctCount.isDefined
-      }
-    }
-    attrToComputeDistinctCount.map {
-      case (attrs, outputIndex) =>
-        val maxDistinctCount = attrs.zipWithIndex.foldLeft[BigInt](0) {
-          case (currentMax, (attr, childIndex)) =>
-            val colStat = union.children(childIndex).stats.attributeStats(attr)
-            currentMax.max(colStat.distinctCount.get)
+    union.children.map(_.output).transpose.zip(union.output).flatMap {
+      case (attrs, outputAttr) =>
+        val maybeMaxDistinctCount = attrs.zip(union.children).foldLeft(Option(BigInt(0))) {
+          case (Some(currentMax), (attr, child)) =>
+            child.stats.attributeStats.get(attr).flatMap(_.distinctCount).map(currentMax.max)
+          case _ => None
         }
-        // Cap distinctCount by outputRows if available
-        val cappedDistinctCount = outputRows match {
-          case Some(rows) => maxDistinctCount.min(rows)
-          case None => maxDistinctCount
+        maybeMaxDistinctCount.map { maxDistinctCount =>
+          // Cap distinctCount by outputRows if available
+          val cappedDistinctCount = outputRows.fold(maxDistinctCount)(maxDistinctCount.min)
+          outputAttr -> ColumnStat(distinctCount = Some(cappedDistinctCount))
         }
-        val newStat = ColumnStat(distinctCount = Some(cappedDistinctCount))
-        unionOutput(outputIndex) -> newStat
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
                                                                                                                                                                                               
Refactored UnionEstimation to consolidate column stats computation into a single, cleaner pass:

- Three compute* methods merged into one computeColumnStats: computeMinMaxStats, computeNullCountStats, and computeDistinctCountStats are replaced by a single method that computes all three
 stat types in one traversal over the union's output columns.
- Stats lookup moved upfront: Instead of repeatedly calling child.stats.attributeStats.get(attr) inside each fold, stats are resolved once via c.output.map(c.stats.attributeStats.get)
before transposing, yielding a Seq[Option[ColumnStat]] per output column (maybeColStats). Folds then operate directly on Option[ColumnStat] values, eliminating redundant index-based lookups
 and attrs.zip(union.children) re-pairings.
- estimate simplified: The multi-pass layering of newMinMaxStats ++ withNullCount ++ withDistinctCount with intermediate AttributeMap merges is replaced by a direct
AttributeMap(computeColumnStats(...)) call.
- Short-circuiting folds: Each stat type uses a foldLeft(Option(...)) that propagates None as soon as any child is missing the required stat, avoiding separate filter+map passes and double
attributeStats lookups.
- collect over filter+map: Used throughout to combine guard and value extraction in one step (e.g. .collect { case s if s.hasMinMaxStats => (s.min.get, s.max.get) }).
- zip(union.output) / zip(union.children): Replaced zipWithIndex + index-based access (unionOutput(outputIndex), union.children(childIndex)) with direct zips, making data relationships
explicit.

### Why are the changes needed?

The previous implementation had several readability and efficiency issues:
- attributeStats was looked up twice per attribute per child (once in the filter guard, once in the computation body).
- Three separate traversals over the same column structure were performed independently.
- Index-based access made the relationship between attributes and their source children implicit.
- The stats merging in estimate duplicated newMinMaxStats entries multiple times, relying on AttributeMap position-based deduplication.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing unit tests in `UnionEstimationSuite` cover the changed logic. No new tests were added as this is a pure refactoring with no behavior change.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Sonnet 4.6
