### PR TITLE
[SPARK-53440][PYTHON] Allow Column.transform() to accept SQL lambda expression strings

### DIFF
--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -425,6 +425,11 @@
       "Collations can only be applied to string types, but the JSON data type is <jsonType>."
     ]
   },
+  "INVALID_LAMBDA_EXPRESSION": {
+    "message": [
+      "Invalid SQL lambda expression: '<expression>'. Expected format: 'param -> expression'."
+    ]
+  },
   "INVALID_MULTIPLE_ARGUMENT_CONDITIONS": {
     "message": [
       "[{arg_names}] cannot be <condition>."

--- a/python/pyspark/sql/classic/column.py
+++ b/python/pyspark/sql/classic/column.py
@@ -610,7 +610,28 @@ class Column(ParentColumn):
         jc = self._jc.over(window._jspec)
         return Column(jc)
 
-    def transform(self, f: Callable[[ParentColumn], ParentColumn]) -> ParentColumn:
+    def transform(self, f: Union[Callable[[ParentColumn], ParentColumn], str]) -> ParentColumn:
+        if isinstance(f, str):
+            from py4j.java_gateway import JVMView
+
+            arrow_idx = f.find("->")
+            if arrow_idx == -1:
+                raise PySparkValueError(
+                    errorClass="INVALID_LAMBDA_EXPRESSION",
+                    messageParameters={"expression": f},
+                )
+
+            param = f[:arrow_idx].strip()
+            if not param.isidentifier():
+                raise PySparkValueError(
+                    errorClass="INVALID_LAMBDA_EXPRESSION",
+                    messageParameters={"expression": f},
+                )
+
+            sc = get_active_spark_context()
+            jvm = cast(JVMView, sc._jvm)
+            jresult = jvm.PythonSQLUtils.applyLambda(self._jc, f)
+            return Column(jresult)
         return f(self)
 
     def outer(self) -> ParentColumn:

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -1512,24 +1512,24 @@ class Column(TableValuedFunctionArgument):
         ...
 
     @dispatch_col_method
-    def transform(self, f: Callable[["Column"], "Column"]) -> "Column":
+    def transform(self, f: Union[Callable[["Column"], "Column"], str]) -> "Column":
         """
-        Applies a transformation function to this column.
+        Applies a transformation to this column.
 
-        This method allows you to apply a function that takes a Column and returns a Column,
-        enabling method chaining and functional transformations.
+        Accepts either a Python callable or a SQL lambda expression string.
 
         .. versionadded:: 4.1.0
 
         Parameters
         ----------
-        f : callable
-            A function that takes a :class:`Column` and returns a :class:`Column`.
+        f : callable or str
+            A function that takes a :class:`Column` and returns a :class:`Column`,
+            or a SQL lambda expression string in the format ``'param -> expression'``.
 
         Returns
         -------
         :class:`Column`
-            The result of applying the function to this column.
+            The result of applying the transformation to this column.
 
         Examples
         --------
@@ -1545,7 +1545,7 @@ class Column(TableValuedFunctionArgument):
         | WORLD|
         +------+
 
-        Example 2: Use lambda functions
+        Example 2: Use Python lambda functions
 
         >>> df = spark.createDataFrame([(10,), (20,), (30,)], ["value"])
         >>> df.select(
@@ -1559,6 +1559,29 @@ class Column(TableValuedFunctionArgument):
         |    20|
         |    40|
         |    60|
+        +------+
+
+        Example 3: Use SQL lambda expression
+
+        >>> df = spark.createDataFrame([(1,), (2,), (3,)], ["value"])
+        >>> df.select(df.value.transform('x -> x * 2').alias("result")).show()
+        +------+
+        |result|
+        +------+
+        |     2|
+        |     4|
+        |     6|
+        +------+
+
+        Example 4: SQL lambda with function calls
+
+        >>> df = spark.createDataFrame([("hello",), ("world",)], ["text"])
+        >>> df.select(df.text.transform('x -> upper(x)').alias("result")).show()
+        +------+
+        |result|
+        +------+
+        | HELLO|
+        | WORLD|
         +------+
         """
         ...

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -44,6 +44,7 @@ from pyspark.sql.connect.expressions import (
     LiteralExpression,
     CaseWhen,
     SortOrder,
+    SQLExpression,
     SubqueryExpression,
     CastExpression,
     WindowExpression,
@@ -465,7 +466,30 @@ class Column(ParentColumn):
 
         return Column(WindowExpression(windowFunction=self._expr, windowSpec=window))
 
-    def transform(self, f: Callable[[ParentColumn], ParentColumn]) -> ParentColumn:
+    def transform(self, f: Union[Callable[[ParentColumn], ParentColumn], str]) -> ParentColumn:
+        if isinstance(f, str):
+            arrow_idx = f.find("->")
+            if arrow_idx == -1:
+                raise PySparkValueError(
+                    errorClass="INVALID_LAMBDA_EXPRESSION",
+                    messageParameters={"expression": f},
+                )
+
+            param = f[:arrow_idx].strip()
+            if not param.isidentifier():
+                raise PySparkValueError(
+                    errorClass="INVALID_LAMBDA_EXPRESSION",
+                    messageParameters={"expression": f},
+                )
+
+            # Build: transform(array(col), lambda)[0]
+            # The server-side parser handles the lambda expression natively.
+            lambda_expr = SQLExpression(f)
+            array_col = Column(UnresolvedFunction("array", [self._expr]))
+            transform_col = Column(
+                UnresolvedFunction("transform", [array_col._expr, lambda_expr])
+            )
+            return transform_col[0]
         return f(self)
 
     def outer(self) -> ParentColumn:

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -502,6 +502,69 @@ class ColumnTestsMixin:
         self.assertEqual(result[1][0], 40)
         self.assertEqual(result[2][0], 60)
 
+    def test_transform_sql_lambda_arithmetic(self):
+        """Test transform() with SQL lambda expression for arithmetic."""
+        df = self.spark.createDataFrame([(1,), (2,), (3,)], ["value"])
+        result = df.select(df.value.transform("x -> x * 2").alias("result")).collect()
+        self.assertEqual(result[0][0], 2)
+        self.assertEqual(result[1][0], 4)
+        self.assertEqual(result[2][0], 6)
+
+    def test_transform_sql_lambda_function_call(self):
+        """Test transform() with SQL lambda using function calls."""
+        df = self.spark.createDataFrame([("hello",), ("world",)], ["text"])
+        result = df.select(df.text.transform("x -> upper(x)").alias("result")).collect()
+        self.assertEqual(result[0][0], "HELLO")
+        self.assertEqual(result[1][0], "WORLD")
+
+    def test_transform_sql_lambda_conditional(self):
+        """Test transform() with SQL lambda using CASE WHEN."""
+        df = self.spark.createDataFrame([(-1,), (0,), (1,)], ["value"])
+        result = df.select(
+            df.value.transform("x -> CASE WHEN x > 0 THEN x ELSE 0 END").alias("result")
+        ).collect()
+        self.assertEqual(result[0][0], 0)
+        self.assertEqual(result[1][0], 0)
+        self.assertEqual(result[2][0], 1)
+
+    def test_transform_sql_lambda_with_nulls(self):
+        """Test transform() with SQL lambda handles nulls."""
+        df = self.spark.createDataFrame([(1,), (None,), (3,)], ["value"])
+        result = df.select(df.value.transform("x -> x * 2").alias("result")).collect()
+        self.assertEqual(result[0][0], 2)
+        self.assertIsNone(result[1][0])
+        self.assertEqual(result[2][0], 6)
+
+    def test_transform_sql_lambda_chaining(self):
+        """Test chaining SQL lambda transform calls."""
+        df = self.spark.createDataFrame([(5,)], ["value"])
+        result = df.select(
+            df.value.transform("x -> x * 2").transform("y -> y + 1").alias("result")
+        ).collect()
+        self.assertEqual(result[0][0], 11)
+
+    def test_transform_sql_lambda_mixed_chaining(self):
+        """Test chaining SQL lambda with Python callable."""
+        df = self.spark.createDataFrame([(5,)], ["value"])
+        result = df.select(
+            df.value.transform("x -> x * 2").transform(lambda c: c + 1).alias("result")
+        ).collect()
+        self.assertEqual(result[0][0], 11)
+
+    def test_transform_sql_lambda_invalid_no_arrow(self):
+        """Test transform() raises error for string without ->."""
+        df = self.spark.createDataFrame([(1,)], ["value"])
+        with self.assertRaises(PySparkValueError) as ctx:
+            df.select(df.value.transform("x * 2")).collect()
+        self.assertIn("INVALID_LAMBDA_EXPRESSION", ctx.exception.getErrorClass())
+
+    def test_transform_sql_lambda_invalid_param(self):
+        """Test transform() raises error for invalid parameter name."""
+        df = self.spark.createDataFrame([(1,)], ["value"])
+        with self.assertRaises(PySparkValueError) as ctx:
+            df.select(df.value.transform("123 -> x * 2")).collect()
+        self.assertIn("INVALID_LAMBDA_EXPRESSION", ctx.exception.getErrorClass())
+
 
 class ColumnTests(ColumnTestsMixin, ReusedSQLTestCase):
     pass

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.classic.ClassicConversions._
+import org.apache.spark.sql.classic.ExpressionUtils
 import org.apache.spark.sql.classic.ExpressionUtils.expression
 import org.apache.spark.sql.execution.{ExplainMode, QueryExecution}
 import org.apache.spark.sql.execution.arrow.ArrowConverters
@@ -179,6 +180,25 @@ private[sql] object PythonSQLUtils extends Logging {
   def lambdaFunction(function: Column, variables: Column*): Column = {
     val arguments = variables.map(_.node.asInstanceOf[internal.UnresolvedNamedLambdaVariable])
     Column(internal.LambdaFunction(function.node, arguments))
+  }
+
+  def applyLambda(col: Column, lambdaExpr: String): Column = {
+    val parsed = CatalystSqlParser.parseExpression(lambdaExpr)
+    parsed match {
+      case LambdaFunction(function, arguments, _) if arguments.size == 1 =>
+        val colExpr = expression(col)
+        val param = arguments.head.asInstanceOf[UnresolvedNamedLambdaVariable]
+        val replaced = function.transform {
+          case v: UnresolvedNamedLambdaVariable if v.nameParts == param.nameParts => colExpr
+        }
+        ExpressionUtils.column(replaced)
+      case _: LambdaFunction =>
+        throw new IllegalArgumentException(
+          s"Expected a single-parameter lambda expression, but got: $lambdaExpr")
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Expected a lambda expression (param -> expr), but got: $lambdaExpr")
+    }
   }
 
   def namedArgumentExpression(name: String, e: Column): Column =


### PR DESCRIPTION
### What changes were proposed in this pull request? 
Extend `Column.transform` to accept a SQL lambda expression string (e.g. `'x -> x * 2'`) in addition to the existing Python callable support.

For Classic mode, the SQL lambda is parsed by `CatalystSqlParser`, the lambda body's parameter variable is replaced with the actual column expression, and the result is returned directly — no intermediate array wrapping.

For Connect mode, the SQL lambda string is sent to the server via `SQLExpression` and evaluated using `transform(array(col), lambda)[0]`, since the client has no local Catalyst parser.

### Why are the changes needed?
Currently `Column.transform` only accepts Python callables. In some situations it is preferable to express transformations using SQL syntax (e.g. `'x -> x + 1'`) since no Python introspection happens, just simple parsing.

### Does this PR introduce _any_ user-facing change?
Yes. `Column.transform` now accepts a `str` argument in addition to `Callable`:
```python
df.value.transform(lambda c: c * 2)   # existing — Python callable
df.value.transform('x -> x * 2')      # new — SQL lambda string
```

### How was this patch tested?
Added 8 new tests in `test_column.py` covering SQL lambda arithmetic, function calls, conditional logic, null handling, chaining (SQL-only and mixed SQL+Python), and error paths (missing arrow, invalid param name).

### Was this patch authored or co-authored using generative AI tooling?
Yes, co-authored with Kiro.
