### PR TITLE
[SPARK-56168][PS][TESTS] Relax groupby diff-length assertions for pandas 3

### DIFF
--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_diff_len.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_diff_len.py
@@ -18,6 +18,7 @@
 import pandas as pd
 
 from pyspark import pandas as ps
+from pyspark.loose_version import LooseVersion
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
@@ -46,37 +47,41 @@ class GroupByDiffLenMixin:
             pd.DataFrame({"a": [1, 2, 6, 4, 4, 6, 4, 3, 7], "b": [4, 2, 7, 3, 3, 1, 1, 1, 2]}),
         ]
 
-        for pdf1, pdf2 in zip(pdfs1, pdfs2):
-            psdf1 = ps.from_pandas(pdf1)
-            psdf2 = ps.from_pandas(pdf2)
+        for as_index in [True, False]:
+            # pandas 3 includes external group keys for as_index=False and can widen
+            # their dtype after aligning mismatched lengths.
+            almost = as_index or LooseVersion(pd.__version__) >= "3.0.0"
 
-            for as_index in [True, False]:
-                if as_index:
+            if as_index:
 
-                    def sort(df):
-                        return df.sort_index()
+                def sort(df):
+                    return df.sort_index()
 
-                else:
+            else:
 
-                    def sort(df):
-                        return df.sort_values("c").reset_index(drop=True)
+                def sort(df):
+                    return df.sort_values("c").reset_index(drop=True)
 
-                self.assert_eq(
-                    sort(psdf1.groupby(psdf2.a, as_index=as_index).sum()),
-                    sort(pdf1.groupby(pdf2.a, as_index=as_index).sum()),
-                    almost=as_index,
-                )
+            for i, (pdf1, pdf2) in enumerate(zip(pdfs1, pdfs2)):
+                psdf1 = ps.from_pandas(pdf1)
+                psdf2 = ps.from_pandas(pdf2)
 
-                self.assert_eq(
-                    sort(psdf1.groupby(psdf2.a, as_index=as_index).c.sum()),
-                    sort(pdf1.groupby(pdf2.a, as_index=as_index).c.sum()),
-                    almost=as_index,
-                )
-                self.assert_eq(
-                    sort(psdf1.groupby(psdf2.a, as_index=as_index)["c"].sum()),
-                    sort(pdf1.groupby(pdf2.a, as_index=as_index)["c"].sum()),
-                    almost=as_index,
-                )
+                with self.subTest(i=i, as_index=as_index):
+                    self.assert_eq(
+                        sort(psdf1.groupby(psdf2.a, as_index=as_index).sum()),
+                        sort(pdf1.groupby(pdf2.a, as_index=as_index).sum()),
+                        almost=almost,
+                    )
+                    self.assert_eq(
+                        sort(psdf1.groupby(psdf2.a, as_index=as_index).c.sum()),
+                        sort(pdf1.groupby(pdf2.a, as_index=as_index).c.sum()),
+                        almost=almost,
+                    )
+                    self.assert_eq(
+                        sort(psdf1.groupby(psdf2.a, as_index=as_index)["c"].sum()),
+                        sort(pdf1.groupby(pdf2.a, as_index=as_index)["c"].sum()),
+                        almost=almost,
+                    )
 
 
 class GroupByDiffLenTests(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the pandas-on-Spark diff-frame groupby length test in `test_groupby_diff_len.py`.

The changes are test-only:
- restructure the test with `subTest` to make the failing case easier to identify
- use `almost=True` for pandas 3.x
- add a short comment explaining that pandas 3 includes external group keys for `as_index=False` and can widen their dtype after aligning mismatched lengths

### Why are the changes needed?

The test behavior differs across pandas versions for mismatched-length external group keys.

With pandas 3.x, `groupby(..., as_index=False)` can include the external group key in the result and widen its dtype after alignment. That makes the strict equality used by this test fail due to dtype differences even though the grouped values still match.

This patch keeps the existing pandas 2 behavior untouched and relaxes the assertions only for pandas 3.x in this localized test.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Updated the related tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)