### PR TITLE
[SPARK-56135][DOCS] Add option to use venv in PySpark docs

### DIFF
--- a/python/docs/source/development/contributing.rst
+++ b/python/docs/source/development/contributing.rst
@@ -145,7 +145,7 @@ Now, you can start developing and `running the tests <testing.rst>`_.
 venv
 ~~~~
 
-If you prefer a lightweight setup without Conda, you can use Python's built-in ``venv`` module:
+You can use Python's built-in ``venv`` module to create an isolated environment:
 
 .. code-block:: bash
 

--- a/python/docs/source/development/contributing.rst
+++ b/python/docs/source/development/contributing.rst
@@ -142,6 +142,18 @@ Once it is set up, make sure you switch to `pyspark-dev-env` before starting the
 
 Now, you can start developing and `running the tests <testing.rst>`_.
 
+venv
+~~~~
+
+If you prefer a lightweight setup without Conda, you can use Python's built-in ``venv`` module:
+
+.. code-block:: bash
+
+    # Python 3.10+ is required
+    python3 -m venv .venv
+    source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+    pip install --upgrade -r dev/requirements.txt
+
 pip
 ~~~
 

--- a/python/docs/source/development/contributing.rst
+++ b/python/docs/source/development/contributing.rst
@@ -151,7 +151,7 @@ You can use Python's built-in ``venv`` module to create an isolated environment:
 
     # Python 3.10+ is required
     python3 -m venv .venv
-    source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+    source .venv/bin/activate
     pip install --upgrade -r dev/requirements.txt
 
 pip

--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -157,6 +157,19 @@ For a short summary about useful conda commands, see their
 `cheat sheet <https://docs.conda.io/projects/conda/en/latest/user-guide/cheatsheet.html>`_.
 
 
+Using venv
+----------
+
+If you prefer a lightweight setup without Conda, you can use Python's built-in ``venv`` module
+to create an isolated environment:
+
+.. code-block:: bash
+
+    python3 -m venv .venv
+    source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+    pip install pyspark
+
+
 Manually Downloading
 --------------------
 

--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -160,8 +160,7 @@ For a short summary about useful conda commands, see their
 Using venv
 ----------
 
-If you prefer a lightweight setup without Conda, you can use Python's built-in ``venv`` module
-to create an isolated environment:
+You can use Python's built-in ``venv`` module to create an isolated environment:
 
 .. code-block:: bash
 

--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -165,7 +165,7 @@ You can use Python's built-in ``venv`` module to create an isolated environment:
 .. code-block:: bash
 
     python3 -m venv .venv
-    source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+    source .venv/bin/activate
     pip install pyspark
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a `venv` section in the PySpark documentation as an alternative to Conda for environment management:

- `python/docs/source/getting_started/install.rst` - new "Using venv" section alongside "Using Conda"
- `python/docs/source/development/contributing.rst` - new "venv" section alongside Conda and pip under Environment Setup

### Why are the changes needed?

The PySpark docs currently only mention pip (without isolation) and Conda for environment setup. Python's built-in `venv` module is a lightweight alternative that doesn't require installing Conda. Adding this option gives users more choices for setting up their development environment.

### Does this PR introduce _any_ user-facing change?

Documentation only.

### How was this patch tested?

N/A (documentation change).

### Was this patch authored or co-authored using generative AI tooling?

Yes.