### PR TITLE
[SPARK-55163][PYTHON][CONNECT] Reuse metadata plans for DataFrames

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -92,6 +92,8 @@ from pyspark.sql.pandas.functions import _validate_vectorized_udf  # type: ignor
 from pyspark.sql.table_arg import TableArg
 
 if TYPE_CHECKING:
+    import pyspark.sql.connect.proto as proto
+
     from pyspark.sql.connect._typing import (
         ColumnOrName,
         ColumnOrNameOrOrdinal,
@@ -147,10 +149,10 @@ class DataFrame(ParentDataFrame):
         self._execution_info: Optional["ExecutionInfo"] = None
 
     @functools.cached_property
-    def _metadata_plan(self):
+    def _metadata_plan(self) -> "proto.Plan":
         # Connect DataFrames are immutable on the client so metadata requests can safely
         # reuse the unresolved proto plan. Keeping metadata on one path also leaves a single
-        # insertion point for future session mscoped metadata caching
+        # insertion point for future session-scoped metadata caching
         try:
             session = self._session.client
         except (AttributeError, LookupError):

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -146,6 +146,21 @@ class DataFrame(ParentDataFrame):
         self._cached_schema_serialized: Optional[bytes] = None
         self._execution_info: Optional["ExecutionInfo"] = None
 
+    @functools.cached_property
+    def _metadata_plan(self):
+        # Connect DataFrames are immutable on the client so metadata requests can safely
+        # reuse the unresolved proto plan. Keeping metadata on one path also leaves a single
+        # insertion point for future session mscoped metadata caching
+        try:
+            session = self._session.client
+        except (AttributeError, LookupError):
+            # Plan only tests use a lightweight mock session without a .client property
+            session = self._session
+        return self._plan.to_proto(session)
+
+    def _resolve_schema(self) -> StructType:
+        return self._session.client.schema(self._metadata_plan)
+
     def __reduce__(self) -> Tuple:
         """
         Custom method for serializing the DataFrame object using Pickle. Since the DataFrame
@@ -1820,8 +1835,7 @@ class DataFrame(ParentDataFrame):
         # etc...) of the plan changes between the schema() call, and a subsequent action, the
         # cached schema might be inconsistent with the end schema.
         if self._cached_schema is None:
-            query = self._plan.to_proto(self._session.client)
-            self._cached_schema = self._session.client.schema(query)
+            self._cached_schema = self._resolve_schema()
             try:
                 self._cached_schema_serialized = CPickleSerializer().dumps(self._schema)
             except Exception as e:
@@ -1843,15 +1857,17 @@ class DataFrame(ParentDataFrame):
 
     @functools.cache
     def isLocal(self) -> bool:
-        query = self._plan.to_proto(self._session.client)
-        result = self._session.client._analyze(method="is_local", plan=query).is_local
+        result = self._session.client._analyze(
+            method="is_local", plan=self._metadata_plan
+        ).is_local
         assert result is not None
         return result
 
     @functools.cached_property
     def isStreaming(self) -> bool:
-        query = self._plan.to_proto(self._session.client)
-        result = self._session.client._analyze(method="is_streaming", plan=query).is_streaming
+        result = self._session.client._analyze(
+            method="is_streaming", plan=self._metadata_plan
+        ).is_streaming
         assert result is not None
         return result
 
@@ -1863,8 +1879,9 @@ class DataFrame(ParentDataFrame):
 
     @functools.cache
     def inputFiles(self) -> List[str]:
-        query = self._plan.to_proto(self._session.client)
-        result = self._session.client._analyze(method="input_files", plan=query).input_files
+        result = self._session.client._analyze(
+            method="input_files", plan=self._metadata_plan
+        ).input_files
         assert result is not None
         return result
 
@@ -1940,8 +1957,7 @@ class DataFrame(ParentDataFrame):
         elif is_extended_as_mode:
             explain_mode = cast(str, extended)
 
-        query = self._plan.to_proto(self._session.client)
-        return self._session.client.explain_string(query, explain_mode)
+        return self._session.client.explain_string(self._metadata_plan, explain_mode)
 
     def explain(
         self, extended: Optional[Union[bool, str]] = None, mode: Optional[str] = None
@@ -2147,14 +2163,14 @@ class DataFrame(ParentDataFrame):
             )
         other = self._check_same_session(other)
         return self._session.client.same_semantics(
-            plan=self._plan.to_proto(self._session.client),
-            other=other._plan.to_proto(other._session.client),
+            plan=self._metadata_plan,
+            other=other._metadata_plan,
         )
 
     @functools.cache
     def semanticHash(self) -> int:
         return self._session.client.semantic_hash(
-            plan=self._plan.to_proto(self._session.client),
+            plan=self._metadata_plan,
         )
 
     def writeTo(self, table: str) -> "DataFrameWriterV2":

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -152,13 +152,12 @@ class DataFrame(ParentDataFrame):
     def _metadata_plan(self) -> "proto.Plan":
         # Connect DataFrames are immutable on the client so metadata requests can safely
         # reuse the unresolved proto plan. Keeping metadata on one path also leaves a single
-        # insertion point for future session-scoped metadata caching
+        # insertion point for future session-scoped metadata caching.
         try:
-            session = self._session.client
+            return self._plan.to_proto(self._session.client)
         except (AttributeError, LookupError):
-            # Plan only tests use a lightweight mock session without a .client property
-            session = self._session
-        return self._plan.to_proto(session)
+            # Plan-only tests use a lightweight mock session without a .client property.
+            return self._plan.to_proto(cast(Any, self._session))
 
     def _resolve_schema(self) -> StructType:
         return self._session.client.schema(self._metadata_plan)

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1857,9 +1857,7 @@ class DataFrame(ParentDataFrame):
 
     @functools.cache
     def isLocal(self) -> bool:
-        result = self._session.client._analyze(
-            method="is_local", plan=self._metadata_plan
-        ).is_local
+        result = self._session.client._analyze(method="is_local", plan=self._metadata_plan).is_local
         assert result is not None
         return result
 

--- a/python/pyspark/sql/tests/connect/test_connect_dataframe_property.py
+++ b/python/pyspark/sql/tests/connect/test_connect_dataframe_property.py
@@ -16,6 +16,7 @@
 #
 
 import unittest
+from unittest.mock import patch
 
 from pyspark.sql.types import (
     StructType,
@@ -50,6 +51,61 @@ if should_test_connect:
 
 
 class SparkConnectDataFramePropertyTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
+    def test_metadata_plan_is_reused_across_metadata_access(self):
+        cdf = self.connect.range(10).withColumn("value2", CF.lit(1))
+        with patch.object(cdf._plan, "to_proto", wraps=cdf._plan.to_proto) as to_proto:
+            self.assertEqual(cdf.columns, ["id", "value2"])
+            self.assertEqual(cdf.schema.fieldNames(), ["id", "value2"])
+            self.assertIsInstance(cdf.isLocal(), bool)
+            self.assertIsInstance(cdf.isStreaming, bool)
+            self.assertEqual(list(cdf.inputFiles()), [])
+            self.assertIsInstance(cdf.semanticHash(), int)
+        self.assertEqual(to_proto.call_count, 1)
+
+    def test_same_object_metadata_uses_single_schema_rpc(self):
+        cdf = self.connect.range(10).withColumn("value2", CF.lit(1))
+
+        with patch.object(
+            cdf._session.client, "schema", wraps=cdf._session.client.schema
+        ) as schema:
+            self.assertEqual(cdf.columns, ["id", "value2"])
+            self.assertEqual(cdf.schema.fieldNames(), ["id", "value2"])
+            self.assertEqual([field for field, _ in cdf.dtypes], ["id", "value2"])
+            self.assertEqual(cdf.schema.fieldNames(), ["id", "value2"])
+
+        self.assertEqual(schema.call_count, 1)
+
+    def test_schema_preserving_metadata_reuses_cached_schema(self):
+        cdf = self.connect.range(10).withColumn("value2", CF.lit(1))
+
+        with patch.object(
+            cdf._session.client, "schema", wraps=cdf._session.client.schema
+        ) as schema:
+            self.assertEqual(cdf.schema.fieldNames(), ["id", "value2"])
+            self.assertEqual(schema.call_count, 1)
+
+            filtered = cdf.where(cdf.value2 > 0)
+            self.assertEqual(filtered.columns, ["id", "value2"])
+            self.assertEqual([field for field, _ in filtered.dtypes], ["id", "value2"])
+
+        self.assertEqual(schema.call_count, 1)
+
+    def test_schema_mutating_metadata_triggers_one_new_schema_rpc(self):
+        base = self.connect.range(10)
+
+        with patch.object(
+            base._session.client, "schema", wraps=base._session.client.schema
+        ) as schema:
+            self.assertEqual(base.schema.fieldNames(), ["id"])
+            self.assertEqual(schema.call_count, 1)
+
+            derived = base.withColumn("value2", CF.lit(1))
+            self.assertEqual(derived.columns, ["id", "value2"])
+            self.assertEqual(schema.call_count, 2)
+            self.assertEqual(derived.schema.fieldNames(), ["id", "value2"])
+
+        self.assertEqual(schema.call_count, 2)
+
     def test_cached_property_is_copied(self):
         schema = StructType(
             [

--- a/python/pyspark/sql/tests/connect/test_connect_plan.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan.py
@@ -19,6 +19,7 @@ import uuid
 import datetime
 import decimal
 import math
+from unittest.mock import patch
 
 from pyspark.testing.connectutils import (
     PlanOnlyTestFixture,
@@ -51,6 +52,13 @@ if should_test_connect:
 class SparkConnectPlanTests(PlanOnlyTestFixture):
     """These test cases exercise the interface to the proto plan
     generation but do not call Spark."""
+
+    def test_metadata_plan_is_cached(self):
+        df = self.connect.readTable(table_name=self.tbl_name)
+        with patch.object(df._plan, "to_proto", wraps=df._plan.to_proto) as to_proto:
+            self.assertIs(df._metadata_plan, df._metadata_plan)
+
+        self.assertEqual(to_proto.call_count, 1)
 
     def test_sql_project(self):
         plan = self.connect.sql("SELECT 1")._plan.to_proto(self.connect)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Hey everyone! I have been diving deeply into the Spark Connect Python DataFrame implementation, and this PR takes a small but, I believe promising, internal step toward tackling SPARK-55163.

While digging through the code, I noticed that several metadata-oriented paths were redundantly rebuilding the exact same unresolved Connect proto plan from an immutable DataFrame plan. To clean this up and make the path more explicit and reusable, I am introducing a private cached _metadata_plan helper.

- schema resolution
- `isLocal`
- `isStreaming`
- `inputFiles`
- `explain`
- `sameSemantics`
- `semanticHash`

I also wanted to make sure our current metadata behavior is really solid and easy to reason about, so I added a bunch of regression tests. The new tests specifically cover:

- repeated metadata access on the same object reusing a single proto-plan build
- repeated `schema` / `columns` access on the same object using a single schema RPC
- schema preserving transformations reusing cached schema
- schema mutating transformations triggering one new schema RPC
- a plan only test for `_metadata_plan` memoization without requiring full query execution

My goal was not to implement the full client side metadata cache proposed in SPARK-55163, but to land a focused and low risk foundation change that makes that future work easier.

### Why are the changes needed?

SPARK-55163 is motivated by the cost of repeated metadata access in Spark Connect.

Before moving on to a broader caching design, it seemed useful to first make the current metadata-resolution path more explicit and reusable. Reusing the unresolved proto plan gives these metadata operations a shared internal path and a clearer place to build on in follow-up work.

This change also avoids rebuilding the same proto plan repeatedly for metadata-only operations on the same immutable DataFrame, while adding regression coverage around the existing schema-caching behavior.

### How was this patch tested?

Built Spark locally with Hive enabled:

```bash
build/sbt -Phive clean package
```

Ran targeted Spark Connect tests with:

```bash
/Users/datun/miniconda3/bin/python3 -u ./python/run-tests.py \
  --python-executables /Users/datun/miniconda3/bin/python3 \
  -p 1 \
  --testnames \
"pyspark.sql.tests.connect.test_connect_plan SparkConnectPlanTests.test_metadata_plan_is_cached,\
pyspark.sql.tests.connect.test_connect_dataframe_property SparkConnectDataFramePropertyTests.test_metadata_plan_is_reused_across_metadata_access,\
pyspark.sql.tests.connect.test_connect_dataframe_property SparkConnectDataFramePropertyTests.test_same_object_metadata_uses_single_schema_rpc,\
pyspark.sql.tests.connect.test_connect_dataframe_property SparkConnectDataFramePropertyTests.test_schema_preserving_metadata_reuses_cached_schema,\
pyspark.sql.tests.connect.test_connect_dataframe_property SparkConnectDataFramePropertyTests.test_schema_mutating_metadata_triggers_one_new_schema_rpc,\
pyspark.sql.tests.connect.test_connect_basic,\
pyspark.sql.tests.connect.test_connect_plan"
```

Also ran broader Connect regression coverage with:

```bash
/Users/datun/miniconda3/bin/python3 -u ./python/run-tests.py \
  --python-executables /Users/datun/miniconda3/bin/python3 \
  -p 1 \
  --testnames pyspark.sql.tests.connect.test_connect_dataframe_property
```

```bash
/Users/datun/miniconda3/bin/python3 -u ./python/run-tests.py \
  --python-executables /Users/datun/miniconda3/bin/python3 \
  -p 1 \
  --testnames pyspark.sql.tests.connect.test_connect_readwriter
```