### PR TITLE
[SPARK-55700][PS][FOLLOW-UP] Use positional access when squeezing a single-element Series

### DIFF
--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -3102,7 +3102,9 @@ class Frame(object, metaclass=ABCMeta):
             # Otherwise, there is no change.
             self_top_two = cast("Series", self).head(2)
             has_single_value = len(self_top_two) == 1
-            return cast(Union[Scalar, ps.Series], self_top_two[0] if has_single_value else self)
+            return cast(
+                Union[Scalar, ps.Series], self_top_two.iloc[0] if has_single_value else self
+            )
 
     def truncate(
         self,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of apache/spark#54499.

This PR fixes `Series.squeeze()` for pandas-on-Spark when the Series contains a single element and uses a non-integer index such as `MultiIndex`.

Today the implementation in `python/pyspark/pandas/generic.py` extracts the scalar with `self_top_two[0]`. That relies on `Series.__getitem__(0)`, which becomes label-based in pandas 3. As a result, squeezing a single-element pandas-on-Spark Series with a `MultiIndex` can return the wrong object instead of a scalar.

This change switches the scalar extraction to `self_top_two.iloc[0]`, so `squeeze()` uses positional access and behaves consistently regardless of index type.

### Why are the changes needed?

`Series.squeeze()` is expected to return a scalar for a single-element Series. pandas itself does that for both regular indexes and `MultiIndex`.

With the current pandas-on-Spark implementation, that behavior depends on integer key fallback in `Series.__getitem__`. In pandas 3, integer keys are no longer treated as positional in this path, so the single-element `MultiIndex` case breaks. Using `.iloc[0]` makes the intent explicit and fixes the behavior with a minimal change.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing tests should pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)