### PR TITLE
[SPARK-56179][PYTHON] Consolidate error classes for type mismatch - part 1

### DIFF
--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -602,72 +602,6 @@
       "Value for `<arg_name>` must be greater than or equal to 0, got '<arg_value>'."
     ]
   },
-  "NOT_BOOL": {
-    "message": [
-      "Argument `<arg_name>` should be a bool, got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
-  "NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_LIST_OR_STR_OR_TUPLE": {
-    "message": [
-      "Argument `<arg_name>` should be a bool, dict, float, int, str or tuple, got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
-  "NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_STR": {
-    "message": [
-      "Argument `<arg_name>` should be a bool, dict, float, int or str, got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
-  "NOT_BOOL_OR_FLOAT_OR_INT": {
-    "message": [
-      "Argument `<arg_name>` should be a bool, float or int, got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
-  "NOT_BOOL_OR_FLOAT_OR_INT_OR_LIST_OR_NONE_OR_STR_OR_TUPLE": {
-    "message": [
-      "Argument `<arg_name>` should be a bool, float, int, list, None, str or tuple, got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
-  "NOT_BOOL_OR_FLOAT_OR_INT_OR_STR": {
-    "message": [
-      "Argument `<arg_name>` should be a bool, float, int or str, got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
-  "NOT_BOOL_OR_STR": {
-    "message": [
-      "Argument `<arg_name>` should be a bool or str, got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
-  "NOT_CALLABLE": {
-    "message": [
-      "Argument `<arg_name>` should be a callable, got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
-  "NOT_COLUMN": {
-    "message": [
-      "Argument `<arg_name>` should be a Column, got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
-  "NOT_COLUMN_OR_DATATYPE_OR_STR": {
-    "message": [
-      "Argument `<arg_name>` should be a Column, str or DataType, but got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
-  "NOT_COLUMN_OR_FLOAT_OR_INT_OR_LIST_OR_STR": {
-    "message": [
-      "Argument `<arg_name>` should be a Column, float, integer, list or string, got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
   "NOT_COLUMN_OR_INT": {
     "message": [
       "Argument `<arg_name>` should be a Column or int, got <arg_type>."
@@ -713,6 +647,12 @@
   "NOT_DICT": {
     "message": [
       "Argument `<arg_name>` should be a dict, got <arg_type>."
+    ],
+    "sqlState": "42K09"
+  },
+  "NOT_EXPECTED_TYPE": {
+    "message": [
+      "Argument `<arg_name>` should be <expected_type>, got <arg_type>."
     ],
     "sqlState": "42K09"
   },

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -956,12 +956,20 @@ def spark_column_equals(left: Column, right: Column) -> bool:
         if not isinstance(left, ConnectColumn):
             raise PySparkTypeError(
                 errorClass="NOT_EXPECTED_TYPE",
-                messageParameters={"expected_type": "Column", "arg_name": "left", "arg_type": type(left).__name__},
+                messageParameters={
+                    "expected_type": "Column",
+                    "arg_name": "left",
+                    "arg_type": type(left).__name__,
+                },
             )
         if not isinstance(right, ConnectColumn):
             raise PySparkTypeError(
                 errorClass="NOT_EXPECTED_TYPE",
-                messageParameters={"expected_type": "Column", "arg_name": "right", "arg_type": type(right).__name__},
+                messageParameters={
+                    "expected_type": "Column",
+                    "arg_name": "right",
+                    "arg_type": type(right).__name__,
+                },
             )
         return repr(left).replace("`", "") == repr(right).replace("`", "")
     else:
@@ -970,12 +978,20 @@ def spark_column_equals(left: Column, right: Column) -> bool:
         if not isinstance(left, ClassicColumn):
             raise PySparkTypeError(
                 errorClass="NOT_EXPECTED_TYPE",
-                messageParameters={"expected_type": "Column", "arg_name": "left", "arg_type": type(left).__name__},
+                messageParameters={
+                    "expected_type": "Column",
+                    "arg_name": "left",
+                    "arg_type": type(left).__name__,
+                },
             )
         if not isinstance(right, ClassicColumn):
             raise PySparkTypeError(
                 errorClass="NOT_EXPECTED_TYPE",
-                messageParameters={"expected_type": "Column", "arg_name": "right", "arg_type": type(right).__name__},
+                messageParameters={
+                    "expected_type": "Column",
+                    "arg_name": "right",
+                    "arg_type": type(right).__name__,
+                },
             )
         return left._jc.equals(right._jc)
 

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -955,13 +955,13 @@ def spark_column_equals(left: Column, right: Column) -> bool:
 
         if not isinstance(left, ConnectColumn):
             raise PySparkTypeError(
-                errorClass="NOT_COLUMN",
-                messageParameters={"arg_name": "left", "arg_type": type(left).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={"expected_type": "Column", "arg_name": "left", "arg_type": type(left).__name__},
             )
         if not isinstance(right, ConnectColumn):
             raise PySparkTypeError(
-                errorClass="NOT_COLUMN",
-                messageParameters={"arg_name": "right", "arg_type": type(right).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={"expected_type": "Column", "arg_name": "right", "arg_type": type(right).__name__},
             )
         return repr(left).replace("`", "") == repr(right).replace("`", "")
     else:
@@ -969,13 +969,13 @@ def spark_column_equals(left: Column, right: Column) -> bool:
 
         if not isinstance(left, ClassicColumn):
             raise PySparkTypeError(
-                errorClass="NOT_COLUMN",
-                messageParameters={"arg_name": "left", "arg_type": type(left).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={"expected_type": "Column", "arg_name": "left", "arg_type": type(left).__name__},
             )
         if not isinstance(right, ClassicColumn):
             raise PySparkTypeError(
-                errorClass="NOT_COLUMN",
-                messageParameters={"arg_name": "right", "arg_type": type(right).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={"expected_type": "Column", "arg_name": "right", "arg_type": type(right).__name__},
             )
         return left._jc.equals(right._jc)
 

--- a/python/pyspark/sql/classic/column.py
+++ b/python/pyspark/sql/classic/column.py
@@ -382,7 +382,11 @@ class Column(ParentColumn):
         if not isinstance(col, Column):
             raise PySparkTypeError(
                 errorClass="NOT_EXPECTED_TYPE",
-                messageParameters={"expected_type": "Column", "arg_name": "col", "arg_type": type(col).__name__},
+                messageParameters={
+                    "expected_type": "Column",
+                    "arg_name": "col",
+                    "arg_type": type(col).__name__,
+                },
             )
 
         return Column(self._jc.withField(fieldName, col._jc))
@@ -588,7 +592,11 @@ class Column(ParentColumn):
         if not isinstance(condition, Column):
             raise PySparkTypeError(
                 errorClass="NOT_EXPECTED_TYPE",
-                messageParameters={"expected_type": "Column", "arg_name": "condition", "arg_type": type(condition).__name__},
+                messageParameters={
+                    "expected_type": "Column",
+                    "arg_name": "condition",
+                    "arg_type": type(condition).__name__,
+                },
             )
         v = value._jc if isinstance(value, Column) else enum_to_value(value)
         jc = self._jc.when(condition._jc, v)

--- a/python/pyspark/sql/classic/column.py
+++ b/python/pyspark/sql/classic/column.py
@@ -381,8 +381,8 @@ class Column(ParentColumn):
 
         if not isinstance(col, Column):
             raise PySparkTypeError(
-                errorClass="NOT_COLUMN",
-                messageParameters={"arg_name": "col", "arg_type": type(col).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={"expected_type": "Column", "arg_name": "col", "arg_type": type(col).__name__},
             )
 
         return Column(self._jc.withField(fieldName, col._jc))
@@ -587,8 +587,8 @@ class Column(ParentColumn):
     def when(self, condition: ParentColumn, value: Any) -> ParentColumn:
         if not isinstance(condition, Column):
             raise PySparkTypeError(
-                errorClass="NOT_COLUMN",
-                messageParameters={"arg_name": "condition", "arg_type": type(condition).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={"expected_type": "Column", "arg_name": "condition", "arg_type": type(condition).__name__},
             )
         v = value._jc if isinstance(value, Column) else enum_to_value(value)
         jc = self._jc.when(condition._jc, v)

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -252,8 +252,9 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         if not (is_no_argument or is_extended_case or is_extended_as_mode or is_mode_case):
             if (extended is not None) and (not isinstance(extended, (bool, str))):
                 raise PySparkTypeError(
-                    errorClass="NOT_BOOL_OR_STR",
+                    errorClass="NOT_EXPECTED_TYPE",
                     messageParameters={
+                        "expected_type": "bool or str",
                         "arg_name": "extended",
                         "arg_type": type(extended).__name__,
                     },
@@ -306,8 +307,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
 
         if not isinstance(vertical, bool):
             raise PySparkTypeError(
-                errorClass="NOT_BOOL",
-                messageParameters={"arg_name": "vertical", "arg_type": type(vertical).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={"expected_type": "bool", "arg_name": "vertical", "arg_type": type(vertical).__name__},
             )
 
         if isinstance(truncate, bool) and truncate:
@@ -317,8 +318,9 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
                 int_truncate = int(truncate)
             except ValueError:
                 raise PySparkTypeError(
-                    errorClass="NOT_BOOL",
+                    errorClass="NOT_EXPECTED_TYPE",
                     messageParameters={
+                        "expected_type": "bool",
                         "arg_name": "truncate",
                         "arg_type": type(truncate).__name__,
                     },
@@ -1013,8 +1015,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             return Column(jc)
         else:
             raise PySparkTypeError(
-                errorClass="NOT_COLUMN_OR_FLOAT_OR_INT_OR_LIST_OR_STR",
-                messageParameters={"arg_name": "item", "arg_type": type(item).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={"expected_type": "Column, float, integer, list or string", "arg_name": "item", "arg_type": type(item).__name__},
             )
 
     def __getattr__(self, name: str) -> Column:
@@ -1285,8 +1287,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     ) -> ParentDataFrame:
         if not isinstance(value, (float, int, str, bool, dict)):
             raise PySparkTypeError(
-                errorClass="NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_STR",
-                messageParameters={"arg_name": "value", "arg_type": type(value).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={"expected_type": "bool, dict, float, int or str", "arg_name": "value", "arg_type": type(value).__name__},
             )
 
         # Note that bool validates isinstance(int), but we don't want to
@@ -1384,8 +1386,9 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         valid_types = (bool, float, int, str, list, tuple)
         if not isinstance(to_replace, valid_types + (dict,)):
             raise PySparkTypeError(
-                errorClass="NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_LIST_OR_STR_OR_TUPLE",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
+                    "expected_type": "bool, dict, float, int, str or tuple",
                     "arg_name": "to_replace",
                     "arg_type": type(to_replace).__name__,
                 },
@@ -1397,8 +1400,9 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             and not isinstance(to_replace, dict)
         ):
             raise PySparkTypeError(
-                errorClass="NOT_BOOL_OR_FLOAT_OR_INT_OR_LIST_OR_NONE_OR_STR_OR_TUPLE",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
+                    "expected_type": "bool, float, int, list, None, str or tuple",
                     "arg_name": "value",
                     "arg_type": type(value).__name__,
                 },
@@ -1648,8 +1652,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def withColumn(self, colName: str, col: Column) -> ParentDataFrame:
         if not isinstance(col, Column):
             raise PySparkTypeError(
-                errorClass="NOT_COLUMN",
-                messageParameters={"arg_name": "col", "arg_type": type(col).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={"expected_type": "Column", "arg_name": "col", "arg_type": type(col).__name__},
             )
         return DataFrame(self._jdf.withColumn(colName, col._jc), self.sparkSession)
 

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -308,7 +308,11 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         if not isinstance(vertical, bool):
             raise PySparkTypeError(
                 errorClass="NOT_EXPECTED_TYPE",
-                messageParameters={"expected_type": "bool", "arg_name": "vertical", "arg_type": type(vertical).__name__},
+                messageParameters={
+                    "expected_type": "bool",
+                    "arg_name": "vertical",
+                    "arg_type": type(vertical).__name__,
+                },
             )
 
         if isinstance(truncate, bool) and truncate:
@@ -1016,7 +1020,11 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         else:
             raise PySparkTypeError(
                 errorClass="NOT_EXPECTED_TYPE",
-                messageParameters={"expected_type": "Column, float, integer, list or string", "arg_name": "item", "arg_type": type(item).__name__},
+                messageParameters={
+                    "expected_type": "Column, float, integer, list or string",
+                    "arg_name": "item",
+                    "arg_type": type(item).__name__,
+                },
             )
 
     def __getattr__(self, name: str) -> Column:
@@ -1288,7 +1296,11 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         if not isinstance(value, (float, int, str, bool, dict)):
             raise PySparkTypeError(
                 errorClass="NOT_EXPECTED_TYPE",
-                messageParameters={"expected_type": "bool, dict, float, int or str", "arg_name": "value", "arg_type": type(value).__name__},
+                messageParameters={
+                    "expected_type": "bool, dict, float, int or str",
+                    "arg_name": "value",
+                    "arg_type": type(value).__name__,
+                },
             )
 
         # Note that bool validates isinstance(int), but we don't want to
@@ -1653,7 +1665,11 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         if not isinstance(col, Column):
             raise PySparkTypeError(
                 errorClass="NOT_EXPECTED_TYPE",
-                messageParameters={"expected_type": "Column", "arg_name": "col", "arg_type": type(col).__name__},
+                messageParameters={
+                    "expected_type": "Column",
+                    "arg_name": "col",
+                    "arg_type": type(col).__name__,
+                },
             )
         return DataFrame(self._jdf.withColumn(colName, col._jc), self.sparkSession)
 

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -301,8 +301,8 @@ class Column(ParentColumn):
     def when(self, condition: ParentColumn, value: Any) -> ParentColumn:
         if not isinstance(condition, Column):
             raise PySparkTypeError(
-                errorClass="NOT_COLUMN",
-                messageParameters={"arg_name": "condition", "arg_type": type(condition).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={"expected_type": "Column", "arg_name": "condition", "arg_type": type(condition).__name__},
             )
 
         if not isinstance(self._expr, CaseWhen):
@@ -527,8 +527,8 @@ class Column(ParentColumn):
 
         if not isinstance(col, Column):
             raise PySparkTypeError(
-                errorClass="NOT_COLUMN",
-                messageParameters={"arg_name": "col", "arg_type": type(col).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={"expected_type": "Column", "arg_name": "col", "arg_type": type(col).__name__},
             )
 
         return Column(WithField(self._expr, fieldName, col._expr))

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -302,7 +302,11 @@ class Column(ParentColumn):
         if not isinstance(condition, Column):
             raise PySparkTypeError(
                 errorClass="NOT_EXPECTED_TYPE",
-                messageParameters={"expected_type": "Column", "arg_name": "condition", "arg_type": type(condition).__name__},
+                messageParameters={
+                    "expected_type": "Column",
+                    "arg_name": "condition",
+                    "arg_type": type(condition).__name__,
+                },
             )
 
         if not isinstance(self._expr, CaseWhen):
@@ -528,7 +532,11 @@ class Column(ParentColumn):
         if not isinstance(col, Column):
             raise PySparkTypeError(
                 errorClass="NOT_EXPECTED_TYPE",
-                messageParameters={"expected_type": "Column", "arg_name": "col", "arg_type": type(col).__name__},
+                messageParameters={
+                    "expected_type": "Column",
+                    "arg_name": "col",
+                    "arg_type": type(col).__name__,
+                },
             )
 
         return Column(WithField(self._expr, fieldName, col._expr))

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -814,8 +814,8 @@ class DataFrame(ParentDataFrame):
             )
         if not isinstance(vertical, bool):
             raise PySparkTypeError(
-                errorClass="NOT_BOOL",
-                messageParameters={"arg_name": "vertical", "arg_type": type(vertical).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={"expected_type": "bool", "arg_name": "vertical", "arg_type": type(vertical).__name__},
             )
 
         _truncate: int = -1
@@ -826,8 +826,9 @@ class DataFrame(ParentDataFrame):
                 _truncate = int(truncate)
             except ValueError:
                 raise PySparkTypeError(
-                    errorClass="NOT_BOOL",
+                    errorClass="NOT_EXPECTED_TYPE",
                     messageParameters={
+                        "expected_type": "bool",
                         "arg_name": "truncate",
                         "arg_type": type(truncate).__name__,
                     },
@@ -873,8 +874,8 @@ class DataFrame(ParentDataFrame):
     def withColumn(self, colName: str, col: Column) -> ParentDataFrame:
         if not isinstance(col, Column):
             raise PySparkTypeError(
-                errorClass="NOT_COLUMN",
-                messageParameters={"arg_name": "col", "arg_type": type(col).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={"expected_type": "Column", "arg_name": "col", "arg_type": type(col).__name__},
             )
         return DataFrame(
             plan.WithColumns(
@@ -1187,8 +1188,8 @@ class DataFrame(ParentDataFrame):
     ) -> ParentDataFrame:
         if not isinstance(value, (float, int, str, bool, dict)):
             raise PySparkTypeError(
-                errorClass="NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_STR",
-                messageParameters={"arg_name": "value", "arg_type": type(value).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={"expected_type": "bool, dict, float, int or str", "arg_name": "value", "arg_type": type(value).__name__},
             )
         if isinstance(value, dict):
             if len(value) == 0:
@@ -1207,8 +1208,9 @@ class DataFrame(ParentDataFrame):
                     )
                 if not isinstance(v, (bool, int, float, str)):
                     raise PySparkTypeError(
-                        errorClass="NOT_BOOL_OR_FLOAT_OR_INT_OR_STR",
+                        errorClass="NOT_EXPECTED_TYPE",
                         messageParameters={
+                            "expected_type": "bool, float, int or str",
                             "arg_name": "value type of dict",
                             "arg_type": type(v).__name__,
                         },
@@ -1343,8 +1345,9 @@ class DataFrame(ParentDataFrame):
         valid_types = (bool, float, int, str, list, tuple)
         if not isinstance(to_replace, valid_types + (dict,)):
             raise PySparkTypeError(
-                errorClass="NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_LIST_OR_STR_OR_TUPLE",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
+                    "expected_type": "bool, dict, float, int, str or tuple",
                     "arg_name": "to_replace",
                     "arg_type": type(to_replace).__name__,
                 },
@@ -1356,8 +1359,8 @@ class DataFrame(ParentDataFrame):
             and not isinstance(to_replace, dict)
         ):
             raise PySparkTypeError(
-                errorClass="NOT_BOOL_OR_FLOAT_OR_INT_OR_LIST_OR_NONE_OR_STR_OR_TUPLE",
-                messageParameters={"arg_name": "value", "arg_type": type(value).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={"expected_type": "bool, float, int, list, None, str or tuple", "arg_name": "value", "arg_type": type(value).__name__},
             )
 
         if isinstance(to_replace, (list, tuple)) and isinstance(value, (list, tuple)):
@@ -1923,8 +1926,9 @@ class DataFrame(ParentDataFrame):
         if not (is_no_argument or is_extended_case or is_extended_as_mode or is_mode_case):
             argtypes = [str(type(arg)) for arg in [extended, mode] if arg is not None]
             raise PySparkTypeError(
-                errorClass="NOT_BOOL_OR_STR",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
+                    "expected_type": "bool or str",
                     "arg_name": "extended (optional) and mode (optional)",
                     "arg_type": ", ".join(argtypes),
                 },

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -815,7 +815,11 @@ class DataFrame(ParentDataFrame):
         if not isinstance(vertical, bool):
             raise PySparkTypeError(
                 errorClass="NOT_EXPECTED_TYPE",
-                messageParameters={"expected_type": "bool", "arg_name": "vertical", "arg_type": type(vertical).__name__},
+                messageParameters={
+                    "expected_type": "bool",
+                    "arg_name": "vertical",
+                    "arg_type": type(vertical).__name__,
+                },
             )
 
         _truncate: int = -1
@@ -875,7 +879,11 @@ class DataFrame(ParentDataFrame):
         if not isinstance(col, Column):
             raise PySparkTypeError(
                 errorClass="NOT_EXPECTED_TYPE",
-                messageParameters={"expected_type": "Column", "arg_name": "col", "arg_type": type(col).__name__},
+                messageParameters={
+                    "expected_type": "Column",
+                    "arg_name": "col",
+                    "arg_type": type(col).__name__,
+                },
             )
         return DataFrame(
             plan.WithColumns(
@@ -1189,7 +1197,11 @@ class DataFrame(ParentDataFrame):
         if not isinstance(value, (float, int, str, bool, dict)):
             raise PySparkTypeError(
                 errorClass="NOT_EXPECTED_TYPE",
-                messageParameters={"expected_type": "bool, dict, float, int or str", "arg_name": "value", "arg_type": type(value).__name__},
+                messageParameters={
+                    "expected_type": "bool, dict, float, int or str",
+                    "arg_name": "value",
+                    "arg_type": type(value).__name__,
+                },
             )
         if isinstance(value, dict):
             if len(value) == 0:
@@ -1360,7 +1372,11 @@ class DataFrame(ParentDataFrame):
         ):
             raise PySparkTypeError(
                 errorClass="NOT_EXPECTED_TYPE",
-                messageParameters={"expected_type": "bool, float, int, list, None, str or tuple", "arg_name": "value", "arg_type": type(value).__name__},
+                messageParameters={
+                    "expected_type": "bool, float, int, list, None, str or tuple",
+                    "arg_name": "value",
+                    "arg_type": type(value).__name__,
+                },
             )
 
         if isinstance(to_replace, (list, tuple)) and isinstance(value, (list, tuple)):

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -445,8 +445,8 @@ def when(condition: Column, value: Any) -> Column:
     # Explicitly not using ColumnOrName type here to make reading condition less opaque
     if not isinstance(condition, Column):
         raise PySparkTypeError(
-            errorClass="NOT_COLUMN",
-            messageParameters={"arg_name": "condition", "arg_type": type(condition).__name__},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={"expected_type": "Column", "arg_name": "condition", "arg_type": type(condition).__name__},
         )
 
     value = _enum_to_value(value)
@@ -1957,8 +1957,8 @@ def from_json(
         _schema = lit(schema.json())
     else:
         raise PySparkTypeError(
-            errorClass="NOT_COLUMN_OR_DATATYPE_OR_STR",
-            messageParameters={"arg_name": "schema", "arg_type": type(schema).__name__},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={"expected_type": "Column, str or DataType", "arg_name": "schema", "arg_type": type(schema).__name__},
         )
 
     if options is None:

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -446,7 +446,11 @@ def when(condition: Column, value: Any) -> Column:
     if not isinstance(condition, Column):
         raise PySparkTypeError(
             errorClass="NOT_EXPECTED_TYPE",
-            messageParameters={"expected_type": "Column", "arg_name": "condition", "arg_type": type(condition).__name__},
+            messageParameters={
+                "expected_type": "Column",
+                "arg_name": "condition",
+                "arg_type": type(condition).__name__,
+            },
         )
 
     value = _enum_to_value(value)
@@ -1958,7 +1962,11 @@ def from_json(
     else:
         raise PySparkTypeError(
             errorClass="NOT_EXPECTED_TYPE",
-            messageParameters={"expected_type": "Column, str or DataType", "arg_name": "schema", "arg_type": type(schema).__name__},
+            messageParameters={
+                "expected_type": "Column, str or DataType",
+                "arg_name": "schema",
+                "arg_type": type(schema).__name__,
+            },
         )
 
     if options is None:

--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -242,7 +242,11 @@ class GroupedData:
                 if not isinstance(v, (bool, float, int, str)):
                     raise PySparkTypeError(
                         errorClass="NOT_EXPECTED_TYPE",
-                        messageParameters={"expected_type": "bool, float, int or str", "arg_name": "value", "arg_type": type(v).__name__},
+                        messageParameters={
+                            "expected_type": "bool, float, int or str",
+                            "arg_name": "value",
+                            "arg_type": type(v).__name__,
+                        },
                     )
 
         return GroupedData(

--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -241,8 +241,8 @@ class GroupedData:
             for v in values:
                 if not isinstance(v, (bool, float, int, str)):
                     raise PySparkTypeError(
-                        errorClass="NOT_BOOL_OR_FLOAT_OR_INT_OR_STR",
-                        messageParameters={"arg_name": "value", "arg_type": type(v).__name__},
+                        errorClass="NOT_EXPECTED_TYPE",
+                        messageParameters={"expected_type": "bool, float, int or str", "arg_name": "value", "arg_type": type(v).__name__},
                     )
 
         return GroupedData(

--- a/python/pyspark/sql/connect/udf.py
+++ b/python/pyspark/sql/connect/udf.py
@@ -142,8 +142,8 @@ class UserDefinedFunction:
     ):
         if not callable(func):
             raise PySparkTypeError(
-                errorClass="NOT_CALLABLE",
-                messageParameters={"arg_name": "func", "arg_type": type(func).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={"expected_type": "callable", "arg_name": "func", "arg_type": type(func).__name__},
             )
 
         if not isinstance(returnType, (DataType, str)):

--- a/python/pyspark/sql/connect/udf.py
+++ b/python/pyspark/sql/connect/udf.py
@@ -143,7 +143,11 @@ class UserDefinedFunction:
         if not callable(func):
             raise PySparkTypeError(
                 errorClass="NOT_EXPECTED_TYPE",
-                messageParameters={"expected_type": "callable", "arg_name": "func", "arg_type": type(func).__name__},
+                messageParameters={
+                    "expected_type": "callable",
+                    "arg_name": "func",
+                    "arg_type": type(func).__name__,
+                },
             )
 
         if not isinstance(returnType, (DataType, str)):

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2189,8 +2189,9 @@ class DataFrame:
         else:
             argtypes = [type(arg).__name__ for arg in [withReplacement, fraction, seed]]
             raise PySparkTypeError(
-                errorClass="NOT_BOOL_OR_FLOAT_OR_INT",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
+                    "expected_type": "bool, float or int",
                     "arg_name": "withReplacement (optional), "
                     + "fraction (required) and seed (optional)",
                     "arg_type": ", ".join(argtypes),

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -8332,8 +8332,8 @@ def when(condition: Column, value: Any) -> Column:
     # Explicitly not using ColumnOrName type here to make reading condition less opaque
     if not isinstance(condition, Column):
         raise PySparkTypeError(
-            errorClass="NOT_COLUMN",
-            messageParameters={"arg_name": "condition", "arg_type": type(condition).__name__},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={"expected_type": "Column", "arg_name": "condition", "arg_type": type(condition).__name__},
         )
     value = _enum_to_value(value)
     v = value._jc if isinstance(value, Column) else _enum_to_value(value)

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -8333,7 +8333,11 @@ def when(condition: Column, value: Any) -> Column:
     if not isinstance(condition, Column):
         raise PySparkTypeError(
             errorClass="NOT_EXPECTED_TYPE",
-            messageParameters={"expected_type": "Column", "arg_name": "condition", "arg_type": type(condition).__name__},
+            messageParameters={
+                "expected_type": "Column",
+                "arg_name": "condition",
+                "arg_type": type(condition).__name__,
+            },
         )
     value = _enum_to_value(value)
     v = value._jc if isinstance(value, Column) else _enum_to_value(value)

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -920,8 +920,8 @@ class SparkConnectColumnTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_COLUMN",
-            messageParameters={"arg_name": "col", "arg_type": "int"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={"expected_type": "Column", "arg_name": "col", "arg_type": "int"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -339,7 +339,11 @@ class SparkConnectFunctionTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
         self.check_error(
             exception=pe.exception,
             errorClass="NOT_EXPECTED_TYPE",
-            messageParameters={"expected_type": "Column", "arg_name": "condition", "arg_type": "bool"},
+            messageParameters={
+                "expected_type": "Column",
+                "arg_name": "condition",
+                "arg_type": "bool",
+            },
         )
 
     def test_sorting_functions_with_column(self):
@@ -1840,7 +1844,11 @@ class SparkConnectFunctionTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
         self.check_error(
             exception=pe.exception,
             errorClass="NOT_EXPECTED_TYPE",
-            messageParameters={"expected_type": "Column, str or DataType", "arg_name": "schema", "arg_type": "list"},
+            messageParameters={
+                "expected_type": "Column, str or DataType",
+                "arg_name": "schema",
+                "arg_type": "list",
+            },
         )
 
         # test get_json_object

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -338,8 +338,8 @@ class SparkConnectFunctionTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_COLUMN",
-            messageParameters={"arg_name": "condition", "arg_type": "bool"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={"expected_type": "Column", "arg_name": "condition", "arg_type": "bool"},
         )
 
     def test_sorting_functions_with_column(self):
@@ -1839,8 +1839,8 @@ class SparkConnectFunctionTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_COLUMN_OR_DATATYPE_OR_STR",
-            messageParameters={"arg_name": "schema", "arg_type": "list"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={"expected_type": "Column, str or DataType", "arg_name": "schema", "arg_type": "list"},
         )
 
         # test get_json_object

--- a/python/pyspark/sql/tests/connect/test_connect_stat.py
+++ b/python/pyspark/sql/tests/connect/test_connect_stat.py
@@ -537,8 +537,9 @@ class SparkConnectStatTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_BOOL_OR_FLOAT_OR_INT_OR_STR",
+            errorClass="NOT_EXPECTED_TYPE",
             messageParameters={
+                "expected_type": "bool, float, int or str",
                 "arg_name": "value",
                 "arg_type": "bytes",
             },

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -210,8 +210,8 @@ class ColumnTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_COLUMN",
-            messageParameters={"arg_name": "col", "arg_type": "int"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={"expected_type": "Column", "arg_name": "col", "arg_type": "int"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -529,8 +529,9 @@ class DataFrameTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_BOOL_OR_FLOAT_OR_INT",
+            errorClass="NOT_EXPECTED_TYPE",
             messageParameters={
+                "expected_type": "bool, float or int",
                 "arg_name": "withReplacement (optional), fraction (required) and seed (optional)",
                 "arg_type": "NoneType, NoneType, NoneType",
             },
@@ -845,8 +846,8 @@ class DataFrameTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_BOOL",
-            messageParameters={"arg_name": "vertical", "arg_type": "str"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={"expected_type": "bool", "arg_name": "vertical", "arg_type": "str"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -854,8 +855,8 @@ class DataFrameTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_BOOL",
-            messageParameters={"arg_name": "truncate", "arg_type": "str"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={"expected_type": "bool", "arg_name": "truncate", "arg_type": "str"},
         )
 
     def test_df_merge_into(self):

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -3545,7 +3545,11 @@ class FunctionsTestsMixin:
         self.check_error(
             exception=pe.exception,
             errorClass="NOT_EXPECTED_TYPE",
-            messageParameters={"expected_type": "Column", "arg_name": "condition", "arg_type": "str"},
+            messageParameters={
+                "expected_type": "Column",
+                "arg_name": "condition",
+                "arg_type": "str",
+            },
         )
 
     def test_window(self):

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -3544,8 +3544,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_COLUMN",
-            messageParameters={"arg_name": "condition", "arg_type": "str"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={"expected_type": "Column", "arg_name": "condition", "arg_type": "str"},
         )
 
     def test_window(self):

--- a/python/pyspark/sql/tests/test_stat.py
+++ b/python/pyspark/sql/tests/test_stat.py
@@ -200,7 +200,11 @@ class DataFrameStatTestsMixin:
         self.check_error(
             exception=pe.exception,
             errorClass="NOT_EXPECTED_TYPE",
-            messageParameters={"expected_type": "bool, dict, float, int or str", "arg_name": "value", "arg_type": "list"},
+            messageParameters={
+                "expected_type": "bool, dict, float, int or str",
+                "arg_name": "value",
+                "arg_type": "list",
+            },
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -408,7 +412,11 @@ class DataFrameStatTestsMixin:
         self.check_error(
             exception=pe.exception,
             errorClass="NOT_EXPECTED_TYPE",
-            messageParameters={"expected_type": "bool, dict, float, int, str or tuple", "arg_name": "to_replace", "arg_type": "function"},
+            messageParameters={
+                "expected_type": "bool, dict, float, int, str or tuple",
+                "arg_name": "to_replace",
+                "arg_type": "function",
+            },
         )
 
     def test_unpivot(self):

--- a/python/pyspark/sql/tests/test_stat.py
+++ b/python/pyspark/sql/tests/test_stat.py
@@ -199,8 +199,8 @@ class DataFrameStatTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_STR",
-            messageParameters={"arg_name": "value", "arg_type": "list"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={"expected_type": "bool, dict, float, int or str", "arg_name": "value", "arg_type": "list"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -407,8 +407,8 @@ class DataFrameStatTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_LIST_OR_STR_OR_TUPLE",
-            messageParameters={"arg_name": "to_replace", "arg_type": "function"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={"expected_type": "bool, dict, float, int, str or tuple", "arg_name": "to_replace", "arg_type": "function"},
         )
 
     def test_unpivot(self):

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -600,8 +600,8 @@ class BaseUDFTestsMixin(object):
 
             self.check_error(
                 exception=pe.exception,
-                errorClass="NOT_CALLABLE",
-                messageParameters={"arg_name": "func", "arg_type": "str"},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={"expected_type": "callable", "arg_name": "func", "arg_type": "str"},
             )
 
     def test_non_existed_udf(self):
@@ -1268,8 +1268,8 @@ class BaseUDFTestsMixin(object):
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_CALLABLE",
-            messageParameters={"arg_name": "func", "arg_type": "str"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={"expected_type": "callable", "arg_name": "func", "arg_type": "str"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -601,7 +601,11 @@ class BaseUDFTestsMixin(object):
             self.check_error(
                 exception=pe.exception,
                 errorClass="NOT_EXPECTED_TYPE",
-                messageParameters={"expected_type": "callable", "arg_name": "func", "arg_type": "str"},
+                messageParameters={
+                    "expected_type": "callable",
+                    "arg_name": "func",
+                    "arg_type": "str",
+                },
             )
 
     def test_non_existed_udf(self):

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -168,8 +168,8 @@ class UserDefinedFunction:
     ):
         if not callable(func):
             raise PySparkTypeError(
-                errorClass="NOT_CALLABLE",
-                messageParameters={"arg_name": "func", "arg_type": type(func).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={"expected_type": "callable", "arg_name": "func", "arg_type": type(func).__name__},
             )
 
         if not isinstance(returnType, (DataType, str)):

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -169,7 +169,11 @@ class UserDefinedFunction:
         if not callable(func):
             raise PySparkTypeError(
                 errorClass="NOT_EXPECTED_TYPE",
-                messageParameters={"expected_type": "callable", "arg_name": "func", "arg_type": type(func).__name__},
+                messageParameters={
+                    "expected_type": "callable",
+                    "arg_name": "func",
+                    "arg_type": type(func).__name__,
+                },
             )
 
         if not isinstance(returnType, (DataType, str)):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Consolidate error classes for mismatched types
As the first step, consolidate the first 11 `NOT_xxx`


### Why are the changes needed?
There are around 40 error classes for type mismatch


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Code (claude-opus-4-6)