### PR TITLE
[SPARK-56200][CORE] Remove jackson JSON nesting depth limitation 

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -22,7 +22,7 @@ import java.util.{Properties, UUID}
 import scala.collection.Map
 import scala.jdk.CollectionConverters._
 
-import com.fasterxml.jackson.core.{JsonGenerator, StreamReadConstraints}
+import com.fasterxml.jackson.core.{JsonGenerator, StreamReadConstraints, StreamWriteConstraints}
 import com.fasterxml.jackson.databind.JsonNode
 import org.json4s.jackson.JsonMethods.compact
 
@@ -67,8 +67,17 @@ private[spark] object JsonProtocol extends JsonUtils {
   // TODO: Remove this file and put JSON serialization into each individual class.
 
   // SPARK-49872: Remove jackson JSON string length limitation.
+  // Remove jackson JSON nesting depth limitation.
   mapper.getFactory.setStreamReadConstraints(
-    StreamReadConstraints.builder().maxStringLength(Int.MaxValue).build()
+    StreamReadConstraints.builder()
+      .maxStringLength(Int.MaxValue)
+      .maxNestingDepth(Int.MaxValue)
+      .build()
+  )
+  mapper.getFactory.setStreamWriteConstraints(
+    StreamWriteConstraints.builder()
+      .maxNestingDepth(Int.MaxValue)
+      .build()
   )
 
   private[util]
@@ -965,7 +974,7 @@ private[spark] object JsonProtocol extends JsonUtils {
       case other =>
         val otherClass = Utils.classForName(other)
         if (classOf[SparkListenerEvent].isAssignableFrom(otherClass)) {
-          mapper.readValue(json.toString, otherClass)
+          mapper.readValue(mapper.writeValueAsString(json), otherClass)
             .asInstanceOf[SparkListenerEvent]
         } else {
           throw new SparkException(s"Unknown event type: $other")
@@ -1610,7 +1619,7 @@ private[spark] object JsonProtocol extends JsonUtils {
   def resourcesMapFromJson(json: JsonNode): Map[String, ResourceInformation] = {
     assert(json.isObject, s"expected object, got ${json.getNodeType}")
     json.properties.asScala.map { field =>
-      val resourceInfo = ResourceInformation.parseJson(field.getValue.toString)
+      val resourceInfo = ResourceInformation.parseJson(mapper.writeValueAsString(field.getValue))
       (field.getKey, resourceInfo)
     }.toMap
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates `JsonProtocol` to remove Jackson nesting-depth limits for both reading and writing JSON, in addition to the existing string-length relaxation from SPARK-49872

It also fixes serialization/deserialization paths for deep event-log JSON nodes by replacing `toString`-based conversion with Jackson mapper serialization (`mapper.writeValueAsString(...)`) in:
- `sparkEventFromJson`
- `resourcesMapFromJson`

These changes make deep nested event-log payloads and resource JSON parsing more robust and consistent with Jackson serialization semantics.


### Why are the changes needed?
With deeply nested JSON payloads, default Jackson stream constraints can fail with depth-limit exceptions during read/write, which can affect Spark listener event log handling.

Also, converting `JsonNode` via `toString` can produce inconsistent behavior in some deep/complex cases. Using Jackson mapper-based serialization ensures stable JSON conversion before parsing into Spark event/resource types.


### Does this PR introduce _any_ user-facing change?

Yes.

For users who have deeply nested JSON content in Spark event logs or resource-related JSON, operations that previously could fail due to Jackson depth constraints (for read/write) will now succeed. This is a behavior fix (robustness improvement), not a new API.


### How was this patch tested?

No new tests were added in this patch.

### Was this patch authored or co-authored using generative AI tooling?

no
