### PR TITLE
[SPARK-56222][PYTHON] Create ArrowStreamGroupSerializer and ArrowStreamCoGroupSerializer

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -20,7 +20,7 @@ Serializers for PyArrow and pandas conversions. See `pyspark.serializers` for mo
 """
 
 from itertools import groupby
-from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Tuple
+from typing import IO, TYPE_CHECKING, Any, Iterator, List, Optional, Tuple
 
 import pyspark
 from pyspark.errors import PySparkRuntimeError, PySparkValueError
@@ -124,28 +124,20 @@ class ArrowCollectSerializer(Serializer):
 
 class ArrowStreamSerializer(Serializer):
     """
-    Serializes Arrow record batches as a stream.
+    Serializes Arrow record batches as a plain stream.
 
     Parameters
     ----------
     write_start_stream : bool
         If True, writes the START_ARROW_STREAM marker before the first
         output batch. Default False.
-    num_dfs : int
-        Number of dataframes per group.
-        For num_dfs=0, plain batch stream without group-count protocol.
-        For num_dfs=1, grouped loading (1 dataframe per group).
-        For num_dfs=2, cogrouped loading (2 dataframes per group).
-        Default 0.
     """
 
-    def __init__(self, write_start_stream: bool = False, num_dfs: int = 0) -> None:
+    def __init__(self, write_start_stream: bool = False) -> None:
         super().__init__()
-        assert num_dfs in (0, 1, 2), "num_dfs must be 0, 1, or 2"
         self._write_start_stream: bool = write_start_stream
-        self._num_dfs: int = num_dfs
 
-    def dump_stream(self, iterator, stream):
+    def dump_stream(self, iterator: Iterator["pa.RecordBatch"], stream: IO[bytes]) -> None:
         """Optionally prepend START_ARROW_STREAM, then write batches."""
         if self._write_start_stream:
             iterator = self._write_stream_start(iterator, stream)
@@ -162,7 +154,7 @@ class ArrowStreamSerializer(Serializer):
                 writer.close()
 
     @classmethod
-    def _read_arrow_stream(cls, stream) -> Iterator["pa.RecordBatch"]:
+    def _read_arrow_stream(cls, stream: IO[bytes]) -> Iterator["pa.RecordBatch"]:
         """Read a plain Arrow IPC stream, yielding one RecordBatch per message."""
         import pyarrow as pa
 
@@ -170,46 +162,12 @@ class ArrowStreamSerializer(Serializer):
         for batch in reader:
             yield batch
 
-    def load_stream(self, stream):
-        """Load batches: plain stream if num_dfs=0, grouped otherwise."""
-        if self._num_dfs == 0:
-            yield from self._read_arrow_stream(stream)
-        elif self._num_dfs == 1:
-            # Grouped loading: yield single dataframe groups
-            for (batches,) in self._load_group_dataframes(stream, num_dfs=1):
-                yield batches
-        elif self._num_dfs == 2:
-            # Cogrouped loading: yield tuples of (left_batches, right_batches)
-            for left_batches, right_batches in self._load_group_dataframes(stream, num_dfs=2):
-                yield left_batches, right_batches
-        else:
-            assert False, f"Unexpected num_dfs: {self._num_dfs}"
-
-    def _load_group_dataframes(self, stream, num_dfs: int = 1) -> Iterator:
-        """
-        Yield groups of dataframes from the stream using the group-count protocol.
-        """
-        dataframes_in_group = None
-
-        while dataframes_in_group is None or dataframes_in_group > 0:
-            dataframes_in_group = read_int(stream)
-
-            if dataframes_in_group == num_dfs:
-                if num_dfs == 1:
-                    # Single dataframe: can use lazy iterator
-                    yield (self._read_arrow_stream(stream),)
-                else:
-                    # Multiple dataframes: must eagerly load sequentially
-                    # to maintain correct stream position
-                    yield tuple(list(self._read_arrow_stream(stream)) for _ in range(num_dfs))
-            elif dataframes_in_group > 0:
-                raise PySparkValueError(
-                    errorClass="INVALID_NUMBER_OF_DATAFRAMES_IN_GROUP",
-                    messageParameters={"dataframes_in_group": str(dataframes_in_group)},
-                )
+    def load_stream(self, stream: IO[bytes]) -> Iterator["pa.RecordBatch"]:
+        """Load batches from a plain Arrow stream."""
+        yield from self._read_arrow_stream(stream)
 
     def _write_stream_start(
-        self, batch_iterator: Iterator["pa.RecordBatch"], stream
+        self, batch_iterator: Iterator["pa.RecordBatch"], stream: IO[bytes]
     ) -> Iterator["pa.RecordBatch"]:
         """Write START_ARROW_STREAM before the first batch, then pass batches through."""
         import itertools
@@ -224,10 +182,57 @@ class ArrowStreamSerializer(Serializer):
         yield from itertools.chain([first], batch_iterator)
 
     def __repr__(self) -> str:
-        return "ArrowStreamSerializer(write_start_stream=%s, num_dfs=%d)" % (
-            self._write_start_stream,
-            self._num_dfs,
-        )
+        return "ArrowStreamSerializer(write_start_stream=%s)" % self._write_start_stream
+
+
+class ArrowStreamGroupSerializer(ArrowStreamSerializer):
+    """
+    Extends :class:`ArrowStreamSerializer` with group-count protocol for loading
+    grouped Arrow record batches (1 dataframe per group).
+    """
+
+    def load_stream(self, stream: IO[bytes]) -> Iterator[Iterator["pa.RecordBatch"]]:
+        """Yield one iterator of record batches per group from the stream."""
+        dataframes_in_group: Optional[int] = None
+
+        while dataframes_in_group is None or dataframes_in_group > 0:
+            dataframes_in_group = read_int(stream)
+
+            if dataframes_in_group == 1:
+                yield self._read_arrow_stream(stream)
+            elif dataframes_in_group > 0:
+                raise PySparkValueError(
+                    errorClass="INVALID_NUMBER_OF_DATAFRAMES_IN_GROUP",
+                    messageParameters={"dataframes_in_group": str(dataframes_in_group)},
+                )
+
+
+class ArrowStreamCoGroupSerializer(ArrowStreamSerializer):
+    """
+    Extends :class:`ArrowStreamSerializer` with group-count protocol for loading
+    cogrouped Arrow record batches (2 dataframes per group).
+    """
+
+    def load_stream(
+        self, stream: IO[bytes]
+    ) -> Iterator[Tuple[List["pa.RecordBatch"], List["pa.RecordBatch"]]]:
+        """Yield pairs of (left_batches, right_batches) from the stream."""
+        dataframes_in_group: Optional[int] = None
+
+        while dataframes_in_group is None or dataframes_in_group > 0:
+            dataframes_in_group = read_int(stream)
+
+            if dataframes_in_group == 2:
+                # Must eagerly load each dataframe to maintain correct stream position
+                yield (
+                    list(self._read_arrow_stream(stream)),
+                    list(self._read_arrow_stream(stream)),
+                )
+            elif dataframes_in_group > 0:
+                raise PySparkValueError(
+                    errorClass="INVALID_NUMBER_OF_DATAFRAMES_IN_GROUP",
+                    messageParameters={"dataframes_in_group": str(dataframes_in_group)},
+                )
 
 
 class ArrowStreamUDFSerializer(ArrowStreamSerializer):
@@ -338,7 +343,7 @@ class ArrowStreamGroupUDFSerializer(ArrowStreamUDFSerializer):
         """
         Load grouped Arrow record batches from stream.
         """
-        for (batches,) in self._load_group_dataframes(stream, num_dfs=1):
+        for batches in ArrowStreamGroupSerializer.load_stream(self, stream):
             yield batches
             # Make sure the batches are fully iterated before getting the next group
             for _ in batches:
@@ -775,7 +780,7 @@ class ArrowStreamAggArrowUDFSerializer(ArrowStreamArrowUDFSerializer):
         Each group yields Iterator[Tuple[pa.Array, ...]], allowing UDF to process batches one by one
         without consuming all batches upfront.
         """
-        for (batches,) in self._load_group_dataframes(stream, num_dfs=1):
+        for batches in ArrowStreamGroupSerializer.load_stream(self, stream):
             # Lazily read and convert Arrow batches one at a time from the stream
             # This avoids loading all batches into memory for the group
             columns_iter = (batch.columns for batch in batches)
@@ -819,7 +824,7 @@ class ArrowStreamAggPandasUDFSerializer(ArrowStreamPandasUDFSerializer):
         Each group yields Iterator[Tuple[pd.Series, ...]], allowing UDF to
         process batches one by one without consuming all batches upfront.
         """
-        for (batches,) in self._load_group_dataframes(stream, num_dfs=1):
+        for batches in ArrowStreamGroupSerializer.load_stream(self, stream):
             # Lazily read and convert Arrow batches to pandas Series one at a time
             # from the stream. This avoids loading all batches into memory for the group
             series_iter = map(
@@ -874,7 +879,7 @@ class GroupPandasUDFSerializer(ArrowStreamPandasUDFSerializer):
         Deserialize Grouped ArrowRecordBatches and yield raw Iterator[pa.RecordBatch].
         Each outer iterator element represents a group.
         """
-        for (batches,) in self._load_group_dataframes(stream, num_dfs=1):
+        for batches in ArrowStreamGroupSerializer.load_stream(self, stream):
             yield batches
             # Make sure the batches are fully iterated before getting the next group
             for _ in batches:
@@ -892,7 +897,7 @@ class GroupPandasUDFSerializer(ArrowStreamPandasUDFSerializer):
         return "GroupPandasUDFSerializer"
 
 
-class CogroupArrowUDFSerializer(ArrowStreamGroupUDFSerializer):
+class CogroupArrowUDFSerializer(ArrowStreamCoGroupSerializer):
     """
     Serializes pyarrow.RecordBatch data with Arrow streaming format.
 
@@ -905,12 +910,28 @@ class CogroupArrowUDFSerializer(ArrowStreamGroupUDFSerializer):
         If True, then DataFrames will get columns by name
     """
 
-    def load_stream(self, stream):
-        """
-        Deserialize Cogrouped ArrowRecordBatches and yield as two `pyarrow.RecordBatch`es.
-        """
-        for left_batches, right_batches in self._load_group_dataframes(stream, num_dfs=2):
-            yield left_batches, right_batches
+    def __init__(self, *, assign_cols_by_name):
+        super().__init__()
+        self._assign_cols_by_name = assign_cols_by_name
+
+    def dump_stream(self, iterator, stream):
+        import pyarrow as pa
+
+        batch_iter = ((batch, arrow_type) for batches, arrow_type in iterator for batch in batches)
+
+        if self._assign_cols_by_name:
+            batch_iter = (
+                (
+                    pa.RecordBatch.from_arrays(
+                        [batch.column(field.name) for field in arrow_type],
+                        names=[field.name for field in arrow_type],
+                    ),
+                    arrow_type,
+                )
+                for batch, arrow_type in batch_iter
+            )
+
+        super().dump_stream(batch_iter, stream)
 
 
 class CogroupPandasUDFSerializer(ArrowStreamPandasUDFSerializer):
@@ -921,7 +942,7 @@ class CogroupPandasUDFSerializer(ArrowStreamPandasUDFSerializer):
         """
         import pyarrow as pa
 
-        for left_batches, right_batches in self._load_group_dataframes(stream, num_dfs=2):
+        for left_batches, right_batches in ArrowStreamCoGroupSerializer.load_stream(self, stream):
             left_table = pa.Table.from_batches(left_batches)
             right_table = pa.Table.from_batches(right_batches)
             yield (

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -153,18 +153,13 @@ class ArrowStreamSerializer(Serializer):
             if writer is not None:
                 writer.close()
 
-    @classmethod
-    def _read_arrow_stream(cls, stream: IO[bytes]) -> Iterator["pa.RecordBatch"]:
-        """Read a plain Arrow IPC stream, yielding one RecordBatch per message."""
+    def load_stream(self, stream: IO[bytes]) -> Iterator["pa.RecordBatch"]:
+        """Load batches from a plain Arrow stream."""
         import pyarrow as pa
 
         reader = pa.ipc.open_stream(stream)
         for batch in reader:
             yield batch
-
-    def load_stream(self, stream: IO[bytes]) -> Iterator["pa.RecordBatch"]:
-        """Load batches from a plain Arrow stream."""
-        yield from self._read_arrow_stream(stream)
 
     def _write_stream_start(
         self, batch_iterator: Iterator["pa.RecordBatch"], stream: IO[bytes]
@@ -193,13 +188,9 @@ class ArrowStreamGroupSerializer(ArrowStreamSerializer):
 
     def load_stream(self, stream: IO[bytes]) -> Iterator[Iterator["pa.RecordBatch"]]:
         """Yield one iterator of record batches per group from the stream."""
-        dataframes_in_group: Optional[int] = None
-
-        while dataframes_in_group is None or dataframes_in_group > 0:
-            dataframes_in_group = read_int(stream)
-
+        while dataframes_in_group := read_int(stream):
             if dataframes_in_group == 1:
-                yield self._read_arrow_stream(stream)
+                yield super().load_stream(stream)
             elif dataframes_in_group > 0:
                 raise PySparkValueError(
                     errorClass="INVALID_NUMBER_OF_DATAFRAMES_IN_GROUP",
@@ -217,16 +208,12 @@ class ArrowStreamCoGroupSerializer(ArrowStreamSerializer):
         self, stream: IO[bytes]
     ) -> Iterator[Tuple[List["pa.RecordBatch"], List["pa.RecordBatch"]]]:
         """Yield pairs of (left_batches, right_batches) from the stream."""
-        dataframes_in_group: Optional[int] = None
-
-        while dataframes_in_group is None or dataframes_in_group > 0:
-            dataframes_in_group = read_int(stream)
-
+        while dataframes_in_group := read_int(stream):
             if dataframes_in_group == 2:
                 # Must eagerly load each dataframe to maintain correct stream position
                 yield (
-                    list(self._read_arrow_stream(stream)),
-                    list(self._read_arrow_stream(stream)),
+                    list(super().load_stream(stream)),
+                    list(super().load_stream(stream)),
                 )
             elif dataframes_in_group > 0:
                 raise PySparkValueError(
@@ -265,7 +252,7 @@ class ArrowStreamUDTFSerializer(ArrowStreamUDFSerializer):
     """
 
     def load_stream(self, stream):
-        return self._read_arrow_stream(stream)
+        return ArrowStreamSerializer.load_stream(self, stream)
 
 
 class ArrowStreamArrowUDTFSerializer(ArrowStreamUDTFSerializer):

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -190,7 +190,7 @@ class ArrowStreamGroupSerializer(ArrowStreamSerializer):
         """Yield one iterator of record batches per group from the stream."""
         while dataframes_in_group := read_int(stream):
             if dataframes_in_group == 1:
-                yield super().load_stream(stream)
+                yield ArrowStreamSerializer.load_stream(self, stream)
             elif dataframes_in_group > 0:
                 raise PySparkValueError(
                     errorClass="INVALID_NUMBER_OF_DATAFRAMES_IN_GROUP",
@@ -212,8 +212,8 @@ class ArrowStreamCoGroupSerializer(ArrowStreamSerializer):
             if dataframes_in_group == 2:
                 # Must eagerly load each dataframe to maintain correct stream position
                 yield (
-                    list(super().load_stream(stream)),
-                    list(super().load_stream(stream)),
+                    list(ArrowStreamSerializer.load_stream(self, stream)),
+                    list(ArrowStreamSerializer.load_stream(self, stream)),
                 )
             elif dataframes_in_group > 0:
                 raise PySparkValueError(

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -897,7 +897,7 @@ class GroupPandasUDFSerializer(ArrowStreamPandasUDFSerializer):
         return "GroupPandasUDFSerializer"
 
 
-class CogroupArrowUDFSerializer(ArrowStreamCoGroupSerializer):
+class CogroupArrowUDFSerializer(ArrowStreamGroupUDFSerializer):
     """
     Serializes pyarrow.RecordBatch data with Arrow streaming format.
 
@@ -910,28 +910,11 @@ class CogroupArrowUDFSerializer(ArrowStreamCoGroupSerializer):
         If True, then DataFrames will get columns by name
     """
 
-    def __init__(self, *, assign_cols_by_name):
-        super().__init__()
-        self._assign_cols_by_name = assign_cols_by_name
-
-    def dump_stream(self, iterator, stream):
-        import pyarrow as pa
-
-        batch_iter = ((batch, arrow_type) for batches, arrow_type in iterator for batch in batches)
-
-        if self._assign_cols_by_name:
-            batch_iter = (
-                (
-                    pa.RecordBatch.from_arrays(
-                        [batch.column(field.name) for field in arrow_type],
-                        names=[field.name for field in arrow_type],
-                    ),
-                    arrow_type,
-                )
-                for batch, arrow_type in batch_iter
-            )
-
-        super().dump_stream(batch_iter, stream)
+    def load_stream(self, stream):
+        """
+        Deserialize Cogrouped ArrowRecordBatches and yield as two `pyarrow.RecordBatch`es.
+        """
+        yield from ArrowStreamCoGroupSerializer.load_stream(self, stream)
 
 
 class CogroupPandasUDFSerializer(ArrowStreamPandasUDFSerializer):

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -20,7 +20,7 @@ Serializers for PyArrow and pandas conversions. See `pyspark.serializers` for mo
 """
 
 from itertools import groupby
-from typing import IO, TYPE_CHECKING, Any, Iterator, List, Optional, Tuple
+from typing import IO, TYPE_CHECKING, Any, Iterable, Iterator, List, Optional, Tuple
 
 import pyspark
 from pyspark.errors import PySparkRuntimeError, PySparkValueError
@@ -137,8 +137,9 @@ class ArrowStreamSerializer(Serializer):
         super().__init__()
         self._write_start_stream: bool = write_start_stream
 
-    def dump_stream(self, iterator: Iterator["pa.RecordBatch"], stream: IO[bytes]) -> None:
+    def dump_stream(self, iterator: Iterable["pa.RecordBatch"], stream: IO[bytes]) -> None:
         """Optionally prepend START_ARROW_STREAM, then write batches."""
+        iterator = iter(iterator)
         if self._write_start_stream:
             iterator = self._write_stream_start(iterator, stream)
         import pyarrow as pa

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -191,7 +191,7 @@ class ArrowStreamGroupSerializer(ArrowStreamSerializer):
         """Yield one iterator of record batches per group from the stream."""
         while dataframes_in_group := read_int(stream):
             if dataframes_in_group == 1:
-                yield super().load_stream(stream)
+                yield ArrowStreamSerializer.load_stream(self, stream)
             elif dataframes_in_group > 0:
                 raise PySparkValueError(
                     errorClass="INVALID_NUMBER_OF_DATAFRAMES_IN_GROUP",
@@ -213,8 +213,8 @@ class ArrowStreamCoGroupSerializer(ArrowStreamSerializer):
             if dataframes_in_group == 2:
                 # Must eagerly load each dataframe to maintain correct stream position
                 yield (
-                    list(super().load_stream(stream)),
-                    list(super().load_stream(stream)),
+                    list(ArrowStreamSerializer.load_stream(self, stream)),
+                    list(ArrowStreamSerializer.load_stream(self, stream)),
                 )
             elif dataframes_in_group > 0:
                 raise PySparkValueError(

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -191,7 +191,7 @@ class ArrowStreamGroupSerializer(ArrowStreamSerializer):
         """Yield one iterator of record batches per group from the stream."""
         while dataframes_in_group := read_int(stream):
             if dataframes_in_group == 1:
-                yield ArrowStreamSerializer.load_stream(self, stream)
+                yield super().load_stream(stream)
             elif dataframes_in_group > 0:
                 raise PySparkValueError(
                     errorClass="INVALID_NUMBER_OF_DATAFRAMES_IN_GROUP",
@@ -213,8 +213,8 @@ class ArrowStreamCoGroupSerializer(ArrowStreamSerializer):
             if dataframes_in_group == 2:
                 # Must eagerly load each dataframe to maintain correct stream position
                 yield (
-                    list(ArrowStreamSerializer.load_stream(self, stream)),
-                    list(ArrowStreamSerializer.load_stream(self, stream)),
+                    list(super().load_stream(stream)),
+                    list(super().load_stream(stream)),
                 )
             elif dataframes_in_group > 0:
                 raise PySparkValueError(

--- a/python/pyspark/sql/streaming/python_streaming_source_runner.py
+++ b/python/pyspark/sql/streaming/python_streaming_source_runner.py
@@ -134,7 +134,7 @@ def send_batch_func(
         write_int(NON_EMPTY_PYARROW_RECORD_BATCHES, outfile)
         write_int(SpecialLengths.START_ARROW_STREAM, outfile)
         serializer = ArrowStreamSerializer()
-        serializer.dump_stream(batches, outfile)
+        serializer.dump_stream(iter(batches), outfile)
     else:
         write_int(EMPTY_PYARROW_RECORD_BATCHES, outfile)
 

--- a/python/pyspark/sql/streaming/python_streaming_source_runner.py
+++ b/python/pyspark/sql/streaming/python_streaming_source_runner.py
@@ -134,7 +134,7 @@ def send_batch_func(
         write_int(NON_EMPTY_PYARROW_RECORD_BATCHES, outfile)
         write_int(SpecialLengths.START_ARROW_STREAM, outfile)
         serializer = ArrowStreamSerializer()
-        serializer.dump_stream(iter(batches), outfile)
+        serializer.dump_stream(batches, outfile)
     else:
         write_int(EMPTY_PYARROW_RECORD_BATCHES, outfile)
 

--- a/python/pyspark/sql/streaming/stateful_processor_api_client.py
+++ b/python/pyspark/sql/streaming/stateful_processor_api_client.py
@@ -18,7 +18,7 @@ from enum import Enum
 import json
 import os
 import socket
-from typing import Any, Dict, List, Union, Optional, Tuple, Iterator
+from typing import IO, Any, Dict, List, Union, Optional, Tuple, Iterator, cast
 
 from pyspark.serializers import write_int, read_int, UTF8Deserializer
 from pyspark.sql.pandas.serializers import ArrowStreamSerializer
@@ -537,11 +537,11 @@ class StatefulProcessorApiClient:
             pd.DataFrame(state, columns=column_names), schema
         )
         batch = pa.RecordBatch.from_pandas(pandas_df)
-        self.serializer.dump_stream(iter([batch]), self.sockfile)
+        self.serializer.dump_stream(iter([batch]), cast(IO[bytes], self.sockfile))
         self.sockfile.flush()
 
     def _read_arrow_state(self) -> Any:
-        return self.serializer.load_stream(self.sockfile)
+        return self.serializer.load_stream(cast(IO[bytes], self.sockfile))
 
     def _send_list_state(self, schema: StructType, state: List[Tuple]) -> None:
         for value in state:

--- a/python/pyspark/sql/streaming/stateful_processor_api_client.py
+++ b/python/pyspark/sql/streaming/stateful_processor_api_client.py
@@ -537,7 +537,7 @@ class StatefulProcessorApiClient:
             pd.DataFrame(state, columns=column_names), schema
         )
         batch = pa.RecordBatch.from_pandas(pandas_df)
-        self.serializer.dump_stream(iter([batch]), cast(IO[bytes], self.sockfile))
+        self.serializer.dump_stream([batch], cast(IO[bytes], self.sockfile))
         self.sockfile.flush()
 
     def _read_arrow_state(self) -> Any:

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -55,6 +55,7 @@ from pyspark.sql.conversion import (
 from pyspark.sql.functions import SkipRestOfInputTableException
 from pyspark.sql.pandas.serializers import (
     ArrowStreamSerializer,
+    ArrowStreamGroupSerializer,
     ArrowStreamPandasUDFSerializer,
     ArrowStreamPandasUDTFSerializer,
     ArrowStreamGroupUDFSerializer,
@@ -2645,7 +2646,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             PythonEvalType.SQL_GROUPED_AGG_ARROW_UDF,
             PythonEvalType.SQL_GROUPED_AGG_ARROW_ITER_UDF,
         ):
-            ser = ArrowStreamSerializer(write_start_stream=True, num_dfs=1)
+            ser = ArrowStreamGroupSerializer(write_start_stream=True)
         elif eval_type == PythonEvalType.SQL_WINDOW_AGG_ARROW_UDF:
             ser = ArrowStreamAggArrowUDFSerializer(safecheck=True, arrow_cast=True)
         elif eval_type in (


### PR DESCRIPTION
### What changes were proposed in this pull request?

Refactors `ArrowStreamSerializer` by extracting group and cogroup loading logic into dedicated subclasses:

```
ArrowStreamSerializer              (plain Arrow stream I/O)
  ├── ArrowStreamGroupSerializer    (grouped loading, 1 df/group)
  ├── ArrowStreamCoGroupSerializer  (cogrouped loading, 2 dfs/group)
  ├── ArrowStreamUDFSerializer
  ├── ArrowStreamPandasSerializer
  └── ArrowStreamArrowUDFSerializer
```

Key changes:
- `ArrowStreamSerializer`: simplified to only handle plain Arrow stream read/write. Removed `num_dfs` parameter.
- `ArrowStreamGroupSerializer(ArrowStreamSerializer)`: new class that overrides `load_stream` with group-count protocol for single-dataframe groups.
- `ArrowStreamCoGroupSerializer(ArrowStreamSerializer)`: new class that overrides `load_stream` with group-count protocol for two-dataframe cogroups.

### Why are the changes needed?

This is part of the ongoing serializer simplification effort (SPARK-55384).  The previous `ArrowStreamSerializer` mixed plain stream I/O with group-count protocol logic via a `num_dfs` parameter and a multi-purpose `_load_group_dataframes` method. This made the return types ambiguous — callers couldn't tell from the type signature whether they'd get `pa.RecordBatch`, `Iterator[pa.RecordBatch]`, or `Tuple[...]`. By splitting group and cogroup into separate classes, each `load_stream` has a clear, precise return type, improving readability and enabling better static analysis.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.