### PR TITLE
[SPARK-56134][SQL] Make BufferedRowIterator.unsafeRow public to avoid IllegalAccessError.

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/BufferedRowIterator.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/BufferedRowIterator.java
@@ -33,7 +33,8 @@ import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 public abstract class BufferedRowIterator {
   protected LinkedList<InternalRow> currentRows = new LinkedList<>();
   // used when there is no column in output
-  protected UnsafeRow unsafeRow = new UnsafeRow(0);
+  // Keep it public for codegen to access.
+  public UnsafeRow unsafeRow = new UnsafeRow(0);
   private long startTimeNs = System.nanoTime();
 
   protected int partitionIndex = -1;

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -777,6 +777,29 @@ class WholeStageCodegenSuite extends SharedSparkSession
     }
   }
 
+  test("SPARK-56134: Codegen working for empty output") {
+    // Create a balanced tree of AND conditions. This prevents generating a very deep tree,
+    // which can cause stack overflow.
+    def balancedAnd(cols: Seq[String]): String = cols match {
+      case Seq(single) => single
+      case seq =>
+        val (left, right) = seq.splitAt(seq.length / 2)
+        balancedAnd(left) + " and " + balancedAnd(right)
+    }
+
+    withTempPath { dir =>
+        val path = dir.getCanonicalPath
+        sql("select array(0) as value from range(0, 1, 1, 1)")
+          .write.mode(SaveMode.Overwrite).parquet(path)
+
+        val numConditions = 1000
+        val conditions = (0 until numConditions).map(i => s"value <= array($i)")
+        val condition = balancedAnd(conditions)
+        val df = spark.read.parquet(path).filter(condition).selectExpr()
+        assert(df.limit(1).selectExpr("count(*)").collect() === Array(Row(1)))
+    }
+  }
+
   test("SPARK-25767: Lazy evaluated stream of expressions handled correctly") {
     val a = Seq(1).toDF("key")
     val b = Seq((1, "a")).toDF("key", "value")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is very similar to https://github.com/apache/spark/pull/20779. When a generated code has split classes and they try to access protected fields in `BufferedRowIterator`, an `IllegalAccessError` will happen.

I am not making `partitionIndex` public too because I cannot find a real example that can trigger an `IllegalAccessError` on it too. In the code base, `partitionIndex` is mostly accessed via `addPartitionInitializationStatement`. Since it is used in the partition initialization code, not in split classes, there should be no issue with it.

### Why are the changes needed?

Fix runtime error in large queries.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.

### Was this patch authored or co-authored using generative AI tooling?

No.
