### PR TITLE
[SPARK-56169][SQL] Fix `ClassCastException` in error reporting when `GetStructField` child type is changed by plan transformation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.expressions
 
 import scala.util.{Either, Left, Right}
 
-import org.apache.spark.QueryContext
+import org.apache.spark.{QueryContext, SparkException}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode}
@@ -184,7 +184,13 @@ case class GetStructField(child: Expression, ordinal: Int, name: Option[String] 
 
   override def inputTypes: Seq[AbstractDataType] = Seq(StructType, IntegralType)
 
-  lazy val childSchema = child.dataType.asInstanceOf[StructType]
+  lazy val childSchema = child.dataType match {
+    case st: StructType => st
+    case other =>
+      throw SparkException.internalError(
+        s"GetStructField requires a StructType child, but got ${other.catalogString}. " +
+        s"The child type may have been changed by a plan transformation.")
+  }
 
   override lazy val canonicalized: Expression = {
     copy(child = child.canonicalized, name = None)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
@@ -94,11 +94,21 @@ package object util extends Logging {
     case Literal(v, t: NumericType) if v != null => PrettyAttribute(v.toString, t)
     case Literal(null, dataType) => PrettyAttribute("NULL", dataType)
     case e: GetStructField =>
-      val name = e.name.getOrElse(e.childSchema(e.ordinal).name)
-      PrettyAttribute(
-        usePrettyExpression(e.child, shouldTrimTempResolvedColumn).sql + "." + name,
-        e.dataType
-      )
+      e.child.dataType match {
+        case st: StructType =>
+          val name = e.name.getOrElse(st(e.ordinal).name)
+          PrettyAttribute(
+            usePrettyExpression(e.child, shouldTrimTempResolvedColumn).sql + "." + name,
+            st(e.ordinal).dataType
+          )
+        case _ =>
+          // Child type was changed by a plan transformation.
+          val name = e.name.getOrElse(s"_${e.ordinal}")
+          PrettyAttribute(
+            usePrettyExpression(e.child, shouldTrimTempResolvedColumn).sql + "." + name,
+            e.child.dataType
+          )
+      }
     case e: GetArrayStructFields =>
       PrettyAttribute(
         s"${usePrettyExpression(e.child, shouldTrimTempResolvedColumn)}.${e.field.name}",

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ComplexTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ComplexTypeSuite.scala
@@ -177,6 +177,27 @@ class ComplexTypeSuite extends SparkFunSuite with ExpressionEvalHelper {
     assert(getStructField(nullStruct, "a").nullable)
   }
 
+  test("GetStructField checkInputDataTypes should fail when child is not StructType") {
+    // Simulate a plan transformation that changes the child's type from StructType to
+    // StringType after the GetStructField was created.
+    val stringAttr = AttributeReference("c2", StringType)()
+    val getField = GetStructField(stringAttr, 0, Some("f1"))
+
+    assert(getField.checkInputDataTypes().isFailure)
+    val result = getField.checkInputDataTypes().asInstanceOf[DataTypeMismatch]
+    assert(result.errorSubClass == "UNEXPECTED_INPUT_TYPE")
+  }
+
+  test("GetStructField toPrettySQL should not crash when child is not StructType") {
+    val stringAttr = AttributeReference("c2", StringType)()
+    val getField = GetStructField(stringAttr, 0, Some("f1"))
+
+    // This should not throw ClassCastException
+    val prettySQL = toPrettySQL(getField)
+    assert(prettySQL.contains("c2"))
+    assert(prettySQL.contains("f1"))
+  }
+
   test("GetArrayStructFields") {
     // test 4 types: struct field nullability X array element nullability
     val type1 = ArrayType(StructType(StructField("a", IntegerType) :: Nil))


### PR DESCRIPTION


### What changes were proposed in this pull request?

SPARK-53470 added `ExpectsInputTypes` to `GetStructField` so that `checkInputDataTypes()` catches the case where a plan transformation changes the child's type from `StructType` to something else. This can happen when an analyzer rule inserts a projection that changes a column's output type after `GetStructField` was already created referencing that column.

However, when `CheckAnalysis` detects this mismatch, the error formatting path (`toPrettySQL` -> `usePrettyExpression`) accesses `GetStructField.dataType` which calls `childSchema` -> `child.dataType.asInstanceOf[StructType]`, throwing a raw `ClassCastException` before the proper `DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE` error can be reported.

This PR fixes two things:
1. `usePrettyExpression` checks `child.dataType` before accessing `childSchema`, falling back to a safe representation when the child is not a `StructType`
2. `childSchema` uses pattern matching instead of an unsafe cast, throwing a clear `SparkException.internalError` instead of `ClassCastException`

### Why are the changes needed?

Without this fix, users see a raw `ClassCastException: StringType$ cannot be cast to StructType` instead of the proper `DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE` error that `checkInputDataTypes()` was trying to report.

### Does this PR introduce _any_ user-facing change?

Yes - users now get a proper `AnalysisException` with error class `DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE` instead of a raw `ClassCastException`.

### How was this patch tested?
New tests.

### Was this patch authored or co-authored using generative AI tooling?

Yes

Co-authored-by: Claude