### PR TITLE
[SPARK-56183][BUILD][TESTS] Upgrade Oracle JDBC to 23.26.1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
     <postgresql.version>42.7.10</postgresql.version>
     <db2.jcc.version>11.5.9.0</db2.jcc.version>
     <mssql.jdbc.version>13.2.1.jre11</mssql.jdbc.version>
-    <ojdbc17.version>23.6.0.24.10</ojdbc17.version>
+    <ojdbc17.version>23.26.1.0.0</ojdbc17.version>
     <databricks.jdbc.version>2.7.1</databricks.jdbc.version>
     <snowflake.jdbc.version>4.0.2</snowflake.jdbc.version>
     <terajdbc.version>20.00.00.39</terajdbc.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This change upgrades the Oracle JDBC driver to version 23.26.1.0.0.

### Why are the changes needed?
Keep up-to-date with Oracle JDBC releases and support, including Oracle's latest DB version, Oracle 26ai.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests

### Was this patch authored or co-authored using generative AI tooling?
No