### PR TITLE
[SPARK-56226][PS][CONNECT] Catch analysis errors before `InternalFrame.__init__` in `.loc`

### DIFF
--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -536,6 +536,12 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                 else:
                     sdf = sdf.limit(sdf.count() + limit)
                 sdf = sdf.drop(NATURAL_ORDER_COLUMN_NAME)
+
+            if is_remote():
+                # Trigger plan analysis on Spark Connect here so analysis errors are caught
+                # before `InternalFrame.__init__`. `isStreaming` also caches the value used
+                # by `InternalFrame.__init__` immediately after.
+                sdf.isStreaming
         except AnalysisException:
             if is_remote():
                 from pyspark.sql.connect.column import Column as ConnectColumn


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the pandas-on-Spark indexing path for Spark Connect in `python/pyspark/pandas/indexing.py`.

When `.loc` builds a filtered Spark DataFrame, Spark Connect can defer plan analysis until `InternalFrame.__init__` accesses `isStreaming`. In that case, `AnalysisException` escapes the existing error handling block in `LocIndexerLike.__getitem__`.

To keep the error handling in one place, this PR explicitly triggers plan analysis on Spark Connect before constructing `InternalFrame` by calling `sdf.isStreaming` inside the existing `try` block. That also reuses the cached `isStreaming` value that `InternalFrame.__init__` checks immediately after.

### Why are the changes needed?

Without this change, analysis errors from Spark Connect can be raised later than the classic path and bypass the existing `AnalysisException` handling in pandas-on-Spark indexing.

This makes the behavior inconsistent between classic and Connect in error cases. Triggering analysis earlier keeps Connect on the same handled path and avoids surfacing the exception from `InternalFrame.__init__`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran the related pandas-on-Spark indexing tests with pandas 3 for both Connect and non-Connect:
- `pyspark.pandas.tests.connect.indexes.test_parity_indexing_adv IndexingAdvParityTests.test_index_operator_datetime`
- `pyspark.pandas.tests.indexes.test_indexing_adv IndexingAdvTests.test_index_operator_datetime`

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
