### PR TITLE
[SPARK-56089][SQL][FOLLOW-UP] Use ctx.freshName for codegen variables in Asinh/Acosh

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
@@ -436,6 +436,7 @@ case class Acosh(child: Expression)
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     nullSafeCodeGen(ctx, ev, c => {
       val sm = "java.lang.StrictMath"
+      val t = ctx.freshName("t")
       s"""
          |if ($c < 1.0) {
          |  ${ev.value} = java.lang.Double.NaN;
@@ -446,8 +447,8 @@ case class Acosh(child: Expression)
          |} else if ($c > 2.0) {
          |  ${ev.value} = $sm.log(2.0 * $c - 1.0 / ($c + java.lang.Math.sqrt($c * $c - 1.0)));
          |} else {
-         |  double t = $c - 1.0;
-         |  ${ev.value} = $sm.log1p(t + java.lang.Math.sqrt(2.0 * t + t * t));
+         |  double $t = $c - 1.0;
+         |  ${ev.value} = $sm.log1p($t + java.lang.Math.sqrt(2.0 * $t + $t * $t));
          |}
          |""".stripMargin
     })
@@ -896,22 +897,25 @@ case class Asinh(child: Expression)
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     nullSafeCodeGen(ctx, ev, c => {
       val sm = "java.lang.StrictMath"
+      val ax = ctx.freshName("ax")
+      val w = ctx.freshName("w")
+      val t = ctx.freshName("t")
       s"""
-         |double ax = java.lang.Math.abs($c);
-         |double w;
-         |if (java.lang.Double.isInfinite(ax) || java.lang.Double.isNaN(ax)) {
-         |  w = ax;
-         |} else if (ax < ${1.0 / (1 << 28)}) {
-         |  w = ax;
-         |} else if (ax > ${1 << 28}.0) {
-         |  w = $sm.log(ax) + $sm.log(2.0);
-         |} else if (ax > 2.0) {
-         |  w = $sm.log(2.0 * ax + 1.0 / (java.lang.Math.sqrt($c * $c + 1.0) + ax));
+         |double $ax = java.lang.Math.abs($c);
+         |double $w;
+         |if (java.lang.Double.isInfinite($ax) || java.lang.Double.isNaN($ax)) {
+         |  $w = $ax;
+         |} else if ($ax < ${1.0 / (1 << 28)}) {
+         |  $w = $ax;
+         |} else if ($ax > ${1 << 28}.0) {
+         |  $w = $sm.log($ax) + $sm.log(2.0);
+         |} else if ($ax > 2.0) {
+         |  $w = $sm.log(2.0 * $ax + 1.0 / (java.lang.Math.sqrt($c * $c + 1.0) + $ax));
          |} else {
-         |  double t = $c * $c;
-         |  w = $sm.log1p(ax + t / (1.0 + java.lang.Math.sqrt(1.0 + t)));
+         |  double $t = $c * $c;
+         |  $w = $sm.log1p($ax + $t / (1.0 + java.lang.Math.sqrt(1.0 + $t)));
          |}
-         |${ev.value} = java.lang.Math.copySign(w, $c);
+         |${ev.value} = java.lang.Math.copySign($w, $c);
          |""".stripMargin
     })
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MathExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MathExpressionsSuite.scala
@@ -1051,9 +1051,25 @@ class MathExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(Acosh(Math.sqrt(Double.MaxValue)), 355.58450362725193)
     checkEvaluation(Asinh(Double.MinValue), -710.4758600739439)
     checkEvaluation(Asinh(-Math.sqrt(Double.MaxValue)), -355.58450362725193)
+    // Large negative values below the overflow threshold
+    checkEvaluation(Asinh(-1E100), -230.95165647996453)
+    checkEvaluation(Asinh(-1E50), -115.82240183026224)
     checkNaN(Acosh(Double.MinValue))
     checkNaN(Acosh(-Math.sqrt(Double.MaxValue) + 1))
     checkNaN(Acosh(-Math.sqrt(Double.MaxValue) + 2))
+  }
+
+  test("SPARK-56089: multiple Asinh/Acosh in same codegen scope should not collide") {
+    // When multiple Asinh/Acosh expressions are codegen'd in the same scope with
+    // non-nullable children, nullSafeCodeGen emits code without an if-block wrapper.
+    // Without ctx.freshName(), hardcoded variable names (ax, w, t) cause
+    // "Redefinition of local variable" compilation errors.
+    checkEvaluation(
+      Add(Asinh(Literal(1.0)), Asinh(Literal(2.0))),
+      0.881373587019543 + 1.4436354751788103)
+    checkEvaluation(
+      Add(Acosh(Literal(1.5)), Acosh(Literal(2.0))),
+      0.9624236501192069 + 1.3169578969248166)
   }
 
   test("SPARK-56089: asinh/acosh fdlibm algorithm coverage") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use `ctx.freshName()` for local variables in `Asinh` and `Acosh` codegen, and add test coverage.

### Why are the changes needed?

1. The fdlibm codegen introduced in https://github.com/apache/spark/pull/54912 uses hardcoded variable names (`ax`, `w`, `t`). When whole-stage codegen inlines multiple `Asinh`/`Acosh` expressions into the same method with non-nullable children, `nullSafeCodeGen` emits code without an `if`-block wrapper, so the hardcoded names cause `CompileException: Redefinition of local variable "ax"`.
2. Large negative values like -1E100 and -1E50 exercise the `log(|x|)+log(2)` branch with sign propagation via `copySign`, which was not covered.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

New test: `Add(Asinh(Literal(1.0)), Asinh(Literal(2.0)))` reproduces the codegen variable collision — non-nullable `Literal` children cause `nullSafeCodeGen` to emit code without scope-isolating `if` blocks, triggering `Redefinition of local variable "ax"` without the fix. Plus two new assertions for large negative asinh values.

### Was this patch authored or co-authored using generative AI tooling?

Yes