### PR TITLE
[SPARK-56190][SQL] Support nested partition columns for DSV2 PartitionPredicate

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/PartitionFieldReference.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/PartitionFieldReference.java
@@ -33,7 +33,7 @@ import org.apache.spark.sql.connector.catalog.Table;
 public interface PartitionFieldReference extends NamedReference {
 
   /**
-   * Returns the 0-based ordinal of this partition column in {@link Table#partitioning()}.
+   * Returns the 0-based ordinal of this partition field in {@link Table#partitioning()}.
    */
   int ordinal();
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/PartitionFieldReference.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/PartitionFieldReference.java
@@ -15,15 +15,25 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.internal.connector
+package org.apache.spark.sql.connector.expressions;
 
-import org.apache.spark.sql.connector.expressions.PartitionColumnReference
+import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.connector.catalog.Table;
 
 /**
- * Implementation of [[PartitionColumnReference]] that carries the position ordinal in
- * Table.partitioning() and the partition column name(s) for that position.
+ * A reference to a partition field in {@link Table#partitioning()}.
+ * <p>
+ * {@link #fieldNames()} returns the partition field name (or names) as reported by
+ * the table's partition schema.
+ * {@link #ordinal()} returns the 0-based position in {@link Table#partitioning()}.
+ *
+ * @since 4.2.0
  */
-private[connector] case class PartitionColumnReferenceImpl(
-    ordinal: Int,
-    fieldNames: Array[String])
-  extends PartitionColumnReference
+@Evolving
+public interface PartitionFieldReference extends NamedReference {
+
+  /**
+   * Returns the 0-based ordinal of this partition column in {@link Table#partitioning()}.
+   */
+  int ordinal();
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/PartitionPredicate.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/PartitionPredicate.java
@@ -21,9 +21,7 @@ import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.expressions.NamedReference;
-import org.apache.spark.sql.connector.expressions.PartitionColumnReference;
-
-import static org.apache.spark.sql.connector.expressions.Expression.EMPTY_EXPRESSION;
+import org.apache.spark.sql.connector.expressions.PartitionFieldReference;
 
 /**
  * Represents a partition predicate that can be evaluated using {@link Table#partitioning()}.
@@ -47,17 +45,17 @@ public abstract class PartitionPredicate extends Predicate {
   /**
    * {@inheritDoc}
    * <p>
-   * For PartitionPredicate, returns {@link PartitionColumnReference} instances that identify
+   * For PartitionPredicate, returns {@link PartitionFieldReference} instances that identify
    * the partition columns (from {@link Table#partitioning()}) referenced by this predicate.
-   * Each reference's {@link PartitionColumnReference#fieldNames()} gives the partition column
-   * name; {@link PartitionColumnReference#ordinal()} gives the 0-based position in
+   * Each reference's {@link PartitionFieldReference#fieldNames()} gives the partition column
+   * name; {@link PartitionFieldReference#ordinal()} gives the 0-based position in
    * {@link Table#partitioning()}.
    * <p>
    * <b>Example:</b> Suppose {@code Table.partitioning()} returns three partition
    * transforms: {@code [years(ts), months(ts), bucket(32, id)]} with ordinals 0, 1, 2.
-   * Each {@link PartitionColumnReference} has {@link PartitionColumnReference#fieldNames()}
+   * Each {@link PartitionFieldReference} has {@link PartitionFieldReference#fieldNames()}
    * (the transform display name, e.g. {@code years(ts)}) and
-   * {@link PartitionColumnReference#ordinal()}:
+   * {@link PartitionFieldReference#ordinal()}:
    * <ul>
    *   <li>{@code years(ts) = 2026} returns one reference: (fieldNames=[years(ts)], ordinal=0).</li>
    *   <li>{@code years(ts) = 2026 and months(ts) = 01} returns two references:

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/PartitionPredicate.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/PartitionPredicate.java
@@ -46,8 +46,8 @@ public abstract class PartitionPredicate extends Predicate {
    * {@inheritDoc}
    * <p>
    * For PartitionPredicate, returns {@link PartitionFieldReference} instances that identify
-   * the partition columns (from {@link Table#partitioning()}) referenced by this predicate.
-   * Each reference's {@link PartitionFieldReference#fieldNames()} gives the partition column
+   * the partition fields (from {@link Table#partitioning()}) referenced by this predicate.
+   * Each reference's {@link PartitionFieldReference#fieldNames()} gives the partition field
    * name; {@link PartitionFieldReference#ordinal()} gives the 0-based position in
    * {@link Table#partitioning()}.
    * <p>
@@ -70,7 +70,7 @@ public abstract class PartitionPredicate extends Predicate {
    * partitioned data) to Spark for post-scan filter, while predicates that reference only
    * initially-added partition transforms may be fully pushed.
    *
-   * @return array of partition column references
+   * @return array of partition field references
    */
   @Override
   public abstract NamedReference[] references();

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/PartitionPredicate.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/PartitionPredicate.java
@@ -79,7 +79,7 @@ public abstract class PartitionPredicate extends Predicate {
    * Evaluates this predicate against a single partition's keys.
    * <p>
    * The caller must pass the <b>full</b> partition key: one value per partition transform in
-   * {@link Table#partitioning()}, in order. A key for only a subset of referenced columns is not
+   * {@link Table#partitioning()}, in order. A key for only a subset of referenced fields is not
    * supported.
    *
    * @param partitionKey the full partition key for one partition, ordered according to

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownV2Filters.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownV2Filters.java
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.connector.read;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.expressions.PartitionColumnReference;
+import org.apache.spark.sql.connector.expressions.PartitionFieldReference;
 import org.apache.spark.sql.connector.expressions.filter.PartitionPredicate;
 import org.apache.spark.sql.connector.expressions.filter.Predicate;
 
@@ -54,8 +54,8 @@ public interface SupportsPushDownV2Filters extends ScanBuilder {
    * {@link #pushedPredicates()} can return predicates from all of them.
    * <p>
    * For each {@link PartitionPredicate}, the implementation can use
-   * {@link PartitionPredicate#references()} (each {@link PartitionColumnReference} has
-   * {@link PartitionColumnReference#ordinal()}) to decide whether to return it for post-scan
+   * {@link PartitionPredicate#references()} (each {@link PartitionFieldReference} has
+   * {@link PartitionFieldReference#ordinal()}) to decide whether to return it for post-scan
    * filtering. For example, data sources with
    * partition spec evolution may return predicates that reference later-added partition
    * transforms (incompletely partitioned data) so Spark evaluates them after the scan, while

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionFieldReferenceImpl.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionFieldReferenceImpl.scala
@@ -15,25 +15,15 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.connector.expressions;
+package org.apache.spark.sql.internal.connector
 
-import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.expressions.PartitionFieldReference
 
 /**
- * A reference to a partition column in {@link Table#partitioning()}.
- * <p>
- * {@link #fieldNames()} returns the partition column name (or names) as reported by
- * the table's partition schema.
- * {@link #ordinal()} returns the 0-based position in {@link Table#partitioning()}.
- *
- * @since 4.2.0
+ * Implementation of [[PartitionFieldReference]] that carries the position ordinal in
+ * Table.partitioning() and the partition field name(s) for that position.
  */
-@Evolving
-public interface PartitionColumnReference extends NamedReference {
-
-  /**
-   * Returns the 0-based ordinal of this partition column in {@link Table#partitioning()}.
-   */
-  int ordinal();
-}
+private[connector] case class PartitionFieldReferenceImpl(
+    ordinal: Int,
+    fieldNames: Array[String])
+  extends PartitionFieldReference

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionFieldReferenceImpl.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionFieldReferenceImpl.scala
@@ -25,5 +25,7 @@ import org.apache.spark.sql.connector.expressions.PartitionFieldReference
  */
 private[connector] case class PartitionFieldReferenceImpl(
     ordinal: Int,
-    fieldNames: Array[String])
-  extends PartitionFieldReference
+    fieldNameParts: Seq[String])
+  extends PartitionFieldReference {
+  override def fieldNames(): Array[String] = fieldNameParts.toArray
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionPredicateField.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionPredicateField.scala
@@ -17,16 +17,22 @@
 
 package org.apache.spark.sql.internal.connector
 
-import org.apache.spark.sql.connector.expressions.NamedReference
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.types.StructField
 
 /**
  * Metadata for one partition field.
  *
- * @param structField the Catalyst field describing the partition column (name, type,
- *                    nullability). For nested columns the name is the dotted path
- *                    (e.g. `"s.tz"`).
- * @param identityRef the [[NamedReference]] from the transform target column
- *                    (e.g. `FieldReference(Seq("s", "tz"))`).
+ * @param fieldNames  the multi-part field name from the table's partitioning
+ *                    (e.g. `Seq("s", "tz")`).
+ * @param attrRef  the [[AttributeReference]] for the partition field.
+ *                 Created from the resolved partition field so it carries the
+ *                 flattened dotted name (e.g. `"s.tz"`) for nested fields.
  */
-case class PartitionPredicateField(structField: StructField, identityRef: NamedReference)
+case class PartitionPredicateField(
+    fieldNames: Seq[String],
+    attrRef: AttributeReference) {
+
+  lazy val structField: StructField =
+    StructField(attrRef.name, attrRef.dataType, attrRef.nullable)
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionPredicateField.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionPredicateField.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.connector.expressions.NamedReference
 import org.apache.spark.sql.types.StructField
 
 /**
- * Metadata for one identity partition field.
+ * Metadata for one partition field.
  *
  * @param structField the Catalyst field describing the partition column (name, type,
  *                    nullability). For nested columns the name is the dotted path

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionPredicateField.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionPredicateField.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.internal.connector
+
+import org.apache.spark.sql.connector.expressions.NamedReference
+import org.apache.spark.sql.types.StructField
+
+/**
+ * Metadata for one identity partition field.
+ *
+ * @param structField the Catalyst field describing the partition column (name, type,
+ *                    nullability). For nested columns the name is the dotted path
+ *                    (e.g. `"s.tz"`).
+ * @param identityRef the [[NamedReference]] from the transform target column
+ *                    (e.g. `FieldReference(Seq("s", "tz"))`).
+ */
+case class PartitionPredicateField(structField: StructField, identityRef: NamedReference)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionPredicateField.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionPredicateField.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.internal.connector
 
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
-import org.apache.spark.sql.types.StructField
 
 /**
  * Metadata for one partition field.
@@ -31,8 +30,4 @@ import org.apache.spark.sql.types.StructField
  */
 case class PartitionPredicateField(
     fieldNames: Seq[String],
-    attrRef: AttributeReference) {
-
-  lazy val structField: StructField =
-    StructField(attrRef.name, attrRef.dataType, attrRef.nullable)
-}
+    attrRef: AttributeReference)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionPredicateImpl.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionPredicateImpl.scala
@@ -21,6 +21,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, BoundReference, Expression => CatalystExpression, Predicate => CatalystPredicate}
+import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.connector.expressions.NamedReference
 import org.apache.spark.sql.connector.expressions.filter.PartitionPredicate
 
@@ -30,8 +31,11 @@ import org.apache.spark.sql.connector.expressions.filter.PartitionPredicate
  */
 class PartitionPredicateImpl private (
     private val catalystExpr: CatalystExpression,
-    private val partitionSchema: Seq[AttributeReference])
+    private val partitionFields: Seq[PartitionPredicateField])
   extends PartitionPredicate with Logging {
+
+  @transient private lazy val partitionAttrs: Seq[AttributeReference] =
+    partitionFields.map(c => DataTypeUtils.toAttribute(c.structField))
 
   /** The wrapped partition filter Catalyst Expression. */
   def expression: CatalystExpression = catalystExpr
@@ -40,20 +44,20 @@ class PartitionPredicateImpl private (
   @transient private lazy val boundPredicate: InternalRow => Boolean = {
     val boundExpr = catalystExpr.transform {
       case a: AttributeReference =>
-        val index = partitionSchema.indexWhere(_.name == a.name)
+        val index = partitionAttrs.indexWhere(_.name == a.name)
         require(index >= 0, s"Column ${a.name} not found in partition schema")
-        BoundReference(index, partitionSchema(index).dataType, nullable = a.nullable)
+        BoundReference(index, partitionAttrs(index).dataType, nullable = a.nullable)
     }
     val predicate = CatalystPredicate.createInterpreted(boundExpr)
     predicate.eval
   }
 
   override def eval(partitionValues: InternalRow): Boolean = {
-    if (partitionValues.numFields != partitionSchema.length) {
+    if (partitionValues.numFields != partitionFields.length) {
       logWarning(
         log"Cannot evaluate partition predicate ${MDC(LogKeys.EXPR, catalystExpr.sql)}: " +
         log"partition value field count (${MDC(LogKeys.COUNT, partitionValues.numFields)}) " +
-        log"does not match schema (${MDC(LogKeys.NUM_PARTITIONS, partitionSchema.length)}). " +
+        log"does not match schema (${MDC(LogKeys.NUM_PARTITIONS, partitionFields.length)}). " +
         log"Including partition in scan result to avoid incorrect filtering.")
       return true
     }
@@ -72,20 +76,24 @@ class PartitionPredicateImpl private (
 
   @transient override lazy val references: Array[NamedReference] = {
     val refNames = catalystExpr.references.map(_.name).toSet
-    partitionSchema.zipWithIndex
+    partitionAttrs.zipWithIndex
       .filter { case (attr, _) => refNames.contains(attr.name) }
-      .map { case (attr, ordinal) => PartitionColumnReferenceImpl(ordinal, Array(attr.name)) }
+      .map { case (_, ordinal) =>
+        PartitionFieldReferenceImpl(
+          ordinal, partitionFields(ordinal).identityRef.fieldNames())
+      }
       .toArray
   }
 
   override def equals(obj: Any): Boolean = obj match {
     case other: PartitionPredicateImpl =>
-      catalystExpr.semanticEquals(other.catalystExpr) && partitionSchema == other.partitionSchema
+      catalystExpr.semanticEquals(other.catalystExpr) &&
+        partitionFields == other.partitionFields
     case _ => false
   }
 
   override def hashCode(): Int = {
-    31 * catalystExpr.semanticHash() + partitionSchema.hashCode()
+    31 * catalystExpr.semanticHash() + partitionFields.hashCode()
   }
 
   override def toString(): String = s"PartitionPredicate(${catalystExpr.sql})"
@@ -95,18 +103,26 @@ object PartitionPredicateImpl {
 
   def apply(
       catalystExpr: CatalystExpression,
-      partitionSchema: Seq[AttributeReference]): PartitionPredicateImpl = {
-    if (partitionSchema.isEmpty) {
+      partitionFields: Seq[PartitionPredicateField]): PartitionPredicateImpl = {
+    validateAndCreate(catalystExpr, partitionFields)
+  }
+
+  private def validateAndCreate(
+      catalystExpr: CatalystExpression,
+      partitionFields: Seq[PartitionPredicateField]): PartitionPredicateImpl = {
+    if (partitionFields.isEmpty) {
       throw SparkException.internalError(
-        s"Cannot evaluate partition predicate ${catalystExpr.sql}: partition schema is empty")
+        s"Cannot evaluate partition predicate ${catalystExpr.sql}: partition fields are empty")
     }
-    val partitionNames = partitionSchema.map(_.name).toSet
+    val partitionNames = partitionFields.map(_.structField.name).toSet
     val refNames = catalystExpr.references.map(_.name).toSet
     if (!refNames.subsetOf(partitionNames)) {
+      val refsStr = refNames.mkString(", ")
+      val fieldsStr = partitionNames.mkString(", ")
       throw SparkException.internalError(
         s"Cannot evaluate partition predicate ${catalystExpr.sql}: expression references " +
-        s"${refNames.mkString(", ")} not all in partition columns ${partitionNames.mkString(", ")}")
+          s"$refsStr not all in partition fields $fieldsStr")
     }
-    new PartitionPredicateImpl(catalystExpr, partitionSchema)
+    new PartitionPredicateImpl(catalystExpr, partitionFields)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionPredicateImpl.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionPredicateImpl.scala
@@ -20,8 +20,7 @@ package org.apache.spark.sql.internal.connector
 import org.apache.spark.SparkException
 import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, BoundReference, Expression => CatalystExpression, Predicate => CatalystPredicate}
-import org.apache.spark.sql.catalyst.types.DataTypeUtils
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, BoundReference, Expression => CatalystExpression, ExprId, Predicate => CatalystPredicate}
 import org.apache.spark.sql.connector.expressions.NamedReference
 import org.apache.spark.sql.connector.expressions.filter.PartitionPredicate
 
@@ -34,8 +33,8 @@ class PartitionPredicateImpl private (
     private val partitionFields: Seq[PartitionPredicateField])
   extends PartitionPredicate with Logging {
 
-  @transient private lazy val partitionAttrs: Seq[AttributeReference] =
-    partitionFields.map(c => DataTypeUtils.toAttribute(c.structField))
+  @transient private lazy val exprIdToIndex: Map[ExprId, Int] =
+    partitionFields.zipWithIndex.map { case (f, i) => f.attrRef.exprId -> i }.toMap
 
   /** The wrapped partition filter Catalyst Expression. */
   def expression: CatalystExpression = catalystExpr
@@ -44,9 +43,9 @@ class PartitionPredicateImpl private (
   @transient private lazy val boundPredicate: InternalRow => Boolean = {
     val boundExpr = catalystExpr.transform {
       case a: AttributeReference =>
-        val index = partitionAttrs.indexWhere(_.name == a.name)
-        require(index >= 0, s"Field ${a.name} not found in partition schema")
-        BoundReference(index, partitionAttrs(index).dataType, nullable = a.nullable)
+        val index = exprIdToIndex.getOrElse(a.exprId,
+          throw new IllegalStateException(s"Field ${a.name} not found in partition schema"))
+        BoundReference(index, partitionFields(index).attrRef.dataType, nullable = a.nullable)
     }
     val predicate = CatalystPredicate.createInterpreted(boundExpr)
     predicate.eval
@@ -75,14 +74,12 @@ class PartitionPredicateImpl private (
   }
 
   @transient override lazy val references: Array[NamedReference] = {
-    val refNames = catalystExpr.references.map(_.name).toSet
-    partitionAttrs.zipWithIndex
-      .filter { case (attr, _) => refNames.contains(attr.name) }
-      .map { case (_, ordinal) =>
-        PartitionFieldReferenceImpl(ordinal,
-          partitionFields(ordinal).identityRef.fieldNames())
-      }
-      .toArray
+    val referencedIndices = catalystExpr.references.flatMap { ref =>
+      exprIdToIndex.get(ref.exprId)
+    }
+    referencedIndices.map { ordinal =>
+      PartitionFieldReferenceImpl(ordinal, partitionFields(ordinal).fieldNames)
+    }.toArray
   }
 
   override def equals(obj: Any): Boolean = obj match {
@@ -115,15 +112,16 @@ object PartitionPredicateImpl {
       throw SparkException.internalError(
         s"Cannot evaluate partition predicate ${catalystExpr.sql}: partition fields are empty")
     }
-    val partitionNames = partitionFields.map(_.structField.name).toSet
-    val refNames = catalystExpr.references.map(_.name).toSet
-    if (!refNames.subsetOf(partitionNames)) {
-      val refsStr = refNames.mkString(", ")
-      val fieldsStr = partitionNames.mkString(", ")
+
+    val partitionExprIds = partitionFields.map(_.attrRef.exprId).toSet
+    val unmatchedRefs = catalystExpr.references.filterNot(r => partitionExprIds.contains(r.exprId))
+    if (unmatchedRefs.nonEmpty) {
       throw SparkException.internalError(
         s"Cannot evaluate partition predicate ${catalystExpr.sql}: expression references " +
-          s"$refsStr not all in partition fields $fieldsStr")
+          s"${unmatchedRefs.map(_.name).mkString(", ")} not found in partition fields " +
+          s"${partitionFields.map(_.fieldNames.mkString(".")).mkString(", ")}")
     }
+
     new PartitionPredicateImpl(catalystExpr, partitionFields)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionPredicateImpl.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionPredicateImpl.scala
@@ -79,8 +79,8 @@ class PartitionPredicateImpl private (
     partitionAttrs.zipWithIndex
       .filter { case (attr, _) => refNames.contains(attr.name) }
       .map { case (_, ordinal) =>
-        PartitionFieldReferenceImpl(
-          ordinal, partitionFields(ordinal).identityRef.fieldNames())
+        PartitionFieldReferenceImpl(ordinal,
+          partitionFields(ordinal).identityRef.fieldNames())
       }
       .toArray
   }
@@ -101,15 +101,16 @@ class PartitionPredicateImpl private (
 
 object PartitionPredicateImpl {
 
-  def apply(
-      catalystExpr: CatalystExpression,
-      partitionFields: Seq[PartitionPredicateField]): PartitionPredicateImpl = {
+  def apply(catalystExpr: CatalystExpression,
+      partitionFields: Seq[PartitionPredicateField])
+  : PartitionPredicateImpl = {
     validateAndCreate(catalystExpr, partitionFields)
   }
 
   private def validateAndCreate(
       catalystExpr: CatalystExpression,
-      partitionFields: Seq[PartitionPredicateField]): PartitionPredicateImpl = {
+      partitionFields: Seq[PartitionPredicateField])
+  : PartitionPredicateImpl = {
     if (partitionFields.isEmpty) {
       throw SparkException.internalError(
         s"Cannot evaluate partition predicate ${catalystExpr.sql}: partition fields are empty")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionPredicateImpl.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionPredicateImpl.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.internal.connector
 
-import org.apache.spark.SparkException
 import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, BoundReference, Expression => CatalystExpression, ExprId, Predicate => CatalystPredicate}
@@ -96,32 +95,32 @@ class PartitionPredicateImpl private (
   override def toString(): String = s"PartitionPredicate(${catalystExpr.sql})"
 }
 
-object PartitionPredicateImpl {
+object PartitionPredicateImpl extends Logging {
 
   def apply(catalystExpr: CatalystExpression,
       partitionFields: Seq[PartitionPredicateField])
-  : PartitionPredicateImpl = {
-    validateAndCreate(catalystExpr, partitionFields)
-  }
-
-  private def validateAndCreate(
-      catalystExpr: CatalystExpression,
-      partitionFields: Seq[PartitionPredicateField])
-  : PartitionPredicateImpl = {
+  : Option[PartitionPredicateImpl] = {
     if (partitionFields.isEmpty) {
-      throw SparkException.internalError(
-        s"Cannot evaluate partition predicate ${catalystExpr.sql}: partition fields are empty")
+      logWarning(
+        log"Cannot create partition predicate ${MDC(LogKeys.EXPR, catalystExpr.sql)}: " +
+        log"partition fields are empty. Skipping pushdown for this predicate.")
+      return None
     }
 
     val partitionExprIds = partitionFields.map(_.attrRef.exprId).toSet
     val unmatchedRefs = catalystExpr.references.filterNot(r => partitionExprIds.contains(r.exprId))
     if (unmatchedRefs.nonEmpty) {
-      throw SparkException.internalError(
-        s"Cannot evaluate partition predicate ${catalystExpr.sql}: expression references " +
-          s"${unmatchedRefs.map(_.name).mkString(", ")} not found in partition fields " +
-          s"${partitionFields.map(_.fieldNames.mkString(".")).mkString(", ")}")
+      logWarning(
+        log"Cannot create partition predicate ${MDC(LogKeys.EXPR, catalystExpr.sql)}: " +
+        log"expression references " +
+        log"${MDC(LogKeys.FIELD_NAME, unmatchedRefs.map(_.name).mkString(", "))} " +
+        log"not found in partition fields " +
+        log"${MDC(LogKeys.PARTITION_SPECIFICATION,
+          partitionFields.map(_.fieldNames.mkString(".")).mkString(", "))}. " +
+        log"Skipping pushdown for this predicate.")
+      return None
     }
 
-    new PartitionPredicateImpl(catalystExpr, partitionFields)
+    Some(new PartitionPredicateImpl(catalystExpr, partitionFields))
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionPredicateImpl.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionPredicateImpl.scala
@@ -45,7 +45,7 @@ class PartitionPredicateImpl private (
     val boundExpr = catalystExpr.transform {
       case a: AttributeReference =>
         val index = partitionAttrs.indexWhere(_.name == a.name)
-        require(index >= 0, s"Column ${a.name} not found in partition schema")
+        require(index >= 0, s"Field ${a.name} not found in partition schema")
         BoundReference(index, partitionAttrs(index).dataType, nullable = a.nullable)
     }
     val predicate = CatalystPredicate.createInterpreted(boundExpr)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionPredicateImpl.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/PartitionPredicateImpl.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.internal.connector
 
 import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, BoundReference, Expression => CatalystExpression, ExprId, Predicate => CatalystPredicate}
+import org.apache.spark.sql.catalyst.expressions.{BindReferences, Expression => CatalystExpression, ExprId, Predicate => CatalystPredicate}
 import org.apache.spark.sql.connector.expressions.NamedReference
 import org.apache.spark.sql.connector.expressions.filter.PartitionPredicate
 
@@ -40,12 +40,7 @@ class PartitionPredicateImpl private (
 
   /** Bound predicate, computed once and reused for all partition rows. */
   @transient private lazy val boundPredicate: InternalRow => Boolean = {
-    val boundExpr = catalystExpr.transform {
-      case a: AttributeReference =>
-        val index = exprIdToIndex.getOrElse(a.exprId,
-          throw new IllegalStateException(s"Field ${a.name} not found in partition schema"))
-        BoundReference(index, partitionFields(index).attrRef.dataType, nullable = a.nullable)
-    }
+    val boundExpr = BindReferences.bindReference(catalystExpr, partitionFields.map(_.attrRef))
     val predicate = CatalystPredicate.createInterpreted(boundExpr)
     predicate.eval
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryEnhancedPartitionFilterTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryEnhancedPartitionFilterTable.scala
@@ -76,11 +76,11 @@ class InMemoryEnhancedPartitionFilterTable(
     override def supportsIterativePushdown(): Boolean = true
 
     override def pushPredicates(predicates: Array[Predicate]): Array[Predicate] = {
-      val partNames = InMemoryEnhancedPartitionFilterTable.this.partCols.flatMap(_.toSeq).toSet
+      val partPaths = InMemoryEnhancedPartitionFilterTable.this.partCols.map(_.mkString(".")).toSet
       def referencesOnlyPartitionCols(p: Predicate): Boolean =
-        p.references().forall(ref => partNames.contains(ref.fieldNames().mkString(".")))
+        p.references().forall(ref => partPaths.contains(ref.fieldNames().mkString(".")))
       def referencesOnlyDataCols(p: Predicate): Boolean =
-        p.references().forall(ref => !partNames.contains(ref.fieldNames().mkString(".")))
+        p.references().forall(ref => !partPaths.contains(ref.fieldNames().mkString(".")))
 
       val returned = ArrayBuffer.empty[Predicate]
 
@@ -120,10 +120,11 @@ class InMemoryEnhancedPartitionFilterTable(
       val partNames =
         InMemoryEnhancedPartitionFilterTable.this.partCols.map(_.toSeq.quoted)
           .toImmutableArraySeq
-      val partNamesSet = InMemoryEnhancedPartitionFilterTable.this.partCols.flatMap(_.toSeq).toSet
+      val partPathSet =
+        InMemoryEnhancedPartitionFilterTable.this.partCols.map(_.mkString(".")).toSet
       // Only partition predicates can be used for partition key filtering (filtersToKeys).
       val firstPassPartitionPredicates = firstPassPushedPredicates.filter { p =>
-        p.references().forall(ref => partNamesSet.contains(ref.fieldNames().mkString(".")))
+        p.references().forall(ref => partPathSet.contains(ref.fieldNames().mkString(".")))
       }
       val allKeys = allPartitions.map(_.asInstanceOf[BufferedRows].key)
       val matchingKeys = InMemoryTableWithV2Filter.filtersToKeys(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/internal/connector/PartitionPredicateImplSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/internal/connector/PartitionPredicateImplSuite.scala
@@ -57,7 +57,7 @@ class PartitionPredicateImplSuite extends SparkFunSuite {
     val ref = DataTypeUtils.toAttribute(StructField("p", IntegerType, nullable = true))
     val expr = GreaterThan(ref, Literal(5))
     val fields = Seq(PartitionPredicateField(Seq("p"), ref))
-    val predicate = PartitionPredicateImpl(expr, fields)
+    val predicate = PartitionPredicateImpl(expr, fields).get
 
     val deserialized = serializer.deserialize[PartitionPredicateImpl](
       serializer.serialize(predicate))
@@ -78,7 +78,7 @@ class PartitionPredicateImplSuite extends SparkFunSuite {
     val ref = DataTypeUtils.toAttribute(StructField("ts.timezone", StringType, nullable = false))
     val expr = GreaterThan(ref, Literal("x"))
     val fields = Seq(PartitionPredicateField(Seq("ts", "timezone"), ref))
-    val predicate = PartitionPredicateImpl(expr, fields)
+    val predicate = PartitionPredicateImpl(expr, fields).get
 
     val deserialized = serializer.deserialize[PartitionPredicateImpl](
       serializer.serialize(predicate))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/internal/connector/PartitionPredicateImplSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/internal/connector/PartitionPredicateImplSuite.scala
@@ -99,13 +99,13 @@ class PartitionPredicateImplSuite extends SparkFunSuite {
     case r: PartitionFieldReference =>
       (r.ordinal(), r.fieldNames().toIndexedSeq)
     case other =>
-      fail(s"Expected PartitionColumnReference, got ${other.getClass.getName}: $other")
+      fail(s"Expected PartitionFieldReference, got ${other.getClass.getName}: $other")
   }
 
   private def refsWithOrdinals(refs: Seq[AnyRef]): Seq[(String, Int)] = refs.map {
       case r: PartitionFieldReference =>
         (r.fieldNames().mkString("."), r.ordinal())
       case other =>
-        fail(s"Expected PartitionColumnReference, got ${other.getClass.getName}: $other")
+        fail(s"Expected PartitionFieldReference, got ${other.getClass.getName}: $other")
     }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/internal/connector/PartitionPredicateImplSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/internal/connector/PartitionPredicateImplSuite.scala
@@ -20,9 +20,11 @@ package org.apache.spark.sql.internal.connector
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.serializer.{JavaSerializer, KryoSerializer, SerializerInstance}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, GreaterThan, Literal}
-import org.apache.spark.sql.connector.expressions.PartitionColumnReference
-import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.catalyst.expressions.{GreaterThan, Literal}
+import org.apache.spark.sql.catalyst.types.DataTypeUtils
+import org.apache.spark.sql.connector.expressions.{FieldReference, PartitionFieldReference}
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField}
+import org.apache.spark.unsafe.types.UTF8String
 
 class PartitionPredicateImplSuite extends SparkFunSuite {
 
@@ -38,12 +40,25 @@ class PartitionPredicateImplSuite extends SparkFunSuite {
     checkPartitionPredicateImplAfterSerialization(serializer)
   }
 
+  test("Kryo: nested partition path in references survives round-trip") {
+    val conf = new SparkConf()
+    val serializer = new KryoSerializer(conf).newInstance()
+    checkNestedPartitionPathReferencesAfterSerialization(serializer)
+  }
+
+  test("Java serialization: nested partition path in references survives round-trip") {
+    val conf = new SparkConf()
+    val serializer = new JavaSerializer(conf).newInstance()
+    checkNestedPartitionPathReferencesAfterSerialization(serializer)
+  }
+
   private def checkPartitionPredicateImplAfterSerialization(
       serializer: SerializerInstance): Unit = {
-    val partitionSchema = Seq(AttributeReference("p", IntegerType)())
-    val ref = AttributeReference("p", IntegerType)()
+    val field = StructField("p", IntegerType, nullable = true)
+    val ref = DataTypeUtils.toAttribute(field)
     val expr = GreaterThan(ref, Literal(5))
-    val predicate = PartitionPredicateImpl(expr, partitionSchema)
+    val fields = Seq(PartitionPredicateField(field, FieldReference(Seq("p"))))
+    val predicate = PartitionPredicateImpl(expr, fields)
 
     val deserialized = serializer.deserialize[PartitionPredicateImpl](
       serializer.serialize(predicate))
@@ -59,8 +74,36 @@ class PartitionPredicateImplSuite extends SparkFunSuite {
     assert(deserialized.equals(predicate))
   }
 
+  private def checkNestedPartitionPathReferencesAfterSerialization(
+      serializer: SerializerInstance): Unit = {
+    val field = StructField("ts.timezone", StringType, nullable = false)
+    val ref = DataTypeUtils.toAttribute(field)
+    val expr = GreaterThan(ref, Literal("x"))
+    val fields = Seq(PartitionPredicateField(field, FieldReference(Seq("ts", "timezone"))))
+    val predicate = PartitionPredicateImpl(expr, fields)
+
+    val deserialized = serializer.deserialize[PartitionPredicateImpl](
+      serializer.serialize(predicate))
+
+    assert(deserialized.eval(InternalRow(UTF8String.fromString("z"))) === true)
+    assert(deserialized.eval(InternalRow(UTF8String.fromString("a"))) === false)
+
+    val expectedRefs = Seq((0, Seq("ts", "timezone")))
+    assert(partitionRefDetails(predicate.references.toSeq) === expectedRefs)
+    assert(partitionRefDetails(deserialized.references.toSeq) === expectedRefs)
+
+    assert(deserialized.equals(predicate))
+  }
+
+  private def partitionRefDetails(refs: Seq[AnyRef]): Seq[(Int, Seq[String])] = refs.map {
+    case r: PartitionFieldReference =>
+      (r.ordinal(), r.fieldNames().toIndexedSeq)
+    case other =>
+      fail(s"Expected PartitionColumnReference, got ${other.getClass.getName}: $other")
+  }
+
   private def refsWithOrdinals(refs: Seq[AnyRef]): Seq[(String, Int)] = refs.map {
-      case r: PartitionColumnReference =>
+      case r: PartitionFieldReference =>
         (r.fieldNames().mkString("."), r.ordinal())
       case other =>
         fail(s"Expected PartitionColumnReference, got ${other.getClass.getName}: $other")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/internal/connector/PartitionPredicateImplSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/internal/connector/PartitionPredicateImplSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.serializer.{JavaSerializer, KryoSerializer, SerializerIn
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{GreaterThan, Literal}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
-import org.apache.spark.sql.connector.expressions.{FieldReference, PartitionFieldReference}
+import org.apache.spark.sql.connector.expressions.PartitionFieldReference
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField}
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -54,10 +54,9 @@ class PartitionPredicateImplSuite extends SparkFunSuite {
 
   private def checkPartitionPredicateImplAfterSerialization(
       serializer: SerializerInstance): Unit = {
-    val field = StructField("p", IntegerType, nullable = true)
-    val ref = DataTypeUtils.toAttribute(field)
+    val ref = DataTypeUtils.toAttribute(StructField("p", IntegerType, nullable = true))
     val expr = GreaterThan(ref, Literal(5))
-    val fields = Seq(PartitionPredicateField(field, FieldReference(Seq("p"))))
+    val fields = Seq(PartitionPredicateField(Seq("p"), ref))
     val predicate = PartitionPredicateImpl(expr, fields)
 
     val deserialized = serializer.deserialize[PartitionPredicateImpl](
@@ -76,10 +75,9 @@ class PartitionPredicateImplSuite extends SparkFunSuite {
 
   private def checkNestedPartitionPathReferencesAfterSerialization(
       serializer: SerializerInstance): Unit = {
-    val field = StructField("ts.timezone", StringType, nullable = false)
-    val ref = DataTypeUtils.toAttribute(field)
+    val ref = DataTypeUtils.toAttribute(StructField("ts.timezone", StringType, nullable = false))
     val expr = GreaterThan(ref, Literal("x"))
-    val fields = Seq(PartitionPredicateField(field, FieldReference(Seq("ts", "timezone"))))
+    val fields = Seq(PartitionPredicateField(Seq("ts", "timezone"), ref))
     val predicate = PartitionPredicateImpl(expr, fields)
 
     val deserialized = serializer.deserialize[PartitionPredicateImpl](

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -279,6 +279,12 @@ object DataSourceUtils extends PredicateHelper {
     }
   }
 
+  /**
+   * Splits `normalizedFilters` into partition filters and data filters by matching
+   * [[AttributeReference]] against the given `partitionSchema` by their names.
+   *
+   * This is suitable for the V1 path where partition columns have non-nested name.
+   */
   def getPartitionFiltersAndDataFilters(
       partitionSchema: StructType,
       normalizedFilters: Seq[Expression]): (Seq[Expression], Seq[Expression]) = {
@@ -288,7 +294,22 @@ object DataSourceUtils extends PredicateHelper {
           attr
       }
     }
-    val partitionSet = AttributeSet(partitionColumns)
+    getPartitionFiltersAndDataFilters(AttributeSet(partitionColumns), normalizedFilters)
+  }
+
+  /**
+   * Splits `normalizedFilters` into partition filters and data filters by matching
+   * [[AttributeReference]] against the given `partitionAttributes` by their `ExprId`s.
+   */
+  def getPartitionFiltersAndDataFilters(
+      partitionAttributes: Seq[AttributeReference],
+      normalizedFilters: Seq[Expression]): (Seq[Expression], Seq[Expression]) = {
+    getPartitionFiltersAndDataFilters(AttributeSet(partitionAttributes), normalizedFilters)
+  }
+
+  private def getPartitionFiltersAndDataFilters(
+      partitionSet: AttributeSet,
+      normalizedFilters: Seq[Expression]): (Seq[Expression], Seq[Expression]) = {
     val (partitionFilters, dataFilters) = normalizedFilters.partition(f =>
       f.references.nonEmpty && f.references.subsetOf(partitionSet)
     )

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -283,7 +283,7 @@ object DataSourceUtils extends PredicateHelper {
    * Splits `normalizedFilters` into partition filters and data filters by matching
    * [[AttributeReference]] against the given `partitionSchema` by their names.
    *
-   * This is suitable for the V1 path where partition columns have non-nested name.
+   * This is suitable for the V1 path where partition columns have non-nested names.
    */
   def getPartitionFiltersAndDataFilters(
       partitionSchema: StructType,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupBasedRowLevelOperationScanPlanning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupBasedRowLevelOperationScanPlanning.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
-import org.apache.spark.internal.{LogKeys}
+import org.apache.spark.internal.LogKeys
 import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, AttributeSet, Expression, ExpressionSet, PredicateHelper, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.planning.{GroupBasedRowLevelOperation, PhysicalOperation}
@@ -27,8 +27,8 @@ import org.apache.spark.sql.connector.expressions.filter.{Predicate => V2Filter}
 import org.apache.spark.sql.connector.read.ScanBuilder
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command.MERGE
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
+import org.apache.spark.sql.internal.connector.PartitionPredicateField
 import org.apache.spark.sql.sources.Filter
-import org.apache.spark.sql.types.StructType
 
 /**
  * A rule that builds scans for group-based row-level operations.
@@ -48,10 +48,10 @@ object GroupBasedRowLevelOperationScanPlanning extends Rule[LogicalPlan] with Pr
 
       val table = relation.table.asRowLevelOperationTable
       val scanBuilder = table.newScanBuilder(relation.options)
-      val partitionSchema = PushDownUtils.getPartitionPredicateSchema(relation)
+      val partitionPredicateFields = PushDownUtils.getPartitionSchemaInfo(relation)
 
       val (pushedFilters, evaluatedFilters, postScanFilters) =
-        pushFilters(cond, relation.output, scanBuilder, partitionSchema)
+        pushFilters(cond, relation.output, scanBuilder, partitionPredicateFields)
 
       val pushedFiltersStr = if (pushedFilters.isLeft) {
         pushedFilters.swap
@@ -100,13 +100,13 @@ object GroupBasedRowLevelOperationScanPlanning extends Rule[LogicalPlan] with Pr
       cond: Expression,
       tableAttrs: Seq[AttributeReference],
       scanBuilder: ScanBuilder,
-      partitionSchema: Option[StructType])
+      partitionPredicateFields: Option[Seq[PartitionPredicateField]])
   : (Either[Seq[Filter], Seq[V2Filter]], Seq[Expression], Seq[Expression]) = {
 
     val (filtersWithSubquery, filtersWithoutSubquery) = findTableFilters(cond, tableAttrs)
 
     val (pushedFilters, postScanFiltersWithoutSubquery) =
-      PushDownUtils.pushFilters(scanBuilder, filtersWithoutSubquery, partitionSchema)
+      PushDownUtils.pushFilters(scanBuilder, filtersWithoutSubquery, partitionPredicateFields)
 
     val postScanFilterSetWithoutSubquery = ExpressionSet(postScanFiltersWithoutSubquery)
     val evaluatedFilters = filtersWithoutSubquery.filterNot { filter =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupBasedRowLevelOperationScanPlanning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupBasedRowLevelOperationScanPlanning.scala
@@ -48,7 +48,7 @@ object GroupBasedRowLevelOperationScanPlanning extends Rule[LogicalPlan] with Pr
 
       val table = relation.table.asRowLevelOperationTable
       val scanBuilder = table.newScanBuilder(relation.options)
-      val partitionPredicateFields = PushDownUtils.getPartitionSchemaInfo(relation)
+      val partitionPredicateFields = PushDownUtils.getPartitionPredicateSchema(relation)
 
       val (pushedFilters, evaluatedFilters, postScanFilters) =
         pushFilters(cond, relation.output, scanBuilder, partitionPredicateFields)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -19,13 +19,15 @@ package org.apache.spark.sql.execution.datasources.v2
 
 import scala.collection.mutable
 
+import org.apache.spark.internal.{Logging, LogKeys}
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSet, Expression, ExpressionSet, GetStructField, NamedExpression, PythonUDF, SchemaPruning, SubqueryExpression}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
-import org.apache.spark.sql.connector.expressions.{IdentityTransform, SortOrder, Transform}
+import org.apache.spark.sql.connector.expressions.{IdentityTransform, SortOrder}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownLimit, SupportsPushDownOffset, SupportsPushDownRequiredColumns, SupportsPushDownTableSample, SupportsPushDownTopN, SupportsPushDownV2Filters}
-import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, DataSourceUtils}
+import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.connector.{PartitionPredicateField, PartitionPredicateImpl, SupportsPushDownCatalystFilters}
 import org.apache.spark.sql.sources
@@ -33,7 +35,7 @@ import org.apache.spark.sql.types.{StructField, StructType}
 import org.apache.spark.util.ArrayImplicits.SparkArrayOps
 import org.apache.spark.util.collection.Utils
 
-object PushDownUtils {
+object PushDownUtils extends Logging {
 
   /**
    * Pushes down filters to the data source reader.
@@ -113,7 +115,7 @@ object PushDownUtils {
           if (!partitionFields.exists(_.nonEmpty) || !r.supportsIterativePushdown) {
             remainingFilters
           } else {
-            pushPartitionPredicates(r, partitionFields.get, remainingFilters)
+            secondPassPushDown(r, partitionFields.get, remainingFilters)
           }
 
         val orderedPostScanFilters = prioritizeFilters(postScanFilters,
@@ -127,122 +129,157 @@ object PushDownUtils {
   }
 
   /**
-   * Normally translated filters (postScanFilters) are simple filters that can be
-   * evaluated faster, while the untranslated filters are complicated filters
-   * that take more time to evaluate, so we want to evaluate the translatable
-   * filters first.
+   * Return a Seq of [[PartitionPredicateField]] representing the fields of a table's
+   * partitioning, only when every partition transform is a resolvable identity transform.
    */
-  private def prioritizeFilters(
-      filters: Seq[Expression],
-      untranslatableFilterSet: ExpressionSet): Seq[Expression] = {
-    val (translatable, untranslatable) = filters.partition(!untranslatableFilterSet.contains(_))
-    translatable ++ untranslatable
+  def getPartitionSchemaInfo(relation: DataSourceV2Relation)
+  : Option[Seq[PartitionPredicateField]] = {
+    val transforms = relation.table.partitioning
+    if (transforms.isEmpty) return None
+    val rootStruct = StructType(relation.output.map(
+      a => StructField(a.name, a.dataType, a.nullable)))
+    val fields = transforms.flatMap {
+      case t: IdentityTransform =>
+        toSupportedPartitionField(t, rootStruct, SQLConf.get.resolver)
+          .map(PartitionPredicateField(_, t.ref))
+      case _ => None
+    }
+    if (fields.length == transforms.length) {
+      Some(fields.toIndexedSeq)
+    } else None
   }
 
   /**
    * If the scan supports iterative filtering, convert partition filters to
    * PartitionPredicates (see SPARK-55596) and push them down in another pass.
    */
-  private def pushPartitionPredicates(
+  private def secondPassPushDown(
       scanBuilder: SupportsPushDownV2Filters,
       partitionFields: Seq[PartitionPredicateField],
       remainingFilters: Seq[Expression]): Seq[Expression] = {
-    val partitionSchema = StructType(partitionFields.map(_.structField))
-    val normalizedFilters = remainingFilters.map(
-      normalizePartitionRefs(_, partitionFields, SQLConf.get.resolver))
-    val (partitionFilters, nonPartitionFilters) =
-      DataSourceUtils.getPartitionFiltersAndDataFilters(partitionSchema, normalizedFilters)
-    val (pushable, nonPushable) = partitionFilters.partition(isPushablePartitionFilter)
-    val partitionPredicates = pushable.map(
-      expr => PartitionPredicateImpl(expr, partitionFields))
-    val rejectedPartitionFilters = scanBuilder.pushPredicates(partitionPredicates.toArray).map {
-      predicate => predicate.asInstanceOf[PartitionPredicateImpl].expression
-    }
-    nonPartitionFilters ++ nonPushable ++ rejectedPartitionFilters
+    val (partFilters, nonPartFilters) = classifyFilters(remainingFilters, partitionFields)
+    val (pushable, nonPushable) = partFilters.partition(isPushablePartitionFilter)
+    val rejected = pushPartitionPredicates(scanBuilder, pushable, partitionFields)
+    nonPartFilters ++ nonPushable ++ rejected
   }
 
   /**
-   * Return a Seq of [[PartitionPredicateField]] representing the fields of a table's
-   * partitioning, only when every partition transform is a resolvable identity transform.
+   * Splits filters into two buckets:
+   * 1. partition filters (referring only to partition fields)
+   * 2. non-partition filters (referring to non-partition fields or a mix).
    */
-  def getPartitionSchemaInfo(
-      relation: DataSourceV2Relation): Option[Seq[PartitionPredicateField]] = {
-    val transforms = relation.table.partitioning
-    if (transforms.isEmpty) {
-      None
-    } else {
-      val fields = transforms.map {
-        case t: IdentityTransform =>
-          toSupportedPartitionField(t, relation.output).map(PartitionPredicateField(_, t.ref))
-        case _ => None
-      }
-      if (fields.forall(_.isDefined)) {
-        Some(fields.map(_.get).toIndexedSeq)
-      } else {
-        None
-      }
+  private def classifyFilters(filters: Seq[Expression],
+      partitionFields: Seq[PartitionPredicateField]) = {
+    val fieldPaths: Set[Seq[String]] = partitionFields.map(_.identityRef.fieldNames().toSeq).toSet
+    filters.partition { expr =>
+      val paths = collectColumnPaths(expr)
+      paths.nonEmpty && paths.forall(p => fieldPaths.exists(pathsMatch(p, _, SQLConf.get.resolver)))
     }
   }
 
   /**
-   * Returns a StructField for the given partition transform if it is
-   * supported for iterative partition predicate push down.
+   * Returns true if the given filter expression is safe to push as a partition predicate
+   * when using iterative pushdown: it must be deterministic, contain
+   * no subquery, and no PythonUDF.
+   */
+  private def isPushablePartitionFilter(f: Expression): Boolean =
+    f.deterministic && !SubqueryExpression.hasSubquery(f) && !f.exists(_.isInstanceOf[PythonUDF])
+
+  /**
+   * Normalizes pushable partition filters, wraps them as
+   * [[PartitionPredicateImpl]], pushes to the scan builder,
+   * and returns rejected filters in original form.
+   */
+  private def pushPartitionPredicates(
+      scanBuilder: SupportsPushDownV2Filters,
+      pushable: Seq[Expression],
+      partitionFields: Seq[PartitionPredicateField]) = {
+    val normalizedToOriginal = normalizePartitionFilters(pushable, partitionFields)
+    val predicates = normalizedToOriginal.keys.toSeq.map(PartitionPredicateImpl(_, partitionFields))
+    scanBuilder.pushPredicates(predicates.toArray).map { p =>
+      val e = p.asInstanceOf[PartitionPredicateImpl].expression
+      normalizedToOriginal.getOrElse(e, e)
+    }.toSeq
+  }
+
+  /**
+   * Extracts every leaf column path from `expr`.
+   *
+   * A `GetStructField` chain is flattened to its full path
+   * (e.g. `GetStructField(attr("s"), "tz")` yields
+   * `Seq("s","tz")`).
+   * A bare [[AttributeReference]] yields `Seq(name)`.
+   */
+  private def collectColumnPaths(expr: Expression)
+  : Set[Seq[String]] = expr match {
+    case g: GetStructField =>
+      flattenStructFieldChain(g) match {
+        case Some((root, suffix)) =>
+          Set(root.name +: suffix)
+        case None =>
+          g.children.flatMap(collectColumnPaths).toSet
+      }
+    case ar: AttributeReference => Set(Seq(ar.name))
+    case _ => expr.children.flatMap(collectColumnPaths).toSet
+  }
+
+  /**
+   * Returns a [[StructField]] for the given identity partition
+   * transform if supported. Returns `None` when the field names
+   * are empty, unresolvable, or drill into a non-struct type.
    */
   private def toSupportedPartitionField(
-      transform: Transform,
-      relationOutput: Seq[AttributeReference]): Option[StructField] = {
-    transform match {
-      case t: IdentityTransform =>
-        val names = t.ref.fieldNames.toIndexedSeq
-        resolveIdentityPartitionField(names, relationOutput)
-      case _ =>
+      transform: IdentityTransform,
+      rootStruct: StructType,
+      resolver: (String, String) => Boolean)
+  : Option[StructField] = {
+    val names = transform.ref.fieldNames().toIndexedSeq
+    if (names.isEmpty) return None
+    try {
+      rootStruct.findNestedField(names, resolver = resolver).map { case (_, leaf) =>
+        StructField(names.mkString("."), leaf.dataType, leaf.nullable)
+      }
+    } catch {
+      case _: AnalysisException =>
+        logWarning(log"Invalid partition reference: " +
+          log"${MDC(LogKeys.FIELD_NAME, names.mkString("."))}," +
+          log" skipping creation of PartitionPredicate.")
         None
     }
   }
 
   /**
-   * Resolves an identity partition column path to a StructField.
-   */
-  private def resolveIdentityPartitionField(
-      names: Seq[String],
-      relationOutput: Seq[AttributeReference]): Option[StructField] = {
-    if (names.isEmpty) {
-      None
-    } else {
-      val resolver = SQLConf.get.resolver
-      val rootStruct =
-        StructType(relationOutput.map(a => StructField(a.name, a.dataType, a.nullable)))
-      rootStruct.findNestedField(names, resolver = resolver).map {
-        case (_, leaf) =>
-          StructField(names.mkString("."), leaf.dataType, leaf.nullable)
-      }
-    }
-  }
-
-  /**
-   * Normalizes filter expressions so that nested struct accesses on partition fields are
-   * replaced with flat [[AttributeReference]]s whose names match the partition schema.
+   * Normalizes filter expressions so that nested struct accesses on
+   * partition fields are replaced with flat [[AttributeReference]]s
+   * whose names match the partition schema.
    *
-   * For example, given a table partitioned by `s.tz` (identity transform on a nested field),
-   * the analyzer produces `GetStructField(attr("s"), "tz")`. This method replaces that chain
-   * with `attr("s.tz")`.
+   * For example, given a table partitioned by `s.tz` (identity
+   * transform on a nested field), the analyzer produces
+   * `GetStructField(attr("s"), "tz")`. This method replaces that
+   * chain with `attr("s.tz")`.
+   *
+   * Returns a map from normalized expression to original.
    */
-  private def normalizePartitionRefs(
-      expr: Expression,
-      partitionFields: Seq[PartitionPredicateField],
-      resolver: (String, String) => Boolean): Expression = {
-    val partitionAttrs = toAttributes(StructType(partitionFields.map(_.structField)))
-    val pathToAttr: Map[Seq[String], AttributeReference] =
-      partitionFields.map(_.identityRef).zip(partitionAttrs)
-        .map { case (ref, attr) => ref.fieldNames().toIndexedSeq -> attr}.toMap
-    doNormalizePartitionRefs(expr, pathToAttr, resolver)
+  private def normalizePartitionFilters(
+      filters: Seq[Expression],
+      partitionFields: Seq[PartitionPredicateField])
+  : Map[Expression, Expression] = {
+    val attrs = toAttributes(StructType(partitionFields.map(_.structField)))
+    val pathToAttr = partitionFields.map(_.identityRef).zip(attrs).map {
+      case (r, a) => r.fieldNames().toSeq -> a
+    }.toMap
+    filters.map { f =>
+      doNormalizePartitionFilters(f, pathToAttr, SQLConf.get.resolver) -> f
+    }.toMap
   }
 
-  private def doNormalizePartitionRefs(
+  private def doNormalizePartitionFilters(
       expr: Expression,
       pathToAttr: Map[Seq[String], AttributeReference],
       resolver: (String, String) => Boolean): Expression = {
-    expr.mapChildren(doNormalizePartitionRefs(_, pathToAttr, resolver)) match {
+    expr.mapChildren(
+      doNormalizePartitionFilters(_, pathToAttr, resolver)
+    ) match {
       case g: GetStructField =>
         flattenStructFieldChain(g) match {
           case Some((root, suffix)) =>
@@ -250,8 +287,8 @@ object PushDownUtils {
             pathToAttr.collectFirst {
               case (path, attr) if pathsMatch(fullPath, path, resolver) =>
                 attr.withNullability(g.nullable)
-            }.getOrElse(g) // Not partition filter
-          case None => g
+            }.getOrElse(g) // Not a partition field
+          case None => g // Single-level struct access, not nested
         }
       case other => other
     }
@@ -279,18 +316,21 @@ object PushDownUtils {
   private def pathsMatch(
       left: Seq[String],
       right: Seq[String],
-      resolver: (String, String) => Boolean): Boolean = {
-    left.length == right.length &&
-      left.zip(right).forall { case (a, b) => resolver(a, b) }
-  }
+      resolver: (String, String) => Boolean) =
+    left.length == right.length && left.zip(right).forall { case (a, b) => resolver(a, b) }
 
   /**
-   * Returns true if the given filter expression is safe to push as a partition predicate
-   * when using iterative pushdown: it must be deterministic, contain
-   * no subquery, and no PythonUDF.
+   * Normally translated filters (postScanFilters) are simple filters that can be
+   * evaluated faster, while the untranslated filters are complicated filters
+   * that take more time to evaluate, so we want to evaluate the translatable
+   * filters first.
    */
-  private def isPushablePartitionFilter(f: Expression): Boolean =
-    f.deterministic && !SubqueryExpression.hasSubquery(f) && !f.exists(_.isInstanceOf[PythonUDF])
+  private def prioritizeFilters(
+      filters: Seq[Expression],
+      untranslatableFilterSet: ExpressionSet): Seq[Expression] = {
+    val (translatable, untranslatable) = filters.partition(!untranslatableFilterSet.contains(_))
+    translatable ++ untranslatable
+  }
 
   /**
    * Pushes down TableSample to the data source Scan

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -162,7 +162,7 @@ object PushDownUtils extends Logging {
    */
   private def resolveIdentityPartitionField(
       transform: IdentityTransform,
-      rootStruct: StructType) = {
+      rootStruct: StructType): Option[StructField] = {
     val names = transform.ref.fieldNames().toSeq
     try {
       rootStruct.findNestedField(names, resolver = SQLConf.get.resolver).map {
@@ -188,10 +188,10 @@ object PushDownUtils extends Logging {
       remainingFilters: Seq[Expression]): Seq[Expression] = {
     val normalizedToOriginal = normalizeNestedPartitionFilters(remainingFilters, partitionFields)
     val normalized = normalizedToOriginal.keys.toSeq
-    val partitionSchema = StructType(partitionFields.map(_.structField))
+    val partitionAttributes = partitionFields.map(_.attrRef)
     // may infer additional partition filters
     val (partFilters, nonPartitionFilters) =
-      DataSourceUtils.getPartitionFiltersAndDataFilters(partitionSchema, normalized)
+      DataSourceUtils.getPartitionFiltersAndDataFilters(partitionAttributes, normalized)
     val (pushable, nonPushable) = partFilters.partition(isPushablePartitionFilter)
     val partitionPredicates = pushable.map(PartitionPredicateImpl(_, partitionFields))
     val rejectedPartitionFilters = scanBuilder.pushPredicates(partitionPredicates.toArray).map {
@@ -208,8 +208,8 @@ object PushDownUtils extends Logging {
       !f.exists(_.isInstanceOf[PythonUDF])
 
   /**
-   * Replaces all partition column references with canonical [[AttributeReference]]s that
-   * share [[ExprId]]s with the [[PartitionPredicateField]]s.
+   * Replaces all partition column references with canonical [[AttributeReference]]
+   * provided by the matching [[PartitionPredicateField]].
    *
    * Nested struct accesses on partition fields are replaced with flat [[AttributeReference]]s
    * whose names match the partition schema. For example, given a table partitioned by `s.tz`

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -129,24 +129,49 @@ object PushDownUtils extends Logging {
   }
 
   /**
-   * Return a Seq of [[PartitionPredicateField]] representing the fields of a table's
-   * partitioning, only when every partition transform is a resolvable identity transform.
+   * Return a Seq of [[PartitionPredicateField]] representing partition transform expression types,
+   * if schema is supported for [[PartitionPredicate]] push down. None if not supported.
    */
-  def getPartitionSchemaInfo(relation: DataSourceV2Relation)
+  def getPartitionPredicateSchema(relation: DataSourceV2Relation)
   : Option[Seq[PartitionPredicateField]] = {
     val transforms = relation.table.partitioning
-    if (transforms.isEmpty) return None
-    val rootStruct = StructType(relation.output.map(
-      a => StructField(a.name, a.dataType, a.nullable)))
-    val fields = transforms.flatMap {
-      case t: IdentityTransform =>
-        toSupportedPartitionField(t, rootStruct, SQLConf.get.resolver)
-          .map(PartitionPredicateField(_, t.ref))
-      case _ => None
+    if (transforms.isEmpty) {
+      None
+    } else {
+      val rootStruct = StructType(relation.output.map { a =>
+        StructField(a.name, a.dataType, a.nullable)})
+      val fields = transforms.flatMap {
+        case t: IdentityTransform =>
+          resolveIdentityPartitionField(t, rootStruct).map(PartitionPredicateField(_, t.ref))
+        case _ => None
+      }
+      if (fields.length == transforms.length) {
+        Some(fields.toSeq)
+      } else {
+        None
+      }
     }
-    if (fields.length == transforms.length) {
-      Some(fields.toIndexedSeq)
-    } else None
+  }
+
+  /**
+   * Returns a [[StructField]] for the given identity partition
+   * transform if it can be resolved, or `None` if it cannot be resolved.
+   */
+  private def resolveIdentityPartitionField(
+      transform: IdentityTransform,
+      rootStruct: StructType) = {
+    val names = transform.ref.fieldNames().toSeq
+    try {
+      rootStruct.findNestedField(names, resolver = SQLConf.get.resolver).map {
+        case (_, leaf) => StructField(names.mkString("."), leaf.dataType, leaf.nullable)
+      }
+    } catch {
+      case _: AnalysisException =>
+        logWarning(log"Invalid partition reference: " +
+          log"${MDC(LogKeys.FIELD_NAME, names.mkString("."))}," +
+          log" skipping creation of PartitionPredicate.")
+        None
+    }
   }
 
   /**
@@ -221,31 +246,6 @@ object PushDownUtils extends Logging {
       }
     case ar: AttributeReference => Set(Seq(ar.name))
     case _ => expr.children.flatMap(collectColumnPaths).toSet
-  }
-
-  /**
-   * Returns a [[StructField]] for the given identity partition
-   * transform if supported. Returns `None` when the field names
-   * are empty, unresolvable, or drill into a non-struct type.
-   */
-  private def toSupportedPartitionField(
-      transform: IdentityTransform,
-      rootStruct: StructType,
-      resolver: (String, String) => Boolean)
-  : Option[StructField] = {
-    val names = transform.ref.fieldNames().toIndexedSeq
-    if (names.isEmpty) return None
-    try {
-      rootStruct.findNestedField(names, resolver = resolver).map { case (_, leaf) =>
-        StructField(names.mkString("."), leaf.dataType, leaf.nullable)
-      }
-    } catch {
-      case _: AnalysisException =>
-        logWarning(log"Invalid partition reference: " +
-          log"${MDC(LogKeys.FIELD_NAME, names.mkString("."))}," +
-          log" skipping creation of PartitionPredicate.")
-        None
-    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -175,8 +175,9 @@ object PushDownUtils extends Logging {
   }
 
   /**
-   * If the scan supports iterative filtering, convert partition filters to PartitionPredicates
-   * (see SPARK-55596) and push them down in another pass.
+   * If the scan supports iterative filtering, infer additional partition filters,
+   * convert these and unused partition filters to PartitionPredicates,
+   * and push them down in another pass. (See SPARK-55596)
    */
   private def pushPartitionPredicates(
       scanBuilder: SupportsPushDownV2Filters,
@@ -185,6 +186,7 @@ object PushDownUtils extends Logging {
     val normalizedToOriginal = normalizeNestedPartitionFilters(remainingFilters, partitionFields)
     val normalized = normalizedToOriginal.keys.toSeq
     val partitionSchema = StructType(partitionFields.map(_.structField))
+    // may infer additional partition filters
     val (partFilters, nonPartitionFilters) =
       DataSourceUtils.getPartitionFiltersAndDataFilters(partitionSchema, normalized)
     val (pushable, nonPushable) = partFilters.partition(isPushablePartitionFilter)
@@ -192,7 +194,9 @@ object PushDownUtils extends Logging {
     val rejectedPartitionFilters = scanBuilder.pushPredicates(partitionPredicates.toArray).map {
       p => p.asInstanceOf[PartitionPredicateImpl].expression
     }.toSeq
-    (nonPartitionFilters ++ nonPushable ++ rejectedPartitionFilters).map(normalizedToOriginal)
+    (nonPartitionFilters ++ nonPushable ++ rejectedPartitionFilters)
+      .filter(normalizedToOriginal.contains)
+      .map(normalizedToOriginal)
   }
 
   private def isPushablePartitionFilter(f: Expression) =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.expressions.{IdentityTransform, SortOrder}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownLimit, SupportsPushDownOffset, SupportsPushDownRequiredColumns, SupportsPushDownTableSample, SupportsPushDownTopN, SupportsPushDownV2Filters}
-import org.apache.spark.sql.execution.datasources.DataSourceStrategy
+import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, DataSourceUtils}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.connector.{PartitionPredicateField, PartitionPredicateImpl, SupportsPushDownCatalystFilters}
 import org.apache.spark.sql.sources
@@ -115,7 +115,7 @@ object PushDownUtils extends Logging {
           if (!partitionFields.exists(_.nonEmpty) || !r.supportsIterativePushdown) {
             remainingFilters
           } else {
-            secondPassPushDown(r, partitionFields.get, remainingFilters)
+            pushPartitionPredicates(r, partitionFields.get, remainingFilters)
           }
 
         val orderedPostScanFilters = prioritizeFilters(postScanFilters,
@@ -175,78 +175,30 @@ object PushDownUtils extends Logging {
   }
 
   /**
-   * If the scan supports iterative filtering, convert partition filters to
-   * PartitionPredicates (see SPARK-55596) and push them down in another pass.
-   */
-  private def secondPassPushDown(
-      scanBuilder: SupportsPushDownV2Filters,
-      partitionFields: Seq[PartitionPredicateField],
-      remainingFilters: Seq[Expression]): Seq[Expression] = {
-    val (partFilters, nonPartFilters) = classifyFilters(remainingFilters, partitionFields)
-    val (pushable, nonPushable) = partFilters.partition(isPushablePartitionFilter)
-    val rejected = pushPartitionPredicates(scanBuilder, pushable, partitionFields)
-    nonPartFilters ++ nonPushable ++ rejected
-  }
-
-  /**
-   * Splits filters into two buckets:
-   * 1. partition filters (referring only to partition fields)
-   * 2. non-partition filters (referring to non-partition fields or a mix).
-   */
-  private def classifyFilters(filters: Seq[Expression],
-      partitionFields: Seq[PartitionPredicateField]) = {
-    val fieldPaths: Set[Seq[String]] = partitionFields.map(_.identityRef.fieldNames().toSeq).toSet
-    filters.partition { expr =>
-      val paths = collectColumnPaths(expr)
-      paths.nonEmpty && paths.forall(p => fieldPaths.exists(pathsMatch(p, _, SQLConf.get.resolver)))
-    }
-  }
-
-  /**
-   * Returns true if the given filter expression is safe to push as a partition predicate
-   * when using iterative pushdown: it must be deterministic, contain
-   * no subquery, and no PythonUDF.
-   */
-  private def isPushablePartitionFilter(f: Expression): Boolean =
-    f.deterministic && !SubqueryExpression.hasSubquery(f) && !f.exists(_.isInstanceOf[PythonUDF])
-
-  /**
-   * Normalizes pushable partition filters, wraps them as
-   * [[PartitionPredicateImpl]], pushes to the scan builder,
-   * and returns rejected filters in original form.
+   * If the scan supports iterative filtering, convert partition filters to PartitionPredicates
+   * (see SPARK-55596) and push them down in another pass.
    */
   private def pushPartitionPredicates(
       scanBuilder: SupportsPushDownV2Filters,
-      pushable: Seq[Expression],
-      partitionFields: Seq[PartitionPredicateField]) = {
-    val normalizedToOriginal = normalizePartitionFilters(pushable, partitionFields)
-    val predicates = normalizedToOriginal.keys.toSeq.map(PartitionPredicateImpl(_, partitionFields))
-    scanBuilder.pushPredicates(predicates.toArray).map { p =>
-      val e = p.asInstanceOf[PartitionPredicateImpl].expression
-      normalizedToOriginal.getOrElse(e, e)
+      partitionFields: Seq[PartitionPredicateField],
+      remainingFilters: Seq[Expression]): Seq[Expression] = {
+    val normalizedToOriginal = normalizeNestedPartitionFilters(remainingFilters, partitionFields)
+    val normalized = normalizedToOriginal.keys.toSeq
+    val partitionSchema = StructType(partitionFields.map(_.structField))
+    val (partFilters, nonPartitionFilters) =
+      DataSourceUtils.getPartitionFiltersAndDataFilters(partitionSchema, normalized)
+    val (pushable, nonPushable) = partFilters.partition(isPushablePartitionFilter)
+    val partitionPredicates = pushable.map(PartitionPredicateImpl(_, partitionFields))
+    val rejectedPartitionFilters = scanBuilder.pushPredicates(partitionPredicates.toArray).map {
+      p => p.asInstanceOf[PartitionPredicateImpl].expression
     }.toSeq
+    (nonPartitionFilters ++ nonPushable ++ rejectedPartitionFilters).map(normalizedToOriginal)
   }
 
-  /**
-   * Extracts every leaf column path from `expr`.
-   *
-   * A `GetStructField` chain is flattened to its full path
-   * (e.g. `GetStructField(attr("s"), "tz")` yields
-   * `Seq("s","tz")`).
-   * A bare [[AttributeReference]] yields `Seq(name)`.
-   */
-  private def collectColumnPaths(expr: Expression)
-  : Set[Seq[String]] = expr match {
-    case g: GetStructField =>
-      flattenStructFieldChain(g) match {
-        case Some((root, suffix)) =>
-          Set(root.name +: suffix)
-        case None =>
-          g.children.flatMap(collectColumnPaths).toSet
-      }
-    case ar: AttributeReference => Set(Seq(ar.name))
-    case _ => expr.children.flatMap(collectColumnPaths).toSet
-  }
+  private def isPushablePartitionFilter(f: Expression) =
+    f.deterministic &&
+      !SubqueryExpression.hasSubquery(f) &&
+      !f.exists(_.isInstanceOf[PythonUDF])
 
   /**
    * Normalizes filter expressions so that nested struct accesses on
@@ -260,7 +212,7 @@ object PushDownUtils extends Logging {
    *
    * Returns a map from normalized expression to original.
    */
-  private def normalizePartitionFilters(
+  private def normalizeNestedPartitionFilters(
       filters: Seq[Expression],
       partitionFields: Seq[PartitionPredicateField])
   : Map[Expression, Expression] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable
 import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSet, Expression, ExpressionSet, GetStructField, NamedExpression, PythonUDF, SchemaPruning, SubqueryExpression}
+import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.expressions.{IdentityTransform, SortOrder}
@@ -142,7 +143,9 @@ object PushDownUtils extends Logging {
         StructField(a.name, a.dataType, a.nullable)})
       val fields = transforms.flatMap {
         case t: IdentityTransform =>
-          resolveIdentityPartitionField(t, rootStruct).map(PartitionPredicateField(_, t.ref))
+          resolveIdentityPartitionField(t, rootStruct).map { sf =>
+            PartitionPredicateField(t.ref.fieldNames().toSeq, DataTypeUtils.toAttribute(sf))
+          }
         case _ => None
       }
       if (fields.length == transforms.length) {
@@ -205,14 +208,13 @@ object PushDownUtils extends Logging {
       !f.exists(_.isInstanceOf[PythonUDF])
 
   /**
-   * Normalizes filter expressions so that nested struct accesses on
-   * partition fields are replaced with flat [[AttributeReference]]s
-   * whose names match the partition schema.
+   * Replaces all partition column references with canonical [[AttributeReference]]s that
+   * share [[ExprId]]s with the [[PartitionPredicateField]]s.
    *
-   * For example, given a table partitioned by `s.tz` (identity
-   * transform on a nested field), the analyzer produces
-   * `GetStructField(attr("s"), "tz")`. This method replaces that
-   * chain with `attr("s.tz")`.
+   * Nested struct accesses on partition fields are replaced with flat [[AttributeReference]]s
+   * whose names match the partition schema. For example, given a table partitioned by `s.tz`
+   * (identity transform on a nested field), the analyzer produces
+   * `GetStructField(attr("s"), "tz")`. This method replaces that chain with `attr("s.tz")`.
    *
    * Returns a map from normalized expression to original.
    */
@@ -220,34 +222,32 @@ object PushDownUtils extends Logging {
       filters: Seq[Expression],
       partitionFields: Seq[PartitionPredicateField])
   : Map[Expression, Expression] = {
-    val attrs = toAttributes(StructType(partitionFields.map(_.structField)))
-    val pathToAttr = partitionFields.map(_.identityRef).zip(attrs).map {
-      case (r, a) => r.fieldNames().toSeq -> a
-    }.toMap
-    filters.map { f =>
-      doNormalizePartitionFilters(f, pathToAttr, SQLConf.get.resolver) -> f
-    }.toMap
+    val pathToAttr = partitionFields.map(f => f.fieldNames -> f.attrRef).toMap
+    filters.map(f => doNormalizePartitionFilters(f, pathToAttr) -> f).toMap
   }
 
   private def doNormalizePartitionFilters(
       expr: Expression,
-      pathToAttr: Map[Seq[String], AttributeReference],
-      resolver: (String, String) => Boolean): Expression = {
+      pathToAttr: Map[Seq[String], AttributeReference]): Expression = {
     expr.mapChildren(
-      doNormalizePartitionFilters(_, pathToAttr, resolver)
+      doNormalizePartitionFilters(_, pathToAttr)
     ) match {
-      case g: GetStructField =>
-        flattenStructFieldChain(g) match {
-          case Some((root, suffix)) =>
-            val fullPath = root.name +: suffix
-            pathToAttr.collectFirst {
-              case (path, attr) if pathsMatch(fullPath, path, resolver) =>
-                attr.withNullability(g.nullable)
-            }.getOrElse(g) // Not a partition field
-          case None => g // Single-level struct access, not nested
-        }
-      case other => other
+      case g: GetStructField => flattenStructFieldChain(g) match {
+        case Some((root, suffix)) => resolvePartitionAttr(root.name +: suffix, g, pathToAttr)
+        case None => g // Not a partition field
+      }
+      case a: AttributeReference => resolvePartitionAttr(Seq(a.name), a, pathToAttr)
+      case other => other // Not a partition field
     }
+  }
+
+  private def resolvePartitionAttr(
+      fieldPath: Seq[String],
+      expr: Expression,
+      pathToAttr: Map[Seq[String], AttributeReference]): Expression = {
+    pathToAttr.collectFirst {
+      case (path, attr) if pathsMatch(fieldPath, path) => attr.withNullability(expr.nullable)
+    }.getOrElse(expr)
   }
 
   /**
@@ -269,11 +269,10 @@ object PushDownUtils extends Logging {
     flatten(expr).filter(_._2.nonEmpty)
   }
 
-  private def pathsMatch(
-      left: Seq[String],
-      right: Seq[String],
-      resolver: (String, String) => Boolean) =
+  private def pathsMatch(left: Seq[String], right: Seq[String]): Boolean = {
+    val resolver = SQLConf.get.resolver
     left.length == right.length && left.zip(right).forall { case (a, b) => resolver(a, b) }
+  }
 
   /**
    * Normally translated filters (postScanFilters) are simple filters that can be

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources.v2
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSet, Expression, ExpressionSet, NamedExpression, PythonUDF, SchemaPruning, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSet, Expression, ExpressionSet, GetStructField, NamedExpression, PythonUDF, SchemaPruning, SubqueryExpression}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.expressions.{IdentityTransform, SortOrder, Transform}
@@ -27,7 +27,7 @@ import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownLimit, SupportsPushDownOffset, SupportsPushDownRequiredColumns, SupportsPushDownTableSample, SupportsPushDownTopN, SupportsPushDownV2Filters}
 import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, DataSourceUtils}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.connector.{PartitionPredicateImpl, SupportsPushDownCatalystFilters}
+import org.apache.spark.sql.internal.connector.{PartitionPredicateField, PartitionPredicateImpl, SupportsPushDownCatalystFilters}
 import org.apache.spark.sql.sources
 import org.apache.spark.sql.types.{StructField, StructType}
 import org.apache.spark.util.ArrayImplicits.SparkArrayOps
@@ -40,15 +40,15 @@ object PushDownUtils {
    *
    * @param scanBuilder The scan builder to push filters to.
    * @param filters Catalyst filter expressions to push down.
-   * @param partitionSchema The schema of [[Table#partitioning() partitioning]].
-   *   When set and the scan supports V2 filters,
-   *   [[PartitionPredicate]] can be pushed for a second pass.
+   * @param partitionFields When non-empty, metadata for [[Table#partitioning()]].
+   *                        When set and the scan supports V2 filters,
+   *                        [[PartitionPredicate]] can be pushed for a second pass.
    * @return pushed filter and post-scan filters.
    */
   def pushFilters(
       scanBuilder: ScanBuilder,
       filters: Seq[Expression],
-      partitionSchema: Option[StructType])
+      partitionFields: Option[Seq[PartitionPredicateField]])
       : (Either[Seq[sources.Filter], Seq[Predicate]], Seq[Expression]) = {
     scanBuilder match {
       case r: SupportsPushDownFilters =>
@@ -109,11 +109,12 @@ object PushDownUtils {
         }
 
         val remainingFilters = (rejectedFilters ++ untranslatableExprs).toSeq
-        val postScanFilters = if (partitionSchema.isEmpty || !r.supportsIterativePushdown) {
-          remainingFilters
-        } else {
-          pushPartitionPredicates(r, partitionSchema.get, remainingFilters)
-        }
+        val postScanFilters =
+          if (!partitionFields.exists(_.nonEmpty) || !r.supportsIterativePushdown) {
+            remainingFilters
+          } else {
+            pushPartitionPredicates(r, partitionFields.get, remainingFilters)
+          }
 
         val orderedPostScanFilters = prioritizeFilters(postScanFilters,
           ExpressionSet(untranslatableExprs))
@@ -144,13 +145,16 @@ object PushDownUtils {
    */
   private def pushPartitionPredicates(
       scanBuilder: SupportsPushDownV2Filters,
-      partitionSchema: StructType,
+      partitionFields: Seq[PartitionPredicateField],
       remainingFilters: Seq[Expression]): Seq[Expression] = {
+    val partitionSchema = StructType(partitionFields.map(_.structField))
+    val normalizedFilters = remainingFilters.map(
+      normalizePartitionRefs(_, partitionFields, SQLConf.get.resolver))
     val (partitionFilters, nonPartitionFilters) =
-      DataSourceUtils.getPartitionFiltersAndDataFilters(partitionSchema, remainingFilters)
+      DataSourceUtils.getPartitionFiltersAndDataFilters(partitionSchema, normalizedFilters)
     val (pushable, nonPushable) = partitionFilters.partition(isPushablePartitionFilter)
-    val partitionAttrs = toAttributes(partitionSchema)
-    val partitionPredicates = pushable.map(expr => PartitionPredicateImpl(expr, partitionAttrs))
+    val partitionPredicates = pushable.map(
+      expr => PartitionPredicateImpl(expr, partitionFields))
     val rejectedPartitionFilters = scanBuilder.pushPredicates(partitionPredicates.toArray).map {
       predicate => predicate.asInstanceOf[PartitionPredicateImpl].expression
     }
@@ -158,18 +162,26 @@ object PushDownUtils {
   }
 
   /**
-   * Returns a table's partitioning expression schema as a StructType, if creation of a
-   * PartitionPredicate is supported for the schema.
-   * Currently only supported if all partitioning expressions are identity transforms on simple
-   * (single-name, non-nested) field references.
-   *
-   * @return Some(StructType) representing partition transform expression types, if schema
-   *         is supported for PartitionPredicate. None if not supported.
+   * Return a Seq of [[PartitionPredicateField]] representing the fields of a table's
+   * partitioning, only when every partition transform is a resolvable identity transform.
    */
-  def getPartitionPredicateSchema(relation: DataSourceV2Relation): Option[StructType] = {
+  def getPartitionSchemaInfo(
+      relation: DataSourceV2Relation): Option[Seq[PartitionPredicateField]] = {
     val transforms = relation.table.partitioning
-    val fields = transforms.flatMap(toSupportedPartitionField(_, relation))
-    Option.when(transforms.nonEmpty && fields.length == transforms.length)(StructType(fields))
+    if (transforms.isEmpty) {
+      None
+    } else {
+      val fields = transforms.map {
+        case t: IdentityTransform =>
+          toSupportedPartitionField(t, relation.output).map(PartitionPredicateField(_, t.ref))
+        case _ => None
+      }
+      if (fields.forall(_.isDefined)) {
+        Some(fields.map(_.get).toIndexedSeq)
+      } else {
+        None
+      }
+    }
   }
 
   /**
@@ -178,16 +190,98 @@ object PushDownUtils {
    */
   private def toSupportedPartitionField(
       transform: Transform,
-      relation: DataSourceV2Relation): Option[StructField] = {
+      relationOutput: Seq[AttributeReference]): Option[StructField] = {
     transform match {
-      case t: IdentityTransform if t.ref.fieldNames.length == 1 =>
-        val colName = t.ref.fieldNames.head
-        relation.output
-          .find(_.name == colName)
-          .map(attr => StructField(colName, attr.dataType, attr.nullable))
+      case t: IdentityTransform =>
+        val names = t.ref.fieldNames.toIndexedSeq
+        resolveIdentityPartitionField(names, relationOutput)
       case _ =>
         None
     }
+  }
+
+  /**
+   * Resolves an identity partition column path to a StructField.
+   */
+  private def resolveIdentityPartitionField(
+      names: Seq[String],
+      relationOutput: Seq[AttributeReference]): Option[StructField] = {
+    if (names.isEmpty) {
+      None
+    } else {
+      val resolver = SQLConf.get.resolver
+      val rootStruct =
+        StructType(relationOutput.map(a => StructField(a.name, a.dataType, a.nullable)))
+      rootStruct.findNestedField(names, resolver = resolver).map {
+        case (_, leaf) =>
+          StructField(names.mkString("."), leaf.dataType, leaf.nullable)
+      }
+    }
+  }
+
+  /**
+   * Normalizes filter expressions so that nested struct accesses on partition fields are
+   * replaced with flat [[AttributeReference]]s whose names match the partition schema.
+   *
+   * For example, given a table partitioned by `s.tz` (identity transform on a nested field),
+   * the analyzer produces `GetStructField(attr("s"), "tz")`. This method replaces that chain
+   * with `attr("s.tz")`.
+   */
+  private def normalizePartitionRefs(
+      expr: Expression,
+      partitionFields: Seq[PartitionPredicateField],
+      resolver: (String, String) => Boolean): Expression = {
+    val partitionAttrs = toAttributes(StructType(partitionFields.map(_.structField)))
+    val pathToAttr: Map[Seq[String], AttributeReference] =
+      partitionFields.map(_.identityRef).zip(partitionAttrs)
+        .map { case (ref, attr) => ref.fieldNames().toIndexedSeq -> attr}.toMap
+    doNormalizePartitionRefs(expr, pathToAttr, resolver)
+  }
+
+  private def doNormalizePartitionRefs(
+      expr: Expression,
+      pathToAttr: Map[Seq[String], AttributeReference],
+      resolver: (String, String) => Boolean): Expression = {
+    expr.mapChildren(doNormalizePartitionRefs(_, pathToAttr, resolver)) match {
+      case g: GetStructField =>
+        flattenStructFieldChain(g) match {
+          case Some((root, suffix)) =>
+            val fullPath = root.name +: suffix
+            pathToAttr.collectFirst {
+              case (path, attr) if pathsMatch(fullPath, path, resolver) =>
+                attr.withNullability(g.nullable)
+            }.getOrElse(g) // Not partition filter
+          case None => g
+        }
+      case other => other
+    }
+  }
+
+  /**
+   * Flattens a nested [[GetStructField]] chain into the root
+   * [[AttributeReference]] and its field-name path. Returns `None`
+   * when the expression is not a nested struct access.
+   *
+   * Example: `GetStructField(GetStructField(a#1, "x"), "y")`
+   *   returns `Some((a#1, Seq("x", "y")))`.
+   */
+  private def flattenStructFieldChain(
+      expr: Expression): Option[(AttributeReference, Seq[String])] = {
+    def flatten(e: Expression): Option[(AttributeReference, Seq[String])] = e match {
+      case ar: AttributeReference => Some((ar, Seq.empty))
+      case g: GetStructField =>
+        flatten(g.child).map { case (ar, tail) => (ar, tail :+ g.extractFieldName) }
+      case _ => None
+    }
+    flatten(expr).filter(_._2.nonEmpty)
+  }
+
+  private def pathsMatch(
+      left: Seq[String],
+      right: Seq[String],
+      resolver: (String, String) => Boolean): Boolean = {
+    left.length == right.length &&
+      left.zip(right).forall { case (a, b) => resolver(a, b) }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -193,11 +193,13 @@ object PushDownUtils extends Logging {
     val (partFilters, nonPartitionFilters) =
       DataSourceUtils.getPartitionFiltersAndDataFilters(partitionAttributes, normalized)
     val (pushable, nonPushable) = partFilters.partition(isPushablePartitionFilter)
-    val partitionPredicates = pushable.map(PartitionPredicateImpl(_, partitionFields))
+    val (partitionPredicates, errorPartitionPredicates) = pushable.partitionMap { e =>
+      PartitionPredicateImpl(e, partitionFields).toLeft(e)
+    }
     val rejectedPartitionFilters = scanBuilder.pushPredicates(partitionPredicates.toArray).map {
       p => p.asInstanceOf[PartitionPredicateImpl].expression
     }.toSeq
-    (nonPartitionFilters ++ nonPushable ++ rejectedPartitionFilters)
+    (nonPartitionFilters ++ nonPushable ++ errorPartitionPredicates ++ rejectedPartitionFilters)
       .filter(normalizedToOriginal.contains)
       .map(normalizedToOriginal)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -130,7 +130,7 @@ object PushDownUtils extends Logging {
   }
 
   /**
-   * Return a Seq of [[PartitionPredicateField]] representing partition transform expression types,
+   * Returns a Seq of [[PartitionPredicateField]] representing partition transform expression types,
    * if schema is supported for [[PartitionPredicate]] push down. None if not supported.
    */
   def getPartitionPredicateSchema(relation: DataSourceV2Relation)
@@ -210,7 +210,7 @@ object PushDownUtils extends Logging {
       !f.exists(_.isInstanceOf[PythonUDF])
 
   /**
-   * Replaces all partition column references with canonical [[AttributeReference]]
+   * Replaces all partition column references with canonical [[AttributeReference]]s
    * provided by the matching [[PartitionPredicateField]].
    *
    * Nested struct accesses on partition fields are replaced with flat [[AttributeReference]]s

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -80,7 +80,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
       // `pushedFilters` will be pushed down and evaluated in the underlying data sources.
       // `postScanFilters` need to be evaluated after the scan.
       // `postScanFilters` and `pushedFilters` can overlap, e.g. the parquet row group filter.
-      val partitionPredicateFields = PushDownUtils.getPartitionSchemaInfo(sHolder.relation)
+      val partitionPredicateFields = PushDownUtils.getPartitionPredicateSchema(sHolder.relation)
       val (pushedFilters, postScanFiltersWithoutSubquery) = PushDownUtils.pushFilters(
         sHolder.builder, normalizedFiltersWithoutSubquery, partitionPredicateFields)
       val pushedFiltersStr = if (pushedFilters.isLeft) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -80,9 +80,9 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
       // `pushedFilters` will be pushed down and evaluated in the underlying data sources.
       // `postScanFilters` need to be evaluated after the scan.
       // `postScanFilters` and `pushedFilters` can overlap, e.g. the parquet row group filter.
-      val partitionSchema = PushDownUtils.getPartitionPredicateSchema(sHolder.relation)
+      val partitionPredicateFields = PushDownUtils.getPartitionSchemaInfo(sHolder.relation)
       val (pushedFilters, postScanFiltersWithoutSubquery) = PushDownUtils.pushFilters(
-        sHolder.builder, normalizedFiltersWithoutSubquery, partitionSchema)
+        sHolder.builder, normalizedFiltersWithoutSubquery, partitionPredicateFields)
       val pushedFiltersStr = if (pushedFilters.isLeft) {
         pushedFilters.swap
           .getOrElse(throw new NoSuchElementException("The left node doesn't have pushedFilters"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2EnhancedPartitionFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2EnhancedPartitionFilterSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, In, PredicateHelpe
 import org.apache.spark.sql.connector.catalog.BufferedRows
 import org.apache.spark.sql.connector.catalog.InMemoryEnhancedPartitionFilterTable
 import org.apache.spark.sql.connector.catalog.InMemoryTableEnhancedPartitionFilterCatalog
-import org.apache.spark.sql.connector.expressions.PartitionColumnReference
+import org.apache.spark.sql.connector.expressions.PartitionFieldReference
 import org.apache.spark.sql.connector.expressions.filter.PartitionPredicate
 import org.apache.spark.sql.execution.ExplainUtils.stripAQEPlan
 import org.apache.spark.sql.execution.FilterExec
@@ -220,6 +220,25 @@ class DataSourceV2EnhancedPartitionFilterSuite
     }
   }
 
+  test("nested identity partition: second-pass PartitionPredicate with UDF on nested key") {
+    withTable(partFilterTableName) {
+      sql(s"CREATE TABLE $partFilterTableName " +
+        s"(s struct<tz: string, x: int>, data string) USING $v2Source PARTITIONED BY (s.tz)")
+      sql(s"INSERT INTO $partFilterTableName VALUES " +
+        "(named_struct('tz', 'LA', 'x', 1), 'a'), (named_struct('tz', 'NY', 'x', 2), 'b')")
+
+      spark.udf.register("my_upper_nested", (s: String) =>
+        if (s == null) null else s.toUpperCase(Locale.ROOT))
+
+      val df = sql(
+        s"SELECT * FROM $partFilterTableName WHERE my_upper_nested(s.tz) = 'LA'")
+      checkAnswer(df, Seq(Row(Row("LA", 1), "a")))
+      assertPushedPartitionPredicates(df, 1)
+      assertScanReturnsPartitionKeys(df, Set("LA"))
+      assertReferencedPartitionColumnOrdinals(df, Array(0), Array("s.tz"))
+    }
+  }
+
   test("referenced partition column ordinals: partition predicate same column twice " +
     "has de-duped ordinals") {
     withTable(partFilterTableName) {
@@ -401,16 +420,16 @@ class DataSourceV2EnhancedPartitionFilterSuite
     val names = expectedPartitionColumnNames
   predicates.foreach { p =>
       val refs = p.references()
-      val ordinals = refs.map(_.asInstanceOf[PartitionColumnReference].ordinal()).sorted
+      val ordinals = refs.map(_.asInstanceOf[PartitionFieldReference].ordinal()).sorted
       assert(ordinals.sameElements(expectedOrdinals.sorted),
         s"Expected references().map(_.ordinal()) " +
           s"${expectedOrdinals.sorted.mkString("[", ", ", "]")}, " +
           s"got ${ordinals.mkString("[", ", ", "]")}")
 
       refs.foreach { ref =>
-        assert(ref.isInstanceOf[PartitionColumnReference],
+        assert(ref.isInstanceOf[PartitionFieldReference],
           s"Expected PartitionColumnReference, got ${ref.getClass.getName}")
-        val partRef = ref.asInstanceOf[PartitionColumnReference]
+        val partRef = ref.asInstanceOf[PartitionFieldReference]
         assert(partRef.fieldNames().nonEmpty,
           s"PartitionColumnReference.ordinal=${partRef.ordinal()} has empty fieldNames")
         assert(partRef.ordinal() < names.length,

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2EnhancedPartitionFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2EnhancedPartitionFilterSuite.scala
@@ -239,6 +239,41 @@ class DataSourceV2EnhancedPartitionFilterSuite
     }
   }
 
+  test("nested identity partition: second-pass rejection returns filter to post-scan") {
+    withTable(partFilterTableName) {
+      sql(s"CREATE TABLE $partFilterTableName " +
+        s"(s struct<tz: string, x: int>, data string) USING $v2Source " +
+        "PARTITIONED BY (s.tz) " +
+        "TBLPROPERTIES('accept-partition-predicates' = 'false')")
+      sql(s"INSERT INTO $partFilterTableName VALUES " +
+        "(named_struct('tz', 'LA', 'x', 1), 'a'), " +
+        "(named_struct('tz', 'NY', 'x', 2), 'b')")
+
+      val df = sql(
+        s"SELECT * FROM $partFilterTableName WHERE s.tz = 'LA'")
+      checkAnswer(df, Seq(Row(Row("LA", 1), "a")))
+      assertPushedPartitionPredicates(df, 0)
+      assertScanReturnsPartitionKeys(df, Set("LA", "NY"))
+    }
+  }
+
+  test("partition filter with data array col filter") {
+    withTable(partFilterTableName) {
+      sql(s"CREATE TABLE $partFilterTableName " +
+        s"(part_col string, arr array<string>, data string) USING $v2Source " +
+        "PARTITIONED BY (part_col)")
+      sql(s"INSERT INTO $partFilterTableName VALUES " +
+        "('a', array('x','y'), 'd1'), ('b', array('z'), 'd2')")
+
+      val df = sql(
+        s"SELECT * FROM $partFilterTableName " +
+        "WHERE part_col LIKE 'a%' AND size(arr) > 1")
+      checkAnswer(df, Seq(Row("a", Seq("x", "y"), "d1")))
+      assertPushedPartitionPredicates(df, 1)
+      assertScanReturnsPartitionKeys(df, Set("a"))
+    }
+  }
+
   test("referenced partition column ordinals: partition predicate same column twice " +
     "has de-duped ordinals") {
     withTable(partFilterTableName) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2EnhancedPartitionFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2EnhancedPartitionFilterSuite.scala
@@ -132,7 +132,7 @@ class DataSourceV2EnhancedPartitionFilterSuite
       checkAnswer(df, Seq(Row("a", "x"), Row("b", "y")))
       assertPushedPartitionPredicates(df, 1)
       assertScanReturnsPartitionKeys(df, Set("a", "b"))
-      assertReferencedPartitionColumnOrdinals(df, Array(0), Array("part_col"))
+      assertReferencedPartitionFieldOrdinals(df, Array(0), Array("part_col"))
     }
   }
 
@@ -197,11 +197,11 @@ class DataSourceV2EnhancedPartitionFilterSuite
       checkAnswer(df, Seq(Row("b", "y"), Row("bc", "z")))
       assertPushedPartitionPredicates(df, 1)
       assertScanReturnsPartitionKeys(df, Set("b", "bc"))
-      assertReferencedPartitionColumnOrdinals(df, Array(0), Array("part_col"))
+      assertReferencedPartitionFieldOrdinals(df, Array(0), Array("part_col"))
     }
   }
 
-  test("case 8: Second-pass PartitionPredicate filter works for UDF filter on partition column") {
+  test("case 8: Second-pass PartitionPredicate filter works for UDF filter on partition field") {
     withTable(partFilterTableName) {
       sql(s"CREATE TABLE $partFilterTableName (part_col string, data string) USING $v2Source " +
         "PARTITIONED BY (part_col)")
@@ -216,7 +216,7 @@ class DataSourceV2EnhancedPartitionFilterSuite
       checkAnswer(df, Seq(Row("a", "x"), Row("A", "y")))
       assertPushedPartitionPredicates(df, 1)
       assertScanReturnsPartitionKeys(df, Set("a", "A"))
-      assertReferencedPartitionColumnOrdinals(df, Array(0), Array("part_col"))
+      assertReferencedPartitionFieldOrdinals(df, Array(0), Array("part_col"))
     }
   }
 
@@ -235,7 +235,7 @@ class DataSourceV2EnhancedPartitionFilterSuite
       checkAnswer(df, Seq(Row(Row("LA", 1), "a")))
       assertPushedPartitionPredicates(df, 1)
       assertScanReturnsPartitionKeys(df, Set("LA"))
-      assertReferencedPartitionColumnOrdinals(df, Array(0), Array("s.tz"))
+      assertReferencedPartitionFieldOrdinals(df, Array(0), Array("s.tz"))
     }
   }
 
@@ -274,7 +274,7 @@ class DataSourceV2EnhancedPartitionFilterSuite
     }
   }
 
-  test("referenced partition column ordinals: partition predicate same column twice " +
+  test("referenced partition field ordinals: partition predicate same field twice " +
     "has de-duped ordinals") {
     withTable(partFilterTableName) {
       sql(s"CREATE TABLE $partFilterTableName (part_col string, data string) USING $v2Source " +
@@ -286,11 +286,11 @@ class DataSourceV2EnhancedPartitionFilterSuite
       checkAnswer(df, Seq(Row("a", "x"), Row("b", "y"), Row("bc", "z")))
       assertPushedPartitionPredicates(df, 1)
       assertScanReturnsPartitionKeys(df, Set("a", "b", "bc"))
-      assertReferencedPartitionColumnOrdinals(df, Array(0), Array("part_col"))
+      assertReferencedPartitionFieldOrdinals(df, Array(0), Array("part_col"))
     }
   }
 
-  test("referenced partition column ordinals: one non-first partition column in second-pass") {
+  test("referenced partition field ordinals: one non-first partition field in second-pass") {
     withTable(partFilterTableName) {
       sql(s"CREATE TABLE $partFilterTableName (p0 string, p1 string, p2 string, data string) " +
         s"USING $v2Source PARTITIONED BY (p0, p1, p2)")
@@ -304,11 +304,11 @@ class DataSourceV2EnhancedPartitionFilterSuite
       checkAnswer(df, Seq(
         Row("a", "x", "1", "d1"), Row("a", "x", "2", "d3"), Row("b", "x", "1", "d4")))
       assertPushedPartitionPredicates(df, 1)
-      assertReferencedPartitionColumnOrdinals(df, Array(1), Array("p0", "p1", "p2"))
+      assertReferencedPartitionFieldOrdinals(df, Array(1), Array("p0", "p1", "p2"))
     }
   }
 
-  test("referenced partition column ordinals: two non-first partition columns in second-pass") {
+  test("referenced partition field ordinals: two non-first partition fields in second-pass") {
     withTable(partFilterTableName) {
       sql(s"CREATE TABLE $partFilterTableName (p0 string, p1 string, p2 string, data string) " +
         s"USING $v2Source PARTITIONED BY (p0, p1, p2)")
@@ -324,7 +324,7 @@ class DataSourceV2EnhancedPartitionFilterSuite
       val df = sql(s"SELECT * FROM $partFilterTableName WHERE concat2(p1, p2) = 'x1'")
       checkAnswer(df, Seq(Row("a", "x", "1", "d1"), Row("b", "x", "1", "d4")))
       assertPushedPartitionPredicates(df, 1)
-      assertReferencedPartitionColumnOrdinals(df, Array(1, 2), Array("p0", "p1", "p2"))
+      assertReferencedPartitionFieldOrdinals(df, Array(1, 2), Array("p0", "p1", "p2"))
     }
   }
 
@@ -439,20 +439,20 @@ class DataSourceV2EnhancedPartitionFilterSuite
   }
 
   /**
-   * Asserts that each pushed partition predicate's references() (PartitionColumnReference,
-   * each with ordinal()) match the expected ordinals and partition column names.
+   * Asserts that each pushed partition predicate's references() (PartitionFieldReference,
+   * each with ordinal()) match the expected ordinals and partition field names.
    *
    * @param df the query result
    * @param expectedOrdinals expected 0-based ordinals from Table.partitioning()
-   * @param expectedPartitionColumnNames partition column names by ordinal
-   *        (names(ordinal) is the name for that partition column)
+   * @param expectedPartitionFieldNames partition field names by ordinal
+   *        (names(ordinal) is the name for that partition field)
    */
-  private def assertReferencedPartitionColumnOrdinals(
+  private def assertReferencedPartitionFieldOrdinals(
       df: DataFrame,
       expectedOrdinals: Array[Int],
-      expectedPartitionColumnNames: Array[String]): Unit = {
+      expectedPartitionFieldNames: Array[String]): Unit = {
     val predicates = getPushedPartitionPredicates(df)
-    val names = expectedPartitionColumnNames
+    val names = expectedPartitionFieldNames
   predicates.foreach { p =>
       val refs = p.references()
       val ordinals = refs.map(_.asInstanceOf[PartitionFieldReference].ordinal()).sorted
@@ -463,17 +463,17 @@ class DataSourceV2EnhancedPartitionFilterSuite
 
       refs.foreach { ref =>
         assert(ref.isInstanceOf[PartitionFieldReference],
-          s"Expected PartitionColumnReference, got ${ref.getClass.getName}")
+          s"Expected PartitionFieldReference, got ${ref.getClass.getName}")
         val partRef = ref.asInstanceOf[PartitionFieldReference]
         assert(partRef.fieldNames().nonEmpty,
-          s"PartitionColumnReference.ordinal=${partRef.ordinal()} has empty fieldNames")
+          s"PartitionFieldReference.ordinal=${partRef.ordinal()} has empty fieldNames")
         assert(partRef.ordinal() < names.length,
-          s"PartitionColumnReference.ordinal=${partRef.ordinal()} " +
+          s"PartitionFieldReference.ordinal=${partRef.ordinal()} " +
             s"out of range for names length ${names.length}")
         val expectedName = names(partRef.ordinal())
         val actualName = partRef.fieldNames().mkString(".")
         assert(actualName === expectedName,
-          s"PartitionColumnReference.ordinal=${partRef.ordinal()}: " +
+          s"PartitionFieldReference.ordinal=${partRef.ordinal()}: " +
             s"expected fieldNames '${expectedName}', got '${actualName}'")
       }
     }
@@ -481,7 +481,7 @@ class DataSourceV2EnhancedPartitionFilterSuite
 
   /**
    * Asserts that the scan reads exactly the given set of partition keys (single-partition
-   * column tables use keyString() which is the partition value).
+   * field tables use keyString() which is the partition value).
    */
   private def assertScanReturnsPartitionKeys(
       df: DataFrame,

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2EnhancedPartitionFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2EnhancedPartitionFilterSuite.scala
@@ -257,6 +257,27 @@ class DataSourceV2EnhancedPartitionFilterSuite
     }
   }
 
+  test("nested identity partition: field name containing a dot") {
+    withTable(partFilterTableName) {
+      sql(s"CREATE TABLE $partFilterTableName " +
+        s"(s struct<`a.b`: string, x: int>, data string) USING $v2Source " +
+        "PARTITIONED BY (s.`a.b`)")
+      sql(s"INSERT INTO $partFilterTableName VALUES " +
+        "(named_struct('a.b', 'LA', 'x', 1), 'v1'), " +
+        "(named_struct('a.b', 'NY', 'x', 2), 'v2')")
+
+      spark.udf.register("my_upper_dot", (s: String) =>
+        if (s == null) null else s.toUpperCase(Locale.ROOT))
+
+      val df = sql(
+        s"SELECT * FROM $partFilterTableName WHERE my_upper_dot(s.`a.b`) = 'LA'")
+      checkAnswer(df, Seq(Row(Row("LA", 1), "v1")))
+      assertPushedPartitionPredicates(df, 1)
+      assertScanReturnsPartitionKeys(df, Set("LA"))
+      assertReferencedPartitionFieldOrdinals(df, Array(0), Array("s.a.b"))
+    }
+  }
+
   test("partition filter with data array col filter") {
     withTable(partFilterTableName) {
       sql(s"CREATE TABLE $partFilterTableName " +
@@ -453,7 +474,7 @@ class DataSourceV2EnhancedPartitionFilterSuite
       expectedPartitionFieldNames: Array[String]): Unit = {
     val predicates = getPushedPartitionPredicates(df)
     val names = expectedPartitionFieldNames
-  predicates.foreach { p =>
+    predicates.foreach { p =>
       val refs = p.references()
       val ordinals = refs.map(_.asInstanceOf[PartitionFieldReference].ordinal()).sorted
       assert(ordinals.sameElements(expectedOrdinals.sorted),


### PR DESCRIPTION

### What changes were proposed in this pull request?
Supported nested columns.
1. Pass an enhanced partitionSchema to the pushdownFilters()
2. Add support to 'flatten' the provided filters (GetStruct(AttributeReference("parent"), "child")) into a schema understood by the partition predicate and pushdown.

### Why are the changes needed?
DSV2 connectors support nested struct fields as partition fields.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add unit tests to DSV2EnhancedPartitionFilterSuite.


### Was this patch authored or co-authored using generative AI tooling?
Yes, cursor with hand refactoring
