### PR TITLE
[SPARK-56018][PYTHON][FOLLOW-UP] Disable black check by default

### DIFF
--- a/dev/lint-python
+++ b/dev/lint-python
@@ -33,7 +33,7 @@ function exit_with_usage {
   echo "lint-python - linter for Python"
   echo ""
   echo "usage:"
-  cl_options="[--compile] [--black] [--custom-pyspark-error] [--ruff] [--mypy] [--mypy-examples] [--mypy-data]"
+  cl_options="[--compile] [--custom-pyspark-error] [--ruff] [--mypy] [--mypy-examples] [--mypy-data]"
   echo "lint-python $cl_options"
   echo ""
   exit 1
@@ -74,9 +74,8 @@ while (( "$#" )); do
   shift
 done
 
-if [[ -z "$COMPILE_TEST$PYSPARK_CUSTOM_ERRORS_CHECK_TEST$FLAKE8_TEST$RUFF_TEST$MYPY_TEST$MYPY_EXAMPLES_TEST$MYPY_DATA_TEST" ]]; then
+if [[ -z "$COMPILE_TEST$BLACK_TEST$PYSPARK_CUSTOM_ERRORS_CHECK_TEST$FLAKE8_TEST$RUFF_TEST$MYPY_TEST$MYPY_EXAMPLES_TEST$MYPY_DATA_TEST" ]]; then
   COMPILE_TEST=true
-  BLACK_TEST=true
   PYSPARK_CUSTOM_ERRORS_CHECK_TEST=true
   RUFF_TEST=true
   MYPY_TEST=true


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of apache/spark#54840.

Disables black check by default.

### Why are the changes needed?

The python formatter moved from `black` to `ruff` at apache/spark#54840, but `lint-python` still runs the black check if no arguments are provided and there is `black` installed, causing many failures.

```sh
% ./dev/lint-python
starting python compilation test...
python compilation succeeded.

starting black test...
black checks failed:
...
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A

### Was this patch authored or co-authored using generative AI tooling?

No.
