### PR TITLE
[SPARK-56122][PS] Use pandas-aware numeric dtype check in Series.cov

### DIFF
--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -54,6 +54,7 @@ from pandas.api.extensions import no_default
 from pandas.api.types import (
     is_list_like,
     is_hashable,
+    is_numeric_dtype,
     CategoricalDtype,
 )
 from pandas.tseries.frequencies import DateOffset  # type: ignore[attr-defined]
@@ -1092,9 +1093,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         """
         if not isinstance(other, Series):
             raise TypeError("unsupported type: %s" % type(other))
-        if not np.issubdtype(self.dtype, np.number):  # type: ignore[arg-type]
+        if not is_numeric_dtype(self.dtype):
             raise TypeError("unsupported dtype: %s" % self.dtype)
-        if not np.issubdtype(other.dtype, np.number):  # type: ignore[arg-type]
+        if not is_numeric_dtype(other.dtype):
             raise TypeError("unsupported dtype: %s" % other.dtype)
         if not isinstance(ddof, int):
             raise TypeError("ddof must be integer")

--- a/python/pyspark/pandas/tests/series/test_stat.py
+++ b/python/pyspark/pandas/tests/series/test_stat.py
@@ -630,9 +630,9 @@ class SeriesStatMixin:
             index=[0, 1, 2],
         )
         psdf = ps.from_pandas(pdf)
-        with self.assertRaisesRegex(TypeError, "unsupported dtype: object"):
+        with self.assertRaisesRegex(TypeError, "unsupported dtype: (object|str)"):
             psdf["s1"].cov(psdf["s2"])
-        with self.assertRaisesRegex(TypeError, "unsupported dtype: object"):
+        with self.assertRaisesRegex(TypeError, "unsupported dtype: (object|str)"):
             psdf["s2"].cov(psdf["s1"])
         with self.assertRaisesRegex(TypeError, "ddof must be integer"):
             psdf["s2"].cov(psdf["s2"], ddof="ddof")
@@ -654,6 +654,29 @@ class SeriesStatMixin:
             index=[0, 1, 2, 3],
         )
         self._test_cov(pdf)
+
+        # Extension Dtypes
+        pdf = pd.DataFrame(
+            {
+                "s1": pd.Series([0.90010907, None, 0.13484424, 0.62036035], dtype="Float64"),
+                "s2": pd.Series([0.12528585, 0.81131178, 0.26962463, 0.51111198], dtype="Float64"),
+            },
+            index=[0, 1, 2, 3],
+        )
+        self._test_cov(pdf)
+
+        pdf = pd.DataFrame(
+            {
+                "s1": pd.Series(["a", "b", "c"], dtype="string"),
+                "s2": pd.Series([0.12528585, 0.26962463, 0.51111198], dtype="Float64"),
+            },
+            index=[0, 1, 2],
+        )
+        psdf = ps.from_pandas(pdf)
+        with self.assertRaisesRegex(TypeError, "unsupported dtype: (object|str)"):
+            psdf["s1"].cov(psdf["s2"])
+        with self.assertRaisesRegex(TypeError, "unsupported dtype: (object|str)"):
+            psdf["s2"].cov(psdf["s1"])
 
     def _test_cov(self, pdf):
         psdf = ps.from_pandas(pdf)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates `pyspark.pandas.Series.cov` to use pandas' `is_numeric_dtype` instead of `np.issubdtype(..., np.number)` when validating the input Series dtypes.

The previous NumPy-based check works for plain NumPy dtypes, but it raises a `TypeError` for pandas extension dtypes such as `StringDtype`, which causes `Series.cov` to fail before it reaches the intended `unsupported dtype` error path.

This PR also updates the related `Series.cov` tests to:
- accept the dtype name shown by both pandas 2 (`object`) and pandas 3 (`str`) for non-numeric string inputs
- add extension dtype coverage for nullable `Float64`
- add a string extension dtype case using pandas `"string"`

### Why are the changes needed?

With pandas 3, `Series(["a", "b", "c"]).dtype` is a pandas extension dtype (`StringDtype`), and `np.issubdtype(self.dtype, np.number)` raises:

`TypeError: Cannot interpret '<StringDtype(na_value=nan)>' as a data type`

That means `Series.cov` fails in dtype validation instead of returning the expected `TypeError("unsupported dtype: ...")`.

Using `is_numeric_dtype` is more appropriate here because it is pandas-aware and works with both NumPy dtypes and pandas extension dtypes. This keeps the existing behavior for numeric inputs while making the validation path robust across pandas versions.

### Does this PR introduce _any_ user-facing change?

Yes.

For pandas extension dtypes such as pandas 3 string dtype, `pyspark.pandas.Series.cov` now raises the intended `TypeError("unsupported dtype: ...")` instead of failing earlier with a NumPy dtype interpretation error.

### How was this patch tested?

Added the related tests and the other existing tests should pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex GPT-5
