### PR TITLE
[SPARK-56209][BUILD] Upgrade `vertx` to 4.5.26

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -268,10 +268,11 @@ threeten-extra/1.8.0//threeten-extra-1.8.0.jar
 tink/1.20.0//tink-1.20.0.jar
 transaction-api/1.1//transaction-api-1.1.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar
-vertx-auth-common/4.5.24//vertx-auth-common-4.5.24.jar
-vertx-core/4.5.24//vertx-core-4.5.24.jar
-vertx-web-client/4.5.24//vertx-web-client-4.5.24.jar
-vertx-web-common/4.5.24//vertx-web-common-4.5.24.jar
+vertx-auth-common/4.5.26//vertx-auth-common-4.5.26.jar
+vertx-core/4.5.26//vertx-core-4.5.26.jar
+vertx-uri-template/4.5.26//vertx-uri-template-4.5.26.jar
+vertx-web-client/4.5.26//vertx-web-client-4.5.26.jar
+vertx-web-common/4.5.26//vertx-web-common-4.5.26.jar
 volcano-client/7.6.1//volcano-client-7.6.1.jar
 volcano-model/7.6.1//volcano-model-7.6.1.jar
 wildfly-openssl/2.2.5.Final//wildfly-openssl-2.2.5.Final.jar

--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,7 @@
     <!-- org.fusesource.leveldbjni will be used except on arm64 platform. -->
     <leveldbjni.group>org.fusesource.leveldbjni</leveldbjni.group>
     <kubernetes-client.version>7.6.1</kubernetes-client.version>
+    <vertx.version>4.5.26</vertx.version>
 
     <test.java.home>${java.home}</test.java.home>
 

--- a/resource-managers/kubernetes/core/pom.xml
+++ b/resource-managers/kubernetes/core/pom.xml
@@ -126,7 +126,22 @@
           <groupId>javax.annotation</groupId>
           <artifactId>javax.annotation-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.vertx</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <version>${vertx.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
+      <version>${vertx.version}</version>
     </dependency>
 
     <!-- Required by kubernetes-client but we exclude it -->

--- a/resource-managers/kubernetes/integration-tests/pom.xml
+++ b/resource-managers/kubernetes/integration-tests/pom.xml
@@ -67,6 +67,22 @@
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
       <version>${kubernetes-client.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.vertx</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <version>${vertx.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
+      <version>${vertx.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades `io.vertx` dependencies (`vertx-core`, `vertx-web-client`) from the transitive version `4.5.24` (brought in by `io.fabric8:kubernetes-client:7.6.1`) to `4.5.26` by excluding them from the transitive dependency and declaring them as direct dependencies.

Specifically:
- Added `vertx.version=4.5.26` property in the root `pom.xml`
- Excluded all `io.vertx:*` transitive dependencies from `kubernetes-client` in both `kubernetes/core` and `kubernetes/integration-tests` modules
- Added `vertx-core` and `vertx-web-client` as direct dependencies with `${vertx.version}`

### Why are the changes needed?

To manage `io.vertx` dependency versions explicitly and keep them up-to-date (`4.5.24` → `4.5.26`) instead of relying on transitive resolution from `kubernetes-client`.

- https://github.com/vert-x3/wiki/wiki/4.5.26-Release-Notes
- https://github.com/vert-x3/wiki/wiki/4.5.25-Release-Notes

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)