### PR TITLE
[SPARK-56065][SQL] Add AQE fallback from failed broadcast joins to shuffle joins

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1233,7 +1233,7 @@ object SQLConf {
     buildConf("spark.sql.adaptive.broadcastJoin.fallbackToShuffle.enabled")
       .doc("When true, adaptive execution retries with broadcast joins disabled if a broadcast " +
         "query stage fails because it exceeds broadcast table row or size limits.")
-      .version("3.5.0")
+      .version("4.2.0")
       .booleanConf
       .createWithDefault(false)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1231,9 +1231,11 @@ object SQLConf {
 
   val ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED =
     buildConf("spark.sql.adaptive.broadcastJoin.fallbackToShuffle.enabled")
-      .doc("When true, adaptive execution retries with broadcast joins disabled if a broadcast " +
-        "query stage fails because it exceeds broadcast table row or size limits.")
+      .doc("When true, adaptive execution retries with the matching broadcast hash join disabled " +
+        "if its broadcast query stage fails because it exceeds broadcast table row or size " +
+        "limits.")
       .version("4.2.0")
+      .withBindingPolicy(ConfigBindingPolicy.SESSION)
       .booleanConf
       .createWithDefault(false)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1229,6 +1229,14 @@ object SQLConf {
       .bytesConf(ByteUnit.BYTE)
       .createOptional
 
+  val ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED =
+    buildConf("spark.sql.adaptive.broadcastJoin.fallbackToShuffle.enabled")
+      .doc("When true, adaptive execution retries with broadcast joins disabled if a broadcast " +
+        "query stage fails because it exceeds broadcast table row or size limits.")
+      .version("3.5.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD =
     buildConf("spark.sql.adaptive.maxShuffledHashJoinLocalMapThreshold")
       .doc("Configures the maximum size in bytes per partition that can be allowed to build " +
@@ -7490,6 +7498,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def nonEmptyPartitionRatioForBroadcastJoin: Double =
     getConf(NON_EMPTY_PARTITION_RATIO_FOR_BROADCAST_JOIN)
+
+  def adaptiveBroadcastJoinFallbackToShuffleEnabled: Boolean =
+    getConf(ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED)
 
   def coalesceShufflePartitionsEnabled: Boolean = getConf(COALESCE_PARTITIONS_ENABLED)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -40,6 +40,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{
   Join,
   JoinHint,
   LogicalPlan,
+  NO_BROADCAST_HASH,
   ReturnAnswer
 }
 import org.apache.spark.sql.catalyst.plans.physical.{Distribution, UnspecifiedDistribution}
@@ -289,7 +290,7 @@ case class AdaptiveSparkPlanExec(
       var stagesToReplace = Seq.empty[QueryStageExec]
       // Persist failed broadcast relations across AQE iterations so later replans
       // cannot reintroduce the same relation and re-trigger the same broadcast failure.
-      val failedBroadcastStages = new mutable.ArrayBuffer[BroadcastQueryStageExec]()
+      val failedBroadcastStagesBuffer = new mutable.ArrayBuffer[BroadcastQueryStageExec]()
       while (!result.allChildStagesMaterialized) {
         currentPhysicalPlan = result.newPlan
         if (result.newStages.nonEmpty) {
@@ -349,7 +350,7 @@ case class AdaptiveSparkPlanExec(
             logInfo("Broadcast query stage failed on table size/row limit; retrying " +
               s"adaptive replanning without broadcast joins. Stage ${stage.id}")
             removeStageFromCache(stage)
-            registerFailedBroadcastStage(failedBroadcastStages, stage)
+            registerFailedBroadcastStage(failedBroadcastStagesBuffer, stage)
             if (!fallbackStages.exists(_.eq(stage))) {
               fallbackStages.append(stage)
             }
@@ -365,7 +366,7 @@ case class AdaptiveSparkPlanExec(
           stagesToReplace = filterStagesToReplaceForFallback(stagesToReplace, fallbackStages.toSeq)
           currentLogicalPlan = removeFailedBroadcastStagesFromLogicalPlan(
             currentLogicalPlan,
-            failedBroadcastStages.toSeq)
+            failedBroadcastStagesBuffer.toSeq)
         }
 
         // In case of errors, we cancel all running stages and throw exception.
@@ -385,18 +386,25 @@ case class AdaptiveSparkPlanExec(
           // plans are updated, we can clear the query stage list because at this point the two
           // plans are semantically and physically in sync again.
           val logicalPlan = replaceWithQueryStagesInLogicalPlan(currentLogicalPlan, stagesToReplace)
-          val forceAdoptBroadcastFallbackPlan = fallbackStages.nonEmpty
-          val afterReOptimize = reOptimize(logicalPlan, forceAdoptBroadcastFallbackPlan)
+          val shouldBroadcastFallback = fallbackStages.nonEmpty
+          val failedBroadcastStages = failedBroadcastStagesBuffer.toSeq
+
+          val afterReOptimize = if (shouldBroadcastFallback) {
+            val targetedLogicalPlan =
+              addNoBroadcastHashHintsForFailedRelations(logicalPlan, failedBroadcastStages)
+            reOptimize(targetedLogicalPlan)
+          } else {
+            reOptimize(logicalPlan)
+          }
+
           if (afterReOptimize.isDefined) {
             val (newPhysicalPlan, newLogicalPlan) = afterReOptimize.get
-            val rejectBroadcastFallbackPlan =
-              shouldRejectBroadcastPlanInFallback(
-                newPhysicalPlan,
-                failedBroadcastStages.toSeq)
+            val rejectBroadcastFallbackPlan = hasFailedBroadcastRelation(
+              newPhysicalPlan, failedBroadcastStages)
             val origCost = costEvaluator.evaluateCost(currentPhysicalPlan)
             val newCost = costEvaluator.evaluateCost(newPhysicalPlan)
             if (rejectBroadcastFallbackPlan) {
-              if (forceAdoptBroadcastFallbackPlan) {
+              if (shouldBroadcastFallback) {
                 logInfo("Adaptive fallback replan still contains failed broadcast relation; " +
                   "aborting without retrying broadcast join fallback.")
                 cleanUpAndThrowException(fallbackErrors.toSeq, None)
@@ -404,7 +412,7 @@ case class AdaptiveSparkPlanExec(
                 logDebug("Rejecting AQE replan because it reintroduces a previously failed " +
                   "broadcast relation.")
               }
-            } else if (forceAdoptBroadcastFallbackPlan || newCost < origCost ||
+            } else if (shouldBroadcastFallback || newCost < origCost ||
               (newCost == origCost && currentPhysicalPlan != newPhysicalPlan)) {
               lazy val plans = sideBySide(
                 currentPhysicalPlan.treeString, newPhysicalPlan.treeString).mkString("\n")
@@ -413,10 +421,8 @@ case class AdaptiveSparkPlanExec(
               currentPhysicalPlan = newPhysicalPlan
               currentLogicalPlan = newLogicalPlan
               stagesToReplace = Seq.empty[QueryStageExec]
-            } else if (forceAdoptBroadcastFallbackPlan) {
-              cleanUpAndThrowException(fallbackErrors.toSeq, None)
             }
-          } else if (forceAdoptBroadcastFallbackPlan) {
+          } else if (shouldBroadcastFallback) {
             cleanUpAndThrowException(fallbackErrors.toSeq, None)
           }
         }
@@ -840,63 +846,30 @@ case class AdaptiveSparkPlanExec(
   /**
    * Re-optimize and run physical planning on the current logical plan based on the latest stats.
    */
-  private def reOptimize(
-      logicalPlan: LogicalPlan,
-      disableBroadcastJoin: Boolean): Option[(SparkPlan, LogicalPlan)] = {
+  private def reOptimize(logicalPlan: LogicalPlan): Option[(SparkPlan, LogicalPlan)] = {
     try {
-      val optimizedLogicalPlan = if (disableBroadcastJoin) {
-        removeBroadcastHints(logicalPlan)
-      } else {
-        logicalPlan
-      }
-      def planFn(
-          optimizerToUse: AQEOptimizer,
-          plannerToUse: SparkPlanner): (SparkPlan, LogicalPlan) = {
-        optimizedLogicalPlan.invalidateStatsCache()
-        val optimized = optimizerToUse.execute(optimizedLogicalPlan)
-        val sparkPlan = plannerToUse.plan(ReturnAnswer(optimized)).next()
-        val newPlan = applyPhysicalRules(
-          applyQueryPostPlannerStrategyRules(sparkPlan),
-          preprocessingRules ++ queryStagePreparationRules,
-          Some((planChangeLogger, "AQE Replanning")))
+      logicalPlan.invalidateStatsCache()
+      val optimized = optimizer.execute(logicalPlan)
+      val sparkPlan = context.session.sessionState.planner.plan(ReturnAnswer(optimized)).next()
+      val newPlan = applyPhysicalRules(
+        applyQueryPostPlannerStrategyRules(sparkPlan),
+        preprocessingRules ++ queryStagePreparationRules,
+        Some((planChangeLogger, "AQE Replanning")))
 
-        // When both enabling AQE and DPP, `PlanAdaptiveDynamicPruningFilters` rule will
-        // add the `BroadcastExchangeExec` node manually in the DPP subquery,
-        // not through `EnsureRequirements` rule. Therefore, when the DPP subquery is
-        // complicated and need to be re-optimized, AQE also need to manually insert the
-        // `BroadcastExchangeExec` node to prevent the loss of the `BroadcastExchangeExec`
-        // node in DPP subquery.
-        // If this adaptive plan must still produce a broadcast result, preserve the root
-        // broadcast exchange even when join fallback disables broadcast joins inside the plan.
-        // Otherwise, avoid reinserting the exchange when the new plan already contains one
-        // after applying the `LogicalQueryStageStrategy` rule.
-        val finalPlan = inputPlan match {
-          case b: BroadcastExchangeLike
-              if !newPlan.isInstanceOf[BroadcastExchangeLike] =>
-            b.withNewChildren(Seq(newPlan))
-          case _ => newPlan
-        }
-        (finalPlan, optimized)
+      // When both enabling AQE and DPP, `PlanAdaptiveDynamicPruningFilters` rule will
+      // add the `BroadcastExchangeExec` node manually in the DPP subquery,
+      // not through `EnsureRequirements` rule. Therefore, when the DPP subquery is complicated
+      // and need to be re-optimized, AQE also need to manually insert the `BroadcastExchangeExec`
+      // node to prevent the loss of the `BroadcastExchangeExec` node in DPP subquery.
+      // Here, we also need to avoid to insert the `BroadcastExchangeExec` node when the newPlan is
+      // already the `BroadcastExchangeExec` plan after apply the `LogicalQueryStageStrategy` rule.
+      val finalPlan = inputPlan match {
+        case b: BroadcastExchangeLike
+          if (!newPlan.isInstanceOf[BroadcastExchangeLike]) => b.withNewChildren(Seq(newPlan))
+        case _ => newPlan
       }
 
-      val result = if (disableBroadcastJoin) {
-        // Use cloneSession to preserve current session state (e.g. runtime SQLConf and planner
-        // customizations) while keeping fallback conf changes isolated from the original session.
-        val fallbackSession = context.session.cloneSession()
-        val fallbackConf = fallbackSession.sessionState.conf
-        fallbackConf.setConfString(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
-        fallbackConf.setConfString(SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
-        val fallbackPlanner = fallbackSession.sessionState.planner
-        SQLConf.withExistingConf(fallbackConf) {
-          val optimizerToUse = new AQEOptimizer(
-            fallbackConf,
-            fallbackSession.sessionState.adaptiveRulesHolder.runtimeOptimizerRules)
-          planFn(optimizerToUse, fallbackPlanner)
-        }
-      } else {
-        planFn(optimizer, context.session.sessionState.planner)
-      }
-      Some(result)
+      Some((finalPlan, optimized))
     } catch {
       case e: InvalidAQEPlanException[_] =>
         logOnLevel(log"Re-optimize - ${MDC(ERROR, e.getMessage())}:\n" +
@@ -960,21 +933,19 @@ case class AdaptiveSparkPlanExec(
   private def filterStagesToReplaceForFallback(
       stagesToReplace: Seq[QueryStageExec],
       failedStages: Seq[QueryStageExec]): Seq[QueryStageExec] = {
-    if (failedStages.isEmpty) {
-      stagesToReplace
-    } else {
-      stagesToReplace.filterNot { stage =>
-        failedStages.exists(_.eq(stage)) || (stage match {
-          case broadcastStage: BroadcastQueryStageExec =>
-            failedStages.exists {
-              case failedBroadcast: BroadcastQueryStageExec =>
-                sameBroadcastRelation(
-                  broadcastStage.broadcast.child, failedBroadcast.broadcast.child)
-              case _ => false
-            }
-          case _ => false
-        })
-      }
+    if (failedStages.isEmpty) return stagesToReplace
+
+    val failedBroadcastStages = failedStages.collect {
+      case b: BroadcastQueryStageExec => b
+    }
+
+    stagesToReplace.filterNot {
+      case stage if failedStages.exists(_ eq stage) => true
+      case stage: BroadcastQueryStageExec =>
+        failedBroadcastStages.exists { failed =>
+          sameBroadcastRelation(stage.broadcast.child, failed.broadcast.child)
+        }
+      case _ => false
     }
   }
 
@@ -994,6 +965,7 @@ case class AdaptiveSparkPlanExec(
     }
   }
 
+  // Check if a Spark physical plan contains any of the previous failed broadcast stages
   private def hasFailedBroadcastRelation(
       plan: SparkPlan,
       failedBroadcastStages: Seq[BroadcastQueryStageExec]): Boolean = {
@@ -1025,13 +997,13 @@ case class AdaptiveSparkPlanExec(
   // Drop stale cache entries for a failed/replaced exchange stage so AQE can rebuild it.
   private def removeStageFromCache(stage: QueryStageExec): Unit = stage match {
     case exchangeStage: ExchangeQueryStageExec =>
-      Seq(exchangeStage.plan.canonicalized, exchangeStage.canonicalized).distinct.foreach { key =>
-        context.stageCache.remove(key)
+      val planKey = exchangeStage.plan.canonicalized
+      val stageKey = exchangeStage.canonicalized
+
+      context.stageCache.remove(planKey)
+      if (stageKey != planKey) {
+        context.stageCache.remove(stageKey)
       }
-      val keysToRemove = context.stageCache.collect {
-        case (key, cachedStage) if cachedStage.eq(exchangeStage) => key
-      }.toSeq
-      keysToRemove.foreach(context.stageCache.remove)
     case _ =>
   }
 
@@ -1050,51 +1022,83 @@ case class AdaptiveSparkPlanExec(
     left.sameResult(right)
   }
 
-  private def rootBroadcastStage(plan: SparkPlan): Option[BroadcastQueryStageExec] = plan match {
-    case stage: BroadcastQueryStageExec => Some(stage)
-    case resultStage: ResultQueryStageExec => rootBroadcastStage(resultStage.plan)
-    case _ => None
-  }
-
   // Root broadcast stages must be preserved (e.g. broadcast subquery output contract).
   // Only exempt the actual root broadcast stage instance, not semantically equivalent relations.
-  private def isRequiredRootBroadcastStage(stage: QueryStageExec): Boolean = {
-    if (!inputPlan.isInstanceOf[BroadcastExchangeLike]) {
-      false
+  private def isRequiredRootBroadcastStage(stage: QueryStageExec): Boolean = stage match {
+    case broadcastStage: BroadcastQueryStageExec if inputPlan.isInstanceOf[BroadcastExchangeLike] =>
+      @tailrec
+      def findRootBroadcast(current: SparkPlan): Option[BroadcastQueryStageExec] = current match {
+        case root: BroadcastQueryStageExec => Some(root)
+        case resultStage: ResultQueryStageExec => findRootBroadcast(resultStage.plan)
+        case _ => None
+      }
+      findRootBroadcast(currentPhysicalPlan).exists(_ eq broadcastStage)
+    case _ => false
+  }
+
+  // Apply side-specific NO_BROADCAST_HASH hints for relations that previously failed
+  // broadcast stage materialization, so targeted fallback can keep unrelated BHJs.
+  private def addNoBroadcastHashHintsForFailedRelations(
+      plan: LogicalPlan,
+      failedBroadcastStages: Seq[BroadcastQueryStageExec]): LogicalPlan = {
+    val failedLogicalPlans = extractFailedBroadcastLogicalPlans(failedBroadcastStages)
+    if (failedLogicalPlans.isEmpty) {
+      plan
     } else {
-      stage match {
-        case broadcastStage: BroadcastQueryStageExec =>
-          rootBroadcastStage(currentPhysicalPlan).exists(_.eq(broadcastStage))
-        case _ => false
+      plan.transformDown {
+        case join: Join =>
+          val disableLeft = shouldDisableBroadcastForJoinSide(join.left, failedLogicalPlans)
+          val disableRight = shouldDisableBroadcastForJoinSide(join.right, failedLogicalPlans)
+          if (!disableLeft && !disableRight) {
+            join
+          } else {
+            val newHint = JoinHint(
+              if (disableLeft) {
+                toNoBroadcastHashHint(join.hint.leftHint)
+              } else {
+                join.hint.leftHint
+              },
+              if (disableRight) {
+                toNoBroadcastHashHint(join.hint.rightHint)
+              } else {
+                join.hint.rightHint
+              })
+            if (newHint != join.hint) join.copy(hint = newHint) else join
+          }
       }
     }
   }
 
-  // Reject fallback replans that still contain the same failed broadcast relation.
-  // Without this check, AQE can repeatedly re-adopt plans that retry the same failing broadcast.
-  private def shouldRejectBroadcastPlanInFallback(
-      newPlan: SparkPlan,
-      failedBroadcastStages: Seq[BroadcastQueryStageExec]): Boolean = {
-    hasFailedBroadcastRelation(newPlan, failedBroadcastStages)
-  }
-
-  // Strip BROADCAST join hints before fallback replanning to avoid forcing broadcast joins.
-  private def removeBroadcastHints(plan: LogicalPlan): LogicalPlan = {
-    plan.transformDown {
-      case join: Join if !join.hint.isEmpty =>
-        val newHint = JoinHint(
-          stripBroadcastHint(join.hint.leftHint),
-          stripBroadcastHint(join.hint.rightHint))
-        if (newHint != join.hint) join.copy(hint = newHint) else join
+  private def extractFailedBroadcastLogicalPlans(
+      failedBroadcastStages: Seq[BroadcastQueryStageExec]): Seq[LogicalPlan] = {
+    val failedLogicalPlans = new mutable.ArrayBuffer[LogicalPlan]()
+    failedBroadcastStages.foreach { stage =>
+      Seq(stage.broadcast.child.logicalLink, stage.broadcast.logicalLink, stage.logicalLink)
+        .flatten
+        .foreach { logicalPlan =>
+          if (!failedLogicalPlans.exists(_.sameResult(logicalPlan))) {
+            failedLogicalPlans.append(logicalPlan)
+          }
+        }
     }
+    failedLogicalPlans.toSeq
   }
 
-  // Remove only BROADCAST strategy from a hint, preserving any other hint strategies.
-  private def stripBroadcastHint(hint: Option[HintInfo]): Option[HintInfo] = {
-    hint.flatMap {
-      case h if h.strategy.contains(BROADCAST) => Some(h.copy(strategy = None))
-      case h => Some(h)
-    }.filter(_.strategy.nonEmpty)
+  private def shouldDisableBroadcastForJoinSide(
+      side: LogicalPlan,
+      failedLogicalPlans: Seq[LogicalPlan]): Boolean = {
+    failedLogicalPlans.exists(side.sameResult)
+  }
+
+  private def toNoBroadcastHashHint(hint: Option[HintInfo]): Option[HintInfo] = {
+    hint match {
+      // Only rewrite explicit BROADCAST hints. Preserve existing non-broadcast
+      // strategies such as NO_BROADCAST_AND_REPLICATION, SHUFFLE_HASH, etc.
+      case Some(h) if h.strategy.contains(BROADCAST) =>
+        Some(h.copy(strategy = Some(NO_BROADCAST_HASH)))
+      case Some(_) => hint
+      case None => Some(HintInfo(strategy = Some(NO_BROADCAST_HASH)))
+    }
   }
 
   // Walk throwable causes and return true if any SparkThrowable has one of the error classes.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -1050,10 +1050,23 @@ case class AdaptiveSparkPlanExec(
     left.sameResult(right)
   }
 
+  private def rootBroadcastStage(plan: SparkPlan): Option[BroadcastQueryStageExec] = plan match {
+    case stage: BroadcastQueryStageExec => Some(stage)
+    case resultStage: ResultQueryStageExec => rootBroadcastStage(resultStage.plan)
+    case _ => None
+  }
+
   // Root broadcast stages must be preserved (e.g. broadcast subquery output contract).
+  // Only exempt the actual root broadcast stage instance, not semantically equivalent relations.
   private def isRequiredRootBroadcastStage(stage: QueryStageExec): Boolean = {
-    broadcastChildPlan(inputPlan).exists { rootBroadcastChild =>
-      broadcastChildPlan(stage).exists(sameBroadcastRelation(_, rootBroadcastChild))
+    if (!inputPlan.isInstanceOf[BroadcastExchangeLike]) {
+      false
+    } else {
+      stage match {
+        case broadcastStage: BroadcastQueryStageExec =>
+          rootBroadcastStage(currentPhysicalPlan).exists(_.eq(broadcastStage))
+        case _ => false
+      }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -20,20 +20,28 @@ package org.apache.spark.sql.execution.adaptive
 import java.util
 import java.util.concurrent.{ConcurrentHashMap, LinkedBlockingQueue}
 
+import scala.annotation.tailrec
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
-import org.apache.spark.SparkException
+import org.apache.spark.{SparkException, SparkThrowable}
 import org.apache.spark.broadcast
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.internal.MessageWithContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, ReturnAnswer}
+import org.apache.spark.sql.catalyst.plans.logical.{
+  BROADCAST,
+  HintInfo,
+  Join,
+  JoinHint,
+  LogicalPlan,
+  ReturnAnswer
+}
 import org.apache.spark.sql.catalyst.plans.physical.{Distribution, UnspecifiedDistribution}
 import org.apache.spark.sql.catalyst.rules.{PlanChangeLogger, Rule}
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
@@ -279,6 +287,9 @@ case class AdaptiveSparkPlanExec(
       val events = new LinkedBlockingQueue[StageMaterializationEvent]()
       val errors = new mutable.ArrayBuffer[Throwable]()
       var stagesToReplace = Seq.empty[QueryStageExec]
+      // Persist failed broadcast relations across AQE iterations so later replans
+      // cannot reintroduce the same relation and re-trigger the same broadcast failure.
+      val failedBroadcastStages = new mutable.ArrayBuffer[BroadcastQueryStageExec]()
       while (!result.allChildStagesMaterialized) {
         currentPhysicalPlan = result.newPlan
         if (result.newStages.nonEmpty) {
@@ -328,12 +339,30 @@ case class AdaptiveSparkPlanExec(
         val nextMsg = events.take()
         val rem = new util.ArrayList[StageMaterializationEvent]()
         events.drainTo(rem)
-        (Seq(nextMsg) ++ rem.asScala).foreach {
+        val stageEvents = Seq(nextMsg) ++ rem.asScala
+        val fallbackStages = new mutable.ArrayBuffer[QueryStageExec]()
+        val fallbackErrors = new mutable.ArrayBuffer[Throwable]()
+        stageEvents.foreach {
           case StageSuccess(stage, res) =>
             stage.resultOption.set(Some(res))
+          case StageFailure(stage, ex) if shouldFallbackToShuffleJoin(stage, ex) =>
+            logInfo("Broadcast query stage failed on table size/row limit; retrying " +
+              s"adaptive replanning without broadcast joins. Stage ${stage.id}")
+            removeStageFromCache(stage)
+            registerFailedBroadcastStage(failedBroadcastStages, stage)
+            if (!fallbackStages.exists(_.eq(stage))) {
+              fallbackStages.append(stage)
+            }
+            fallbackErrors.append(ex)
           case StageFailure(stage, ex) =>
             stage.error.set(Some(ex))
             errors.append(ex)
+        }
+
+        // Do not carry failed fallback stages into the next logical-plan replacement pass.
+        // They are intentionally invalidated and must be rebuilt by replanning.
+        if (fallbackStages.nonEmpty) {
+          stagesToReplace = filterStagesToReplaceForFallback(stagesToReplace, fallbackStages.toSeq)
         }
 
         // In case of errors, we cancel all running stages and throw exception.
@@ -353,12 +382,26 @@ case class AdaptiveSparkPlanExec(
           // plans are updated, we can clear the query stage list because at this point the two
           // plans are semantically and physically in sync again.
           val logicalPlan = replaceWithQueryStagesInLogicalPlan(currentLogicalPlan, stagesToReplace)
-          val afterReOptimize = reOptimize(logicalPlan)
+          val forceAdoptBroadcastFallbackPlan = fallbackStages.nonEmpty
+          val afterReOptimize = reOptimize(logicalPlan, forceAdoptBroadcastFallbackPlan)
           if (afterReOptimize.isDefined) {
             val (newPhysicalPlan, newLogicalPlan) = afterReOptimize.get
+            val rejectBroadcastFallbackPlan =
+              shouldRejectBroadcastPlanInFallback(
+                newPhysicalPlan,
+                failedBroadcastStages.toSeq)
             val origCost = costEvaluator.evaluateCost(currentPhysicalPlan)
             val newCost = costEvaluator.evaluateCost(newPhysicalPlan)
-            if (newCost < origCost ||
+            if (rejectBroadcastFallbackPlan) {
+              if (forceAdoptBroadcastFallbackPlan) {
+                logInfo("Adaptive fallback replan still contains failed broadcast relation; " +
+                  "aborting without retrying broadcast join fallback.")
+                cleanUpAndThrowException(fallbackErrors.toSeq, None)
+              } else {
+                logDebug("Rejecting AQE replan because it reintroduces a previously failed " +
+                  "broadcast relation.")
+              }
+            } else if (forceAdoptBroadcastFallbackPlan || newCost < origCost ||
               (newCost == origCost && currentPhysicalPlan != newPhysicalPlan)) {
               lazy val plans = sideBySide(
                 currentPhysicalPlan.treeString, newPhysicalPlan.treeString).mkString("\n")
@@ -367,7 +410,11 @@ case class AdaptiveSparkPlanExec(
               currentPhysicalPlan = newPhysicalPlan
               currentLogicalPlan = newLogicalPlan
               stagesToReplace = Seq.empty[QueryStageExec]
+            } else if (forceAdoptBroadcastFallbackPlan) {
+              cleanUpAndThrowException(fallbackErrors.toSeq, None)
             }
+          } else if (forceAdoptBroadcastFallbackPlan) {
+            cleanUpAndThrowException(fallbackErrors.toSeq, None)
           }
         }
         // Now that some stages have finished, we can try creating new stages.
@@ -790,30 +837,68 @@ case class AdaptiveSparkPlanExec(
   /**
    * Re-optimize and run physical planning on the current logical plan based on the latest stats.
    */
-  private def reOptimize(logicalPlan: LogicalPlan): Option[(SparkPlan, LogicalPlan)] = {
+  private def reOptimize(
+      logicalPlan: LogicalPlan,
+      disableBroadcastJoin: Boolean): Option[(SparkPlan, LogicalPlan)] = {
     try {
-      logicalPlan.invalidateStatsCache()
-      val optimized = optimizer.execute(logicalPlan)
-      val sparkPlan = context.session.sessionState.planner.plan(ReturnAnswer(optimized)).next()
-      val newPlan = applyPhysicalRules(
-        applyQueryPostPlannerStrategyRules(sparkPlan),
-        preprocessingRules ++ queryStagePreparationRules,
-        Some((planChangeLogger, "AQE Replanning")))
+      val optimizedLogicalPlan = if (disableBroadcastJoin) {
+        removeBroadcastHints(logicalPlan)
+      } else {
+        logicalPlan
+      }
+      def planFn(optimizerToUse: AQEOptimizer): (SparkPlan, LogicalPlan) = {
+        optimizedLogicalPlan.invalidateStatsCache()
+        val optimized = optimizerToUse.execute(optimizedLogicalPlan)
+        val sparkPlan = context.session.sessionState.planner.plan(ReturnAnswer(optimized)).next()
+        val newPlan = applyPhysicalRules(
+          applyQueryPostPlannerStrategyRules(sparkPlan),
+          preprocessingRules ++ queryStagePreparationRules,
+          Some((planChangeLogger, "AQE Replanning")))
 
-      // When both enabling AQE and DPP, `PlanAdaptiveDynamicPruningFilters` rule will
-      // add the `BroadcastExchangeExec` node manually in the DPP subquery,
-      // not through `EnsureRequirements` rule. Therefore, when the DPP subquery is complicated
-      // and need to be re-optimized, AQE also need to manually insert the `BroadcastExchangeExec`
-      // node to prevent the loss of the `BroadcastExchangeExec` node in DPP subquery.
-      // Here, we also need to avoid to insert the `BroadcastExchangeExec` node when the newPlan is
-      // already the `BroadcastExchangeExec` plan after apply the `LogicalQueryStageStrategy` rule.
-      val finalPlan = inputPlan match {
-        case b: BroadcastExchangeLike
-          if (!newPlan.isInstanceOf[BroadcastExchangeLike]) => b.withNewChildren(Seq(newPlan))
-        case _ => newPlan
+        // When both enabling AQE and DPP, `PlanAdaptiveDynamicPruningFilters` rule will
+        // add the `BroadcastExchangeExec` node manually in the DPP subquery,
+        // not through `EnsureRequirements` rule. Therefore, when the DPP subquery is
+        // complicated and need to be re-optimized, AQE also need to manually insert the
+        // `BroadcastExchangeExec` node to prevent the loss of the `BroadcastExchangeExec`
+        // node in DPP subquery.
+        // If this adaptive plan must still produce a broadcast result, preserve the root
+        // broadcast exchange even when join fallback disables broadcast joins inside the plan.
+        // Otherwise, avoid reinserting the exchange when the new plan already contains one
+        // after applying the `LogicalQueryStageStrategy` rule.
+        val finalPlan = inputPlan match {
+          case b: BroadcastExchangeLike
+              if !newPlan.isInstanceOf[BroadcastExchangeLike] =>
+            b.withNewChildren(Seq(newPlan))
+          case _ => newPlan
+        }
+        (finalPlan, optimized)
       }
 
-      Some((finalPlan, optimized))
+      val result = if (disableBroadcastJoin) {
+        val sessionConf = context.session.sessionState.conf
+        val confKeys = Seq(
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key,
+          SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key)
+        val confBackup = confKeys.map(k => k -> sessionConf.getAllConfs.get(k)).toMap
+        sessionConf.setConfString(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
+        sessionConf.setConfString(SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
+        try {
+          SQLConf.withExistingConf(sessionConf) {
+            val optimizerToUse = new AQEOptimizer(
+              sessionConf,
+              context.session.sessionState.adaptiveRulesHolder.runtimeOptimizerRules)
+            planFn(optimizerToUse)
+          }
+        } finally {
+          confBackup.foreach {
+            case (key, Some(value)) => sessionConf.setConfString(key, value)
+            case (key, None) => sessionConf.unsetConf(key)
+          }
+        }
+      } else {
+        planFn(optimizer)
+      }
+      Some(result)
     } catch {
       case e: InvalidAQEPlanException[_] =>
         logOnLevel(log"Re-optimize - ${MDC(ERROR, e.getMessage())}:\n" +
@@ -858,6 +943,147 @@ case class AdaptiveSparkPlanExec(
         context.qe.explainString(planDescriptionMode),
         SparkPlanInfo.fromSparkPlan(context.qe.executedPlan)))
     }
+  }
+
+  private def shouldFallbackToShuffleJoin(stage: QueryStageExec, error: Throwable): Boolean = {
+    // Detect errors such as:
+    //   - Cannot broadcast the table over <maxBroadcastTableRows> rows: <numRows> rows.
+    //   - Cannot broadcast the table that is larger than <maxBroadcastTableBytes>: <dataSize>.
+    // Check error-classes.json for details
+    conf.adaptiveBroadcastJoinFallbackToShuffleEnabled &&
+      !isRequiredRootBroadcastStage(stage) &&
+      stage.isInstanceOf[BroadcastQueryStageExec] &&
+      hasErrorClass(error, "_LEGACY_ERROR_TEMP_2248", "_LEGACY_ERROR_TEMP_2249")
+  }
+
+  // Remove failed fallback stages from the replacement set before replanning.
+  // For broadcast stages, remove semantically equivalent siblings as well, so
+  // reused/duplicated broadcast stages for the same relation don't leak through.
+  private def filterStagesToReplaceForFallback(
+      stagesToReplace: Seq[QueryStageExec],
+      failedStages: Seq[QueryStageExec]): Seq[QueryStageExec] = {
+    if (failedStages.isEmpty) {
+      stagesToReplace
+    } else {
+      stagesToReplace.filterNot { stage =>
+        failedStages.exists(_.eq(stage)) || (stage match {
+          case broadcastStage: BroadcastQueryStageExec =>
+            failedStages.exists {
+              case failedBroadcast: BroadcastQueryStageExec =>
+                sameBroadcastRelation(
+                  broadcastStage.broadcast.child, failedBroadcast.broadcast.child)
+              case _ => false
+            }
+          case _ => false
+        })
+      }
+    }
+  }
+
+  // Track failed broadcast relations using semantic equality so equivalent stages
+  // in later AQE replans are treated as the same failed relation.
+  private def registerFailedBroadcastStage(
+      failedBroadcastStages: mutable.ArrayBuffer[BroadcastQueryStageExec],
+      stage: QueryStageExec): Unit = {
+    stage match {
+      case failedStage: BroadcastQueryStageExec =>
+        if (!failedBroadcastStages.exists { existing =>
+          sameBroadcastRelation(existing.broadcast.child, failedStage.broadcast.child)
+        }) {
+          failedBroadcastStages.append(failedStage)
+        }
+      case _ =>
+    }
+  }
+
+  // Drop stale cache entries for a failed/replaced exchange stage so AQE can rebuild it.
+  private def removeStageFromCache(stage: QueryStageExec): Unit = stage match {
+    case exchangeStage: ExchangeQueryStageExec =>
+      Seq(exchangeStage.plan.canonicalized, exchangeStage.canonicalized).distinct.foreach { key =>
+        context.stageCache.remove(key)
+      }
+      val keysToRemove = context.stageCache.collect {
+        case (key, cachedStage) if cachedStage.eq(exchangeStage) => key
+      }.toSeq
+      keysToRemove.foreach(context.stageCache.remove)
+    case _ =>
+  }
+
+  // Normalize different wrappers to the underlying broadcast child plan when present.
+  private def broadcastChildPlan(plan: SparkPlan): Option[SparkPlan] = plan match {
+    case stage: BroadcastQueryStageExec => Some(stage.broadcast.child)
+    case exchange: BroadcastExchangeLike => Some(exchange.child)
+    case ReusedExchangeExec(_, exchange: BroadcastExchangeLike) => Some(exchange.child)
+    case _ => None
+  }
+
+  // Compare broadcast inputs by semantic plan equivalence, with a schema-level fallback.
+  private def sameBroadcastRelation(left: SparkPlan, right: SparkPlan): Boolean = {
+    left.sameResult(right) || {
+      left.output.length == right.output.length &&
+        left.output.zip(right.output).forall { case (leftAttr, rightAttr) =>
+          leftAttr.semanticEquals(rightAttr)
+        }
+    }
+  }
+
+  // Root broadcast stages must be preserved (e.g. broadcast subquery output contract).
+  private def isRequiredRootBroadcastStage(stage: QueryStageExec): Boolean = {
+    broadcastChildPlan(inputPlan).exists { rootBroadcastChild =>
+      broadcastChildPlan(stage).exists(sameBroadcastRelation(_, rootBroadcastChild))
+    }
+  }
+
+  // Reject fallback replans that still contain the same failed broadcast relation.
+  // Without this check, AQE can repeatedly re-adopt plans that retry the same failing broadcast.
+  private def shouldRejectBroadcastPlanInFallback(
+      newPlan: SparkPlan,
+      failedBroadcastStages: Seq[BroadcastQueryStageExec]): Boolean = {
+    failedBroadcastStages.nonEmpty && newPlan.exists { p =>
+      broadcastChildPlan(p).exists { child =>
+        failedBroadcastStages.exists { failed =>
+          sameBroadcastRelation(child, failed.broadcast.child)
+        }
+      }
+    }
+  }
+
+  // Strip BROADCAST join hints before fallback replanning to avoid forcing broadcast joins.
+  private def removeBroadcastHints(plan: LogicalPlan): LogicalPlan = {
+    plan.transformDown {
+      case join: Join if !join.hint.isEmpty =>
+        val newHint = JoinHint(
+          stripBroadcastHint(join.hint.leftHint),
+          stripBroadcastHint(join.hint.rightHint))
+        if (newHint != join.hint) join.copy(hint = newHint) else join
+    }
+  }
+
+  // Remove only BROADCAST strategy from a hint, preserving any other hint strategies.
+  private def stripBroadcastHint(hint: Option[HintInfo]): Option[HintInfo] = {
+    hint.flatMap {
+      case h if h.strategy.contains(BROADCAST) => Some(h.copy(strategy = None))
+      case h => Some(h)
+    }.filter(_.strategy.nonEmpty)
+  }
+
+  // Walk throwable causes and return true if any SparkThrowable has one of the error classes.
+  private def hasErrorClass(error: Throwable, errorClasses: String*): Boolean = {
+    @tailrec
+    def loop(current: Throwable): Boolean = {
+      if (current == null) {
+        false
+      } else {
+        current match {
+          case sparkThrowable: SparkThrowable
+              if errorClasses.contains(sparkThrowable.getCondition) =>
+            true
+          case _ =>
+            loop(current.getCause)
+        }
+      }
+    }
+    loop(error)
   }
 
   private def assertStageNotFailed(stage: QueryStageExec): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -363,6 +363,9 @@ case class AdaptiveSparkPlanExec(
         // They are intentionally invalidated and must be rebuilt by replanning.
         if (fallbackStages.nonEmpty) {
           stagesToReplace = filterStagesToReplaceForFallback(stagesToReplace, fallbackStages.toSeq)
+          currentLogicalPlan = removeFailedBroadcastStagesFromLogicalPlan(
+            currentLogicalPlan,
+            failedBroadcastStages.toSeq)
         }
 
         // In case of errors, we cancel all running stages and throw exception.
@@ -975,6 +978,34 @@ case class AdaptiveSparkPlanExec(
     }
   }
 
+  // Remove failed broadcast query-stage wrappers that may have been embedded in prior adopted
+  // logical plans, so fallback replanning does not keep retrying the same failed relation.
+  private def removeFailedBroadcastStagesFromLogicalPlan(
+      plan: LogicalPlan,
+      failedBroadcastStages: Seq[BroadcastQueryStageExec]): LogicalPlan = {
+    if (failedBroadcastStages.isEmpty) {
+      plan
+    } else {
+      plan.transformDown {
+        case stage: LogicalQueryStage
+            if hasFailedBroadcastRelation(stage.physicalPlan, failedBroadcastStages) =>
+          stage.logicalPlan
+      }
+    }
+  }
+
+  private def hasFailedBroadcastRelation(
+      plan: SparkPlan,
+      failedBroadcastStages: Seq[BroadcastQueryStageExec]): Boolean = {
+    failedBroadcastStages.nonEmpty && plan.exists { p =>
+      broadcastChildPlan(p).exists { child =>
+        failedBroadcastStages.exists { failed =>
+          sameBroadcastRelation(child, failed.broadcast.child)
+        }
+      }
+    }
+  }
+
   // Track failed broadcast relations using semantic equality so equivalent stages
   // in later AQE replans are treated as the same failed relation.
   private def registerFailedBroadcastStage(
@@ -1031,13 +1062,7 @@ case class AdaptiveSparkPlanExec(
   private def shouldRejectBroadcastPlanInFallback(
       newPlan: SparkPlan,
       failedBroadcastStages: Seq[BroadcastQueryStageExec]): Boolean = {
-    failedBroadcastStages.nonEmpty && newPlan.exists { p =>
-      broadcastChildPlan(p).exists { child =>
-        failedBroadcastStages.exists { failed =>
-          sameBroadcastRelation(child, failed.broadcast.child)
-        }
-      }
-    }
+    hasFailedBroadcastRelation(newPlan, failedBroadcastStages)
   }
 
   // Strip BROADCAST join hints before fallback replanning to avoid forcing broadcast joins.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -877,20 +877,17 @@ case class AdaptiveSparkPlanExec(
       }
 
       val result = if (disableBroadcastJoin) {
-        val fallbackConf = context.session.sessionState.conf.clone()
+        // Use a cloned session to preserve SessionState planner customizations while keeping
+        // fallback conf changes isolated from the original shared session.
+        val fallbackSession = context.session.newSession()
+        val fallbackConf = fallbackSession.sessionState.conf
         fallbackConf.setConfString(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
         fallbackConf.setConfString(SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
-        val sessionPlanner = context.session.sessionState.planner
-        val fallbackPlanner = new SparkPlanner(
-          context.session,
-          context.session.sessionState.experimentalMethods) {
-          override def conf: SQLConf = fallbackConf
-          override def extraPlanningStrategies = sessionPlanner.extraPlanningStrategies
-        }
+        val fallbackPlanner = fallbackSession.sessionState.planner
         SQLConf.withExistingConf(fallbackConf) {
           val optimizerToUse = new AQEOptimizer(
             fallbackConf,
-            context.session.sessionState.adaptiveRulesHolder.runtimeOptimizerRules)
+            fallbackSession.sessionState.adaptiveRulesHolder.runtimeOptimizerRules)
           planFn(optimizerToUse, fallbackPlanner)
         }
       } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -1015,14 +1015,11 @@ case class AdaptiveSparkPlanExec(
     case _ => None
   }
 
-  // Compare broadcast inputs by semantic plan equivalence, with a schema-level fallback.
+  // Compare broadcast inputs by semantic plan equivalence.
+  // Do not fall back to output-attribute equality: different plans can share
+  // output schemas while producing different relations.
   private def sameBroadcastRelation(left: SparkPlan, right: SparkPlan): Boolean = {
-    left.sameResult(right) || {
-      left.output.length == right.output.length &&
-        left.output.zip(right.output).forall { case (leftAttr, rightAttr) =>
-          leftAttr.semanticEquals(rightAttr)
-        }
-    }
+    left.sameResult(right)
   }
 
   // Root broadcast stages must be preserved (e.g. broadcast subquery output contract).

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -877,9 +877,9 @@ case class AdaptiveSparkPlanExec(
       }
 
       val result = if (disableBroadcastJoin) {
-        // Use a cloned session to preserve SessionState planner customizations while keeping
-        // fallback conf changes isolated from the original shared session.
-        val fallbackSession = context.session.newSession()
+        // Use cloneSession to preserve current session state (e.g. runtime SQLConf and planner
+        // customizations) while keeping fallback conf changes isolated from the original session.
+        val fallbackSession = context.session.cloneSession()
         val fallbackConf = fallbackSession.sessionState.conf
         fallbackConf.setConfString(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
         fallbackConf.setConfString(SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -846,10 +846,12 @@ case class AdaptiveSparkPlanExec(
       } else {
         logicalPlan
       }
-      def planFn(optimizerToUse: AQEOptimizer): (SparkPlan, LogicalPlan) = {
+      def planFn(
+          optimizerToUse: AQEOptimizer,
+          plannerToUse: SparkPlanner): (SparkPlan, LogicalPlan) = {
         optimizedLogicalPlan.invalidateStatsCache()
         val optimized = optimizerToUse.execute(optimizedLogicalPlan)
-        val sparkPlan = context.session.sessionState.planner.plan(ReturnAnswer(optimized)).next()
+        val sparkPlan = plannerToUse.plan(ReturnAnswer(optimized)).next()
         val newPlan = applyPhysicalRules(
           applyQueryPostPlannerStrategyRules(sparkPlan),
           preprocessingRules ++ queryStagePreparationRules,
@@ -875,28 +877,24 @@ case class AdaptiveSparkPlanExec(
       }
 
       val result = if (disableBroadcastJoin) {
-        val sessionConf = context.session.sessionState.conf
-        val confKeys = Seq(
-          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key,
-          SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key)
-        val confBackup = confKeys.map(k => k -> sessionConf.getAllConfs.get(k)).toMap
-        sessionConf.setConfString(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
-        sessionConf.setConfString(SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
-        try {
-          SQLConf.withExistingConf(sessionConf) {
-            val optimizerToUse = new AQEOptimizer(
-              sessionConf,
-              context.session.sessionState.adaptiveRulesHolder.runtimeOptimizerRules)
-            planFn(optimizerToUse)
-          }
-        } finally {
-          confBackup.foreach {
-            case (key, Some(value)) => sessionConf.setConfString(key, value)
-            case (key, None) => sessionConf.unsetConf(key)
-          }
+        val fallbackConf = context.session.sessionState.conf.clone()
+        fallbackConf.setConfString(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
+        fallbackConf.setConfString(SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
+        val sessionPlanner = context.session.sessionState.planner
+        val fallbackPlanner = new SparkPlanner(
+          context.session,
+          context.session.sessionState.experimentalMethods) {
+          override def conf: SQLConf = fallbackConf
+          override def extraPlanningStrategies = sessionPlanner.extraPlanningStrategies
+        }
+        SQLConf.withExistingConf(fallbackConf) {
+          val optimizerToUse = new AQEOptimizer(
+            fallbackConf,
+            context.session.sessionState.adaptiveRulesHolder.runtimeOptimizerRules)
+          planFn(optimizerToUse, fallbackPlanner)
         }
       } else {
-        planFn(optimizer)
+        planFn(optimizer, context.session.sessionState.planner)
       }
       Some(result)
     } catch {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -237,6 +237,10 @@ case class AdaptiveSparkPlanExec(
     allChildStagesMaterialized: Boolean,
     newStages: Seq[QueryStageExec])
 
+  private case class BroadcastFallbackResult(
+    fallbackStages: Seq[BroadcastQueryStageExec],
+    fallbackErrors: Seq[Throwable])
+
   def executedPlan: SparkPlan = currentPhysicalPlan
 
   def isFinalPlan: Boolean = _isFinalPlan
@@ -345,37 +349,17 @@ case class AdaptiveSparkPlanExec(
         val rem = new util.ArrayList[StageMaterializationEvent]()
         events.drainTo(rem)
         val stageEvents = Seq(nextMsg) ++ rem.asScala
-        val fallbackStages = new mutable.ArrayBuffer[QueryStageExec]()
-        val fallbackErrors = new mutable.ArrayBuffer[Throwable]()
-        stageEvents.foreach {
-          case StageSuccess(stage, res) =>
-            stage.resultOption.set(Some(res))
-          case StageFailure(stage: BroadcastQueryStageExec, ex)
-              if shouldFallbackToShuffleJoin(stage, ex) =>
-            removeStageFromCache(stage)
-            logInfo("Broadcast query stage failed on table size/row limit; retrying " +
-              s"adaptive replanning with matching broadcast hash joins disabled. " +
-              s"Stage ${stage.id}")
-            registerFailedBroadcastStage(failedBroadcastStagesBuffer, stage)
-            if (!fallbackStages.exists(_.eq(stage))) {
-              fallbackStages.append(stage)
-            }
-            fallbackErrors.append(ex)
-          case StageFailure(stage: BroadcastQueryStageExec, ex)
-              if shouldIgnoreStaleBroadcastStageFailure(
-                stage, ex, failedBroadcastStagesBuffer.toSeq) =>
-            logDebug("Ignoring stale broadcast query stage failure for a previously failed " +
-              s"broadcast input. Stage ${stage.id}")
-            removeStageFromCache(stage)
-          case StageFailure(stage, ex) =>
-            stage.error.set(Some(ex))
-            errors.append(ex)
-        }
+        val fallbackResult =
+          processStageMaterializationEvents(stageEvents, failedBroadcastStagesBuffer, errors)
+        val fallbackStages = fallbackResult.fallbackStages
+        val fallbackErrors = fallbackResult.fallbackErrors
 
         // Do not carry failed fallback stages into the next logical-plan replacement pass.
         // They are intentionally invalidated and must be rebuilt by replanning.
         if (fallbackStages.nonEmpty) {
-          stagesToReplace = filterStagesToReplaceForFallback(stagesToReplace, fallbackStages.toSeq)
+          stagesToReplace = filterStagesToReplaceForFallback(
+            stagesToReplace,
+            failedBroadcastStagesBuffer.toSeq)
           currentLogicalPlan = removeFailedBroadcastStagesFromLogicalPlan(
             currentLogicalPlan,
             failedBroadcastStagesBuffer.toSeq)
@@ -402,11 +386,8 @@ case class AdaptiveSparkPlanExec(
           val failedBroadcastStages = failedBroadcastStagesBuffer.toSeq
 
           val afterReOptimize = if (shouldBroadcastFallback) {
-            val fallbackLogicalPlan = removeFailedBroadcastStagesFromLogicalPlan(
-              logicalPlan,
-              failedBroadcastStages)
             val targetedLogicalPlan =
-              addNoBroadcastHashHintsForFailedRelations(fallbackLogicalPlan, failedBroadcastStages)
+              addNoBroadcastHashHintsForFailedRelations(logicalPlan, failedBroadcastStages)
             reOptimize(targetedLogicalPlan)
           } else {
             reOptimize(logicalPlan)
@@ -926,6 +907,40 @@ case class AdaptiveSparkPlanExec(
     }
   }
 
+  private def processStageMaterializationEvents(
+      stageEvents: Seq[StageMaterializationEvent],
+      failedBroadcastStages: mutable.ArrayBuffer[BroadcastQueryStageExec],
+      errors: mutable.ArrayBuffer[Throwable]): BroadcastFallbackResult = {
+    val fallbackStages = new mutable.ArrayBuffer[BroadcastQueryStageExec]()
+    val fallbackErrors = new mutable.ArrayBuffer[Throwable]()
+
+    stageEvents.foreach {
+      case StageSuccess(stage, res) =>
+        stage.resultOption.set(Some(res))
+      case StageFailure(stage: BroadcastQueryStageExec, ex)
+          if shouldFallbackToShuffleJoin(stage, ex) =>
+        removeStageFromCache(stage)
+        logInfo("Broadcast query stage failed on table size/row limit; retrying " +
+          s"adaptive replanning with matching broadcast hash joins disabled. " +
+          s"Stage ${stage.id}")
+        registerFailedBroadcastStage(failedBroadcastStages, stage)
+        if (!fallbackStages.exists(_.eq(stage))) {
+          fallbackStages.append(stage)
+        }
+        fallbackErrors.append(ex)
+      case StageFailure(stage: BroadcastQueryStageExec, ex)
+          if shouldIgnoreStaleBroadcastStageFailure(stage, ex, failedBroadcastStages.toSeq) =>
+        logDebug("Ignoring stale broadcast query stage failure for a previously failed " +
+          s"broadcast input. Stage ${stage.id}")
+        removeStageFromCache(stage)
+      case StageFailure(stage, ex) =>
+        stage.error.set(Some(ex))
+        errors.append(ex)
+    }
+
+    BroadcastFallbackResult(fallbackStages.toSeq, fallbackErrors.toSeq)
+  }
+
   private def shouldFallbackToShuffleJoin(stage: QueryStageExec, error: Throwable): Boolean = {
     // Detect errors such as:
     //   - Cannot broadcast the table over <maxBroadcastTableRows> rows: <numRows> rows.
@@ -1112,12 +1127,20 @@ case class AdaptiveSparkPlanExec(
           if (!disableLeft && !disableRight) {
             join
           } else {
-            // If either join side is the failed broadcast relation, add NO_BROADCAST_HASH
-            // where the join does not already carry an explicit non-broadcast strategy.
-            // This preserves existing join-strategy intent such as PREFER_SHUFFLE_HASH.
+            // For each failed broadcast side, add NO_BROADCAST_HASH where the join does not
+            // already carry an explicit non-broadcast strategy. This preserves existing
+            // join-strategy intent such as PREFER_SHUFFLE_HASH.
             val newHint = JoinHint(
-              toNoBroadcastHashHint(join.hint.leftHint),
-              toNoBroadcastHashHint(join.hint.rightHint))
+              if (disableLeft) {
+                toNoBroadcastHashHint(join.hint.leftHint)
+              } else {
+                join.hint.leftHint
+              },
+              if (disableRight) {
+                toNoBroadcastHashHint(join.hint.rightHint)
+              } else {
+                join.hint.rightHint
+              })
             if (newHint != join.hint) join.copy(hint = newHint) else join
           }
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -34,6 +34,7 @@ import org.apache.spark.internal.MessageWithContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
 import org.apache.spark.sql.catalyst.plans.logical.{
   BROADCAST,
   HintInfo,
@@ -41,7 +42,9 @@ import org.apache.spark.sql.catalyst.plans.logical.{
   JoinHint,
   LogicalPlan,
   NO_BROADCAST_HASH,
-  ReturnAnswer
+  ResolvedHint,
+  ReturnAnswer,
+  SubqueryAlias
 }
 import org.apache.spark.sql.catalyst.plans.physical.{Distribution, UnspecifiedDistribution}
 import org.apache.spark.sql.catalyst.rules.{PlanChangeLogger, Rule}
@@ -54,6 +57,7 @@ import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec._
 import org.apache.spark.sql.execution.bucketing.{CoalesceBucketsInJoin, DisableUnnecessaryBucketedScan}
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanLike
 import org.apache.spark.sql.execution.exchange._
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec}
 import org.apache.spark.sql.execution.ui.{SparkListenerSQLAdaptiveExecutionUpdate, SparkListenerSQLAdaptiveSQLMetricUpdates, SQLPlanMetric}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -346,15 +350,23 @@ case class AdaptiveSparkPlanExec(
         stageEvents.foreach {
           case StageSuccess(stage, res) =>
             stage.resultOption.set(Some(res))
-          case StageFailure(stage, ex) if shouldFallbackToShuffleJoin(stage, ex) =>
-            logInfo("Broadcast query stage failed on table size/row limit; retrying " +
-              s"adaptive replanning without broadcast joins. Stage ${stage.id}")
+          case StageFailure(stage: BroadcastQueryStageExec, ex)
+              if shouldFallbackToShuffleJoin(stage, ex) =>
             removeStageFromCache(stage)
+            logInfo("Broadcast query stage failed on table size/row limit; retrying " +
+              s"adaptive replanning with matching broadcast hash joins disabled. " +
+              s"Stage ${stage.id}")
             registerFailedBroadcastStage(failedBroadcastStagesBuffer, stage)
             if (!fallbackStages.exists(_.eq(stage))) {
               fallbackStages.append(stage)
             }
             fallbackErrors.append(ex)
+          case StageFailure(stage: BroadcastQueryStageExec, ex)
+              if shouldIgnoreStaleBroadcastStageFailure(
+                stage, ex, failedBroadcastStagesBuffer.toSeq) =>
+            logDebug("Ignoring stale broadcast query stage failure for a previously failed " +
+              s"broadcast input. Stage ${stage.id}")
+            removeStageFromCache(stage)
           case StageFailure(stage, ex) =>
             stage.error.set(Some(ex))
             errors.append(ex)
@@ -390,8 +402,11 @@ case class AdaptiveSparkPlanExec(
           val failedBroadcastStages = failedBroadcastStagesBuffer.toSeq
 
           val afterReOptimize = if (shouldBroadcastFallback) {
+            val fallbackLogicalPlan = removeFailedBroadcastStagesFromLogicalPlan(
+              logicalPlan,
+              failedBroadcastStages)
             val targetedLogicalPlan =
-              addNoBroadcastHashHintsForFailedRelations(logicalPlan, failedBroadcastStages)
+              addNoBroadcastHashHintsForFailedRelations(fallbackLogicalPlan, failedBroadcastStages)
             reOptimize(targetedLogicalPlan)
           } else {
             reOptimize(logicalPlan)
@@ -772,12 +787,7 @@ case class AdaptiveSparkPlanExec(
    * `EnsureRequirements`.
    */
   private def setLogicalLinkForNewQueryStage(stage: QueryStageExec, plan: SparkPlan): Unit = {
-    val link = plan.getTagValue(TEMP_LOGICAL_PLAN_TAG).orElse(
-      plan.logicalLink.orElse(plan.collectFirst {
-        case p if p.containsTag(TEMP_LOGICAL_PLAN_TAG) =>
-          p.getTagValue(TEMP_LOGICAL_PLAN_TAG).get
-        case p if p.logicalLink.isDefined => p.logicalLink.get
-      }))
+    val link = resolveLogicalPlan(plan)
     assert(link.isDefined)
     stage.setLogicalLink(link.get)
   }
@@ -920,11 +930,22 @@ case class AdaptiveSparkPlanExec(
     // Detect errors such as:
     //   - Cannot broadcast the table over <maxBroadcastTableRows> rows: <numRows> rows.
     //   - Cannot broadcast the table that is larger than <maxBroadcastTableBytes>: <dataSize>.
-    // Check error-classes.json for details
+    // Only BHJ fallback is supported here.
     conf.adaptiveBroadcastJoinFallbackToShuffleEnabled &&
       !isRequiredRootBroadcastStage(stage) &&
       stage.isInstanceOf[BroadcastQueryStageExec] &&
+      usedOnlyByBroadcastHashJoin(stage.asInstanceOf[BroadcastQueryStageExec]) &&
       hasErrorClass(error, "_LEGACY_ERROR_TEMP_2248", "_LEGACY_ERROR_TEMP_2249")
+  }
+
+  private def shouldIgnoreStaleBroadcastStageFailure(
+      stage: BroadcastQueryStageExec,
+      error: Throwable,
+      failedBroadcastStages: Seq[BroadcastQueryStageExec]): Boolean = {
+    hasErrorClass(error, "_LEGACY_ERROR_TEMP_2248", "_LEGACY_ERROR_TEMP_2249") &&
+      failedBroadcastStages.exists { failed =>
+        sameBroadcastInputPlan(failed.broadcast.child, stage.broadcast.child)
+      }
   }
 
   // Remove failed fallback stages from the replacement set before replanning.
@@ -940,10 +961,10 @@ case class AdaptiveSparkPlanExec(
     }
 
     stagesToReplace.filterNot {
-      case stage if failedStages.exists(_ eq stage) => true
+      case stage if failedStages.exists(_.eq(stage)) => true
       case stage: BroadcastQueryStageExec =>
         failedBroadcastStages.exists { failed =>
-          sameBroadcastRelation(stage.broadcast.child, failed.broadcast.child)
+          sameBroadcastInputPlan(stage.broadcast.child, failed.broadcast.child)
         }
       case _ => false
     }
@@ -969,28 +990,10 @@ case class AdaptiveSparkPlanExec(
   private def hasFailedBroadcastRelation(
       plan: SparkPlan,
       failedBroadcastStages: Seq[BroadcastQueryStageExec]): Boolean = {
-    failedBroadcastStages.nonEmpty && plan.exists { p =>
-      broadcastChildPlan(p).exists { child =>
-        failedBroadcastStages.exists { failed =>
-          sameBroadcastRelation(child, failed.broadcast.child)
-        }
+    failedBroadcastStages.nonEmpty && hasMatchingBroadcastInputPlan(plan) { child =>
+      failedBroadcastStages.exists { failed =>
+        sameBroadcastInputPlan(child, failed.broadcast.child)
       }
-    }
-  }
-
-  // Track failed broadcast relations using semantic equality so equivalent stages
-  // in later AQE replans are treated as the same failed relation.
-  private def registerFailedBroadcastStage(
-      failedBroadcastStages: mutable.ArrayBuffer[BroadcastQueryStageExec],
-      stage: QueryStageExec): Unit = {
-    stage match {
-      case failedStage: BroadcastQueryStageExec =>
-        if (!failedBroadcastStages.exists { existing =>
-          sameBroadcastRelation(existing.broadcast.child, failedStage.broadcast.child)
-        }) {
-          failedBroadcastStages.append(failedStage)
-        }
-      case _ =>
     }
   }
 
@@ -1015,11 +1018,68 @@ case class AdaptiveSparkPlanExec(
     case _ => None
   }
 
-  // Compare broadcast inputs by semantic plan equivalence.
+  // Compare full broadcast input plans (including filters/projects under the exchange)
+  // by semantic plan equivalence.
   // Do not fall back to output-attribute equality: different plans can share
   // output schemas while producing different relations.
-  private def sameBroadcastRelation(left: SparkPlan, right: SparkPlan): Boolean = {
+  private def sameBroadcastInputPlan(left: SparkPlan, right: SparkPlan): Boolean = {
     left.sameResult(right)
+  }
+
+  // Track failed broadcast input plans by semantic equality so equivalent stages
+  // in later AQE replans are treated as the same failed input.
+  private def registerFailedBroadcastStage(
+      failedBroadcastStages: mutable.ArrayBuffer[BroadcastQueryStageExec],
+      failedStage: BroadcastQueryStageExec): Unit = {
+    if (!failedBroadcastStages.exists { existing =>
+      sameBroadcastInputPlan(existing.broadcast.child, failedStage.broadcast.child)
+    }) {
+      failedBroadcastStages.append(failedStage)
+    }
+  }
+
+  private def usedOnlyByBroadcastHashJoin(stage: BroadcastQueryStageExec): Boolean = {
+    val consumers = currentPhysicalPlan.collect {
+      case join: BroadcastHashJoinExec
+          if usesBroadcastInputPlan(
+            broadcastBuildPlan(join.buildSide, join.left, join.right), stage) =>
+        join
+      case join: BroadcastNestedLoopJoinExec
+          if usesBroadcastInputPlan(
+            broadcastBuildPlan(join.buildSide, join.left, join.right), stage) =>
+        join
+    }
+    // We do not support fallback for `BroadcastNestedLoopJoinExec` (BNLJ), as there is no good
+    // "hash join" replacement of it that preserves the same semantics. Under the simpler
+    // relation-based fallback scope, if the same broadcast input plan is consumed by both BHJ
+    // and BNLJ, conservatively abandon the fallback and preserve the original behavior.
+    consumers.nonEmpty && consumers.forall(_.isInstanceOf[BroadcastHashJoinExec])
+  }
+
+  private def broadcastBuildPlan(
+      buildSide: BuildSide,
+      left: SparkPlan,
+      right: SparkPlan): SparkPlan = {
+    buildSide match {
+      case BuildLeft => left
+      case BuildRight => right
+    }
+  }
+
+  // Check whether a join build side consumes the same broadcast input plan as a failed stage.
+  private def usesBroadcastInputPlan(
+      plan: SparkPlan,
+      stage: BroadcastQueryStageExec): Boolean = {
+    hasMatchingBroadcastInputPlan(plan) { child =>
+      sameBroadcastInputPlan(child, stage.broadcast.child)
+    }
+  }
+
+  private def hasMatchingBroadcastInputPlan(
+      plan: SparkPlan)(matches: SparkPlan => Boolean): Boolean = {
+    plan.exists { p =>
+      broadcastChildPlan(p).exists(matches)
+    }
   }
 
   // Root broadcast stages must be preserved (e.g. broadcast subquery output contract).
@@ -1036,8 +1096,8 @@ case class AdaptiveSparkPlanExec(
     case _ => false
   }
 
-  // Apply side-specific NO_BROADCAST_HASH hints for relations that previously failed
-  // broadcast stage materialization, so targeted fallback can keep unrelated BHJs.
+  // Apply NO_BROADCAST_HASH hints for joins whose input matches a previously failed
+  // broadcast relation, so targeted fallback can keep unrelated BHJs.
   private def addNoBroadcastHashHintsForFailedRelations(
       plan: LogicalPlan,
       failedBroadcastStages: Seq[BroadcastQueryStageExec]): LogicalPlan = {
@@ -1052,17 +1112,12 @@ case class AdaptiveSparkPlanExec(
           if (!disableLeft && !disableRight) {
             join
           } else {
+            // If either join side is the failed broadcast relation, add NO_BROADCAST_HASH
+            // where the join does not already carry an explicit non-broadcast strategy.
+            // This preserves existing join-strategy intent such as PREFER_SHUFFLE_HASH.
             val newHint = JoinHint(
-              if (disableLeft) {
-                toNoBroadcastHashHint(join.hint.leftHint)
-              } else {
-                join.hint.leftHint
-              },
-              if (disableRight) {
-                toNoBroadcastHashHint(join.hint.rightHint)
-              } else {
-                join.hint.rightHint
-              })
+              toNoBroadcastHashHint(join.hint.leftHint),
+              toNoBroadcastHashHint(join.hint.rightHint))
             if (newHint != join.hint) join.copy(hint = newHint) else join
           }
       }
@@ -1073,28 +1128,41 @@ case class AdaptiveSparkPlanExec(
       failedBroadcastStages: Seq[BroadcastQueryStageExec]): Seq[LogicalPlan] = {
     val failedLogicalPlans = new mutable.ArrayBuffer[LogicalPlan]()
     failedBroadcastStages.foreach { stage =>
-      Seq(stage.broadcast.child.logicalLink, stage.broadcast.logicalLink, stage.logicalLink)
-        .flatten
+      Seq(stage.broadcast.child, stage.broadcast, stage)
+        .iterator
+        .flatMap(resolveLogicalPlan)
         .foreach { logicalPlan =>
-          val normalizedPlan =
-            logicalPlan.transformDown {
-              case stage: LogicalQueryStage => stage.logicalPlan
-            }
+          val normalizedPlan = normalizePlanForBroadcastFallback(logicalPlan)
           if (!failedLogicalPlans.exists(_.sameResult(normalizedPlan))) {
             failedLogicalPlans.append(normalizedPlan)
           }
-        }
+      }
     }
     failedLogicalPlans.toSeq
+  }
+
+  private def resolveLogicalPlan(plan: SparkPlan): Option[LogicalPlan] = {
+    plan.getTagValue(TEMP_LOGICAL_PLAN_TAG).orElse(
+      plan.logicalLink.orElse(plan.collectFirst {
+        case p if p.containsTag(TEMP_LOGICAL_PLAN_TAG) =>
+          p.getTagValue(TEMP_LOGICAL_PLAN_TAG).get
+        case p if p.logicalLink.isDefined => p.logicalLink.get
+      }))
   }
 
   private def shouldDisableBroadcastForJoinSide(
       side: LogicalPlan,
       failedLogicalPlans: Seq[LogicalPlan]): Boolean = {
-    val normalizedSide = side.transformDown {
-      case stage: LogicalQueryStage => stage.logicalPlan
-    }
+    val normalizedSide = normalizePlanForBroadcastFallback(side)
     failedLogicalPlans.exists(normalizedSide.sameResult)
+  }
+
+  private def normalizePlanForBroadcastFallback(plan: LogicalPlan): LogicalPlan = {
+    plan.transformDown {
+      case stage: LogicalQueryStage => stage.logicalPlan
+      case ResolvedHint(child, _) => child
+      case alias: SubqueryAlias => alias.child
+    }
   }
 
   private def toNoBroadcastHashHint(hint: Option[HintInfo]): Option[HintInfo] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -1076,8 +1076,12 @@ case class AdaptiveSparkPlanExec(
       Seq(stage.broadcast.child.logicalLink, stage.broadcast.logicalLink, stage.logicalLink)
         .flatten
         .foreach { logicalPlan =>
-          if (!failedLogicalPlans.exists(_.sameResult(logicalPlan))) {
-            failedLogicalPlans.append(logicalPlan)
+          val normalizedPlan =
+            logicalPlan.transformDown {
+              case stage: LogicalQueryStage => stage.logicalPlan
+            }
+          if (!failedLogicalPlans.exists(_.sameResult(normalizedPlan))) {
+            failedLogicalPlans.append(normalizedPlan)
           }
         }
     }
@@ -1087,7 +1091,10 @@ case class AdaptiveSparkPlanExec(
   private def shouldDisableBroadcastForJoinSide(
       side: LogicalPlan,
       failedLogicalPlans: Seq[LogicalPlan]): Boolean = {
-    failedLogicalPlans.exists(side.sameResult)
+    val normalizedSide = side.transformDown {
+      case stage: LogicalQueryStage => stage.logicalPlan
+    }
+    failedLogicalPlans.exists(normalizedSide.sameResult)
   }
 
   private def toNoBroadcastHashHint(hint: Option[HintInfo]): Option[HintInfo] = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -709,6 +709,10 @@ class AdaptiveQueryExecSuite
           sql("SELECT a FROM testData2").queryExecution.sparkPlan)
       val innerStage =
         BroadcastQueryStageExec(1, innerBroadcastPlan, innerBroadcastPlan.canonicalized)
+      val equivalentInnerBroadcastPlan =
+        BroadcastExchangeExec(IdentityBroadcastMode, qe.sparkPlan)
+      val equivalentInnerStage = BroadcastQueryStageExec(
+        2, equivalentInnerBroadcastPlan, equivalentInnerBroadcastPlan.canonicalized)
       val shouldFallbackToShuffleJoin =
         PrivateMethod[Boolean](Symbol("shouldFallbackToShuffleJoin"))
 
@@ -724,10 +728,12 @@ class AdaptiveQueryExecSuite
       assert(regularSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
         stage,
         QueryExecutionErrors.cannotBroadcastTableOverMaxTableRowsError(1, 2))))
-      assert(!broadcastSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+      // `stage` is a synthetic stage instance, not the stage currently at the plan root.
+      // Only the actual root stage instance is exempt from fallback.
+      assert(broadcastSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
         stage,
         QueryExecutionErrors.cannotBroadcastTableOverMaxTableBytesError(1, 2))))
-      assert(!broadcastSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+      assert(broadcastSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
         stage,
         QueryExecutionErrors.cannotBroadcastTableOverMaxTableRowsError(1, 2))))
       assert(broadcastSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
@@ -735,6 +741,12 @@ class AdaptiveQueryExecSuite
         QueryExecutionErrors.cannotBroadcastTableOverMaxTableBytesError(1, 2))))
       assert(broadcastSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
         innerStage,
+        QueryExecutionErrors.cannotBroadcastTableOverMaxTableRowsError(1, 2))))
+      assert(broadcastSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        equivalentInnerStage,
+        QueryExecutionErrors.cannotBroadcastTableOverMaxTableBytesError(1, 2))))
+      assert(broadcastSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        equivalentInnerStage,
         QueryExecutionErrors.cannotBroadcastTableOverMaxTableRowsError(1, 2))))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -32,7 +32,9 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.physical.IdentityBroadcastMode
 import org.apache.spark.sql.classic.Strategy
+import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
 import org.apache.spark.sql.execution.columnar.{InMemoryTableScanExec, InMemoryTableScanLike}
@@ -622,6 +624,260 @@ class AdaptiveQueryExecSuite
       val sub = findReusedSubquery(adaptivePlan)
       assert(sub.isEmpty)
     }
+  }
+
+  test("Fallback to shuffled join should replan hinted broadcast joins without broadcast") {
+    withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+        SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+        SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true",
+        SQLConf.PREFER_SORTMERGEJOIN.key -> "true") {
+      val df = sql("SELECT /*+ BROADCAST(testData2) */ * FROM testData JOIN testData2 ON key = a")
+      val adaptivePlan = df.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+      val logicalPlan = adaptivePlan.inputPlan.logicalLink.get
+      val reOptimize =
+        PrivateMethod[Option[(SparkPlan, LogicalPlan)]](Symbol("reOptimize"))
+
+      val withBroadcast = adaptivePlan.invokePrivate(reOptimize(logicalPlan, false)).get._1
+      assert(findTopLevelBroadcastHashJoin(withBroadcast).size == 1)
+
+      val withoutBroadcast = adaptivePlan.invokePrivate(reOptimize(logicalPlan, true)).get._1
+      assert(findTopLevelBroadcastHashJoin(withoutBroadcast).isEmpty)
+      assert(
+        findTopLevelSortMergeJoin(withoutBroadcast).nonEmpty ||
+          findTopLevelShuffledHashJoin(withoutBroadcast).nonEmpty)
+    }
+  }
+
+  test("Fallback to shuffled join should apply disabled broadcast conf during replanning") {
+    withTable("t1", "t2") {
+      withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10000",
+          SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10000",
+          SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.PREFER_SORTMERGEJOIN.key -> "true",
+          SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
+        sql("CREATE TABLE t1 USING PARQUET AS SELECT 1 c1")
+        sql("CREATE TABLE t2 USING PARQUET AS SELECT 1 c1")
+
+        val df = sql("SELECT * FROM t1 JOIN t2 ON t1.c1 = t2.c1")
+        val adaptivePlan = df.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+        val logicalPlan = adaptivePlan.inputPlan.logicalLink.get
+        val reOptimize =
+          PrivateMethod[Option[(SparkPlan, LogicalPlan)]](Symbol("reOptimize"))
+
+        val withBroadcast = adaptivePlan.invokePrivate(reOptimize(logicalPlan, false)).get._1
+        assert(findTopLevelBroadcastHashJoin(withBroadcast).size == 1)
+
+        val withoutBroadcast = adaptivePlan.invokePrivate(reOptimize(logicalPlan, true)).get._1
+        assert(findTopLevelBroadcastHashJoin(withoutBroadcast).isEmpty)
+        assert(
+          findTopLevelSortMergeJoin(withoutBroadcast).nonEmpty ||
+            findTopLevelShuffledHashJoin(withoutBroadcast).nonEmpty)
+      }
+    }
+  }
+
+  test("Fallback to shuffled join should recognize broadcast limit failures") {
+    withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+        SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true") {
+      val qe = sql("SELECT key FROM testData").queryExecution
+      val broadcastInputPlan = BroadcastExchangeExec(IdentityBroadcastMode, qe.sparkPlan)
+      val adaptivePlan = AdaptiveSparkPlanExec(
+        qe.sparkPlan,
+        AdaptiveExecutionContext(spark, qe),
+        Seq.empty,
+        isSubquery = false)
+      val broadcastSubqueryAdaptivePlan = AdaptiveSparkPlanExec(
+        broadcastInputPlan,
+        AdaptiveExecutionContext(spark, qe),
+        Seq.empty,
+        isSubquery = true)
+      val regularSubqueryAdaptivePlan = AdaptiveSparkPlanExec(
+        qe.sparkPlan,
+        AdaptiveExecutionContext(spark, qe),
+        Seq.empty,
+        isSubquery = true)
+      val stage =
+        BroadcastQueryStageExec(0, broadcastInputPlan, broadcastInputPlan.canonicalized)
+      val innerBroadcastPlan =
+        BroadcastExchangeExec(
+          IdentityBroadcastMode,
+          sql("SELECT a FROM testData2").queryExecution.sparkPlan)
+      val innerStage =
+        BroadcastQueryStageExec(1, innerBroadcastPlan, innerBroadcastPlan.canonicalized)
+      val shouldFallbackToShuffleJoin =
+        PrivateMethod[Boolean](Symbol("shouldFallbackToShuffleJoin"))
+
+      assert(adaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        stage,
+        QueryExecutionErrors.cannotBroadcastTableOverMaxTableBytesError(1, 2))))
+      assert(adaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        stage,
+        QueryExecutionErrors.cannotBroadcastTableOverMaxTableRowsError(1, 2))))
+      assert(regularSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        stage,
+        QueryExecutionErrors.cannotBroadcastTableOverMaxTableBytesError(1, 2))))
+      assert(regularSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        stage,
+        QueryExecutionErrors.cannotBroadcastTableOverMaxTableRowsError(1, 2))))
+      assert(!broadcastSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        stage,
+        QueryExecutionErrors.cannotBroadcastTableOverMaxTableBytesError(1, 2))))
+      assert(!broadcastSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        stage,
+        QueryExecutionErrors.cannotBroadcastTableOverMaxTableRowsError(1, 2))))
+      assert(broadcastSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        innerStage,
+        QueryExecutionErrors.cannotBroadcastTableOverMaxTableBytesError(1, 2))))
+      assert(broadcastSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        innerStage,
+        QueryExecutionErrors.cannotBroadcastTableOverMaxTableRowsError(1, 2))))
+    }
+  }
+
+  test("Fallback to shuffled join should be disabled when conf is false") {
+    withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+        SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "false") {
+      val qe = sql("SELECT key FROM testData").queryExecution
+      val broadcastInputPlan = BroadcastExchangeExec(IdentityBroadcastMode, qe.sparkPlan)
+      val adaptivePlan = AdaptiveSparkPlanExec(
+        qe.sparkPlan,
+        AdaptiveExecutionContext(spark, qe),
+        Seq.empty,
+        isSubquery = false)
+      val stage =
+        BroadcastQueryStageExec(0, broadcastInputPlan, broadcastInputPlan.canonicalized)
+      val shouldFallbackToShuffleJoin =
+        PrivateMethod[Boolean](Symbol("shouldFallbackToShuffleJoin"))
+
+      assert(!adaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        stage,
+        QueryExecutionErrors.cannotBroadcastTableOverMaxTableBytesError(1, 2))))
+      assert(!adaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        stage,
+        QueryExecutionErrors.cannotBroadcastTableOverMaxTableRowsError(1, 2))))
+    }
+  }
+
+  test("Fallback to shuffled join should preserve input broadcast exchange") {
+    val qe = sql("SELECT key FROM testData").queryExecution
+    val inputPlan = BroadcastExchangeExec(IdentityBroadcastMode, qe.sparkPlan)
+    val adaptivePlan = AdaptiveSparkPlanExec(
+      inputPlan,
+      AdaptiveExecutionContext(spark, qe),
+      Seq.empty,
+      isSubquery = true)
+    val logicalPlan = qe.optimizedPlan
+    val reOptimize =
+      PrivateMethod[Option[(SparkPlan, LogicalPlan)]](Symbol("reOptimize"))
+
+    val replanned = adaptivePlan.invokePrivate(reOptimize(logicalPlan, false)).get._1
+    assert(replanned.isInstanceOf[BroadcastExchangeExec])
+
+    val fallbackReplanned = adaptivePlan.invokePrivate(reOptimize(logicalPlan, true)).get._1
+    assert(fallbackReplanned.isInstanceOf[BroadcastExchangeExec])
+  }
+
+  test("Fallback to shuffled join should reject replans containing failed broadcast relation") {
+    val qe = sql("SELECT key FROM testData").queryExecution
+    val adaptivePlan = AdaptiveSparkPlanExec(
+      qe.sparkPlan,
+      AdaptiveExecutionContext(spark, qe),
+      Seq.empty,
+      isSubquery = false)
+    val shouldRejectBroadcastPlanInFallback =
+      PrivateMethod[Boolean](Symbol("shouldRejectBroadcastPlanInFallback"))
+
+    val failedExchange = BroadcastExchangeExec(
+      IdentityBroadcastMode, sql("SELECT a FROM testData2").queryExecution.sparkPlan)
+    val failedStage = BroadcastQueryStageExec(0, failedExchange, failedExchange.canonicalized)
+
+    val sameExchange = BroadcastExchangeExec(
+      IdentityBroadcastMode, sql("SELECT a FROM testData2").queryExecution.sparkPlan)
+    val reusedSameExchange = ReusedExchangeExec(sameExchange.output, sameExchange)
+    val otherExchange = BroadcastExchangeExec(
+      IdentityBroadcastMode, sql("SELECT key FROM testData").queryExecution.sparkPlan)
+
+    assert(adaptivePlan.invokePrivate(
+      shouldRejectBroadcastPlanInFallback(sameExchange, Seq(failedStage))))
+    assert(adaptivePlan.invokePrivate(
+      shouldRejectBroadcastPlanInFallback(reusedSameExchange, Seq(failedStage))))
+    assert(!adaptivePlan.invokePrivate(
+      shouldRejectBroadcastPlanInFallback(otherExchange, Seq(failedStage))))
+    assert(!adaptivePlan.invokePrivate(
+      shouldRejectBroadcastPlanInFallback(qe.sparkPlan, Seq(failedStage))))
+    assert(!adaptivePlan.invokePrivate(
+      shouldRejectBroadcastPlanInFallback(sameExchange, Seq.empty[BroadcastQueryStageExec])))
+  }
+
+  test("Fallback to shuffled join should persist failed broadcast relation across iterations") {
+    val qe = sql("SELECT key FROM testData").queryExecution
+    val adaptivePlan = AdaptiveSparkPlanExec(
+      qe.sparkPlan,
+      AdaptiveExecutionContext(spark, qe),
+      Seq.empty,
+      isSubquery = false)
+    val registerFailedBroadcastStage =
+      PrivateMethod[Unit](Symbol("registerFailedBroadcastStage"))
+    val shouldRejectBroadcastPlanInFallback =
+      PrivateMethod[Boolean](Symbol("shouldRejectBroadcastPlanInFallback"))
+
+    val failedStages = new scala.collection.mutable.ArrayBuffer[BroadcastQueryStageExec]()
+    val failedExchange1 = BroadcastExchangeExec(
+      IdentityBroadcastMode, sql("SELECT a FROM testData2").queryExecution.sparkPlan)
+    val failedStage1 = BroadcastQueryStageExec(0, failedExchange1, failedExchange1.canonicalized)
+    adaptivePlan.invokePrivate(registerFailedBroadcastStage(failedStages, failedStage1))
+
+    // Equivalent failed relation from a later iteration should be deduplicated.
+    val failedExchange2 = BroadcastExchangeExec(
+      IdentityBroadcastMode, sql("SELECT a FROM testData2").queryExecution.sparkPlan)
+    val failedStage2 = BroadcastQueryStageExec(1, failedExchange2, failedExchange2.canonicalized)
+    adaptivePlan.invokePrivate(registerFailedBroadcastStage(failedStages, failedStage2))
+
+    assert(failedStages.size == 1)
+
+    val sameExchange = BroadcastExchangeExec(
+      IdentityBroadcastMode, sql("SELECT a FROM testData2").queryExecution.sparkPlan)
+    assert(adaptivePlan.invokePrivate(
+      shouldRejectBroadcastPlanInFallback(sameExchange, failedStages.toSeq)))
+  }
+
+  test("Fallback to shuffled join should remove equivalent failed broadcast stages") {
+    val qe = sql("SELECT key FROM testData").queryExecution
+    val adaptivePlan = AdaptiveSparkPlanExec(
+      qe.sparkPlan,
+      AdaptiveExecutionContext(spark, qe),
+      Seq.empty,
+      isSubquery = false)
+    val filterStagesToReplaceForFallback =
+      PrivateMethod[Seq[QueryStageExec]](Symbol("filterStagesToReplaceForFallback"))
+
+    val failedExchange = BroadcastExchangeExec(
+      IdentityBroadcastMode, sql("SELECT a FROM testData2").queryExecution.sparkPlan)
+    val failedStage = BroadcastQueryStageExec(0, failedExchange, failedExchange.canonicalized)
+
+    val equivalentExchange = BroadcastExchangeExec(
+      IdentityBroadcastMode, sql("SELECT a FROM testData2").queryExecution.sparkPlan)
+    val equivalentStage =
+      BroadcastQueryStageExec(1, equivalentExchange, equivalentExchange.canonicalized)
+
+    val otherExchange = BroadcastExchangeExec(
+      IdentityBroadcastMode, sql("SELECT key FROM testData").queryExecution.sparkPlan)
+    val otherStage = BroadcastQueryStageExec(2, otherExchange, otherExchange.canonicalized)
+
+    val filtered = adaptivePlan.invokePrivate(
+      filterStagesToReplaceForFallback(
+        Seq(failedStage, equivalentStage, otherStage),
+        Seq(failedStage)))
+
+    assert(!filtered.exists(_.eq(failedStage)))
+    assert(!filtered.exists(_.eq(equivalentStage)))
+    assert(filtered.exists(_.eq(otherStage)))
   }
 
   test("Union/Except/Intersect queries") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -884,6 +884,40 @@ class AdaptiveQueryExecSuite
     assert(filtered.exists(_.eq(otherStage)))
   }
 
+  test("Fallback to shuffled join should remove failed broadcast logical query stages") {
+    val qe = sql("SELECT key FROM testData").queryExecution
+    val adaptivePlan = AdaptiveSparkPlanExec(
+      qe.sparkPlan,
+      AdaptiveExecutionContext(spark, qe),
+      Seq.empty,
+      isSubquery = false)
+    val removeFailedBroadcastStagesFromLogicalPlan =
+      PrivateMethod[LogicalPlan](Symbol("removeFailedBroadcastStagesFromLogicalPlan"))
+
+    val failedLogical = sql("SELECT a FROM testData2").queryExecution.optimizedPlan
+    val failedExchange = BroadcastExchangeExec(
+      IdentityBroadcastMode, sql("SELECT a FROM testData2").queryExecution.sparkPlan)
+    val failedStage = BroadcastQueryStageExec(0, failedExchange, failedExchange.canonicalized)
+    val failedLogicalStage = LogicalQueryStage(failedLogical, failedStage)
+
+    val otherLogical = sql("SELECT key FROM testData").queryExecution.optimizedPlan
+    val otherExchange = BroadcastExchangeExec(
+      IdentityBroadcastMode, sql("SELECT key FROM testData").queryExecution.sparkPlan)
+    val otherStage = BroadcastQueryStageExec(1, otherExchange, otherExchange.canonicalized)
+    val otherLogicalStage = LogicalQueryStage(otherLogical, otherStage)
+
+    val logicalPlan =
+      org.apache.spark.sql.catalyst.plans.logical.Union(Seq(failedLogicalStage, otherLogicalStage))
+    val updated = adaptivePlan.invokePrivate(
+      removeFailedBroadcastStagesFromLogicalPlan(logicalPlan, Seq(failedStage)))
+    val remainingLogicalStages = updated.collect {
+      case stage: LogicalQueryStage => stage
+    }
+
+    assert(remainingLogicalStages.size == 1)
+    assert(remainingLogicalStages.head.physicalPlan.eq(otherStage))
+  }
+
   test("Union/Except/Intersect queries") {
     withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
       runAdaptiveAndVerifyResult(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -31,7 +31,15 @@ import org.apache.spark.sql.{DataFrame, Dataset, QueryTest, Row, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
-import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{
+  Aggregate,
+  BROADCAST,
+  HintInfo,
+  Join,
+  LogicalPlan,
+  NO_BROADCAST_AND_REPLICATION,
+  NO_BROADCAST_HASH
+}
 import org.apache.spark.sql.catalyst.plans.physical.IdentityBroadcastMode
 import org.apache.spark.sql.classic.Strategy
 import org.apache.spark.sql.errors.QueryExecutionErrors
@@ -626,57 +634,107 @@ class AdaptiveQueryExecSuite
     }
   }
 
-  test("Fallback to shuffled join should replan hinted broadcast joins without broadcast") {
+  test("Fallback to shuffled join should apply NO_BROADCAST_HASH only to failed relation") {
     withSQLConf(
         SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
         SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
         SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
         SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true",
-        SQLConf.PREFER_SORTMERGEJOIN.key -> "true") {
-      val df = sql("SELECT /*+ BROADCAST(testData2) */ * FROM testData JOIN testData2 ON key = a")
+        SQLConf.PREFER_SORTMERGEJOIN.key -> "false") {
+      val df = sql(
+        "SELECT /*+ BROADCAST(t2), BROADCAST(t3) */ * " +
+          "FROM testData t1 JOIN testData2 t2 ON t1.key = t2.a " +
+          "JOIN testData3 t3 ON t1.key = t3.a")
       val adaptivePlan = df.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
       val logicalPlan = adaptivePlan.inputPlan.logicalLink.get
-      val reOptimize =
-        PrivateMethod[Option[(SparkPlan, LogicalPlan)]](Symbol("reOptimize"))
+      val addNoBroadcastHashHintsForFailedRelations =
+        PrivateMethod[LogicalPlan](Symbol("addNoBroadcastHashHintsForFailedRelations"))
 
-      val withBroadcast = adaptivePlan.invokePrivate(reOptimize(logicalPlan, false)).get._1
-      assert(findTopLevelBroadcastHashJoin(withBroadcast).size == 1)
+      val failedExchange = BroadcastExchangeExec(
+        IdentityBroadcastMode, sql("SELECT * FROM testData2").queryExecution.sparkPlan)
+      val failedStage = BroadcastQueryStageExec(0, failedExchange, failedExchange.canonicalized)
 
-      val withoutBroadcast = adaptivePlan.invokePrivate(reOptimize(logicalPlan, true)).get._1
-      assert(findTopLevelBroadcastHashJoin(withoutBroadcast).isEmpty)
-      assert(
-        findTopLevelSortMergeJoin(withoutBroadcast).nonEmpty ||
-          findTopLevelShuffledHashJoin(withoutBroadcast).nonEmpty)
+      val targetedLogicalPlan = adaptivePlan.invokePrivate(
+        addNoBroadcastHashHintsForFailedRelations(logicalPlan, Seq(failedStage)))
+
+      val joinsWithNoBroadcastHash = targetedLogicalPlan.collect {
+        case join: Join
+            if join.hint.leftHint.exists(_.strategy.contains(NO_BROADCAST_HASH)) ||
+              join.hint.rightHint.exists(_.strategy.contains(NO_BROADCAST_HASH)) =>
+          join
+      }
+      assert(joinsWithNoBroadcastHash.nonEmpty)
+      assert(targetedLogicalPlan.collect {
+        case join: Join
+            if !join.hint.leftHint.exists(_.strategy.contains(NO_BROADCAST_HASH)) &&
+              !join.hint.rightHint.exists(_.strategy.contains(NO_BROADCAST_HASH)) =>
+          join
+      }.nonEmpty)
     }
   }
 
-  test("Fallback to shuffled join should apply disabled broadcast conf during replanning") {
-    withTable("t1", "t2") {
-      withSQLConf(
-          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
-          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10000",
-          SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10000",
-          SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true",
-          SQLConf.PREFER_SORTMERGEJOIN.key -> "true",
-          SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
-        sql("CREATE TABLE t1 USING PARQUET AS SELECT 1 c1")
-        sql("CREATE TABLE t2 USING PARQUET AS SELECT 1 c1")
+  test("Fallback to shuffled join should preserve non-broadcast side hint strategies") {
+    val qe = sql("SELECT key FROM testData").queryExecution
+    val adaptivePlan = AdaptiveSparkPlanExec(
+      qe.sparkPlan,
+      AdaptiveExecutionContext(spark, qe),
+      Seq.empty,
+      isSubquery = false)
+    val toNoBroadcastHashHint =
+      PrivateMethod[Option[HintInfo]](Symbol("toNoBroadcastHashHint"))
 
-        val df = sql("SELECT * FROM t1 JOIN t2 ON t1.c1 = t2.c1")
-        val adaptivePlan = df.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
-        val logicalPlan = adaptivePlan.inputPlan.logicalLink.get
-        val reOptimize =
-          PrivateMethod[Option[(SparkPlan, LogicalPlan)]](Symbol("reOptimize"))
+    val noBroadcastAndReplicationHint =
+      Some(HintInfo(strategy = Some(NO_BROADCAST_AND_REPLICATION)))
+    val preservedNoBroadcastAndReplication =
+      adaptivePlan.invokePrivate(toNoBroadcastHashHint(noBroadcastAndReplicationHint))
+    assert(preservedNoBroadcastAndReplication == noBroadcastAndReplicationHint)
 
-        val withBroadcast = adaptivePlan.invokePrivate(reOptimize(logicalPlan, false)).get._1
-        assert(findTopLevelBroadcastHashJoin(withBroadcast).size == 1)
+    val noBroadcastHashHint = Some(HintInfo(strategy = Some(NO_BROADCAST_HASH)))
+    val preservedNoBroadcastHash =
+      adaptivePlan.invokePrivate(toNoBroadcastHashHint(noBroadcastHashHint))
+    assert(preservedNoBroadcastHash == noBroadcastHashHint)
 
-        val withoutBroadcast = adaptivePlan.invokePrivate(reOptimize(logicalPlan, true)).get._1
-        assert(findTopLevelBroadcastHashJoin(withoutBroadcast).isEmpty)
-        assert(
-          findTopLevelSortMergeJoin(withoutBroadcast).nonEmpty ||
-            findTopLevelShuffledHashJoin(withoutBroadcast).nonEmpty)
-      }
+    val broadcastHint = Some(HintInfo(strategy = Some(BROADCAST)))
+    val rewrittenBroadcastHint = adaptivePlan.invokePrivate(toNoBroadcastHashHint(broadcastHint))
+    assert(rewrittenBroadcastHint.exists(_.strategy.contains(NO_BROADCAST_HASH)))
+  }
+
+  test("Fallback to shuffled join should keep unrelated BHJs after targeted fallback replan") {
+    withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+        SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+        SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true",
+        SQLConf.PREFER_SORTMERGEJOIN.key -> "false") {
+      val df = sql(
+        "SELECT /*+ BROADCAST(t2), BROADCAST(t3) */ * " +
+          "FROM testData t1 JOIN testData2 t2 ON t1.key = t2.a " +
+          "JOIN testData3 t3 ON t1.key = t3.a")
+      val adaptivePlan = df.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+      val logicalPlan = adaptivePlan.inputPlan.logicalLink.get
+
+      val reOptimize =
+        PrivateMethod[Option[(SparkPlan, LogicalPlan)]](Symbol("reOptimize"))
+      val hasFailedBroadcastRelation =
+        PrivateMethod[Boolean](Symbol("hasFailedBroadcastRelation"))
+      val addNoBroadcastHashHintsForFailedRelations =
+        PrivateMethod[LogicalPlan](Symbol("addNoBroadcastHashHintsForFailedRelations"))
+
+      val failedExchange = BroadcastExchangeExec(
+        IdentityBroadcastMode, sql("SELECT * FROM testData2").queryExecution.sparkPlan)
+      val failedStage = BroadcastQueryStageExec(0, failedExchange, failedExchange.canonicalized)
+
+      val baselinePlan = adaptivePlan.invokePrivate(reOptimize(logicalPlan)).get._1
+      assert(adaptivePlan.invokePrivate(
+        hasFailedBroadcastRelation(baselinePlan, Seq(failedStage))))
+
+      val targetedLogicalPlan = adaptivePlan.invokePrivate(
+        addNoBroadcastHashHintsForFailedRelations(logicalPlan, Seq(failedStage)))
+      val targetedPlan = adaptivePlan.invokePrivate(reOptimize(targetedLogicalPlan)).get._1
+
+      assert(findTopLevelBroadcastHashJoin(targetedPlan).nonEmpty)
+      assert(!adaptivePlan.invokePrivate(
+        hasFailedBroadcastRelation(targetedPlan, Seq(failedStage))))
     }
   }
 
@@ -776,7 +834,7 @@ class AdaptiveQueryExecSuite
     }
   }
 
-  test("Fallback to shuffled join should preserve input broadcast exchange") {
+  test("Re-optimize should preserve input broadcast exchange") {
     val qe = sql("SELECT key FROM testData").queryExecution
     val inputPlan = BroadcastExchangeExec(IdentityBroadcastMode, qe.sparkPlan)
     val adaptivePlan = AdaptiveSparkPlanExec(
@@ -788,11 +846,8 @@ class AdaptiveQueryExecSuite
     val reOptimize =
       PrivateMethod[Option[(SparkPlan, LogicalPlan)]](Symbol("reOptimize"))
 
-    val replanned = adaptivePlan.invokePrivate(reOptimize(logicalPlan, false)).get._1
+    val replanned = adaptivePlan.invokePrivate(reOptimize(logicalPlan)).get._1
     assert(replanned.isInstanceOf[BroadcastExchangeExec])
-
-    val fallbackReplanned = adaptivePlan.invokePrivate(reOptimize(logicalPlan, true)).get._1
-    assert(fallbackReplanned.isInstanceOf[BroadcastExchangeExec])
   }
 
   test("Fallback to shuffled join should reject replans containing failed broadcast relation") {
@@ -802,8 +857,8 @@ class AdaptiveQueryExecSuite
       AdaptiveExecutionContext(spark, qe),
       Seq.empty,
       isSubquery = false)
-    val shouldRejectBroadcastPlanInFallback =
-      PrivateMethod[Boolean](Symbol("shouldRejectBroadcastPlanInFallback"))
+    val hasFailedBroadcastRelation =
+      PrivateMethod[Boolean](Symbol("hasFailedBroadcastRelation"))
 
     val failedExchange = BroadcastExchangeExec(
       IdentityBroadcastMode, sql("SELECT a FROM testData2").queryExecution.sparkPlan)
@@ -818,17 +873,17 @@ class AdaptiveQueryExecSuite
       IdentityBroadcastMode, sql("SELECT key FROM testData").queryExecution.sparkPlan)
 
     assert(adaptivePlan.invokePrivate(
-      shouldRejectBroadcastPlanInFallback(sameExchange, Seq(failedStage))))
+      hasFailedBroadcastRelation(sameExchange, Seq(failedStage))))
     assert(adaptivePlan.invokePrivate(
-      shouldRejectBroadcastPlanInFallback(reusedSameExchange, Seq(failedStage))))
+      hasFailedBroadcastRelation(reusedSameExchange, Seq(failedStage))))
     assert(!adaptivePlan.invokePrivate(
-      shouldRejectBroadcastPlanInFallback(sameOutputDifferentRelation, Seq(failedStage))))
+      hasFailedBroadcastRelation(sameOutputDifferentRelation, Seq(failedStage))))
     assert(!adaptivePlan.invokePrivate(
-      shouldRejectBroadcastPlanInFallback(otherExchange, Seq(failedStage))))
+      hasFailedBroadcastRelation(otherExchange, Seq(failedStage))))
     assert(!adaptivePlan.invokePrivate(
-      shouldRejectBroadcastPlanInFallback(qe.sparkPlan, Seq(failedStage))))
+      hasFailedBroadcastRelation(qe.sparkPlan, Seq(failedStage))))
     assert(!adaptivePlan.invokePrivate(
-      shouldRejectBroadcastPlanInFallback(sameExchange, Seq.empty[BroadcastQueryStageExec])))
+      hasFailedBroadcastRelation(sameExchange, Seq.empty[BroadcastQueryStageExec])))
   }
 
   test("Fallback to shuffled join should persist failed broadcast relation across iterations") {
@@ -840,8 +895,8 @@ class AdaptiveQueryExecSuite
       isSubquery = false)
     val registerFailedBroadcastStage =
       PrivateMethod[Unit](Symbol("registerFailedBroadcastStage"))
-    val shouldRejectBroadcastPlanInFallback =
-      PrivateMethod[Boolean](Symbol("shouldRejectBroadcastPlanInFallback"))
+    val hasFailedBroadcastRelation =
+      PrivateMethod[Boolean](Symbol("hasFailedBroadcastRelation"))
 
     val failedStages = new scala.collection.mutable.ArrayBuffer[BroadcastQueryStageExec]()
     val failedExchange1 = BroadcastExchangeExec(
@@ -860,7 +915,7 @@ class AdaptiveQueryExecSuite
     val sameExchange = BroadcastExchangeExec(
       IdentityBroadcastMode, sql("SELECT a FROM testData2").queryExecution.sparkPlan)
     assert(adaptivePlan.invokePrivate(
-      shouldRejectBroadcastPlanInFallback(sameExchange, failedStages.toSeq)))
+      hasFailedBroadcastRelation(sameExchange, failedStages.toSeq)))
   }
 
   test("Fallback to shuffled join should remove equivalent failed broadcast stages") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -800,6 +800,8 @@ class AdaptiveQueryExecSuite
     val sameExchange = BroadcastExchangeExec(
       IdentityBroadcastMode, sql("SELECT a FROM testData2").queryExecution.sparkPlan)
     val reusedSameExchange = ReusedExchangeExec(sameExchange.output, sameExchange)
+    val sameOutputDifferentRelation = BroadcastExchangeExec(
+      IdentityBroadcastMode, sql("SELECT a FROM testData2 WHERE a > 1").queryExecution.sparkPlan)
     val otherExchange = BroadcastExchangeExec(
       IdentityBroadcastMode, sql("SELECT key FROM testData").queryExecution.sparkPlan)
 
@@ -807,6 +809,8 @@ class AdaptiveQueryExecSuite
       shouldRejectBroadcastPlanInFallback(sameExchange, Seq(failedStage))))
     assert(adaptivePlan.invokePrivate(
       shouldRejectBroadcastPlanInFallback(reusedSameExchange, Seq(failedStage))))
+    assert(!adaptivePlan.invokePrivate(
+      shouldRejectBroadcastPlanInFallback(sameOutputDifferentRelation, Seq(failedStage))))
     assert(!adaptivePlan.invokePrivate(
       shouldRejectBroadcastPlanInFallback(otherExchange, Seq(failedStage))))
     assert(!adaptivePlan.invokePrivate(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -659,20 +659,11 @@ class AdaptiveQueryExecSuite
 
       val targetedLogicalPlan = adaptivePlan.invokePrivate(
         addNoBroadcastHashHintsForFailedRelations(logicalPlan, Seq(failedStage)))
+      val joins = targetedLogicalPlan.collect { case join: Join => join }
 
-      val joinsWithNoBroadcastHash = targetedLogicalPlan.collect {
-        case join: Join
-            if join.hint.leftHint.exists(_.strategy.contains(NO_BROADCAST_HASH)) ||
-              join.hint.rightHint.exists(_.strategy.contains(NO_BROADCAST_HASH)) =>
-          join
-      }
-      assert(joinsWithNoBroadcastHash.nonEmpty)
-      assert(targetedLogicalPlan.collect {
-        case join: Join
-            if !join.hint.leftHint.exists(_.strategy.contains(NO_BROADCAST_HASH)) &&
-              !join.hint.rightHint.exists(_.strategy.contains(NO_BROADCAST_HASH)) =>
-          join
-      }.nonEmpty)
+      assert(joins.count(_.hint.leftHint.exists(_.strategy.contains(NO_BROADCAST_HASH))) == 0)
+      assert(joins.count(_.hint.rightHint.exists(_.strategy.contains(NO_BROADCAST_HASH))) == 1)
+      assert(joins.count(_.hint.rightHint.exists(_.strategy.contains(BROADCAST))) == 1)
     }
   }
 
@@ -1088,6 +1079,162 @@ class AdaptiveQueryExecSuite
         val finalPlan = stripAQEPlan(df.queryExecution.executedPlan)
         assert(findTopLevelBroadcastHashJoin(finalPlan).isEmpty)
         assert(findTopLevelSortMergeJoin(finalPlan).nonEmpty)
+      }
+    }
+  }
+
+  test("Fallback to shuffled join should preserve broadcast failure when disabled") {
+    withTempView("fallback_t1", "fallback_t2") {
+      spark.range(0, 100).selectExpr("id AS k").createOrReplaceTempView("fallback_t1")
+      spark.range(0, 50).selectExpr("id AS k").createOrReplaceTempView("fallback_t2")
+      withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+          SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+          SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "false",
+          SQLConf.MAX_BROADCAST_TABLE_SIZE.key -> "1") {
+        val df = sql(
+          "SELECT /*+ BROADCAST(fallback_t2) */ COUNT(*) " +
+            "FROM fallback_t1 JOIN fallback_t2 ON fallback_t1.k = fallback_t2.k")
+        val adaptivePlan = df.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+
+        assert(findTopLevelBroadcastHashJoin(adaptivePlan.executedPlan).nonEmpty)
+
+        val error = intercept[SparkException] {
+          df.collect()
+        }
+        assert(containsBroadcastLimitError(error), error)
+      }
+    }
+  }
+
+  test("Fallback to shuffled join should recover from broadcast size failure in self-join") {
+    withTempView("fallback_self") {
+      spark.range(0, 100)
+        .selectExpr("id AS k", "repeat('x', 2000) AS payload")
+        .createOrReplaceTempView("fallback_self")
+      withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+          SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+          SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.MAX_BROADCAST_TABLE_SIZE.key -> "16KB",
+          SQLConf.PREFER_SORTMERGEJOIN.key -> "true") {
+        val df = sql(
+          "SELECT /*+ BROADCAST(t2) */ COUNT(*) " +
+            "FROM fallback_self t1 JOIN fallback_self t2 ON t1.k = t2.k")
+        val adaptivePlan = df.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+
+        assert(findTopLevelBroadcastHashJoin(adaptivePlan.executedPlan).nonEmpty)
+
+        checkAnswer(df, Row(100))
+
+        val finalPlan = stripAQEPlan(df.queryExecution.executedPlan)
+        assert(findTopLevelBroadcastHashJoin(finalPlan).isEmpty, s"$finalPlan")
+        assert(findTopLevelSortMergeJoin(finalPlan).nonEmpty, s"$finalPlan")
+      }
+    }
+  }
+
+  test("Fallback to shuffled join should recover when two broadcasts fail") {
+    withTempView("fallback_t1", "fallback_t2", "fallback_t3") {
+      spark.range(0, 100).selectExpr("id AS k").createOrReplaceTempView("fallback_t1")
+      spark.range(0, 50)
+        .selectExpr("id AS k", "repeat('x', 2000) AS payload")
+        .createOrReplaceTempView("fallback_t2")
+      spark.range(0, 50)
+        .selectExpr("id AS k", "repeat('y', 2000) AS payload")
+        .createOrReplaceTempView("fallback_t3")
+      withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+          SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+          SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.MAX_BROADCAST_TABLE_SIZE.key -> "16KB",
+          SQLConf.PREFER_SORTMERGEJOIN.key -> "true") {
+        val df = sql(
+          "SELECT /*+ BROADCAST(fallback_t2), BROADCAST(fallback_t3) */ COUNT(*) " +
+            "FROM fallback_t1 " +
+            "JOIN fallback_t2 ON fallback_t1.k = fallback_t2.k " +
+            "JOIN fallback_t3 ON fallback_t1.k = fallback_t3.k")
+        val adaptivePlan = df.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+
+        assert(findTopLevelBroadcastHashJoin(adaptivePlan.executedPlan).size == 2)
+
+        checkAnswer(df, Row(50))
+
+        val finalPlan = stripAQEPlan(df.queryExecution.executedPlan)
+        assert(findTopLevelBaseJoin(finalPlan).size == 2, s"$finalPlan")
+        assert(findTopLevelBroadcastHashJoin(finalPlan).isEmpty, s"$finalPlan")
+        assert(findTopLevelSortMergeJoin(finalPlan).size == 2, s"$finalPlan")
+      }
+    }
+  }
+
+  test("Fallback to shuffled join should recover from broadcast failure in subquery") {
+    withTempView("fallback_t1", "fallback_t2", "fallback_t3") {
+      spark.range(0, 100).selectExpr("id AS k").createOrReplaceTempView("fallback_t1")
+      spark.range(0, 50)
+        .selectExpr("id AS k", "repeat('x', 2000) AS payload")
+        .createOrReplaceTempView("fallback_t2")
+      spark.range(0, 100).selectExpr("id AS k").createOrReplaceTempView("fallback_t3")
+      withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+          SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+          SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.MAX_BROADCAST_TABLE_SIZE.key -> "16KB",
+          SQLConf.PREFER_SORTMERGEJOIN.key -> "true") {
+        val df = sql(
+          "SELECT k FROM fallback_t1 WHERE k IN (" +
+            "SELECT /*+ BROADCAST(fallback_t2) */ fallback_t2.k " +
+            "FROM fallback_t3 JOIN fallback_t2 ON fallback_t3.k = fallback_t2.k)")
+
+        checkAnswer(df, (0L until 50L).map(Row(_)))
+
+        val finalPlan = df.queryExecution.executedPlan
+        assert(collectWithSubqueries(finalPlan) {
+          case j: BroadcastHashJoinExec => j
+        }.isEmpty, s"$finalPlan")
+        assert(collectWithSubqueries(finalPlan) {
+          case j: SortMergeJoinExec => j
+        }.nonEmpty, s"$finalPlan")
+      }
+    }
+  }
+
+  test("Fallback to shuffled join should keep AQE coalesce after fallback replan") {
+    withTempView("fallback_t1", "fallback_t2") {
+      spark.range(0, 1000).selectExpr("id AS k").createOrReplaceTempView("fallback_t1")
+      spark.range(0, 1000)
+        .selectExpr("id AS k", "repeat('x', 2000) AS payload")
+        .createOrReplaceTempView("fallback_t2")
+      withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+          SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+          SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.MAX_BROADCAST_TABLE_SIZE.key -> "16KB",
+          SQLConf.PREFER_SORTMERGEJOIN.key -> "true",
+          SQLConf.COALESCE_PARTITIONS_ENABLED.key -> "true",
+          SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "1MB",
+          SQLConf.SHUFFLE_PARTITIONS.key -> "20") {
+        val df = sql(
+          "SELECT /*+ BROADCAST(fallback_t2) */ fallback_t1.k, COUNT(*) " +
+            "FROM fallback_t1 JOIN fallback_t2 ON fallback_t1.k = fallback_t2.k " +
+            "GROUP BY fallback_t1.k")
+        val adaptivePlan = df.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+
+        assert(findTopLevelBroadcastHashJoin(adaptivePlan.executedPlan).nonEmpty)
+
+        checkAnswer(df, (0L until 1000L).map(i => Row(i, 1L)))
+
+        val finalPlan = stripAQEPlan(df.queryExecution.executedPlan)
+        assert(findTopLevelBroadcastHashJoin(finalPlan).isEmpty, s"$finalPlan")
+        assert(findTopLevelSortMergeJoin(finalPlan).nonEmpty, s"$finalPlan")
+        assert(collect(finalPlan) {
+          case read: AQEShuffleReadExec if read.hasCoalescedPartition => read
+        }.nonEmpty, s"$finalPlan")
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -137,6 +137,13 @@ class AdaptiveQueryExecSuite
     }
   }
 
+  private def broadcastHashJoinBuildOutput(join: BroadcastHashJoinExec): Seq[String] = {
+    join.buildSide match {
+      case BuildLeft => join.left.output.map(_.name)
+      case BuildRight => join.right.output.map(_.name)
+    }
+  }
+
   def findTopLevelBroadcastNestedLoopJoin(plan: SparkPlan): Seq[BaseJoinExec] = {
     collect(plan) {
       case j: BroadcastNestedLoopJoinExec => j
@@ -879,13 +886,12 @@ class AdaptiveQueryExecSuite
         val joins = targetedLogicalPlan.collect { case join: Join => join }
         val targetedPlan = adaptivePlan.invokePrivate(reOptimize(targetedLogicalPlan)).get._1
         val finalBhjs = findTopLevelBroadcastHashJoin(targetedPlan)
-        val finalSmjs = findTopLevelSortMergeJoin(targetedPlan)
+        val bhjBuildOutputs = finalBhjs.map(broadcastHashJoinBuildOutput)
 
         assert(joins.exists(_.hint.rightHint.exists(_.strategy.contains(NO_BROADCAST_HASH))))
         assert(joins.exists(_.hint.rightHint.exists(_.strategy.contains(BROADCAST))))
-        assert(finalBhjs.size == 1, s"$targetedPlan")
-        assert(finalBhjs.head.output.exists(_.name == "tag"), s"$targetedPlan")
-        assert(finalSmjs.size == 1, s"$targetedPlan")
+        assert(bhjBuildOutputs.exists(_.contains("tag")), s"$targetedPlan")
+        assert(!bhjBuildOutputs.exists(_.contains("payload")), s"$targetedPlan")
         assert(!adaptivePlan.invokePrivate(
           hasFailedBroadcastRelation(targetedPlan, Seq(failedStage))))
       }
@@ -1395,12 +1401,11 @@ class AdaptiveQueryExecSuite
 
         val finalPlan = stripAQEPlan(df.queryExecution.executedPlan)
         val finalBhjs = findTopLevelBroadcastHashJoin(finalPlan)
-        val finalSmjs = findTopLevelSortMergeJoin(finalPlan)
+        val bhjBuildOutputs = finalBhjs.map(broadcastHashJoinBuildOutput)
 
         assert(findTopLevelBaseJoin(finalPlan).size == 2, s"$finalPlan")
-        assert(finalBhjs.size == 1, s"$finalPlan")
-        assert(finalBhjs.head.output.exists(_.name == "tag"), s"$finalPlan")
-        assert(finalSmjs.size == 1, s"$finalPlan")
+        assert(bhjBuildOutputs.exists(_.contains("tag")), s"$finalPlan")
+        assert(!bhjBuildOutputs.exists(_.contains("payload")), s"$finalPlan")
         assert(findTopLevelBroadcastNestedLoopJoin(finalPlan).isEmpty, s"$finalPlan")
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -738,6 +738,45 @@ class AdaptiveQueryExecSuite
     }
   }
 
+  test("Fallback to shuffled join should match failed relation with nested logical query stages") {
+    withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+        SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+        SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true",
+        SQLConf.PREFER_SORTMERGEJOIN.key -> "false") {
+      val joinDf = sql(
+        "SELECT /*+ BROADCAST(t2) */ * " +
+          "FROM testData t1 " +
+          "JOIN (SELECT a, b FROM testData2 WHERE a > 1) t2 " +
+          "ON t1.key = t2.a")
+      val adaptivePlan = joinDf.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+      val addNoBroadcastHashHintsForFailedRelations =
+        PrivateMethod[LogicalPlan](Symbol("addNoBroadcastHashHintsForFailedRelations"))
+
+      val relationLogicalPlan = sql("SELECT a, b FROM testData2").queryExecution.optimizedPlan
+      val relationPhysicalPlan = sql("SELECT a, b FROM testData2").queryExecution.sparkPlan
+      val materializedRelation = LogicalQueryStage(
+        relationLogicalPlan,
+        ResultQueryStageExec(0, relationPhysicalPlan, _ => ()))
+
+      val logicalPlanWithStage = joinDf.queryExecution.optimizedPlan.transformDown {
+        case plan if plan.sameResult(relationLogicalPlan) => materializedRelation
+      }
+
+      val failedExchange = BroadcastExchangeExec(
+        IdentityBroadcastMode,
+        sql("SELECT a, b FROM testData2 WHERE a > 1").queryExecution.sparkPlan)
+      val failedStage = BroadcastQueryStageExec(0, failedExchange, failedExchange.canonicalized)
+
+      val targetedLogicalPlan = adaptivePlan.invokePrivate(
+        addNoBroadcastHashHintsForFailedRelations(logicalPlanWithStage, Seq(failedStage)))
+      val join = targetedLogicalPlan.collectFirst { case j: Join => j }.get
+
+      assert(join.hint.rightHint.exists(_.strategy.contains(NO_BROADCAST_HASH)))
+    }
+  }
+
   test("Fallback to shuffled join should recognize broadcast limit failures") {
     withSQLConf(
         SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -834,6 +834,98 @@ class AdaptiveQueryExecSuite
     }
   }
 
+  test("Fallback to shuffled join should recover from runtime broadcast size failure") {
+    withTempView("fallback_t1", "fallback_t2") {
+      spark.range(0, 100).selectExpr("id AS k").createOrReplaceTempView("fallback_t1")
+      spark.range(0, 50).selectExpr("id AS k").createOrReplaceTempView("fallback_t2")
+      withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+          SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+          SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.MAX_BROADCAST_TABLE_SIZE.key -> "1",
+          SQLConf.PREFER_SORTMERGEJOIN.key -> "true") {
+        val df = sql(
+          "SELECT /*+ BROADCAST(fallback_t2) */ COUNT(*) " +
+            "FROM fallback_t1 JOIN fallback_t2 ON fallback_t1.k = fallback_t2.k")
+        val adaptivePlan = df.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+
+        assert(findTopLevelBroadcastHashJoin(adaptivePlan.executedPlan).nonEmpty)
+
+        checkAnswer(df, Row(50))
+
+        val finalPlan = stripAQEPlan(df.queryExecution.executedPlan)
+        assert(findTopLevelBroadcastHashJoin(finalPlan).isEmpty)
+        assert(findTopLevelSortMergeJoin(finalPlan).nonEmpty)
+      }
+    }
+  }
+
+  test("Fallback to shuffled join should not disable broadcast joins globally") {
+    withTempView("fallback_t1", "fallback_t2", "fallback_t3") {
+      spark.range(0, 100).selectExpr("id AS k").createOrReplaceTempView("fallback_t1")
+      spark.range(0, 50).selectExpr("id AS k").createOrReplaceTempView("fallback_t2")
+      spark.range(0, 5).selectExpr("id AS k").createOrReplaceTempView("fallback_t3")
+      withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+          SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+          SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.PREFER_SORTMERGEJOIN.key -> "true") {
+        withSQLConf(SQLConf.MAX_BROADCAST_TABLE_SIZE.key -> "1") {
+          val fallbackDf = sql(
+            "SELECT /*+ BROADCAST(fallback_t2) */ COUNT(*) " +
+              "FROM fallback_t1 JOIN fallback_t2 ON fallback_t1.k = fallback_t2.k")
+          checkAnswer(fallbackDf, Row(50))
+          val fallbackFinalPlan = stripAQEPlan(fallbackDf.queryExecution.executedPlan)
+          assert(findTopLevelBroadcastHashJoin(fallbackFinalPlan).isEmpty)
+          assert(findTopLevelSortMergeJoin(fallbackFinalPlan).nonEmpty)
+        }
+
+        withSQLConf(SQLConf.MAX_BROADCAST_TABLE_SIZE.key -> "10MB") {
+          val broadcastDf = sql(
+            "SELECT /*+ BROADCAST(fallback_t3) */ COUNT(*) " +
+              "FROM fallback_t1 JOIN fallback_t3 ON fallback_t1.k = fallback_t3.k")
+          checkAnswer(broadcastDf, Row(5))
+          val broadcastFinalPlan = stripAQEPlan(broadcastDf.queryExecution.executedPlan)
+          assert(findTopLevelBroadcastHashJoin(broadcastFinalPlan).nonEmpty)
+        }
+      }
+    }
+  }
+
+  test("Fallback to shuffled join should preserve unrelated broadcast join in same query") {
+    withTempView("fallback_t1", "fallback_t2", "fallback_t3") {
+      spark.range(0, 100).selectExpr("id AS k").createOrReplaceTempView("fallback_t1")
+      spark.range(0, 50)
+        .selectExpr("id AS k", "repeat('x', 200) AS payload")
+        .createOrReplaceTempView("fallback_t2")
+      spark.range(0, 5).selectExpr("id AS k").createOrReplaceTempView("fallback_t3")
+      withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+          SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+          SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.MAX_BROADCAST_TABLE_SIZE.key -> "1KB",
+          SQLConf.PREFER_SORTMERGEJOIN.key -> "true") {
+        val df = sql(
+          "SELECT /*+ BROADCAST(fallback_t2), BROADCAST(fallback_t3) */ COUNT(*) " +
+            "FROM fallback_t1 " +
+            "JOIN fallback_t2 ON fallback_t1.k = fallback_t2.k " +
+            "JOIN fallback_t3 ON fallback_t1.k = fallback_t3.k")
+        val adaptivePlan = df.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+
+        assert(findTopLevelBroadcastHashJoin(adaptivePlan.executedPlan).size == 2)
+
+        checkAnswer(df, Row(5))
+
+        val finalPlan = stripAQEPlan(df.queryExecution.executedPlan)
+        assert(findTopLevelBroadcastHashJoin(finalPlan).size == 1)
+        assert(findTopLevelSortMergeJoin(finalPlan).nonEmpty)
+      }
+    }
+  }
+
   test("Re-optimize should preserve input broadcast exchange") {
     val qe = sql("SELECT key FROM testData").queryExecution
     val inputPlan = BroadcastExchangeExec(IdentityBroadcastMode, qe.sparkPlan)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -38,7 +38,10 @@ import org.apache.spark.sql.catalyst.plans.logical.{
   Join,
   LogicalPlan,
   NO_BROADCAST_AND_REPLICATION,
-  NO_BROADCAST_HASH
+  NO_BROADCAST_HASH,
+  PREFER_SHUFFLE_HASH,
+  SHUFFLE_HASH,
+  SHUFFLE_MERGE
 }
 import org.apache.spark.sql.catalyst.plans.physical.IdentityBroadcastMode
 import org.apache.spark.sql.classic.Strategy
@@ -697,6 +700,12 @@ class AdaptiveQueryExecSuite
     val broadcastHint = Some(HintInfo(strategy = Some(BROADCAST)))
     val rewrittenBroadcastHint = adaptivePlan.invokePrivate(toNoBroadcastHashHint(broadcastHint))
     assert(rewrittenBroadcastHint.exists(_.strategy.contains(NO_BROADCAST_HASH)))
+
+    Seq(PREFER_SHUFFLE_HASH, SHUFFLE_HASH, SHUFFLE_MERGE).foreach { strategy =>
+      val preservedHint =
+        Some(HintInfo(strategy = Some(strategy)))
+      assert(adaptivePlan.invokePrivate(toNoBroadcastHashHint(preservedHint)) == preservedHint)
+    }
   }
 
   test("Fallback to shuffled join should keep unrelated BHJs after targeted fallback replan") {
@@ -733,6 +742,60 @@ class AdaptiveQueryExecSuite
       val targetedPlan = adaptivePlan.invokePrivate(reOptimize(targetedLogicalPlan)).get._1
 
       assert(findTopLevelBroadcastHashJoin(targetedPlan).nonEmpty)
+      assert(!adaptivePlan.invokePrivate(
+        hasFailedBroadcastRelation(targetedPlan, Seq(failedStage))))
+    }
+  }
+
+  test("Fallback to shuffled join should not disable other broadcasts from same base relation") {
+    withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+        SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+        SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true",
+        SQLConf.PREFER_SORTMERGEJOIN.key -> "true") {
+      val df = sql(
+        "SELECT /*+ BROADCAST(failed_t2), BROADCAST(other_t2) */ failed_t2.failed_b, " +
+          "other_t2.other_a " +
+          "FROM testData t1 " +
+          "JOIN (SELECT a AS failed_a, b AS failed_b FROM testData2 WHERE a > 1) failed_t2 " +
+          "ON t1.key = failed_t2.failed_a " +
+          "JOIN (SELECT a AS other_a FROM testData2 WHERE a <= 2) other_t2 " +
+          "ON t1.key = other_t2.other_a")
+      val adaptivePlan = df.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+      val logicalPlan = adaptivePlan.inputPlan.logicalLink.get
+
+      val reOptimize =
+        PrivateMethod[Option[(SparkPlan, LogicalPlan)]](Symbol("reOptimize"))
+      val hasFailedBroadcastRelation =
+        PrivateMethod[Boolean](Symbol("hasFailedBroadcastRelation"))
+      val addNoBroadcastHashHintsForFailedRelations =
+        PrivateMethod[LogicalPlan](Symbol("addNoBroadcastHashHintsForFailedRelations"))
+
+      val failedExchange = BroadcastExchangeExec(
+        IdentityBroadcastMode,
+        sql("SELECT a AS failed_a, b AS failed_b FROM testData2 WHERE a > 1")
+          .queryExecution.sparkPlan)
+      val failedStage = BroadcastQueryStageExec(0, failedExchange, failedExchange.canonicalized)
+
+      val targetedLogicalPlan = adaptivePlan.invokePrivate(
+        addNoBroadcastHashHintsForFailedRelations(logicalPlan, Seq(failedStage)))
+      val joins = targetedLogicalPlan.collect { case join: Join => join }
+      val targetedPlan = adaptivePlan.invokePrivate(reOptimize(targetedLogicalPlan)).get._1
+      val finalBhjs = findTopLevelBroadcastHashJoin(targetedPlan)
+      val finalSmjs = findTopLevelSortMergeJoin(targetedPlan)
+      val broadcastBuildOutput = finalBhjs.headOption.map { bhj =>
+        bhj.buildSide match {
+          case BuildLeft => bhj.left.output.map(_.name)
+          case BuildRight => bhj.right.output.map(_.name)
+        }
+      }.getOrElse(Nil)
+
+      assert(joins.count(_.hint.rightHint.exists(_.strategy.contains(NO_BROADCAST_HASH))) == 1)
+      assert(joins.count(_.hint.rightHint.exists(_.strategy.contains(BROADCAST))) == 1)
+      assert(finalBhjs.size == 1, s"$targetedPlan")
+      assert(broadcastBuildOutput.contains("other_a"), s"$targetedPlan")
+      assert(finalSmjs.size == 1, s"$targetedPlan")
       assert(!adaptivePlan.invokePrivate(
         hasFailedBroadcastRelation(targetedPlan, Seq(failedStage))))
     }
@@ -777,73 +840,174 @@ class AdaptiveQueryExecSuite
     }
   }
 
-  test("Fallback to shuffled join should recognize broadcast limit failures") {
+  test("Fallback to shuffled join should keep unrelated BHJ for nested failed branch replan") {
+    withTempView("fallback_t1", "fallback_t2", "fallback_t3") {
+      spark.range(0, 100).selectExpr("id AS k").createOrReplaceTempView("fallback_t1")
+      spark.range(0, 50)
+        .selectExpr("id AS k", "repeat('x', 2000) AS payload")
+        .createOrReplaceTempView("fallback_t2")
+      spark.range(0, 5)
+        .selectExpr("id AS k", "concat('small_', cast(id AS string)) AS tag")
+        .createOrReplaceTempView("fallback_t3")
+      withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+          SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+          SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.PREFER_SORTMERGEJOIN.key -> "true") {
+        val df = sql(
+          "SELECT /*+ BROADCAST(fallback_t3) */ failed_branch.k, failed_branch.payload, " +
+            "fallback_t3.tag " +
+            "FROM (" +
+            "  SELECT /*+ BROADCAST(fallback_t2) */ fallback_t1.k, fallback_t2.payload " +
+            "  FROM fallback_t1 " +
+            "  JOIN fallback_t2 ON fallback_t1.k = fallback_t2.k" +
+            ") failed_branch " +
+            "JOIN fallback_t3 ON failed_branch.k = fallback_t3.k")
+        val adaptivePlan = df.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+        val logicalPlan = adaptivePlan.inputPlan.logicalLink.get
+
+        val reOptimize =
+          PrivateMethod[Option[(SparkPlan, LogicalPlan)]](Symbol("reOptimize"))
+        val addNoBroadcastHashHintsForFailedRelations =
+          PrivateMethod[LogicalPlan](Symbol("addNoBroadcastHashHintsForFailedRelations"))
+        val hasFailedBroadcastRelation =
+          PrivateMethod[Boolean](Symbol("hasFailedBroadcastRelation"))
+
+        val failedBroadcastChild = sql("SELECT k FROM fallback_t2").queryExecution.sparkPlan
+        val failedExchange = adaptivePlan.executedPlan.collectFirst {
+          case exchange: BroadcastExchangeExec if exchange.child.sameResult(failedBroadcastChild) =>
+            exchange
+        }.getOrElse {
+          fail(s"Expected broadcast exchange for fallback_t2 branch:\n${adaptivePlan.executedPlan}")
+        }
+        val failedStage = BroadcastQueryStageExec(0, failedExchange, failedExchange.canonicalized)
+
+        val targetedLogicalPlan = adaptivePlan.invokePrivate(
+          addNoBroadcastHashHintsForFailedRelations(logicalPlan, Seq(failedStage)))
+        val joins = targetedLogicalPlan.collect { case join: Join => join }
+        val targetedPlan = adaptivePlan.invokePrivate(reOptimize(targetedLogicalPlan)).get._1
+        val finalBhjs = findTopLevelBroadcastHashJoin(targetedPlan)
+        val finalSmjs = findTopLevelSortMergeJoin(targetedPlan)
+
+        assert(joins.exists(_.hint.rightHint.exists(_.strategy.contains(NO_BROADCAST_HASH))))
+        assert(joins.exists(_.hint.rightHint.exists(_.strategy.contains(BROADCAST))))
+        assert(finalBhjs.size == 1, s"$targetedPlan")
+        assert(finalBhjs.head.output.exists(_.name == "tag"), s"$targetedPlan")
+        assert(finalSmjs.size == 1, s"$targetedPlan")
+        assert(!adaptivePlan.invokePrivate(
+          hasFailedBroadcastRelation(targetedPlan, Seq(failedStage))))
+      }
+    }
+  }
+
+  test("Fallback to shuffled join should only apply to exclusively broadcast hash join stages") {
     withSQLConf(
         SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
         SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true") {
-      val qe = sql("SELECT key FROM testData").queryExecution
-      val broadcastInputPlan = BroadcastExchangeExec(IdentityBroadcastMode, qe.sparkPlan)
-      val adaptivePlan = AdaptiveSparkPlanExec(
-        qe.sparkPlan,
-        AdaptiveExecutionContext(spark, qe),
-        Seq.empty,
-        isSubquery = false)
-      val broadcastSubqueryAdaptivePlan = AdaptiveSparkPlanExec(
-        broadcastInputPlan,
-        AdaptiveExecutionContext(spark, qe),
-        Seq.empty,
-        isSubquery = true)
-      val regularSubqueryAdaptivePlan = AdaptiveSparkPlanExec(
-        qe.sparkPlan,
-        AdaptiveExecutionContext(spark, qe),
-        Seq.empty,
-        isSubquery = true)
-      val stage =
-        BroadcastQueryStageExec(0, broadcastInputPlan, broadcastInputPlan.canonicalized)
-      val innerBroadcastPlan =
-        BroadcastExchangeExec(
-          IdentityBroadcastMode,
-          sql("SELECT a FROM testData2").queryExecution.sparkPlan)
-      val innerStage =
-        BroadcastQueryStageExec(1, innerBroadcastPlan, innerBroadcastPlan.canonicalized)
-      val equivalentInnerBroadcastPlan =
-        BroadcastExchangeExec(IdentityBroadcastMode, qe.sparkPlan)
-      val equivalentInnerStage = BroadcastQueryStageExec(
-        2, equivalentInnerBroadcastPlan, equivalentInnerBroadcastPlan.canonicalized)
+      def buildBroadcastStage(join: BaseJoinExec): BroadcastQueryStageExec = {
+        val buildPlan = join match {
+          case bhj: BroadcastHashJoinExec =>
+            bhj.buildSide match {
+              case BuildLeft => bhj.left
+              case BuildRight => bhj.right
+            }
+          case bnlj: BroadcastNestedLoopJoinExec =>
+            bnlj.buildSide match {
+              case BuildLeft => bnlj.left
+              case BuildRight => bnlj.right
+            }
+        }
+        buildPlan.collectFirst { case stage: BroadcastQueryStageExec => stage }
+          .orElse {
+            buildPlan.collectFirst { case exchange: BroadcastExchangeExec =>
+              BroadcastQueryStageExec(0, exchange, exchange.canonicalized)
+            }
+          }.getOrElse {
+            fail(s"Expected broadcast query stage:\n$join")
+        }
+      }
+
+      val bhjDf = sql(
+        "SELECT /*+ BROADCAST(t2) */ * " +
+          "FROM testData t1 JOIN testData2 t2 ON t1.key = t2.a")
+      val bhjAdaptivePlan = bhjDf.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+      val bhjStage = buildBroadcastStage(findTopLevelBroadcastHashJoin(
+        bhjAdaptivePlan.executedPlan).head)
+
+      val bnljDf = sql(
+        "SELECT /*+ BROADCAST(t2) */ * " +
+          "FROM testData t1 JOIN testData2 t2 ON t1.key > t2.a")
+      val bnljAdaptivePlan = bnljDf.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+      val bnljStage = buildBroadcastStage(findTopLevelBroadcastNestedLoopJoin(
+        bnljAdaptivePlan.executedPlan).head)
+
       val shouldFallbackToShuffleJoin =
         PrivateMethod[Boolean](Symbol("shouldFallbackToShuffleJoin"))
 
-      assert(adaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
-        stage,
+      assert(bhjAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        bhjStage,
         QueryExecutionErrors.cannotBroadcastTableOverMaxTableBytesError(1, 2))))
-      assert(adaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
-        stage,
+      assert(bhjAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        bhjStage,
         QueryExecutionErrors.cannotBroadcastTableOverMaxTableRowsError(1, 2))))
-      assert(regularSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
-        stage,
+      assert(!bnljAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        bnljStage,
         QueryExecutionErrors.cannotBroadcastTableOverMaxTableBytesError(1, 2))))
-      assert(regularSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
-        stage,
+      assert(!bnljAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        bnljStage,
         QueryExecutionErrors.cannotBroadcastTableOverMaxTableRowsError(1, 2))))
-      // `stage` is a synthetic stage instance, not the stage currently at the plan root.
-      // Only the actual root stage instance is exempt from fallback.
-      assert(broadcastSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
-        stage,
+
+      val mixedDf = sql(
+        "SELECT /*+ BROADCAST(eq_t2), BROADCAST(range_t2) */ t1.key " +
+          "FROM testData t1 " +
+          "JOIN (SELECT a FROM testData2) eq_t2 ON t1.key = eq_t2.a " +
+          "JOIN (SELECT a FROM testData2) range_t2 ON t1.key > range_t2.a")
+      val mixedAdaptivePlan =
+        mixedDf.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+      val mixedBhjs = findTopLevelBroadcastHashJoin(mixedAdaptivePlan.executedPlan)
+      val mixedBnljs = findTopLevelBroadcastNestedLoopJoin(mixedAdaptivePlan.executedPlan)
+      val mixedBhjStage = buildBroadcastStage(mixedBhjs.head)
+      val mixedBnljStage = buildBroadcastStage(mixedBnljs.head)
+
+      assert(mixedBhjs.size == 1, s"${mixedAdaptivePlan.executedPlan}")
+      assert(mixedBnljs.size == 1, s"${mixedAdaptivePlan.executedPlan}")
+      assert(mixedBhjStage.broadcast ne mixedBnljStage.broadcast,
+        s"${mixedAdaptivePlan.executedPlan}")
+      assert(mixedBhjStage.broadcast.child.sameResult(mixedBnljStage.broadcast.child),
+        s"${mixedAdaptivePlan.executedPlan}")
+      assert(!mixedAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        mixedBhjStage,
         QueryExecutionErrors.cannotBroadcastTableOverMaxTableBytesError(1, 2))))
-      assert(broadcastSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
-        stage,
+      assert(!mixedAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        mixedBhjStage,
         QueryExecutionErrors.cannotBroadcastTableOverMaxTableRowsError(1, 2))))
-      assert(broadcastSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
-        innerStage,
+      assert(!mixedAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        mixedBnljStage,
         QueryExecutionErrors.cannotBroadcastTableOverMaxTableBytesError(1, 2))))
-      assert(broadcastSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
-        innerStage,
+      assert(!mixedAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        mixedBnljStage,
         QueryExecutionErrors.cannotBroadcastTableOverMaxTableRowsError(1, 2))))
-      assert(broadcastSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
-        equivalentInnerStage,
+
+      val subqueryQe = sql("SELECT key FROM testData").queryExecution
+      val inputPlan = BroadcastExchangeExec(IdentityBroadcastMode, subqueryQe.sparkPlan)
+      inputPlan.setLogicalLink(subqueryQe.optimizedPlan)
+      val subqueryAdaptivePlan = AdaptiveSparkPlanExec(
+        inputPlan,
+        AdaptiveExecutionContext(spark, subqueryQe),
+        Seq.empty,
+        isSubquery = true)
+      val rootStage = subqueryAdaptivePlan.finalPhysicalPlan match {
+        case stage: BroadcastQueryStageExec => stage
+        case plan =>
+          fail(s"Expected root broadcast query stage:\n$plan")
+      }
+
+      assert(!subqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        rootStage,
         QueryExecutionErrors.cannotBroadcastTableOverMaxTableBytesError(1, 2))))
-      assert(broadcastSubqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
-        equivalentInnerStage,
+      assert(!subqueryAdaptivePlan.invokePrivate(shouldFallbackToShuffleJoin(
+        rootStage,
         QueryExecutionErrors.cannotBroadcastTableOverMaxTableRowsError(1, 2))))
     }
   }
@@ -900,67 +1064,197 @@ class AdaptiveQueryExecSuite
     }
   }
 
-  test("Fallback to shuffled join should not disable broadcast joins globally") {
-    withTempView("fallback_t1", "fallback_t2", "fallback_t3") {
+  test("Fallback to shuffled join should recover from runtime broadcast size failure " +
+      "without explicit broadcast hint") {
+    withTempView("fallback_t1", "fallback_t2") {
       spark.range(0, 100).selectExpr("id AS k").createOrReplaceTempView("fallback_t1")
       spark.range(0, 50).selectExpr("id AS k").createOrReplaceTempView("fallback_t2")
-      spark.range(0, 5).selectExpr("id AS k").createOrReplaceTempView("fallback_t3")
       withSQLConf(
           SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
           SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
           SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
           SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.MAX_BROADCAST_TABLE_SIZE.key -> "1",
           SQLConf.PREFER_SORTMERGEJOIN.key -> "true") {
-        withSQLConf(SQLConf.MAX_BROADCAST_TABLE_SIZE.key -> "1") {
-          val fallbackDf = sql(
-            "SELECT /*+ BROADCAST(fallback_t2) */ COUNT(*) " +
-              "FROM fallback_t1 JOIN fallback_t2 ON fallback_t1.k = fallback_t2.k")
-          checkAnswer(fallbackDf, Row(50))
-          val fallbackFinalPlan = stripAQEPlan(fallbackDf.queryExecution.executedPlan)
-          assert(findTopLevelBroadcastHashJoin(fallbackFinalPlan).isEmpty)
-          assert(findTopLevelSortMergeJoin(fallbackFinalPlan).nonEmpty)
-        }
+        val df = sql(
+          "SELECT COUNT(*) " +
+            "FROM fallback_t1 JOIN fallback_t2 ON fallback_t1.k = fallback_t2.k")
+        val adaptivePlan = df.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
 
-        withSQLConf(SQLConf.MAX_BROADCAST_TABLE_SIZE.key -> "10MB") {
-          val broadcastDf = sql(
-            "SELECT /*+ BROADCAST(fallback_t3) */ COUNT(*) " +
-              "FROM fallback_t1 JOIN fallback_t3 ON fallback_t1.k = fallback_t3.k")
-          checkAnswer(broadcastDf, Row(5))
-          val broadcastFinalPlan = stripAQEPlan(broadcastDf.queryExecution.executedPlan)
-          assert(findTopLevelBroadcastHashJoin(broadcastFinalPlan).nonEmpty)
-        }
+        assert(findTopLevelBroadcastHashJoin(adaptivePlan.executedPlan).nonEmpty)
+
+        checkAnswer(df, Row(50))
+
+        val finalPlan = stripAQEPlan(df.queryExecution.executedPlan)
+        assert(findTopLevelBroadcastHashJoin(finalPlan).isEmpty)
+        assert(findTopLevelSortMergeJoin(finalPlan).nonEmpty)
       }
     }
   }
 
-  test("Fallback to shuffled join should preserve unrelated broadcast join in same query") {
+  test("Fallback to shuffled join should not retry mixed BHJ and BNLJ consumers at runtime") {
+    withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+        SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+        SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true",
+        SQLConf.MAX_BROADCAST_TABLE_SIZE.key -> "1") {
+      val df = sql(
+        "SELECT /*+ BROADCAST(eq_t2), BROADCAST(range_t2) */ COUNT(*) " +
+          "FROM testData t1 " +
+          "JOIN (SELECT a FROM testData2) eq_t2 ON t1.key = eq_t2.a " +
+          "JOIN (SELECT a FROM testData2) range_t2 ON t1.key > range_t2.a")
+      val adaptivePlan = df.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+      val logAppender = new LogAppender("mixed BHJ BNLJ fallback")
+
+      assert(findTopLevelBroadcastHashJoin(adaptivePlan.executedPlan).size == 1)
+      assert(findTopLevelBroadcastNestedLoopJoin(adaptivePlan.executedPlan).size == 1)
+
+      withLogAppender(
+          logAppender,
+          loggerNames = Seq(AdaptiveSparkPlanExec.getClass.getName.dropRight(1)),
+          level = Some(Level.INFO)) {
+        val error = intercept[SparkException] {
+          df.collect()
+        }
+        assert(containsBroadcastLimitError(error), error)
+      }
+
+      assert(!logAppender.loggingEvents.exists { event =>
+        event.getMessage.getFormattedMessage.contains(
+          "retrying adaptive replanning with matching broadcast hash joins disabled")
+      })
+    }
+  }
+
+  test("Fallback to shuffled join should recover from nested failed broadcast branch") {
     withTempView("fallback_t1", "fallback_t2", "fallback_t3") {
+      val widePayload = "x" * 2000
       spark.range(0, 100).selectExpr("id AS k").createOrReplaceTempView("fallback_t1")
       spark.range(0, 50)
-        .selectExpr("id AS k", "repeat('x', 200) AS payload")
+        .selectExpr("id AS k", "repeat('x', 2000) AS payload")
         .createOrReplaceTempView("fallback_t2")
-      spark.range(0, 5).selectExpr("id AS k").createOrReplaceTempView("fallback_t3")
+      spark.range(0, 5)
+        .selectExpr("id AS k", "concat('small_', cast(id AS string)) AS tag")
+        .createOrReplaceTempView("fallback_t3")
       withSQLConf(
           SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
           SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
           SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
           SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true",
-          SQLConf.MAX_BROADCAST_TABLE_SIZE.key -> "1KB",
+          SQLConf.MAX_BROADCAST_TABLE_SIZE.key -> "16KB",
           SQLConf.PREFER_SORTMERGEJOIN.key -> "true") {
         val df = sql(
-          "SELECT /*+ BROADCAST(fallback_t2), BROADCAST(fallback_t3) */ COUNT(*) " +
-            "FROM fallback_t1 " +
-            "JOIN fallback_t2 ON fallback_t1.k = fallback_t2.k " +
-            "JOIN fallback_t3 ON fallback_t1.k = fallback_t3.k")
+          "SELECT /*+ BROADCAST(fallback_t3) */ failed_branch.k, failed_branch.payload, " +
+            "fallback_t3.tag " +
+            "FROM (" +
+            "  SELECT /*+ BROADCAST(fallback_t2) */ fallback_t1.k, fallback_t2.payload " +
+            "  FROM fallback_t1 " +
+            "  JOIN fallback_t2 ON fallback_t1.k = fallback_t2.k" +
+            ") failed_branch " +
+            "JOIN fallback_t3 ON failed_branch.k = fallback_t3.k")
         val adaptivePlan = df.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
 
         assert(findTopLevelBroadcastHashJoin(adaptivePlan.executedPlan).size == 2)
 
-        checkAnswer(df, Row(5))
+        val expected = (0L until 5L).map(i => Row(i, widePayload, s"small_$i"))
+        checkAnswer(df, expected)
 
         val finalPlan = stripAQEPlan(df.queryExecution.executedPlan)
-        assert(findTopLevelBroadcastHashJoin(finalPlan).size == 1)
-        assert(findTopLevelSortMergeJoin(finalPlan).nonEmpty)
+        val finalBhjs = findTopLevelBroadcastHashJoin(finalPlan)
+        val finalSmjs = findTopLevelSortMergeJoin(finalPlan)
+
+        assert(findTopLevelBaseJoin(finalPlan).size == 2, s"$finalPlan")
+        assert(finalBhjs.forall(_.output.exists(_.name == "tag")), s"$finalPlan")
+        assert(finalSmjs.nonEmpty, s"$finalPlan")
+        assert(findTopLevelBroadcastNestedLoopJoin(finalPlan).isEmpty, s"$finalPlan")
+      }
+    }
+  }
+
+  test("Fallback to shuffled join should remove equivalent failed broadcast input everywhere") {
+    withTempView("fallback_t1", "fallback_t2") {
+      val largePayload = "x" * 2000
+      spark.range(0, 100).selectExpr("id AS k").createOrReplaceTempView("fallback_t1")
+      spark.range(0, 50)
+        .selectExpr("id AS k", "repeat('x', 2000) AS payload")
+        .createOrReplaceTempView("fallback_t2")
+      withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+          SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+          SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.MAX_BROADCAST_TABLE_SIZE.key -> "16KB",
+          SQLConf.PREFER_SORTMERGEJOIN.key -> "true") {
+        val df = sql(
+          "SELECT /*+ BROADCAST(f2a), BROADCAST(f2b) */ base.k, " +
+            "f2a.payload AS payload_a, f2b.payload AS payload_b " +
+            "FROM (SELECT k FROM fallback_t1 WHERE k < 5) base " +
+            "JOIN fallback_t2 f2a ON base.k = f2a.k " +
+            "JOIN fallback_t2 f2b ON base.k = f2b.k")
+        val adaptivePlan = df.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+
+        assert(findTopLevelBroadcastHashJoin(adaptivePlan.executedPlan).size == 2)
+
+        val expected = (0L until 5L).map(i => Row(i, largePayload, largePayload))
+        checkAnswer(df, expected)
+
+        val finalPlan = stripAQEPlan(df.queryExecution.executedPlan)
+        assert(findTopLevelBaseJoin(finalPlan).size == 2, s"$finalPlan")
+        assert(findTopLevelBroadcastHashJoin(finalPlan).isEmpty, s"$finalPlan")
+        assert(findTopLevelSortMergeJoin(finalPlan).nonEmpty, s"$finalPlan")
+        assert(findTopLevelBroadcastNestedLoopJoin(finalPlan).isEmpty, s"$finalPlan")
+      }
+    }
+  }
+
+  test("Fallback to shuffled join should keep other runtime broadcasts from same base relation") {
+    withTempView("fallback_t1", "fallback_t2") {
+      val largePayload = "x" * 9000
+      spark.range(0, 10000).selectExpr("id AS k").createOrReplaceTempView("fallback_t1")
+      spark.range(0, 10000)
+        .selectExpr(
+          "CAST(id AS INT) AS k",
+          "concat(CAST(id AS STRING), repeat('x', 9000)) AS payload")
+        .createOrReplaceTempView("fallback_t2")
+      withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "100MB",
+          SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "100MB",
+          SQLConf.ADAPTIVE_BROADCAST_JOIN_FALLBACK_TO_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.MAX_BROADCAST_TABLE_SIZE.key -> "80MB",
+          SQLConf.PREFER_SORTMERGEJOIN.key -> "true") {
+        val df = sql(
+          "SELECT /*+ BROADCAST(failed_t2) */ base.k, failed_t2.payload " +
+            "FROM (SELECT CAST(k AS INT) AS k FROM fallback_t1 WHERE k < 10000) base " +
+            "JOIN (SELECT k, payload FROM fallback_t2 WHERE k < 10000) failed_t2 " +
+            "ON base.k = failed_t2.k " +
+            "UNION ALL " +
+            "SELECT /*+ BROADCAST(other_t2) */ base.k, other_t2.tag AS payload " +
+            "FROM (SELECT CAST(k AS INT) AS k FROM fallback_t1 WHERE k < 2) base " +
+            "JOIN (" +
+            "  SELECT k, CAST(k AS STRING) AS tag " +
+            "  FROM fallback_t2 WHERE k < 2" +
+            ") other_t2 " +
+            "ON base.k = other_t2.k")
+        val adaptivePlan = df.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+
+        assert(findTopLevelBroadcastHashJoin(adaptivePlan.executedPlan).size == 2)
+
+        val expected =
+          (0 until 10000).map(i => Row(i, s"$i$largePayload")) ++
+            (0 until 2).map(i => Row(i, i.toString))
+        checkAnswer(df, expected)
+
+        val finalPlan = stripAQEPlan(df.queryExecution.executedPlan)
+        val finalBhjs = findTopLevelBroadcastHashJoin(finalPlan)
+        val finalSmjs = findTopLevelSortMergeJoin(finalPlan)
+
+        assert(findTopLevelBaseJoin(finalPlan).size == 2, s"$finalPlan")
+        assert(finalBhjs.size == 1, s"$finalPlan")
+        assert(finalBhjs.head.output.exists(_.name == "tag"), s"$finalPlan")
+        assert(finalSmjs.size == 1, s"$finalPlan")
+        assert(findTopLevelBroadcastNestedLoopJoin(finalPlan).isEmpty, s"$finalPlan")
       }
     }
   }
@@ -1017,36 +1311,49 @@ class AdaptiveQueryExecSuite
       hasFailedBroadcastRelation(sameExchange, Seq.empty[BroadcastQueryStageExec])))
   }
 
-  test("Fallback to shuffled join should persist failed broadcast relation across iterations") {
+  test("Fallback to shuffled join should ignore stale equivalent broadcast stage failures") {
     val qe = sql("SELECT key FROM testData").queryExecution
     val adaptivePlan = AdaptiveSparkPlanExec(
       qe.sparkPlan,
       AdaptiveExecutionContext(spark, qe),
       Seq.empty,
       isSubquery = false)
-    val registerFailedBroadcastStage =
-      PrivateMethod[Unit](Symbol("registerFailedBroadcastStage"))
-    val hasFailedBroadcastRelation =
-      PrivateMethod[Boolean](Symbol("hasFailedBroadcastRelation"))
+    val shouldIgnoreStaleBroadcastStageFailure =
+      PrivateMethod[Boolean](Symbol("shouldIgnoreStaleBroadcastStageFailure"))
 
-    val failedStages = new scala.collection.mutable.ArrayBuffer[BroadcastQueryStageExec]()
-    val failedExchange1 = BroadcastExchangeExec(
+    val failedExchange = BroadcastExchangeExec(
       IdentityBroadcastMode, sql("SELECT a FROM testData2").queryExecution.sparkPlan)
-    val failedStage1 = BroadcastQueryStageExec(0, failedExchange1, failedExchange1.canonicalized)
-    adaptivePlan.invokePrivate(registerFailedBroadcastStage(failedStages, failedStage1))
+    val failedStage = BroadcastQueryStageExec(0, failedExchange, failedExchange.canonicalized)
 
-    // Equivalent failed relation from a later iteration should be deduplicated.
-    val failedExchange2 = BroadcastExchangeExec(
+    val equivalentExchange = BroadcastExchangeExec(
       IdentityBroadcastMode, sql("SELECT a FROM testData2").queryExecution.sparkPlan)
-    val failedStage2 = BroadcastQueryStageExec(1, failedExchange2, failedExchange2.canonicalized)
-    adaptivePlan.invokePrivate(registerFailedBroadcastStage(failedStages, failedStage2))
+    val equivalentStage =
+      BroadcastQueryStageExec(1, equivalentExchange, equivalentExchange.canonicalized)
 
-    assert(failedStages.size == 1)
+    val otherExchange = BroadcastExchangeExec(
+      IdentityBroadcastMode, sql("SELECT key FROM testData").queryExecution.sparkPlan)
+    val otherStage = BroadcastQueryStageExec(2, otherExchange, otherExchange.canonicalized)
 
-    val sameExchange = BroadcastExchangeExec(
-      IdentityBroadcastMode, sql("SELECT a FROM testData2").queryExecution.sparkPlan)
     assert(adaptivePlan.invokePrivate(
-      hasFailedBroadcastRelation(sameExchange, failedStages.toSeq)))
+      shouldIgnoreStaleBroadcastStageFailure(
+        equivalentStage,
+        QueryExecutionErrors.cannotBroadcastTableOverMaxTableBytesError(1, 2),
+        Seq(failedStage))))
+    assert(adaptivePlan.invokePrivate(
+      shouldIgnoreStaleBroadcastStageFailure(
+        equivalentStage,
+        QueryExecutionErrors.cannotBroadcastTableOverMaxTableRowsError(1, 2),
+        Seq(failedStage))))
+    assert(!adaptivePlan.invokePrivate(
+      shouldIgnoreStaleBroadcastStageFailure(
+        otherStage,
+        QueryExecutionErrors.cannotBroadcastTableOverMaxTableBytesError(1, 2),
+        Seq(failedStage))))
+    assert(!adaptivePlan.invokePrivate(
+      shouldIgnoreStaleBroadcastStageFailure(
+        equivalentStage,
+        new SparkException("non-broadcast-limit failure"),
+        Seq(failedStage))))
   }
 
   test("Fallback to shuffled join should remove equivalent failed broadcast stages") {
@@ -1114,6 +1421,28 @@ class AdaptiveQueryExecSuite
 
     assert(remainingLogicalStages.size == 1)
     assert(remainingLogicalStages.head.physicalPlan.eq(otherStage))
+  }
+
+  private def containsBroadcastLimitError(error: Throwable): Boolean = {
+    val errors = new scala.collection.mutable.ArrayDeque[Throwable]()
+    if (error != null) {
+      errors.append(error)
+    }
+    while (errors.nonEmpty) {
+      val current = errors.removeHead()
+      if (current.isInstanceOf[org.apache.spark.SparkThrowable] &&
+          (current.asInstanceOf[org.apache.spark.SparkThrowable]
+            .getCondition == "_LEGACY_ERROR_TEMP_2248" ||
+            current.asInstanceOf[org.apache.spark.SparkThrowable]
+              .getCondition == "_LEGACY_ERROR_TEMP_2249")) {
+        return true
+      }
+      if (current.getCause != null) {
+        errors.append(current.getCause)
+      }
+      errors.appendAll(current.getSuppressed)
+    }
+    false
   }
 
   test("Union/Except/Intersect queries") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds an opt-in AQE fallback path for broadcast join failures caused by broadcast table size/row limits.

When `spark.sql.adaptive.broadcastJoin.fallbackToShuffle.enabled` is enabled, AQE catches qualifying broadcast stage failures and retries adaptive replanning with broadcast joins disabled, so the query can proceed with shuffle-based joins (for example SMJ/SHJ) instead of failing immediately.

The change also includes safety checks to avoid repeatedly retrying the same failed broadcast relation, and test coverage in `AdaptiveQueryExecSuite`.

### Why are the changes needed?

Today, a query can fail if a planned broadcast side exceeds runtime broadcast limits, even though a shuffle join strategy could still complete successfully.

This PR provides a controlled fallback path to improve robustness for those cases while keeping existing behavior unchanged by default.

### Does this PR introduce _any_ user-facing change?

Yes.

A new SQL config is added:

- `spark.sql.adaptive.broadcastJoin.fallbackToShuffle.enabled` (default: `false`)

When enabled, queries that would otherwise fail due to broadcast table row/size limits may instead continue with shuffle-based joins. When disabled, existing behavior remains unchanged.

### How was this patch tested?

- Added/updated unit tests in `sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala`, including:
  - fallback enable/disable behavior
  - preserving required input broadcast exchange behavior
  - rejecting fallback replans that still contain the failed broadcast relation
- Ran AQE adaptive query test coverage relevant to the new fallback path.
- Manually validated with real jobs that the plan can transition from initial BHJ to final SMJ under AQE when fallback is enabled.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Yes, Codex 5.3 High with a lot of harnessing