### PR TITLE
[SPARK-55809][CORE] HeapHistogram uses DiagnosticCommandMBean instead of jmap subprocess

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -32,6 +32,7 @@ import java.util.{HexFormat, Locale, Properties, Random, UUID}
 import java.util.concurrent._
 import java.util.concurrent.TimeUnit.NANOSECONDS
 import java.util.zip.{GZIPInputStream, ZipInputStream}
+import javax.management.ObjectName
 
 import scala.annotation.tailrec
 import scala.collection.Map
@@ -2144,19 +2145,18 @@ private[spark] object Utils
 
   /** Return a heap dump. Used to capture dumps for the web UI */
   def getHeapHistogram(): Array[String] = {
-    val pid = String.valueOf(ProcessHandle.current().pid())
-    val jmap = System.getProperty("java.home") + "/bin/jmap"
-    val builder = new ProcessBuilder(jmap, "-histo:live", pid)
-    val p = builder.start()
-    val rows = ArrayBuffer.empty[String]
-    Utils.tryWithResource(new BufferedReader(new InputStreamReader(p.getInputStream()))) { r =>
-      var line = ""
-      while (line != null) {
-        if (line.nonEmpty) rows += line
-        line = r.readLine()
-      }
-    }
-    rows.toArray
+    // SPARK-55809: Use DiagnosticCommandMBean in-process instead of spawning jmap as
+    // a subprocess.
+    // Spawning `jmap -histo <pid>` requires a self-attach via signal/socket handshake.
+    // Any concurrent GC (G1, ZGC, Shenandoah) can put the JVM into states where the
+    // Signal Dispatcher cannot service the attachment handshake, causing jmap to hang.
+    // DiagnosticCommandMBean runs gcClassHistogram in-process and coordinates with GC
+    // through internal JVM APIs, avoiding the unreliable inter-process attach.
+    val server = ManagementFactory.getPlatformMBeanServer
+    val on = new ObjectName("com.sun.management:type=DiagnosticCommand")
+    val result = server.invoke(on, "gcClassHistogram",
+      Array[AnyRef](Array[String]()), Array[String]("[Ljava.lang.String;"))
+    result.asInstanceOf[String].split("\n").filter(_.nonEmpty)
   }
 
   def getThreadDumpForThread(threadId: Long): Option[ThreadStackTrace] = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Re-implement `Utils.getHeapHistogram` to use `DiagnosticCommandMBean` in-process instead of spawning `jmap` as a subprocess.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

I found Heap Histogram might cause a hang in JDK 25. The reproduction steps:

1. Run `spark-shell` or `spark-sql` CLI
2. Access the UI Executors tab, and click "Heap Histogram" of the driver
3. Both UI and CLI are stuck
4. Try to run `jstack <pid>`, also stuck
5. Switching to ZGC does not help.

Explanation from Claude:

> Spawning `jmap -histo <pid>` requires a self-attach via signal/socket handshake.
> Any concurrent GC (G1, ZGC, Shenandoah) can put the JVM into states where the
> Signal Dispatcher cannot service the attachment handshake, causing jmap to hang.
> DiagnosticCommandMBean runs gcClassHistogram in-process and coordinates with GC
> through internal JVM APIs, avoiding the unreliable inter-process attach.

(Update: above is incorrect, root cause is https://bugs.openjdk.org/browse/JDK-8354460)

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Tested with JDK 17, 25, works as expected

<img width="1728" height="1027" alt="image" src="https://github.com/user-attachments/assets/b2263bbf-60f0-4b89-8d8f-29fd48b26b57" />

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Code.