### PR TITLE
[SPARK-56151][SQL] Improve CreateVariable display string

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/v2ResolutionPlans.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/v2ResolutionPlans.scala
@@ -251,7 +251,9 @@ case class ResolvedNonPersistentFunc(
 case class ResolvedIdentifier(
     catalog: CatalogPlugin,
     identifier: Identifier,
-    override val output: Seq[Attribute] = Nil) extends LeafNodeWithoutStats
+    override val output: Seq[Attribute] = Nil) extends LeafNodeWithoutStats {
+  def name: String = (catalog.name +: identifier.namespace :+ identifier.name).quoted
+}
 
 object ResolvedIdentifier {
   def unapply(ri: ResolvedIdentifier): Option[(CatalogPlugin, Identifier)] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ColumnDefinition.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ColumnDefinition.scala
@@ -248,7 +248,9 @@ case class DefaultValueExpression(
   final override val nodePatterns: Seq[TreePattern] = Seq(ANALYSIS_AWARE_EXPRESSION)
 
   override def dataType: DataType = child.dataType
-  override def stringArgs: Iterator[Any] = Iterator(child, originalSQL)
+  override def prettyName: String = "default"
+  override def sql: String = s"DEFAULT $originalSQL"
+  override def stringArgs: Iterator[Any] = Iterator(child, s"sql='$originalSQL'")
   override def markAsAnalyzed(): DefaultValueExpression =
     copy(analyzedChild = Some(child))
   override protected def withNewChildInternal(newChild: Expression): Expression =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/CreateVariableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/CreateVariableExec.scala
@@ -38,6 +38,9 @@ case class CreateVariableExec(
     defaultExpr: DefaultValueExpression,
     replace: Boolean) extends LeafV2CommandExec with ExpressionsEvaluator {
 
+  override def stringArgs: Iterator[Any] =
+    Iterator(resolvedIdentifiers.map(_.name), defaultExpr, s"replace=$replace")
+
   override protected def run(): Seq[InternalRow] = {
     val scriptingVariableManager = SqlScriptingContextManager.get().flatMap(_.getVariableManager)
     val tempVariableManager = session.sessionState.catalogManager.tempVariableManager

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/execute-immediate.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/execute-immediate.sql.out
@@ -33,7 +33,7 @@ CreateDataSourceTableCommand `spark_catalog`.`default`.`x`, false
 -- !query
 DECLARE sql_string STRING
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), false
+CreateVariable default(null, sql='null'), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.sql_string
 
 
@@ -126,7 +126,7 @@ SetVariable [variablereference(system.session.sql_string='SELECT * from tbl_view
 -- !query
 DECLARE a STRING
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), false
+CreateVariable default(null, sql='null'), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.a
 
 
@@ -231,7 +231,7 @@ SetVariable [variablereference(system.session.sql_string='SELECT * from tbl_view
 -- !query
 DECLARE b INT
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), false
+CreateVariable default(null, sql='null'), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.b
 
 
@@ -327,7 +327,7 @@ Project [variablereference(system.session.sql_string='SELECT id from tbl_view wh
 -- !query
 DECLARE res_id INT
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), false
+CreateVariable default(null, sql='null'), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.res_id
 
 
@@ -507,7 +507,7 @@ org.apache.spark.sql.AnalysisException
 -- !query
 DECLARE OR REPLACE testvarA INT
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), true
+CreateVariable default(null, sql='null'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.testvarA
 
 
@@ -782,7 +782,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 -- !query
 DECLARE p = 10
 -- !query analysis
-CreateVariable defaultvalueexpression(10, 10), false
+CreateVariable default(10, sql='10'), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.p
 
 
@@ -924,7 +924,7 @@ org.apache.spark.sql.AnalysisException
 -- !query
 DECLARE int_var INT
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), false
+CreateVariable default(null, sql='null'), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.int_var
 
 
@@ -952,7 +952,7 @@ org.apache.spark.sql.AnalysisException
 -- !query
 DECLARE null_var STRING
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), false
+CreateVariable default(null, sql='null'), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.null_var
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/identifier-clause-legacy.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/identifier-clause-legacy.sql.out
@@ -571,7 +571,7 @@ DropFunctionCommand myDoubleAvg, false, true
 -- !query
 DECLARE var = 'sometable'
 -- !query analysis
-CreateVariable defaultvalueexpression(sometable, 'sometable'), false
+CreateVariable default(sometable, sql=''sometable''), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var
 
 
@@ -1115,21 +1115,21 @@ DropTable false, false
 -- !query
 DECLARE agg = 'max'
 -- !query analysis
-CreateVariable defaultvalueexpression(max, 'max'), false
+CreateVariable default(max, sql=''max''), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.agg
 
 
 -- !query
 DECLARE col = 'c1'
 -- !query analysis
-CreateVariable defaultvalueexpression(c1, 'c1'), false
+CreateVariable default(c1, sql=''c1''), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.col
 
 
 -- !query
 DECLARE tab = 'T'
 -- !query analysis
-CreateVariable defaultvalueexpression(T, 'T'), false
+CreateVariable default(T, sql=''T''), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.tab
 
 
@@ -1805,7 +1805,7 @@ DropTable false, false
 -- !query
 DECLARE IDENTIFIER('my_var') = 'value'
 -- !query analysis
-CreateVariable defaultvalueexpression(value, 'value'), false
+CreateVariable default(value, sql=''value''), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.my_var
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/identifier-clause.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/identifier-clause.sql.out
@@ -571,7 +571,7 @@ DropFunctionCommand myDoubleAvg, false, true
 -- !query
 DECLARE var = 'sometable'
 -- !query analysis
-CreateVariable defaultvalueexpression(sometable, 'sometable'), false
+CreateVariable default(sometable, sql=''sometable''), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var
 
 
@@ -1115,21 +1115,21 @@ DropTable false, false
 -- !query
 DECLARE agg = 'max'
 -- !query analysis
-CreateVariable defaultvalueexpression(max, 'max'), false
+CreateVariable default(max, sql=''max''), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.agg
 
 
 -- !query
 DECLARE col = 'c1'
 -- !query analysis
-CreateVariable defaultvalueexpression(c1, 'c1'), false
+CreateVariable default(c1, sql=''c1''), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.col
 
 
 -- !query
 DECLARE tab = 'T'
 -- !query analysis
-CreateVariable defaultvalueexpression(T, 'T'), false
+CreateVariable default(T, sql=''T''), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.tab
 
 
@@ -1713,7 +1713,7 @@ DropTable false, false
 -- !query
 DECLARE IDENTIFIER('my_var') = 'value'
 -- !query analysis
-CreateVariable defaultvalueexpression(value, 'value'), false
+CreateVariable default(value, sql=''value''), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.my_var
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/parse-query-correctness-old-behavior.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/parse-query-correctness-old-behavior.sql.out
@@ -987,7 +987,7 @@ DropTableCommand `spark_catalog`.`default`.`v1`, false, true, false
 -- !query
 DECLARE v1 INT
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), false
+CreateVariable default(null, sql='null'), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.v1
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/parse-query-correctness.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/parse-query-correctness.sql.out
@@ -1115,7 +1115,7 @@ DropTableCommand `spark_catalog`.`default`.`v1`, false, true, false
 -- !query
 DECLARE v1 INT
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), false
+CreateVariable default(null, sql='null'), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.v1
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
@@ -4777,7 +4777,7 @@ Project [x#x, y#x, extend#x, (x + 1)#x, y#x]
 -- !query
 declare or replace extend int = 5
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(5 as int), 5), true
+CreateVariable default(cast(5 as int), sql='5'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.extend
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pivot.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pivot.sql.out
@@ -792,6 +792,7 @@ Project [a#x, z#x, b#x, y#x, c#x, x#x, d#x, w#x, dotNET#xL, Java#xL]
                            +- SubqueryAlias courseSales
                               +- LocalRelation [course#x, year#x, earnings#x]
 
+
 -- !query
 SELECT pv.year, pv.net, pv.jv FROM (
   SELECT year, course, earnings FROM courseSales

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/session-variable-precedence.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/session-variable-precedence.sql.out
@@ -8,14 +8,14 @@ CreateDataSourceTableCommand `spark_catalog`.`default`.`t1`, false
 -- !query
 DECLARE all = 1
 -- !query analysis
-CreateVariable defaultvalueexpression(1, 1), false
+CreateVariable default(1, sql='1'), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.all
 
 
 -- !query
 DECLARE a = 1
 -- !query analysis
-CreateVariable defaultvalueexpression(1, 1), false
+CreateVariable default(1, sql='1'), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.a
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/sql-session-variables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/sql-session-variables.sql.out
@@ -8,7 +8,7 @@ SetCommand (spark.sql.ansi.enabled,Some(true))
 -- !query
 DECLARE title STRING
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), false
+CreateVariable default(null, sql='null'), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.title
 
 
@@ -23,7 +23,7 @@ SetVariable [variablereference(system.session.title=CAST(NULL AS STRING))]
 -- !query
 DECLARE var1 INT = 5
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(5 as int), 5), false
+CreateVariable default(cast(5 as int), sql='5'), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -67,7 +67,7 @@ SetVariable [variablereference(system.session.title='-- Basic sanity --')]
 -- !query
 DECLARE VARIABLE var1 INT
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), false
+CreateVariable default(null, sql='null'), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -81,7 +81,7 @@ Project [Expect: INT, NULL AS Expect: INT, NULL#x, typeof(variablereference(syst
 -- !query
 DECLARE OR REPLACE VARIABLE var1 DOUBLE
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), true
+CreateVariable default(null, sql='null'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -152,7 +152,7 @@ SetVariable [variablereference(system.session.title='Create Variable - Failure C
 -- !query
 DECLARE VAR var1 INT
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), false
+CreateVariable default(null, sql='null'), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -213,7 +213,7 @@ DropVariable true
 -- !query
 DECLARE VARIABLE var1 INT
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), false
+CreateVariable default(null, sql='null'), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -263,7 +263,7 @@ SetVariable [variablereference(system.session.title='Drop Variable')]
 -- !query
 DECLARE VARIABLE var1 INT DEFAULT 1
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(1 as int), 1), false
+CreateVariable default(cast(1 as int), sql='1'), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -292,7 +292,7 @@ Project [2 AS Expected#x, variablereference(system.session.var1=2) AS Unqualifie
 -- !query
 DECLARE OR REPLACE VARIABLE session.var1 INT DEFAULT 1
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(1 as int), 1), true
+CreateVariable default(cast(1 as int), sql='1'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -321,7 +321,7 @@ Project [2 AS Expected#x, variablereference(system.session.var1=2) AS Unqualifie
 -- !query
 DECLARE OR REPLACE VARIABLE system.session.var1 INT DEFAULT 1
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(1 as int), 1), true
+CreateVariable default(cast(1 as int), sql='1'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -350,7 +350,7 @@ Project [2 AS Expected#x, variablereference(system.session.var1=2) AS Unqualifie
 -- !query
 DECLARE OR REPLACE VARIABLE sySteM.sEssIon.vAr1 INT DEFAULT 1
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(1 as int), 1), true
+CreateVariable default(cast(1 as int), sql='1'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.vAr1
 
 
@@ -379,7 +379,7 @@ Project [2 AS Expected#x, variablereference(system.session.var1=2) AS Unqualifie
 -- !query
 DECLARE OR REPLACE VARIABLE var1 INT
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), true
+CreateVariable default(null, sql='null'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -406,7 +406,7 @@ org.apache.spark.sql.AnalysisException
 -- !query
 DECLARE OR REPLACE VARIABLE var1 INT
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), true
+CreateVariable default(null, sql='null'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -433,7 +433,7 @@ org.apache.spark.sql.AnalysisException
 -- !query
 DECLARE OR REPLACE VARIABLE var1 INT
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), true
+CreateVariable default(null, sql='null'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -460,7 +460,7 @@ org.apache.spark.sql.AnalysisException
 -- !query
 DECLARE OR REPLACE VARIABLE var1 INT
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), true
+CreateVariable default(null, sql='null'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -556,7 +556,7 @@ org.apache.spark.sql.AnalysisException
 -- !query
 DECLARE OR REPLACE VARIABLE var1 INT
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), true
+CreateVariable default(null, sql='null'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -679,7 +679,7 @@ SetVariable [variablereference(system.session.title='Test qualifiers - fail')]
 -- !query
 DECLARE OR REPLACE VARIABLE var1 INT DEFAULT 1
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(1 as int), 1), true
+CreateVariable default(cast(1 as int), sql='1'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -706,7 +706,7 @@ Project [true AS Expected#x, (variablereference(system.session.var1=1.0239069642
 -- !query
 DECLARE OR REPLACE VARIABLE var1 = 'Hello'
 -- !query analysis
-CreateVariable defaultvalueexpression(Hello, 'Hello'), true
+CreateVariable default(Hello, sql=''Hello''), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -720,7 +720,7 @@ Project [STRING, Hello AS Expected#x, typeof(variablereference(system.session.va
 -- !query
 DECLARE OR REPLACE VARIABLE var1 DEFAULT NULL
 -- !query analysis
-CreateVariable defaultvalueexpression(null, NULL), true
+CreateVariable default(null, sql='NULL'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -734,7 +734,7 @@ Project [VOID, NULL AS Expected#x, typeof(variablereference(system.session.var1=
 -- !query
 DECLARE OR REPLACE VARIABLE INT DEFAULT 5.0
 -- !query analysis
-CreateVariable defaultvalueexpression(5.0, 5.0), true
+CreateVariable default(5.0, sql='5.0'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.INT
 
 
@@ -748,7 +748,7 @@ Project [INT, 5 AS Expected#x, typeof(variablereference(system.session.var1=NULL
 -- !query
 DECLARE OR REPLACE VARIABLE var1 MAP<string, double> DEFAULT MAP('Hello', 5.1, 'World', -7.1E10)
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(map(Hello, cast(5.1 as double), World, -7.1E10) as map<string,double>), MAP('Hello', 5.1, 'World', -7.1E10)), true
+CreateVariable default(cast(map(Hello, cast(5.1 as double), World, -7.1E10) as map<string,double>), sql='MAP('Hello', 5.1, 'World', -7.1E10)'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -762,7 +762,7 @@ Project [MAP<string, double>, [Hello -> 5.1, World -> -7E10] AS Expected#x, type
 -- !query
 DECLARE OR REPLACE VARIABLE var1 INT DEFAULT NULL
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(null as int), NULL), true
+CreateVariable default(cast(null as int), sql='NULL'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -776,7 +776,7 @@ Project [NULL AS Expected#x, variablereference(system.session.var1=CAST(NULL AS 
 -- !query
 DECLARE OR REPLACE VARIABLE var1 STRING DEFAULT CURRENT_DATABASE()
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(current_schema() as string), CURRENT_DATABASE()), true
+CreateVariable default(cast(current_schema() as string), sql='CURRENT_DATABASE()'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -904,7 +904,7 @@ SetVariable [variablereference(system.session.title='Test DEFAULT on create - fa
 -- !query
 DECLARE OR REPLACE VARIABLE var1 INT DEFAULT 5
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(5 as int), 5), true
+CreateVariable default(cast(5 as int), sql='5'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -1080,7 +1080,7 @@ org.apache.spark.SparkNumberFormatException
 -- !query
 DECLARE OR REPLACE VARIABLE var1 INT DEFAULT 5
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(5 as int), 5), true
+CreateVariable default(cast(5 as int), sql='5'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -1117,21 +1117,21 @@ SetVariable [variablereference(system.session.title='SET VARIABLE - single targe
 -- !query
 DECLARE OR REPLACE VARIABLE var1 INT DEFAULT 5
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(5 as int), 5), true
+CreateVariable default(cast(5 as int), sql='5'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
 -- !query
 DECLARE OR REPLACE VARIABLE var2 STRING DEFAULT 'hello'
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(hello as string), 'hello'), true
+CreateVariable default(cast(hello as string), sql=''hello''), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var2
 
 
 -- !query
 DECLARE OR REPLACE VARIABLE var3 DOUBLE DEFAULT 2
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(2 as double), 2), true
+CreateVariable default(cast(2 as double), sql='2'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var3
 
 
@@ -1169,21 +1169,21 @@ Project [variablereference(system.session.var1=7) AS 7#x, variablereference(syst
 -- !query
 DECLARE OR REPLACE VARIABLE var1 INT DEFAULT 5
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(5 as int), 5), true
+CreateVariable default(cast(5 as int), sql='5'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
 -- !query
 DECLARE OR REPLACE VARIABLE var2 STRING DEFAULT 'hello'
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(hello as string), 'hello'), true
+CreateVariable default(cast(hello as string), sql=''hello''), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var2
 
 
 -- !query
 DECLARE OR REPLACE VARIABLE var3 DOUBLE DEFAULT 2
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(2 as double), 2), true
+CreateVariable default(cast(2 as double), sql='2'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var3
 
 
@@ -1257,7 +1257,7 @@ SetVariable [variablereference(system.session.title='SET VARIABLE - comma separa
 -- !query
 DECLARE VARIABLE var1, var2, var3 INT
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), false
+CreateVariable default(null, sql='null'), false
 :- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 :- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var2
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var3
@@ -1272,7 +1272,7 @@ DECLARE VARIABLE var4, var5, var6 INT DEFAULT CAST(RAND(0) * 10 AS INT)
 -- !query
 DECLARE VARIABLE var7, var8, var9 DEFAULT 5
 -- !query analysis
-CreateVariable defaultvalueexpression(5, 5), false
+CreateVariable default(5, sql='5'), false
 :- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var7
 :- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var8
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var9
@@ -1288,7 +1288,7 @@ Project [(variablereference(system.session.var4=7) = variablereference(system.se
 -- !query
 DECLARE OR REPLACE VARIABLE var1, var2, var3 DOUBLE
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), true
+CreateVariable default(null, sql='null'), true
 :- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 :- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var2
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var3
@@ -1303,7 +1303,7 @@ DECLARE OR REPLACE VARIABLE var4, var5, var6 DOUBLE DEFAULT RAND(0)
 -- !query
 DECLARE OR REPLACE VARIABLE var7, var8, var9 DEFAULT 1.5
 -- !query analysis
-CreateVariable defaultvalueexpression(1.5, 1.5), true
+CreateVariable default(1.5, sql='1.5'), true
 :- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var7
 :- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var8
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var9
@@ -1424,21 +1424,21 @@ SetVariable [variablereference(system.session.title='DECLARE VARIABLE - duplicat
 -- !query
 DECLARE OR REPLACE VARIABLE var1 INT DEFAULT 5
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(5 as int), 5), true
+CreateVariable default(cast(5 as int), sql='5'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
 -- !query
 DECLARE OR REPLACE VARIABLE var2 STRING DEFAULT 'hello'
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(hello as string), 'hello'), true
+CreateVariable default(cast(hello as string), sql=''hello''), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var2
 
 
 -- !query
 DECLARE OR REPLACE VARIABLE var3 DOUBLE DEFAULT 2
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(2 as double), 2), true
+CreateVariable default(cast(2 as double), sql='2'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var3
 
 
@@ -1626,21 +1626,21 @@ SetVariable [variablereference(system.session.title='SET VARIABLE - row assignme
 -- !query
 DECLARE OR REPLACE VARIABLE var1 STRING DEFAULT 'default1'
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(default1 as string), 'default1'), true
+CreateVariable default(cast(default1 as string), sql=''default1''), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
 -- !query
 DECLARE OR REPLACE VARIABLE var2 STRING DEFAULT 'default2'
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(default2 as string), 'default2'), true
+CreateVariable default(cast(default2 as string), sql=''default2''), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var2
 
 
 -- !query
 DECLARE OR REPLACE VARIABLE var3 STRING DEFAULT 'default3'
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(default3 as string), 'default3'), true
+CreateVariable default(cast(default3 as string), sql=''default3''), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var3
 
 
@@ -1936,7 +1936,7 @@ SetVariable [variablereference(system.session.title='DEFAULT expression usage')]
 -- !query
 DECLARE OR REPLACE VARIABLE var1 INT DEFAULT 1
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(1 as int), 1), true
+CreateVariable default(cast(1 as int), sql='1'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -2052,7 +2052,7 @@ DropVariable false
 -- !query
 DECLARE OR REPLACE VARIABLE var1 INT DEFAULT 1
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(1 as int), 1), true
+CreateVariable default(cast(1 as int), sql='1'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -2116,7 +2116,7 @@ SetVariable [variablereference(system.session.title='SET command')]
 -- !query
 DECLARE OR REPLACE VARIABLE var1 INT DEFAULT 1
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(1 as int), 1), true
+CreateVariable default(cast(1 as int), sql='1'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -2267,7 +2267,7 @@ SetVariable [variablereference(system.session.title='variable references -- visi
 -- !query
 DECLARE OR REPLACE VARIABLE var1 INT DEFAULT 1
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(1 as int), 1), true
+CreateVariable default(cast(1 as int), sql='1'), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 
@@ -2311,7 +2311,7 @@ SetVariable [variablereference(system.session.title='variable references -- proh
 -- !query
 DECLARE OR REPLACE VARIABLE var1 STRING DEFAULT 'a INT'
 -- !query analysis
-CreateVariable defaultvalueexpression(cast(a INT as string), 'a INT'), true
+CreateVariable default(cast(a INT as string), sql=''a INT''), true
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/to_from_avro.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/to_from_avro.sql.out
@@ -13,7 +13,7 @@ CreateDataSourceTableAsSelectCommand `spark_catalog`.`default`.`t`, ErrorIfExist
 -- !query
 declare avro_schema string
 -- !query analysis
-CreateVariable defaultvalueexpression(null, null), false
+CreateVariable default(null, sql='null'), false
 +- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.avro_schema
 
 

--- a/sql/core/src/test/resources/sql-tests/results/predicate-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/predicate-functions.sql.out
@@ -743,6 +743,7 @@ struct<(NOT (NULL IN (1, 2, NULL))):boolean>
 -- !query output
 NULL
 
+
 -- !query
 select 1 in ()
 -- !query schema
@@ -779,6 +780,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
     "fragment" : "not in ()"
   } ]
 }
+
 
 -- !query
 select 1 between 0 and 2


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
As the title.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Improve readability.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, better display string in UI and explain output.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

For `DECLARE total INT DEFAULT 0;`, before vs. after

<img width="1050" height="333" alt="Xnip2026-03-23_15-18-54" src="https://github.com/user-attachments/assets/66ce7bfe-f236-4470-b1a4-9cd4a5c7086c" />

<img width="1050" height="319" alt="Xnip2026-03-23_15-19-10" src="https://github.com/user-attachments/assets/507d156b-8e54-48ce-bf53-331db02e6d75" />


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.