### PR TITLE
[SPARK-56204][SQL] Strip `Alias` wrappers from inline table row expressions in parser

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2725,8 +2725,14 @@ class AstBuilder extends DataTypeAstBuilder
         // inline table comes in two styles:
         // style 1: values (1), (2), (3)  -- multiple columns are supported
         // style 2: values 1, 2, 3  -- only a single column is supported here
-        case struct: CreateNamedStruct => struct.valExprs // style 1
-        case child => Seq(child)                          // style 2
+        // Strip Alias wrappers from row values — CreateStruct.apply preserves them for
+        // expressions like `(1 AS id, 'a' AS name)`, but they are redundant here since
+        // column names are determined by the table alias or generated defaults.
+        case struct: CreateNamedStruct => struct.valExprs.map {
+          case a: Alias => a.child
+          case other => other
+        } // style 1
+        case child => Seq(child) // style 2
       }
     }
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/inline-table.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/inline-table.sql.out
@@ -256,3 +256,24 @@ select count(distinct ct) from values now(), now(), now() as data(ct)
 select count(distinct ct) from values current_timestamp(), current_timestamp() as data(ct)
 -- !query analysis
 [Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select a from (values (1 as id, current_timestamp() as ts), (2 as id, current_timestamp() as ts)) as t(a, b)
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select * from values (1 as id, 'a' as name), (2 as id, 'b' as name) as t(a, b)
+-- !query analysis
+Project [a#x, b#x]
++- SubqueryAlias t
+   +- LocalRelation [a#x, b#x]
+
+
+-- !query
+select * from values (1 as a, 2 as b)
+-- !query analysis
+Project [col1#x, col2#x]
++- LocalRelation [col1#x, col2#x]

--- a/sql/core/src/test/resources/sql-tests/inputs/inline-table.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/inline-table.sql
@@ -66,3 +66,12 @@ select count(distinct ct) from values now(), now(), now() as data(ct);
 
 -- current_timestamp() should be kept as tempResolved inline expression.
 select count(distinct ct) from values current_timestamp(), current_timestamp() as data(ct);
+
+-- aliased expressions in multi-column rows with current_timestamp (non-foldable)
+select a from (values (1 as id, current_timestamp() as ts), (2 as id, current_timestamp() as ts)) as t(a, b);
+
+-- aliased expressions in multi-column rows
+select * from values (1 as id, 'a' as name), (2 as id, 'b' as name) as t(a, b);
+
+-- aliased expressions without table alias
+select * from values (1 as a, 2 as b);

--- a/sql/core/src/test/resources/sql-tests/results/inline-table.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/inline-table.sql.out
@@ -287,3 +287,29 @@ select count(distinct ct) from values current_timestamp(), current_timestamp() a
 struct<count(DISTINCT ct):bigint>
 -- !query output
 1
+
+
+-- !query
+select a from (values (1 as id, current_timestamp() as ts), (2 as id, current_timestamp() as ts)) as t(a, b)
+-- !query schema
+struct<a:int>
+-- !query output
+1
+2
+
+
+-- !query
+select * from values (1 as id, 'a' as name), (2 as id, 'b' as name) as t(a, b)
+-- !query schema
+struct<a:int,b:string>
+-- !query output
+1	a
+2	b
+
+
+-- !query
+select * from values (1 as a, 2 as b)
+-- !query schema
+struct<col1:int,col2:int>
+-- !query output
+1	2


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
When the SQL parser processes `VALUES (1 AS id, 'a' AS name)`, the parenthesized expression is parsed as a `CreateNamedStruct` via `CreateStruct.apply`, which preserves `Alias` wrappers as value expressions. These `Alias` nodes then propagate into `UnresolvedInlineTable.rows` through `struct.valExprs`.

The aliases are redundant for inline tables since column names are determined separately (either from the explicit table alias identifier list or generated defaults). Their presence causes issues during single-pass analysis where the `ExpressionIdAssigner` mapping is not yet initialized when processing inline table row expressions.

This patch strips `Alias` wrappers from inline table row expressions in `visitInlineTable`, extracting just `alias.child`. This is safe because the alias names are already captured in the struct's name expressions and are not used for inline table column naming.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
To achieve compatibility between single-pass and fixed-point analyzers
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Added new golden file tests
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
