### PR TITLE
[SPARK-56184][SQL] Replace `assert` with proper `SparkRuntimeException` in partition column parsing

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1991,6 +1991,18 @@
     ],
     "sqlState" : "42604"
   },
+  "EMPTY_PARTITION_COLUMN_NAME" : {
+    "message" : [
+      "Found an empty partition column name in the path segment '<columnSpec>'. Each partition directory must have a non-empty column name before the '=' sign (e.g., 'col=value')."
+    ],
+    "sqlState" : "KD009"
+  },
+  "EMPTY_PARTITION_COLUMN_VALUE" : {
+    "message" : [
+      "Found an empty partition column value in the path segment '<columnSpec>'. Each partition directory must have a non-empty value after the '=' sign (e.g., 'col=value')."
+    ],
+    "sqlState" : "KD009"
+  },
   "EMPTY_SCHEMA_NOT_SUPPORTED_FOR_DATASOURCE" : {
     "message" : [
       "The <format> datasource does not support writing empty or nested empty schemas. Please make sure the data schema has at least one or more column(s)."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -3088,6 +3088,20 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
     )
   }
 
+  def emptyPartitionColumnNameError(columnSpec: String): SparkRuntimeException = {
+    new SparkRuntimeException(
+      errorClass = "EMPTY_PARTITION_COLUMN_NAME",
+      messageParameters = Map("columnSpec" -> columnSpec)
+    )
+  }
+
+  def emptyPartitionColumnValueError(columnSpec: String): SparkRuntimeException = {
+    new SparkRuntimeException(
+      errorClass = "EMPTY_PARTITION_COLUMN_VALUE",
+      messageParameters = Map("columnSpec" -> columnSpec)
+    )
+  }
+
   def conflictingDirectoryStructuresError(
       discoveredBasePaths: Seq[String]): SparkRuntimeException = {
     new SparkRuntimeException(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -308,10 +308,14 @@ object PartitioningUtils extends SQLConfHelper {
       None
     } else {
       val columnName = unescapePathName(columnSpec.take(equalSignIndex))
-      assert(columnName.nonEmpty, s"Empty partition column name in '$columnSpec'")
+      if (columnName.isEmpty) {
+        throw QueryExecutionErrors.emptyPartitionColumnNameError(columnSpec)
+      }
 
       val rawColumnValue = columnSpec.drop(equalSignIndex + 1)
-      assert(rawColumnValue.nonEmpty, s"Empty partition column value in '$columnSpec'")
+      if (rawColumnValue.isEmpty) {
+        throw QueryExecutionErrors.emptyPartitionColumnValueError(columnSpec)
+      }
 
       val dataType = if (userSpecifiedDataTypes.contains(columnName)) {
         // SPARK-26188: if user provides corresponding column schema, get the column value without

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
@@ -256,8 +256,38 @@ abstract class ParquetPartitionDiscoverySuite
     check("file://path/a=10/_temporary/c=1.5", None)
     check("file://path/a=10/c=1.5/_temporary", None)
 
-    checkThrows[AssertionError]("file://path/=10", "Empty partition column name")
-    checkThrows[AssertionError]("file://path/a=", "Empty partition column value")
+    checkError(
+      exception = intercept[SparkRuntimeException] {
+        parsePartition(new Path("file://path/=10"), true, Set.empty[Path], Map.empty, true,
+          timeZoneId, df, tf, tif)
+      },
+      condition = "EMPTY_PARTITION_COLUMN_NAME",
+      parameters = Map("columnSpec" -> "=10")
+    )
+    checkError(
+      exception = intercept[SparkRuntimeException] {
+        parsePartition(new Path("file://path/a="), true, Set.empty[Path], Map.empty, true,
+          timeZoneId, df, tf, tif)
+      },
+      condition = "EMPTY_PARTITION_COLUMN_VALUE",
+      parameters = Map("columnSpec" -> "a=")
+    )
+    checkError(
+      exception = intercept[SparkRuntimeException] {
+        parsePartition(new Path("file://path/a=1/=value"), true, Set.empty[Path], Map.empty, true,
+          timeZoneId, df, tf, tif)
+      },
+      condition = "EMPTY_PARTITION_COLUMN_NAME",
+      parameters = Map("columnSpec" -> "=value")
+    )
+    checkError(
+      exception = intercept[SparkRuntimeException] {
+        parsePartition(new Path("file://path/a=/b=1"), true, Set.empty[Path], Map.empty, true,
+          timeZoneId, df, tf, tif)
+      },
+      condition = "EMPTY_PARTITION_COLUMN_VALUE",
+      parameters = Map("columnSpec" -> "a=")
+    )
   }
 
   test("parse partition with base paths") {


### PR DESCRIPTION

### What changes were proposed in this pull request?
Replace bare `assert()` calls in `PartitioningUtils.parsePartitionColumn` with proper `SparkRuntimeException` using new error classes `EMPTY_PARTITION_COLUMN_NAME` and `EMPTY_PARTITION_COLUMN_VALUE`.

When a partition path contains a malformed directory segment with an empty column name (e.g., `=value`) or empty column value (e.g., `col=`), the code previously threw `java.lang.AssertionError` - an internal error with no actionable message. This change throws a user-facing `SparkRuntimeException` with clear error messages instead.


### Why are the changes needed?
Better error message.


### Does this PR introduce _any_ user-facing change?
Yes, better error message.


### How was this patch tested?
New tests.


### Was this patch authored or co-authored using generative AI tooling?
Yes, Claude