### PR TITLE
[SPARK-56207][SQL] Replace legacy error codes with named errors in DSv2 connector API

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5667,12 +5667,6 @@
     ],
     "sqlState" : "428FT"
   },
-  "TRUNCATE_PARTITIONS_NOT_SUPPORTED" : {
-    "message" : [
-      "Truncate partitions is not supported."
-    ],
-    "sqlState" : "0A000"
-  },
   "PARTITION_BY_NOT_ALLOWED_WITH_INSERT_INTO" : {
     "message" : [
       "partitionBy() cannot be used with insertInto(). Partition columns for table <tableName> are determined by the table definition."
@@ -5696,12 +5690,6 @@
       "The expression <expression> must be inside 'partitionedBy'."
     ],
     "sqlState" : "42S23"
-  },
-  "TRUNCATE_PARTITION_NOT_SUPPORTED" : {
-    "message" : [
-      "Truncate partition is not supported."
-    ],
-    "sqlState" : "0A000"
   },
   "PATH_ALREADY_EXISTS" : {
     "message" : [
@@ -7014,6 +7002,18 @@
       "Transpose requires non-index columns to share a least common type, but <dt1> and <dt2> do not."
     ],
     "sqlState" : "42K09"
+  },
+  "TRUNCATE_PARTITIONS_NOT_SUPPORTED" : {
+    "message" : [
+      "Truncate partitions is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
+  "TRUNCATE_PARTITION_NOT_SUPPORTED" : {
+    "message" : [
+      "Truncate partition is not supported."
+    ],
+    "sqlState" : "0A000"
   },
   "TUPLE_INVALID_INPUT_SKETCH_BUFFER" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1445,6 +1445,78 @@
     ],
     "sqlState" : "KD011"
   },
+  "DATASOURCE_BATCH_SCAN_NOT_SUPPORTED" : {
+    "message" : [
+      "<description>: Batch scan is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_BATCH_WRITE_BUILD_NOT_SUPPORTED" : {
+    "message" : [
+      "<class> does not support batch write."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_BATCH_WRITE_NOT_SUPPORTED" : {
+    "message" : [
+      "<description>: Batch write is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_COLUMNAR_READER_NOT_SUPPORTED" : {
+    "message" : [
+      "Cannot create columnar reader."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_CONTINUOUS_SCAN_NOT_SUPPORTED" : {
+    "message" : [
+      "<description>: Continuous scan is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_DELTA_BATCH_WRITE_NOT_SUPPORTED" : {
+    "message" : [
+      "<description>: Delta batch write is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_DELTA_WRITE_BUILD_NOT_IMPLEMENTED" : {
+    "message" : [
+      "<class> does not implement build."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_METADATA_SCHEMA_NOT_IMPLEMENTED" : {
+    "message" : [
+      "<class> does not implement metadataSchema."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_MICRO_BATCH_SCAN_NOT_SUPPORTED" : {
+    "message" : [
+      "<description>: Micro-batch scan is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_ROW_ID_SCHEMA_NOT_IMPLEMENTED" : {
+    "message" : [
+      "<class> does not implement rowIdSchema."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_STREAMING_WRITE_BUILD_NOT_SUPPORTED" : {
+    "message" : [
+      "<class> does not support streaming write."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_STREAMING_WRITE_NOT_SUPPORTED" : {
+    "message" : [
+      "<description>: Streaming write is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
   "DATATYPE_CANNOT_ORDER" : {
     "message" : [
       "Type <dataType> does not support ordered operations."
@@ -1786,78 +1858,6 @@
       "Expected schema: <expectedSchema>"
     ],
     "sqlState" : "42K03"
-  },
-  "DATASOURCE_BATCH_SCAN_NOT_SUPPORTED" : {
-    "message" : [
-      "<description>: Batch scan is not supported."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATASOURCE_BATCH_WRITE_BUILD_NOT_SUPPORTED" : {
-    "message" : [
-      "<class> does not support batch write."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATASOURCE_BATCH_WRITE_NOT_SUPPORTED" : {
-    "message" : [
-      "<description>: Batch write is not supported."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATASOURCE_COLUMNAR_READER_NOT_SUPPORTED" : {
-    "message" : [
-      "Cannot create columnar reader."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATASOURCE_CONTINUOUS_SCAN_NOT_SUPPORTED" : {
-    "message" : [
-      "<description>: Continuous scan is not supported."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATASOURCE_DELTA_BATCH_WRITE_NOT_SUPPORTED" : {
-    "message" : [
-      "<description>: Delta batch write is not supported."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATASOURCE_DELTA_WRITE_BUILD_NOT_IMPLEMENTED" : {
-    "message" : [
-      "<class> does not implement build."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATASOURCE_METADATA_SCHEMA_NOT_IMPLEMENTED" : {
-    "message" : [
-      "<class> does not implement metadataSchema."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATASOURCE_MICRO_BATCH_SCAN_NOT_SUPPORTED" : {
-    "message" : [
-      "<description>: Micro-batch scan is not supported."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATASOURCE_ROW_ID_SCHEMA_NOT_IMPLEMENTED" : {
-    "message" : [
-      "<class> does not implement rowIdSchema."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATASOURCE_STREAMING_WRITE_BUILD_NOT_SUPPORTED" : {
-    "message" : [
-      "<class> does not support streaming write."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATASOURCE_STREAMING_WRITE_NOT_SUPPORTED" : {
-    "message" : [
-      "<description>: Streaming write is not supported."
-    ],
-    "sqlState" : "0A000"
   },
   "DATETIME_FIELD_OUT_OF_BOUNDS" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1787,6 +1787,78 @@
     ],
     "sqlState" : "42K03"
   },
+  "DATASOURCE_BATCH_SCAN_NOT_SUPPORTED" : {
+    "message" : [
+      "<description>: Batch scan is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_BATCH_WRITE_BUILD_NOT_SUPPORTED" : {
+    "message" : [
+      "<class> does not support batch write."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_BATCH_WRITE_NOT_SUPPORTED" : {
+    "message" : [
+      "<description>: Batch write is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_COLUMNAR_READER_NOT_SUPPORTED" : {
+    "message" : [
+      "Cannot create columnar reader."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_CONTINUOUS_SCAN_NOT_SUPPORTED" : {
+    "message" : [
+      "<description>: Continuous scan is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_DELTA_BATCH_WRITE_NOT_SUPPORTED" : {
+    "message" : [
+      "<description>: Delta batch write is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_DELTA_WRITE_BUILD_NOT_IMPLEMENTED" : {
+    "message" : [
+      "<class> does not implement build."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_METADATA_SCHEMA_NOT_IMPLEMENTED" : {
+    "message" : [
+      "<class> does not implement metadataSchema."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_MICRO_BATCH_SCAN_NOT_SUPPORTED" : {
+    "message" : [
+      "<description>: Micro-batch scan is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_ROW_ID_SCHEMA_NOT_IMPLEMENTED" : {
+    "message" : [
+      "<class> does not implement rowIdSchema."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_STREAMING_WRITE_BUILD_NOT_SUPPORTED" : {
+    "message" : [
+      "<class> does not support streaming write."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATASOURCE_STREAMING_WRITE_NOT_SUPPORTED" : {
+    "message" : [
+      "<description>: Streaming write is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
   "DATETIME_FIELD_OUT_OF_BOUNDS" : {
     "message" : [
       "<rangeMessage>."
@@ -5595,6 +5667,12 @@
     ],
     "sqlState" : "428FT"
   },
+  "PARTITIONS_TRUNCATE_NOT_SUPPORTED" : {
+    "message" : [
+      "Partitions truncate is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
   "PARTITION_BY_NOT_ALLOWED_WITH_INSERT_INTO" : {
     "message" : [
       "partitionBy() cannot be used with insertInto(). Partition columns for table <tableName> are determined by the table definition."
@@ -5607,11 +5685,23 @@
     ],
     "sqlState" : "42000"
   },
+  "PARTITION_RENAME_NOT_SUPPORTED" : {
+    "message" : [
+      "Partition renaming is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
   "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY" : {
     "message" : [
       "The expression <expression> must be inside 'partitionedBy'."
     ],
     "sqlState" : "42S23"
+  },
+  "PARTITION_TRUNCATE_NOT_SUPPORTED" : {
+    "message" : [
+      "Partition truncate is not supported."
+    ],
+    "sqlState" : "0A000"
   },
   "PATH_ALREADY_EXISTS" : {
     "message" : [
@@ -7055,6 +7145,12 @@
     ],
     "sqlState" : "XX000"
   },
+  "UNEXPECTED_V2_EXPRESSION" : {
+    "message" : [
+      "Unexpected V2 expression: <expr>."
+    ],
+    "sqlState" : "42000"
+  },
   "UNION_NOT_SUPPORTED_IN_RECURSIVE_CTE" : {
     "message" : [
       "The UNION operator is not yet supported within recursive common table expressions (WITH clauses that refer to themselves, directly or indirectly). Please use UNION ALL instead."
@@ -8286,6 +8382,18 @@
       "<inferredDataSchema>"
     ],
     "sqlState" : "42000"
+  },
+  "V2_EXPRESSION_SQL_BUILDER_UDAF_NOT_SUPPORTED" : {
+    "message" : [
+      "<class> does not support user defined aggregate function: <funcName>."
+    ],
+    "sqlState" : "0A000"
+  },
+  "V2_EXPRESSION_SQL_BUILDER_UDF_NOT_SUPPORTED" : {
+    "message" : [
+      "<class> does not support user defined function: <funcName>."
+    ],
+    "sqlState" : "0A000"
   },
   "VARIABLE_ALREADY_EXISTS" : {
     "message" : [
@@ -10760,91 +10868,6 @@
       "CaseInsensitiveStringMap is read-only."
     ]
   },
-  "_LEGACY_ERROR_TEMP_3133" : {
-    "message" : [
-      "<class> does not implement rowIdSchema"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3134" : {
-    "message" : [
-      "<class> does not implement metadataSchema"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3135" : {
-    "message" : [
-      "<class> does not support batch write"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3136" : {
-    "message" : [
-      "<class> does not support streaming write"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3137" : {
-    "message" : [
-      "<description>: Batch write is not supported"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3138" : {
-    "message" : [
-      "<description>: Streaming write is not supported"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3139" : {
-    "message" : [
-      "<description>: Delta batch write is not supported"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3140" : {
-    "message" : [
-      "<class> does not implement build"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3141" : {
-    "message" : [
-      "<class> does not support user defined function: <funcName>"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3142" : {
-    "message" : [
-      "<class> does not support user defined aggregate function: <funcName>"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3143" : {
-    "message" : [
-      "Partition renaming is not supported"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3144" : {
-    "message" : [
-      "Partition truncate is not supported"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3145" : {
-    "message" : [
-      "Partitions truncate is not supported"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3147" : {
-    "message" : [
-      "<description>: Batch scan are not supported"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3148" : {
-    "message" : [
-      "<description>: Micro-batch scan are not supported"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3149" : {
-    "message" : [
-      "<description>: Continuous scan are not supported"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3150" : {
-    "message" : [
-      "Cannot create columnar reader."
-    ]
-  },
   "_LEGACY_ERROR_TEMP_3152" : {
     "message" : [
       "Datatype not supported <dataType>"
@@ -11048,11 +11071,6 @@
   "_LEGACY_ERROR_TEMP_3206" : {
     "message" : [
       "<value> is not a boolean string."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3207" : {
-    "message" : [
-      "Unexpected V2 expression: <expr>"
     ]
   },
   "_LEGACY_ERROR_TEMP_3208" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1445,73 +1445,73 @@
     ],
     "sqlState" : "KD011"
   },
-  "DATASOURCE_BATCH_SCAN_NOT_SUPPORTED" : {
+  "DATA_SOURCE_BATCH_SCAN_NOT_SUPPORTED" : {
     "message" : [
       "<description>: Batch scan is not supported."
     ],
     "sqlState" : "0A000"
   },
-  "DATASOURCE_BATCH_WRITE_BUILDER_NOT_SUPPORTED" : {
+  "DATA_SOURCE_BATCH_WRITE_BUILDER_NOT_SUPPORTED" : {
     "message" : [
       "<class> does not support batch write."
     ],
     "sqlState" : "0A000"
   },
-  "DATASOURCE_BATCH_WRITE_NOT_SUPPORTED" : {
+  "DATA_SOURCE_BATCH_WRITE_NOT_SUPPORTED" : {
     "message" : [
       "<description>: Batch write is not supported."
     ],
     "sqlState" : "0A000"
   },
-  "DATASOURCE_COLUMNAR_READER_NOT_SUPPORTED" : {
+  "DATA_SOURCE_COLUMNAR_READER_NOT_SUPPORTED" : {
     "message" : [
       "<class> cannot create columnar reader."
     ],
     "sqlState" : "0A000"
   },
-  "DATASOURCE_CONTINUOUS_SCAN_NOT_SUPPORTED" : {
+  "DATA_SOURCE_CONTINUOUS_SCAN_NOT_SUPPORTED" : {
     "message" : [
       "<description>: Continuous scan is not supported."
     ],
     "sqlState" : "0A000"
   },
-  "DATASOURCE_DELTA_BATCH_WRITE_NOT_SUPPORTED" : {
+  "DATA_SOURCE_DELTA_BATCH_WRITE_NOT_SUPPORTED" : {
     "message" : [
       "<description>: Delta batch write is not supported."
     ],
     "sqlState" : "0A000"
   },
-  "DATASOURCE_DELTA_WRITE_BUILD_NOT_IMPLEMENTED" : {
+  "DATA_SOURCE_DELTA_WRITE_BUILD_NOT_IMPLEMENTED" : {
     "message" : [
       "<class> does not implement build."
     ],
     "sqlState" : "0A000"
   },
-  "DATASOURCE_METADATA_SCHEMA_NOT_IMPLEMENTED" : {
+  "DATA_SOURCE_METADATA_SCHEMA_NOT_IMPLEMENTED" : {
     "message" : [
       "<class> does not implement metadataSchema."
     ],
     "sqlState" : "0A000"
   },
-  "DATASOURCE_MICRO_BATCH_SCAN_NOT_SUPPORTED" : {
+  "DATA_SOURCE_MICRO_BATCH_SCAN_NOT_SUPPORTED" : {
     "message" : [
       "<description>: Micro-batch scan is not supported."
     ],
     "sqlState" : "0A000"
   },
-  "DATASOURCE_ROW_ID_SCHEMA_NOT_IMPLEMENTED" : {
+  "DATA_SOURCE_ROW_ID_SCHEMA_NOT_IMPLEMENTED" : {
     "message" : [
       "<class> does not implement rowIdSchema."
     ],
     "sqlState" : "0A000"
   },
-  "DATASOURCE_STREAMING_WRITE_BUILD_NOT_SUPPORTED" : {
+  "DATA_SOURCE_STREAMING_WRITE_BUILD_NOT_SUPPORTED" : {
     "message" : [
       "<class> does not support streaming write."
     ],
     "sqlState" : "0A000"
   },
-  "DATASOURCE_STREAMING_WRITE_NOT_SUPPORTED" : {
+  "DATA_SOURCE_STREAMING_WRITE_NOT_SUPPORTED" : {
     "message" : [
       "<description>: Streaming write is not supported."
     ],

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1465,7 +1465,7 @@
   },
   "DATASOURCE_COLUMNAR_READER_NOT_SUPPORTED" : {
     "message" : [
-      "<class>: Cannot create columnar reader."
+      "<class> cannot create columnar reader."
     ],
     "sqlState" : "0A000"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1451,7 +1451,7 @@
     ],
     "sqlState" : "0A000"
   },
-  "DATASOURCE_BATCH_WRITE_BUILD_NOT_SUPPORTED" : {
+  "DATASOURCE_BATCH_WRITE_BUILDER_NOT_SUPPORTED" : {
     "message" : [
       "<class> does not support batch write."
     ],
@@ -1465,7 +1465,7 @@
   },
   "DATASOURCE_COLUMNAR_READER_NOT_SUPPORTED" : {
     "message" : [
-      "Cannot create columnar reader."
+      "<class>: Cannot create columnar reader."
     ],
     "sqlState" : "0A000"
   },
@@ -5667,9 +5667,9 @@
     ],
     "sqlState" : "428FT"
   },
-  "PARTITIONS_TRUNCATE_NOT_SUPPORTED" : {
+  "TRUNCATE_PARTITIONS_NOT_SUPPORTED" : {
     "message" : [
-      "Partitions truncate is not supported."
+      "Truncate partitions is not supported."
     ],
     "sqlState" : "0A000"
   },
@@ -5697,9 +5697,9 @@
     ],
     "sqlState" : "42S23"
   },
-  "PARTITION_TRUNCATE_NOT_SUPPORTED" : {
+  "TRUNCATE_PARTITION_NOT_SUPPORTED" : {
     "message" : [
-      "Partition truncate is not supported."
+      "Truncate partition is not supported."
     ],
     "sqlState" : "0A000"
   },
@@ -7149,7 +7149,7 @@
     "message" : [
       "Unexpected V2 expression: <expr>."
     ],
-    "sqlState" : "42000"
+    "sqlState" : "XX000"
   },
   "UNION_NOT_SUPPORTED_IN_RECURSIVE_CTE" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -7005,13 +7005,13 @@
   },
   "TRUNCATE_PARTITIONS_NOT_SUPPORTED" : {
     "message" : [
-      "Truncate partitions is not supported."
+      "Truncating partitions is not supported."
     ],
     "sqlState" : "0A000"
   },
   "TRUNCATE_PARTITION_NOT_SUPPORTED" : {
     "message" : [
-      "Truncate partition is not supported."
+      "Truncating partition is not supported."
     ],
     "sqlState" : "0A000"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1445,78 +1445,6 @@
     ],
     "sqlState" : "KD011"
   },
-  "DATA_SOURCE_BATCH_SCAN_NOT_SUPPORTED" : {
-    "message" : [
-      "<description>: Batch scan is not supported."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATA_SOURCE_BATCH_WRITE_BUILDER_NOT_SUPPORTED" : {
-    "message" : [
-      "<class> does not support batch write."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATA_SOURCE_BATCH_WRITE_NOT_SUPPORTED" : {
-    "message" : [
-      "<description>: Batch write is not supported."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATA_SOURCE_COLUMNAR_READER_NOT_SUPPORTED" : {
-    "message" : [
-      "<class> cannot create columnar reader."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATA_SOURCE_CONTINUOUS_SCAN_NOT_SUPPORTED" : {
-    "message" : [
-      "<description>: Continuous scan is not supported."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATA_SOURCE_DELTA_BATCH_WRITE_NOT_SUPPORTED" : {
-    "message" : [
-      "<description>: Delta batch write is not supported."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATA_SOURCE_DELTA_WRITE_BUILD_NOT_IMPLEMENTED" : {
-    "message" : [
-      "<class> does not implement build."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATA_SOURCE_METADATA_SCHEMA_NOT_IMPLEMENTED" : {
-    "message" : [
-      "<class> does not implement metadataSchema."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATA_SOURCE_MICRO_BATCH_SCAN_NOT_SUPPORTED" : {
-    "message" : [
-      "<description>: Micro-batch scan is not supported."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATA_SOURCE_ROW_ID_SCHEMA_NOT_IMPLEMENTED" : {
-    "message" : [
-      "<class> does not implement rowIdSchema."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATA_SOURCE_STREAMING_WRITE_BUILD_NOT_SUPPORTED" : {
-    "message" : [
-      "<class> does not support streaming write."
-    ],
-    "sqlState" : "0A000"
-  },
-  "DATA_SOURCE_STREAMING_WRITE_NOT_SUPPORTED" : {
-    "message" : [
-      "<description>: Streaming write is not supported."
-    ],
-    "sqlState" : "0A000"
-  },
   "DATATYPE_CANNOT_ORDER" : {
     "message" : [
       "Type <dataType> does not support ordered operations."
@@ -1833,11 +1761,65 @@
     ],
     "sqlState" : "42710"
   },
+  "DATA_SOURCE_BATCH_SCAN_NOT_SUPPORTED" : {
+    "message" : [
+      "<description>: Batch scan is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATA_SOURCE_BATCH_WRITE_BUILDER_NOT_SUPPORTED" : {
+    "message" : [
+      "<class> does not support batch write."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATA_SOURCE_BATCH_WRITE_NOT_SUPPORTED" : {
+    "message" : [
+      "<description>: Batch write is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATA_SOURCE_COLUMNAR_READER_NOT_SUPPORTED" : {
+    "message" : [
+      "<class> cannot create columnar reader."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATA_SOURCE_CONTINUOUS_SCAN_NOT_SUPPORTED" : {
+    "message" : [
+      "<description>: Continuous scan is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATA_SOURCE_DELTA_BATCH_WRITE_NOT_SUPPORTED" : {
+    "message" : [
+      "<description>: Delta batch write is not supported."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATA_SOURCE_DELTA_WRITE_BUILD_NOT_IMPLEMENTED" : {
+    "message" : [
+      "<class> does not implement build."
+    ],
+    "sqlState" : "0A000"
+  },
   "DATA_SOURCE_EXTERNAL_ERROR" : {
     "message" : [
       "Encountered error when saving to external data source."
     ],
     "sqlState" : "KD010"
+  },
+  "DATA_SOURCE_METADATA_SCHEMA_NOT_IMPLEMENTED" : {
+    "message" : [
+      "<class> does not implement metadataSchema."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATA_SOURCE_MICRO_BATCH_SCAN_NOT_SUPPORTED" : {
+    "message" : [
+      "<description>: Micro-batch scan is not supported."
+    ],
+    "sqlState" : "0A000"
   },
   "DATA_SOURCE_NOT_EXIST" : {
     "message" : [
@@ -1850,6 +1832,24 @@
       "Failed to find the data source: <provider>. Make sure the provider name is correct and the package is properly registered and compatible with your Spark version."
     ],
     "sqlState" : "42K02"
+  },
+  "DATA_SOURCE_ROW_ID_SCHEMA_NOT_IMPLEMENTED" : {
+    "message" : [
+      "<class> does not implement rowIdSchema."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATA_SOURCE_STREAMING_WRITE_BUILD_NOT_SUPPORTED" : {
+    "message" : [
+      "<class> does not support streaming write."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DATA_SOURCE_STREAMING_WRITE_NOT_SUPPORTED" : {
+    "message" : [
+      "<description>: Streaming write is not supported."
+    ],
+    "sqlState" : "0A000"
   },
   "DATA_SOURCE_TABLE_SCHEMA_MISMATCH" : {
     "message" : [

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsAtomicPartitionManagement.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsAtomicPartitionManagement.java
@@ -127,6 +127,6 @@ public interface SupportsAtomicPartitionManagement extends SupportsPartitionMana
    */
   default boolean truncatePartitions(InternalRow[] idents)
       throws NoSuchPartitionException, SparkUnsupportedOperationException {
-    throw new SparkUnsupportedOperationException("_LEGACY_ERROR_TEMP_3145");
+    throw new SparkUnsupportedOperationException("PARTITIONS_TRUNCATE_NOT_SUPPORTED");
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsAtomicPartitionManagement.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsAtomicPartitionManagement.java
@@ -127,6 +127,6 @@ public interface SupportsAtomicPartitionManagement extends SupportsPartitionMana
    */
   default boolean truncatePartitions(InternalRow[] idents)
       throws NoSuchPartitionException, SparkUnsupportedOperationException {
-    throw new SparkUnsupportedOperationException("PARTITIONS_TRUNCATE_NOT_SUPPORTED");
+    throw new SparkUnsupportedOperationException("TRUNCATE_PARTITIONS_NOT_SUPPORTED");
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsPartitionManagement.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsPartitionManagement.java
@@ -157,7 +157,7 @@ public interface SupportsPartitionManagement extends Table {
         throws SparkUnsupportedOperationException,
                PartitionsAlreadyExistException,
                NoSuchPartitionException {
-      throw new SparkUnsupportedOperationException("_LEGACY_ERROR_TEMP_3143");
+      throw new SparkUnsupportedOperationException("PARTITION_RENAME_NOT_SUPPORTED");
     }
 
     /**
@@ -172,6 +172,6 @@ public interface SupportsPartitionManagement extends Table {
      */
     default boolean truncatePartition(InternalRow ident)
         throws NoSuchPartitionException, SparkUnsupportedOperationException {
-      throw new SparkUnsupportedOperationException("_LEGACY_ERROR_TEMP_3144");
+      throw new SparkUnsupportedOperationException("PARTITION_TRUNCATE_NOT_SUPPORTED");
     }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsPartitionManagement.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsPartitionManagement.java
@@ -172,6 +172,6 @@ public interface SupportsPartitionManagement extends Table {
      */
     default boolean truncatePartition(InternalRow ident)
         throws NoSuchPartitionException, SparkUnsupportedOperationException {
-      throw new SparkUnsupportedOperationException("PARTITION_TRUNCATE_NOT_SUPPORTED");
+      throw new SparkUnsupportedOperationException("TRUNCATE_PARTITION_NOT_SUPPORTED");
     }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/PartitionReaderFactory.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/PartitionReaderFactory.java
@@ -51,7 +51,7 @@ public interface PartitionReaderFactory extends Serializable {
    * {@link InputPartition} class defined for the data source.
    */
   default PartitionReader<ColumnarBatch> createColumnarReader(InputPartition partition) {
-    throw new SparkUnsupportedOperationException("_LEGACY_ERROR_TEMP_3150");
+    throw new SparkUnsupportedOperationException("DATASOURCE_COLUMNAR_READER_NOT_SUPPORTED");
   }
 
   /**

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/PartitionReaderFactory.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/PartitionReaderFactory.java
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.connector.read;
 
 import java.io.Serializable;
+import java.util.Map;
 
 import org.apache.spark.SparkUnsupportedOperationException;
 import org.apache.spark.annotation.Evolving;
@@ -51,7 +52,8 @@ public interface PartitionReaderFactory extends Serializable {
    * {@link InputPartition} class defined for the data source.
    */
   default PartitionReader<ColumnarBatch> createColumnarReader(InputPartition partition) {
-    throw new SparkUnsupportedOperationException("DATASOURCE_COLUMNAR_READER_NOT_SUPPORTED");
+    throw new SparkUnsupportedOperationException(
+      "DATASOURCE_COLUMNAR_READER_NOT_SUPPORTED", Map.of("class", getClass().getName()));
   }
 
   /**

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/PartitionReaderFactory.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/PartitionReaderFactory.java
@@ -53,7 +53,7 @@ public interface PartitionReaderFactory extends Serializable {
    */
   default PartitionReader<ColumnarBatch> createColumnarReader(InputPartition partition) {
     throw new SparkUnsupportedOperationException(
-      "DATASOURCE_COLUMNAR_READER_NOT_SUPPORTED", Map.of("class", getClass().getName()));
+      "DATA_SOURCE_COLUMNAR_READER_NOT_SUPPORTED", Map.of("class", getClass().getName()));
   }
 
   /**

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/Scan.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/Scan.java
@@ -78,7 +78,7 @@ public interface Scan {
    */
   default Batch toBatch() {
     throw new SparkUnsupportedOperationException(
-      "_LEGACY_ERROR_TEMP_3147", Map.of("description", description()));
+      "DATASOURCE_BATCH_SCAN_NOT_SUPPORTED", Map.of("description", description()));
   }
 
   /**
@@ -95,7 +95,7 @@ public interface Scan {
    */
   default MicroBatchStream toMicroBatchStream(String checkpointLocation) {
     throw new SparkUnsupportedOperationException(
-      "_LEGACY_ERROR_TEMP_3148", Map.of("description", description()));
+      "DATASOURCE_MICRO_BATCH_SCAN_NOT_SUPPORTED", Map.of("description", description()));
   }
 
   /**
@@ -112,7 +112,7 @@ public interface Scan {
    */
   default ContinuousStream toContinuousStream(String checkpointLocation) {
     throw new SparkUnsupportedOperationException(
-      "_LEGACY_ERROR_TEMP_3149", Map.of("description", description()));
+      "DATASOURCE_CONTINUOUS_SCAN_NOT_SUPPORTED", Map.of("description", description()));
   }
 
   /**

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/Scan.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/Scan.java
@@ -78,7 +78,7 @@ public interface Scan {
    */
   default Batch toBatch() {
     throw new SparkUnsupportedOperationException(
-      "DATASOURCE_BATCH_SCAN_NOT_SUPPORTED", Map.of("description", description()));
+      "DATA_SOURCE_BATCH_SCAN_NOT_SUPPORTED", Map.of("description", description()));
   }
 
   /**
@@ -95,7 +95,7 @@ public interface Scan {
    */
   default MicroBatchStream toMicroBatchStream(String checkpointLocation) {
     throw new SparkUnsupportedOperationException(
-      "DATASOURCE_MICRO_BATCH_SCAN_NOT_SUPPORTED", Map.of("description", description()));
+      "DATA_SOURCE_MICRO_BATCH_SCAN_NOT_SUPPORTED", Map.of("description", description()));
   }
 
   /**
@@ -112,7 +112,7 @@ public interface Scan {
    */
   default ContinuousStream toContinuousStream(String checkpointLocation) {
     throw new SparkUnsupportedOperationException(
-      "DATASOURCE_CONTINUOUS_SCAN_NOT_SUPPORTED", Map.of("description", description()));
+      "DATA_SOURCE_CONTINUOUS_SCAN_NOT_SUPPORTED", Map.of("description", description()));
   }
 
   /**

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/ContinuousPartitionReaderFactory.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/ContinuousPartitionReaderFactory.java
@@ -41,6 +41,6 @@ public interface ContinuousPartitionReaderFactory extends PartitionReaderFactory
   @Override
   default ContinuousPartitionReader<ColumnarBatch> createColumnarReader(InputPartition partition) {
     throw new SparkUnsupportedOperationException(
-      "DATASOURCE_COLUMNAR_READER_NOT_SUPPORTED", Map.of("class", getClass().getName()));
+      "DATA_SOURCE_COLUMNAR_READER_NOT_SUPPORTED", Map.of("class", getClass().getName()));
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/ContinuousPartitionReaderFactory.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/ContinuousPartitionReaderFactory.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.connector.read.streaming;
 
+import java.util.Map;
+
 import org.apache.spark.SparkUnsupportedOperationException;
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -38,6 +40,7 @@ public interface ContinuousPartitionReaderFactory extends PartitionReaderFactory
 
   @Override
   default ContinuousPartitionReader<ColumnarBatch> createColumnarReader(InputPartition partition) {
-    throw new SparkUnsupportedOperationException("DATASOURCE_COLUMNAR_READER_NOT_SUPPORTED");
+    throw new SparkUnsupportedOperationException(
+      "DATASOURCE_COLUMNAR_READER_NOT_SUPPORTED", Map.of("class", getClass().getName()));
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/ContinuousPartitionReaderFactory.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/ContinuousPartitionReaderFactory.java
@@ -38,6 +38,6 @@ public interface ContinuousPartitionReaderFactory extends PartitionReaderFactory
 
   @Override
   default ContinuousPartitionReader<ColumnarBatch> createColumnarReader(InputPartition partition) {
-    throw new SparkUnsupportedOperationException("_LEGACY_ERROR_TEMP_3150");
+    throw new SparkUnsupportedOperationException("DATASOURCE_COLUMNAR_READER_NOT_SUPPORTED");
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
@@ -319,20 +319,20 @@ public class V2ExpressionSQLBuilder {
   protected String visitUserDefinedScalarFunction(
       String funcName, String canonicalName, String[] inputs) {
     throw new SparkUnsupportedOperationException(
-      "_LEGACY_ERROR_TEMP_3141",
+      "V2_EXPRESSION_SQL_BUILDER_UDF_NOT_SUPPORTED",
       Map.of("class", this.getClass().getSimpleName(), "funcName", funcName));
   }
 
   protected String visitUserDefinedAggregateFunction(
       String funcName, String canonicalName, boolean isDistinct, String[] inputs) {
     throw new SparkUnsupportedOperationException(
-      "_LEGACY_ERROR_TEMP_3142",
+      "V2_EXPRESSION_SQL_BUILDER_UDAF_NOT_SUPPORTED",
       Map.of("class", this.getClass().getSimpleName(), "funcName", funcName));
   }
 
   protected String visitUnexpectedExpr(Expression expr) throws IllegalArgumentException {
     throw new SparkIllegalArgumentException(
-      "_LEGACY_ERROR_TEMP_3207", Map.of("expr", String.valueOf(expr)));
+      "UNEXPECTED_V2_EXPRESSION", Map.of("expr", String.valueOf(expr)));
   }
 
   protected String visitPartitionPredicate(PartitionPredicate partitionPredicate) {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
@@ -320,14 +320,14 @@ public class V2ExpressionSQLBuilder {
       String funcName, String canonicalName, String[] inputs) {
     throw new SparkUnsupportedOperationException(
       "V2_EXPRESSION_SQL_BUILDER_UDF_NOT_SUPPORTED",
-      Map.of("class", this.getClass().getSimpleName(), "funcName", funcName));
+      Map.of("class", this.getClass().getName(), "funcName", funcName));
   }
 
   protected String visitUserDefinedAggregateFunction(
       String funcName, String canonicalName, boolean isDistinct, String[] inputs) {
     throw new SparkUnsupportedOperationException(
       "V2_EXPRESSION_SQL_BUILDER_UDAF_NOT_SUPPORTED",
-      Map.of("class", this.getClass().getSimpleName(), "funcName", funcName));
+      Map.of("class", this.getClass().getName(), "funcName", funcName));
   }
 
   protected String visitUnexpectedExpr(Expression expr) throws IllegalArgumentException {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/DeltaWrite.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/DeltaWrite.java
@@ -32,6 +32,6 @@ public interface DeltaWrite extends Write {
   @Override
   default DeltaBatchWrite toBatch() {
     throw new SparkUnsupportedOperationException(
-      "DATASOURCE_DELTA_BATCH_WRITE_NOT_SUPPORTED", Map.of("description", description()));
+      "DATA_SOURCE_DELTA_BATCH_WRITE_NOT_SUPPORTED", Map.of("description", description()));
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/DeltaWrite.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/DeltaWrite.java
@@ -32,6 +32,6 @@ public interface DeltaWrite extends Write {
   @Override
   default DeltaBatchWrite toBatch() {
     throw new SparkUnsupportedOperationException(
-      "_LEGACY_ERROR_TEMP_3139", Map.of("description", description()));
+      "DATASOURCE_DELTA_BATCH_WRITE_NOT_SUPPORTED", Map.of("description", description()));
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/DeltaWriteBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/DeltaWriteBuilder.java
@@ -32,6 +32,6 @@ public interface DeltaWriteBuilder extends WriteBuilder {
   @Override
   default DeltaWrite build() {
     throw new SparkUnsupportedOperationException(
-      "_LEGACY_ERROR_TEMP_3140", Map.of("class", getClass().getName()));
+      "DATASOURCE_DELTA_WRITE_BUILD_NOT_IMPLEMENTED", Map.of("class", getClass().getName()));
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/DeltaWriteBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/DeltaWriteBuilder.java
@@ -32,6 +32,6 @@ public interface DeltaWriteBuilder extends WriteBuilder {
   @Override
   default DeltaWrite build() {
     throw new SparkUnsupportedOperationException(
-      "DATASOURCE_DELTA_WRITE_BUILD_NOT_IMPLEMENTED", Map.of("class", getClass().getName()));
+      "DATA_SOURCE_DELTA_WRITE_BUILD_NOT_IMPLEMENTED", Map.of("class", getClass().getName()));
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/LogicalWriteInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/LogicalWriteInfo.java
@@ -55,7 +55,7 @@ public interface LogicalWriteInfo {
    */
   default Optional<StructType> rowIdSchema() {
     throw new SparkUnsupportedOperationException(
-      "DATASOURCE_ROW_ID_SCHEMA_NOT_IMPLEMENTED", Map.of("class", getClass().getName()));
+      "DATA_SOURCE_ROW_ID_SCHEMA_NOT_IMPLEMENTED", Map.of("class", getClass().getName()));
   }
 
   /**
@@ -63,6 +63,6 @@ public interface LogicalWriteInfo {
    */
   default Optional<StructType> metadataSchema() {
     throw new SparkUnsupportedOperationException(
-      "DATASOURCE_METADATA_SCHEMA_NOT_IMPLEMENTED", Map.of("class", getClass().getName()));
+      "DATA_SOURCE_METADATA_SCHEMA_NOT_IMPLEMENTED", Map.of("class", getClass().getName()));
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/LogicalWriteInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/LogicalWriteInfo.java
@@ -55,7 +55,7 @@ public interface LogicalWriteInfo {
    */
   default Optional<StructType> rowIdSchema() {
     throw new SparkUnsupportedOperationException(
-      "_LEGACY_ERROR_TEMP_3133", Map.of("class", getClass().getName()));
+      "DATASOURCE_ROW_ID_SCHEMA_NOT_IMPLEMENTED", Map.of("class", getClass().getName()));
   }
 
   /**
@@ -63,6 +63,6 @@ public interface LogicalWriteInfo {
    */
   default Optional<StructType> metadataSchema() {
     throw new SparkUnsupportedOperationException(
-      "_LEGACY_ERROR_TEMP_3134", Map.of("class", getClass().getName()));
+      "DATASOURCE_METADATA_SCHEMA_NOT_IMPLEMENTED", Map.of("class", getClass().getName()));
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/Write.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/Write.java
@@ -56,7 +56,7 @@ public interface Write {
    */
   default BatchWrite toBatch() {
     throw new SparkUnsupportedOperationException(
-      "DATASOURCE_BATCH_WRITE_NOT_SUPPORTED", Map.of("description", description()));
+      "DATA_SOURCE_BATCH_WRITE_NOT_SUPPORTED", Map.of("description", description()));
   }
 
   /**
@@ -67,7 +67,7 @@ public interface Write {
    */
   default StreamingWrite toStreaming() {
     throw new SparkUnsupportedOperationException(
-      "DATASOURCE_STREAMING_WRITE_NOT_SUPPORTED", Map.of("description", description()));
+      "DATA_SOURCE_STREAMING_WRITE_NOT_SUPPORTED", Map.of("description", description()));
   }
 
   /**

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/Write.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/Write.java
@@ -56,7 +56,7 @@ public interface Write {
    */
   default BatchWrite toBatch() {
     throw new SparkUnsupportedOperationException(
-      "_LEGACY_ERROR_TEMP_3137", Map.of("description", description()));
+      "DATASOURCE_BATCH_WRITE_NOT_SUPPORTED", Map.of("description", description()));
   }
 
   /**
@@ -67,7 +67,7 @@ public interface Write {
    */
   default StreamingWrite toStreaming() {
     throw new SparkUnsupportedOperationException(
-      "_LEGACY_ERROR_TEMP_3138", Map.of("description", description()));
+      "DATASOURCE_STREAMING_WRITE_NOT_SUPPORTED", Map.of("description", description()));
   }
 
   /**

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/WriteBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/WriteBuilder.java
@@ -62,7 +62,7 @@ public interface WriteBuilder {
   @Deprecated(since = "3.2.0")
   default BatchWrite buildForBatch() {
     throw new SparkUnsupportedOperationException(
-      "DATASOURCE_BATCH_WRITE_BUILDER_NOT_SUPPORTED", Map.of("class", getClass().getName()));
+      "DATA_SOURCE_BATCH_WRITE_BUILDER_NOT_SUPPORTED", Map.of("class", getClass().getName()));
   }
 
   /**
@@ -73,6 +73,6 @@ public interface WriteBuilder {
   @Deprecated(since = "3.2.0")
   default StreamingWrite buildForStreaming() {
     throw new SparkUnsupportedOperationException(
-      "DATASOURCE_STREAMING_WRITE_BUILD_NOT_SUPPORTED", Map.of("class", getClass().getName()));
+      "DATA_SOURCE_STREAMING_WRITE_BUILD_NOT_SUPPORTED", Map.of("class", getClass().getName()));
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/WriteBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/WriteBuilder.java
@@ -62,7 +62,7 @@ public interface WriteBuilder {
   @Deprecated(since = "3.2.0")
   default BatchWrite buildForBatch() {
     throw new SparkUnsupportedOperationException(
-      "_LEGACY_ERROR_TEMP_3135", Map.of("class", getClass().getName()));
+      "DATASOURCE_BATCH_WRITE_BUILD_NOT_SUPPORTED", Map.of("class", getClass().getName()));
   }
 
   /**
@@ -73,6 +73,6 @@ public interface WriteBuilder {
   @Deprecated(since = "3.2.0")
   default StreamingWrite buildForStreaming() {
     throw new SparkUnsupportedOperationException(
-      "_LEGACY_ERROR_TEMP_3136", Map.of("class", getClass().getName()));
+      "DATASOURCE_STREAMING_WRITE_BUILD_NOT_SUPPORTED", Map.of("class", getClass().getName()));
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/WriteBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/WriteBuilder.java
@@ -62,7 +62,7 @@ public interface WriteBuilder {
   @Deprecated(since = "3.2.0")
   default BatchWrite buildForBatch() {
     throw new SparkUnsupportedOperationException(
-      "DATASOURCE_BATCH_WRITE_BUILD_NOT_SUPPORTED", Map.of("class", getClass().getName()));
+      "DATASOURCE_BATCH_WRITE_BUILDER_NOT_SUPPORTED", Map.of("class", getClass().getName()));
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

  Replaced 18 _LEGACY_ERROR_TEMP_* error codes in the Data Source V2 (DSv2) connector API with properly named, descriptive error conditions. The affected interfaces are all in                                 
  sql/catalyst/src/main/java/org/apache/spark/sql/connector/:                                                                                                                                                   
                                                                                                                                                                                                                
  - Read: Scan, PartitionReaderFactory, ContinuousPartitionReaderFactory                                                                                                                                        
  - Write: Write, WriteBuilder, DeltaWrite, DeltaWriteBuilder, LogicalWriteInfo
  - Catalog: SupportsPartitionManagement, SupportsAtomicPartitionManagement                                                                                                                                     
  - Util: V2ExpressionSQLBuilder                                                                                                                                                                                
                                                                                                                                                                                                                
  New error names follow established Spark conventions (DATASOURCE_*, PARTITION_*, V2_EXPRESSION_SQL_BUILDER_*, UNEXPECTED_*) and are inserted alphabetically into error-conditions.json. All new entries       
  include a sqlState (0A000 for unsupported operations, 42000 for illegal arguments) and messages ending with a period.                                                                                         

### Why are the changes needed?
  Legacy error codes (_LEGACY_ERROR_TEMP_*) are opaque and hard to search, cross-reference, or document. Named error codes make it easier for users and downstream connectors to identify and handle specific   
  error conditions.


### Does this PR introduce _any_ user-facing change?
  Yes — error messages now include a sqlState and names are surfaced in error output, but the message text is preserved (with minor normalization: trailing periods added for consistency).                     

### How was this patch tested?
  Existing unit and integration tests cover these code paths. No behavioral changes were made.                                                                                                                  

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code