### PR TITLE
[SPARK-56100][SQL] Fail the query when IN list has no left-hand column or expression in the where clause

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4372,12 +4372,6 @@
           "IN predicate requires at least one value. Empty IN clauses like 'IN ()' are not allowed. Consider using 'WHERE FALSE' if you need an always-false condition, or provide at least one value in the IN list."
         ]
       },
-      "MISSING_COLUMN_BEFORE_IN" : {
-        "message" : [
-          "Invalid IN predicate: a column or expression must appear before IN and its parenthesized value list.",
-          "For example, use `WHERE id IN (1, 2)` instead of `WHERE IN (1, 2)` or `WHERE in (1)` with no expression before `in`."
-        ]
-      },
       "EMPTY_PARTITION_VALUE" : {
         "message" : [
           "Partition key <partKey> must set value."
@@ -4411,6 +4405,12 @@
       "LATERAL_WITHOUT_SUBQUERY_OR_TABLE_VALUED_FUNC" : {
         "message" : [
           "LATERAL can only be used with subquery and table-valued functions."
+        ]
+      },
+      "MISSING_COLUMN_BEFORE_IN" : {
+        "message" : [
+          "Invalid IN predicate: a column or expression must appear before IN and its parenthesized value list.",
+          "For example, use `WHERE id IN (1, 2)` instead of `WHERE IN (1, 2)` or `WHERE in (1)` with no expression before `in`."
         ]
       },
       "MULTI_PART_NAME" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4372,6 +4372,14 @@
           "IN predicate requires at least one value. Empty IN clauses like 'IN ()' are not allowed. Consider using 'WHERE FALSE' if you need an always-false condition, or provide at least one value in the IN list."
         ]
       },
+      "MISSING_COLUMN_BEFORE_IN" : {
+        "message" : [
+          "Column name is missing before IN clause.", 
+          "Expected syntax: <column> IN (value1, value2, ...)", 
+          "Found: IN (values)",
+          "For example: SELECT * FROM t WHERE id IN (1, 2)"
+        ]
+      },
       "EMPTY_PARTITION_VALUE" : {
         "message" : [
           "Partition key <partKey> must set value."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4374,10 +4374,8 @@
       },
       "MISSING_COLUMN_BEFORE_IN" : {
         "message" : [
-          "Column name is missing before IN clause.", 
-          "Expected syntax: <column> IN (value1, value2, ...)", 
-          "Found: IN (values)",
-          "For example: SELECT * FROM t WHERE id IN (1, 2)"
+          "Invalid IN predicate: a column or expression must appear before IN and its parenthesized value list.",
+          "For example, use `WHERE id IN (1, 2)` instead of `WHERE IN (1, 2)` or `WHERE in (1)` with no expression before `in`."
         ]
       },
       "EMPTY_PARTITION_VALUE" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -302,6 +302,10 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
       case u: UnresolvedRelation =>
         u.tableNotFound(u.multipartIdentifier)
 
+      // Rare: identifier "in" as column + IN (list) when "in" is a valid unquoted identifier.
+      case f @ Filter(In(UnresolvedAttribute(Seq(name)), _), _) if name.equalsIgnoreCase("in") =>
+        throw QueryCompilationErrors.missingColumnBeforeInError(f.condition.origin)
+
       case u: UnresolvedFunctionName =>
         val catalogPath = currentCatalog.name +: catalogManager.currentNamespace
         val searchPath = SQLConf.get.resolutionSearchPath(catalogPath.toSeq)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -924,7 +924,7 @@ object FunctionRegistry {
     // predicates
     expression[Between]("between"),
     expression[And]("and"),
-    expression[In]("in"),
+    expressionBuilder("in", InPredicateExpressionBuilder),
     expression[Not]("not"),
     expression[Or]("or"),
 
@@ -1344,6 +1344,29 @@ object TableFunctionRegistry {
  * representations are constructed in [[FunctionRegistry]].
  */
 trait ExpressionBuilder extends FunctionBuilderBase[Expression]
+
+/**
+ * SQL `in(col, v1, ...)` as a function. Rejects:
+ *   - `in(v)` — how `WHERE in (v)` is parsed (column omitted before IN list).
+ *   - `in(v1, v2, ...)` when every argument is a [[Literal]] — how
+ *     `WHERE IN ('a','b','c')` / `DELETE ... WHERE IN (...)` is parsed (no column).
+ * Legitimate `in(col, v1, v2)` has a non-literal first argument (the column).
+ */
+private[analysis] object InPredicateExpressionBuilder extends ExpressionBuilder {
+  override def build(funcName: String, expressions: Seq[Expression]): Expression = {
+    expressions.length match {
+      case 0 =>
+        throw QueryCompilationErrors.wrongNumArgsError(funcName, Seq(2), 0)
+      case 1 =>
+        throw QueryCompilationErrors.missingColumnBeforeInError(expressions.head.origin)
+      case _ =>
+        if (expressions.forall(_.isInstanceOf[Literal])) {
+          throw QueryCompilationErrors.missingColumnBeforeInError(expressions.head.origin)
+        }
+        In(expressions.head, expressions.tail)
+    }
+  }
+}
 
 /**
  * This is a trait used for table valued functions that defines how their expression

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -453,6 +453,14 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = commonParam ++ proposalParam)
   }
 
+  def missingColumnBeforeInError(origin: Origin): Throwable = {
+    new AnalysisException(
+      errorClass = "INVALID_SQL_SYNTAX.MISSING_COLUMN_BEFORE_IN",
+      messageParameters = Map.empty,
+      origin = origin
+    )
+  }
+
   def unresolvedFieldError(
       fieldName: String,
       columnPath: Seq[String],

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -1062,6 +1062,39 @@ class AnalysisErrorSuite extends AnalysisTest with DataTypeErrorsBase {
         "expressionList" -> "max(DISTINCT b)"))
   }
 
+  test("Error when column name is missing before IN in WHERE clause") {
+    val a = AttributeReference("a", StringType)()
+    val plan = Filter(
+      In(UnresolvedAttribute("in"), Seq(Literal("2024-07-05"))),
+      LocalRelation(a))
+    assertAnalysisErrorCondition(plan,
+      expectedErrorCondition = "INVALID_SQL_SYNTAX.MISSING_COLUMN_BEFORE_IN",
+      expectedMessageParameters = Map.empty)
+  }
+
+  test("Error when WHERE uses in(v) as function — same as Spark SQL WHERE in (1)") {
+    val a = AttributeReference("id", IntegerType)()
+    val plan = Filter(
+      UnresolvedFunction("in", Seq(Literal(1)), isDistinct = false),
+      LocalRelation(a))
+    assertAnalysisErrorCondition(plan,
+      expectedErrorCondition = "INVALID_SQL_SYNTAX.MISSING_COLUMN_BEFORE_IN",
+      expectedMessageParameters = Map.empty)
+  }
+
+  test("Error when in(...) has only literals — no column before IN list (e.g. WHERE IN (v1,v2,...))") {
+    val a = AttributeReference("id", IntegerType)()
+    val plan = Filter(
+      UnresolvedFunction(
+        "in",
+        Seq(Literal(1), Literal(2), Literal(3)),
+        isDistinct = false),
+      LocalRelation(a))
+    assertAnalysisErrorCondition(plan,
+      expectedErrorCondition = "INVALID_SQL_SYNTAX.MISSING_COLUMN_BEFORE_IN",
+      expectedMessageParameters = Map.empty)
+  }
+
   test("SPARK-30811: CTE should not cause stack overflow when " +
     "it refers to non-existent table with same name") {
     val plan = UnresolvedWith(


### PR DESCRIPTION

### What changes were proposed in this pull request?
This PR rejects invalid IN predicates where the parser never attaches a left-hand value expression (column or expression) before the IN list, and surfaces a single clear analysis error instead of allowing the query to run in a misleading way.
* error-conditions.json: add INVALID_SQL_SYNTAX.MISSING_COLUMN_BEFORE_IN 
* FunctionRegistry: register builtin in with InPredicateExpressionBuilder so shapes that parse as in(<literal>) or in(<literals only...>) (e.g. WHERE in (1), WHERE IN (1, 2)) fail with that condition.
* CheckAnalysis: handle Filter(In(UnresolvedAttribute("in"), …)) when in is an unquoted identifier used as the left side of IN (...).
* QueryCompilationErrors: missingColumnBeforeInError(origin) throwing AnalysisException with the new condition and SQL origin.

Closes: https://issues.apache.org/jira/browse/SPARK-56100


### Why are the changes needed?
WHERE clauses that omit the column or expression before IN—for example treating IN (1, 2) as if it were a standalone predicate—are not valid SQL. In Spark, those cases could still run successfully while not applying the filter the user thought they had written. That is easy to misread as “the query worked,” when in reality the IN list was not doing what the author assumed, which is a dangerous silent logical error rather than a loud failure. This PR fails analysis with a dedicated INVALID_SQL_SYNTAX subcondition so users immediately see that the predicate is malformed and how to write it correctly (e.g. WHERE id IN (1, 2)).

### Does this PR introduce _any_ user-facing change?
Yes

Before: For invalid IN usage with no column or expression on the left (e.g. WHERE IN (1, 2)), the query could finish without error, so it looked like the IN condition was applied when it was not, a misleading success.
After: The same invalid pattern fails at analysis time with an AnalysisException and condition INVALID_SQL_SYNTAX.MISSING_COLUMN_BEFORE_IN, plus a short explanation and examples.
Example:
SELECT * FROM t WHERE IN (1, 2);
-- After this PR: analysis fails with INVALID_SQL_SYNTAX.MISSING_COLUMN_BEFORE_IN

-- Intended form:
SELECT * FROM t WHERE id IN (1, 2);


### How was this patch tested?
New unit tests in AnalysisErrorSuite: three cases using assertAnalysisErrorCondition / checkError so analyzer.checkAnalysis(analyzer.execute(plan)) fails with condition INVALID_SQL_SYNTAX.MISSING_COLUMN_BEFORE_IN and empty parameters (covers In(UnresolvedAttribute("in"), …), UnresolvedFunction("in", Seq(Literal)), and UnresolvedFunction("in", literals only)).

### Was this patch authored or co-authored using generative AI tooling?
Yes, Generated-by: Cursor 2.6.18


