### PR TITLE
[MINOR] Add quotes to fix erroneous pip install command in SDP Prog Guide

### DIFF
--- a/docs/declarative-pipelines-programming-guide.md
+++ b/docs/declarative-pipelines-programming-guide.md
@@ -40,7 +40,7 @@ The key advantage of SDP is its declarative approach - you define what tables sh
 A quick way to install SDP is with pip:
 
 ```
-pip install pyspark[pipelines]
+pip install "pyspark[pipelines]"
 ```
 
 See the [downloads page](//spark.apache.org/downloads.html) for more installation options.

--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -47,11 +47,11 @@ If you want to install extra dependencies for a specific component, you can inst
 .. code-block:: bash
 
     # Spark SQL
-    pip install pyspark[sql]
+    pip install "pyspark[sql]"
     # pandas API on Spark
-    pip install pyspark[pandas_on_spark] plotly  # to plot your data, you can install plotly together.
+    pip install "pyspark[pandas_on_spark]" plotly  # to plot your data, you can install plotly together.
     # Spark Connect
-    pip install pyspark[connect]
+    pip install "pyspark[connect]"
 
 
 See :ref:`optional-dependencies` for more detail about extra dependencies.

--- a/python/docs/source/tutorial/sql/arrow_pandas.rst
+++ b/python/docs/source/tutorial/sql/arrow_pandas.rst
@@ -34,7 +34,7 @@ Ensure PyArrow Installed
 To use Apache Arrow in PySpark, `the recommended version of PyArrow <arrow_pandas.rst#recommended-pandas-and-pyarrow-versions>`_
 should be installed.
 If you install PySpark using pip, then PyArrow can be brought in as an extra dependency of the
-SQL module with the command ``pip install pyspark[sql]``. Otherwise, you must ensure that PyArrow
+SQL module with the command ``pip install "pyspark[sql]"``. Otherwise, you must ensure that PyArrow
 is installed and available on all cluster nodes.
 You can install it using pip or conda from the conda-forge channel. See PyArrow
 `installation <https://arrow.apache.org/docs/python/install.html>`_ for details.


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Add quotes around the pip install command in the SDP Programming Guide. 


### Why are the changes needed?
- In the programming guide, the `pip install pyspark[pipelines]` command errors out on Mac Terminal without quotes. The quotes don't affect the command on other bash terminals while ensuring it works on the Mac Terminal OOB. 
- Also just affects the latest Spark version since SDP is in 4.1.x. 

### Does this PR introduce _any_ user-facing change?
- Yes - it changes the [SDP programming guide](https://spark.apache.org/docs/latest/declarative-pipelines-programming-guide.html#quick-install)

### How was this patch tested?
- Simple docs change, tested markdown rendering to ensure no styling errors were found


### Was this patch authored or co-authored using generative AI tooling?
- No