### PR TITLE
[SPARK-55999][SS][FOLLOW-UP] Explicitly set forceSnapshotUploadOnLag=false in remaining lag-reporting tests

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCoordinatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCoordinatorSuite.scala
@@ -592,7 +592,8 @@ class StateStoreCoordinatorSuite extends SparkFunSuite with SharedSparkContext {
       SQLConf.STATE_STORE_COORDINATOR_REPORT_SNAPSHOT_UPLOAD_LAG.key -> "true",
       SQLConf.STATE_STORE_COORDINATOR_MULTIPLIER_FOR_MIN_TIME_DIFF_TO_LOG.key -> "1",
       SQLConf.STATE_STORE_COORDINATOR_MULTIPLIER_FOR_MIN_VERSION_DIFF_TO_LOG.key -> "1",
-      SQLConf.STATE_STORE_COORDINATOR_SNAPSHOT_LAG_REPORT_INTERVAL.key -> "0"
+      SQLConf.STATE_STORE_COORDINATOR_SNAPSHOT_LAG_REPORT_INTERVAL.key -> "0",
+      SQLConf.STATE_STORE_FORCE_SNAPSHOT_UPLOAD_ON_LAG.key -> "false"
     ) {
       case (coordRef, spark) =>
         import spark.implicits._
@@ -637,7 +638,8 @@ class StateStoreCoordinatorSuite extends SparkFunSuite with SharedSparkContext {
       SQLConf.STATE_STORE_COORDINATOR_REPORT_SNAPSHOT_UPLOAD_LAG.key -> "true",
       SQLConf.STATE_STORE_COORDINATOR_MULTIPLIER_FOR_MIN_TIME_DIFF_TO_LOG.key -> "1",
       SQLConf.STATE_STORE_COORDINATOR_MULTIPLIER_FOR_MIN_VERSION_DIFF_TO_LOG.key -> "2",
-      SQLConf.STATE_STORE_COORDINATOR_SNAPSHOT_LAG_REPORT_INTERVAL.key -> "0"
+      SQLConf.STATE_STORE_COORDINATOR_SNAPSHOT_LAG_REPORT_INTERVAL.key -> "0",
+      SQLConf.STATE_STORE_FORCE_SNAPSHOT_UPLOAD_ON_LAG.key -> "false"
     ) {
       case (coordRef, spark) =>
         import spark.implicits._
@@ -682,7 +684,8 @@ class StateStoreCoordinatorStreamingSuite extends StreamTest {
         SQLConf.STATE_STORE_COORDINATOR_REPORT_SNAPSHOT_UPLOAD_LAG.key -> "true",
         SQLConf.STATE_STORE_COORDINATOR_MULTIPLIER_FOR_MIN_VERSION_DIFF_TO_LOG.key -> "2",
         SQLConf.STATE_STORE_COORDINATOR_MULTIPLIER_FOR_MIN_TIME_DIFF_TO_LOG.key -> "5",
-        SQLConf.STATE_STORE_COORDINATOR_SNAPSHOT_LAG_REPORT_INTERVAL.key -> "0"
+        SQLConf.STATE_STORE_COORDINATOR_SNAPSHOT_LAG_REPORT_INTERVAL.key -> "0",
+        SQLConf.STATE_STORE_FORCE_SNAPSHOT_UPLOAD_ON_LAG.key -> "false"
       ) {
         withTempDir { srcDir =>
           val inputData = MemoryStream[Int](spark)
@@ -805,7 +808,8 @@ class StateStoreCoordinatorStreamingSuite extends StreamTest {
       SQLConf.STATE_STORE_COORDINATOR_REPORT_SNAPSHOT_UPLOAD_LAG.key -> "true",
       SQLConf.STATE_STORE_COORDINATOR_MULTIPLIER_FOR_MIN_VERSION_DIFF_TO_LOG.key -> "1",
       SQLConf.STATE_STORE_COORDINATOR_MULTIPLIER_FOR_MIN_TIME_DIFF_TO_LOG.key -> "5",
-      SQLConf.STATE_STORE_COORDINATOR_SNAPSHOT_LAG_REPORT_INTERVAL.key -> "0"
+      SQLConf.STATE_STORE_COORDINATOR_SNAPSHOT_LAG_REPORT_INTERVAL.key -> "0",
+      SQLConf.STATE_STORE_FORCE_SNAPSHOT_UPLOAD_ON_LAG.key -> "false"
     ) {
       withTempDir { srcDir =>
         val inputData = MemoryStream[Int](spark)
@@ -884,7 +888,8 @@ class StateStoreCoordinatorStreamingSuite extends StreamTest {
         SQLConf.STATE_STORE_COORDINATOR_REPORT_SNAPSHOT_UPLOAD_LAG.key -> "true",
         SQLConf.STATE_STORE_COORDINATOR_MULTIPLIER_FOR_MIN_VERSION_DIFF_TO_LOG.key -> "2",
         SQLConf.STATE_STORE_COORDINATOR_MULTIPLIER_FOR_MIN_TIME_DIFF_TO_LOG.key -> "50",
-        SQLConf.STATE_STORE_COORDINATOR_SNAPSHOT_LAG_REPORT_INTERVAL.key -> "0"
+        SQLConf.STATE_STORE_COORDINATOR_SNAPSHOT_LAG_REPORT_INTERVAL.key -> "0",
+        SQLConf.STATE_STORE_FORCE_SNAPSHOT_UPLOAD_ON_LAG.key -> "false"
       ) {
         withTempDir { srcDir =>
           val inputData = MemoryStream[Int](spark)


### PR DESCRIPTION
### What changes were proposed in this pull request?

After SPARK-55999 changed the default of `forceSnapshotUploadOnLag` from `false` to `true`, 5 additional SPARK-51358 lag-reporting tests need the explicit `false` setting to prevent the forced snapshot upload mechanism from interfering with their lag detection/reporting assertions.

The tests affected are:
1. "Snapshot uploads in RocksDB are not reported if changelog checkpointing is disabled"
2. "Snapshot lag reports properly detects when all state stores are lagging"
3. "Restarting queries do not mark state stores as lagging" (parameterized for RocksDB/HDFS)
4. "Restarting queries with updated SQLConf get propagated to the coordinator"
5. "Infrequent maintenance with ... using Trigger.AvailableNow should be reported" (parameterized for RocksDB/HDFS)

### Why are the changes needed?

The original SPARK-55999 commit correctly added `forceSnapshotUploadOnLag=false` to 3 test configurations that test lag detection, but missed these 5 additional tests. All of these tests enable lag reporting (`REPORT_SNAPSHOT_UPLOAD_LAG=true`) and set `SNAPSHOT_LAG_REPORT_INTERVAL=0` to test lag detection behavior. Without explicitly disabling forced snapshot uploads, the forced upload mechanism will attempt to remediate lag during test execution, potentially masking the lag that these tests are trying to detect and assert on.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Existing tests — no new tests needed. This change only adds explicit config settings to existing tests to ensure they continue testing the intended behavior after the default change.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code