### PR TITLE
[SPARK-56126][INFRA][4.1] Sync `docker`-related GitHub Actions versions to the ASF approved patterns

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -412,7 +412,7 @@ jobs:
       packages: write
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -432,13 +432,13 @@ jobs:
           git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
           git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - name: Build and push for branch-3.5
         if: inputs.branch == 'branch-3.5'
         id: docker_build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/infra/
           push: true
@@ -449,7 +449,7 @@ jobs:
       - name: Build and push (Documentation)
         if: ${{ inputs.branch != 'branch-3.5' && fromJson(needs.precondition.outputs.required).docs == 'true' && hashFiles('dev/spark-test-image/docs/Dockerfile') != '' }}
         id: docker_build_docs
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/docs/
           push: true
@@ -460,7 +460,7 @@ jobs:
       - name: Build and push (Linter)
         if: ${{ inputs.branch != 'branch-3.5' && fromJson(needs.precondition.outputs.required).lint == 'true' && hashFiles('dev/spark-test-image/lint/Dockerfile') != '' }}
         id: docker_build_lint
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/lint/
           push: true
@@ -471,7 +471,7 @@ jobs:
       - name: Build and push (SparkR)
         if: ${{ inputs.branch != 'branch-3.5' && fromJson(needs.precondition.outputs.required).sparkr == 'true' && hashFiles('dev/spark-test-image/sparkr/Dockerfile') != '' }}
         id: docker_build_sparkr
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/sparkr/
           push: true
@@ -483,7 +483,7 @@ jobs:
         if: ${{ inputs.branch != 'branch-3.5' && (fromJson(needs.precondition.outputs.required).pyspark == 'true' || fromJson(needs.precondition.outputs.required).pyspark-pandas == 'true') && env.PYSPARK_IMAGE_TO_TEST != '' }}
         id: docker_build_pyspark
         env: ${{ fromJSON(inputs.envs) }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/${{ env.PYSPARK_IMAGE_TO_TEST }}/
           push: true

--- a/.github/workflows/build_infra_images_cache.yml
+++ b/.github/workflows/build_infra_images_cache.yml
@@ -55,18 +55,18 @@ jobs:
       - name: Checkout Spark repository
         uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/infra/
           push: true
@@ -78,7 +78,7 @@ jobs:
       - name: Build and push (Documentation)
         if: hashFiles('dev/spark-test-image/docs/Dockerfile') != ''
         id: docker_build_docs
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/docs/
           push: true
@@ -91,7 +91,7 @@ jobs:
       - name: Build and push (Linter)
         if: hashFiles('dev/spark-test-image/lint/Dockerfile') != ''
         id: docker_build_lint
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/lint/
           push: true
@@ -104,7 +104,7 @@ jobs:
       - name: Build and push (SparkR)
         if: hashFiles('dev/spark-test-image/sparkr/Dockerfile') != ''
         id: docker_build_sparkr
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/sparkr/
           push: true
@@ -117,7 +117,7 @@ jobs:
       - name: Build and push (PySpark with old dependencies)
         if: hashFiles('dev/spark-test-image/python-minimum/Dockerfile') != ''
         id: docker_build_pyspark_python_minimum
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/python-minimum/
           push: true
@@ -130,7 +130,7 @@ jobs:
       - name: Build and push (PySpark PS with old dependencies)
         if: hashFiles('dev/spark-test-image/python-ps-minimum/Dockerfile') != ''
         id: docker_build_pyspark_python_ps_minimum
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/python-ps-minimum/
           push: true
@@ -143,7 +143,7 @@ jobs:
       - name: Build and push (PySpark with PyPy 3.10)
         if: hashFiles('dev/spark-test-image/pypy-310/Dockerfile') != ''
         id: docker_build_pyspark_pypy_310
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/pypy-310/
           push: true
@@ -156,7 +156,7 @@ jobs:
       - name: Build and push (PySpark with Python 3.10)
         if: hashFiles('dev/spark-test-image/python-310/Dockerfile') != ''
         id: docker_build_pyspark_python_310
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/python-310/
           push: true
@@ -169,7 +169,7 @@ jobs:
       - name: Build and push (PySpark with Python 3.11)
         if: hashFiles('dev/spark-test-image/python-311/Dockerfile') != ''
         id: docker_build_pyspark_python_311
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/python-311/
           push: true
@@ -182,7 +182,7 @@ jobs:
       - name: Build and push (PySpark Classic Only with Python 3.11)
         if: hashFiles('dev/spark-test-image/python-311-classic-only/Dockerfile') != ''
         id: docker_build_pyspark_python_311_classic_only
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/python-311-classic-only/
           push: true
@@ -195,7 +195,7 @@ jobs:
       - name: Build and push (PySpark with Python 3.12)
         if: hashFiles('dev/spark-test-image/python-312/Dockerfile') != ''
         id: docker_build_pyspark_python_312
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/python-312/
           push: true
@@ -208,7 +208,7 @@ jobs:
       - name: Build and push (PySpark with Python 3.13)
         if: hashFiles('dev/spark-test-image/python-313/Dockerfile') != ''
         id: docker_build_pyspark_python_313
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/python-313/
           push: true
@@ -221,7 +221,7 @@ jobs:
       - name: Build and push (PySpark with Python 3.13 no GIL)
         if: hashFiles('dev/spark-test-image/python-313-nogil/Dockerfile') != ''
         id: docker_build_pyspark_python_313_nogil
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/python-313-nogil/
           push: true
@@ -234,7 +234,7 @@ jobs:
       - name: Build and push (PySpark with Python 3.14)
         if: hashFiles('dev/spark-test-image/python-314/Dockerfile') != ''
         id: docker_build_pyspark_python_314
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/python-314/
           push: true
@@ -247,7 +247,7 @@ jobs:
       - name: Build and push (PySpark with Numpy 2.1.3)
         if: hashFiles('dev/spark-test-image/numpy-213/Dockerfile') != ''
         id: docker_build_pyspark_numpy_213
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/numpy-213/
           push: true


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to sync `docker`-related GitHub Actions versions to the ASF approved patterns.

### Why are the changes needed?

Currently, the `branch-4.1` CI is blocked by the ASF check because of the recent change.
- https://github.com/apache/spark/actions/workflows/build_branch41_non_ansi.yml
  - https://github.com/apache/spark/actions/runs/23370546081

  > The actions docker/login-action@v3, docker/setup-qemu-action@v3, docker/setup-buildx-action@v3, and docker/build-push-action@v6 are not allowed in apache/spark because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns:

This is due to the following change.
- https://github.com/apache/infrastructure-actions/pull/547

As of now, the updated patterns are the following.

- https://github.com/apache/infrastructure-actions/blob/07f5f9d2b05fe0ec9886e3ef0a9d79797817f0cb/approved_patterns.yml#L100-L104
```
- docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
- docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
- docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051
- docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
- docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually check like the following because the updated CI should be triggered manually.

```
$ git grep 'uses: docker' | sort | uniq -c
   5 .github/workflows/build_and_test.yml:        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
   1 .github/workflows/build_and_test.yml:        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
   1 .github/workflows/build_and_test.yml:        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
   1 .github/workflows/build_and_test.yml:        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
  15 .github/workflows/build_infra_images_cache.yml:        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
   1 .github/workflows/build_infra_images_cache.yml:        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
   1 .github/workflows/build_infra_images_cache.yml:        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
   1 .github/workflows/build_infra_images_cache.yml:        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)