### PR TITLE
[SPARK-56161][K8S] Ban `org.apache.hadoop.util.StringUtils.stringifyException`

### DIFF
--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -219,6 +219,10 @@
             <property name="message" value="Use String concatenation instead." />
         </module>
         <module name="RegexpSinglelineJava">
+            <property name="format" value="StringUtils\.stringifyException"/>
+            <property name="message" value="Use org.apache.spark.util.Utils.stringifyException instead." />
+        </module>
+        <module name="RegexpSinglelineJava">
             <property name="format" value="Files\.equal\("/>
             <property name="message" value="Use contentEquals of SparkFileUtils or Utils instead." />
         </module>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesDiagnosticsSetter.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesDiagnosticsSetter.scala
@@ -19,7 +19,6 @@ package org.apache.spark.deploy.k8s
 import io.fabric8.kubernetes.api.model.PodBuilder
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.dsl.base.{PatchContext, PatchType}
-import org.apache.hadoop.util.StringUtils
 
 import org.apache.spark.{SparkConf, SparkMasterRegex}
 import org.apache.spark.deploy.SparkDiagnosticsSetter
@@ -60,7 +59,7 @@ private[spark] class SparkKubernetesDiagnosticsSetter(clientProvider: Kubernetes
   }
 
   override def setDiagnostics(throwable: Throwable, conf: SparkConf): Unit = {
-    val diagnostics = SparkStringUtils.abbreviate(StringUtils.stringifyException(throwable),
+    val diagnostics = SparkStringUtils.abbreviate(Utils.stringifyException(throwable),
       KUBERNETES_EXIT_EXCEPTION_MESSAGE_LIMIT_BYTES)
     Utils.tryWithResource(clientProvider.create(conf)) { client =>
       conf.get(KUBERNETES_DRIVER_POD_NAME).foreach { podName =>

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/SparkKubernetesDiagnosticsSetterSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/SparkKubernetesDiagnosticsSetterSuite.scala
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.Pod
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.dsl.PodResource
 import io.fabric8.kubernetes.client.dsl.base.PatchContext
-import org.apache.hadoop.util.StringUtils
 import org.mockito.{ArgumentCaptor, Mock, MockitoAnnotations}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
@@ -31,6 +30,7 @@ import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants.EXIT_EXCEPTION_ANNOTATION
 import org.apache.spark.deploy.k8s.Fabric8Aliases.PODS
+import org.apache.spark.util.Utils
 
 class SparkKubernetesDiagnosticsSetterSuite extends SparkFunSuite
   with MockitoSugar with BeforeAndAfterEach {
@@ -78,6 +78,6 @@ class SparkKubernetesDiagnosticsSetterSuite extends SparkFunSuite
     verify(driverPodOperations).patch(any(classOf[PatchContext]), podCaptor.capture())
 
     assert(podCaptor.getValue.getMetadata.getAnnotations.get(EXIT_EXCEPTION_ANNOTATION)
-      == StringUtils.stringifyException(diagnostics))
+      == Utils.stringifyException(diagnostics))
   }
 }

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -534,6 +534,11 @@ This file is divided into 3 sections:
     <customMessage>Use Java String.substring instead.</customMessage>
   </check>
 
+  <check customId="hadoopstringifyexception" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">\bStringUtils\.stringifyException\b</parameter></parameters>
+    <customMessage>Use org.apache.spark.util.Utils.stringifyException instead.</customMessage>
+  </check>
+
   <check customId="uribuilder" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">\bUriBuilder\.fromUri\b</parameter></parameters>
     <customMessage>Use Utils.getUriBuilder instead.</customMessage>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR replaces `org.apache.hadoop.util.StringUtils.stringifyException` with `org.apache.spark.util.Utils.stringifyException` in the `Kubernetes` resource manager module, and bans the Hadoop variant via both `Scalastyle` and `Checkstyle` rules.

### Why are the changes needed?

Spark has its own `Utils.stringifyException` method since Apache Spark 4.1.0 and has been used it.

- https://github.com/apache/spark/pull/51540

Using the Hadoop variant introduces an unnecessary dependency and this regression was added here.

- https://github.com/apache/spark/pull/52068

So, this PR adds the lint rules in order to prevent future regression, too.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)