### PR TITLE
[SPARK-56128][K8S] Use Java `21-jre` instead of `21` image in K8s Dockerfile

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 ARG java_image_name=azul/zulu-openjdk
-ARG java_image_tag=21
+ARG java_image_tag=21-jre
 
 FROM ${java_image_name}:${java_image_tag}
 LABEL org.opencontainers.image.authors="Apache Spark project <dev@spark.apache.org>"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes the default Java base image tag from `21` (full JDK) to `21-jre` (JRE only) in the Spark Kubernetes Dockerfile for Apache Spark 4.2.0.

### Why are the changes needed?

Since Apache Spark 3.5, SPARK-44153 starts to use `jmap` for UI.
- https://github.com/apache/spark/pull/41709

Since Apache Spark 4.0, we used `21` by default.
- #45761

Since Apache Spark 4.2, we can use `21-jre` back by default because we removed `jmap` dependency.
- #54919

The JRE image is significantly smaller than the full JDK image since it excludes development tools (compiler, debugger, etc.) that are not needed at runtime. This reduces the Spark container image size for Kubernetes deployments.

```
$ docker images
IMAGE                                              ID             DISK USAGE   CONTENT SIZE   EXTRA
azul/zulu-openjdk:21                               4cfeb0cae1b1        651MB          203MB
azul/zulu-openjdk:21-jre                           27894d1c0e9d        461MB          114MB
```

### Does this PR introduce _any_ user-facing change?

No behavior change. In addition, users who need the full JDK can still override via `--build-arg java_image_tag=21`.

### How was this patch tested?

Pass the CIs and manual review of the Dockerfile change.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)