### PR TITLE
[SPARK-55809][CORE][FOLLOWUP] HeapHistogram uses DiagnosticCommandMBean instead of jmap subprocess

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2147,11 +2147,11 @@ private[spark] object Utils
   def getHeapHistogram(): Array[String] = {
     // SPARK-55809: Use DiagnosticCommandMBean in-process instead of spawning jmap as
     // a subprocess.
-    // Spawning `jmap -histo <pid>` requires a self-attach via signal/socket handshake.
-    // Any concurrent GC (G1, ZGC, Shenandoah) can put the JVM into states where the
-    // Signal Dispatcher cannot service the attachment handshake, causing jmap to hang.
+    // JDK 25 (JDK-8354460) changed `jmap -histo` to use streaming output. When jmap is
+    // spawned as a subprocess, its stdout must be drained continuously; if the caller
+    // blocks on waitFor() without reading, the pipe buffer fills up and jmap hangs.
     // DiagnosticCommandMBean runs gcClassHistogram in-process and coordinates with GC
-    // through internal JVM APIs, avoiding the unreliable inter-process attach.
+    // through internal JVM APIs, avoiding the subprocess pipe-buffer issue entirely.
     val server = ManagementFactory.getPlatformMBeanServer
     val on = new ObjectName("com.sun.management:type=DiagnosticCommand")
     val result = server.invoke(on, "gcClassHistogram",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Modify the comments of org.apache.spark.util.Utils.getHeapHistogram method.

### Why are the changes needed?
https://github.com/apache/spark/pull/54919#discussion_r2973620249

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
GHA

### Was this patch authored or co-authored using generative AI tooling?
No