### PR TITLE
[SPARK-56224][PYTHON] Polish type annotations for accumulators.py

### DIFF
--- a/python/pyspark/accumulators.py
+++ b/python/pyspark/accumulators.py
@@ -28,13 +28,13 @@ from pyspark.errors import PySparkRuntimeError
 
 if TYPE_CHECKING:
     from pyspark._typing import SupportsIAdd
-    import socketserver.BaseRequestHandler  # type: ignore[import-not-found]
+    from socketserver import BaseRequestHandler
 
 
 __all__ = ["Accumulator", "AccumulatorParam"]
 
 T = TypeVar("T")
-U = TypeVar("U", bound="SupportsIAdd")
+U = TypeVar("U", bound=Union["SupportsIAdd", int, float, complex])
 
 pickleSer = CPickleSerializer()
 
@@ -240,14 +240,14 @@ class AddingAccumulatorParam(AccumulatorParam[U]):
         return self.zero_value
 
     def addInPlace(self, value1: U, value2: U) -> U:
-        value1 += value2  # type: ignore[operator]
+        value1 += value2  # type: ignore[operator, assignment]
         return value1
 
 
 # Singleton accumulator params for some standard types
-INT_ACCUMULATOR_PARAM = AddingAccumulatorParam(0)  # type: ignore[type-var]
-FLOAT_ACCUMULATOR_PARAM = AddingAccumulatorParam(0.0)  # type: ignore[type-var]
-COMPLEX_ACCUMULATOR_PARAM = AddingAccumulatorParam(0.0j)  # type: ignore[type-var]
+INT_ACCUMULATOR_PARAM = AddingAccumulatorParam(0)
+FLOAT_ACCUMULATOR_PARAM = AddingAccumulatorParam(0.0)
+COMPLEX_ACCUMULATOR_PARAM = AddingAccumulatorParam(0.0j)
 
 
 class UpdateRequestHandler(socketserver.StreamRequestHandler):
@@ -256,10 +256,12 @@ class UpdateRequestHandler(socketserver.StreamRequestHandler):
     server is shutdown.
     """
 
+    server: Union["AccumulatorTCPServer", "AccumulatorUnixServer"]
+
     def handle(self) -> None:
         from pyspark.accumulators import _accumulatorRegistry
 
-        auth_token = self.server.auth_token  # type: ignore[attr-defined]
+        auth_token = self.server.auth_token
 
         def poll(func: Callable[[], bool]) -> None:
             poller = None
@@ -269,7 +271,7 @@ class UpdateRequestHandler(socketserver.StreamRequestHandler):
                 poller = select.poll()
                 poller.register(self.rfile, select.POLLIN)
 
-            while not self.server.server_shutdown:  # type: ignore[attr-defined]
+            while not self.server.server_shutdown:
                 # Poll every 1 second for new data -- don't block in case of shutdown.
                 if poller is not None:
                     r = []
@@ -302,6 +304,7 @@ class UpdateRequestHandler(socketserver.StreamRequestHandler):
             return False
 
         def authenticate_and_accum_updates() -> bool:
+            assert auth_token is not None
             received_token: Union[bytes, str] = self.rfile.read(len(auth_token))
             if isinstance(received_token, bytes):
                 received_token = received_token.decode("utf-8")
@@ -329,7 +332,7 @@ class AccumulatorTCPServer(socketserver.TCPServer):
     def __init__(
         self,
         server_address: Tuple[str, int],
-        RequestHandlerClass: Type["socketserver.BaseRequestHandler"],
+        RequestHandlerClass: Type["BaseRequestHandler"],
         auth_token: str,
     ):
         super().__init__(server_address, RequestHandlerClass)
@@ -348,9 +351,7 @@ if hasattr(socketserver, "UnixStreamServer"):
     class AccumulatorUnixServer(socketserver.UnixStreamServer):
         server_shutdown = False
 
-        def __init__(
-            self, socket_path: str, RequestHandlerClass: Type[socketserver.BaseRequestHandler]
-        ):
+        def __init__(self, socket_path: str, RequestHandlerClass: Type["BaseRequestHandler"]):
             super().__init__(socket_path, RequestHandlerClass)
             self.auth_token = None
 
@@ -358,15 +359,14 @@ if hasattr(socketserver, "UnixStreamServer"):
             self.server_shutdown = True
             super().shutdown()
             self.server_close()
-            if os.path.exists(self.server_address):  # type: ignore[arg-type]
-                os.remove(self.server_address)  # type: ignore[arg-type]
+            assert isinstance(self.server_address, str)
+            if os.path.exists(self.server_address):
+                os.remove(self.server_address)
 
 else:
 
     class AccumulatorUnixServer(socketserver.TCPServer):  # type: ignore[no-redef]
-        def __init__(
-            self, socket_path: str, RequestHandlerClass: Type[socketserver.BaseRequestHandler]
-        ):
+        def __init__(self, socket_path: str, RequestHandlerClass: Type["BaseRequestHandler"]):
             raise NotImplementedError(
                 "Unix Domain Sockets are not supported on this platform. "
                 "Please disable it by setting spark.python.unix.domain.socket.enabled to false."
@@ -377,13 +377,14 @@ def _start_update_server(
     auth_token: str, is_unix_domain_sock: bool, socket_path: Optional[str] = None
 ) -> Union[AccumulatorTCPServer, AccumulatorUnixServer]:
     """Start a TCP or Unix Domain Socket server for accumulator updates."""
+    server: Union[AccumulatorTCPServer, AccumulatorUnixServer]
     if is_unix_domain_sock:
         assert socket_path is not None
         if os.path.exists(socket_path):
             os.remove(socket_path)
         server = AccumulatorUnixServer(socket_path, UpdateRequestHandler)
     else:
-        server = AccumulatorTCPServer(("localhost", 0), UpdateRequestHandler, auth_token)  # type: ignore[assignment]
+        server = AccumulatorTCPServer(("localhost", 0), UpdateRequestHandler, auth_token)
 
     thread = threading.Thread(target=server.serve_forever)
     thread.daemon = True


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Reduced the number of type ignores in `accumulators.py` by
* Adding asserts to types that we are sure
* Use correct import mechanism
* Support basic types for type var
* Forward type declaration for variables assigned separately in if/else

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We want less "exceptions" (in this case, `type: ignore`) in our code base. Type checker would be more helpful if we have less exceptions.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

mypy passed locally.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.