### PR TITLE
[SPARK-56179][PYTHON] Consolidate error classes for type mismatch - part 3

### DIFF
--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -625,87 +625,15 @@
     ],
     "sqlState": "42K09"
   },
-  "NOT_LIST_OF_COLUMN": {
-    "message": [
-      "Argument `<arg_name>` should be a list[Column]."
-    ],
-    "sqlState": "42K09"
-  },
-  "NOT_LIST_OF_FLOAT_OR_INT": {
-    "message": [
-      "Argument `<arg_name>` should be a list[float, int], got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
-  "NOT_LIST_OF_STR": {
-    "message": [
-      "Argument `<arg_name>` should be a list[str], got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
-  "NOT_LIST_OR_NONE_OR_STRUCT": {
-    "message": [
-      "Argument `<arg_name>` should be a list, None or StructType, got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
-  "NOT_LIST_OR_STR_OR_TUPLE": {
-    "message": [
-      "Argument `<arg_name>` should be a list, str or tuple, got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
-  "NOT_LIST_OR_TUPLE": {
-    "message": [
-      "Argument `<arg_name>` should be a list or tuple, got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
   "NOT_NUMERIC_COLUMNS": {
     "message": [
       "Numeric aggregation function can only be applied on numeric columns, got <invalid_columns>."
     ],
     "sqlState": "42K09"
   },
-  "NOT_OBSERVATION_OR_STR": {
-    "message": [
-      "Argument `<arg_name>` should be an Observation or str, got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
   "NOT_SAME_TYPE": {
     "message": [
       "Argument `<arg_name1>` and `<arg_name2>` should be the same type, got <arg_type1> and <arg_type2>."
-    ],
-    "sqlState": "42K09"
-  },
-  "NOT_STR": {
-    "message": [
-      "Argument `<arg_name>` should be a str, got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
-  "NOT_STRUCT": {
-    "message": [
-      "Argument `<arg_name>` should be a struct type, got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
-  "NOT_STR_OR_LIST_OF_RDD": {
-    "message": [
-      "Argument `<arg_name>` should be a str or list[RDD], got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
-  "NOT_STR_OR_STRUCT": {
-    "message": [
-      "Argument `<arg_name>` should be a str or struct type, got <arg_type>."
-    ],
-    "sqlState": "42K09"
-  },
-  "NOT_WINDOWSPEC": {
-    "message": [
-      "Argument `<arg_name>` should be a WindowSpec, got <arg_type>."
     ],
     "sqlState": "42K09"
   },

--- a/python/pyspark/pipelines/api.py
+++ b/python/pyspark/pipelines/api.py
@@ -49,8 +49,12 @@ def append_flow(
     """
     if name is not None and type(name) is not str:
         raise PySparkTypeError(
-            errorClass="NOT_STR",
-            messageParameters={"arg_name": "name", "arg_type": type(name).__name__},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "arg_name": "name",
+                "expected_type": "str",
+                "arg_type": type(name).__name__,
+            },
         )
 
     source_code_location = get_caller_source_code_location(stacklevel=1)
@@ -80,8 +84,12 @@ def _validate_stored_dataset_args(
 ) -> None:
     if name is not None and type(name) is not str:
         raise PySparkTypeError(
-            errorClass="NOT_STR",
-            messageParameters={"arg_name": "name", "arg_type": type(name).__name__},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "arg_name": "name",
+                "expected_type": "str",
+                "arg_type": type(name).__name__,
+            },
         )
     if table_properties is not None and not isinstance(table_properties, dict):
         raise PySparkTypeError(
@@ -346,8 +354,12 @@ def temporary_view(
     """
     if name is not None and type(name) is not str:
         raise PySparkTypeError(
-            errorClass="NOT_STR",
-            messageParameters={"arg_name": "name", "arg_type": type(name).__name__},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "arg_name": "name",
+                "expected_type": "str",
+                "arg_type": type(name).__name__,
+            },
         )
 
     source_code_location = get_caller_source_code_location(stacklevel=1)
@@ -430,8 +442,12 @@ def create_streaming_table(
     """
     if type(name) is not str:
         raise PySparkTypeError(
-            errorClass="NOT_STR",
-            messageParameters={"arg_name": "name", "arg_type": type(name).__name__},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "arg_name": "name",
+                "expected_type": "str",
+                "arg_type": type(name).__name__,
+            },
         )
     if table_properties is not None and not isinstance(table_properties, dict):
         raise PySparkTypeError(
@@ -476,13 +492,21 @@ def create_sink(
     """
     if type(name) is not str:
         raise PySparkTypeError(
-            errorClass="NOT_STR",
-            messageParameters={"arg_name": "name", "arg_type": type(name).__name__},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "arg_name": "name",
+                "expected_type": "str",
+                "arg_type": type(name).__name__,
+            },
         )
     if type(format) is not str:
         raise PySparkTypeError(
-            errorClass="NOT_STR",
-            messageParameters={"arg_name": "format", "arg_type": type(format).__name__},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "arg_name": "format",
+                "expected_type": "str",
+                "arg_type": type(format).__name__,
+            },
         )
     if options is not None and not isinstance(options, dict):
         raise PySparkTypeError(

--- a/python/pyspark/pipelines/tests/test_decorators.py
+++ b/python/pyspark/pipelines/tests/test_decorators.py
@@ -30,8 +30,9 @@ class DecoratorsTest(unittest.TestCase):
                 def dataset_with_non_string_name():
                     raise NotImplementedError()
 
-            assert context.exception.getCondition() == "NOT_STR"
+            assert context.exception.getCondition() == "NOT_EXPECTED_TYPE"
             assert context.exception.getMessageParameters() == {
+                "expected_type": "str",
                 "arg_name": "name",
                 "arg_type": "int",
             }, context.exception.getMessageParameters()
@@ -44,8 +45,9 @@ class DecoratorsTest(unittest.TestCase):
                 def dataset_with_invalid_partition_cols():
                     raise NotImplementedError()
 
-            assert context.exception.getCondition() == "NOT_LIST_OF_STR"
+            assert context.exception.getCondition() == "NOT_EXPECTED_TYPE"
             assert context.exception.getMessageParameters() == {
+                "expected_type": "list[str]",
                 "arg_name": "partition_cols",
                 "arg_type": "list",
             }, context.exception.getMessageParameters()

--- a/python/pyspark/pipelines/type_error_utils.py
+++ b/python/pyspark/pipelines/type_error_utils.py
@@ -33,9 +33,10 @@ def validate_optional_list_of_str_arg(arg_name: str, arg_value: Optional[List[st
 
     if not isinstance(arg_value, list):
         raise PySparkTypeError(
-            errorClass="NOT_LIST_OF_STR",
+            errorClass="NOT_EXPECTED_TYPE",
             messageParameters={
                 "arg_name": arg_name,
+                "expected_type": "list[str]",
                 "arg_type": type(arg_value).__name__,
             },
         )
@@ -43,9 +44,10 @@ def validate_optional_list_of_str_arg(arg_name: str, arg_value: Optional[List[st
     for el in arg_value:
         if not isinstance(el, str):
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OF_STR",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": arg_name,
+                    "expected_type": "list[str]",
                     "arg_type": type(arg_value).__name__,
                 },
             )

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -854,9 +854,10 @@ class Catalog:
         else:
             if not isinstance(schema, StructType):
                 raise PySparkTypeError(
-                    errorClass="NOT_STRUCT",
+                    errorClass="NOT_EXPECTED_TYPE",
                     messageParameters={
                         "arg_name": "schema",
+                        "expected_type": "struct type",
                         "arg_type": type(schema).__name__,
                     },
                 )

--- a/python/pyspark/sql/classic/column.py
+++ b/python/pyspark/sql/classic/column.py
@@ -379,8 +379,12 @@ class Column(ParentColumn):
     def withField(self, fieldName: str, col: ParentColumn) -> ParentColumn:
         if not isinstance(fieldName, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "fieldName", "arg_type": type(fieldName).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "fieldName",
+                    "expected_type": "str",
+                    "arg_type": type(fieldName).__name__,
+                },
             )
 
         if not isinstance(col, Column):
@@ -628,8 +632,12 @@ class Column(ParentColumn):
 
         if not isinstance(window, WindowSpec):
             raise PySparkTypeError(
-                errorClass="NOT_WINDOWSPEC",
-                messageParameters={"arg_name": "window", "arg_type": type(window).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "window",
+                    "expected_type": "WindowSpec",
+                    "arg_type": type(window).__name__,
+                },
             )
         jc = self._jc.over(window._jspec)
         return Column(jc)

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -261,8 +261,12 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
                 )
             if (mode is not None) and (not isinstance(mode, str)):
                 raise PySparkTypeError(
-                    errorClass="NOT_STR",
-                    messageParameters={"arg_name": "mode", "arg_type": type(mode).__name__},
+                    errorClass="NOT_EXPECTED_TYPE",
+                    messageParameters={
+                        "arg_name": "mode",
+                        "expected_type": "str",
+                        "arg_type": type(mode).__name__,
+                    },
                 )
 
         # Sets an explain mode depending on a given argument
@@ -404,14 +408,19 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def withWatermark(self, eventTime: str, delayThreshold: str) -> ParentDataFrame:
         if not eventTime or type(eventTime) is not str:
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "eventTime", "arg_type": type(eventTime).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "eventTime",
+                    "expected_type": "str",
+                    "arg_type": type(eventTime).__name__,
+                },
             )
         if not delayThreshold or type(delayThreshold) is not str:
             raise PySparkTypeError(
-                errorClass="NOT_STR",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "delayThreshold",
+                    "expected_type": "str",
                     "arg_type": type(delayThreshold).__name__,
                 },
             )
@@ -426,8 +435,12 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
 
         if not isinstance(name, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "name", "arg_type": type(name).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "name",
+                    "expected_type": "str",
+                    "arg_type": type(name).__name__,
+                },
             )
 
         allowed_types = (str, float, int, Column, list)
@@ -720,8 +733,12 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def metadataColumn(self, colName: str) -> Column:
         if not isinstance(colName, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "colName", "arg_type": type(colName).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "colName",
+                    "expected_type": "str",
+                    "arg_type": type(colName).__name__,
+                },
             )
         jc = self._jdf.metadataColumn(colName)
         return Column(jc)
@@ -729,8 +746,12 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def colRegex(self, colName: str) -> Column:
         if not isinstance(colName, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "colName", "arg_type": type(colName).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "colName",
+                    "expected_type": "str",
+                    "arg_type": type(colName).__name__,
+                },
             )
         jc = self._jdf.colRegex(colName)
         return Column(jc)
@@ -1200,8 +1221,12 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             )
         if not all(isinstance(c, Column) for c in exprs):
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OF_COLUMN",
-                messageParameters={"arg_name": "exprs"},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "exprs",
+                    "expected_type": "list[Column]",
+                    "arg_type": type(exprs).__name__,
+                },
             )
 
         if isinstance(observation, Observation):
@@ -1215,9 +1240,10 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             )
         else:
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OF_COLUMN",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "observation",
+                    "expected_type": "Observation or str",
                     "arg_type": type(observation).__name__,
                 },
             )
@@ -1245,8 +1271,12 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def dropDuplicates(self, subset: Optional[List[str]] = None) -> ParentDataFrame:
         if subset is not None and (not isinstance(subset, Iterable) or isinstance(subset, str)):
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OR_TUPLE",
-                messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "subset",
+                    "expected_type": "list or tuple",
+                    "arg_type": type(subset).__name__,
+                },
             )
 
         if subset is None:
@@ -1255,8 +1285,12 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             for c in subset:
                 if not isinstance(c, str):
                     raise PySparkTypeError(
-                        errorClass="NOT_STR",
-                        messageParameters={"arg_name": "subset", "arg_type": type(c).__name__},
+                        errorClass="NOT_EXPECTED_TYPE",
+                        messageParameters={
+                            "arg_name": "subset",
+                            "expected_type": "str",
+                            "arg_type": type(c).__name__,
+                        },
                     )
             jdf = self._jdf.dropDuplicates(self._jseq(subset))
         return DataFrame(jdf, self.sparkSession)
@@ -1264,8 +1298,12 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def dropDuplicatesWithinWatermark(self, subset: Optional[List[str]] = None) -> ParentDataFrame:
         if subset is not None and (not isinstance(subset, Iterable) or isinstance(subset, str)):
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OR_TUPLE",
-                messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "subset",
+                    "expected_type": "list or tuple",
+                    "arg_type": type(subset).__name__,
+                },
             )
 
         if subset is None:
@@ -1274,8 +1312,12 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             for c in subset:
                 if not isinstance(c, str):
                     raise PySparkTypeError(
-                        errorClass="NOT_STR",
-                        messageParameters={"arg_name": "subset", "arg_type": type(c).__name__},
+                        errorClass="NOT_EXPECTED_TYPE",
+                        messageParameters={
+                            "arg_name": "subset",
+                            "expected_type": "str",
+                            "arg_type": type(c).__name__,
+                        },
                     )
             jdf = self._jdf.dropDuplicatesWithinWatermark(self._jseq(subset))
         return DataFrame(jdf, self.sparkSession)
@@ -1298,8 +1340,12 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             subset = [subset]
         elif not isinstance(subset, (list, tuple)):
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OR_STR_OR_TUPLE",
-                messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "subset",
+                    "expected_type": "list, str or tuple",
+                    "arg_type": type(subset).__name__,
+                },
             )
 
         if thresh is None:
@@ -1337,8 +1383,12 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
                 subset = [subset]
             elif not isinstance(subset, (list, tuple)):
                 raise PySparkTypeError(
-                    errorClass="NOT_LIST_OR_TUPLE",
-                    messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
+                    errorClass="NOT_EXPECTED_TYPE",
+                    messageParameters={
+                        "arg_name": "subset",
+                        "expected_type": "list or tuple",
+                        "arg_type": type(subset).__name__,
+                    },
                 )
 
             return DataFrame(self._jdf.na().fill(value, self._jseq(subset)), self.sparkSession)
@@ -1453,8 +1503,12 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
 
         if not (subset is None or isinstance(subset, (list, tuple, str))):
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OR_STR_OR_TUPLE",
-                messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "subset",
+                    "expected_type": "list, str or tuple",
+                    "arg_type": type(subset).__name__,
+                },
             )
 
         # Reshape input arguments if necessary
@@ -1516,8 +1570,12 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     ) -> Union[List[float], List[List[float]]]:
         if not isinstance(col, (str, list, tuple)):
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OR_STR_OR_TUPLE",
-                messageParameters={"arg_name": "col", "arg_type": type(col).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "col",
+                    "expected_type": "list, str or tuple",
+                    "arg_type": type(col).__name__,
+                },
             )
 
         isStr = isinstance(col, str)
@@ -1542,9 +1600,10 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
 
         if not isinstance(probabilities, (list, tuple)):
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OR_TUPLE",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "probabilities",
+                    "expected_type": "list or tuple",
                     "arg_type": type(probabilities).__name__,
                 },
             )
@@ -1553,9 +1612,10 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         for p in probabilities:
             if not isinstance(p, (float, int)) or p < 0 or p > 1:
                 raise PySparkTypeError(
-                    errorClass="NOT_LIST_OF_FLOAT_OR_INT",
+                    errorClass="NOT_EXPECTED_TYPE",
                     messageParameters={
                         "arg_name": "probabilities",
+                        "expected_type": "list[float, int]",
                         "arg_type": type(p).__name__,
                     },
                 )
@@ -1587,13 +1647,21 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def corr(self, col1: str, col2: str, method: Optional[str] = None) -> float:
         if not isinstance(col1, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "col1", "arg_type": type(col1).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "col1",
+                    "expected_type": "str",
+                    "arg_type": type(col1).__name__,
+                },
             )
         if not isinstance(col2, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "col2", "arg_type": type(col2).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "col2",
+                    "expected_type": "str",
+                    "arg_type": type(col2).__name__,
+                },
             )
         if not method:
             method = "pearson"
@@ -1607,26 +1675,42 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def cov(self, col1: str, col2: str) -> float:
         if not isinstance(col1, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "col1", "arg_type": type(col1).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "col1",
+                    "expected_type": "str",
+                    "arg_type": type(col1).__name__,
+                },
             )
         if not isinstance(col2, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "col2", "arg_type": type(col2).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "col2",
+                    "expected_type": "str",
+                    "arg_type": type(col2).__name__,
+                },
             )
         return self._jdf.stat().cov(col1, col2)
 
     def crosstab(self, col1: str, col2: str) -> ParentDataFrame:
         if not isinstance(col1, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "col1", "arg_type": type(col1).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "col1",
+                    "expected_type": "str",
+                    "arg_type": type(col1).__name__,
+                },
             )
         if not isinstance(col2, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "col2", "arg_type": type(col2).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "col2",
+                    "expected_type": "str",
+                    "arg_type": type(col2).__name__,
+                },
             )
         return DataFrame(self._jdf.stat().crosstab(col1, col2), self.sparkSession)
 
@@ -1637,8 +1721,12 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             cols = list(cols)
         if not isinstance(cols, list):
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OR_TUPLE",
-                messageParameters={"arg_name": "cols", "arg_type": type(cols).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "cols",
+                    "expected_type": "list or tuple",
+                    "arg_type": type(cols).__name__,
+                },
             )
         if not support:
             support = 0.01
@@ -1774,8 +1862,12 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         for col in cols:
             if not isinstance(col, str):
                 raise PySparkTypeError(
-                    errorClass="NOT_LIST_OF_STR",
-                    messageParameters={"arg_name": "cols", "arg_type": type(col).__name__},
+                    errorClass="NOT_EXPECTED_TYPE",
+                    messageParameters={
+                        "arg_name": "cols",
+                        "expected_type": "list[str]",
+                        "arg_type": type(col).__name__,
+                    },
                 )
         jdf = self._jdf.toDF(self._jseq(cols))
         return DataFrame(jdf, self.sparkSession)

--- a/python/pyspark/sql/conf.py
+++ b/python/pyspark/sql/conf.py
@@ -136,9 +136,10 @@ class RuntimeConfig:
         """Assert that an object is of type str."""
         if not isinstance(obj, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": identifier,
+                    "expected_type": "str",
                     "arg_type": type(obj).__name__,
                 },
             )

--- a/python/pyspark/sql/connect/catalog.py
+++ b/python/pyspark/sql/connect/catalog.py
@@ -251,9 +251,10 @@ class Catalog:
     ) -> "DataFrame":
         if schema is not None and not isinstance(schema, StructType):
             raise PySparkTypeError(
-                errorClass="NOT_STRUCT",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "schema",
+                    "expected_type": "struct type",
                     "arg_type": type(schema).__name__,
                 },
             )

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -479,8 +479,12 @@ class Column(ParentColumn):
 
         if not isinstance(window, WindowSpec):
             raise PySparkTypeError(
-                errorClass="NOT_WINDOWSPEC",
-                messageParameters={"arg_name": "window", "arg_type": type(window).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "window",
+                    "expected_type": "WindowSpec",
+                    "arg_type": type(window).__name__,
+                },
             )
 
         return Column(WindowExpression(windowFunction=self._expr, windowSpec=window))
@@ -541,8 +545,12 @@ class Column(ParentColumn):
     def withField(self, fieldName: str, col: ParentColumn) -> ParentColumn:
         if not isinstance(fieldName, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "fieldName", "arg_type": type(fieldName).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "fieldName",
+                    "expected_type": "str",
+                    "arg_type": type(fieldName).__name__,
+                },
             )
 
         if not isinstance(col, Column):
@@ -562,9 +570,10 @@ class Column(ParentColumn):
         for fieldName in fieldNames:
             if not isinstance(fieldName, str):
                 raise PySparkTypeError(
-                    errorClass="NOT_STR",
+                    errorClass="NOT_EXPECTED_TYPE",
                     messageParameters={
                         "arg_name": "fieldName",
+                        "expected_type": "str",
                         "arg_type": type(fieldName).__name__,
                     },
                 )

--- a/python/pyspark/sql/connect/conf.py
+++ b/python/pyspark/sql/connect/conf.py
@@ -121,9 +121,10 @@ class RuntimeConf:
         """Assert that an object is of type str."""
         if not isinstance(obj, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": identifier,
+                    "expected_type": "str",
                     "arg_type": type(obj).__name__,
                 },
             )

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -335,16 +335,24 @@ class DataFrame(ParentDataFrame):
     def metadataColumn(self, colName: str) -> Column:
         if not isinstance(colName, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "colName", "arg_type": type(colName).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "colName",
+                    "expected_type": "str",
+                    "arg_type": type(colName).__name__,
+                },
             )
         return self._col(colName, is_metadata_column=True)
 
     def colRegex(self, colName: str) -> Column:
         if not isinstance(colName, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "colName", "arg_type": type(colName).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "colName",
+                    "expected_type": "str",
+                    "arg_type": type(colName).__name__,
+                },
             )
         return ConnectColumn(UnresolvedRegex(colName, self._plan._plan_id))
 
@@ -513,8 +521,12 @@ class DataFrame(ParentDataFrame):
     def dropDuplicates(self, subset: Optional[List[str]] = None) -> ParentDataFrame:
         if subset is not None and not isinstance(subset, (list, tuple)):
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OR_TUPLE",
-                messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "subset",
+                    "expected_type": "list or tuple",
+                    "arg_type": type(subset).__name__,
+                },
             )
 
         if subset is None:
@@ -525,8 +537,12 @@ class DataFrame(ParentDataFrame):
             for c in subset:
                 if not isinstance(c, str):
                     raise PySparkTypeError(
-                        errorClass="NOT_STR",
-                        messageParameters={"arg_name": "subset", "arg_type": type(c).__name__},
+                        errorClass="NOT_EXPECTED_TYPE",
+                        messageParameters={
+                            "arg_name": "subset",
+                            "expected_type": "str",
+                            "arg_type": type(c).__name__,
+                        },
                     )
             res = DataFrame(
                 plan.Deduplicate(child=self._plan, column_names=subset), session=self._session
@@ -540,8 +556,12 @@ class DataFrame(ParentDataFrame):
     def dropDuplicatesWithinWatermark(self, subset: Optional[List[str]] = None) -> ParentDataFrame:
         if subset is not None and not isinstance(subset, (list, tuple)):
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OR_TUPLE",
-                messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "subset",
+                    "expected_type": "list or tuple",
+                    "arg_type": type(subset).__name__,
+                },
             )
 
         if subset is None:
@@ -553,8 +573,12 @@ class DataFrame(ParentDataFrame):
             for c in subset:
                 if not isinstance(c, str):
                     raise PySparkTypeError(
-                        errorClass="NOT_STR",
-                        messageParameters={"arg_name": "subset", "arg_type": type(c).__name__},
+                        errorClass="NOT_EXPECTED_TYPE",
+                        messageParameters={
+                            "arg_name": "subset",
+                            "expected_type": "str",
+                            "arg_type": type(c).__name__,
+                        },
                     )
             return DataFrame(
                 plan.Deduplicate(child=self._plan, column_names=subset, within_watermark=True),
@@ -978,14 +1002,19 @@ class DataFrame(ParentDataFrame):
         # TODO: reuse error handling code in sql.DataFrame.withWatermark()
         if not eventTime or type(eventTime) is not str:
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "eventTime", "arg_type": type(eventTime).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "eventTime",
+                    "expected_type": "str",
+                    "arg_type": type(eventTime).__name__,
+                },
             )
         if not delayThreshold or type(delayThreshold) is not str:
             raise PySparkTypeError(
-                errorClass="NOT_STR",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "delayThreshold",
+                    "expected_type": "str",
                     "arg_type": type(delayThreshold).__name__,
                 },
             )
@@ -1007,8 +1036,12 @@ class DataFrame(ParentDataFrame):
 
         if not isinstance(name, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "name", "arg_type": type(name).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "name",
+                    "expected_type": "str",
+                    "arg_type": type(name).__name__,
+                },
             )
 
         allowed_types = (str, float, int, Column, list)
@@ -1104,8 +1137,12 @@ class DataFrame(ParentDataFrame):
             )
         if not all(isinstance(c, Column) for c in exprs):
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OF_COLUMN",
-                messageParameters={"arg_name": "exprs"},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "exprs",
+                    "expected_type": "list[Column]",
+                    "arg_type": type(exprs).__name__,
+                },
             )
 
         if isinstance(observation, Observation):
@@ -1117,9 +1154,10 @@ class DataFrame(ParentDataFrame):
             )
         else:
             raise PySparkTypeError(
-                errorClass="NOT_OBSERVATION_OR_STR",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "observation",
+                    "expected_type": "Observation or str",
                     "arg_type": type(observation).__name__,
                 },
             )
@@ -1247,9 +1285,10 @@ class DataFrame(ParentDataFrame):
             for c, v in value.items():
                 if not isinstance(c, str):
                     raise PySparkTypeError(
-                        errorClass="NOT_STR",
+                        errorClass="NOT_EXPECTED_TYPE",
                         messageParameters={
                             "arg_name": "key type of dict",
+                            "expected_type": "str",
                             "arg_type": type(c).__name__,
                         },
                     )
@@ -1271,14 +1310,22 @@ class DataFrame(ParentDataFrame):
                 for c in subset:
                     if not isinstance(c, str):
                         raise PySparkTypeError(
-                            errorClass="NOT_LIST_OR_STR_OR_TUPLE",
-                            messageParameters={"arg_name": "cols", "arg_type": type(c).__name__},
+                            errorClass="NOT_EXPECTED_TYPE",
+                            messageParameters={
+                                "arg_name": "cols",
+                                "expected_type": "list, str or tuple",
+                                "arg_type": type(c).__name__,
+                            },
                         )
                 _cols = list(subset)
             else:
                 raise PySparkTypeError(
-                    errorClass="NOT_LIST_OR_TUPLE",
-                    messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
+                    errorClass="NOT_EXPECTED_TYPE",
+                    messageParameters={
+                        "arg_name": "subset",
+                        "expected_type": "list or tuple",
+                        "arg_type": type(subset).__name__,
+                    },
                 )
 
         if isinstance(value, dict):
@@ -1303,8 +1350,12 @@ class DataFrame(ParentDataFrame):
         if how is not None:
             if not isinstance(how, str):
                 raise PySparkTypeError(
-                    errorClass="NOT_STR",
-                    messageParameters={"arg_name": "how", "arg_type": type(how).__name__},
+                    errorClass="NOT_EXPECTED_TYPE",
+                    messageParameters={
+                        "arg_name": "how",
+                        "expected_type": "str",
+                        "arg_type": type(how).__name__,
+                    },
                 )
             if how == "all":
                 min_non_nulls = 1
@@ -1338,14 +1389,22 @@ class DataFrame(ParentDataFrame):
                 for c in subset:
                     if not isinstance(c, str):
                         raise PySparkTypeError(
-                            errorClass="NOT_LIST_OR_STR_OR_TUPLE",
-                            messageParameters={"arg_name": "cols", "arg_type": type(c).__name__},
+                            errorClass="NOT_EXPECTED_TYPE",
+                            messageParameters={
+                                "arg_name": "cols",
+                                "expected_type": "list, str or tuple",
+                                "arg_type": type(c).__name__,
+                            },
                         )
                 _cols = list(subset)
             else:
                 raise PySparkTypeError(
-                    errorClass="NOT_LIST_OR_STR_OR_TUPLE",
-                    messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
+                    errorClass="NOT_EXPECTED_TYPE",
+                    messageParameters={
+                        "arg_name": "subset",
+                        "expected_type": "list, str or tuple",
+                        "arg_type": type(subset).__name__,
+                    },
                 )
 
         return DataFrame(
@@ -1432,8 +1491,12 @@ class DataFrame(ParentDataFrame):
 
         if not (subset is None or isinstance(subset, (list, tuple, str))):
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OR_STR_OR_TUPLE",
-                messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "subset",
+                    "expected_type": "list, str or tuple",
+                    "arg_type": type(subset).__name__,
+                },
             )
 
         # Reshape input arguments if necessary
@@ -1494,8 +1557,12 @@ class DataFrame(ParentDataFrame):
         for s in _statistics:
             if not isinstance(s, str):
                 raise PySparkTypeError(
-                    errorClass="NOT_LIST_OF_STR",
-                    messageParameters={"arg_name": "statistics", "arg_type": type(s).__name__},
+                    errorClass="NOT_EXPECTED_TYPE",
+                    messageParameters={
+                        "arg_name": "statistics",
+                        "expected_type": "list[str]",
+                        "arg_type": type(s).__name__,
+                    },
                 )
         return DataFrame(
             plan.StatSummary(child=self._plan, statistics=_statistics),
@@ -1520,13 +1587,21 @@ class DataFrame(ParentDataFrame):
     def cov(self, col1: str, col2: str) -> float:
         if not isinstance(col1, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "col1", "arg_type": type(col1).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "col1",
+                    "expected_type": "str",
+                    "arg_type": type(col1).__name__,
+                },
             )
         if not isinstance(col2, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "col2", "arg_type": type(col2).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "col2",
+                    "expected_type": "str",
+                    "arg_type": type(col2).__name__,
+                },
             )
         table, _ = DataFrame(
             plan.StatCov(child=self._plan, col1=col1, col2=col2),
@@ -1537,13 +1612,21 @@ class DataFrame(ParentDataFrame):
     def corr(self, col1: str, col2: str, method: Optional[str] = None) -> float:
         if not isinstance(col1, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "col1", "arg_type": type(col1).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "col1",
+                    "expected_type": "str",
+                    "arg_type": type(col1).__name__,
+                },
             )
         if not isinstance(col2, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "col2", "arg_type": type(col2).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "col2",
+                    "expected_type": "str",
+                    "arg_type": type(col2).__name__,
+                },
             )
         if not method:
             method = "pearson"
@@ -1566,8 +1649,12 @@ class DataFrame(ParentDataFrame):
     ) -> Union[List[float], List[List[float]]]:
         if not isinstance(col, (str, list, tuple)):
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OR_STR_OR_TUPLE",
-                messageParameters={"arg_name": "col", "arg_type": type(col).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "col",
+                    "expected_type": "list, str or tuple",
+                    "arg_type": type(col).__name__,
+                },
             )
 
         isStr = isinstance(col, str)
@@ -1580,15 +1667,20 @@ class DataFrame(ParentDataFrame):
         for c in col:
             if not isinstance(c, str):
                 raise PySparkTypeError(
-                    errorClass="NOT_LIST_OF_STR",
-                    messageParameters={"arg_name": "columns", "arg_type": type(c).__name__},
+                    errorClass="NOT_EXPECTED_TYPE",
+                    messageParameters={
+                        "arg_name": "columns",
+                        "expected_type": "list[str]",
+                        "arg_type": type(c).__name__,
+                    },
                 )
 
         if not isinstance(probabilities, (list, tuple)):
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OR_TUPLE",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "probabilities",
+                    "expected_type": "list or tuple",
                     "arg_type": type(probabilities).__name__,
                 },
             )
@@ -1597,9 +1689,10 @@ class DataFrame(ParentDataFrame):
         for p in probabilities:
             if not isinstance(p, (float, int)) or p < 0 or p > 1:
                 raise PySparkTypeError(
-                    errorClass="NOT_LIST_OF_FLOAT_OR_INT",
+                    errorClass="NOT_EXPECTED_TYPE",
                     messageParameters={
                         "arg_name": "probabilities",
+                        "expected_type": "list[float, int]",
                         "arg_type": type(p).__name__,
                     },
                 )
@@ -1638,13 +1731,21 @@ class DataFrame(ParentDataFrame):
     def crosstab(self, col1: str, col2: str) -> ParentDataFrame:
         if not isinstance(col1, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "col1", "arg_type": type(col1).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "col1",
+                    "expected_type": "str",
+                    "arg_type": type(col1).__name__,
+                },
             )
         if not isinstance(col2, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "col2", "arg_type": type(col2).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "col2",
+                    "expected_type": "str",
+                    "arg_type": type(col2).__name__,
+                },
             )
         return DataFrame(
             plan.StatCrosstab(child=self._plan, col1=col1, col2=col2),
@@ -1658,8 +1759,12 @@ class DataFrame(ParentDataFrame):
             cols = list(cols)
         if not isinstance(cols, list):
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OR_TUPLE",
-                messageParameters={"arg_name": "cols", "arg_type": type(cols).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "cols",
+                    "expected_type": "list or tuple",
+                    "arg_type": type(cols).__name__,
+                },
             )
         if not support:
             support = 0.01
@@ -1952,8 +2057,12 @@ class DataFrame(ParentDataFrame):
         for col_ in cols:
             if not isinstance(col_, str):
                 raise PySparkTypeError(
-                    errorClass="NOT_LIST_OF_STR",
-                    messageParameters={"arg_name": "cols", "arg_type": type(col_).__name__},
+                    errorClass="NOT_EXPECTED_TYPE",
+                    messageParameters={
+                        "arg_name": "cols",
+                        "expected_type": "list[str]",
+                        "arg_type": type(col_).__name__,
+                    },
                 )
         return DataFrame(plan.ToDF(self._plan, list(cols)), self._session)
 

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -3736,24 +3736,30 @@ def window(
 ) -> Column:
     if windowDuration is None or not isinstance(windowDuration, str):
         raise PySparkTypeError(
-            errorClass="NOT_STR",
+            errorClass="NOT_EXPECTED_TYPE",
             messageParameters={
                 "arg_name": "windowDuration",
+                "expected_type": "str",
                 "arg_type": type(windowDuration).__name__,
             },
         )
     if slideDuration is not None and not isinstance(slideDuration, str):
         raise PySparkTypeError(
-            errorClass="NOT_STR",
+            errorClass="NOT_EXPECTED_TYPE",
             messageParameters={
                 "arg_name": "slideDuration",
+                "expected_type": "str",
                 "arg_type": type(slideDuration).__name__,
             },
         )
     if startTime is not None and not isinstance(startTime, str):
         raise PySparkTypeError(
-            errorClass="NOT_STR",
-            messageParameters={"arg_name": "startTime", "arg_type": type(startTime).__name__},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "arg_name": "startTime",
+                "expected_type": "str",
+                "arg_type": type(startTime).__name__,
+            },
         )
 
     time_col = _to_col(timeColumn)

--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -228,8 +228,12 @@ class GroupedData:
 
         if not isinstance(pivot_col, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "pivot_col", "arg_type": type(pivot_col).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "pivot_col",
+                    "expected_type": "str",
+                    "arg_type": type(pivot_col).__name__,
+                },
             )
 
         if values is not None:

--- a/python/pyspark/sql/connect/observation.py
+++ b/python/pyspark/sql/connect/observation.py
@@ -36,8 +36,12 @@ class Observation:
         if name is not None:
             if not isinstance(name, str):
                 raise PySparkTypeError(
-                    errorClass="NOT_STR",
-                    messageParameters={"arg_name": "name", "arg_type": type(name).__name__},
+                    errorClass="NOT_EXPECTED_TYPE",
+                    messageParameters={
+                        "arg_name": "name",
+                        "expected_type": "str",
+                        "arg_type": type(name).__name__,
+                    },
                 )
             if name == "":
                 raise PySparkValueError(

--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -79,9 +79,10 @@ class DataFrameReader(OptionUtils):
             self._schema = schema
         else:
             raise PySparkTypeError(
-                errorClass="NOT_STR_OR_STRUCT",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "schema",
+                    "expected_type": "str or struct type",
                     "arg_type": type(schema).__name__,
                 },
             )
@@ -569,17 +570,19 @@ class DataFrameWriter(OptionUtils):
         for c in cols:
             if not isinstance(c, str):
                 raise PySparkTypeError(
-                    errorClass="NOT_LIST_OF_STR",
+                    errorClass="NOT_EXPECTED_TYPE",
                     messageParameters={
                         "arg_name": "cols",
+                        "expected_type": "list[str]",
                         "arg_type": type(c).__name__,
                     },
                 )
         if not isinstance(col, str):
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OF_STR",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "col",
+                    "expected_type": "list[str]",
                     "arg_type": type(col).__name__,
                 },
             )
@@ -613,17 +616,19 @@ class DataFrameWriter(OptionUtils):
         for c in cols:
             if not isinstance(c, str):
                 raise PySparkTypeError(
-                    errorClass="NOT_LIST_OF_STR",
+                    errorClass="NOT_EXPECTED_TYPE",
                     messageParameters={
                         "arg_name": "cols",
+                        "expected_type": "list[str]",
                         "arg_type": type(c).__name__,
                     },
                 )
         if not isinstance(col, str):
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OF_STR",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "col",
+                    "expected_type": "list[str]",
                     "arg_type": type(col).__name__,
                 },
             )

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -375,8 +375,12 @@ class SparkSession:
     def table(self, tableName: str) -> ParentDataFrame:
         if not isinstance(tableName, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "tableName", "arg_type": type(tableName).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "tableName",
+                    "expected_type": "str",
+                    "arg_type": type(tableName).__name__,
+                },
             )
 
         return self.read.table(tableName)
@@ -502,9 +506,10 @@ class SparkSession:
 
         elif schema is not None:
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OR_NONE_OR_STRUCT",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "schema",
+                    "expected_type": "list, None or StructType",
                     "arg_type": type(schema).__name__,
                 },
             )

--- a/python/pyspark/sql/connect/streaming/readwriter.py
+++ b/python/pyspark/sql/connect/streaming/readwriter.py
@@ -67,8 +67,12 @@ class DataStreamReader(OptionUtils):
             self._schema = schema
         else:
             raise PySparkTypeError(
-                errorClass="NOT_STR_OR_STRUCT",
-                messageParameters={"arg_name": "schema", "arg_type": type(schema).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "schema",
+                    "expected_type": "str or struct type",
+                    "arg_type": type(schema).__name__,
+                },
             )
         return self
 
@@ -90,9 +94,10 @@ class DataStreamReader(OptionUtils):
     def name(self, source_name: str) -> "DataStreamReader":
         if not isinstance(source_name, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "source_name",
+                    "expected_type": "str",
                     "arg_type": type(source_name).__name__,
                 },
             )
@@ -194,8 +199,12 @@ class DataStreamReader(OptionUtils):
             return self.load(path=path, format="json")
         else:
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "path",
+                    "expected_type": "str",
+                    "arg_type": type(path).__name__,
+                },
             )
 
     json.__doc__ = PySparkDataStreamReader.json.__doc__
@@ -216,8 +225,12 @@ class DataStreamReader(OptionUtils):
             return self.load(path=path, format="orc")
         else:
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "path",
+                    "expected_type": "str",
+                    "arg_type": type(path).__name__,
+                },
             )
 
     orc.__doc__ = PySparkDataStreamReader.orc.__doc__
@@ -249,8 +262,12 @@ class DataStreamReader(OptionUtils):
             return self.load(path=path, format="parquet")
         else:
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "path",
+                    "expected_type": "str",
+                    "arg_type": type(path).__name__,
+                },
             )
 
     parquet.__doc__ = PySparkDataStreamReader.parquet.__doc__
@@ -273,8 +290,12 @@ class DataStreamReader(OptionUtils):
             return self.load(path=path, format="text")
         else:
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "path",
+                    "expected_type": "str",
+                    "arg_type": type(path).__name__,
+                },
             )
 
     text.__doc__ = PySparkDataStreamReader.text.__doc__
@@ -349,8 +370,12 @@ class DataStreamReader(OptionUtils):
             return self.load(path=path, format="csv")
         else:
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "path",
+                    "expected_type": "str",
+                    "arg_type": type(path).__name__,
+                },
             )
 
     csv.__doc__ = PySparkDataStreamReader.csv.__doc__
@@ -403,8 +428,12 @@ class DataStreamReader(OptionUtils):
             return self.load(path=path, format="xml")
         else:
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "path",
+                    "expected_type": "str",
+                    "arg_type": type(path).__name__,
+                },
             )
 
     xml.__doc__ = PySparkDataStreamReader.xml.__doc__

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -13213,8 +13213,12 @@ def window(
     def check_string_field(field, fieldName):  # type: ignore[no-untyped-def]
         if not field or type(field) is not str:
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": fieldName, "arg_type": type(field).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": fieldName,
+                    "expected_type": "str",
+                    "arg_type": type(field).__name__,
+                },
             )
 
     windowDuration = _enum_to_value(windowDuration)

--- a/python/pyspark/sql/observation.py
+++ b/python/pyspark/sql/observation.py
@@ -90,8 +90,12 @@ class Observation:
         if name is not None:
             if not isinstance(name, str):
                 raise PySparkTypeError(
-                    errorClass="NOT_STR",
-                    messageParameters={"arg_name": "name", "arg_type": type(name).__name__},
+                    errorClass="NOT_EXPECTED_TYPE",
+                    messageParameters={
+                        "arg_name": "name",
+                        "expected_type": "str",
+                        "arg_type": type(name).__name__,
+                    },
                 )
             if name == "":
                 raise PySparkValueError(

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -154,9 +154,10 @@ class DataFrameReader(OptionUtils):
             self._jreader = self._jreader.schema(schema)
         else:
             raise PySparkTypeError(
-                errorClass="NOT_STR_OR_STRUCT",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "schema",
+                    "expected_type": "str or struct type",
                     "arg_type": type(schema).__name__,
                 },
             )
@@ -487,9 +488,10 @@ class DataFrameReader(OptionUtils):
             return self._df(self._jreader.json(jrdd))
         else:
             raise PySparkTypeError(
-                errorClass="NOT_STR_OR_LIST_OF_RDD",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "path",
+                    "expected_type": "str or list[RDD]",
                     "arg_type": type(path).__name__,
                 },
             )
@@ -863,9 +865,10 @@ class DataFrameReader(OptionUtils):
             return self._df(self._jreader.csv(jdataset))
         else:
             raise PySparkTypeError(
-                errorClass="NOT_STR_OR_LIST_OF_RDD",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "path",
+                    "expected_type": "str or list[RDD]",
                     "arg_type": type(path).__name__,
                 },
             )
@@ -990,9 +993,10 @@ class DataFrameReader(OptionUtils):
             return self._df(self._jreader.xml(jdataset))
         else:
             raise PySparkTypeError(
-                errorClass="NOT_STR_OR_LIST_OF_RDD",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "path",
+                    "expected_type": "str or list[RDD]",
                     "arg_type": type(path).__name__,
                 },
             )
@@ -1531,17 +1535,19 @@ class DataFrameWriter(OptionUtils):
         for c in cols:
             if not isinstance(c, str):
                 raise PySparkTypeError(
-                    errorClass="NOT_LIST_OF_STR",
+                    errorClass="NOT_EXPECTED_TYPE",
                     messageParameters={
                         "arg_name": "cols",
+                        "expected_type": "list[str]",
                         "arg_type": type(c).__name__,
                     },
                 )
         if not isinstance(col, str):
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OF_STR",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "col",
+                    "expected_type": "list[str]",
                     "arg_type": type(col).__name__,
                 },
             )
@@ -1613,17 +1619,19 @@ class DataFrameWriter(OptionUtils):
         for c in cols:
             if not isinstance(c, str):
                 raise PySparkTypeError(
-                    errorClass="NOT_LIST_OF_STR",
+                    errorClass="NOT_EXPECTED_TYPE",
                     messageParameters={
                         "arg_name": "cols",
+                        "expected_type": "list[str]",
                         "arg_type": type(c).__name__,
                     },
                 )
         if not isinstance(col, str):
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OF_STR",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "col",
+                    "expected_type": "list[str]",
                     "arg_type": type(col).__name__,
                 },
             )

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1219,9 +1219,10 @@ class SparkSession(SparkConversionMixin):
 
         else:
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OR_NONE_OR_STRUCT",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "schema",
+                    "expected_type": "list, None or StructType",
                     "arg_type": type(schema).__name__,
                 },
             )
@@ -1261,9 +1262,10 @@ class SparkSession(SparkConversionMixin):
 
         else:
             raise PySparkTypeError(
-                errorClass="NOT_LIST_OR_NONE_OR_STRUCT",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "schema",
+                    "expected_type": "list, None or StructType",
                     "arg_type": type(schema).__name__,
                 },
             )
@@ -1904,8 +1906,12 @@ class SparkSession(SparkConversionMixin):
         """
         if not isinstance(tableName, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "tableName", "arg_type": type(tableName).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "tableName",
+                    "expected_type": "str",
+                    "arg_type": type(tableName).__name__,
+                },
             )
 
         return DataFrame(self._jsparkSession.table(tableName), self)

--- a/python/pyspark/sql/streaming/readwriter.py
+++ b/python/pyspark/sql/streaming/readwriter.py
@@ -172,8 +172,12 @@ class DataStreamReader(OptionUtils):
             self._jreader = self._jreader.schema(schema)
         else:
             raise PySparkTypeError(
-                errorClass="NOT_STR_OR_STRUCT",
-                messageParameters={"arg_name": "schema", "arg_type": type(schema).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "schema",
+                    "expected_type": "str or struct type",
+                    "arg_type": type(schema).__name__,
+                },
             )
         return self
 
@@ -271,9 +275,10 @@ class DataStreamReader(OptionUtils):
         """
         if not isinstance(source_name, str):
             raise PySparkTypeError(
-                errorClass="NOT_STR",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
                     "arg_name": "source_name",
+                    "expected_type": "str",
                     "arg_type": type(source_name).__name__,
                 },
             )
@@ -462,8 +467,12 @@ class DataStreamReader(OptionUtils):
             return self._df(self._jreader.json(path))
         else:
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "path",
+                    "expected_type": "str",
+                    "arg_type": type(path).__name__,
+                },
             )
 
     def orc(
@@ -513,8 +522,12 @@ class DataStreamReader(OptionUtils):
             return self._df(self._jreader.orc(path))
         else:
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "path",
+                    "expected_type": "str",
+                    "arg_type": type(path).__name__,
+                },
             )
 
     def parquet(
@@ -575,8 +588,12 @@ class DataStreamReader(OptionUtils):
             return self._df(self._jreader.parquet(path))
         else:
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "path",
+                    "expected_type": "str",
+                    "arg_type": type(path).__name__,
+                },
             )
 
     def text(
@@ -644,8 +661,12 @@ class DataStreamReader(OptionUtils):
             return self._df(self._jreader.text(path))
         else:
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "path",
+                    "expected_type": "str",
+                    "arg_type": type(path).__name__,
+                },
             )
 
     def csv(
@@ -767,8 +788,12 @@ class DataStreamReader(OptionUtils):
             return self._df(self._jreader.csv(path))
         else:
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "path",
+                    "expected_type": "str",
+                    "arg_type": type(path).__name__,
+                },
             )
 
     def xml(
@@ -866,8 +891,12 @@ class DataStreamReader(OptionUtils):
             return self._df(self._jreader.xml(path))
         else:
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "path",
+                    "expected_type": "str",
+                    "arg_type": type(path).__name__,
+                },
             )
 
     def table(self, tableName: str) -> "DataFrame":
@@ -915,8 +944,12 @@ class DataStreamReader(OptionUtils):
             return self._df(self._jreader.table(tableName))
         else:
             raise PySparkTypeError(
-                errorClass="NOT_STR",
-                messageParameters={"arg_name": "tableName", "arg_type": type(tableName).__name__},
+                errorClass="NOT_EXPECTED_TYPE",
+                messageParameters={
+                    "arg_name": "tableName",
+                    "expected_type": "str",
+                    "arg_type": type(tableName).__name__,
+                },
             )
 
 

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -954,8 +954,12 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_LIST_OF_COLUMN",
-            messageParameters={"arg_name": "exprs"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "expected_type": "list[Column]",
+                "arg_name": "exprs",
+                "arg_type": "tuple",
+            },
         )
 
     def test_with_columns(self):

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -916,8 +916,12 @@ class SparkConnectColumnTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_STR",
-            messageParameters={"arg_name": "fieldName", "arg_type": "Column"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "expected_type": "str",
+                "arg_name": "fieldName",
+                "arg_type": "Column",
+            },
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -934,8 +938,8 @@ class SparkConnectColumnTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_STR",
-            messageParameters={"arg_name": "fieldName", "arg_type": "int"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={"expected_type": "str", "arg_name": "fieldName", "arg_type": "int"},
         )
 
         with self.assertRaises(PySparkValueError) as pe:

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -893,8 +893,12 @@ class SparkConnectFunctionTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_WINDOWSPEC",
-            messageParameters={"arg_name": "window", "arg_type": "Column"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "expected_type": "WindowSpec",
+                "arg_name": "window",
+                "arg_type": "Column",
+            },
         )
 
         # invalid window function
@@ -2393,8 +2397,12 @@ class SparkConnectFunctionTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_STR",
-            messageParameters={"arg_name": "slideDuration", "arg_type": "int"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "expected_type": "str",
+                "arg_name": "slideDuration",
+                "arg_type": "int",
+            },
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -2402,8 +2410,8 @@ class SparkConnectFunctionTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_STR",
-            messageParameters={"arg_name": "startTime", "arg_type": "int"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={"expected_type": "str", "arg_name": "startTime", "arg_type": "int"},
         )
 
         # test session_window

--- a/python/pyspark/sql/tests/connect/test_connect_stat.py
+++ b/python/pyspark/sql/tests/connect/test_connect_stat.py
@@ -194,8 +194,9 @@ class SparkConnectStatTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_STR",
+            errorClass="NOT_EXPECTED_TYPE",
             messageParameters={
+                "expected_type": "str",
                 "arg_name": "col1",
                 "arg_type": "int",
             },
@@ -206,8 +207,9 @@ class SparkConnectStatTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_STR",
+            errorClass="NOT_EXPECTED_TYPE",
             messageParameters={
+                "expected_type": "str",
                 "arg_name": "col2",
                 "arg_type": "int",
             },
@@ -240,8 +242,9 @@ class SparkConnectStatTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_LIST_OR_STR_OR_TUPLE",
+            errorClass="NOT_EXPECTED_TYPE",
             messageParameters={
+                "expected_type": "list, str or tuple",
                 "arg_name": "col",
                 "arg_type": "int",
             },
@@ -252,8 +255,9 @@ class SparkConnectStatTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_LIST_OR_TUPLE",
+            errorClass="NOT_EXPECTED_TYPE",
             messageParameters={
+                "expected_type": "list or tuple",
                 "arg_name": "probabilities",
                 "arg_type": "float",
             },
@@ -265,8 +269,12 @@ class SparkConnectStatTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_LIST_OF_FLOAT_OR_INT",
-            messageParameters={"arg_name": "probabilities", "arg_type": "float"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "expected_type": "list[float, int]",
+                "arg_name": "probabilities",
+                "arg_type": "float",
+            },
         )
         with self.assertRaises(PySparkTypeError) as pe:
             self.connect.read.table(self.tbl_name2).stat.approxQuantile(
@@ -316,8 +324,9 @@ class SparkConnectStatTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_LIST_OR_TUPLE",
+            errorClass="NOT_EXPECTED_TYPE",
             messageParameters={
+                "expected_type": "list or tuple",
                 "arg_name": "cols",
                 "arg_type": "str",
             },

--- a/python/pyspark/sql/tests/test_catalog.py
+++ b/python/pyspark/sql/tests/test_catalog.py
@@ -82,7 +82,7 @@ class CatalogTestsMixin:
                     schema = StructType([StructField("a", IntegerType(), True)])
                     description = "this a table created via Catalog.createTable()"
 
-                    with self.assertRaisesRegex(PySparkTypeError, "should be a struct type"):
+                    with self.assertRaisesRegex(PySparkTypeError, "should be struct type"):
                         # Test deprecated API and negative error case.
                         spark.catalog.createExternalTable(
                             "invalid_table_creation", schema=IntegerType(), description=description

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -227,8 +227,12 @@ class ColumnTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_STR",
-            messageParameters={"arg_name": "fieldName", "arg_type": "Column"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "expected_type": "str",
+                "arg_name": "fieldName",
+                "arg_type": "Column",
+            },
         )
 
     def test_drop_fields(self):
@@ -315,8 +319,12 @@ class ColumnTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_WINDOWSPEC",
-            messageParameters={"arg_name": "window", "arg_type": "int"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "expected_type": "WindowSpec",
+                "arg_name": "window",
+                "arg_type": "int",
+            },
         )
 
     def test_eqnullsafe_classmethod_usage(self):

--- a/python/pyspark/sql/tests/test_conf.py
+++ b/python/pyspark/sql/tests/test_conf.py
@@ -69,8 +69,9 @@ class ConfTestsMixin:
 
             self.check_error(
                 exception=pe.exception,
-                errorClass="NOT_STR",
+                errorClass="NOT_EXPECTED_TYPE",
                 messageParameters={
+                    "expected_type": "str",
                     "arg_name": "key",
                     "arg_type": "int",
                 },

--- a/python/pyspark/sql/tests/test_creation.py
+++ b/python/pyspark/sql/tests/test_creation.py
@@ -176,8 +176,12 @@ class DataFrameCreationTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_LIST_OR_NONE_OR_STRUCT",
-            messageParameters={"arg_name": "schema", "arg_type": "int"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "expected_type": "list, None or StructType",
+                "arg_name": "schema",
+                "arg_type": "int",
+            },
         )
 
         with self.assertRaises(PySparkTypeError) as pe:

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -79,8 +79,12 @@ class DataFrameTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_STR",
-            messageParameters={"arg_name": "tableName", "arg_type": "NoneType"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "expected_type": "str",
+                "arg_name": "tableName",
+                "arg_type": "NoneType",
+            },
         )
 
     def test_dataframe_star(self):
@@ -362,8 +366,12 @@ class DataFrameTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_LIST_OR_TUPLE",
-            messageParameters={"arg_name": "subset", "arg_type": "str"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "expected_type": "list or tuple",
+                "arg_name": "subset",
+                "arg_type": "str",
+            },
         )
 
         # Should raise proper error when taking non-string values
@@ -372,8 +380,12 @@ class DataFrameTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_STR",
-            messageParameters={"arg_name": "subset", "arg_type": "NoneType"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "expected_type": "str",
+                "arg_name": "subset",
+                "arg_type": "NoneType",
+            },
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -381,8 +393,8 @@ class DataFrameTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_STR",
-            messageParameters={"arg_name": "subset", "arg_type": "int"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={"expected_type": "str", "arg_name": "subset", "arg_type": "int"},
         )
 
     def test_drop_duplicates_with_ambiguous_reference(self):
@@ -563,8 +575,12 @@ class DataFrameTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_LIST_OF_STR",
-            messageParameters={"arg_name": "cols", "arg_type": "NoneType"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "expected_type": "list[str]",
+                "arg_name": "cols",
+                "arg_type": "NoneType",
+            },
         )
 
     def test_toDF_with_schema_string(self):
@@ -1000,8 +1016,8 @@ class DataFrameTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_STR",
-            messageParameters={"arg_name": "colName", "arg_type": "int"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={"expected_type": "str", "arg_name": "colName", "arg_type": "int"},
         )
 
     def test_where(self):

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -281,8 +281,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_STR",
-            messageParameters={"arg_name": "col1", "arg_type": "int"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={"expected_type": "str", "arg_name": "col1", "arg_type": "int"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -290,8 +290,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_STR",
-            messageParameters={"arg_name": "col2", "arg_type": "bool"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={"expected_type": "str", "arg_name": "col2", "arg_type": "bool"},
         )
 
     def test_crosstab(self):
@@ -3603,8 +3603,12 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_STR",
-            messageParameters={"arg_name": "windowDuration", "arg_type": "int"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "expected_type": "str",
+                "arg_name": "windowDuration",
+                "arg_type": "int",
+            },
         )
 
     def test_session_window(self):

--- a/python/pyspark/sql/tests/test_observation.py
+++ b/python/pyspark/sql/tests/test_observation.py
@@ -87,7 +87,7 @@ class DataFrameObservationTestsMixin:
         )
 
         # observation requires name (if given) to be non empty string
-        with self.assertRaisesRegex(TypeError, "`name` should be a str, got int"):
+        with self.assertRaisesRegex(PySparkTypeError, "`name` should be str, got int"):
             Observation(123)
         with self.assertRaisesRegex(ValueError, "`name` must be a non-empty string, got ''."):
             Observation("")
@@ -110,8 +110,12 @@ class DataFrameObservationTestsMixin:
 
                 self.check_error(
                     exception=pe.exception,
-                    errorClass="NOT_LIST_OF_COLUMN",
-                    messageParameters={"arg_name": "exprs"},
+                    errorClass="NOT_EXPECTED_TYPE",
+                    messageParameters={
+                        "expected_type": "list[Column]",
+                        "arg_name": "exprs",
+                        "arg_type": "tuple",
+                    },
                 )
 
     def test_observe_str(self):

--- a/python/pyspark/sql/tests/test_stat.py
+++ b/python/pyspark/sql/tests/test_stat.py
@@ -119,8 +119,12 @@ class DataFrameStatTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_LIST_OR_STR_OR_TUPLE",
-            messageParameters={"arg_name": "subset", "arg_type": "int"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "expected_type": "list, str or tuple",
+                "arg_name": "subset",
+                "arg_type": "int",
+            },
         )
 
     def test_fillna(self):
@@ -212,8 +216,12 @@ class DataFrameStatTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_LIST_OR_TUPLE",
-            messageParameters={"arg_name": "subset", "arg_type": "int"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "expected_type": "list or tuple",
+                "arg_name": "subset",
+                "arg_type": "int",
+            },
         )
 
     def test_replace(self):

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -142,8 +142,12 @@ class TypesTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_LIST_OR_NONE_OR_STRUCT",
-            messageParameters={"arg_name": "schema", "arg_type": "int"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "expected_type": "list, None or StructType",
+                "arg_name": "schema",
+                "arg_type": "int",
+            },
         )
 
         df = self.spark.createDataFrame(rdd)

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -1378,8 +1378,12 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            errorClass="NOT_STRUCT",
-            messageParameters={"arg_name": "actual", "arg_type": "str"},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "expected_type": "struct type",
+                "arg_name": "actual",
+                "arg_type": "str",
+            },
         )
 
     def test_spark_sql(self):

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -593,13 +593,21 @@ def assertSchemaEqual(
     """
     if not isinstance(actual, StructType):
         raise PySparkTypeError(
-            errorClass="NOT_STRUCT",
-            messageParameters={"arg_name": "actual", "arg_type": type(actual).__name__},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "arg_name": "actual",
+                "expected_type": "struct type",
+                "arg_type": type(actual).__name__,
+            },
         )
     if not isinstance(expected, StructType):
         raise PySparkTypeError(
-            errorClass="NOT_STRUCT",
-            messageParameters={"arg_name": "expected", "arg_type": type(expected).__name__},
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "arg_name": "expected",
+                "expected_type": "struct type",
+                "arg_type": type(expected).__name__,
+            },
         )
 
     def compare_schemas_ignore_nullable(s1: StructType, s2: StructType):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Consolidate the last 12 `NOT_*` error classes into `NOT_EXPECTED_TYPE`:
- `NOT_LIST_OF_COLUMN`
- `NOT_LIST_OF_FLOAT_OR_INT`
- `NOT_LIST_OF_STR`
- `NOT_LIST_OR_NONE_OR_STRUCT`
- `NOT_LIST_OR_STR_OR_TUPLE`
- `NOT_LIST_OR_TUPLE`
- `NOT_OBSERVATION_OR_STR`
- `NOT_STR`
- `NOT_STRUCT`
- `NOT_STR_OR_LIST_OF_RDD`
- `NOT_STR_OR_STRUCT`
- `NOT_WINDOWSPEC`

This is a follow-up to #54978 and #54997.

### Why are the changes needed?
There are around 40 error classes for type mismatch, they can be consolidated into a single `NOT_EXPECTED_TYPE` class.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (claude-opus-4-6)