### PR TITLE
[SPARK-56123][PYTHON] Refactor SQL_GROUPED_AGG_ARROW_UDF and SQL_GROUPED_AGG_ARROW_ITER_UDF

### DIFF
--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2912,27 +2912,20 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             prefers_large_types=runner_conf.use_large_var_types,
         )
 
-        def func(split_index: int, batches: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
-            """Apply grouped aggregate Arrow UDFs."""
+        def func(split_index: int, batches: Iterator[Any]) -> Iterator[pa.RecordBatch]:
             for group_batches in batches:
-                # Concatenate all batches in this group into one
                 batch_list = list(group_batches)
                 if not batch_list:
                     continue
                 concatenated = pa.concat_batches(batch_list)
-
-                # Call each UDF with appropriate columns
-                result_arrays = [
-                    pa.array(
-                        [
-                            udf_func(
-                                *[concatenated.column(o) for o in args_offsets],
-                                **{k: concatenated.column(v) for k, v in kwargs_offsets.items()},
-                            )
-                        ]
+                results = [
+                    udf_func(
+                        *[concatenated.column(o) for o in args_offsets],
+                        **{k: concatenated.column(v) for k, v in kwargs_offsets.items()},
                     )
                     for udf_func, args_offsets, kwargs_offsets, _ in udfs
                 ]
+                result_arrays = [pa.array([r]) for r in results]
                 batch = pa.RecordBatch.from_arrays(result_arrays, col_names)
                 yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 
@@ -2951,23 +2944,17 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             prefers_large_types=runner_conf.use_large_var_types,
         )
 
-        def func(split_index: int, batches: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
-            """Apply grouped aggregate Arrow iterator UDF."""
+        def extract_args(batch):
+            args = tuple(batch.column(o) for o in args_offsets)
+            return args[0] if len(args) == 1 else args
+
+        def func(split_index: int, batches: Iterator[Any]) -> Iterator[pa.RecordBatch]:
             for group_batches in batches:
-                # Convert RecordBatch iterator to column iterator
-                if len(args_offsets) == 1:
-                    batch_iter = (batch.column(args_offsets[0]) for batch in group_batches)
-                else:
-                    batch_iter = (
-                        tuple(batch.column(o) for o in args_offsets) for batch in group_batches
-                    )
-
+                batch_iter = map(extract_args, group_batches)
                 result = udf_func(batch_iter)
-
-                # Drain any remaining batches to maintain stream position
+                # Drain remaining batches to maintain stream position
                 for _ in batch_iter:
                     pass
-
                 batch = pa.RecordBatch.from_arrays([pa.array([result])], ["_0"])
                 yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -1048,45 +1048,6 @@ def wrap_grouped_agg_pandas_udf(f, args_offsets, kwargs_offsets, return_type, ru
     )
 
 
-def wrap_grouped_agg_arrow_udf(f, args_offsets, kwargs_offsets, return_type, runner_conf):
-    func, args_kwargs_offsets = wrap_kwargs_support(f, args_offsets, kwargs_offsets)
-
-    arrow_return_type = to_arrow_type(
-        return_type, timezone="UTC", prefers_large_types=runner_conf.use_large_var_types
-    )
-
-    def wrapped(*series):
-        import pyarrow as pa
-
-        result = func(*series)
-        return pa.array([result])
-
-    return (
-        args_kwargs_offsets,
-        lambda *a: (wrapped(*a), arrow_return_type),
-    )
-
-
-def wrap_grouped_agg_arrow_iter_udf(f, args_offsets, kwargs_offsets, return_type, runner_conf):
-    func, args_kwargs_offsets = wrap_kwargs_support(f, args_offsets, kwargs_offsets)
-
-    arrow_return_type = to_arrow_type(
-        return_type, timezone="UTC", prefers_large_types=runner_conf.use_large_var_types
-    )
-
-    def wrapped(batch_iter):
-        import pyarrow as pa
-
-        # batch_iter: Iterator[pa.Array] (single) or Iterator[Tuple[pa.Array, ...]] (multiple)
-        result = func(batch_iter)
-        return pa.array([result])
-
-    return (
-        args_kwargs_offsets,
-        lambda *a: (wrapped(*a), arrow_return_type),
-    )
-
-
 def wrap_grouped_agg_pandas_iter_udf(f, args_offsets, kwargs_offsets, return_type, runner_conf):
     func, args_kwargs_offsets = wrap_kwargs_support(f, args_offsets, kwargs_offsets)
 
@@ -1456,14 +1417,11 @@ def read_single_udf(pickleSer, infile, eval_type, runner_conf, udf_index):
         return wrap_grouped_agg_pandas_udf(
             func, args_offsets, kwargs_offsets, return_type, runner_conf
         )
-    elif eval_type == PythonEvalType.SQL_GROUPED_AGG_ARROW_UDF:
-        return wrap_grouped_agg_arrow_udf(
-            func, args_offsets, kwargs_offsets, return_type, runner_conf
-        )
-    elif eval_type == PythonEvalType.SQL_GROUPED_AGG_ARROW_ITER_UDF:
-        return wrap_grouped_agg_arrow_iter_udf(
-            func, args_offsets, kwargs_offsets, return_type, runner_conf
-        )
+    elif eval_type in (
+        PythonEvalType.SQL_GROUPED_AGG_ARROW_UDF,
+        PythonEvalType.SQL_GROUPED_AGG_ARROW_ITER_UDF,
+    ):
+        return func, args_offsets, kwargs_offsets, return_type
     elif eval_type == PythonEvalType.SQL_GROUPED_AGG_PANDAS_ITER_UDF:
         return wrap_grouped_agg_pandas_iter_udf(
             func, args_offsets, kwargs_offsets, return_type, runner_conf
@@ -2686,8 +2644,9 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
         elif eval_type in (
             PythonEvalType.SQL_GROUPED_AGG_ARROW_UDF,
             PythonEvalType.SQL_GROUPED_AGG_ARROW_ITER_UDF,
-            PythonEvalType.SQL_WINDOW_AGG_ARROW_UDF,
         ):
+            ser = ArrowStreamSerializer(write_start_stream=True, num_dfs=1)
+        elif eval_type == PythonEvalType.SQL_WINDOW_AGG_ARROW_UDF:
             ser = ArrowStreamAggArrowUDFSerializer(safecheck=True, arrow_cast=True)
         elif eval_type in (
             PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF,
@@ -2938,6 +2897,79 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
                 args_iter,
                 error_class="INPUT_NOT_FULLY_CONSUMED",
             )
+
+        # profiling is not supported for UDF
+        return func, None, ser, ser
+
+    if eval_type == PythonEvalType.SQL_GROUPED_AGG_ARROW_UDF:
+        import pyarrow as pa
+
+        # Pre-compute target schema for output coercion
+        col_names = ["_%d" % i for i in range(len(udfs))]
+        return_schema = to_arrow_schema(
+            StructType([StructField(name, rt) for name, (_, _, _, rt) in zip(col_names, udfs)]),
+            timezone="UTC",
+            prefers_large_types=runner_conf.use_large_var_types,
+        )
+
+        def func(split_index: int, batches: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
+            """Apply grouped aggregate Arrow UDFs."""
+            for group_batches in batches:
+                # Concatenate all batches in this group into one
+                batch_list = list(group_batches)
+                if not batch_list:
+                    continue
+                concatenated = pa.concat_batches(batch_list)
+
+                # Call each UDF with appropriate columns
+                result_arrays = [
+                    pa.array(
+                        [
+                            udf_func(
+                                *[concatenated.column(o) for o in args_offsets],
+                                **{k: concatenated.column(v) for k, v in kwargs_offsets.items()},
+                            )
+                        ]
+                    )
+                    for udf_func, args_offsets, kwargs_offsets, _ in udfs
+                ]
+                batch = pa.RecordBatch.from_arrays(result_arrays, col_names)
+                yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
+
+        # profiling is not supported for UDF
+        return func, None, ser, ser
+
+    if eval_type == PythonEvalType.SQL_GROUPED_AGG_ARROW_ITER_UDF:
+        import pyarrow as pa
+
+        assert num_udfs == 1, "One GROUPED_AGG_ARROW_ITER UDF expected here."
+        udf_func, args_offsets, kwargs_offsets, return_type = udfs[0]
+
+        return_schema = to_arrow_schema(
+            StructType([StructField("_0", return_type)]),
+            timezone="UTC",
+            prefers_large_types=runner_conf.use_large_var_types,
+        )
+
+        def func(split_index: int, batches: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
+            """Apply grouped aggregate Arrow iterator UDF."""
+            for group_batches in batches:
+                # Convert RecordBatch iterator to column iterator
+                if len(args_offsets) == 1:
+                    batch_iter = (batch.column(args_offsets[0]) for batch in group_batches)
+                else:
+                    batch_iter = (
+                        tuple(batch.column(o) for o in args_offsets) for batch in group_batches
+                    )
+
+                result = udf_func(batch_iter)
+
+                # Drain any remaining batches to maintain stream position
+                for _ in batch_iter:
+                    pass
+
+                batch = pa.RecordBatch.from_arrays([pa.array([result])], ["_0"])
+                yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 
         # profiling is not supported for UDF
         return func, None, ser, ser
@@ -3342,22 +3374,6 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             df2_vals = table_from_batches(a[1], parsed_offsets[1][1])
             return f(df1_keys, df1_vals, df2_keys, df2_vals)
 
-    elif eval_type == PythonEvalType.SQL_GROUPED_AGG_ARROW_ITER_UDF:
-        # We assume there is only one UDF here because grouped agg doesn't
-        # support combining multiple UDFs.
-        assert num_udfs == 1
-
-        arg_offsets, f = udfs[0]
-
-        # Convert to iterator of batches: Iterator[pa.Array] for single column,
-        # or Iterator[Tuple[pa.Array, ...]] for multiple columns
-        def mapper(a):
-            if len(arg_offsets) == 1:
-                batch_iter = (batch_columns[arg_offsets[0]] for batch_columns in a)
-            else:
-                batch_iter = (tuple(batch_columns[o] for o in arg_offsets) for batch_columns in a)
-            return f(batch_iter)
-
     elif eval_type == PythonEvalType.SQL_GROUPED_AGG_PANDAS_ITER_UDF:
         # We assume there is only one UDF here because grouped agg doesn't
         # support combining multiple UDFs.
@@ -3382,13 +3398,10 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
                 )
             return f(series_iter)
 
-    elif eval_type in (
-        PythonEvalType.SQL_GROUPED_AGG_ARROW_UDF,
-        PythonEvalType.SQL_WINDOW_AGG_ARROW_UDF,
-    ):
+    elif eval_type == PythonEvalType.SQL_WINDOW_AGG_ARROW_UDF:
         import pyarrow as pa
 
-        # For SQL_GROUPED_AGG_ARROW_UDF and SQL_WINDOW_AGG_ARROW_UDF,
+        # For SQL_WINDOW_AGG_ARROW_UDF,
         # convert iterator of batch columns to a concatenated RecordBatch
         def mapper(a):
             # a is Iterator[Tuple[pa.Array, ...]] - convert to RecordBatch


### PR DESCRIPTION
### What changes were proposed in this pull request?

Refactor `SQL_GROUPED_AGG_ARROW_UDF` and `SQL_GROUPED_AGG_ARROW_ITER_UDF` to use `ArrowStreamSerializer` as a pure I/O layer, moving all processing logic into `read_udfs()` in `worker.py`.

### Why are the changes needed?

Part of SPARK-55388.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.

ASV micro-benchmarks with `repeat=(3, 5, 5.0)` show consistent improvements:

**SQL_GROUPED_AGG_ARROW_UDF (time)**

| Scenario | UDF | Before | After | Change |
|---|---|---|---|---|
| few_groups_sm | sum | 8.32ms | 7.28ms | -12% |
| few_groups_sm | mean_multi | 7.38ms | 6.01ms | -19% |
| few_groups_lg | sum | 29.7ms | 29.7ms | 0% |
| few_groups_lg | mean_multi | 30.4ms | 29.9ms | -2% |
| many_groups_sm | sum | 231ms | 181ms | -22% |
| many_groups_sm | mean_multi | 206ms | 144ms | -30% |
| many_groups_lg | sum | 109ms | 95.9ms | -12% |
| many_groups_lg | mean_multi | 107ms | 85.0ms | -21% |
| wide_cols | sum | 75.9ms | 59.9ms | -21% |
| wide_cols | mean_multi | 74.7ms | 57.1ms | -24% |

**SQL_GROUPED_AGG_ARROW_ITER_UDF (time)**

| Scenario | UDF | Before | After | Change |
|---|---|---|---|---|
| few_groups_sm | sum | 6.41ms | 5.66ms | -12% |
| few_groups_sm | mean_multi | 5.37ms | 4.63ms | -14% |
| few_groups_lg | sum | 18.2ms | 17.9ms | -2% |
| few_groups_lg | mean_multi | 20.7ms | 20.3ms | -2% |
| many_groups_sm | sum | 190ms | 166ms | -13% |
| many_groups_sm | mean_multi | 156ms | 131ms | -16% |
| many_groups_lg | sum | 78.4ms | 72.8ms | -7% |
| many_groups_lg | mean_multi | 71.1ms | 65.5ms | -8% |
| wide_cols | sum | 49.1ms | 44.0ms | -10% |
| wide_cols | mean_multi | 45.7ms | 39.8ms | -13% |

**Peak memory**: No change (~1.15G for all scenarios).

### Was this patch authored or co-authored using generative AI tooling?

No.