### PR TITLE
[SPARK-56104][BUILD] Upgrade `junit` to 6.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
     <netty.version>4.2.10.Final</netty.version>
     <netty-tcnative.version>2.0.75.Final</netty-tcnative.version>
     <icu4j.version>78.2</icu4j.version>
-    <junit.version>6.0.1</junit.version>
+    <junit.version>6.0.3</junit.version>
     <jline.version>2.14.6</jline.version>
     <!--
       SPARK-50299: When updating `sbt-jupiter-interface.version`,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades `junit` to 6.0.3.

### Why are the changes needed?

To bring the latest bug fixes and improvements:
- https://docs.junit.org/6.0.3/release-notes.html#v6.0.3
  - A deadlock issue in NamespacedHierarchicalStore.computeIfAbsent(N, K, Function) has been fixed.
- https://docs.junit.org/6.0.2/release-notes.html#v6.0.2
  - Make ConsoleLauncher compatible with JDK 26 by avoiding final field mutations.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the existing CI.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)