### PR TITLE
[SPARK-56205][SS] Validate base state store checkpoint ID before committing microbatch

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -6224,6 +6224,14 @@
     },
     "sqlState" : "55019"
   },
+  "STATE_STORE_BASE_CHECKPOINT_ID_MISMATCH" : {
+    "message" : [
+      "State store checkpoint validation failed for batch <batchVersion>.",
+      "The base checkpoint ID reported by partition <partitionId> of operator <operatorId> does not match the expected checkpoint ID.",
+      "Expected: <expectedBaseId>. Actual: <actualBaseId>."
+    ],
+    "sqlState" : "XXKST"
+  },
   "STATE_STORE_CANNOT_CREATE_COLUMN_FAMILY_WITH_RESERVED_CHARS" : {
     "message" : [
       "Failed to create column family with unsupported starting character and name=<colFamilyName>."

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -1241,7 +1241,21 @@ class MicroBatchExecution(
       execCtx: MicroBatchExecutionContext,
       opId: Long,
       checkpointInfo: Array[StatefulOpStateStoreCheckpointInfo]): Unit = {
-    // TODO validate baseStateStoreCkptId
+    // Validate that each partition's baseStateStoreCkptId matches what the driver sent
+    currentStateStoreCkptId.get(opId).foreach { previousCkptIds =>
+      checkpointInfo.foreach { info =>
+        val expectedBaseId = previousCkptIds(info.partitionId)
+        val actualBaseId = info.baseStateStoreCkptId
+        if (!actualBaseId.exists(_.sameElements(expectedBaseId))) {
+          throw StateStoreErrors.stateStoreBaseCheckpointIdMismatch(
+            info.batchVersion,
+            info.partitionId,
+            opId,
+            expectedBaseId.mkString("[", ", ", "]"),
+            actualBaseId.map(_.mkString("[", ", ", "]")).getOrElse("None"))
+        }
+      }
+    }
     checkpointInfo.map(_.batchVersion).foreach { v =>
       assert(
         execCtx.batchId == -1 || v == execCtx.batchId + 1,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
@@ -292,6 +292,16 @@ object StateStoreErrors {
     new StateStoreCheckpointIdsNotSupported(msg)
   }
 
+  def stateStoreBaseCheckpointIdMismatch(
+      batchVersion: Long,
+      partitionId: Int,
+      operatorId: Long,
+      expectedBaseId: String,
+      actualBaseId: String): StateStoreBaseCheckpointIdMismatch = {
+    new StateStoreBaseCheckpointIdMismatch(
+      batchVersion, partitionId, operatorId, expectedBaseId, actualBaseId)
+  }
+
   def unknownInternalColumnFamily(colFamilyName: String):
       StateStoreUnknownInternalColumnFamily = {
     new StateStoreUnknownInternalColumnFamily(colFamilyName)
@@ -647,3 +657,20 @@ class StateStoreUnknownInternalColumnFamily(colFamilyName: String)
   extends SparkRuntimeException(
     errorClass = "STATE_STORE_UNKNOWN_INTERNAL_COLUMN_FAMILY",
     messageParameters = Map("colFamilyName" -> colFamilyName))
+
+class StateStoreBaseCheckpointIdMismatch(
+    batchVersion: Long,
+    partitionId: Int,
+    operatorId: Long,
+    expectedBaseId: String,
+    actualBaseId: String)
+  extends SparkRuntimeException(
+    errorClass = "STATE_STORE_BASE_CHECKPOINT_ID_MISMATCH",
+    messageParameters = Map(
+      "batchVersion" -> batchVersion.toString,
+      "partitionId" -> partitionId.toString,
+      "operatorId" -> operatorId.toString,
+      "expectedBaseId" -> expectedBaseId,
+      "actualBaseId" -> actualBaseId
+    )
+  )

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreCheckpointFormatV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreCheckpointFormatV2Suite.scala
@@ -1312,6 +1312,148 @@ class RocksDBStateStoreCheckpointFormatV2Suite extends StreamTest
     }
   }
 
+  testWithCheckpointInfoTracked(
+    s"checkpointFormatVersion2 validate baseStateStoreCkptId matches driver's sent ID") {
+    withTempDir { checkpointDir =>
+      val inputData = MemoryStream[Int]
+      val aggregated =
+        inputData
+          .toDF()
+          .groupBy($"value")
+          .agg(count("*"))
+          .as[(Int, Long)]
+
+      testStream(aggregated, Update)(
+        StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
+        AddData(inputData, 3),
+        CheckLastBatch((3, 1)),
+        AddData(inputData, 3, 2),
+        CheckLastBatch((3, 2), (2, 1)),
+        AddData(inputData, 3, 2, 1),
+        CheckLastBatch((3, 3), (2, 2), (1, 1)),
+        StopStream
+      )
+
+      val checkpointInfoList = CkptIdCollectingStateStoreWrapper.getStateStoreCheckpointInfos
+
+      // Read the commit log to get the checkpoint IDs the driver persisted
+      val commitLogPath = new Path(
+        new Path(checkpointDir.getAbsolutePath), "commits").toString
+      val commitLog = new CommitLog(spark, commitLogPath)
+
+      // Verify that the executor-reported baseStateStoreCkptId for batch N+1 matches
+      // the stateStoreCkptId the driver stored in the commit log for batch N
+      val pickedInfos = pickCheckpointInfoFromCommitLog(checkpointDir, checkpointInfoList)
+      assert(pickedInfos.isDefined, "No lineage information matches with commit log")
+
+      // For each batch after the first, verify the baseStateStoreCkptId matches
+      // the commit log's checkpoint ID for the previous batch
+      val infoByBatch = pickedInfos.get.groupBy(_.batchVersion)
+      for (batchVersion <- 2 to 3) {
+        val prevBatchId = batchVersion - 2 // commit log uses batchId = batchVersion - 1
+        val prevCommitMetadata = commitLog.get(Some(prevBatchId), Some(prevBatchId)).head._2
+        val prevCkptIds = prevCommitMetadata.stateUniqueIds.get(0L)
+
+        infoByBatch(batchVersion).foreach { info =>
+          val expectedBaseId = prevCkptIds(info.partitionId)(0)
+          assert(info.baseStateStoreCkptId.isDefined,
+            s"baseStateStoreCkptId should be defined for batch $batchVersion, " +
+              s"partition ${info.partitionId}")
+          assert(info.baseStateStoreCkptId.get == expectedBaseId,
+            s"baseStateStoreCkptId mismatch for batch $batchVersion, " +
+              s"partition ${info.partitionId}: " +
+              s"expected $expectedBaseId, got ${info.baseStateStoreCkptId.get}")
+        }
+      }
+    }
+  }
+
+  testWithCheckpointInfoTracked(
+    s"checkpointFormatVersion2 validate baseStateStoreCkptId across stream restart") {
+    withTempDir { checkpointDir =>
+      val inputData = MemoryStream[Int]
+      val aggregated =
+        inputData
+          .toDF()
+          .groupBy($"value")
+          .agg(count("*"))
+          .as[(Int, Long)]
+
+      // First run: 2 batches
+      testStream(aggregated, Update)(
+        StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
+        AddData(inputData, 3),
+        CheckLastBatch((3, 1)),
+        AddData(inputData, 3, 2),
+        CheckLastBatch((3, 2), (2, 1)),
+        StopStream
+      )
+
+      CkptIdCollectingStateStoreWrapper.clear()
+
+      // Second run: restart from commit log, then run 2 more batches.
+      // This exercises the populateStartOffsets -> commit log recovery path
+      // for currentStateStoreCkptId, then validates the executor's
+      // baseStateStoreCkptId matches across the restart boundary.
+      testStream(aggregated, Update)(
+        StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
+        AddData(inputData, 3, 2, 1),
+        CheckLastBatch((3, 3), (2, 2), (1, 1)),
+        AddData(inputData, 10),
+        CheckLastBatch((10, 1)),
+        StopStream
+      )
+
+      val checkpointInfoList = CkptIdCollectingStateStoreWrapper.getStateStoreCheckpointInfos
+
+      // Read the commit log to get the IDs the driver persisted before the restart
+      val commitLogPath = new Path(
+        new Path(checkpointDir.getAbsolutePath), "commits").toString
+      val commitLog = new CommitLog(spark, commitLogPath)
+
+      // Batch version 3 is the first batch after restart.
+      // Its baseStateStoreCkptId should match the commit log entry for batchId 1
+      // (which is state version 2, written before the restart).
+      val prevCommitMetadata = commitLog.get(Some(1), Some(1)).head._2
+      val prevCkptIds = prevCommitMetadata.stateUniqueIds.get(0L)
+
+      // Get the batch version 3 infos directly from collected checkpoint infos.
+      // With speculative execution, there may be multiple entries per partition;
+      // all should have a valid baseStateStoreCkptId matching the commit log.
+      val batch3Infos = checkpointInfoList.filter(_.batchVersion == 3)
+      assert(batch3Infos.nonEmpty, "Should have checkpoint info for batch version 3")
+
+      batch3Infos.foreach { info =>
+        val expectedBaseId = prevCkptIds(info.partitionId)(0)
+        assert(info.baseStateStoreCkptId.isDefined,
+          s"baseStateStoreCkptId should be defined for first batch after restart, " +
+            s"partition ${info.partitionId}")
+        assert(info.baseStateStoreCkptId.get == expectedBaseId,
+          s"baseStateStoreCkptId mismatch after restart for " +
+            s"partition ${info.partitionId}: " +
+            s"expected $expectedBaseId, got ${info.baseStateStoreCkptId.get}")
+      }
+    }
+  }
+
+  test("StateStoreBaseCheckpointIdMismatch error has correct error class and message") {
+    val exception = StateStoreErrors.stateStoreBaseCheckpointIdMismatch(
+      batchVersion = 5L,
+      partitionId = 2,
+      operatorId = 0L,
+      expectedBaseId = "[abc-123]",
+      actualBaseId = "[xyz-789]"
+    )
+    assert(exception.isInstanceOf[StateStoreBaseCheckpointIdMismatch])
+    assert(exception.getCondition === "STATE_STORE_BASE_CHECKPOINT_ID_MISMATCH")
+    val message = exception.getMessage
+    assert(message.contains("batch 5"))
+    assert(message.contains("partition 2"))
+    assert(message.contains("operator 0"))
+    assert(message.contains("[abc-123]"))
+    assert(message.contains("[xyz-789]"))
+  }
+
   test("checkpointFormatVersion2 racing commits don't return incorrect checkpointInfo") {
     val sqlConf = new SQLConf()
     sqlConf.setConf(SQLConf.STATE_STORE_CHECKPOINT_FORMAT_VERSION, 2)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
- Validate that the executor-reported `baseStateStoreCkptId` matches the checkpoint ID the driver originally sent (`currentStateStoreCkptId`) before accepting the microbatch commit
- Add `STATE_STORE_BASE_CHECKPOINT_ID_MISMATCH` error class with `StateStoreBaseCheckpointIdMismatch` exception
- Replace the `// TODO validate baseStateStoreCkptId` in `MicroBatchExecution.updateStateStoreCkptIdForOperator` with validation logic

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To ensure that we have the right lineage of checkpoint files

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
- Add integration test verifying `baseStateStoreCkptId` matches commit log across batches within a single stream run
- Add integration test verifying `baseStateStoreCkptId` matches commit log across stream stop/restart (exercises the `populateStartOffsets` commit log recovery path)
- Add unit test verifying `StateStoreBaseCheckpointIdMismatch` error class produces correct error condition and message

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated by: Claude Opus 4.6