### PR TITLE
[SPARK-55690][SQL][Follow-up] Fix dead references

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1567,7 +1567,7 @@ class Analyzer(
                 // assignments will be added by ResolveRowLevelCommandAssignments later.
                 val assignments = if (m.schemaEvolutionEnabled) {
                   // For schema evolution case, generate assignments for missing target columns.
-                  // These columns will be added by ResolveMergeIntoTableSchemaEvolution later.
+                  // These columns will be added by ResolveSchemaEvolution later.
                   sourceTable.output.map { sourceAttr =>
                     val key = findAttrInTarget(sourceAttr.name).getOrElse(
                       UnresolvedAttribute(sourceAttr.name))
@@ -1603,7 +1603,7 @@ class Analyzer(
                 // assignments will be added by ResolveRowLevelCommandAssignments later.
                 val assignments = if (m.schemaEvolutionEnabled) {
                   // For schema evolution case, generate assignments for missing target columns.
-                  // These columns will be added by ResolveMergeIntoTableSchemaEvolution later.
+                  // These columns will be added by ResolveSchemaEvolution later.
                   sourceTable.output.map { sourceAttr =>
                     val key = findAttrInTarget(sourceAttr.name).getOrElse(
                       UnresolvedAttribute(sourceAttr.name))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -1016,7 +1016,7 @@ case class MergeIntoTable(
 
   // Guard that assignments are either resolved or candidates for evolution before
   // evaluating schema evolution. We need to use resolved assignment values to check
-  // candidates, see MergeIntoTable.isSchemaEvolutionCandidate for details.
+  // candidates; see `isSchemaEvolutionCandidate` in the MergeIntoTable companion object.
   override lazy val schemaEvolutionReady: Boolean = {
     targetTable.resolved && sourceTable.resolved && actionsSchemaEvolutionReady
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/DataTypeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/DataTypeUtils.scala
@@ -258,39 +258,6 @@ object DataTypeUtils {
   }
 
   /**
-   * Extracts all struct field paths from a nested StructType.
-   */
-  def extractAllFieldPaths(schema: StructType, basePath: Seq[String] = Seq.empty):
-  Seq[Seq[String]] = {
-    schema.flatMap { field =>
-      val fieldPath = basePath :+ field.name
-      field.dataType match {
-        case struct: StructType =>
-          fieldPath +: extractAllFieldPaths(struct, fieldPath)
-        case _ =>
-          Seq(fieldPath)
-      }
-    }
-  }
-
-  /**
-   * Extracts only leaf-level field paths from a nested StructType.
-   * Unlike extractAllFieldPaths, this method does not include intermediate struct paths.
-   */
-  def extractLeafFieldPaths(schema: StructType, basePath: Seq[String] = Seq.empty):
-  Seq[Seq[String]] = {
-    schema.flatMap { field =>
-      val fieldPath = basePath :+ field.name
-      field.dataType match {
-        case struct: StructType =>
-          extractLeafFieldPaths(struct, fieldPath)
-        case _ =>
-          Seq(fieldPath)
-      }
-    }
-  }
-
-  /**
    * Returns true if the two StringTypes have the same base type, i.e., both are [[CharType]],
    * both are [[VarcharType]], or both are plain [[StringType]].
    */


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up cleanup after [merge / V2 write schema evolution refactors](https://github.com/apache/spark/pull/54488):

- Remove unused `DataTypeUtils.extractAllFieldPaths` and `extractLeafFieldPaths` (no call sites).
- Update `Analyzer` comments that still referred to the removed rule name `ResolveMergeIntoTableSchemaEvolution`; the rule is now `ResolveSchemaEvolution`.
- Clarify the `MergeIntoTable.schemaEvolutionReady` comment: `isSchemaEvolutionCandidate` lives on the companion object and is private.

### Why are the changes needed?

Avoid misleading references to deleted APIs and dead utility code.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Existing tests; change is comment + unused API removal only.