### PR TITLE
[SPARK-56202][SS] Refactor streaming join tests: split Base/Suite hierarchy and simplify mode dispatch

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
@@ -42,78 +42,78 @@ import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.execution.streaming.state._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.sql.types.{BooleanType, IntegerType, LongType, StructType}
 import org.apache.spark.tags.SlowSQLTest
 import org.apache.spark.util.Utils
 
-trait AlsoTestWithVirtualColumnFamilyJoins extends SQLTestUtils {
-  /** Tests both with and without join ops using virtual column families */
+abstract class StreamingJoinSuite
+  extends StreamTest with StateStoreMetricsTest with BeforeAndAfter {
+
+  /** Whether this suite runs tests with virtual column families (VCF). */
+  protected def useVirtualColumnFamilies: Boolean
+
+  /** Dispatches each test to VCF or non-VCF mode based on [[useVirtualColumnFamilies]]. */
   override protected def test(testName: String, testTags: Tag*)(testBody: => Any)(
     implicit pos: Position): Unit = {
-    // Test with virtual column family joins with changelog checkpointing enabled and disabled
-    // Since virtual column family joins require RocksDB, we only test with RocksDB here.
-    Seq("false", "true").foreach { enabled =>
-      testWithVirtualColumnFamilyJoins(
-        testName + s" with (with changelog checkpointing = $enabled)", testTags: _*) {
-        withSQLConf(
-          "spark.sql.streaming.stateStore.rocksdb.changelogCheckpointing.enabled" -> enabled
-        ) {
-          testBody
+    if (useVirtualColumnFamilies) {
+      // Test with VCF with changelog checkpointing enabled and disabled.
+      // Since VCF requires RocksDB, we only test with RocksDB here.
+      Seq("false", "true").foreach { enabled =>
+        testWithVirtualColumnFamilyJoins(
+          testName + s" (with changelog checkpointing = $enabled)", testTags: _*) {
+          withSQLConf(
+            "spark.sql.streaming.stateStore.rocksdb.changelogCheckpointing.enabled" -> enabled
+          ) {
+            testBody
+          }
         }
       }
-    }
-
-    // Test with both RocksDB and HDFS state store providers without virtual column family joins
-    val providers = Seq(
-      classOf[RocksDBStateStoreProvider].getName,
-      classOf[HDFSBackedStateStoreProvider].getName
-    )
-
-    providers.foreach { provider =>
-      testWithoutVirtualColumnFamilyJoins(testName + s" (with $provider)", testTags: _*) {
-        withSQLConf(
-          SQLConf.STATE_STORE_PROVIDER_CLASS.key -> provider
-        ) {
-          testBody
+    } else {
+      // Test with both RocksDB and HDFS state store providers without VCF.
+      val providers = Seq(
+        classOf[RocksDBStateStoreProvider].getName,
+        classOf[HDFSBackedStateStoreProvider].getName
+      )
+      providers.foreach { provider =>
+        testWithoutVirtualColumnFamilyJoins(testName + s" (with $provider)", testTags: _*) {
+          withSQLConf(
+            SQLConf.STATE_STORE_PROVIDER_CLASS.key -> provider
+          ) {
+            testBody
+          }
         }
       }
     }
   }
 
-  def testWithVirtualColumnFamilyJoins(testName: String, testTags: Tag*)(testBody: => Any): Unit = {
-    super.test(testName + " (with virtual column family joins)", testTags: _*) {
-      // in case tests have any code that needs to execute before every test
-      super.beforeEach()
-      // We must be using RocksDB for virtual column family joins
-      withSQLConf(
-        SQLConf.STREAMING_JOIN_STATE_FORMAT_VERSION.key -> "3",
-        SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName
-      ) {
-        testBody
+  def testWithVirtualColumnFamilyJoins(testName: String, testTags: Tag*)(
+    testBody: => Any): Unit = {
+    if (useVirtualColumnFamilies) {
+      super.test(testName + " (with virtual column family joins)", testTags: _*) {
+        super.beforeEach()
+        withSQLConf(
+          SQLConf.STREAMING_JOIN_STATE_FORMAT_VERSION.key -> "3",
+          SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName
+        ) {
+          testBody
+        }
+        super.afterEach()
       }
-      // in case tests have any code that needs to execute after every test
-      super.afterEach()
     }
   }
 
   def testWithoutVirtualColumnFamilyJoins(testName: String, testTags: Tag*)(
     testBody: => Any): Unit = {
-    super.test(testName + " (without virtual column family joins)", testTags: _*) {
-      // in case tests have any code that needs to execute before every test
-      super.beforeEach()
-      withSQLConf(SQLConf.STREAMING_JOIN_STATE_FORMAT_VERSION.key -> "2") {
-        testBody
+    if (!useVirtualColumnFamilies) {
+      super.test(testName + " (without virtual column family joins)", testTags: _*) {
+        super.beforeEach()
+        withSQLConf(SQLConf.STREAMING_JOIN_STATE_FORMAT_VERSION.key -> "2") {
+          testBody
+        }
+        super.afterEach()
       }
-      // in case tests have any code that needs to execute after every test
-      super.afterEach()
     }
   }
-}
-
-abstract class StreamingJoinSuite
-  extends StreamTest with StateStoreMetricsTest with BeforeAndAfter
-  with AlsoTestWithVirtualColumnFamilyJoins {
 
   import testImplicits._
 
@@ -318,7 +318,7 @@ abstract class StreamingJoinSuite
 }
 
 @SlowSQLTest
-class StreamingInnerJoinSuite extends StreamingJoinSuite {
+abstract class StreamingInnerJoinBase extends StreamingJoinSuite {
 
   import testImplicits._
   test("stream stream inner join on non-time column") {
@@ -388,55 +388,6 @@ class StreamingInnerJoinSuite extends StreamingJoinSuite {
       CheckNewAnswer(),
       AddData(input2, 5),
       CheckNewAnswer((5, 10, 10, 15))     // No filter by any watermark
-    )
-  }
-
-  test("stream stream inner join on windows - with watermark") {
-    val input1 = MemoryStream[Int]
-    val input2 = MemoryStream[Int]
-
-    val df1 = input1.toDF()
-      .select($"value" as "key", timestamp_seconds($"value") as "timestamp",
-        ($"value" * 2) as "leftValue")
-      .withWatermark("timestamp", "10 seconds")
-      .select($"key", window($"timestamp", "10 second"), $"leftValue")
-
-    val df2 = input2.toDF()
-      .select($"value" as "key", timestamp_seconds($"value") as "timestamp",
-        ($"value" * 3) as "rightValue")
-      .select($"key", window($"timestamp", "10 second"), $"rightValue")
-
-    val joined = df1.join(df2, Seq("key", "window"))
-      .select($"key", $"window.end".cast("long"), $"leftValue", $"rightValue")
-
-    testStream(joined)(
-      AddData(input1, 1),
-      CheckAnswer(),
-      assertNumStateRows(total = 1, updated = 1),
-
-      AddData(input2, 1),
-      CheckAnswer((1, 10, 2, 3)),
-      assertNumStateRows(total = 2, updated = 1),
-      StopStream,
-      StartStream(),
-
-      AddData(input1, 25),
-      CheckNewAnswer(),   // watermark = 15, no-data-batch should remove 2 rows having window=[0,10]
-      assertNumStateRows(total = 1, updated = 1),
-
-      AddData(input2, 25),
-      CheckNewAnswer((25, 30, 50, 75)),
-      assertNumStateRows(total = 2, updated = 1),
-      StopStream,
-      StartStream(),
-
-      AddData(input2, 1),
-      CheckNewAnswer(),                             // Should not join as < 15 removed
-      assertNumStateRows(total = 2, updated = 0),   // row not add as 1 < state key watermark = 15
-
-      AddData(input1, 5),
-      CheckNewAnswer(),                             // Same reason as above
-      assertNumStateRows(total = 2, updated = 0, droppedByWatermark = 1)
     )
   }
 
@@ -922,59 +873,6 @@ class StreamingInnerJoinSuite extends StreamingJoinSuite {
     )
   }
 
-  test("SPARK-35896: metrics in StateOperatorProgress are output correctly") {
-    val input1 = MemoryStream[Int]
-    val input2 = MemoryStream[Int]
-
-    val df1 = input1.toDF()
-      .select($"value" as "key", timestamp_seconds($"value") as "timestamp",
-        ($"value" * 2) as "leftValue")
-      .withWatermark("timestamp", "10 seconds")
-      .select($"key", window($"timestamp", "10 second"), $"leftValue")
-
-    val df2 = input2.toDF()
-      .select($"value" as "key", timestamp_seconds($"value") as "timestamp",
-        ($"value" * 3) as "rightValue")
-      .select($"key", window($"timestamp", "10 second"), $"rightValue")
-
-    val joined = df1.join(df2, Seq("key", "window"))
-      .select($"key", $"window.end".cast("long"), $"leftValue", $"rightValue")
-
-    val useVirtualColumnFamilies =
-      spark.sessionState.conf.getConf(SQLConf.STREAMING_JOIN_STATE_FORMAT_VERSION) >= 3
-    // Number of shuffle partitions being used is 3
-    val numStateStoreInstances = if (useVirtualColumnFamilies) {
-      // Only one state store is created per partition if we're using virtual column families
-      3
-    } else {
-      // Four state stores are created per partition otherwise
-      3 * 4
-    }
-
-    testStream(joined)(
-      StartStream(additionalConfs = Map(SQLConf.SHUFFLE_PARTITIONS.key -> "3")),
-      AddData(input1, 1),
-      CheckAnswer(),
-      assertStateOperatorProgressMetric(operatorName = "symmetricHashJoin",
-        numShufflePartitions = 3, numStateStoreInstances = numStateStoreInstances),
-
-      AddData(input2, 1),
-      CheckAnswer((1, 10, 2, 3)),
-      assertNumStateRows(
-        total = Seq(2), updated = Seq(1), droppedByWatermark = Seq(0), removed = Some(Seq(0))),
-
-      AddData(input1, 25),
-      CheckNewAnswer(),   // watermark = 15, no-data-batch should remove 2 rows having window=[0,10]
-      assertNumStateRows(
-        total = Seq(1), updated = Seq(1), droppedByWatermark = Seq(0), removed = Some(Seq(2))),
-
-      AddData(input2, 25),
-      CheckNewAnswer((25, 30, 50, 75)),
-      assertNumStateRows(
-        total = Seq(2), updated = Seq(1), droppedByWatermark = Seq(0), removed = Some(Seq(0)))
-    )
-  }
-
   test("joining non-nullable left join key with nullable right join key") {
     val input1 = MemoryStream[Int]
     val input2 = MemoryStream[JInteger]
@@ -1012,91 +910,6 @@ class StreamingInnerJoinSuite extends StreamingJoinSuite {
         Row(JInteger.valueOf(5), JInteger.valueOf(5), JInteger.valueOf(10), JInteger.valueOf(15)),
         Row(null, null, null, null))
     )
-  }
-
-  // Only ran with virtual column family joins as the previous join version uses different schemas
-  testWithVirtualColumnFamilyJoins(
-    "SPARK-51779 Verify StateSchemaV3 writes correct key and value schemas for join operator") {
-    withTempDir { checkpointDir =>
-      val input1 = MemoryStream[Int]
-      val input2 = MemoryStream[Int]
-
-      val df1 = input1.toDF().select($"value" as "key", ($"value" * 2) as "leftValue")
-      val df2 = input2.toDF().select($"value" as "key", ($"value" * 3) as "rightValue")
-      val joined = df1.join(df2, "key")
-
-      val metadataPathPostfix = "state/0/_stateSchema/default"
-      val stateSchemaPath = new Path(checkpointDir.toString, s"$metadataPathPostfix")
-      val hadoopConf = spark.sessionState.newHadoopConf()
-      val fm = CheckpointFileManager.create(stateSchemaPath, hadoopConf)
-
-      val keySchemaForNums = new StructType().add("field0", IntegerType, nullable = false)
-      val keySchemaForIndex = keySchemaForNums.add("index", LongType)
-      val numSchema: StructType = new StructType().add("value", LongType)
-      val leftIndexSchema: StructType = new StructType()
-        .add("key", IntegerType, nullable = false)
-        .add("leftValue", IntegerType, nullable = false)
-        .add("matched", BooleanType)
-      val rightIndexSchema: StructType = new StructType()
-        .add("key", IntegerType, nullable = false)
-        .add("rightValue", IntegerType, nullable = false)
-        .add("matched", BooleanType)
-
-      val schemaLeftIndex = StateStoreColFamilySchema(
-        "left-keyWithIndexToValue", 0,
-        keySchemaForIndex, 0,
-        leftIndexSchema,
-        Some(NoPrefixKeyStateEncoderSpec(keySchemaForIndex)),
-        None
-      )
-      val schemaLeftNum = StateStoreColFamilySchema(
-        "left-keyToNumValues", 0,
-        keySchemaForNums, 0,
-        numSchema,
-        Some(NoPrefixKeyStateEncoderSpec(keySchemaForNums)),
-        None
-      )
-      val schemaRightIndex = StateStoreColFamilySchema(
-        "right-keyWithIndexToValue", 0,
-        keySchemaForIndex, 0,
-        rightIndexSchema,
-        Some(NoPrefixKeyStateEncoderSpec(keySchemaForIndex)),
-        None
-      )
-      val schemaRightNum = StateStoreColFamilySchema(
-        "right-keyToNumValues", 0,
-        keySchemaForNums, 0,
-        numSchema,
-        Some(NoPrefixKeyStateEncoderSpec(keySchemaForNums)),
-        None
-      )
-
-      testStream(joined)(
-        StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
-        AddData(input1, 1),
-        CheckAnswer(),
-        AddData(input2, 1, 10),
-        CheckNewAnswer((1, 2, 3)),
-        Execute { q =>
-          val schemaFilePath = fm.list(stateSchemaPath).toSeq.head.getPath
-          val providerId = StateStoreProviderId(
-            StateStoreId(checkpointDir.getCanonicalPath, 0, 0), q.lastProgress.runId
-          )
-          val checker = new StateSchemaCompatibilityChecker(
-            providerId,
-            hadoopConf,
-            List(schemaFilePath)
-          )
-          val colFamilySeq = checker.readSchemaFile()
-          // Verify schema count and contents
-          assert(colFamilySeq.length == 4)
-          assert(colFamilySeq.map(_.toString).toSet == Set(
-            schemaLeftIndex, schemaLeftNum, schemaRightIndex, schemaRightNum
-          ).map(_.toString))
-        },
-        StopStream
-      )
-    }
   }
 
   testWithVirtualColumnFamilyJoins(
@@ -1229,9 +1042,200 @@ class StreamingInnerJoinSuite extends StreamingJoinSuite {
   }
 }
 
+/** Adds tests that are specific to state format V1-V3 (not compatible with V4). */
+abstract class StreamingInnerJoinSuite extends StreamingInnerJoinBase {
+  import testImplicits._
+
+  test("stream stream inner join on windows - with watermark") {
+    val input1 = MemoryStream[Int]
+    val input2 = MemoryStream[Int]
+
+    val df1 = input1.toDF()
+      .select($"value" as "key", timestamp_seconds($"value") as "timestamp",
+        ($"value" * 2) as "leftValue")
+      .withWatermark("timestamp", "10 seconds")
+      .select($"key", window($"timestamp", "10 second"), $"leftValue")
+
+    val df2 = input2.toDF()
+      .select($"value" as "key", timestamp_seconds($"value") as "timestamp",
+        ($"value" * 3) as "rightValue")
+      .select($"key", window($"timestamp", "10 second"), $"rightValue")
+
+    val joined = df1.join(df2, Seq("key", "window"))
+      .select($"key", $"window.end".cast("long"), $"leftValue", $"rightValue")
+
+    testStream(joined)(
+      AddData(input1, 1),
+      CheckAnswer(),
+      assertNumStateRows(total = 1, updated = 1),
+
+      AddData(input2, 1),
+      CheckAnswer((1, 10, 2, 3)),
+      assertNumStateRows(total = 2, updated = 1),
+      StopStream,
+      StartStream(),
+
+      AddData(input1, 25),
+      CheckNewAnswer(),   // watermark = 15, no-data-batch should remove 2 rows having window=[0,10]
+      assertNumStateRows(total = 1, updated = 1),
+
+      AddData(input2, 25),
+      CheckNewAnswer((25, 30, 50, 75)),
+      assertNumStateRows(total = 2, updated = 1),
+      StopStream,
+      StartStream(),
+
+      AddData(input2, 1),
+      CheckNewAnswer(),                             // Should not join as < 15 removed
+      assertNumStateRows(total = 2, updated = 0),   // row not add as 1 < state key watermark = 15
+
+      AddData(input1, 5),
+      CheckNewAnswer(),                             // Same reason as above
+      assertNumStateRows(total = 2, updated = 0, droppedByWatermark = 1)
+    )
+  }
+
+  test("SPARK-35896: metrics in StateOperatorProgress are output correctly") {
+    val input1 = MemoryStream[Int]
+    val input2 = MemoryStream[Int]
+
+    val df1 = input1.toDF()
+      .select($"value" as "key", timestamp_seconds($"value") as "timestamp",
+        ($"value" * 2) as "leftValue")
+      .withWatermark("timestamp", "10 seconds")
+      .select($"key", window($"timestamp", "10 second"), $"leftValue")
+
+    val df2 = input2.toDF()
+      .select($"value" as "key", timestamp_seconds($"value") as "timestamp",
+        ($"value" * 3) as "rightValue")
+      .select($"key", window($"timestamp", "10 second"), $"rightValue")
+
+    val joined = df1.join(df2, Seq("key", "window"))
+      .select($"key", $"window.end".cast("long"), $"leftValue", $"rightValue")
+
+    val useVirtualColumnFamilies =
+      spark.sessionState.conf.getConf(SQLConf.STREAMING_JOIN_STATE_FORMAT_VERSION) >= 3
+    // Number of shuffle partitions being used is 3
+    val numStateStoreInstances = if (useVirtualColumnFamilies) {
+      // Only one state store is created per partition if we're using virtual column families
+      3
+    } else {
+      // Four state stores are created per partition otherwise
+      3 * 4
+    }
+
+    testStream(joined)(
+      StartStream(additionalConfs = Map(SQLConf.SHUFFLE_PARTITIONS.key -> "3")),
+      AddData(input1, 1),
+      CheckAnswer(),
+      assertStateOperatorProgressMetric(operatorName = "symmetricHashJoin",
+        numShufflePartitions = 3, numStateStoreInstances = numStateStoreInstances),
+
+      AddData(input2, 1),
+      CheckAnswer((1, 10, 2, 3)),
+      assertNumStateRows(
+        total = Seq(2), updated = Seq(1), droppedByWatermark = Seq(0), removed = Some(Seq(0))),
+
+      AddData(input1, 25),
+      CheckNewAnswer(),   // watermark = 15, no-data-batch should remove 2 rows having window=[0,10]
+      assertNumStateRows(
+        total = Seq(1), updated = Seq(1), droppedByWatermark = Seq(0), removed = Some(Seq(2))),
+
+      AddData(input2, 25),
+      CheckNewAnswer((25, 30, 50, 75)),
+      assertNumStateRows(
+        total = Seq(2), updated = Seq(1), droppedByWatermark = Seq(0), removed = Some(Seq(0)))
+    )
+  }
+
+  // Only ran with virtual column family joins as the previous join version uses different schemas
+  testWithVirtualColumnFamilyJoins(
+    "SPARK-51779 Verify StateSchemaV3 writes correct key and value schemas for join operator") {
+    withTempDir { checkpointDir =>
+      val input1 = MemoryStream[Int]
+      val input2 = MemoryStream[Int]
+
+      val df1 = input1.toDF().select($"value" as "key", ($"value" * 2) as "leftValue")
+      val df2 = input2.toDF().select($"value" as "key", ($"value" * 3) as "rightValue")
+      val joined = df1.join(df2, "key")
+
+      val metadataPathPostfix = "state/0/_stateSchema/default"
+      val stateSchemaPath = new Path(checkpointDir.toString, s"$metadataPathPostfix")
+      val hadoopConf = spark.sessionState.newHadoopConf()
+      val fm = CheckpointFileManager.create(stateSchemaPath, hadoopConf)
+
+      val keySchemaForNums = new StructType().add("field0", IntegerType, nullable = false)
+      val keySchemaForIndex = keySchemaForNums.add("index", LongType)
+      val numSchema: StructType = new StructType().add("value", LongType)
+      val leftIndexSchema: StructType = new StructType()
+        .add("key", IntegerType, nullable = false)
+        .add("leftValue", IntegerType, nullable = false)
+        .add("matched", BooleanType)
+      val rightIndexSchema: StructType = new StructType()
+        .add("key", IntegerType, nullable = false)
+        .add("rightValue", IntegerType, nullable = false)
+        .add("matched", BooleanType)
+
+      val schemaLeftIndex = StateStoreColFamilySchema(
+        "left-keyWithIndexToValue", 0,
+        keySchemaForIndex, 0,
+        leftIndexSchema,
+        Some(NoPrefixKeyStateEncoderSpec(keySchemaForIndex)),
+        None
+      )
+      val schemaLeftNum = StateStoreColFamilySchema(
+        "left-keyToNumValues", 0,
+        keySchemaForNums, 0,
+        numSchema,
+        Some(NoPrefixKeyStateEncoderSpec(keySchemaForNums)),
+        None
+      )
+      val schemaRightIndex = StateStoreColFamilySchema(
+        "right-keyWithIndexToValue", 0,
+        keySchemaForIndex, 0,
+        rightIndexSchema,
+        Some(NoPrefixKeyStateEncoderSpec(keySchemaForIndex)),
+        None
+      )
+      val schemaRightNum = StateStoreColFamilySchema(
+        "right-keyToNumValues", 0,
+        keySchemaForNums, 0,
+        numSchema,
+        Some(NoPrefixKeyStateEncoderSpec(keySchemaForNums)),
+        None
+      )
+
+      testStream(joined)(
+        StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
+        AddData(input1, 1),
+        CheckAnswer(),
+        AddData(input2, 1, 10),
+        CheckNewAnswer((1, 2, 3)),
+        Execute { q =>
+          val schemaFilePath = fm.list(stateSchemaPath).toSeq.head.getPath
+          val providerId = StateStoreProviderId(
+            StateStoreId(checkpointDir.getCanonicalPath, 0, 0), q.lastProgress.runId
+          )
+          val checker = new StateSchemaCompatibilityChecker(
+            providerId,
+            hadoopConf,
+            List(schemaFilePath)
+          )
+          val colFamilySeq = checker.readSchemaFile()
+          // Verify schema count and contents
+          assert(colFamilySeq.length == 4)
+          assert(colFamilySeq.map(_.toString).toSet == Set(
+            schemaLeftIndex, schemaLeftNum, schemaRightIndex, schemaRightNum
+          ).map(_.toString))
+        },
+        StopStream
+      )
+    }
+  }
+}
 
 @SlowSQLTest
-class StreamingOuterJoinSuite extends StreamingJoinSuite {
+abstract class StreamingOuterJoinBase extends StreamingJoinSuite {
 
   import testImplicits._
   import org.apache.spark.sql.functions._
@@ -1877,6 +1881,12 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
     }
   }
 
+}
+
+/** Adds tests that are specific to state format V1-V3 (not compatible with V4). */
+abstract class StreamingOuterJoinSuite extends StreamingOuterJoinBase {
+  import testImplicits._
+
   test(
     "SPARK-49829 left-outer join, input being unmatched is between WM for late event and " +
     "WM for eviction") {
@@ -1940,7 +1950,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
 }
 
 @SlowSQLTest
-class StreamingFullOuterJoinSuite extends StreamingJoinSuite {
+abstract class StreamingFullOuterJoinBase extends StreamingJoinSuite {
 
   test("windowed full outer join") {
     withTempDir { checkpointDir =>
@@ -2156,8 +2166,11 @@ class StreamingFullOuterJoinSuite extends StreamingJoinSuite {
   }
 }
 
+/** No V3-specific tests for full outer joins. */
+abstract class StreamingFullOuterJoinSuite extends StreamingFullOuterJoinBase
+
 @SlowSQLTest
-class StreamingLeftSemiJoinSuite extends StreamingJoinSuite {
+abstract class StreamingLeftSemiJoinBase extends StreamingJoinSuite {
 
   import testImplicits._
 
@@ -2400,6 +2413,12 @@ class StreamingLeftSemiJoinSuite extends StreamingJoinSuite {
     )
   }
 
+}
+
+/** Adds tests that are specific to state format V1-V3 (not compatible with V4). */
+abstract class StreamingLeftSemiJoinSuite extends StreamingLeftSemiJoinBase {
+  import testImplicits._
+
   test(
     "SPARK-49829 two chained stream-stream left outer joins among three input streams") {
     withSQLConf(SQLConf.STREAMING_NO_DATA_MICRO_BATCHES_ENABLED.key -> "false") {
@@ -2524,4 +2543,46 @@ class StreamingLeftSemiJoinSuite extends StreamingJoinSuite {
        */
     }
   }
+}
+
+// Concrete single-mode suites for parallel CI execution and failure isolation.
+
+@SlowSQLTest
+class StreamingInnerJoinWithVCFSuite extends StreamingInnerJoinSuite {
+  override protected def useVirtualColumnFamilies = true
+}
+
+@SlowSQLTest
+class StreamingInnerJoinWithoutVCFSuite extends StreamingInnerJoinSuite {
+  override protected def useVirtualColumnFamilies = false
+}
+
+@SlowSQLTest
+class StreamingOuterJoinWithVCFSuite extends StreamingOuterJoinSuite {
+  override protected def useVirtualColumnFamilies = true
+}
+
+@SlowSQLTest
+class StreamingOuterJoinWithoutVCFSuite extends StreamingOuterJoinSuite {
+  override protected def useVirtualColumnFamilies = false
+}
+
+@SlowSQLTest
+class StreamingFullOuterJoinWithVCFSuite extends StreamingFullOuterJoinSuite {
+  override protected def useVirtualColumnFamilies = true
+}
+
+@SlowSQLTest
+class StreamingFullOuterJoinWithoutVCFSuite extends StreamingFullOuterJoinSuite {
+  override protected def useVirtualColumnFamilies = false
+}
+
+@SlowSQLTest
+class StreamingLeftSemiJoinWithVCFSuite extends StreamingLeftSemiJoinSuite {
+  override protected def useVirtualColumnFamilies = true
+}
+
+@SlowSQLTest
+class StreamingLeftSemiJoinWithoutVCFSuite extends StreamingLeftSemiJoinSuite {
+  override protected def useVirtualColumnFamilies = false
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
@@ -49,46 +49,52 @@ import org.apache.spark.util.Utils
 abstract class StreamingJoinSuite
   extends StreamTest with StateStoreMetricsTest with BeforeAndAfter {
 
-  /** Whether this suite runs tests with virtual column families (VCF). */
-  protected def useVirtualColumnFamilies: Boolean
+  sealed trait Mode
+  object Mode {
+    case object WithVCF extends Mode
+    case object WithoutVCF extends Mode
+  }
 
-  /** Dispatches each test to VCF or non-VCF mode based on [[useVirtualColumnFamilies]]. */
+  protected def testMode: Mode
+
+  /** Dispatches each test to VCF or non-VCF mode based on [[testMode]]. */
   override protected def test(testName: String, testTags: Tag*)(testBody: => Any)(
     implicit pos: Position): Unit = {
-    if (useVirtualColumnFamilies) {
-      // Test with VCF with changelog checkpointing enabled and disabled.
-      // Since VCF requires RocksDB, we only test with RocksDB here.
-      Seq("false", "true").foreach { enabled =>
-        testWithVirtualColumnFamilyJoins(
-          testName + s" (with changelog checkpointing = $enabled)", testTags: _*) {
-          withSQLConf(
-            "spark.sql.streaming.stateStore.rocksdb.changelogCheckpointing.enabled" -> enabled
-          ) {
-            testBody
+    testMode match {
+      case Mode.WithVCF =>
+        // Test with VCF with changelog checkpointing enabled and disabled.
+        // Since VCF requires RocksDB, we only test with RocksDB here.
+        Seq("false", "true").foreach { enabled =>
+          testWithVirtualColumnFamilyJoins(
+            testName + s" (with changelog checkpointing = $enabled)", testTags: _*) {
+            withSQLConf(
+              "spark.sql.streaming.stateStore.rocksdb.changelogCheckpointing.enabled" -> enabled
+            ) {
+              testBody
+            }
           }
         }
-      }
-    } else {
-      // Test with both RocksDB and HDFS state store providers without VCF.
-      val providers = Seq(
-        classOf[RocksDBStateStoreProvider].getName,
-        classOf[HDFSBackedStateStoreProvider].getName
-      )
-      providers.foreach { provider =>
-        testWithoutVirtualColumnFamilyJoins(testName + s" (with $provider)", testTags: _*) {
-          withSQLConf(
-            SQLConf.STATE_STORE_PROVIDER_CLASS.key -> provider
-          ) {
-            testBody
+      case Mode.WithoutVCF =>
+        // Test with both RocksDB and HDFS state store providers without VCF.
+        val providers = Seq(
+          classOf[RocksDBStateStoreProvider].getName,
+          classOf[HDFSBackedStateStoreProvider].getName
+        )
+        providers.foreach { provider =>
+          testWithoutVirtualColumnFamilyJoins(testName + s" (with $provider)", testTags: _*) {
+            withSQLConf(
+              SQLConf.STATE_STORE_PROVIDER_CLASS.key -> provider
+            ) {
+              testBody
+            }
           }
         }
-      }
     }
   }
 
   def testWithVirtualColumnFamilyJoins(testName: String, testTags: Tag*)(
     testBody: => Any): Unit = {
-    if (useVirtualColumnFamilies) {
+    if (testMode == Mode.WithVCF) {
       super.test(testName + " (with virtual column family joins)", testTags: _*) {
         withSQLConf(
           SQLConf.STREAMING_JOIN_STATE_FORMAT_VERSION.key -> "3",
@@ -102,7 +108,7 @@ abstract class StreamingJoinSuite
 
   def testWithoutVirtualColumnFamilyJoins(testName: String, testTags: Tag*)(
     testBody: => Any): Unit = {
-    if (!useVirtualColumnFamilies) {
+    if (testMode == Mode.WithoutVCF) {
       super.test(testName + " (without virtual column family joins)", testTags: _*) {
         withSQLConf(SQLConf.STREAMING_JOIN_STATE_FORMAT_VERSION.key -> "2") {
           testBody
@@ -2545,40 +2551,40 @@ abstract class StreamingLeftSemiJoinSuite extends StreamingLeftSemiJoinBase {
 
 @SlowSQLTest
 class StreamingInnerJoinWithVCFSuite extends StreamingInnerJoinSuite {
-  override protected def useVirtualColumnFamilies = true
+  override protected def testMode = Mode.WithVCF
 }
 
 @SlowSQLTest
 class StreamingInnerJoinWithoutVCFSuite extends StreamingInnerJoinSuite {
-  override protected def useVirtualColumnFamilies = false
+  override protected def testMode = Mode.WithoutVCF
 }
 
 @SlowSQLTest
 class StreamingOuterJoinWithVCFSuite extends StreamingOuterJoinSuite {
-  override protected def useVirtualColumnFamilies = true
+  override protected def testMode = Mode.WithVCF
 }
 
 @SlowSQLTest
 class StreamingOuterJoinWithoutVCFSuite extends StreamingOuterJoinSuite {
-  override protected def useVirtualColumnFamilies = false
+  override protected def testMode = Mode.WithoutVCF
 }
 
 @SlowSQLTest
 class StreamingFullOuterJoinWithVCFSuite extends StreamingFullOuterJoinSuite {
-  override protected def useVirtualColumnFamilies = true
+  override protected def testMode = Mode.WithVCF
 }
 
 @SlowSQLTest
 class StreamingFullOuterJoinWithoutVCFSuite extends StreamingFullOuterJoinSuite {
-  override protected def useVirtualColumnFamilies = false
+  override protected def testMode = Mode.WithoutVCF
 }
 
 @SlowSQLTest
 class StreamingLeftSemiJoinWithVCFSuite extends StreamingLeftSemiJoinSuite {
-  override protected def useVirtualColumnFamilies = true
+  override protected def testMode = Mode.WithVCF
 }
 
 @SlowSQLTest
 class StreamingLeftSemiJoinWithoutVCFSuite extends StreamingLeftSemiJoinSuite {
-  override protected def useVirtualColumnFamilies = false
+  override protected def testMode = Mode.WithoutVCF
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
@@ -90,14 +90,12 @@ abstract class StreamingJoinSuite
     testBody: => Any): Unit = {
     if (useVirtualColumnFamilies) {
       super.test(testName + " (with virtual column family joins)", testTags: _*) {
-        super.beforeEach()
         withSQLConf(
           SQLConf.STREAMING_JOIN_STATE_FORMAT_VERSION.key -> "3",
           SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName
         ) {
           testBody
         }
-        super.afterEach()
       }
     }
   }
@@ -106,11 +104,9 @@ abstract class StreamingJoinSuite
     testBody: => Any): Unit = {
     if (!useVirtualColumnFamilies) {
       super.test(testName + " (without virtual column family joins)", testTags: _*) {
-        super.beforeEach()
         withSQLConf(SQLConf.STREAMING_JOIN_STATE_FORMAT_VERSION.key -> "2") {
           testBody
         }
-        super.afterEach()
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinV4Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinV4Suite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.streaming
 
 import org.apache.hadoop.fs.Path
-import org.scalatest.{Args, Status, Tag}
+import org.scalatest.Tag
 
 import org.apache.spark.sql.execution.streaming.checkpointing.CheckpointFileManager
 import org.apache.spark.sql.execution.streaming.operators.stateful.join.StreamingSymmetricHashJoinExec
@@ -35,7 +35,8 @@ import org.apache.spark.tags.SlowSQLTest
  * RocksDB with virtual column families. The innermost withSQLConf wins,
  * so wrapping the test body overrides the V3 setting from the parent trait.
  */
-trait TestWithV4StateFormat extends AlsoTestWithVirtualColumnFamilyJoins {
+trait TestWithV4StateFormat { self: StreamingJoinSuite =>
+  override protected def useVirtualColumnFamilies = true
 
   override def testWithVirtualColumnFamilyJoins(
       testName: String, testTags: Tag*)(testBody: => Any): Unit = {
@@ -47,40 +48,11 @@ trait TestWithV4StateFormat extends AlsoTestWithVirtualColumnFamilyJoins {
       }
     }
   }
-
-  // V4 always uses virtual column families, so skip non-VCF tests.
-  override def testWithoutVirtualColumnFamilyJoins(
-      testName: String, testTags: Tag*)(testBody: => Any): Unit = {}
-
-  // Use lazy val because the parent constructor registers tests before
-  // subclass vals are initialized.
-  private lazy val testsToSkip = Seq(
-    // V4's timestamp-based indexing does not support window structs
-    // in join keys.
-    "stream stream inner join on windows - with watermark",
-    // V4 uses 1 store with VCFs instead of V3's 4*partitions layout,
-    // so metric assertions about number of state store instances differ.
-    "SPARK-35896: metrics in StateOperatorProgress are output correctly",
-    // V4 uses different column families and encoder specs than V3;
-    // overridden in StreamingInnerJoinV4Suite with V4-specific assertions.
-    "SPARK-51779 Verify StateSchemaV3 writes correct key and value " +
-      "schemas for join operator",
-    // V4's key encoding is not yet supported by StateDataSource reader.
-    "SPARK-49829"
-  )
-
-  override def runTest(testName: String, args: Args): Status = {
-    if (testsToSkip.exists(testName.contains)) {
-      org.scalatest.SucceededStatus
-    } else {
-      super.runTest(testName, args)
-    }
-  }
 }
 
 @SlowSQLTest
 class StreamingInnerJoinV4Suite
-  extends StreamingInnerJoinSuite
+  extends StreamingInnerJoinBase
   with TestWithV4StateFormat {
 
   import testImplicits._
@@ -216,15 +188,15 @@ class StreamingInnerJoinV4Suite
 
 @SlowSQLTest
 class StreamingOuterJoinV4Suite
-  extends StreamingOuterJoinSuite
+  extends StreamingOuterJoinBase
   with TestWithV4StateFormat
 
 @SlowSQLTest
 class StreamingFullOuterJoinV4Suite
-  extends StreamingFullOuterJoinSuite
+  extends StreamingFullOuterJoinBase
   with TestWithV4StateFormat
 
 @SlowSQLTest
 class StreamingLeftSemiJoinV4Suite
-  extends StreamingLeftSemiJoinSuite
+  extends StreamingLeftSemiJoinBase
     with TestWithV4StateFormat

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinV4Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinV4Suite.scala
@@ -36,7 +36,7 @@ import org.apache.spark.tags.SlowSQLTest
  * so wrapping the test body overrides the V3 setting from the parent trait.
  */
 trait TestWithV4StateFormat { self: StreamingJoinSuite =>
-  override protected def useVirtualColumnFamilies = true
+  override protected def testMode: Mode = Mode.WithVCF
 
   override def testWithVirtualColumnFamilyJoins(
       testName: String, testTags: Tag*)(testBody: => Any): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinV4Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinV4Suite.scala
@@ -35,7 +35,7 @@ import org.apache.spark.tags.SlowSQLTest
  * RocksDB with virtual column families. The innermost withSQLConf wins,
  * so wrapping the test body overrides the V3 setting from the parent trait.
  */
-trait TestWithV4StateFormat { self: StreamingJoinSuite =>
+trait TestWithV4StateFormat extends StreamingJoinSuite {
   override protected def testMode: Mode = Mode.WithVCF
 
   override def testWithVirtualColumnFamilyJoins(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Refactor streaming join test suites to separate test mode dispatch from the test hierarchy.

**Before:** `AlsoTestWithVirtualColumnFamilyJoins` runs every test in both VCF and non-VCF
modes within a single suite class. V4 suites extend these classes and use a string-matching
skip list to exclude incompatible tests.

**After:** Each join type has a two-layer hierarchy:

```
StreamingInnerJoinBase          (universal tests — all state format versions)
├── StreamingInnerJoinSuite     (adds V3-specific tests: window joins, metrics, schema)
│   ├── StreamingInnerJoinWithVCFSuite      (testMode = WithVCF)
│   └── StreamingInnerJoinWithoutVCFSuite   (testMode = WithoutVCF)
└── StreamingInnerJoinV4Suite   (testMode = WithVCF, stateFormatVersion = 4)
```

Mode dispatch uses a `testMode: Mode` enum in `StreamingJoinSuite`, replacing the
`AlsoTestWithVirtualColumnFamilyJoins` trait. Each concrete suite overrides `testMode`
with a single `Mode` value. The enum is more future-proof than a boolean — new modes
can be added without changing the dispatch type. V4 suites extend `*Base` directly —
no skip list needed.

### Why are the changes needed?

1. **Failure isolation**: Suite name identifies the exact mode — no long disambiguating suffixes.
2. **Selective retrigger**: Rerun only the failing mode's suite without rerunning the passing mode.
3. **No skip lists**: V4 suites get only universal tests by inheriting from `*Base`, not `*Suite`. Adding V3-specific tests in the future won't accidentally break V4.
4. **Extensible dispatch**: A `Mode` enum replaces a trait with hard-coded dual-mode dispatch. Adding new modes (e.g., Avro encoding) is a new enum case + a one-liner suite.

### Does this PR introduce _any_ user-facing change?

No. Test infrastructure only. Same tests, same coverage.

### How was this patch tested?

Existing tests — the `*WithVCFSuite` and `*WithoutVCFSuite` classes run the same tests as before, split by mode.

### Was this patch authored or co-authored using generative AI tooling?

Yes
