### PR TITLE
[SPARK-56126][INFRA][4.0] Sync `docker`-related GitHub Actions versions to the ASF approved patterns

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -404,7 +404,7 @@ jobs:
       packages: write
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -424,13 +424,13 @@ jobs:
           git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
           git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - name: Build and push for branch-3.5
         if: inputs.branch == 'branch-3.5'
         id: docker_build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/infra/
           push: true
@@ -441,7 +441,7 @@ jobs:
       - name: Build and push (Documentation)
         if: ${{ inputs.branch != 'branch-3.5' && fromJson(needs.precondition.outputs.required).docs == 'true' && hashFiles('dev/spark-test-image/docs/Dockerfile') != '' }}
         id: docker_build_docs
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/docs/
           push: true
@@ -452,7 +452,7 @@ jobs:
       - name: Build and push (Linter)
         if: ${{ inputs.branch != 'branch-3.5' && fromJson(needs.precondition.outputs.required).lint == 'true' && hashFiles('dev/spark-test-image/lint/Dockerfile') != '' }}
         id: docker_build_lint
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/lint/
           push: true
@@ -463,7 +463,7 @@ jobs:
       - name: Build and push (SparkR)
         if: ${{ inputs.branch != 'branch-3.5' && fromJson(needs.precondition.outputs.required).sparkr == 'true' && hashFiles('dev/spark-test-image/sparkr/Dockerfile') != '' }}
         id: docker_build_sparkr
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/sparkr/
           push: true
@@ -475,7 +475,7 @@ jobs:
         if: ${{ inputs.branch != 'branch-3.5' && (fromJson(needs.precondition.outputs.required).pyspark == 'true' || fromJson(needs.precondition.outputs.required).pyspark-pandas == 'true') && env.PYSPARK_IMAGE_TO_TEST != '' }}
         id: docker_build_pyspark
         env: ${{ fromJSON(inputs.envs) }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/${{ env.PYSPARK_IMAGE_TO_TEST }}/
           push: true

--- a/.github/workflows/build_infra_images_cache.yml
+++ b/.github/workflows/build_infra_images_cache.yml
@@ -50,18 +50,18 @@ jobs:
       - name: Checkout Spark repository
         uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/infra/
           push: true
@@ -73,7 +73,7 @@ jobs:
       - name: Build and push (Documentation)
         if: hashFiles('dev/spark-test-image/docs/Dockerfile') != ''
         id: docker_build_docs
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/docs/
           push: true
@@ -86,7 +86,7 @@ jobs:
       - name: Build and push (Linter)
         if: hashFiles('dev/spark-test-image/lint/Dockerfile') != ''
         id: docker_build_lint
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/lint/
           push: true
@@ -99,7 +99,7 @@ jobs:
       - name: Build and push (SparkR)
         if: hashFiles('dev/spark-test-image/sparkr/Dockerfile') != ''
         id: docker_build_sparkr
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/sparkr/
           push: true
@@ -112,7 +112,7 @@ jobs:
       - name: Build and push (PySpark with old dependencies)
         if: hashFiles('dev/spark-test-image/python-minimum/Dockerfile') != ''
         id: docker_build_pyspark_python_minimum
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/python-minimum/
           push: true
@@ -125,7 +125,7 @@ jobs:
       - name: Build and push (PySpark PS with old dependencies)
         if: hashFiles('dev/spark-test-image/python-ps-minimum/Dockerfile') != ''
         id: docker_build_pyspark_python_ps_minimum
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/python-ps-minimum/
           push: true
@@ -138,7 +138,7 @@ jobs:
       - name: Build and push (PySpark with PyPy 3.10)
         if: hashFiles('dev/spark-test-image/pypy-310/Dockerfile') != ''
         id: docker_build_pyspark_pypy_310
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/pypy-310/
           push: true
@@ -151,7 +151,7 @@ jobs:
       - name: Build and push (PySpark with Python 3.9)
         if: hashFiles('dev/spark-test-image/python-309/Dockerfile') != ''
         id: docker_build_pyspark_python_309
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/python-309/
           push: true
@@ -164,7 +164,7 @@ jobs:
       - name: Build and push (PySpark with Python 3.10)
         if: hashFiles('dev/spark-test-image/python-310/Dockerfile') != ''
         id: docker_build_pyspark_python_310
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/python-310/
           push: true
@@ -177,7 +177,7 @@ jobs:
       - name: Build and push (PySpark with Python 3.11)
         if: hashFiles('dev/spark-test-image/python-311/Dockerfile') != ''
         id: docker_build_pyspark_python_311
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/python-311/
           push: true
@@ -190,7 +190,7 @@ jobs:
       - name: Build and push (PySpark with Python 3.12)
         if: hashFiles('dev/spark-test-image/python-312/Dockerfile') != ''
         id: docker_build_pyspark_python_312
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/python-312/
           push: true
@@ -203,7 +203,7 @@ jobs:
       - name: Build and push (PySpark with Python 3.13)
         if: hashFiles('dev/spark-test-image/python-313/Dockerfile') != ''
         id: docker_build_pyspark_python_313
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dev/spark-test-image/python-313/
           push: true


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to sync `docker`-related GitHub Actions versions to the ASF approved patterns.

### Why are the changes needed?

Currently, the `branch-4.0` CI is blocked by the ASF check because of the recent change.
- https://github.com/apache/spark/actions/workflows/build_branch40_non_ansi.yml
  - https://github.com/apache/spark/actions/runs/23370475022

  > The actions docker/login-action@v3, docker/setup-qemu-action@v3, docker/setup-buildx-action@v3, and docker/build-push-action@v6 are not allowed in apache/spark because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns:

This is due to the following change.
- https://github.com/apache/infrastructure-actions/pull/547

As of now, the updated patterns are the following.

- https://github.com/apache/infrastructure-actions/blob/07f5f9d2b05fe0ec9886e3ef0a9d79797817f0cb/approved_patterns.yml#L100-L104
```
- docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
- docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
- docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051
- docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
- docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually check like the following because the updated CI should be triggered manually.

```
$ git grep 'uses: docker' | sort | uniq -c
   5 .github/workflows/build_and_test.yml:        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
   1 .github/workflows/build_and_test.yml:        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
   1 .github/workflows/build_and_test.yml:        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
   1 .github/workflows/build_and_test.yml:        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
  12 .github/workflows/build_infra_images_cache.yml:        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
   1 .github/workflows/build_infra_images_cache.yml:        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
   1 .github/workflows/build_infra_images_cache.yml:        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
   1 .github/workflows/build_infra_images_cache.yml:        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)