### PR TITLE
[SPARK-56163][CORE][K8S] Move `uploadFileToHadoopCompatibleFS` to `Utils`

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1887,6 +1887,23 @@ private[spark] object Utils
   }
 
   /**
+   * Upload a file to a Hadoop-compatible filesystem.
+   */
+  def uploadFileToHadoopCompatibleFS(
+      src: Path,
+      dest: Path,
+      fs: FileSystem,
+      delSrc: Boolean = false,
+      overwrite: Boolean = true): Unit = {
+    try {
+      fs.copyFromLocalFile(delSrc, overwrite, src, dest)
+    } catch {
+      case e: IOException =>
+        throw new SparkException(s"Error uploading file ${src.getName}", e)
+    }
+  }
+
+  /**
    * Whether the underlying JVM prefer IPv6 addresses.
    */
   val preferIPv6 = "true".equals(System.getProperty("java.net.preferIPv6Addresses"))

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.deploy.k8s
 
-import java.io.{File, IOException}
+import java.io.File
 import java.net.URI
 import java.security.SecureRandom
 import java.util.{Collections, HexFormat, UUID}
@@ -25,7 +25,7 @@ import scala.jdk.CollectionConverters._
 
 import io.fabric8.kubernetes.api.model.{Container, ContainerBuilder, ContainerStateRunning, ContainerStateTerminated, ContainerStateWaiting, ContainerStatus, EnvVar, EnvVarBuilder, EnvVarSourceBuilder, HasMetadata, OwnerReferenceBuilder, Pod, PodBuilder, Quantity}
 import io.fabric8.kubernetes.client.KubernetesClient
-import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.fs.Path
 
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.annotation.{DeveloperApi, Since, Unstable}
@@ -37,7 +37,7 @@ import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.resource.ResourceUtils
 import org.apache.spark.util.{Clock, SystemClock, Utils}
 import org.apache.spark.util.DependencyUtils.downloadFile
-import org.apache.spark.util.Utils.getHadoopFileSystem
+import org.apache.spark.util.Utils.{getHadoopFileSystem, uploadFileToHadoopCompatibleFS}
 
 /**
  * :: DeveloperApi ::
@@ -331,23 +331,6 @@ object KubernetesUtils extends Logging {
             "spark.kubernetes.file.upload.path property.")
         }
       case _ => throw new SparkException("Spark configuration is missing...")
-    }
-  }
-
-  /**
-   * Upload a file to a Hadoop-compatible filesystem.
-   */
-  private def uploadFileToHadoopCompatibleFS(
-      src: Path,
-      dest: Path,
-      fs: FileSystem,
-      delSrc : Boolean = false,
-      overwrite: Boolean = true): Unit = {
-    try {
-      fs.copyFromLocalFile(delSrc, overwrite, src, dest)
-    } catch {
-      case e: IOException =>
-        throw new SparkException(s"Error uploading file ${src.getName}", e)
     }
   }
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesUtilsSuite.scala
@@ -30,6 +30,7 @@ import org.apache.hadoop.fs.Path
 import org.scalatest.PrivateMethodTester
 
 import org.apache.spark.{SparkException, SparkFunSuite}
+import org.apache.spark.util.Utils
 
 class KubernetesUtilsSuite extends SparkFunSuite with PrivateMethodTester {
   private val HOST = "test-host"
@@ -77,7 +78,6 @@ class KubernetesUtilsSuite extends SparkFunSuite with PrivateMethodTester {
   test("SPARK-38201: check uploadFileToHadoopCompatibleFS with different delSrc and overwrite") {
     withTempDir { srcDir =>
       withTempDir { destDir =>
-        val upload = PrivateMethod[Unit](Symbol("uploadFileToHadoopCompatibleFS"))
         val fileName = "test.txt"
         val srcFile = new File(srcDir, fileName)
         val src = new Path(srcFile.getAbsolutePath)
@@ -86,14 +86,14 @@ class KubernetesUtilsSuite extends SparkFunSuite with PrivateMethodTester {
 
         def checkUploadException(delSrc: Boolean, overwrite: Boolean): Unit = {
           val message = intercept[SparkException] {
-            KubernetesUtils.invokePrivate(upload(src, dest, fs, delSrc, overwrite))
+            Utils.uploadFileToHadoopCompatibleFS(src, dest, fs, delSrc, overwrite)
           }.getMessage
           assert(message.contains("Error uploading file"))
         }
 
         def appendFileAndUpload(content: String, delSrc: Boolean, overwrite: Boolean): Unit = {
           Files.writeString(srcFile.toPath, content, StandardCharsets.UTF_8, CREATE, WRITE, APPEND)
-          KubernetesUtils.invokePrivate(upload(src, dest, fs, delSrc, overwrite))
+          Utils.uploadFileToHadoopCompatibleFS(src, dest, fs, delSrc, overwrite)
         }
 
         // Write a new file, upload file with delSrc = false and overwrite = true.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR moves the `uploadFileToHadoopCompatibleFS` function from `org.apache.spark.deploy.k8s.KubernetesUtils` to `org.apache.spark.util.Utils`. This places the utility function right alongside `getHadoopFileSystem`.

### Why are the changes needed?

Centralizing `Hadoop-compatible FileSystem operations` (like URI operations and uploads) into `Utils` makes the codebase cleaner, improves reusability, and properly separates general file utilities from Kubernetes-specific tooling.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`.