### PR TITLE
[SPARK-56225][SQL] Improve View WITH SCHEMA EVOLUTION error message

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2321,6 +2321,16 @@
     ],
     "sqlState" : "54001"
   },
+  "FAILED_UPDATE_VIEW_SCHEMA" : {
+    "message" : [
+      "The schema of view <viewName> is out of sync with its query output. Queries on this view will fail until the schema is updated.",
+      "Because the view is created <schemaMode>, an automatic sync was attempted but the catalog failed to apply the update.",
+      "Stored view schema: <existingSchema>",
+      "Query output schema: <newSchema>",
+      "To resolve this, ALTER the view schema manually or ask an administrator to do so. Alternatively, consider running ALTER VIEW <viewName> WITH SCHEMA COMPENSATION, which casts the query output to match the stored view schema at query time and does not require updating the catalog."
+    ],
+    "sqlState" : "58030"
+  },
   "FEATURE_NOT_ENABLED" : {
     "message" : [
       "The feature <featureName> is not enabled. Consider setting the config <configKey> to <configValue> to enable this capability."

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -21,8 +21,9 @@ import java.util.Locale
 
 import scala.collection.mutable.{HashMap, HashSet}
 import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
 
-import org.apache.spark.SparkUnsupportedOperationException
+import org.apache.spark.{SparkException, SparkUnsupportedOperationException}
 import org.apache.spark.sql.{AnalysisException, SaveMode}
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.catalog._
@@ -806,7 +807,19 @@ object ViewSyncSchemaToMetaStore extends (LogicalPlan => Unit) {
           SchemaUtils.checkColumnNameDuplication(fieldNames.toImmutableArraySeq,
             session.sessionState.conf.resolver)
           val updatedViewMeta = metaData.copy(schema = newSchema)
-          session.sessionState.catalog.alterTable(updatedViewMeta)
+          try {
+            session.sessionState.catalog.alterTable(updatedViewMeta)
+          } catch {
+            case NonFatal(e) =>
+              throw new SparkException(
+                errorClass = "FAILED_UPDATE_VIEW_SCHEMA",
+                messageParameters = Map(
+                  "viewName" -> metaData.qualifiedName,
+                  "schemaMode" -> s"WITH SCHEMA ${viewSchemaMode.toString}",
+                  "newSchema" -> newSchema.treeString,
+                  "existingSchema" -> metaData.schema.treeString),
+                cause = e)
+          }
         }
       case _ => // OK
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

When a view is created `WITH SCHEMA EVOLUTION` or `WITH SCHEMA TYPE EVOLUTION`, Spark automatically syncs the view schema to the catalog when the underlying query output changes. If the catalog update fails (e.g. due to permissions), this previously resulted in an opaque error from the catalog.

This PR wraps the `alterTable` call in `ViewSyncSchemaToMetaStore` with a try-catch that produces a structured `SparkException` (`FAILED_UPDATE_VIEW_SCHEMA`) with an actionable error message explaining:

1. The view schema is out of sync with its query output
2. Subsequent queries will fail until the schema is updated
3. An automatic sync was attempted (because the view uses schema evolution mode) but the catalog rejected the update
4. Both the stored view schema and the query output schema
5. How to resolve: ALTER the view schema manually, ask an administrator, or switch to `WITH SCHEMA COMPENSATION` which casts the query output to match the stored view schema at query time and does not require catalog updates

### Why are the changes needed?

Users who encounter catalog failures during view schema evolution currently see low-level catalog errors with no guidance on what went wrong or how to fix it. This change provides a clear, actionable error message.

### Does this PR introduce _any_ user-facing change?

Yes. Users will see a structured error message (`FAILED_UPDATE_VIEW_SCHEMA`) instead of an opaque catalog exception when the automatic view schema sync fails.

### How was this patch tested?

- `SparkThrowableSuite` passes (validates error class format, SQLSTATE, naming conventions)
- Manual compilation of `sql/core`

### Was this patch authored or co-authored using generative AI tooling?

Yes.