### PR TITLE
[SPARK-56032][SQL][FOLLOW-UP] Fix comments in FilterExec CSE 

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -259,8 +259,8 @@ case class FilterExec(condition: Expression, child: SparkPlan)
         val boundOtherPreds = otherPreds.map(
           BindReferences.bindReference(_, output))
         // Pre-evaluate input variables before CSE analysis: CSE clears
-        // ctx.currentVars[i].code as a side effect, which causes "is not an rvalue"
-        // errors if notNullPreds reference the same inputs.
+        // ctx.currentVars[i].code as a side effect; without this pre-evaluation, Janino fails
+        // with "Unknown variable or type" when notNullPreds reference the same input columns.
         val otherPredInputAttrs = AttributeSet(otherPreds.flatMap(_.references))
         val inputVarsEvalCode = evaluateRequiredVariables(
           child.output, input, otherPredInputAttrs)
@@ -275,6 +275,13 @@ case class FilterExec(condition: Expression, child: SparkPlan)
           }
           code
         }
+        // Note: subExprs.exprCodesNeedEvaluate is intentionally not used here, unlike ProjectExec.
+        // evaluateRequiredVariables above cleared input[i].code = EmptyBlock for all
+        // otherPredInputAttrs before CSE analysis ran, so getLocalInputVariableValues never
+        // adds them to exprCodesNeedEvaluate — it is always empty. Do NOT replace the
+        // pre-evaluation above with evaluateVariables(subExprs.exprCodesNeedEvaluate):
+        // that would leave notNullPreds referencing undeclared variables (Janino: "Unknown
+        // variable or type") for any input column shared between notNullPreds and otherPreds.
         (inputVarsEvalCode, ctx.evaluateSubExprEliminationState(subExprs.states.values), predCode)
       } else {
         ("", "", generatePredicateCode(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -278,7 +278,7 @@ case class FilterExec(condition: Expression, child: SparkPlan)
         // Note: subExprs.exprCodesNeedEvaluate is intentionally not used here, unlike ProjectExec.
         // evaluateRequiredVariables above cleared input[i].code = EmptyBlock for all
         // otherPredInputAttrs before CSE analysis ran, so getLocalInputVariableValues never
-        // adds them to exprCodesNeedEvaluate — it is always empty. Do NOT replace the
+        // adds them to exprCodesNeedEvaluate -- it is always empty. Do NOT replace the
         // pre-evaluation above with evaluateVariables(subExprs.exprCodesNeedEvaluate):
         // that would leave notNullPreds referencing undeclared variables (Janino: "Unknown
         // variable or type") for any input column shared between notNullPreds and otherPreds.


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR addresses review [comments](https://github.com/apache/spark/pull/54862#pullrequestreview-3993828913) from cloud-fan in #54862

### Why are the changes needed?
To improve code clarity and prevent potential future bugs from incorrect refactoring. 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions


### Was this patch authored or co-authored using generative AI tooling?
No
