### PR TITLE
[SPARK-56118][PS] Match pandas 3.0 bool handling in GroupBy.quantile

### DIFF
--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -754,12 +754,15 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         if not 0 <= q <= 1:
             raise ValueError("'q' must be between 0 and 1. Got '%s' instead" % q)
         if any(isinstance(_agg_col.spark.data_type, BooleanType) for _agg_col in self._agg_columns):
-            warnings.warn(
-                f"Allowing bool dtype in {self.__class__.__name__}.quantile is deprecated "
-                "and will raise in a future version, matching the Series/DataFrame behavior. "
-                "Cast to uint8 dtype before calling quantile instead.",
-                FutureWarning,
-            )
+            if LooseVersion(pd.__version__) < "3.0.0":
+                warnings.warn(
+                    f"Allowing bool dtype in {self.__class__.__name__}.quantile is deprecated "
+                    "and will raise in a future version, matching the Series/DataFrame behavior. "
+                    "Cast to uint8 dtype before calling quantile instead.",
+                    FutureWarning,
+                )
+            else:
+                raise TypeError("Cannot use quantile with bool dtype")
 
         return self._reduce_for_stat_function(
             lambda col: F.percentile_approx(col.cast(DoubleType()), q, accuracy),

--- a/python/pyspark/pandas/tests/groupby/test_stat_adv.py
+++ b/python/pyspark/pandas/tests/groupby/test_stat_adv.py
@@ -18,6 +18,7 @@
 import numpy as np
 import pandas as pd
 
+from pyspark.loose_version import LooseVersion
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
@@ -41,46 +42,72 @@ class GroupbyStatAdvMixin(GroupbyStatTestingFuncMixin):
         return ps.from_pandas(self.pdf)
 
     def test_quantile(self):
-        dfs = [
-            pd.DataFrame(
-                [["a", 1], ["a", 2], ["a", 3], ["b", 1], ["b", 3], ["b", 5]], columns=["key", "val"]
-            ),
-            pd.DataFrame(
-                [["a", True], ["a", True], ["a", False], ["b", True], ["b", True], ["b", False]],
-                columns=["key", "val"],
-            ),
-        ]
-        for df in dfs:
-            psdf = ps.from_pandas(df)
-            # q accept float and int between 0 and 1
-            for i in [0, 0.1, 0.5, 1]:
-                self.assert_eq(
-                    df.groupby("key").quantile(q=i, interpolation="lower"),
-                    psdf.groupby("key").quantile(q=i),
-                    almost=True,
-                )
-                self.assert_eq(
-                    df.groupby("key")["val"].quantile(q=i, interpolation="lower"),
-                    psdf.groupby("key")["val"].quantile(q=i),
-                    almost=True,
-                )
-            # raise ValueError when q not in [0, 1]
-            with self.assertRaises(ValueError):
-                psdf.groupby("key").quantile(q=1.1)
-            with self.assertRaises(ValueError):
-                psdf.groupby("key").quantile(q=-0.1)
-            with self.assertRaises(ValueError):
-                psdf.groupby("key").quantile(q=2)
-            with self.assertRaises(ValueError):
-                psdf.groupby("key").quantile(q=np.nan)
-            # raise TypeError when q type mismatch
-            with self.assertRaises(TypeError):
-                psdf.groupby("key").quantile(q="0.1")
-            # raise NotImplementedError when q is list like type
-            with self.assertRaises(NotImplementedError):
-                psdf.groupby("key").quantile(q=(0.1, 0.5))
-            with self.assertRaises(NotImplementedError):
-                psdf.groupby("key").quantile(q=[0.1, 0.5])
+        df = pd.DataFrame(
+            [["a", 1], ["a", 2], ["a", 3], ["b", 1], ["b", 3], ["b", 5]], columns=["key", "val"]
+        )
+        boolean_df = pd.DataFrame(
+            [["a", True], ["a", True], ["a", False], ["b", True], ["b", True], ["b", False]],
+            columns=["key", "val"],
+        )
+
+        if LooseVersion(pd.__version__) < "3.0.0":
+            dfs = [df, boolean_df]
+            error_dfs = []
+        else:
+            dfs = [df]
+            error_dfs = [boolean_df]
+
+        for i, pdf in enumerate(dfs):
+            with self.subTest(i=i):
+                psdf = ps.from_pandas(pdf)
+                # q accept float and int between 0 and 1
+                for q in [0, 0.1, 0.5, 1]:
+                    with self.subTest(q=q):
+                        self.assert_eq(
+                            pdf.groupby("key").quantile(q=q, interpolation="lower"),
+                            psdf.groupby("key").quantile(q=q),
+                            almost=True,
+                        )
+                        self.assert_eq(
+                            pdf.groupby("key")["val"].quantile(q=q, interpolation="lower"),
+                            psdf.groupby("key")["val"].quantile(q=q),
+                            almost=True,
+                        )
+
+        for i, pdf in enumerate(error_dfs):
+            with self.subTest(i=i):
+                psdf = ps.from_pandas(pdf)
+                for q in [0, 0.1, 0.5, 1]:
+                    with self.subTest(q=q):
+                        with self.assertRaisesRegex(
+                            TypeError, "Cannot use quantile with bool dtype"
+                        ):
+                            psdf.groupby("key").quantile(q=q)
+                        with self.assertRaisesRegex(
+                            TypeError, "Cannot use quantile with bool dtype"
+                        ):
+                            psdf.groupby("key")["val"].quantile(q=q)
+
+        for i, pdf in enumerate([df, boolean_df]):
+            with self.subTest(i=i):
+                psdf = ps.from_pandas(pdf)
+                # raise ValueError when q not in [0, 1]
+                with self.assertRaises(ValueError):
+                    psdf.groupby("key").quantile(q=1.1)
+                with self.assertRaises(ValueError):
+                    psdf.groupby("key").quantile(q=-0.1)
+                with self.assertRaises(ValueError):
+                    psdf.groupby("key").quantile(q=2)
+                with self.assertRaises(ValueError):
+                    psdf.groupby("key").quantile(q=np.nan)
+                # raise TypeError when q type mismatch
+                with self.assertRaises(TypeError):
+                    psdf.groupby("key").quantile(q="0.1")
+                # raise NotImplementedError when q is list like type
+                with self.assertRaises(NotImplementedError):
+                    psdf.groupby("key").quantile(q=(0.1, 0.5))
+                with self.assertRaises(NotImplementedError):
+                    psdf.groupby("key").quantile(q=[0.1, 0.5])
 
     def test_first(self):
         self._test_stat_func(lambda groupby_obj: groupby_obj.first())

--- a/python/pyspark/pandas/tests/groupby/test_stat_adv.py
+++ b/python/pyspark/pandas/tests/groupby/test_stat_adv.py
@@ -74,6 +74,7 @@ class GroupbyStatAdvMixin(GroupbyStatTestingFuncMixin):
                             almost=True,
                         )
 
+        # raise TypeError when bool dtype with pandas 3
         for i, pdf in enumerate(error_dfs):
             with self.subTest(i=i):
                 psdf = ps.from_pandas(pdf)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates pandas API on Spark `GroupBy.quantile` to align its bool-dtype behavior with pandas 3.0.

Currently, `GroupBy.quantile` allows bool input and emits a `FutureWarning`. With this change, pandas API on Spark keeps that warning-based behavior when running against pandas versions earlier than 3.0, but raises `TypeError("Cannot use quantile with bool dtype")` when running with pandas 3.0 or later.

The related groupby quantile tests were also updated to cover both version-dependent paths:
- normal quantile behavior for numeric data
- warning-compatible behavior for bool data on pandas < 3.0
- `TypeError` for bool data on pandas >= 3.0
- existing invalid `q` input checks

### Why are the changes needed?

pandas 3.0 no longer allows `quantile` on bool dtype. pandas API on Spark should follow that behavior so groupby quantile results stay consistent with the pandas version it targets.

Without this change, pandas API on Spark would continue accepting bool input under pandas 3.0 and diverge from pandas behavior.

### Does this PR introduce _any_ user-facing change?

Yes, it will behave more like pandas 3.

### How was this patch tested?

Updated the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
