### PR TITLE
[SPARK-56234][CORE] Support disabling log directory scanning by path pattern in SHS

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -19,7 +19,7 @@ package org.apache.spark.deploy.history
 
 import java.io.{File, FileNotFoundException, IOException}
 import java.lang.{Long => JLong}
-import java.util.{Date, Locale, NoSuchElementException, ServiceLoader}
+import java.util.{Date, NoSuchElementException, ServiceLoader}
 import java.util.concurrent.{ConcurrentHashMap, ExecutorService, TimeUnit}
 import java.util.zip.ZipOutputStream
 
@@ -109,8 +109,19 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
   private val logDirs = conf.get(History.HISTORY_LOG_DIR)
     .split(",").map(_.trim).filter(_.nonEmpty).toSeq
 
-  private val scanDisabledSchemes = conf.get(History.SCAN_DISABLED_SCHEMES)
-    .split(",").map(_.trim.toLowerCase(Locale.ROOT)).filter(_.nonEmpty).toSet
+  private val scanDisabledPathPatterns = conf.get(History.SCAN_DISABLED_PATH_PATTERNS)
+    .map(_.r)
+
+  /** Check if scanning is disabled for a directory by matching its path against patterns. */
+  private def isScanDisabled(dir: String): Boolean = {
+    if (scanDisabledPathPatterns.isEmpty) return false
+    val qualifiedPath = {
+      val path = new Path(dir)
+      val dirFs = logDirFs(dir)
+      path.makeQualified(dirFs.getUri, dirFs.getWorkingDirectory).toString
+    }
+    scanDisabledPathPatterns.exists(_.pattern.matcher(qualifiedPath).matches())
+  }
 
   private val historyUiAclsEnable = conf.get(History.HISTORY_SERVER_UI_ACLS_ENABLE)
   private val historyUiAdminAcls = conf.get(History.HISTORY_SERVER_UI_ADMIN_ACLS)
@@ -566,10 +577,9 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
 
     logDirs.foreach { dir =>
       try {
-        val scheme = logDirFs(dir).getUri.getScheme.toLowerCase(Locale.ROOT)
-        if (scanDisabledSchemes.contains(scheme)) {
+        if (isScanDisabled(dir)) {
           logDebug(log"Skipping scan for directory ${MDC(HISTORY_DIR, dir)}" +
-            log" (scan disabled for its URI scheme)")
+            log" (scan disabled for this directory)")
           skippedDirs += dir
         } else {
           checkForLogsInDir(dir, newLastScanTime, allNotStale)

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -19,7 +19,7 @@ package org.apache.spark.deploy.history
 
 import java.io.{File, FileNotFoundException, IOException}
 import java.lang.{Long => JLong}
-import java.util.{Date, NoSuchElementException, ServiceLoader}
+import java.util.{Date, Locale, NoSuchElementException, ServiceLoader}
 import java.util.concurrent.{ConcurrentHashMap, ExecutorService, TimeUnit}
 import java.util.zip.ZipOutputStream
 
@@ -108,6 +108,9 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
 
   private val logDirs = conf.get(History.HISTORY_LOG_DIR)
     .split(",").map(_.trim).filter(_.nonEmpty).toSeq
+
+  private val scanDisabledSchemes = conf.get(History.SCAN_DISABLED_SCHEMES)
+    .split(",").map(_.trim.toLowerCase(Locale.ROOT)).filter(_.nonEmpty).toSet
 
   private val historyUiAclsEnable = conf.get(History.HISTORY_SERVER_UI_ACLS_ENABLE)
   private val historyUiAdminAcls = conf.get(History.HISTORY_SERVER_UI_ADMIN_ACLS)
@@ -559,10 +562,18 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
   private[history] def checkForLogs(): Unit = {
     val newLastScanTime = clock.getTimeMillis()
     val allNotStale = mutable.HashSet[String]()
+    val skippedDirs = mutable.ArrayBuffer[String]()
 
     logDirs.foreach { dir =>
       try {
-        checkForLogsInDir(dir, newLastScanTime, allNotStale)
+        val scheme = logDirFs(dir).getUri.getScheme.toLowerCase(Locale.ROOT)
+        if (scanDisabledSchemes.contains(scheme)) {
+          logDebug(log"Skipping scan for directory ${MDC(HISTORY_DIR, dir)}" +
+            log" (scan disabled for its URI scheme)")
+          skippedDirs += dir
+        } else {
+          checkForLogsInDir(dir, newLastScanTime, allNotStale)
+        }
       } catch {
         case e: IOException =>
           logError(log"Error checking for logs in directory ${MDC(HISTORY_DIR, dir)}", e)
@@ -572,6 +583,8 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     // Delete all information about applications whose log files disappeared from storage.
     // This is done after scanning ALL directories to avoid incorrectly marking entries from
     // other directories as stale.
+    // Entries from scan-disabled directories are excluded from stale detection because
+    // they are never scanned and their lastProcessed time is never updated.
     val stale = listing.synchronized {
       KVUtils.viewToSeq(listing.view(classOf[LogInfo])
         .index("lastProcessed")
@@ -579,6 +592,8 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     }
     stale.filterNot(isProcessing)
       .filterNot(info => allNotStale.contains(info.logPath))
+      .filterNot(info => skippedDirs.exists(dir =>
+        logDirForPath(new Path(info.logPath)) == dir))
       .foreach { log =>
         log.appId.foreach { appId =>
           cleanAppData(appId, log.attemptId, log.logPath)

--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -43,6 +43,16 @@ private[spark] object History {
     .stringConf
     .createOptional
 
+  val SCAN_DISABLED_SCHEMES = ConfigBuilder("spark.history.fs.update.disabledSchemes")
+    .doc("Comma-separated list of URI schemes for which periodic log directory scanning is " +
+      "disabled. Directories with these schemes rely on on-demand loading " +
+      "instead of scanning. Applications in these directories will not appear in the " +
+      "listing until accessed by appId. Log compaction and cleaner may not fully function " +
+      "for these directories; use external lifecycle management (e.g., S3 Lifecycle Policies).")
+    .version("4.2.0")
+    .stringConf
+    .createWithDefault("")
+
   val SAFEMODE_CHECK_INTERVAL_S = ConfigBuilder("spark.history.fs.safemodeCheck.interval")
     .version("1.6.0")
     .doc("Interval between HDFS safemode checks for the event log directory")

--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -43,15 +43,19 @@ private[spark] object History {
     .stringConf
     .createOptional
 
-  val SCAN_DISABLED_SCHEMES = ConfigBuilder("spark.history.fs.update.disabledSchemes")
-    .doc("Comma-separated list of URI schemes for which periodic log directory scanning is " +
-      "disabled. Directories with these schemes rely on on-demand loading " +
-      "instead of scanning. Applications in these directories will not appear in the " +
-      "listing until accessed by appId. Log compaction and cleaner may not fully function " +
-      "for these directories; use external lifecycle management (e.g., S3 Lifecycle Policies).")
+  val SCAN_DISABLED_PATH_PATTERNS =
+    ConfigBuilder("spark.history.fs.update.scanDisabledPathPatterns")
+    .doc("Comma-separated list of regular expressions matched against log directory paths. " +
+      "Directories whose full path matches any pattern will not be scanned periodically. " +
+      "Applications in these directories rely on on-demand loading instead of scanning and " +
+      "will not appear in the listing until accessed by appId. When accessed, accurate metadata " +
+      "is populated immediately. Logs that are never accessed are not subject to the cleaner; " +
+      "use external lifecycle management (e.g., S3 Lifecycle Policies) for those. " +
+      "Example: \"s3a://.*,gs://.*\" disables scanning for all S3 and GCS directories.")
     .version("4.2.0")
     .stringConf
-    .createWithDefault("")
+    .toSequence
+    .createWithDefault(Nil)
 
   val SAFEMODE_CHECK_INTERVAL_S = ConfigBuilder("spark.history.fs.safemodeCheck.interval")
     .version("1.6.0")

--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -43,20 +43,6 @@ private[spark] object History {
     .stringConf
     .createOptional
 
-  val SCAN_DISABLED_PATH_PATTERNS =
-    ConfigBuilder("spark.history.fs.update.scanDisabledPathPatterns")
-    .doc("Comma-separated list of regular expressions matched against log directory paths. " +
-      "Directories whose full path matches any pattern will not be scanned periodically. " +
-      "Applications in these directories rely on on-demand loading instead of scanning and " +
-      "will not appear in the listing until accessed by appId. When accessed, accurate metadata " +
-      "is populated immediately. Logs that are never accessed are not subject to the cleaner; " +
-      "use external lifecycle management (e.g., S3 Lifecycle Policies) for those. " +
-      "Example: \"s3a://.*,gs://.*\" disables scanning for all S3 and GCS directories.")
-    .version("4.2.0")
-    .stringConf
-    .toSequence
-    .createWithDefault(Nil)
-
   val SAFEMODE_CHECK_INTERVAL_S = ConfigBuilder("spark.history.fs.safemodeCheck.interval")
     .version("1.6.0")
     .doc("Interval between HDFS safemode checks for the event log directory")
@@ -78,6 +64,21 @@ private[spark] object History {
     .intConf
     .checkValue(v => v > 0, "The update batchSize should be a positive integer.")
     .createWithDefault(Int.MaxValue)
+
+  val SCAN_DISABLED_PATH_PATTERNS =
+    ConfigBuilder("spark.history.fs.update.scanDisabledPathPatterns")
+      .doc("Comma-separated list of regular expressions matched against log directory " +
+        "paths. Directories whose full path matches any pattern will not be scanned " +
+        "periodically. Applications in these directories rely on on-demand loading " +
+        "instead of scanning and will not appear in the listing until accessed by appId. " +
+        "When accessed, accurate metadata is populated immediately. Logs that are never " +
+        "accessed are not subject to the cleaner; use external lifecycle management " +
+        "(e.g., S3 Lifecycle Policies) for those. " +
+        "Example: \"s3a://.*,gs://.*\" disables scanning for all S3 and GCS directories.")
+      .version("4.2.0")
+      .stringConf
+      .toSequence
+      .createWithDefault(Nil)
 
   val CLEANER_ENABLED = ConfigBuilder("spark.history.fs.cleaner.enabled")
     .version("1.4.0")

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -2413,6 +2413,85 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
     }
   }
 
+  test("scan disabled for file scheme skips scanning but on-demand loading still works") {
+    withTempDir { dir =>
+      val conf = createTestConf(true)
+      conf.set(HISTORY_LOG_DIR, dir.getAbsolutePath)
+      conf.set(SCAN_DISABLED_SCHEMES, "file")
+      conf.set(EVENT_LOG_ROLLING_ON_DEMAND_LOAD_ENABLED, true)
+      val hadoopConf = SparkHadoopUtil.newConfiguration(conf)
+      val provider = new FsHistoryProvider(conf)
+
+      // Write a rolling event log
+      val writer = new RollingEventLogFilesWriter("app1", None, dir.toURI, conf, hadoopConf)
+      writer.start()
+      writeEventsToRollingWriter(writer, Seq(
+        SparkListenerApplicationStart("app1", Some("app1"), 0, "user", None),
+        SparkListenerJobStart(1, 0, Seq.empty)), rollFile = false)
+      writer.stop()
+
+      // Scan should skip this directory -- listing remains empty
+      provider.checkForLogs()
+      assert(provider.getListing().length === 0)
+
+      // On-demand loading should still work
+      assert(provider.getAppUI("app1", None).isDefined)
+      assert(provider.getListing().length === 1)
+
+      // Subsequent scan should NOT remove the on-demand loaded app (stale protection)
+      provider.checkForLogs()
+      assert(provider.getListing().length === 1)
+
+      provider.stop()
+    }
+  }
+
+  test("scan disabled schemes do not affect directories with non-matching schemes") {
+    withTempDir { dir =>
+      val conf = createTestConf(true)
+      conf.set(HISTORY_LOG_DIR, dir.getAbsolutePath)
+      // Disable scanning for s3a/gs -- should not affect local file:// directories
+      conf.set(SCAN_DISABLED_SCHEMES, "s3a,gs")
+      val provider = new FsHistoryProvider(conf)
+      val hadoopConf = SparkHadoopUtil.newConfiguration(conf)
+
+      val writer = new RollingEventLogFilesWriter("app1", None, dir.toURI, conf, hadoopConf)
+      writer.start()
+      writeEventsToRollingWriter(writer, Seq(
+        SparkListenerApplicationStart("app1", Some("app1"), 0, "user", None),
+        SparkListenerJobStart(1, 0, Seq.empty)), rollFile = false)
+      writer.stop()
+
+      // file:// scheme is not disabled, so scanning should work normally
+      provider.checkForLogs()
+      assert(provider.getListing().length === 1)
+
+      provider.stop()
+    }
+  }
+
+  test("scan disabled with empty config does not disable any scheme") {
+    withTempDir { dir =>
+      val conf = createTestConf(true)
+      conf.set(HISTORY_LOG_DIR, dir.getAbsolutePath)
+      conf.set(SCAN_DISABLED_SCHEMES, "")
+      val provider = new FsHistoryProvider(conf)
+      val hadoopConf = SparkHadoopUtil.newConfiguration(conf)
+
+      val writer = new RollingEventLogFilesWriter("app1", None, dir.toURI, conf, hadoopConf)
+      writer.start()
+      writeEventsToRollingWriter(writer, Seq(
+        SparkListenerApplicationStart("app1", Some("app1"), 0, "user", None),
+        SparkListenerJobStart(1, 0, Seq.empty)), rollFile = false)
+      writer.stop()
+
+      provider.checkForLogs()
+      assert(provider.getListing().length === 1)
+
+      provider.stop()
+    }
+  }
+
   private class SafeModeTestProvider(conf: SparkConf, clock: Clock)
     extends FsHistoryProvider(conf, clock) {
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -2413,11 +2413,11 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
     }
   }
 
-  test("scan disabled for file scheme skips scanning but on-demand loading still works") {
+  test("SPARK-56234: Skips scanning but on-demand loading still works") {
     withTempDir { dir =>
       val conf = createTestConf(true)
       conf.set(HISTORY_LOG_DIR, dir.getAbsolutePath)
-      conf.set(SCAN_DISABLED_SCHEMES, "file")
+      conf.set(SCAN_DISABLED_PATH_PATTERNS, Seq("file:.*"))
       conf.set(EVENT_LOG_ROLLING_ON_DEMAND_LOAD_ENABLED, true)
       val hadoopConf = SparkHadoopUtil.newConfiguration(conf)
       val provider = new FsHistoryProvider(conf)
@@ -2438,6 +2438,12 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
       assert(provider.getAppUI("app1", None).isDefined)
       assert(provider.getListing().length === 1)
 
+      // Metadata should be accurate (not dummy) since mergeApplicationListing runs
+      // for scan-disabled directories
+      val appInfo = provider.getListing().next()
+      assert(appInfo.name === "app1")
+      assert(appInfo.attempts.head.appSparkVersion !== "unknown")
+
       // Subsequent scan should NOT remove the on-demand loaded app (stale protection)
       provider.checkForLogs()
       assert(provider.getListing().length === 1)
@@ -2446,12 +2452,12 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
     }
   }
 
-  test("scan disabled schemes do not affect directories with non-matching schemes") {
+  test("SPARK-56234: Scan disabled schemes do not affect directories with non-matching schemes") {
     withTempDir { dir =>
       val conf = createTestConf(true)
       conf.set(HISTORY_LOG_DIR, dir.getAbsolutePath)
       // Disable scanning for s3a/gs -- should not affect local file:// directories
-      conf.set(SCAN_DISABLED_SCHEMES, "s3a,gs")
+      conf.set(SCAN_DISABLED_PATH_PATTERNS, Seq("s3a://.*", "gs://.*"))
       val provider = new FsHistoryProvider(conf)
       val hadoopConf = SparkHadoopUtil.newConfiguration(conf)
 
@@ -2470,11 +2476,11 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
     }
   }
 
-  test("scan disabled with empty config does not disable any scheme") {
+  test("SPARK-56234: Scan disabled with empty config does not disable any scheme") {
     withTempDir { dir =>
       val conf = createTestConf(true)
       conf.set(HISTORY_LOG_DIR, dir.getAbsolutePath)
-      conf.set(SCAN_DISABLED_SCHEMES, "")
+      conf.set(SCAN_DISABLED_PATH_PATTERNS, Seq.empty[String])
       val provider = new FsHistoryProvider(conf)
       val hadoopConf = SparkHadoopUtil.newConfiguration(conf)
 
@@ -2489,6 +2495,83 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
       assert(provider.getListing().length === 1)
 
       provider.stop()
+    }
+  }
+
+  test("SPARK-56234: On-demand loading populates accurate metadata via mergeApplicationListing") {
+    withTempDir { dir =>
+      val conf = createTestConf(true)
+      conf.set(HISTORY_LOG_DIR, dir.getAbsolutePath)
+      conf.set(SCAN_DISABLED_PATH_PATTERNS, Seq("file:.*"))
+      conf.set(EVENT_LOG_ROLLING_ON_DEMAND_LOAD_ENABLED, true)
+      val hadoopConf = SparkHadoopUtil.newConfiguration(conf)
+      val provider = new FsHistoryProvider(conf)
+
+      val writer = new RollingEventLogFilesWriter("app1", None, dir.toURI, conf, hadoopConf)
+      writer.start()
+      writeEventsToRollingWriter(writer, Seq(
+        SparkListenerApplicationStart("app1", Some("app1"), 1000, "testuser", None),
+        SparkListenerJobStart(1, 0, Seq.empty),
+        SparkListenerApplicationEnd(5000)), rollFile = false)
+      writer.stop()
+
+      // On-demand load without prior scan
+      assert(provider.getAppUI("app1", None).isDefined)
+
+      // Listing should have accurate metadata from mergeApplicationListing,
+      // not dummy values (sparkVersion="unknown", sparkUser="spark", etc.)
+      val appInfo = provider.getListing().next()
+      assert(appInfo.name === "app1")
+      assert(appInfo.attempts.head.appSparkVersion !== "unknown")
+      assert(appInfo.attempts.head.sparkUser === "testuser")
+      assert(appInfo.attempts.head.completed)
+      assert(appInfo.attempts.head.duration > 0)
+
+      provider.stop()
+    }
+  }
+
+  test("SPARK-56234: Scan disabled by path pattern skips matching directories") {
+    val dir2 = Utils.createTempDir(namePrefix = "logDir2")
+    try {
+      val conf = createTestConf(true)
+      conf.set(HISTORY_LOG_DIR, s"${testDir.getAbsolutePath},${dir2.getAbsolutePath}")
+      conf.set(SCAN_DISABLED_PATH_PATTERNS, Seq(s".*${dir2.getName}"))
+      conf.set(EVENT_LOG_ROLLING_ON_DEMAND_LOAD_ENABLED, true)
+      val hadoopConf = SparkHadoopUtil.newConfiguration(conf)
+      val provider = new FsHistoryProvider(conf)
+
+      // Write app in active dir (scan enabled)
+      val writer1 = new RollingEventLogFilesWriter(
+        "app1", None, testDir.toURI, conf, hadoopConf)
+      writer1.start()
+      writeEventsToRollingWriter(writer1, Seq(
+        SparkListenerApplicationStart("app1", Some("app1"), 0, "user", None),
+        SparkListenerJobStart(1, 0, Seq.empty)), rollFile = false)
+      writer1.stop()
+
+      // Write app in archive dir (scan disabled)
+      val writer2 = new RollingEventLogFilesWriter(
+        "app2", None, dir2.toURI, conf, hadoopConf)
+      writer2.start()
+      writeEventsToRollingWriter(writer2, Seq(
+        SparkListenerApplicationStart("app2", Some("app2"), 0, "user", None),
+        SparkListenerJobStart(2, 0, Seq.empty)), rollFile = false)
+      writer2.stop()
+
+      // Only app1 should be discovered by scan
+      provider.checkForLogs()
+      val listing = provider.getListing().toSeq
+      assert(listing.size === 1)
+      assert(listing.head.id === "app1")
+
+      // app2 should be loadable on demand
+      assert(provider.getAppUI("app2", None).isDefined)
+      assert(provider.getListing().toSeq.size === 2)
+
+      provider.stop()
+    } finally {
+      Utils.deleteRecursively(dir2)
     }
   }
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -208,16 +208,17 @@ Security options for the Spark History Server are covered more detail in the
     <td>1.4.0</td>
   </tr>
   <tr>
-    <td>spark.history.fs.update.disabledSchemes</td>
+    <td>spark.history.fs.update.scanDisabledPathPatterns</td>
     <td>(none)</td>
     <td>
-      Comma-separated list of URI schemes for which periodic log directory scanning is disabled
-      (e.g., <code>s3a,gs</code>). Directories with these schemes rely on on-demand loading
-      (<a href="https://issues.apache.org/jira/browse/SPARK-52914">SPARK-52914</a>, rolling event
-      logs only) instead of scanning. Applications in these directories will not appear in the
-      listing until accessed by appId. Log compaction and the cleaner may not fully function for
-      these directories; use external lifecycle management (e.g., S3 Lifecycle Policies, GCS Object
-      Lifecycle Management) instead.
+      Comma-separated list of regular expressions matched against log directory paths.
+      Directories whose full path matches any pattern will not be scanned periodically
+      (e.g., <code>s3a://.*,gs://.*</code> disables scanning for all S3 and GCS directories).
+      Applications in these directories rely on on-demand loading instead of scanning and
+      will not appear in the listing until accessed by appId. When accessed, accurate metadata
+      is populated immediately. Logs that are never accessed are not subject to the cleaner;
+      use external lifecycle management (e.g., S3 Lifecycle Policies, GCS Object Lifecycle
+      Management) for those.
     </td>
     <td>4.2.0</td>
   </tr>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -208,6 +208,20 @@ Security options for the Spark History Server are covered more detail in the
     <td>1.4.0</td>
   </tr>
   <tr>
+    <td>spark.history.fs.update.disabledSchemes</td>
+    <td>(none)</td>
+    <td>
+      Comma-separated list of URI schemes for which periodic log directory scanning is disabled
+      (e.g., <code>s3a,gs</code>). Directories with these schemes rely on on-demand loading
+      (<a href="https://issues.apache.org/jira/browse/SPARK-52914">SPARK-52914</a>, rolling event
+      logs only) instead of scanning. Applications in these directories will not appear in the
+      listing until accessed by appId. Log compaction and the cleaner may not fully function for
+      these directories; use external lifecycle management (e.g., S3 Lifecycle Policies, GCS Object
+      Lifecycle Management) instead.
+    </td>
+    <td>4.2.0</td>
+  </tr>
+  <tr>
     <td>spark.history.retainedApplications</td>
     <td>50</td>
     <td>

--- a/sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions
+++ b/sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions
@@ -167,6 +167,7 @@ spark.history.fs.numReplayThreads
 spark.history.fs.safemodeCheck.interval
 spark.history.fs.update.batchSize
 spark.history.fs.update.interval
+spark.history.fs.update.scanDisabledPathPatterns
 spark.history.kerberos.enabled
 spark.history.kerberos.keytab
 spark.history.kerberos.principal


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds a new configuration `spark.history.fs.update.scanDisabledPathPatterns` that allows disabling initial/periodic log directory scanning by matching directory paths against regular expressions in the Spark History Server.

When a log directory's qualified path matches any of the configured patterns, `checkForLogs` skips scanning that directory entirely. Applications in scan-disabled directories are not discovered by periodic scanning but can still be loaded on demand via the on-demand loading feature (rolling event logs only). Once accessed by appId, `mergeApplicationListing` is invoked to populate accurate metadata immediately, and the application is protected from stale entry cleanup in subsequent scan cycles.

Example configuration:
```
spark.history.fs.logDirectory=hdfs:///spark-logs,s3a://bucket/spark-logs
spark.history.fs.update.scanDisabledPathPatterns=s3a://.*,gs://.*
```


### Why are the changes needed?
On object storages such as S3 and GCS, the `listStatus` API call used during initial/periodic scanning can be expensive. When a log directory contains a large number of event logs, each scan cycle incurs significant cost and latency. While `spark.history.fs.update.interval` can be increased to reduce scan frequency, the initial scan at SHS startup is still unavoidable.

For users who access applications exclusively by appId, periodic scanning provides no benefit. This change allows such users to disable scanning for specific directories and rely solely on on-demand loading, eliminating `listStatus` costs entirely.

Using regular expressions provides flexibility to disable scanning by URI scheme (e.g., `s3a://.*`), by specific path (e.g., `.*long-term.*`), or any combination.

### Does this PR introduce _any_ user-facing change?
Yes. A new configuration is added:

| Config | Default | Description |
|--------|---------|-------------|
| `spark.history.fs.update.scanDisabledPathPatterns` | (none) | Comma-separated list of regular expressions matched against log directory paths. Directories whose full path matches any pattern will not be scanned. |

**Caveats when scanning is disabled for a directory:**
- Applications do not appear in the listing until accessed by appId
- When accessed, accurate metadata (Spark version, user, duration, etc.) is populated immediately via `mergeApplicationListing`
- Logs that are never accessed are not subject to the cleaner; use external lifecycle management (e.g., S3 Lifecycle Policies) for those
- In-progress application state is not automatically updated (re-access updates it)

### How was this patch tested?
Added tests in `FsHistoryProviderSuite`.

### Was this patch authored or co-authored using generative AI tooling?
Kiro CLI / Opus 4.6
