### PR TITLE
[MINOR] Fix typo errors in code comments across multiple modules

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -81,7 +81,7 @@ private[v2] trait V2JDBCTest
     // nullable is true in the expectedSchema because Spark always sets nullable to true
     // regardless of the JDBC metadata https://github.com/apache/spark/pull/18445
     var expectedSchema = new StructType().add("ID", StringType, true, defaultMetadata())
-    // If function is not overriden we don't want to compare external engine types
+    // If function is not overridden we don't want to compare external engine types
     var expectedSchemaWithoutJdbcClientType =
       removeMetadataFromAllFields(expectedSchema, "jdbcClientType")
     var schemaWithoutJdbcClientType =
@@ -91,7 +91,7 @@ private[v2] trait V2JDBCTest
     t = spark.table(s"$catalogName.alt_table")
     expectedSchema = new StructType().add("ID", StringType, true, defaultMetadata())
 
-    // If function is not overriden we don't want to compare external engine types
+    // If function is not overridden we don't want to compare external engine types
     expectedSchemaWithoutJdbcClientType =
       removeMetadataFromAllFields(expectedSchema, "jdbcClientType")
     schemaWithoutJdbcClientType =
@@ -118,7 +118,7 @@ private[v2] trait V2JDBCTest
       .add("ID1", StringType, true, defaultMetadata())
       .add("ID2", StringType, true, defaultMetadata())
 
-    // If function is not overriden we don't want to compare external engine types
+    // If function is not overridden we don't want to compare external engine types
     val expectedSchemaWithoutJdbcClientType =
       removeMetadataFromAllFields(expectedSchema, "jdbcClientType")
     val schemaWithoutJdbcClientType =

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -82,7 +82,7 @@ private[v2] trait V2JDBCTest
     // nullable is true in the expectedSchema because Spark always sets nullable to true
     // regardless of the JDBC metadata https://github.com/apache/spark/pull/18445
     var expectedSchema = new StructType().add("ID", StringType, true, defaultMetadata())
-    // If function is not overriden we don't want to compare external engine types
+    // If function is not overridden we don't want to compare external engine types
     var expectedSchemaWithoutJdbcClientType =
       removeMetadataFromAllFields(expectedSchema, "jdbcClientType")
     var schemaWithoutJdbcClientType =
@@ -92,7 +92,7 @@ private[v2] trait V2JDBCTest
     t = spark.table(s"$catalogName.alt_table")
     expectedSchema = new StructType().add("ID", StringType, true, defaultMetadata())
 
-    // If function is not overriden we don't want to compare external engine types
+    // If function is not overridden we don't want to compare external engine types
     expectedSchemaWithoutJdbcClientType =
       removeMetadataFromAllFields(expectedSchema, "jdbcClientType")
     schemaWithoutJdbcClientType =
@@ -119,7 +119,7 @@ private[v2] trait V2JDBCTest
       .add("ID1", StringType, true, defaultMetadata())
       .add("ID2", StringType, true, defaultMetadata())
 
-    // If function is not overriden we don't want to compare external engine types
+    // If function is not overridden we don't want to compare external engine types
     val expectedSchemaWithoutJdbcClientType =
       removeMetadataFromAllFields(expectedSchema, "jdbcClientType")
     val schemaWithoutJdbcClientType =

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -1506,7 +1506,7 @@ private[scheduler] case class BarrierPendingLaunchTask(
     taskLocality: TaskLocality.TaskLocality,
     assignedResources: Map[String, Map[String, Long]]) {
   // Stored the corresponding index of the WorkerOffer which is responsible to launch the task.
-  // Used to revert the assigned resources (e.g., cores, custome resources) when the barrier
+  // Used to revert the assigned resources (e.g., cores, custom resources) when the barrier
   // task set doesn't launch successfully in a single resourceOffers round.
   var assignedOfferIndex: Int = _
   var assignedCores: Int = 0

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -1580,7 +1580,7 @@ private[scheduler] case class BarrierPendingLaunchTask(
     taskLocality: TaskLocality.TaskLocality,
     assignedResources: Map[String, Map[String, Long]]) {
   // Stored the corresponding index of the WorkerOffer which is responsible to launch the task.
-  // Used to revert the assigned resources (e.g., cores, custome resources) when the barrier
+  // Used to revert the assigned resources (e.g., cores, custom resources) when the barrier
   // task set doesn't launch successfully in a single resourceOffers round.
   var assignedOfferIndex: Int = _
   var assignedCores: BigDecimal = CpuAmount.normalize(BigDecimal(0))

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -856,7 +856,7 @@ private[spark] class Client(
    * The archive also contains some Spark configuration. Namely, it saves the contents of
    * SparkConf in a file to be loaded by the AM process.
    *
-   * @param confsToOverride configs that should overriden when creating the final spark conf file
+   * @param confsToOverride configs that should overridden when creating the final spark conf file
    */
   private def createConfArchive(confsToOverride: Map[String, String]): File = {
     val hadoopConfFiles = new HashMap[String, File]()

--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/columnNodes.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/columnNodes.scala
@@ -579,7 +579,7 @@ private[sql] case class UpdateFields(
 
 /**
  * Evaluate one or more conditional branches. The value of the first branch for which the
- * predicate evalutes to true is returned. If none of the branches evaluate to true, the value of
+ * predicate evaluates to true is returned. If none of the branches evaluate to true, the value of
  * `otherwise` is returned.
  *
  * @param branches

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2587,7 +2587,7 @@ case class Get(left: Expression, right: Expression)
 
   override def inputTypes: Seq[AbstractDataType] = left.dataType match {
     case _: ArrayType => Seq(ArrayType, IntegerType)
-    // Do not apply implicit cast if the first arguement is not array type.
+    // Do not apply implicit cast if the first argument is not array type.
     case _ => Nil
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2822,7 +2822,7 @@ case class Get(left: Expression, right: Expression)
 
   override def inputTypes: Seq[AbstractDataType] = left.dataType match {
     case _: ArrayType => Seq(ArrayType, IntegerType)
-    // Do not apply implicit cast if the first arguement is not array type.
+    // Do not apply implicit cast if the first argument is not array type.
     case _ => Nil
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/streaming/WriteToStreamStatement.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/streaming/WriteToStreamStatement.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableCatalog}
 import org.apache.spark.sql.streaming.{OutputMode, Trigger}
 
 /**
- * A statement for Stream writing. It contains all neccessary param and will be resolved in the
+ * A statement for Stream writing. It contains all necessary param and will be resolved in the
  * rule [[ResolveStreamWrite]].
  *
  * @param userSpecifiedName  Query name optionally specified by the user.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -3417,7 +3417,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
     val threadId = threadInfo.get.threadRef.get.get.getId
     assert(
       threadId == Thread.currentThread().getId,
-      s"acquired thread should be curent thread ${Thread.currentThread().getId} " +
+      s"acquired thread should be current thread ${Thread.currentThread().getId} " +
         s"after load but was $threadId")
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -2208,7 +2208,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
       version = store.commit()
     }
 
-    // Reload the store from the commited version and repeat the above test.
+    // Reload the store from the committed version and repeat the above test.
     tryWithProviderResource(newStoreProvider(storeId, colFamiliesEnabled)) { provider =>
       assert(version > 0)
       val store = provider.getStore(version)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -1887,7 +1887,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
       version = store.commit()
     }
 
-    // Reload the store from the commited version and repeat the above test.
+    // Reload the store from the committed version and repeat the above test.
     tryWithProviderResource(newStoreProvider(storeId, colFamiliesEnabled)) { provider =>
       assert(version > 0)
       val store = provider.getStore(version)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeE2ESuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeE2ESuite.scala
@@ -159,16 +159,16 @@ class StreamRealTimeModeE2ESuite extends StreamRealTimeModeE2ESuiteBase {
               .batchId should be(i + 1)
             query.lastProgress.sources(0).numInputRows should be(numRows * 3)
 
-            val commitedResults = new mutable.ListBuffer[String]()
+            val committedResults = new mutable.ListBuffer[String]()
             val numPartitions = if (withUnion) 10 else 5
             for (v <- 0 until numPartitions) {
               val it = ResultsCollector.get(s"$uniqueSinkName-${i}-$v").iterator()
               while (it.hasNext) {
-                commitedResults += it.next()
+                committedResults += it.next()
               }
             }
 
-            commitedResults.sorted should equal(expectedResultsByBatch(i).sorted)
+            committedResults.sorted should equal(expectedResultsByBatch(i).sorted)
           }
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeSuite.scala
@@ -362,7 +362,7 @@ class StreamRealTimeModeWithManualClockSuite extends StreamRealTimeModeManualClo
   }
 
   test("purge offsetLog when it doesn't match with the commit log") {
-    // Simulate when the query fails after commiting the offset log but before the commit log
+    // Simulate when the query fails after committing the offset log but before the commit log
     // by manually deleting the last entry of the commit log.
     val inputData = LowLatencyMemoryStream[Int](1)
     val mapped = inputData.toDS().map(_ + 1)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeSuite.scala
@@ -421,7 +421,7 @@ class StreamRealTimeModeWithManualClockSuite extends StreamRealTimeModeManualClo
   }
 
   test("purge offsetLog when it doesn't match with the commit log") {
-    // Simulate when the query fails after commiting the offset log but before the commit log
+    // Simulate when the query fails after committing the offset log but before the commit log
     // by manually deleting the last entry of the commit log.
     val inputData = LowLatencyMemoryStream[Int](1)
     val mapped = inputData.toDS().map(_ + 1)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Correct spelling in comments and Scaladoc across ten Scala files, one test assertion message, and the `commitedResults` local test variable and its uses.

Rebased the previously approved patch onto current master. Every added and removed line is identical to the reviewed patch. The later #57182 overlaps some comment corrections; this earlier approved PR also covers the scheduler and streaming-test corrections outside that PR.

### Why are the changes needed?

These spelling errors remain on current master. The patch improves readability without changing runtime logic or test expectations.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Verified the full rebased diff, exact equality of added/removed lines with the approved patch, ASCII and 100-column limits for added lines, and `git diff --check`. No new tests were added for these mechanical spelling corrections.

The previous fork run [27261902858](https://github.com/r266-tech/spark/actions/runs/27261902858) ultimately failed two `AutoCdcScd1FullRefreshSuite` tests. The earlier comment reported that it had started, not that it passed. Fresh fork CI for `83a663a6` is [running here](https://github.com/r266-tech/spark/actions/runs/34213479664); no passing result is claimed yet. The upstream notification check ran before this exact-SHA run appeared and reported an unsynced commit; current master has a scheduled missing-Build-check backfill.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-6). This update preserves the original commit author and the previously reviewed patch.
