### PR TITLE
[SPARK-56201][SS] Run SPARK-49829 tests with VCF joins now that StateDataSource supports it

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
@@ -1877,9 +1877,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
     }
   }
 
-  // This test is currently marked to run without virtual column family joins because it requires
-  // inferSchema from StateDataSource, which is not supported for this version of joins yet.
-  testWithoutVirtualColumnFamilyJoins(
+  test(
     "SPARK-49829 left-outer join, input being unmatched is between WM for late event and " +
     "WM for eviction") {
 
@@ -2402,9 +2400,7 @@ class StreamingLeftSemiJoinSuite extends StreamingJoinSuite {
     )
   }
 
-  // This test is currently marked to run without virtual column family joins because it requires
-  // inferSchema from StateDataSource, which is not supported for this version of joins yet.
-  testWithoutVirtualColumnFamilyJoins(
+  test(
     "SPARK-49829 two chained stream-stream left outer joins among three input streams") {
     withSQLConf(SQLConf.STREAMING_NO_DATA_MICRO_BATCHES_ENABLED.key -> "false") {
       val memoryStream1 = MemoryStream[(Long, Int)]

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinV4Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinV4Suite.scala
@@ -55,13 +55,18 @@ trait TestWithV4StateFormat extends AlsoTestWithVirtualColumnFamilyJoins {
   // Use lazy val because the parent constructor registers tests before
   // subclass vals are initialized.
   private lazy val testsToSkip = Seq(
+    // V4's timestamp-based indexing does not support window structs
+    // in join keys.
+    "stream stream inner join on windows - with watermark",
     // V4 uses 1 store with VCFs instead of V3's 4*partitions layout,
     // so metric assertions about number of state store instances differ.
     "SPARK-35896: metrics in StateOperatorProgress are output correctly",
     // V4 uses different column families and encoder specs than V3;
     // overridden in StreamingInnerJoinV4Suite with V4-specific assertions.
     "SPARK-51779 Verify StateSchemaV3 writes correct key and value " +
-      "schemas for join operator"
+      "schemas for join operator",
+    // V4's key encoding is not yet supported by StateDataSource reader.
+    "SPARK-49829"
   )
 
   override def runTest(testName: String, args: Args): Status = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the SPARK-49829 stream-stream join tests from `testWithoutVirtualColumnFamilyJoins` to `test()` so they run in both VCF (virtual column families) and non-VCF modes.

Also add `SPARK-49829` and the window join test to `TestWithV4StateFormat`'s skip list, since V4's timestamp-based key encoding is not yet supported by the StateDataSource reader.

### Why are the changes needed?

1. The SPARK-49829 tests were excluded from VCF testing with a comment saying StateDataSource `inferSchema` was "not supported for this version of joins yet." This is no longer true — VCF support for joins has since been added (`isReadAllColFamiliesOnJoinWithVCF` in `StateDataSource`).
2. Running these tests with VCF increases test coverage for the V3 state format path.
3. The V4 incompatibility is handled precisely in `TestWithV4StateFormat` rather than by blanket-excluding the tests from all VCF modes.

### Does this PR introduce _any_ user-facing change?

No. Test-only change.

### How was this patch tested?

Existing tests — the SPARK-49829 tests now run in both VCF and non-VCF modes. V4 suites skip them via `TestWithV4StateFormat.testsToSkip`.

### Was this patch authored or co-authored using generative AI tooling?

Yes