### PR TITLE
[SPARK-56020][SQL][FOLLOW-UP] Use `Reducer.displayName()` in `GroupPartitions` textual representation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupPartitionsExec.scala
@@ -200,11 +200,11 @@ case class GroupPartitionsExec(
 
   private def planSummaryParts(joinKeyMaxFields: Int): Iterator[String] = {
     val joinKeyStr = joinKeyPositions.map { p =>
-      s"JoinKeyPositions: ${truncatedString(p, "[", ",", "]", joinKeyMaxFields)}"
+      s"JoinKeyPositions: ${truncatedString(p, "[", ", ", "]", joinKeyMaxFields)}"
     }.iterator
     val expectedStr = expectedPartitionKeys.map(ks => s"ExpectedPartitionKeys: ${ks.size}")
     val reducersStr = reducers.map { seq =>
-      val names = seq.map(_.map(_.toString()).getOrElse("identity"))
+      val names = seq.map(_.map(_.displayName()).getOrElse("identity"))
       s"Reducers: ${truncatedString(names, "[", ", ", "]", joinKeyMaxFields)}"
     }
     val distributeStr = Iterator(s"DistributePartitions: $distributePartitions")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Minor follow-up to https://github.com/apache/spark/pull/54842 to fix text representation of `GroupPartitions`.

### Why are the changes needed?

`Reducer`s should be shown using `Reducer.displayName()`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UTs.

### Was this patch authored or co-authored using generative AI tooling?

No.