### PR TITLE
[SPARK-56188][PS] Align Series.map({}) with pandas 3 empty-dict behavior

### DIFF
--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -1116,7 +1116,6 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             sdf = sdf.select(SF.covar(F.col(sdf.columns[0]), F.col(sdf.columns[1]), ddof))
             return sdf.head(1)[0][0]
 
-    # TODO: NaN and None when ``arg`` is an empty dict
     # TODO: Support ps.Series ``arg``
     def map(
         self, arg: Union[Dict, Callable[[Any], Any], pd.Series], na_action: Optional[str] = None
@@ -1211,6 +1210,15 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         dtype: object
         """
         if isinstance(arg, (dict, pd.Series)):
+            if (
+                isinstance(arg, dict)
+                and len(arg) == 0
+                and not hasattr(arg, "__missing__")
+                and LooseVersion(pd.__version__) >= "3.0.0"
+            ):
+                # pandas 3 returns an all-NaN float64 Series for ``Series.map({})``.
+                return self._with_new_scol(F.lit(None).cast(DoubleType()))
+
             is_start = True
             # In case dictionary is empty.
             current = F.when(F.lit(False), F.lit(None).cast(self.spark.data_type))

--- a/python/pyspark/pandas/tests/series/test_series.py
+++ b/python/pyspark/pandas/tests/series/test_series.py
@@ -488,8 +488,11 @@ class SeriesTestsMixin:
         psser = ps.from_pandas(pser)
 
         # dict correspondence
-        # Currently pandas API on Spark doesn't return NaN as pandas does.
-        self.assert_eq(psser.map({}), pser.map({}).replace({np.nan: None}))
+        if LooseVersion(pd.__version__) < "3.0.0":
+            # Currently pandas API on Spark doesn't return NaN as pandas does.
+            self.assert_eq(psser.map({}), pser.map({}).replace({np.nan: None}))
+        else:
+            self.assert_eq(psser.map({}), pser.map({}))
 
         d = defaultdict(lambda: "abc")
         self.assertTrue("abc" in repr(psser.map(d)))
@@ -510,7 +513,7 @@ class SeriesTestsMixin:
         )
 
         def to_upper(string) -> str:
-            return string.upper() if string else ""
+            return string.upper() if isinstance(string, str) else ""
 
         self.assert_eq(psser.map(to_upper), pser.map(to_upper))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates pandas-on-Spark `Series.map` for the pandas 3 case when the mapper is an empty plain `dict`.

In pandas 3, `pandas.Series.map({})` returns an all-`NaN` `float64` Series. pandas-on-Spark was preserving the input Spark string type for this path, so a string Series produced a pandas `StringDtype` result instead. This PR adds a pandas-3-only branch in `pyspark.pandas.Series.map` so `Series.map({})` returns a null `DoubleType` column for an empty plain dict, which materializes as the same all-`NaN` `float64` result as pandas.

The related test was updated to check the pandas 3 expectation directly, while keeping the pre-pandas-3 expectation unchanged. The existing `defaultdict` coverage remains in place so dict subclasses with `__missing__` continue to follow the existing behavior. This patch also includes a small test adjustment so the local helper used in `test_map` only uppercases string inputs.

### Why are the changes needed?

Without this change, pandas-on-Spark diverges from pandas 3 for `Series.map({})`. For example, a string Series currently returns a pandas `StringDtype` result in pandas-on-Spark, while pandas returns an all-`NaN` `float64` Series.

Aligning this narrow case avoids a pandas-version-specific mismatch in pandas-on-Spark behavior and keeps the test expectation consistent with pandas 3 internals.

### Does this PR introduce _any_ user-facing change?

Yes, it will behave more like pandas 3.

### How was this patch tested?

Updated the related tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)