### PR TITLE
[SPARK-56216][SS] Integrate checkpoint V2 with auto-repair snapshot

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/AutoSnapshotLoader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/AutoSnapshotLoader.scala
@@ -65,6 +65,20 @@ abstract class AutoSnapshotLoader(
   protected def getEligibleSnapshots(versionToLoad: Long): Seq[Long]
 
   /**
+   * Called once when the first snapshot load fails and auto-repair is about to begin.
+   * Returns the eligible snapshots to use for the repair loop. Subclasses can override
+   * this to return an enriched set of snapshots (e.g., by building a fuller lineage
+   * that was initially sparse for optimization).
+   *
+   * The default delegates to [[getEligibleSnapshots]].
+   *
+   * @param versionToLoad The version being loaded
+   * @return Eligible snapshot versions for repair
+   */
+  protected def getEligibleSnapshotsForRepair(versionToLoad: Long): Seq[Long] =
+    getEligibleSnapshots(versionToLoad)
+
+  /**
    * Load the latest snapshot for the specified version from the checkpoint directory.
    * If Auto snapshot repair is enabled, the snapshot version loaded may be lower than
    * the latest snapshot version, if the latest is corrupt.
@@ -114,13 +128,15 @@ abstract class AutoSnapshotLoader(
       // we would only get here if auto snapshot repair is enabled
       assert(autoSnapshotRepairEnabled)
 
-      val remainingEligibleSnapshots = if (eligibleSnapshots.length > 1) {
-        // skip the first snapshot, since we already tried it
-        eligibleSnapshots.tail
-      } else {
-        // no more snapshots to try
-        Seq.empty
-      }
+      // getEligibleSnapshotsForRepair may return a different list than the original
+      // getEligibleSnapshots (e.g., V2 enriches a sparse lineage to discover more
+      // snapshots). We filter by value rather than using .tail because the first
+      // snapshot we already tried may appear at any position in the new list.
+      val remainingEligibleSnapshots =
+        (getEligibleSnapshotsForRepair(versionToLoad) :+ 0L)
+        .distinct
+        .sorted(Ordering[Long].reverse)
+        .filter(_ != firstEligibleSnapshot)
 
       // select remaining snapshots that are within the maxChangeFileReplay limit
       val selectedRemainingSnapshots = remainingEligibleSnapshots.filter(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/AutoSnapshotLoader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/AutoSnapshotLoader.scala
@@ -23,7 +23,7 @@ import scala.util.control.NonFatal
 import org.apache.hadoop.fs.{Path, PathFilter}
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.LogKeys.{NUM_RETRIES, NUM_RETRY, VERSION_NUM}
+import org.apache.spark.internal.LogKeys.{NUM_RETRIES, NUM_RETRY, UUID, VERSION_NUM}
 import org.apache.spark.sql.execution.streaming.checkpointing.CheckpointFileManager
 
 /**
@@ -79,9 +79,6 @@ abstract class AutoSnapshotLoader(
    * newly-discovered snapshots. The results are merged with the initial eligible
    * snapshots (duplicates are removed by version).
    *
-   * Default: no additional snapshots, which avoids redundant DFS listings for
-   * V1 and HDFS callers that have no additional snapshots to discover.
-   *
    * @param versionToLoad The version being loaded
    * @return Additional eligible snapshot (version, uniqueId) pairs for repair
    */
@@ -123,7 +120,8 @@ abstract class AutoSnapshotLoader(
           onLoadSnapshotFromCheckpointFailure()
           numFailuresForFirstSnapshot += 1
           logError(log"Failed to load snapshot version " +
-            log"${MDC(VERSION_NUM, firstEligibleSnapshot._1)}, " +
+            log"${MDC(VERSION_NUM, firstEligibleSnapshot._1)} " +
+            log"(uniqueId: ${MDC(UUID, firstEligibleSnapshot._2.getOrElse(""))}), " +
             log"attempt ${MDC(NUM_RETRY, numFailuresForFirstSnapshot)} out of " +
             log"${MDC(NUM_RETRIES, maxNumFailures)} attempts", e)
           lastException = e
@@ -168,12 +166,14 @@ abstract class AutoSnapshotLoader(
           loadSnapshotFromCheckpoint(snapshot._1, snapshot._2)
           loadedSnapshot = Some(snapshot._1)
           logInfo(log"Successfully loaded snapshot version " +
-            log"${MDC(VERSION_NUM, snapshot._1)}. Repair complete.")
+            log"${MDC(VERSION_NUM, snapshot._1)} " +
+            log"(uniqueId: ${MDC(UUID, snapshot._2.getOrElse(""))}). Repair complete.")
         } catch {
           case NonFatal(e) =>
             logError(log"Failed to load snapshot version " +
-              log"${MDC(VERSION_NUM, snapshot._1)}, will retry repair with " +
-              log"the next eligible snapshot version", e)
+              log"${MDC(VERSION_NUM, snapshot._1)} " +
+              log"(uniqueId: ${MDC(UUID, snapshot._2.getOrElse(""))}), will retry repair " +
+              log"with the next eligible snapshot version", e)
             onLoadSnapshotFromCheckpointFailure()
             lastException = e
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/AutoSnapshotLoader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/AutoSnapshotLoader.scala
@@ -66,21 +66,15 @@ abstract class AutoSnapshotLoader(
 
   /**
    * Called once when the first snapshot load fails and auto-repair is about to begin.
-   * Returns the eligible snapshots to use for the repair loop. Subclasses can override
-   * this to return an enriched set of snapshots (e.g., by building a fuller lineage
-   * that was initially sparse for optimization).
+   * Returns the eligible snapshots to use for the repair loop.
    *
-   * The default delegates to [[getEligibleSnapshots]], which means it re-calls that method
-   * rather than reusing the initial list. This is intentional: V2 overrides this method to
-   * enrich the lineage first, then re-discovers snapshots from the enriched lineage.
-   * For V1 callers (which do not override), the re-call is benign since
-   * [[getEligibleSnapshots]] returns a consistent result from DFS listing.
+   * V2 overrides this to enrich a sparse lineage (via getFullLineage) before
+   * re-discovering snapshots. V1 can simply delegate to [[getEligibleSnapshots]].
    *
    * @param versionToLoad The version being loaded
    * @return Eligible snapshot versions for repair
    */
-  protected def getEligibleSnapshotsForRepair(versionToLoad: Long): Seq[Long] =
-    getEligibleSnapshots(versionToLoad)
+  protected def getEligibleSnapshotsForRepair(versionToLoad: Long): Seq[Long]
 
   /**
    * Load the latest snapshot for the specified version from the checkpoint directory.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/AutoSnapshotLoader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/AutoSnapshotLoader.scala
@@ -54,27 +54,39 @@ abstract class AutoSnapshotLoader(
   /**
    * Attempt to load the specified snapshot version from the checkpoint directory.
    * Should throw an exception if the snapshot is corrupt.
+   * @param snapshotVersion The snapshot version to load
+   * @param uniqueId The unique checkpoint ID for V2, or None for V1
    * @note Must support loading version 0
    * */
-  protected def loadSnapshotFromCheckpoint(snapshotVersion: Long): Unit
+  protected def loadSnapshotFromCheckpoint(
+      snapshotVersion: Long, uniqueId: Option[String]): Unit
 
   /** Called when load fails, to do any necessary cleanup/variable reset */
   protected def onLoadSnapshotFromCheckpointFailure(): Unit
 
-  /** Get a list of eligible snapshot versions in the checkpoint directory that can be loaded */
-  protected def getEligibleSnapshots(versionToLoad: Long): Seq[Long]
+  /**
+   * Get a list of eligible snapshot (version, uniqueId) pairs in the checkpoint directory
+   * that can be loaded. For V1, uniqueId is None.
+   */
+  protected def getEligibleSnapshots(
+      versionToLoad: Long): Seq[(Long, Option[String])]
 
   /**
-   * Called once when the first snapshot load fails and auto-repair is about to begin.
-   * Returns the eligible snapshots to use for the repair loop.
+   * Returns additional eligible snapshots discovered during auto-repair.
+   * Called once when the first snapshot load fails and auto-repair begins.
    *
-   * V2 overrides this to enrich a sparse lineage (via getFullLineage) before
-   * re-discovering snapshots. V1 can simply delegate to [[getEligibleSnapshots]].
+   * V2 overrides this to enrich a sparse lineage (via getFullLineage) and return
+   * newly-discovered snapshots. The results are merged with the initial eligible
+   * snapshots (duplicates are removed by version).
+   *
+   * Default: no additional snapshots, which avoids redundant DFS listings for
+   * V1 and HDFS callers that have no additional snapshots to discover.
    *
    * @param versionToLoad The version being loaded
-   * @return Eligible snapshot versions for repair
+   * @return Additional eligible snapshot (version, uniqueId) pairs for repair
    */
-  protected def getEligibleSnapshotsForRepair(versionToLoad: Long): Seq[Long]
+  protected def getAdditionalEligibleSnapshots(
+      versionToLoad: Long): Seq[(Long, Option[String])] = Seq.empty
 
   /**
    * Load the latest snapshot for the specified version from the checkpoint directory.
@@ -86,9 +98,9 @@ abstract class AutoSnapshotLoader(
    * */
   def loadSnapshot(versionToLoad: Long): (Long, Boolean) = {
     val eligibleSnapshots =
-      (getEligibleSnapshots(versionToLoad) :+ 0L) // always include the initial snapshot
-      .distinct // Ensure no duplicate version numbers
-      .sorted(Ordering[Long].reverse)
+      (getEligibleSnapshots(versionToLoad) :+ (0L, Option.empty[String]))
+      .distinctBy(_._1) // Ensure no duplicate version numbers
+      .sortBy(_._1)(Ordering[Long].reverse)
 
     // Start with the latest snapshot
     val firstEligibleSnapshot = eligibleSnapshots.head
@@ -102,8 +114,8 @@ abstract class AutoSnapshotLoader(
       beforeLoad() // if this fails, then we should fail
       try {
         // try to load the first eligible snapshot
-        loadSnapshotFromCheckpoint(firstEligibleSnapshot)
-        loadedSnapshot = Some(firstEligibleSnapshot)
+        loadSnapshotFromCheckpoint(firstEligibleSnapshot._1, firstEligibleSnapshot._2)
+        loadedSnapshot = Some(firstEligibleSnapshot._1)
       } catch {
         // Swallow only if auto snapshot repair is enabled
         // If auto snapshot repair is not enabled, we should fail immediately
@@ -111,7 +123,7 @@ abstract class AutoSnapshotLoader(
           onLoadSnapshotFromCheckpointFailure()
           numFailuresForFirstSnapshot += 1
           logError(log"Failed to load snapshot version " +
-            log"${MDC(VERSION_NUM, firstEligibleSnapshot)}, " +
+            log"${MDC(VERSION_NUM, firstEligibleSnapshot._1)}, " +
             log"attempt ${MDC(NUM_RETRY, numFailuresForFirstSnapshot)} out of " +
             log"${MDC(NUM_RETRIES, maxNumFailures)} attempts", e)
           lastException = e
@@ -126,40 +138,41 @@ abstract class AutoSnapshotLoader(
       // we would only get here if auto snapshot repair is enabled
       assert(autoSnapshotRepairEnabled)
 
-      // getEligibleSnapshotsForRepair may return a different list than the original
-      // getEligibleSnapshots (e.g., V2 enriches a sparse lineage to discover more
-      // snapshots). We filter by value rather than using .tail because the first
-      // snapshot we already tried may appear at any position in the new list.
+      // Merge initial eligible snapshots with any additional ones discovered during
+      // repair (e.g., V2 enriches a sparse lineage to discover more snapshots).
+      // Deduplicate by version and filter out the first snapshot we already tried.
       val remainingEligibleSnapshots =
-        (getEligibleSnapshotsForRepair(versionToLoad) :+ 0L)
-        .distinct
-        .sorted(Ordering[Long].reverse)
-        .filter(_ != firstEligibleSnapshot)
+        (eligibleSnapshots ++ getAdditionalEligibleSnapshots(versionToLoad)
+          :+ (0L, Option.empty[String]))
+        .distinctBy(_._1)
+        .sortBy(_._1)(Ordering[Long].reverse)
+        .filter(_._1 != firstEligibleSnapshot._1)
 
       // select remaining snapshots that are within the maxChangeFileReplay limit
       val selectedRemainingSnapshots = remainingEligibleSnapshots.filter(
-        s => versionToLoad - s <= maxChangeFileReplay)
+        s => versionToLoad - s._1 <= maxChangeFileReplay)
 
       logInfo(log"Attempting to auto repair snapshot by skipping " +
-        log"snapshot version ${MDC(VERSION_NUM, firstEligibleSnapshot)} " +
+        log"snapshot version ${MDC(VERSION_NUM, firstEligibleSnapshot._1)} " +
         log"and trying to load with one of the selected snapshots " +
-        log"${MDC(VERSION_NUM, selectedRemainingSnapshots)}, out of eligible snapshots " +
-        log"${MDC(VERSION_NUM, remainingEligibleSnapshots)}. " +
+        log"${MDC(VERSION_NUM, selectedRemainingSnapshots.map(_._1))}, " +
+        log"out of eligible snapshots " +
+        log"${MDC(VERSION_NUM, remainingEligibleSnapshots.map(_._1))}. " +
         log"maxChangeFileReplay: ${MDC(VERSION_NUM, maxChangeFileReplay)}")
 
       // Now try to load using any of the selected snapshots,
       // remember they are sorted in descending order
-      for (snapshotVersion <- selectedRemainingSnapshots if loadedSnapshot.isEmpty) {
+      for (snapshot <- selectedRemainingSnapshots if loadedSnapshot.isEmpty) {
         beforeLoad() // if this fails, then we should fail
         try {
-          loadSnapshotFromCheckpoint(snapshotVersion)
-          loadedSnapshot = Some(snapshotVersion)
+          loadSnapshotFromCheckpoint(snapshot._1, snapshot._2)
+          loadedSnapshot = Some(snapshot._1)
           logInfo(log"Successfully loaded snapshot version " +
-            log"${MDC(VERSION_NUM, snapshotVersion)}. Repair complete.")
+            log"${MDC(VERSION_NUM, snapshot._1)}. Repair complete.")
         } catch {
           case NonFatal(e) =>
             logError(log"Failed to load snapshot version " +
-              log"${MDC(VERSION_NUM, snapshotVersion)}, will retry repair with " +
+              log"${MDC(VERSION_NUM, snapshot._1)}, will retry repair with " +
               log"the next eligible snapshot version", e)
             onLoadSnapshotFromCheckpointFailure()
             lastException = e
@@ -169,12 +182,14 @@ abstract class AutoSnapshotLoader(
       if (loadedSnapshot.isEmpty) {
         // we tried all eligible snapshots and failed to load any of them
         logError(log"Auto snapshot repair failed to load any snapshot:" +
-          log" latestSnapshotVersion: ${MDC(VERSION_NUM, firstEligibleSnapshot)}, " +
-          log"attemptedSnapshots: ${MDC(VERSION_NUM, selectedRemainingSnapshots)}, " +
-          log"eligibleSnapshots:  ${MDC(VERSION_NUM, remainingEligibleSnapshots)}, " +
+          log" latestSnapshotVersion: ${MDC(VERSION_NUM, firstEligibleSnapshot._1)}, " +
+          log"attemptedSnapshots: ${MDC(VERSION_NUM, selectedRemainingSnapshots.map(_._1))}, " +
+          log"eligibleSnapshots:  ${MDC(VERSION_NUM, remainingEligibleSnapshots.map(_._1))}, " +
           log"maxChangeFileReplay: ${MDC(VERSION_NUM, maxChangeFileReplay)}", lastException)
         throw StateStoreErrors.autoSnapshotRepairFailed(
-          loggingId, firstEligibleSnapshot, selectedRemainingSnapshots, remainingEligibleSnapshots,
+          loggingId, firstEligibleSnapshot._1,
+          selectedRemainingSnapshots.map(_._1),
+          remainingEligibleSnapshots.map(_._1),
           lastException)
       } else {
         autoRepairCompleted = true

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/AutoSnapshotLoader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/AutoSnapshotLoader.scala
@@ -70,7 +70,11 @@ abstract class AutoSnapshotLoader(
    * this to return an enriched set of snapshots (e.g., by building a fuller lineage
    * that was initially sparse for optimization).
    *
-   * The default delegates to [[getEligibleSnapshots]].
+   * The default delegates to [[getEligibleSnapshots]], which means it re-calls that method
+   * rather than reusing the initial list. This is intentional: V2 overrides this method to
+   * enrich the lineage first, then re-discovers snapshots from the enriched lineage.
+   * For V1 callers (which do not override), the re-call is benign since
+   * [[getEligibleSnapshots]] returns a consistent result from DFS listing.
    *
    * @param versionToLoad The version being loaded
    * @return Eligible snapshot versions for repair

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -731,7 +731,8 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
       storeIdStr) {
       override protected def beforeLoad(): Unit = {}
 
-      override protected def loadSnapshotFromCheckpoint(snapshotVersion: Long): Unit = {
+      override protected def loadSnapshotFromCheckpoint(
+          snapshotVersion: Long, uniqueId: Option[String]): Unit = {
         loadedMap = if (snapshotVersion <= 0) {
           // Use an empty map for versions 0 or less.
           Some(createHDFSBackedStateStoreMap())
@@ -744,7 +745,8 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
 
       override protected def onLoadSnapshotFromCheckpointFailure(): Unit = {}
 
-      override protected def getEligibleSnapshots(versionToLoad: Long): Seq[Long] = {
+      override protected def getEligibleSnapshots(
+          versionToLoad: Long): Seq[(Long, Option[String])] = {
         val snapshotVersions = SnapshotLoaderHelper.getEligibleSnapshotsForVersion(
           versionToLoad, fm, baseDir, onlySnapshotFiles, fileSuffix = ".snapshot")
 
@@ -754,11 +756,7 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
         }.filter(_ <= versionToLoad)
 
         // Combine the two sets of versions, so we can check both during load
-        (snapshotVersions ++ cachedVersions).distinct
-      }
-
-      override protected def getEligibleSnapshotsForRepair(versionToLoad: Long): Seq[Long] = {
-        getEligibleSnapshots(versionToLoad)
+        (snapshotVersions ++ cachedVersions).distinct.map((_, None))
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -756,6 +756,10 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
         // Combine the two sets of versions, so we can check both during load
         (snapshotVersions ++ cachedVersions).distinct
       }
+
+      override protected def getEligibleSnapshotsForRepair(versionToLoad: Long): Seq[Long] = {
+        getEligibleSnapshots(versionToLoad)
+      }
     }
 
     val (loadedVersion, autoRepairCompleted) = snapshotLoader.loadSnapshot(versionToLoad)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -490,89 +490,27 @@ class RocksDB(
         // Handle normal checkpoint loading
         closeDB(ignoreException = false)
 
-        val (latestSnapshotVersion, latestSnapshotUniqueId) = {
-          // Special handling when version is 0.
-          // When loading the very first version (0), stateStoreCkptId does not need to be defined
-          // because there won't be 0.changelog / 0.zip file created in RocksDB under v2.
-          if (version == 0) {
-            assert(stateStoreCkptId.isEmpty,
-              "stateStoreCkptId should be empty when version is zero")
-            (0L, None)
-          // When there is a snapshot file, it is the ground truth, we can skip
-          // reconstructing the lineage from changelog file.
-          } else if (fileManager.existsSnapshotFile(version, stateStoreCkptId)) {
+        // Build initial lineage for version > 0. Version 0 is the empty initial state
+        // with no checkpoint files, so lineage stays empty.
+        if (version > 0) {
+          // If the exact snapshot file exists on DFS, use a sparse lineage (just the
+          // target version) as an optimization to skip reading the changelog header.
+          // If auto-repair is needed later, getEligibleSnapshotsForRepair() will
+          // enrich this to the full lineage via getFullLineage().
+          if (fileManager.existsSnapshotFile(version, stateStoreCkptId)) {
             currVersionLineage = Array(LineageItem(version, stateStoreCkptId.get))
-            (version, stateStoreCkptId)
           } else {
             currVersionLineage = getLineageFromChangelogFile(version, stateStoreCkptId) :+
               LineageItem(version, stateStoreCkptId.get)
             currVersionLineage = currVersionLineage.sortBy(_.version)
-
-            val latestSnapshotVersionsAndUniqueId =
-              fileManager.getLatestSnapshotVersionAndUniqueIdFromLineage(currVersionLineage)
-            latestSnapshotVersionsAndUniqueId match {
-              case Some(pair) => (pair._1, Option(pair._2))
-              case None if currVersionLineage.head.version == 1L =>
-                logDebug(log"Cannot find latest snapshot based on lineage but first version " +
-                  log"is 1, use 0 as default. Lineage: ${MDC(LogKeys.LINEAGE, lineageManager)}")
-                (0L, None)
-              case _ =>
-                throw QueryExecutionErrors.cannotFindBaseSnapshotCheckpoint(
-                  printLineageItems(currVersionLineage))
-            }
           }
         }
 
-        logInfo(log"Loaded latestSnapshotVersion: ${
-          MDC(LogKeys.SNAPSHOT_VERSION, latestSnapshotVersion)}, latestSnapshotUniqueId: ${
-          MDC(LogKeys.UUID, latestSnapshotUniqueId)}")
-
-        try {
-          val metadata = fileManager.loadCheckpointFromDfs(latestSnapshotVersion,
-            workingDir, rocksDBFileMapping, latestSnapshotUniqueId)
-          loadedFromDfs = version > 0
-          loadedVersion = latestSnapshotVersion
-
-          lastSnapshotVersion = latestSnapshotVersion
-          lineageManager.resetLineage(currVersionLineage)
-
-          fileManager.setMaxSeenVersion(version)
-          reportSnapshotUploadToCoordinator(latestSnapshotVersion)
-
-          openLocalRocksDB(metadata)
-
-          if (loadedVersion != version) {
-            val versionsAndUniqueIds = currVersionLineage.collect {
-              case i if i.version > loadedVersion && i.version <= version =>
-                (i.version, Option(i.checkpointUniqueId))
-            }
-            replayChangelog(versionsAndUniqueIds)
-            loadedVersion = version
-            lineageManager.resetLineage(currVersionLineage)
-          }
-        } catch {
-          case NonFatal(e) if enableChangelogCheckpointing &&
-              conf.stateStoreConf.autoSnapshotRepairEnabled =>
-            logWarning(log"Failed to load V2 snapshot/changelog for version ${
-              MDC(LogKeys.VERSION_NUM, version)}, attempting auto-repair", e)
-            // Build the full lineage from version 1 to the target version so that
-            // auto-repair can fall back to any snapshot (including version 0 with
-            // full changelog replay). getFullLineage walks backward through
-            // changelog file headers to reconstruct the complete chain.
-            if (stateStoreCkptId.isDefined) {
-              try {
-                currVersionLineage = getFullLineage(1, version, stateStoreCkptId)
-              } catch {
-                case NonFatal(_) => // keep existing lineage; may limit fallback options
-              }
-            }
-            val (_, _, autoRepaired) =
-              loadSnapshotWithCheckpointId(version, currVersionLineage)
-            performedSnapshotAutoRepair = autoRepaired
-            loadedFromDfs = version > 0
-            loadedVersion = version
-            lineageManager.resetLineage(currVersionLineage)
-        }
+        // Delegate to AutoSnapshotLoader which handles both the happy path
+        // and auto-repair fallback to older snapshots.
+        loadSnapshotWithCheckpointId(version, stateStoreCkptId, currVersionLineage)
+        loadedFromDfs = version > 0
+        lineageManager.resetLineage(currVersionLineage)
         // After changelog replay the numKeysOnWritingVersion will be updated to
         // the correct number of keys in the loaded version.
         numKeysOnLoadedVersion = numKeysOnWritingVersion
@@ -752,13 +690,20 @@ class RocksDB(
    * Changelog replay is included inside the load callback so that corrupt changelogs
    * also trigger fallback to the next older snapshot.
    *
+   * Sets [[performedSnapshotAutoRepair]] as a side effect if auto-repair was used.
+   *
    * @param versionToLoad The target version to load
-   * @param currVersionLineage The lineage for the target version
-   * @return (loadedSnapshotVersion, loadedSnapshotUniqueId, autoRepairCompleted)
+   * @param stateStoreCkptId The checkpoint ID for the target version (for lineage enrichment)
+   * @param initialLineage The lineage for the target version (may be enriched by
+   *                       getEligibleSnapshotsForRepair during auto-repair)
    */
   private def loadSnapshotWithCheckpointId(
       versionToLoad: Long,
-      currVersionLineage: Array[LineageItem]): (Long, Option[String], Boolean) = {
+      stateStoreCkptId: Option[String],
+      initialLineage: Array[LineageItem]): Unit = {
+    // Local var so that beforeRepair can enrich the lineage and getEligibleSnapshots
+    // (re-called after beforeRepair) sees the updated lineage.
+    var currVersionLineage = initialLineage
     val allowAutoSnapshotRepair = if (enableChangelogCheckpointing) {
       conf.stateStoreConf.autoSnapshotRepairEnabled
     } else {
@@ -814,11 +759,26 @@ class RocksDB(
         }
         snapshotsInLineage.map(_._1)
       }
+
+      override protected def getEligibleSnapshotsForRepair(version: Long): Seq[Long] = {
+        // Build the full lineage from version 1 to the target version so that
+        // auto-repair can fall back to any snapshot (including version 0 with
+        // full changelog replay). getFullLineage walks backward through
+        // changelog file headers to reconstruct the complete chain.
+        if (stateStoreCkptId.isDefined) {
+          try {
+            currVersionLineage = getFullLineage(1, versionToLoad, stateStoreCkptId)
+          } catch {
+            case NonFatal(_) => // keep existing lineage; may limit fallback options
+          }
+        }
+        // Re-discover eligible snapshots from the (potentially enriched) lineage
+        getEligibleSnapshots(version)
+      }
     }
 
-    val (version, autoRepairCompleted) = snapshotLoader.loadSnapshot(versionToLoad)
+    val (_, autoRepairCompleted) = snapshotLoader.loadSnapshot(versionToLoad)
     performedSnapshotAutoRepair = autoRepairCompleted
-    (version, loadedSnapshotUniqueId, autoRepairCompleted)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -527,32 +527,51 @@ class RocksDB(
           MDC(LogKeys.SNAPSHOT_VERSION, latestSnapshotVersion)}, latestSnapshotUniqueId: ${
           MDC(LogKeys.UUID, latestSnapshotUniqueId)}")
 
-        val metadata = fileManager.loadCheckpointFromDfs(latestSnapshotVersion,
-          workingDir, rocksDBFileMapping, latestSnapshotUniqueId)
-        // version 0 is the empty initial state; loadCheckpointFromDfs skips DFS for it
-        loadedFromDfs = version > 0
-        loadedVersion = latestSnapshotVersion
+        try {
+          val metadata = fileManager.loadCheckpointFromDfs(latestSnapshotVersion,
+            workingDir, rocksDBFileMapping, latestSnapshotUniqueId)
+          loadedFromDfs = version > 0
+          loadedVersion = latestSnapshotVersion
 
-        // reset the last snapshot version to the latest available snapshot version
-        lastSnapshotVersion = latestSnapshotVersion
-        lineageManager.resetLineage(currVersionLineage)
-
-        // Initialize maxVersion upon successful load from DFS
-        fileManager.setMaxSeenVersion(version)
-
-        // Report this snapshot version to the coordinator
-        reportSnapshotUploadToCoordinator(latestSnapshotVersion)
-
-        openLocalRocksDB(metadata)
-
-        if (loadedVersion != version) {
-          val versionsAndUniqueIds = currVersionLineage.collect {
-            case i if i.version > loadedVersion && i.version <= version =>
-              (i.version, Option(i.checkpointUniqueId))
-          }
-          replayChangelog(versionsAndUniqueIds)
-          loadedVersion = version
+          lastSnapshotVersion = latestSnapshotVersion
           lineageManager.resetLineage(currVersionLineage)
+
+          fileManager.setMaxSeenVersion(version)
+          reportSnapshotUploadToCoordinator(latestSnapshotVersion)
+
+          openLocalRocksDB(metadata)
+
+          if (loadedVersion != version) {
+            val versionsAndUniqueIds = currVersionLineage.collect {
+              case i if i.version > loadedVersion && i.version <= version =>
+                (i.version, Option(i.checkpointUniqueId))
+            }
+            replayChangelog(versionsAndUniqueIds)
+            loadedVersion = version
+            lineageManager.resetLineage(currVersionLineage)
+          }
+        } catch {
+          case NonFatal(e) if enableChangelogCheckpointing &&
+              conf.stateStoreConf.autoSnapshotRepairEnabled =>
+            logWarning(log"Failed to load V2 snapshot/changelog for version ${
+              MDC(LogKeys.VERSION_NUM, version)}, attempting auto-repair", e)
+            // Build the full lineage from version 1 to the target version so that
+            // auto-repair can fall back to any snapshot (including version 0 with
+            // full changelog replay). getFullLineage walks backward through
+            // changelog file headers to reconstruct the complete chain.
+            if (stateStoreCkptId.isDefined) {
+              try {
+                currVersionLineage = getFullLineage(1, version, stateStoreCkptId)
+              } catch {
+                case NonFatal(_) => // keep existing lineage; may limit fallback options
+              }
+            }
+            val (_, _, autoRepaired) =
+              loadSnapshotWithCheckpointId(version, currVersionLineage)
+            performedSnapshotAutoRepair = autoRepaired
+            loadedFromDfs = version > 0
+            loadedVersion = version
+            lineageManager.resetLineage(currVersionLineage)
         }
         // After changelog replay the numKeysOnWritingVersion will be updated to
         // the correct number of keys in the loaded version.
@@ -725,6 +744,81 @@ class RocksDB(
     val (version, autoRepairCompleted) = snapshotLoader.loadSnapshot(versionToLoad)
     performedSnapshotAutoRepair = autoRepairCompleted
     version
+  }
+
+  /**
+   * V2-aware snapshot loading with auto-repair support.
+   * Uses lineage to discover eligible snapshots and falls back to older ones if corrupt.
+   * Changelog replay is included inside the load callback so that corrupt changelogs
+   * also trigger fallback to the next older snapshot.
+   *
+   * @param versionToLoad The target version to load
+   * @param currVersionLineage The lineage for the target version
+   * @return (loadedSnapshotVersion, loadedSnapshotUniqueId, autoRepairCompleted)
+   */
+  private def loadSnapshotWithCheckpointId(
+      versionToLoad: Long,
+      currVersionLineage: Array[LineageItem]): (Long, Option[String], Boolean) = {
+    val allowAutoSnapshotRepair = if (enableChangelogCheckpointing) {
+      conf.stateStoreConf.autoSnapshotRepairEnabled
+    } else {
+      false
+    }
+
+    // Side-channel map: version -> uniqueId, populated by getEligibleSnapshots,
+    // consumed by loadSnapshotFromCheckpoint
+    val eligibleSnapshotUniqueIds = mutable.Map[Long, String]()
+    var loadedSnapshotUniqueId: Option[String] = None
+
+    val snapshotLoader = new AutoSnapshotLoader(
+      allowAutoSnapshotRepair,
+      conf.stateStoreConf.autoSnapshotRepairNumFailuresBeforeActivating,
+      conf.stateStoreConf.autoSnapshotRepairMaxChangeFileReplay,
+      loggingId) {
+      override protected def beforeLoad(): Unit = closeDB(ignoreException = false)
+
+      override protected def loadSnapshotFromCheckpoint(snapshotVersion: Long): Unit = {
+        val uniqueId = eligibleSnapshotUniqueIds.get(snapshotVersion)
+        val remoteMetaData = fileManager.loadCheckpointFromDfs(snapshotVersion,
+          workingDir, rocksDBFileMapping, uniqueId)
+
+        loadedVersion = snapshotVersion
+        fileManager.setMaxSeenVersion(snapshotVersion)
+        openLocalRocksDB(remoteMetaData)
+        lastSnapshotVersion = snapshotVersion
+        reportSnapshotUploadToCoordinator(snapshotVersion)
+
+        // Replay changelogs from snapshot to target version
+        if (snapshotVersion != versionToLoad) {
+          val versionsAndUniqueIds = currVersionLineage.collect {
+            case i if i.version > snapshotVersion && i.version <= versionToLoad =>
+              (i.version, Option(i.checkpointUniqueId))
+          }
+          replayChangelog(versionsAndUniqueIds)
+          loadedVersion = versionToLoad
+        }
+
+        loadedSnapshotUniqueId = uniqueId
+      }
+
+      override protected def onLoadSnapshotFromCheckpointFailure(): Unit = {
+        loadedVersion = -1
+      }
+
+      override protected def getEligibleSnapshots(version: Long): Seq[Long] = {
+        val snapshotsInLineage =
+          fileManager.getSnapshotVersionsAndUniqueIdsFromLineage(currVersionLineage)
+        eligibleSnapshotUniqueIds.clear()
+        snapshotsInLineage.foreach { case (ver, id) =>
+          eligibleSnapshotUniqueIds.put(ver, id)
+        }
+        snapshotsInLineage.map(_._1)
+      }
+    }
+
+    val (version, autoRepairCompleted) = snapshotLoader.loadSnapshot(versionToLoad)
+    performedSnapshotAutoRepair = autoRepairCompleted
+    (version, loadedSnapshotUniqueId, autoRepairCompleted)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -492,6 +492,13 @@ class RocksDB(
 
         // Build initial lineage for version > 0. Version 0 is the empty initial state
         // with no checkpoint files, so lineage stays empty.
+        if (version == 0) {
+          assert(stateStoreCkptId.isEmpty,
+            "stateStoreCkptId should be empty when version is zero")
+          // Clear stale lineage from a previous session so that
+          // loadSnapshotWithCheckpointId only considers version 0 (empty state).
+          currVersionLineage = Array.empty
+        }
         if (version > 0) {
           // If the exact snapshot file exists on DFS, use a sparse lineage (just the
           // target version) as an optimization to skip reading the changelog header.
@@ -508,7 +515,8 @@ class RocksDB(
 
         // Delegate to AutoSnapshotLoader which handles both the happy path
         // and auto-repair fallback to older snapshots.
-        loadSnapshotWithCheckpointId(version, stateStoreCkptId, currVersionLineage)
+        currVersionLineage =
+          loadSnapshotWithCheckpointId(version, stateStoreCkptId, currVersionLineage)
         loadedFromDfs = version > 0
         lineageManager.resetLineage(currVersionLineage)
         // After changelog replay the numKeysOnWritingVersion will be updated to
@@ -696,11 +704,13 @@ class RocksDB(
    * @param stateStoreCkptId The checkpoint ID for the target version (for lineage enrichment)
    * @param initialLineage The lineage for the target version (may be enriched by
    *                       getEligibleSnapshotsForRepair during auto-repair)
+   * @return The (potentially enriched) lineage after loading. During auto-repair,
+   *         this may contain more entries than the initial sparse lineage.
    */
   private def loadSnapshotWithCheckpointId(
       versionToLoad: Long,
       stateStoreCkptId: Option[String],
-      initialLineage: Array[LineageItem]): Unit = {
+      initialLineage: Array[LineageItem]): Array[LineageItem] = {
     // Local var so that beforeRepair can enrich the lineage and getEligibleSnapshots
     // (re-called after beforeRepair) sees the updated lineage.
     var currVersionLineage = initialLineage
@@ -713,7 +723,6 @@ class RocksDB(
     // Side-channel map: version -> uniqueId, populated by getEligibleSnapshots,
     // consumed by loadSnapshotFromCheckpoint
     val eligibleSnapshotUniqueIds = mutable.Map[Long, String]()
-    var loadedSnapshotUniqueId: Option[String] = None
 
     val snapshotLoader = new AutoSnapshotLoader(
       allowAutoSnapshotRepair,
@@ -728,7 +737,7 @@ class RocksDB(
           workingDir, rocksDBFileMapping, uniqueId)
 
         loadedVersion = snapshotVersion
-        fileManager.setMaxSeenVersion(snapshotVersion)
+        fileManager.setMaxSeenVersion(versionToLoad)
         openLocalRocksDB(remoteMetaData)
         lastSnapshotVersion = snapshotVersion
         reportSnapshotUploadToCoordinator(snapshotVersion)
@@ -743,7 +752,6 @@ class RocksDB(
           loadedVersion = versionToLoad
         }
 
-        loadedSnapshotUniqueId = uniqueId
       }
 
       override protected def onLoadSnapshotFromCheckpointFailure(): Unit = {
@@ -769,7 +777,10 @@ class RocksDB(
           try {
             currVersionLineage = getFullLineage(1, versionToLoad, stateStoreCkptId)
           } catch {
-            case NonFatal(_) => // keep existing lineage; may limit fallback options
+            case NonFatal(e) =>
+              logWarning(log"Failed to enrich lineage via getFullLineage during " +
+                log"auto-repair for version ${MDC(LogKeys.VERSION_NUM, versionToLoad)}. " +
+                log"Falling back to existing lineage; repair options may be limited.", e)
           }
         }
         // Re-discover eligible snapshots from the (potentially enriched) lineage
@@ -779,6 +790,7 @@ class RocksDB(
 
     val (_, autoRepairCompleted) = snapshotLoader.loadSnapshot(versionToLoad)
     performedSnapshotAutoRepair = autoRepairCompleted
+    currVersionLineage
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -490,20 +490,24 @@ class RocksDB(
         // Handle normal checkpoint loading
         closeDB(ignoreException = false)
 
-        // Build initial lineage for version > 0. Version 0 is the empty initial state
-        // with no checkpoint files, so lineage stays empty.
         if (version == 0) {
+          // Version 0 is the empty initial state — load directly without
+          // DFS listing or auto-repair overhead.
           assert(stateStoreCkptId.isEmpty,
             "stateStoreCkptId should be empty when version is zero")
-          // Clear stale lineage from a previous session so that
-          // loadSnapshotWithCheckpointId only considers version 0 (empty state).
           currVersionLineage = Array.empty
-        }
-        if (version > 0) {
-          // If the exact snapshot file exists on DFS, use a sparse lineage (just the
-          // target version) as an optimization to skip reading the changelog header.
-          // If auto-repair is needed later, getEligibleSnapshotsForRepair() will
-          // enrich this to the full lineage via getFullLineage().
+          val metadata = fileManager.loadCheckpointFromDfs(0,
+            workingDir, rocksDBFileMapping, None)
+          loadedVersion = 0
+          lastSnapshotVersion = 0
+          fileManager.setMaxSeenVersion(0)
+          openLocalRocksDB(metadata)
+          reportSnapshotUploadToCoordinator(0)
+        } else {
+          // Build initial lineage. If the exact snapshot file exists on DFS, use a
+          // sparse lineage (just the target version) as an optimization to skip reading
+          // the changelog header. If auto-repair is needed later,
+          // getEligibleSnapshotsForRepair() will enrich this via getFullLineage().
           if (fileManager.existsSnapshotFile(version, stateStoreCkptId)) {
             currVersionLineage = Array(LineageItem(version, stateStoreCkptId.get))
           } else {
@@ -511,12 +515,11 @@ class RocksDB(
               LineageItem(version, stateStoreCkptId.get)
             currVersionLineage = currVersionLineage.sortBy(_.version)
           }
+          // Delegate to AutoSnapshotLoader which handles both the happy path
+          // and auto-repair fallback to older snapshots.
+          currVersionLineage =
+            loadSnapshotWithCheckpointId(version, stateStoreCkptId, currVersionLineage)
         }
-
-        // Delegate to AutoSnapshotLoader which handles both the happy path
-        // and auto-repair fallback to older snapshots.
-        currVersionLineage =
-          loadSnapshotWithCheckpointId(version, stateStoreCkptId, currVersionLineage)
         loadedFromDfs = version > 0
         lineageManager.resetLineage(currVersionLineage)
         // After changelog replay the numKeysOnWritingVersion will be updated to
@@ -704,16 +707,17 @@ class RocksDB(
    * @param stateStoreCkptId The checkpoint ID for the target version (for lineage enrichment)
    * @param initialLineage The lineage for the target version (may be enriched by
    *                       getEligibleSnapshotsForRepair during auto-repair)
-   * @return The (potentially enriched) lineage after loading. During auto-repair,
+   * @return The lineage array to assign to currVersionLineage. During auto-repair,
    *         this may contain more entries than the initial sparse lineage.
    */
   private def loadSnapshotWithCheckpointId(
       versionToLoad: Long,
       stateStoreCkptId: Option[String],
       initialLineage: Array[LineageItem]): Array[LineageItem] = {
-    // Local var so that beforeRepair can enrich the lineage and getEligibleSnapshots
-    // (re-called after beforeRepair) sees the updated lineage.
-    var currVersionLineage = initialLineage
+    // Local var (intentionally named differently from the class field currVersionLineage)
+    // so that getEligibleSnapshotsForRepair can enrich the lineage and getEligibleSnapshots
+    // (re-called after enrichment) sees the updated lineage.
+    var workingLineage = initialLineage
     val allowAutoSnapshotRepair = if (enableChangelogCheckpointing) {
       conf.stateStoreConf.autoSnapshotRepairEnabled
     } else {
@@ -721,7 +725,9 @@ class RocksDB(
     }
 
     // Side-channel map: version -> uniqueId, populated by getEligibleSnapshots,
-    // consumed by loadSnapshotFromCheckpoint
+    // consumed by loadSnapshotFromCheckpoint. These two methods are tightly coupled:
+    // getEligibleSnapshots must always be called before loadSnapshotFromCheckpoint
+    // for a given snapshot version to ensure the uniqueId is available.
     val eligibleSnapshotUniqueIds = mutable.Map[Long, String]()
 
     val snapshotLoader = new AutoSnapshotLoader(
@@ -744,7 +750,7 @@ class RocksDB(
 
         // Replay changelogs from snapshot to target version
         if (snapshotVersion != versionToLoad) {
-          val versionsAndUniqueIds = currVersionLineage.collect {
+          val versionsAndUniqueIds = workingLineage.collect {
             case i if i.version > snapshotVersion && i.version <= versionToLoad =>
               (i.version, Option(i.checkpointUniqueId))
           }
@@ -760,7 +766,7 @@ class RocksDB(
 
       override protected def getEligibleSnapshots(version: Long): Seq[Long] = {
         val snapshotsInLineage =
-          fileManager.getSnapshotVersionsAndUniqueIdsFromLineage(currVersionLineage)
+          fileManager.getSnapshotVersionsAndUniqueIdsFromLineage(workingLineage)
         eligibleSnapshotUniqueIds.clear()
         snapshotsInLineage.foreach { case (ver, id) =>
           eligibleSnapshotUniqueIds.put(ver, id)
@@ -775,7 +781,7 @@ class RocksDB(
         // changelog file headers to reconstruct the complete chain.
         if (stateStoreCkptId.isDefined) {
           try {
-            currVersionLineage = getFullLineage(1, versionToLoad, stateStoreCkptId)
+            workingLineage = getFullLineage(1, versionToLoad, stateStoreCkptId)
           } catch {
             case NonFatal(e) =>
               logWarning(log"Failed to enrich lineage via getFullLineage during " +
@@ -790,7 +796,7 @@ class RocksDB(
 
     val (_, autoRepairCompleted) = snapshotLoader.loadSnapshot(versionToLoad)
     performedSnapshotAutoRepair = autoRepairCompleted
-    currVersionLineage
+    workingLineage
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -688,6 +688,10 @@ class RocksDB(
       override protected def getEligibleSnapshots(version: Long): Seq[Long] = {
         fileManager.getEligibleSnapshotsForVersion(version)
       }
+
+      override protected def getEligibleSnapshotsForRepair(version: Long): Seq[Long] = {
+        getEligibleSnapshots(version)
+      }
     }
 
     val (version, autoRepairCompleted) = snapshotLoader.loadSnapshot(versionToLoad)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -662,7 +662,8 @@ class RocksDB(
       loggingId) {
       override protected def beforeLoad(): Unit = closeDB(ignoreException = false)
 
-      override protected def loadSnapshotFromCheckpoint(snapshotVersion: Long): Unit = {
+      override protected def loadSnapshotFromCheckpoint(
+          snapshotVersion: Long, uniqueId: Option[String]): Unit = {
         val remoteMetaData = fileManager.loadCheckpointFromDfs(snapshotVersion,
           workingDir, rocksDBFileMapping)
 
@@ -685,12 +686,9 @@ class RocksDB(
         loadedVersion = -1  // invalidate loaded data
       }
 
-      override protected def getEligibleSnapshots(version: Long): Seq[Long] = {
-        fileManager.getEligibleSnapshotsForVersion(version)
-      }
-
-      override protected def getEligibleSnapshotsForRepair(version: Long): Seq[Long] = {
-        getEligibleSnapshots(version)
+      override protected def getEligibleSnapshots(
+          version: Long): Seq[(Long, Option[String])] = {
+        fileManager.getEligibleSnapshotsForVersion(version).map((_, None))
       }
     }
 
@@ -702,15 +700,13 @@ class RocksDB(
   /**
    * V2-aware snapshot loading with auto-repair support.
    * Uses lineage to discover eligible snapshots and falls back to older ones if corrupt.
-   * Changelog replay is included inside the load callback so that corrupt changelogs
-   * also trigger fallback to the next older snapshot.
    *
    * Sets [[performedSnapshotAutoRepair]] as a side effect if auto-repair was used.
    *
    * @param versionToLoad The target version to load
    * @param stateStoreCkptId The checkpoint ID for the target version (for lineage enrichment)
    * @param initialLineage The lineage for the target version (may be enriched by
-   *                       getEligibleSnapshotsForRepair during auto-repair)
+   *                       getAdditionalEligibleSnapshots during auto-repair)
    * @return The lineage array to assign to currVersionLineage. During auto-repair,
    *         this may contain more entries than the initial sparse lineage.
    */
@@ -719,20 +715,14 @@ class RocksDB(
       stateStoreCkptId: Option[String],
       initialLineage: Array[LineageItem]): Array[LineageItem] = {
     // Local var (intentionally named differently from the class field currVersionLineage)
-    // so that getEligibleSnapshotsForRepair can enrich the lineage and getEligibleSnapshots
-    // (re-called after enrichment) sees the updated lineage.
+    // so that getAdditionalEligibleSnapshots can enrich the lineage and
+    // getEligibleSnapshots (re-called after enrichment) sees the updated lineage.
     var workingLineage = initialLineage
     val allowAutoSnapshotRepair = if (enableChangelogCheckpointing) {
       conf.stateStoreConf.autoSnapshotRepairEnabled
     } else {
       false
     }
-
-    // Side-channel map: version -> uniqueId, populated by getEligibleSnapshots,
-    // consumed by loadSnapshotFromCheckpoint. These two methods are tightly coupled:
-    // getEligibleSnapshots must always be called before loadSnapshotFromCheckpoint
-    // for a given snapshot version to ensure the uniqueId is available.
-    val eligibleSnapshotUniqueIds = mutable.Map[Long, String]()
 
     val snapshotLoader = new AutoSnapshotLoader(
       allowAutoSnapshotRepair,
@@ -741,8 +731,26 @@ class RocksDB(
       loggingId) {
       override protected def beforeLoad(): Unit = closeDB(ignoreException = false)
 
-      override protected def loadSnapshotFromCheckpoint(snapshotVersion: Long): Unit = {
-        val uniqueId = eligibleSnapshotUniqueIds.get(snapshotVersion)
+      override protected def loadSnapshotFromCheckpoint(
+          snapshotVersion: Long, uniqueId: Option[String]): Unit = {
+        // Validate that the working lineage covers all versions needed to replay
+        // from this snapshot to versionToLoad. If not, throw so AutoSnapshotLoader
+        // treats this as a snapshot load failure and tries the next snapshot.
+        // This guards against falling back to a snapshot (e.g., version 0) when
+        // the lineage was not enriched (e.g., getFullLineage failed).
+        if (snapshotVersion != versionToLoad) {
+          val neededVersions = ((snapshotVersion + 1) to versionToLoad).toSet
+          val availableVersions = workingLineage.collect {
+            case i if i.version > snapshotVersion && i.version <= versionToLoad => i.version
+          }.toSet
+          if (availableVersions != neededVersions) {
+            throw new IllegalStateException(
+              s"Cannot replay changelogs from snapshot $snapshotVersion to $versionToLoad: " +
+              s"lineage is incomplete, missing versions " +
+              s"${(neededVersions diff availableVersions).toSeq.sorted.mkString(",")}")
+          }
+        }
+
         val remoteMetaData = fileManager.loadCheckpointFromDfs(snapshotVersion,
           workingDir, rocksDBFileMapping, uniqueId)
 
@@ -751,41 +759,29 @@ class RocksDB(
         openLocalRocksDB(remoteMetaData)
         lastSnapshotVersion = snapshotVersion
         reportSnapshotUploadToCoordinator(snapshotVersion)
-
-        // Replay changelogs from snapshot to target version
-        if (snapshotVersion != versionToLoad) {
-          val versionsAndUniqueIds = workingLineage.collect {
-            case i if i.version > snapshotVersion && i.version <= versionToLoad =>
-              (i.version, Option(i.checkpointUniqueId))
-          }
-          replayChangelog(versionsAndUniqueIds)
-          loadedVersion = versionToLoad
-        }
-
       }
 
       override protected def onLoadSnapshotFromCheckpointFailure(): Unit = {
         loadedVersion = -1
       }
 
-      override protected def getEligibleSnapshots(version: Long): Seq[Long] = {
-        val snapshotsInLineage =
-          fileManager.getSnapshotVersionsAndUniqueIdsFromLineage(workingLineage)
-        eligibleSnapshotUniqueIds.clear()
-        snapshotsInLineage.foreach { case (ver, id) =>
-          eligibleSnapshotUniqueIds.put(ver, id)
-        }
-        snapshotsInLineage.map(_._1)
+      override protected def getEligibleSnapshots(
+          version: Long): Seq[(Long, Option[String])] = {
+        fileManager.getSnapshotVersionsAndUniqueIdsFromLineage(workingLineage)
+          .map { case (ver, id) => (ver, Option(id)) }
       }
 
-      override protected def getEligibleSnapshotsForRepair(version: Long): Seq[Long] = {
-        // Build the full lineage from version 1 to the target version so that
-        // auto-repair can fall back to any snapshot (including version 0 with
-        // full changelog replay). getFullLineage walks backward through
-        // changelog file headers to reconstruct the complete chain.
+      override protected def getAdditionalEligibleSnapshots(
+          version: Long): Seq[(Long, Option[String])] = {
+        // Build lineage back to (versionToLoad - maxChangeFileReplay) so that
+        // auto-repair can discover older snapshots in the lineage. We don't walk
+        // all the way to version 1 since snapshots beyond maxChangeFileReplay
+        // would be filtered out anyway.
         if (stateStoreCkptId.isDefined) {
           try {
-            workingLineage = getFullLineage(1, versionToLoad, stateStoreCkptId)
+            val startVer = math.max(1L,
+              versionToLoad - conf.stateStoreConf.autoSnapshotRepairMaxChangeFileReplay)
+            workingLineage = getFullLineage(startVer, versionToLoad, stateStoreCkptId)
           } catch {
             case NonFatal(e) =>
               logWarning(log"Failed to enrich lineage via getFullLineage during " +
@@ -798,8 +794,19 @@ class RocksDB(
       }
     }
 
-    val (_, autoRepairCompleted) = snapshotLoader.loadSnapshot(versionToLoad)
+    val (snapshotVersion, autoRepairCompleted) = snapshotLoader.loadSnapshot(versionToLoad)
     performedSnapshotAutoRepair = autoRepairCompleted
+
+    // Replay changelogs from loaded snapshot to target version
+    if (snapshotVersion != versionToLoad) {
+      val versionsAndUniqueIds = workingLineage.collect {
+        case i if i.version > snapshotVersion && i.version <= versionToLoad =>
+          (i.version, Option(i.checkpointUniqueId))
+      }
+      replayChangelog(versionsAndUniqueIds)
+      loadedVersion = versionToLoad
+    }
+
     workingLineage
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -516,9 +516,20 @@ class RocksDB(
             currVersionLineage = currVersionLineage.sortBy(_.version)
           }
           // Delegate to AutoSnapshotLoader which handles both the happy path
-          // and auto-repair fallback to older snapshots.
+          // and auto-repair fallback to older snapshots. Sets loadedVersion to
+          // the actually loaded snapshot version as a side effect.
           currVersionLineage =
             loadSnapshotWithCheckpointId(version, stateStoreCkptId, currVersionLineage)
+
+          // Replay changelogs from the loaded snapshot version to the target version.
+          if (loadedVersion != version) {
+            val versionsAndUniqueIds = currVersionLineage.collect {
+              case i if i.version > loadedVersion && i.version <= version =>
+                (i.version, Option(i.checkpointUniqueId))
+            }
+            replayChangelog(versionsAndUniqueIds)
+            loadedVersion = version
+          }
         }
         loadedFromDfs = version > 0
         lineageManager.resetLineage(currVersionLineage)
@@ -647,14 +658,20 @@ class RocksDB(
     this
   }
 
-  private def loadSnapshotWithoutCheckpointId(versionToLoad: Long): Long = {
-    // Don't allow auto snapshot repair if changelog checkpointing is not enabled
-    // since it relies on changelog to rebuild state.
-    val allowAutoSnapshotRepair = if (enableChangelogCheckpointing) {
+  /**
+   * Whether auto snapshot repair is allowed. Repair is only allowed when
+   * changelog checkpointing is enabled, since repair relies on replaying
+   * changelogs to rebuild state from an older snapshot.
+   */
+  private def allowAutoSnapshotRepair: Boolean = {
+    if (enableChangelogCheckpointing) {
       conf.stateStoreConf.autoSnapshotRepairEnabled
     } else {
       false
     }
+  }
+
+  private def loadSnapshotWithoutCheckpointId(versionToLoad: Long): Long = {
     val snapshotLoader = new AutoSnapshotLoader(
       allowAutoSnapshotRepair,
       conf.stateStoreConf.autoSnapshotRepairNumFailuresBeforeActivating,
@@ -700,8 +717,11 @@ class RocksDB(
   /**
    * V2-aware snapshot loading with auto-repair support.
    * Uses lineage to discover eligible snapshots and falls back to older ones if corrupt.
+   * Loads only the snapshot; changelog replay to reach versionToLoad is the caller's
+   * responsibility.
    *
-   * Sets [[performedSnapshotAutoRepair]] as a side effect if auto-repair was used.
+   * Sets [[performedSnapshotAutoRepair]] as a side effect if auto-repair was used,
+   * and sets [[loadedVersion]] to the actually loaded snapshot version.
    *
    * @param versionToLoad The target version to load
    * @param stateStoreCkptId The checkpoint ID for the target version (for lineage enrichment)
@@ -718,11 +738,6 @@ class RocksDB(
     // so that getAdditionalEligibleSnapshots can enrich the lineage and
     // getEligibleSnapshots (re-called after enrichment) sees the updated lineage.
     var workingLineage = initialLineage
-    val allowAutoSnapshotRepair = if (enableChangelogCheckpointing) {
-      conf.stateStoreConf.autoSnapshotRepairEnabled
-    } else {
-      false
-    }
 
     val snapshotLoader = new AutoSnapshotLoader(
       allowAutoSnapshotRepair,
@@ -794,19 +809,8 @@ class RocksDB(
       }
     }
 
-    val (snapshotVersion, autoRepairCompleted) = snapshotLoader.loadSnapshot(versionToLoad)
+    val (_, autoRepairCompleted) = snapshotLoader.loadSnapshot(versionToLoad)
     performedSnapshotAutoRepair = autoRepairCompleted
-
-    // Replay changelogs from loaded snapshot to target version
-    if (snapshotVersion != versionToLoad) {
-      val versionsAndUniqueIds = workingLineage.collect {
-        case i if i.version > snapshotVersion && i.version <= versionToLoad =>
-          (i.version, Option(i.checkpointUniqueId))
-      }
-      replayChangelog(versionsAndUniqueIds)
-      loadedVersion = versionToLoad
-    }
-
     workingLineage
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -455,14 +455,14 @@ class RocksDBFileManager(
   /**
    * Based on the ground truth lineage loaded from changelog file (lineage), this function
    * does file listing to find all snapshot (version, uniqueId) pairs, and finds
-   * the ground truth latest snapshot (version, uniqueId) the db instance needs to load.
+   * all snapshots that match the lineage, sorted by version descending.
    *
    * @param lineage The ground truth lineage loaded from changelog file, sorted by id
-   * @return The ground truth latest snapshot (version, uniqueId) the db instance needs to load,
-   *         when the return value is None it means ther is no such snapshot found.
+   * @return All snapshot (version, uniqueId) pairs matching the lineage, sorted descending
+   *         by version. Empty if no matching snapshots found.
    */
-  def getLatestSnapshotVersionAndUniqueIdFromLineage(
-      lineage: Array[LineageItem]): Option[(Long, String)] = {
+  def getSnapshotVersionsAndUniqueIdsFromLineage(
+      lineage: Array[LineageItem]): Seq[(Long, String)] = {
     val path = new Path(dfsRootDir)
     if (fm.exists(path)) {
       fm.list(path, onlyZipFiles)
@@ -473,10 +473,24 @@ class RocksDBFileManager(
         }
         .sortBy(_._1)
         .reverse
-        .headOption
+        .toSeq
     } else {
-      None
+      Seq.empty
     }
+  }
+
+  /**
+   * Based on the ground truth lineage loaded from changelog file (lineage), this function
+   * does file listing to find all snapshot (version, uniqueId) pairs, and finds
+   * the ground truth latest snapshot (version, uniqueId) the db instance needs to load.
+   *
+   * @param lineage The ground truth lineage loaded from changelog file, sorted by id
+   * @return The ground truth latest snapshot (version, uniqueId) the db instance needs to load,
+   *         when the return value is None it means ther is no such snapshot found.
+   */
+  def getLatestSnapshotVersionAndUniqueIdFromLineage(
+      lineage: Array[LineageItem]): Option[(Long, String)] = {
+    getSnapshotVersionsAndUniqueIdsFromLineage(lineage).headOption
   }
 
   /** Get the latest version available in the DFS directory. If no data present, it returns 0. */

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/AutoSnapshotLoaderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/AutoSnapshotLoaderSuite.scala
@@ -171,6 +171,9 @@ class TestAutoSnapshotLoader(
   override protected def onLoadSnapshotFromCheckpointFailure(): Unit = {}
 
   override protected def getEligibleSnapshots(versionToLoad: Long): Seq[Long] = eligibleSnapshots
+
+  override protected def getEligibleSnapshotsForRepair(versionToLoad: Long): Seq[Long] =
+    getEligibleSnapshots(versionToLoad)
 }
 
 class TestLoadException(val snapshotVersion: Long)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/AutoSnapshotLoaderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/AutoSnapshotLoaderSuite.scala
@@ -158,7 +158,8 @@ class TestAutoSnapshotLoader(
 
   override protected def beforeLoad(): Unit = {}
 
-  override protected def loadSnapshotFromCheckpoint(snapshotVersion: Long): Unit = {
+  override protected def loadSnapshotFromCheckpoint(
+      snapshotVersion: Long, uniqueId: Option[String]): Unit = {
     // Track the snapshot version
     requestedSnapshotVersions += snapshotVersion
 
@@ -170,10 +171,8 @@ class TestAutoSnapshotLoader(
 
   override protected def onLoadSnapshotFromCheckpointFailure(): Unit = {}
 
-  override protected def getEligibleSnapshots(versionToLoad: Long): Seq[Long] = eligibleSnapshots
-
-  override protected def getEligibleSnapshotsForRepair(versionToLoad: Long): Seq[Long] =
-    getEligibleSnapshots(versionToLoad)
+  override protected def getEligibleSnapshots(
+      versionToLoad: Long): Seq[(Long, Option[String])] = eligibleSnapshots.map((_, None))
 }
 
 class TestLoadException(val snapshotVersion: Long)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -4256,6 +4256,275 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
     }
   }
 
+  testWithChangelogCheckpointingEnabled(
+      "V2 auto-repair respects maxChangeFileReplay limit") {
+    withSQLConf(
+      SQLConf.STREAMING_CHECKPOINT_FILE_CHECKSUM_ENABLED.key -> false.toString,
+      SQLConf.STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT.key -> "2",
+      SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_ENABLED.key -> true.toString,
+      SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_NUM_FAILURES_BEFORE_ACTIVATING.key -> "1"
+    ) {
+      withTempDir { dir =>
+        val remoteDir = dir.getCanonicalPath
+        val versionToUniqueId = mutable.Map[Long, String]()
+
+        // Build 6 versions with snapshots at 2, 4, and 6
+        withDB(remoteDir, enableStateStoreCheckpointIds = true,
+            versionToUniqueId = versionToUniqueId) { db =>
+          for (i <- 0 until 6) {
+            db.load(i)
+            db.put(s"k$i", s"v$i")
+            db.commit()
+            if (i > 0 && i % 2 == 1) db.doMaintenance() // snapshots at 2, 4, 6
+          }
+        }
+
+        def corruptFile(file: File): Unit =
+          new PrintWriter(file) { close() }
+
+        // Corrupt snapshots at version 6 and 4
+        val uuid6 = versionToUniqueId(6)
+        val uuid4 = versionToUniqueId(4)
+        corruptFile(new File(remoteDir, s"6_${uuid6}.zip"))
+        corruptFile(new File(remoteDir, s"4_${uuid4}.zip"))
+
+        // With maxChangeFileReplay=2, snapshot 2 (4 changelogs away) should be
+        // skipped, and version 0 (6 changelogs away) should also be skipped.
+        // Auto-repair should fail since no eligible snapshot is within range.
+        withSQLConf(
+          SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_MAX_CHANGE_FILE_REPLAY.key -> "2"
+        ) {
+          withDB(remoteDir, enableStateStoreCheckpointIds = true,
+              versionToUniqueId = versionToUniqueId) { db =>
+            intercept[StateStoreAutoSnapshotRepairFailed] {
+              db.load(6)
+            }
+          }
+        }
+
+        // With maxChangeFileReplay=5, snapshot 2 (4 changelogs away) should be
+        // eligible and auto-repair should succeed.
+        withSQLConf(
+          SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_MAX_CHANGE_FILE_REPLAY.key -> "5"
+        ) {
+          withDB(remoteDir, enableStateStoreCheckpointIds = true,
+              versionToUniqueId = versionToUniqueId) { db =>
+            db.load(6)
+            for (i <- 0 until 6) {
+              assert(toStr(db.get(s"k$i")) == s"v$i")
+            }
+            db.commit()
+            assert(db.metricsOpt.get.numSnapshotsAutoRepaired == 1)
+          }
+        }
+      }
+    }
+  }
+
+  testWithChangelogCheckpointingEnabled(
+      "V2 auto-repair followed by commit produces valid state for subsequent loads") {
+    withSQLConf(
+      SQLConf.STREAMING_CHECKPOINT_FILE_CHECKSUM_ENABLED.key -> false.toString,
+      SQLConf.STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT.key -> "2",
+      SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_ENABLED.key -> true.toString,
+      SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_NUM_FAILURES_BEFORE_ACTIVATING.key -> "1",
+      SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_MAX_CHANGE_FILE_REPLAY.key -> "5"
+    ) {
+      withTempDir { dir =>
+        val remoteDir = dir.getCanonicalPath
+        val versionToUniqueId = mutable.Map[Long, String]()
+
+        // Build 4 versions with snapshots at 2 and 4
+        withDB(remoteDir, enableStateStoreCheckpointIds = true,
+            versionToUniqueId = versionToUniqueId) { db =>
+          db.load(0)
+          db.put("a", "0")
+          db.commit()
+
+          db.load(1)
+          db.put("b", "1")
+          db.commit()
+          db.doMaintenance() // snapshot at 2
+
+          db.load(2)
+          db.put("c", "2")
+          db.commit()
+
+          db.load(3)
+          db.put("d", "3")
+          db.commit()
+          db.doMaintenance() // snapshot at 4
+        }
+
+        def corruptFile(file: File): Unit =
+          new PrintWriter(file) { close() }
+
+        // Corrupt snapshot at version 4
+        val uuid4 = versionToUniqueId(4)
+        corruptFile(new File(remoteDir, s"4_${uuid4}.zip"))
+
+        // Auto-repair loads version 4 from snapshot 2 + replay, then commit version 5
+        withDB(remoteDir, enableStateStoreCheckpointIds = true,
+            versionToUniqueId = versionToUniqueId) { db =>
+          db.load(4)
+          assert(toStr(db.get("d")) == "3")
+          db.put("e", "4")
+          db.commit()
+          assert(db.metricsOpt.get.numSnapshotsAutoRepaired == 1)
+          db.doMaintenance() // upload snapshot at version 5
+        }
+
+        // Reload version 5 in a fresh DB instance - verifies the lineage chain is intact
+        withDB(remoteDir, enableStateStoreCheckpointIds = true,
+            versionToUniqueId = versionToUniqueId) { db =>
+          db.load(5)
+          assert(toStr(db.get("a")) == "0")
+          assert(toStr(db.get("b")) == "1")
+          assert(toStr(db.get("c")) == "2")
+          assert(toStr(db.get("d")) == "3")
+          assert(toStr(db.get("e")) == "4")
+
+          // Commit another version to verify the chain continues
+          db.put("f", "5")
+          db.commit()
+          assert(db.metricsOpt.get.numSnapshotsAutoRepaired == 0)
+        }
+
+        // Reload version 6 to verify continued integrity
+        withDB(remoteDir, enableStateStoreCheckpointIds = true,
+            versionToUniqueId = versionToUniqueId) { db =>
+          db.load(6)
+          assert(toStr(db.get("f")) == "5")
+          db.commit()
+          assert(db.metricsOpt.get.numSnapshotsAutoRepaired == 0)
+        }
+      }
+    }
+  }
+
+  testWithChangelogCheckpointingEnabled(
+      "V2 auto-repair with no snapshots falls back to version 0 + full replay") {
+    withSQLConf(
+      SQLConf.STREAMING_CHECKPOINT_FILE_CHECKSUM_ENABLED.key -> false.toString,
+      // Set very high so no snapshots are ever created
+      SQLConf.STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT.key -> "100",
+      SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_ENABLED.key -> true.toString,
+      SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_NUM_FAILURES_BEFORE_ACTIVATING.key -> "1",
+      SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_MAX_CHANGE_FILE_REPLAY.key -> "10"
+    ) {
+      withTempDir { dir =>
+        val remoteDir = dir.getCanonicalPath
+        val versionToUniqueId = mutable.Map[Long, String]()
+
+        // Build 4 versions with only changelogs (no snapshots due to high minDeltas)
+        withDB(remoteDir, enableStateStoreCheckpointIds = true,
+            versionToUniqueId = versionToUniqueId) { db =>
+          for (i <- 0 until 4) {
+            db.load(i)
+            db.put(s"k$i", s"v$i")
+            db.commit()
+            db.doMaintenance() // no snapshot will be uploaded
+          }
+        }
+
+        // Verify no snapshot files exist
+        val snapshotFiles = dir.listFiles().filter(_.getName.endsWith(".zip"))
+        assert(snapshotFiles.isEmpty, "Expected no snapshot files")
+
+        // Loading should succeed via version 0 + full changelog replay.
+        // getEligibleSnapshots returns empty (no snapshots in lineage),
+        // AutoSnapshotLoader appends 0L, so we load version 0 and replay all changelogs.
+        withDB(remoteDir, enableStateStoreCheckpointIds = true,
+            versionToUniqueId = versionToUniqueId) { db =>
+          db.load(4)
+          for (i <- 0 until 4) {
+            assert(toStr(db.get(s"k$i")) == s"v$i")
+          }
+          db.commit()
+          // No auto-repair since version 0 is the first eligible and succeeds
+          assert(db.metricsOpt.get.numSnapshotsAutoRepaired == 0)
+        }
+      }
+    }
+  }
+
+  testWithChangelogCheckpointingEnabled(
+      "V2 auto-repair with getFullLineage failure falls back using sparse lineage") {
+    withSQLConf(
+      SQLConf.STREAMING_CHECKPOINT_FILE_CHECKSUM_ENABLED.key -> false.toString,
+      SQLConf.STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT.key -> "2",
+      SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_ENABLED.key -> true.toString,
+      SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_NUM_FAILURES_BEFORE_ACTIVATING.key -> "1",
+      SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_MAX_CHANGE_FILE_REPLAY.key -> "10"
+    ) {
+      withTempDir { dir =>
+        val remoteDir = dir.getCanonicalPath
+        val versionToUniqueId = mutable.Map[Long, String]()
+
+        // Build 4 versions with snapshots at 2 and 4
+        withDB(remoteDir, enableStateStoreCheckpointIds = true,
+            versionToUniqueId = versionToUniqueId) { db =>
+          db.load(0)
+          db.put("a", "0")
+          db.commit()
+
+          db.load(1)
+          db.put("b", "1")
+          db.commit()
+          db.doMaintenance() // snapshot at 2
+
+          db.load(2)
+          db.put("c", "2")
+          db.commit()
+
+          db.load(3)
+          db.put("d", "3")
+          db.commit()
+          db.doMaintenance() // snapshot at 4
+        }
+
+        def corruptFile(file: File): Unit =
+          new PrintWriter(file) { close() }
+
+        // Corrupt snapshot at version 4 (to trigger auto-repair)
+        val uuid4 = versionToUniqueId(4)
+        corruptFile(new File(remoteDir, s"4_${uuid4}.zip"))
+
+        // Also corrupt changelog at version 2 to break getFullLineage's backward walk.
+        // getFullLineage reads changelogs from version 4 backward; corrupting version 2's
+        // changelog means the backward walk will fail. The NonFatal catch should handle
+        // this gracefully and repair using the sparse lineage (just version 4).
+        // With sparse lineage, the only fallback is version 0 + full replay.
+        val uuid2 = versionToUniqueId(2)
+        corruptFile(new File(remoteDir, s"2_${uuid2}.changelog"))
+
+        // Auto-repair should still succeed by catching the getFullLineage failure
+        // and falling back to version 0 + replay from whatever changelogs are available.
+        // Note: version 2's snapshot is still intact, but it's not discoverable
+        // because getFullLineage failed to enrich the sparse lineage.
+        // Version 0 is always available as a fallback. Changelog replay from version 0
+        // uses changelogs 1, 3, 4 (changelog 2 is corrupt but we don't cross it since
+        // version 2's data is already included in changelog 1 and 3's cumulative state).
+        // Actually, replay from version 0 needs ALL changelogs 1-4, so if changelog 2
+        // is corrupt, version 0 fallback also fails. But version 2's snapshot is intact
+        // and if the sparse lineage includes it, we can load from snapshot 2.
+        // Since the sparse lineage only has version 4, and getFullLineage failed,
+        // the only fallback is version 0 + full replay which needs all changelogs.
+        // Changelog 2 is corrupt, so this path also fails.
+        // The test verifies getFullLineage failure is handled gracefully (logged, not thrown).
+        withDB(remoteDir, enableStateStoreCheckpointIds = true,
+            versionToUniqueId = versionToUniqueId) { db =>
+          // All repair paths fail: snapshot 4 corrupt, getFullLineage fails,
+          // sparse lineage only knows version 4, version 0 + full replay fails
+          // because changelog 2 is corrupt.
+          intercept[StateStoreAutoSnapshotRepairFailed] {
+            db.load(4)
+          }
+        }
+      }
+    }
+  }
+
   testWithChangelogCheckpointingEnabled("SPARK-51922 - Changelog writer v1 with large key" +
     " does not cause UTFDataFormatException") {
     val remoteDir = Utils.createTempDir()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -4166,6 +4166,96 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
     }
   }
 
+  testWithChangelogCheckpointingEnabled(
+      "Auto snapshot repair with checkpoint format V2") {
+    withSQLConf(
+      SQLConf.STREAMING_CHECKPOINT_FILE_CHECKSUM_ENABLED.key -> false.toString,
+      SQLConf.STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT.key -> "2"
+    ) {
+      withTempDir { dir =>
+        val remoteDir = dir.getCanonicalPath
+        val versionToUniqueId = mutable.Map[Long, String]()
+
+        // Build up state: 4 versions with snapshots at versions 2 and 4
+        withDB(remoteDir, enableStateStoreCheckpointIds = true,
+            versionToUniqueId = versionToUniqueId) { db =>
+          db.load(0)
+          db.put("a", "0")
+          db.commit()
+          assert(db.metricsOpt.get.numSnapshotsAutoRepaired == 0)
+
+          db.load(1)
+          db.put("b", "1")
+          db.commit() // snapshot is created
+          assert(db.metricsOpt.get.numSnapshotsAutoRepaired == 0)
+          db.doMaintenance() // upload snapshot 2_{uuid}.zip
+
+          db.load(2)
+          db.put("c", "2")
+          db.commit()
+          assert(db.metricsOpt.get.numSnapshotsAutoRepaired == 0)
+
+          db.load(3)
+          db.put("d", "3")
+          db.commit() // snapshot is created
+          assert(db.metricsOpt.get.numSnapshotsAutoRepaired == 0)
+          db.doMaintenance() // upload snapshot 4_{uuid}.zip
+        }
+
+        def corruptFile(file: File): Unit =
+          new PrintWriter(file) { close() }
+
+        // Corrupt the latest V2 snapshot (version 4)
+        val uuid4 = versionToUniqueId(4)
+        corruptFile(new File(remoteDir, s"4_${uuid4}.zip"))
+
+        // Without auto-repair, this should fail
+        withDB(remoteDir, enableStateStoreCheckpointIds = true,
+            versionToUniqueId = versionToUniqueId) { db =>
+          val ex = intercept[java.nio.file.NoSuchFileException] {
+            db.load(4)
+          }
+          assert(ex.getMessage.contains("/metadata"))
+        }
+
+        // With auto-repair enabled, should succeed by falling back to snapshot at version 2
+        withSQLConf(SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_ENABLED.key -> true.toString,
+          SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_NUM_FAILURES_BEFORE_ACTIVATING.key -> "1",
+          SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_MAX_CHANGE_FILE_REPLAY.key -> "5"
+        ) {
+          withDB(remoteDir, enableStateStoreCheckpointIds = true,
+              versionToUniqueId = versionToUniqueId) { db =>
+            db.load(4)
+            assert(toStr(db.get("a")) == "0")
+            assert(toStr(db.get("b")) == "1")
+            assert(toStr(db.get("c")) == "2")
+            assert(toStr(db.get("d")) == "3")
+            db.put("e", "4")
+            db.commit()
+            assert(db.metricsOpt.get.numSnapshotsAutoRepaired == 1)
+            assert(db.metricsOpt.get.loadedFromDfs === 1)
+            db.doMaintenance() // upload new snapshot
+          }
+
+          // Corrupt all V2 snapshot files - should fall back to version 0 + replay
+          val uuid2 = versionToUniqueId(2)
+          val uuid5 = versionToUniqueId(5)
+          corruptFile(new File(remoteDir, s"2_${uuid2}.zip"))
+          corruptFile(new File(remoteDir, s"5_${uuid5}.zip"))
+
+          withDB(remoteDir, enableStateStoreCheckpointIds = true,
+              versionToUniqueId = versionToUniqueId) { db =>
+            db.load(5)
+            assert(toStr(db.get("b")) == "1")
+            db.commit()
+            assert(db.metricsOpt.get.numSnapshotsAutoRepaired == 1)
+            assert(db.metricsOpt.get.loadedFromDfs === 1)
+          }
+        }
+      }
+    }
+  }
+
   testWithChangelogCheckpointingEnabled("SPARK-51922 - Changelog writer v1 with large key" +
     " does not cause UTFDataFormatException") {
     val remoteDir = Utils.createTempDir()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -4214,8 +4214,7 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
         // With auto-repair enabled, should succeed by falling back to snapshot at version 2
         withSQLConf(SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_ENABLED.key -> true.toString,
           SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_NUM_FAILURES_BEFORE_ACTIVATING.key -> "1",
-          SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_MAX_CHANGE_FILE_REPLAY.key -> "5"
-        ) {
+          SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_MAX_CHANGE_FILE_REPLAY.key -> "5") {
           withDB(remoteDir, enableStateStoreCheckpointIds = true,
               versionToUniqueId = versionToUniqueId) { db =>
             db.load(4)
@@ -4255,8 +4254,7 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
       SQLConf.STREAMING_CHECKPOINT_FILE_CHECKSUM_ENABLED.key -> false.toString,
       SQLConf.STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT.key -> "2",
       SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_ENABLED.key -> true.toString,
-      SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_NUM_FAILURES_BEFORE_ACTIVATING.key -> "1"
-    ) {
+      SQLConf.STATE_STORE_AUTO_SNAPSHOT_REPAIR_NUM_FAILURES_BEFORE_ACTIVATING.key -> "1") {
       withTempDir { dir =>
         val remoteDir = dir.getCanonicalPath
         val versionToUniqueId = mutable.Map[Long, String]()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -4480,11 +4480,11 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
         val uuid2 = versionToUniqueId(2)
         corruptFile(new File(remoteDir, s"2_${uuid2}.changelog"))
 
-        // When getFullLineage fails and the sparse lineage has no valid repair path,
-        // auto-repair should fail gracefully with StateStoreAutoSnapshotRepairFailed.
-        // Here: snapshot 4 is corrupt, getFullLineage fails (corrupt changelog 2),
-        // sparse lineage only knows version 4, and version 0 + full replay also fails
-        // because changelog 2 is corrupt.
+        // When getFullLineage fails, we fall back to the sparse lineage which only
+        // contains the target version. The version 0 fallback is rejected by the
+        // lineage-completeness check inside loadSnapshotFromCheckpoint (sparse lineage
+        // doesn't cover versions 1..3), so auto-repair fails with
+        // StateStoreAutoSnapshotRepairFailed.
         withDB(remoteDir, enableStateStoreCheckpointIds = true,
             versionToUniqueId = versionToUniqueId) { db =>
           intercept[StateStoreAutoSnapshotRepairFailed] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -4117,10 +4117,6 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
           db.doMaintenance() // upload snapshot 4.zip
         }
 
-        def corruptFile(file: File): Unit =
-          // overwrite the file content to become empty
-          new PrintWriter(file) { close() }
-
         // corrupt snapshot 4.zip
         corruptFile(new File(remoteDir, "4.zip"))
 
@@ -4202,9 +4198,6 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
           db.doMaintenance() // upload snapshot 4_{uuid}.zip
         }
 
-        def corruptFile(file: File): Unit =
-          new PrintWriter(file) { close() }
-
         // Corrupt the latest V2 snapshot (version 4)
         val uuid4 = versionToUniqueId(4)
         corruptFile(new File(remoteDir, s"4_${uuid4}.zip"))
@@ -4279,9 +4272,6 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
           }
         }
 
-        def corruptFile(file: File): Unit =
-          new PrintWriter(file) { close() }
-
         // Corrupt snapshots at version 6 and 4
         val uuid6 = versionToUniqueId(6)
         val uuid4 = versionToUniqueId(4)
@@ -4355,9 +4345,6 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
           db.commit()
           db.doMaintenance() // snapshot at 4
         }
-
-        def corruptFile(file: File): Unit =
-          new PrintWriter(file) { close() }
 
         // Corrupt snapshot at version 4
         val uuid4 = versionToUniqueId(4)
@@ -4483,9 +4470,6 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
           db.doMaintenance() // snapshot at 4
         }
 
-        def corruptFile(file: File): Unit =
-          new PrintWriter(file) { close() }
-
         // Corrupt snapshot at version 4 (to trigger auto-repair)
         val uuid4 = versionToUniqueId(4)
         corruptFile(new File(remoteDir, s"4_${uuid4}.zip"))
@@ -4498,25 +4482,13 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
         val uuid2 = versionToUniqueId(2)
         corruptFile(new File(remoteDir, s"2_${uuid2}.changelog"))
 
-        // Auto-repair should still succeed by catching the getFullLineage failure
-        // and falling back to version 0 + replay from whatever changelogs are available.
-        // Note: version 2's snapshot is still intact, but it's not discoverable
-        // because getFullLineage failed to enrich the sparse lineage.
-        // Version 0 is always available as a fallback. Changelog replay from version 0
-        // uses changelogs 1, 3, 4 (changelog 2 is corrupt but we don't cross it since
-        // version 2's data is already included in changelog 1 and 3's cumulative state).
-        // Actually, replay from version 0 needs ALL changelogs 1-4, so if changelog 2
-        // is corrupt, version 0 fallback also fails. But version 2's snapshot is intact
-        // and if the sparse lineage includes it, we can load from snapshot 2.
-        // Since the sparse lineage only has version 4, and getFullLineage failed,
-        // the only fallback is version 0 + full replay which needs all changelogs.
-        // Changelog 2 is corrupt, so this path also fails.
-        // The test verifies getFullLineage failure is handled gracefully (logged, not thrown).
+        // When getFullLineage fails and the sparse lineage has no valid repair path,
+        // auto-repair should fail gracefully with StateStoreAutoSnapshotRepairFailed.
+        // Here: snapshot 4 is corrupt, getFullLineage fails (corrupt changelog 2),
+        // sparse lineage only knows version 4, and version 0 + full replay also fails
+        // because changelog 2 is corrupt.
         withDB(remoteDir, enableStateStoreCheckpointIds = true,
             versionToUniqueId = versionToUniqueId) { db =>
-          // All repair paths fail: snapshot 4 corrupt, getFullLineage fails,
-          // sparse lineage only knows version 4, version 0 + full replay fails
-          // because changelog 2 is corrupt.
           intercept[StateStoreAutoSnapshotRepairFailed] {
             db.load(4)
           }
@@ -5093,6 +5065,10 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
   def toStr(kv: ByteArrayPair): (String, String) = (toStr(kv.key), toStr(kv.value))
 
   def iterator(db: RocksDB): Iterator[(String, String)] = db.iterator().map(toStr)
+
+  /** Overwrite a file with empty content to simulate corruption. */
+  def corruptFile(file: File): Unit =
+    new PrintWriter(file) { close() }
 
   def listFiles(file: File): Seq[File] = {
     if (!file.exists()) return Seq.empty


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds auto-repair snapshot support to the checkpoint V2 (state store checkpoint IDs) load path. Previously, auto-repair and V2 were completely disjoint: `loadWithCheckpointId` had no recovery logic for corrupt snapshots, and the auto-repair path (`loadSnapshotWithoutCheckpointId`) only handled V1 files without UUID awareness.

Changes:
- **RocksDBFileManager**: Added `getSnapshotVersionsAndUniqueIdsFromLineage()` which returns all lineage-matching snapshots sorted descending (the V2 equivalent of `getEligibleSnapshotsForVersion`). Refactored `getLatestSnapshotVersionAndUniqueIdFromLineage()` to delegate to it.
- **RocksDB**: Added `loadSnapshotWithCheckpointId()` which uses `AutoSnapshotLoader` with V2-specific callbacks that map version to uniqueId via a side-channel map. Changelog replay is included inside the load callback so corrupt changelogs also trigger fallback to the next older snapshot.
- **RocksDB**: Wrapped the snapshot load + changelog replay block in `loadWithCheckpointId()` with a try-catch that delegates to the new auto-repair method when enabled. Uses `getFullLineage()` to build the complete lineage chain (back to version 1) so that version 0 fallback with full changelog replay works correctly.

### Why are the changes needed?

Without this change, any corrupt or missing snapshot file in V2 mode causes a hard query failure with no recovery path. V1 mode already had auto-repair (falling back to older snapshots and replaying changelogs), but V2's `loadWithCheckpointId` bypassed that entirely. This is especially important because speculative execution can produce orphaned or incomplete snapshot files that V2 is designed to handle, but corruption of the "winning" snapshot had no fallback.

### Does this PR introduce _any_ user-facing change?

No. This is an internal improvement to fault tolerance. Queries using checkpoint V2 that previously would fail on corrupt snapshots will now automatically recover when `autoSnapshotRepair.enabled` is true (the production default).

### How was this patch tested?

Added integration test "Auto snapshot repair with checkpoint format V2" in `RocksDBSuite` covering:
- Single corrupt V2 snapshot: falls back to older snapshot in lineage
- All V2 snapshots corrupt: falls back to version 0 with full changelog replay
- Verified state correctness and `numSnapshotsAutoRepaired` metric after repair

Also verified existing tests pass:
- `AutoSnapshotLoaderSuite` (5/5)
- `RocksDBSuite` V1 auto-repair test
- `RocksDBStateStoreCheckpointFormatV2Suite` (24/24)

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.6)