### PR TITLE
[SPARK-56181][SQL] Guard against unresolved attributes in constraint inference

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
@@ -100,7 +100,7 @@ trait ConstraintHelper {
 
     // Second, we infer additional constraints from non-nullable attributes that are part of the
     // operator's output
-    val nonNullableAttributes = output.filterNot(_.nullable)
+    val nonNullableAttributes = output.filter(a => a.resolved && !a.nullable)
     isNotNullConstraints ++= nonNullableAttributes.map(IsNotNull)
 
     isNotNullConstraints -- constraints

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromConstraintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromConstraintsSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions._
@@ -398,5 +399,31 @@ class InferFiltersFromConstraintsSuite extends PlanTest {
     val optimizedQuery = InferFiltersFromConstraints(originalQuery)
     comparePlans(optimizedQuery, correctAnswer)
     comparePlans(InferFiltersFromConstraints(optimizedQuery), correctAnswer)
+  }
+
+  test("SPARK-56181: should not crash when plan output contains unresolved attributes") {
+    // Reproduces an issue where a REPLACE TABLE AS SELECT query submitted via Spark Connect
+    // hit UnresolvedException during optimizer constraint inference. The stack trace:
+    //   UnresolvedAttribute.nullable -> constructIsNotNullConstraints -> constraints ->
+    //   InferFiltersFromConstraints.inferFilters
+    //
+    // Root cause: a plan node's output contained UnresolvedAttribute (produced by
+    // Alias.toAttribute when the Alias is unresolved), and constructIsNotNullConstraints
+    // called output.filterNot(_.nullable) which threw on the UnresolvedAttribute.
+    val resolvedAttr = testRelation.output.head
+    val unresolvedAlias = Alias(UnresolvedAttribute("unknown_col"), "x")()
+    val projectWithUnresolved = Project(
+      Seq(resolvedAttr, unresolvedAlias),
+      testRelation
+    )
+    val filterPlan = Filter(
+      GreaterThan(resolvedAttr, Literal(5)),
+      projectWithUnresolved
+    )
+
+    // Without the fix, this throws:
+    //   org.apache.spark.sql.catalyst.analysis.UnresolvedException: nullable
+    val result = InferFiltersFromConstraints(filterPlan)
+    assert(result != null)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
@@ -428,4 +428,15 @@ class ConstraintPropagationSuite extends SparkFunSuite with PlanTest {
       assert(aliasedRelation.analyze.constraints.isEmpty)
     }
   }
+
+  test("constructIsNotNullConstraints should not crash on unresolved attributes") {
+    val helper = new ConstraintHelper {}
+    val resolved = AttributeReference("a", IntegerType, nullable = false)()
+    val unresolved = UnresolvedAttribute("b")
+    val output = Seq(resolved, unresolved)
+
+    val result = helper.constructIsNotNullConstraints(ExpressionSet(), output)
+    assert(result.contains(IsNotNull(resolved)))
+    assert(result.size === 1)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Guard against `UnresolvedAttribute` in `ConstraintHelper.constructIsNotNullConstraints` by checking `Attribute.resolved` before accessing `Attribute.nullable`.

The change is a one-line fix in `QueryPlanConstraints.scala`:

Before:
```scala
val nonNullableAttributes = output.filterNot(_.nullable)
```

After:
```scala
val nonNullableAttributes = output.filter(a => a.resolved && !a.nullable)
```

### Why are the changes needed?

`constructIsNotNullConstraints` is called from the `constraints` lazy val on `LogicalPlan`, which is evaluated lazily during optimization (e.g., by `InferFiltersFromConstraints`). If a plan node's `output` contains an `UnresolvedAttribute`, calling `.nullable` on it throws `UnresolvedException` because `UnresolvedAttribute.nullable` is defined as:

```scala
override def nullable: Boolean = throw new UnresolvedException("nullable")
```

An `UnresolvedAttribute` can appear in a plan's `output` when `Alias.toAttribute` is called on an unresolved `Alias`:

```scala
// namedExpressions.scala
override def toAttribute: Attribute = {
  if (resolved) {
    AttributeReference(name, child.dataType, child.nullable, metadata)(exprId, qualifier)
  } else {
    UnresolvedAttribute.quoted(name)  // <-- this leaks into Project.output
  }
}
```

Since `Project.output` is computed as `projectList.map(_.toAttribute)`, any unresolved `Alias` in the project list produces an `UnresolvedAttribute` in the output. This can occur when plans are constructed through non-standard paths (e.g., Spark Connect plan deserialization) where the plan may not be fully analyzed before optimizer rules access the `constraints` lazy val.

The stack trace:

```
UnresolvedException: [INTERNAL_ERROR] Invalid call to nullable on an unresolved named expression
  at UnresolvedAttribute.nullable(unresolved.scala:330)
  at ConstraintHelper.constructIsNotNullConstraints(QueryPlanConstraints.scala:103)
  at QueryPlanConstraints.constraints(QueryPlanConstraints.scala:36)
  at InferFiltersFromConstraints.inferFilters(Optimizer.scala:...)
```

The fix is safe because unresolved attributes have unknown nullability, so skipping them for `IsNotNull` constraint inference is semantically correct — we simply cannot infer anything about attributes whose nullability is unknown.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Two new tests were added:

1. **`ConstraintPropagationSuite`** — unit test that directly validates `constructIsNotNullConstraints` handles a mix of resolved and unresolved attributes in the output without crashing, and correctly infers `IsNotNull` only for the resolved non-nullable attributes.
2. **`InferFiltersFromConstraintsSuite`** — optimizer-level regression test that constructs a `Filter` on top of a `Project` with an unresolved `Alias` (simulating the production plan topology) and applies `InferFiltersFromConstraints` directly. Verified that the test **fails without the fix** with the exact production stack trace and **passes with the fix**.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)
