### PR TITLE
[SPARK-56050][SQL][FOLLOWUP] Add comment to withIdentClause about withOrigin pitfall

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -69,6 +69,13 @@ class AstBuilder extends DataTypeAstBuilder
   import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
   import ParserUtils._
 
+  // Note: Do NOT add withOrigin(ctx) to this method. Builders often create full command plans
+  // (e.g., ReplaceTable, CreateFunction), not just identifier plans. Wrapping the body with
+  // withOrigin(ctx) would set CurrentOrigin to the identifier reference for ALL code in the
+  // builder, including error-throwing validation. Since ParseException.getQueryContext() reads
+  // from CurrentOrigin, this would cause error contexts to point to the identifier instead of
+  // the full statement. If a specific call site needs the identifier Origin on the plan it
+  // creates, add withOrigin(ctx) inside that call site's builder lambda instead.
   protected def withIdentClause(
       ctx: IdentifierReferenceContext,
       builder: Seq[String] => LogicalPlan): LogicalPlan = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Followup to https://github.com/apache/spark/pull/54888.

This PR adds a documentation comment to `withIdentClause` in `AstBuilder` explaining why `withOrigin(ctx)` should not be added to the method body, and where to place it instead (inside specific call site builder lambdas).

### Why are the changes needed?

1. `withIdentClause` is called from many places with builders that create different types of plans — some create full command plans (e.g., `ReplaceTable`, `CreateFunction`), not just identifier-related plans.
2. Adding `withOrigin(ctx)` to the method body would set `CurrentOrigin` to the identifier reference for all code in the builder, including error-throwing validation code. Since `ParseException.getQueryContext()` reads from `CurrentOrigin`, this would cause error contexts to incorrectly point to the identifier instead of the full statement.
3. This is a non-obvious pitfall that is worth documenting to prevent future contributors from introducing this bug.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Comment-only change, no tests needed.

### Was this patch authored or co-authored using generative AI tooling?

Yes