### PR TITLE
[SPARK-56235][CORE] Add reverse index in TaskSetManager to avoid O(N) scans in executorLost

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -1148,7 +1148,7 @@ private[spark] class TaskSetManager(
 
   /** Called by TaskScheduler when an executor is lost so we can re-enqueue our tasks */
   override def executorLost(execId: String, host: String, reason: ExecutorLossReason): Unit = {
-    val taskIdsOnExec = executorIdToTaskIds.getOrElse(execId, TaskSetManager.emptyLongSet)
+    val taskIdsOnExec = executorIdToTaskIds.getOrElse(execId, TaskSetManager.EMPTY_LONG_SET)
     // Re-enqueue any tasks with potential shuffle data loss that ran on the failed executor
     // if this is a shuffle map stage, and we are not using an external shuffle server which
     // could serve the shuffle outputs or the executor lost is caused by decommission (which
@@ -1467,7 +1467,7 @@ private[spark] object TaskSetManager {
 
   // Shared empty set used as default value for executorIdToTaskIds lookups
   // to avoid allocating a new empty set on each executorLost call.
-  private val emptyLongSet = new OpenHashSet[Long](0)
+  private val EMPTY_LONG_SET = new OpenHashSet[Long](0)
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -35,7 +35,7 @@ import org.apache.spark.internal.LogKeys._
 import org.apache.spark.internal.config._
 import org.apache.spark.scheduler.SchedulingMode._
 import org.apache.spark.util.{AccumulatorV2, Clock, LongAccumulator, SystemClock, Utils}
-import org.apache.spark.util.collection.PercentileHeap
+import org.apache.spark.util.collection.{OpenHashSet, PercentileHeap}
 
 /**
  * Schedules the tasks within a single TaskSet in the TaskSchedulerImpl. This class keeps track of
@@ -199,6 +199,12 @@ private[spark] class TaskSetManager(
 
   // Task index, start and finish time for each task attempt (indexed by task ID)
   private[scheduler] val taskInfos = new HashMap[Long, TaskInfo]
+
+  // Reverse index: executor ID -> set of task IDs that were launched on that executor.
+  // This includes both running and completed tasks, used to efficiently look up tasks
+  // when an executor is lost, avoiding O(N) scans over all taskInfos.
+  // Uses OpenHashSet[Long] (specialized for Long) to avoid boxing overhead.
+  private[scheduler] val executorIdToTaskIds = new HashMap[String, OpenHashSet[Long]]
 
   // Use a MedianHeap to record durations of successful tasks so we know when to launch
   // speculative tasks. This is only used when speculation is enabled, to avoid the overhead
@@ -537,6 +543,7 @@ private[spark] class TaskSetManager(
       taskId, index, attemptNum, task.partitionId, launchTime,
       execId, host, taskLocality, speculative)
     taskInfos(taskId) = info
+    executorIdToTaskIds.getOrElseUpdate(execId, new OpenHashSet[Long]).add(taskId)
     taskAttempts(index) = info :: taskAttempts(index)
     // Serialize and return the task
     val serializedTask: ByteBuffer = try {
@@ -1141,6 +1148,7 @@ private[spark] class TaskSetManager(
 
   /** Called by TaskScheduler when an executor is lost so we can re-enqueue our tasks */
   override def executorLost(execId: String, host: String, reason: ExecutorLossReason): Unit = {
+    val taskIdsOnExec = executorIdToTaskIds.getOrElse(execId, TaskSetManager.emptyLongSet)
     // Re-enqueue any tasks with potential shuffle data loss that ran on the failed executor
     // if this is a shuffle map stage, and we are not using an external shuffle server which
     // could serve the shuffle outputs or the executor lost is caused by decommission (which
@@ -1150,7 +1158,10 @@ private[spark] class TaskSetManager(
       !sched.sc.shuffleDriverComponents.supportsReliableStorage() &&
       (reason.isInstanceOf[ExecutorDecommission] || !env.blockManager.externalShuffleServiceEnabled)
     if (maybeShuffleMapOutputLoss && !isZombie) {
-      for ((tid, info) <- taskInfos if info.executorId == execId) {
+      val iter1 = taskIdsOnExec.iterator
+      while (iter1.hasNext) {
+        val tid = iter1.next()
+        val info = taskInfos(tid)
         val index = info.index
         lazy val isShuffleMapOutputAvailable = reason match {
           case ExecutorDecommission(_, _) =>
@@ -1192,18 +1203,23 @@ private[spark] class TaskSetManager(
         }
       }
     }
-    for ((tid, info) <- taskInfos if info.running && info.executorId == execId) {
-      val exitCausedByApp: Boolean = reason match {
-        case ExecutorExited(_, false, _) => false
-        case ExecutorKilled | ExecutorDecommission(_, _) => false
-        case ExecutorProcessLost(_, _, false) => false
-        // If the task is launching, this indicates that Driver has sent LaunchTask to Executor,
-        // but Executor has not sent StatusUpdate(TaskState.RUNNING) to Driver. Hence, we assume
-        // that the task is not running, and it is NetworkFailure rather than TaskFailure.
-        case _ => !info.launching
+    val iter2 = taskIdsOnExec.iterator
+    while (iter2.hasNext) {
+      val tid = iter2.next()
+      val info = taskInfos(tid)
+      if (info.running) {
+        val exitCausedByApp: Boolean = reason match {
+          case ExecutorExited(_, false, _) => false
+          case ExecutorKilled | ExecutorDecommission(_, _) => false
+          case ExecutorProcessLost(_, _, false) => false
+          // If the task is launching, this indicates that Driver has sent LaunchTask to Executor,
+          // but Executor has not sent StatusUpdate(TaskState.RUNNING) to Driver. Hence, we assume
+          // that the task is not running, and it is NetworkFailure rather than TaskFailure.
+          case _ => !info.launching
+        }
+        handleFailedTask(tid, TaskState.FAILED, ExecutorLostFailure(info.executorId,
+          exitCausedByApp, Some(reason.toString)))
       }
-      handleFailedTask(tid, TaskState.FAILED, ExecutorLostFailure(info.executorId, exitCausedByApp,
-        Some(reason.toString)))
     }
     // recalculate valid locality levels and waits when executor is lost
     recomputeLocality()
@@ -1448,6 +1464,10 @@ private[spark] object TaskSetManager {
 
   // 1 minute
   val BARRIER_LOGGING_INTERVAL = 60000
+
+  // Shared empty set used as default value for executorIdToTaskIds lookups
+  // to avoid allocating a new empty set on each executorLost call.
+  private val emptyLongSet = new OpenHashSet[Long](0)
 }
 
 /**

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -1745,6 +1745,114 @@ class TaskSetManagerSuite
 
   }
 
+  test("SPARK-56235 Reverse index is correctly maintained and used by executorLost") {
+    sc = new SparkContext("local", "test")
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"))
+    // Create a task set with 4 tasks
+    val taskSet = FakeTask.createTaskSet(4,
+      Seq(TaskLocation("host1", "exec1")),
+      Seq(TaskLocation("host1", "exec1")),
+      Seq(TaskLocation("host2", "exec2")),
+      Seq(TaskLocation("host2", "exec2")))
+    val clock = new ManualClock()
+    clock.advance(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
+
+    // Initially, the reverse index should be empty
+    assert(manager.executorIdToTaskIds.isEmpty)
+
+    // Offer resources: tasks 0, 1 on exec1; tasks 2, 3 on exec2
+    val task0 = manager.resourceOffer("exec1", "host1", PROCESS_LOCAL)._1.get
+    val task1 = manager.resourceOffer("exec1", "host1", PROCESS_LOCAL)._1.get
+    val task2 = manager.resourceOffer("exec2", "host2", PROCESS_LOCAL)._1.get
+    val task3 = manager.resourceOffer("exec2", "host2", PROCESS_LOCAL)._1.get
+
+    // Verify reverse index is correctly populated
+    assert(manager.executorIdToTaskIds.size === 2)
+    assert(manager.executorIdToTaskIds("exec1").size === 2)
+    assert(manager.executorIdToTaskIds("exec1").contains(task0.taskId))
+    assert(manager.executorIdToTaskIds("exec1").contains(task1.taskId))
+    assert(manager.executorIdToTaskIds("exec2").size === 2)
+    assert(manager.executorIdToTaskIds("exec2").contains(task2.taskId))
+    assert(manager.executorIdToTaskIds("exec2").contains(task3.taskId))
+
+    assert(manager.runningTasks === 4)
+
+    // Lose exec1 - only tasks on exec1 should be affected
+    sched.removeExecutor("exec1")
+    manager.executorLost("exec1", "host1", ExecutorProcessLost())
+
+    // Tasks on exec1 should be failed (no longer running)
+    assert(manager.runningTasks === 2)
+    // Tasks on exec2 should still be running
+    assert(manager.taskInfos(task2.taskId).running)
+    assert(manager.taskInfos(task3.taskId).running)
+    // Tasks on exec1 should not be running
+    assert(!manager.taskInfos(task0.taskId).running)
+    assert(!manager.taskInfos(task1.taskId).running)
+  }
+
+  test("SPARK-56235 Reverse index works correctly with speculative tasks") {
+    val conf = new SparkConf().set(config.SPECULATION_ENABLED, true)
+    sc = new SparkContext("local", "test", conf)
+    sc.conf.set(config.SPECULATION_MULTIPLIER, 0.0)
+    sc.conf.set(config.SPECULATION_QUANTILE, 0.5)
+
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"),
+      ("exec2", "host2"), ("exec3", "host3"))
+    sched.initialize(new FakeSchedulerBackend() {
+      override def killTask(
+          taskId: Long,
+          executorId: String,
+          interruptThread: Boolean,
+          reason: String): Unit = {}
+    })
+
+    val taskSet = FakeTask.createTaskSet(2,
+      Seq(TaskLocation("host1", "exec1")),
+      Seq(TaskLocation("host2", "exec2")))
+    val clock = new ManualClock()
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
+
+    // Launch tasks: task 0 on exec1, task 1 on exec2
+    val task0 = manager.resourceOffer("exec1", "host1", PROCESS_LOCAL)._1.get
+    val task1 = manager.resourceOffer("exec2", "host2", PROCESS_LOCAL)._1.get
+
+    assert(manager.executorIdToTaskIds("exec1").size === 1)
+    assert(manager.executorIdToTaskIds("exec1").contains(task0.taskId))
+    assert(manager.executorIdToTaskIds("exec2").size === 1)
+    assert(manager.executorIdToTaskIds("exec2").contains(task1.taskId))
+
+    // Complete task 0, so that speculative task can be launched for task 1
+    clock.advance(1)
+    val directTaskResult = new DirectTaskResult[String]() {
+      override def value(resultSer: SerializerInstance): String = ""
+    }
+    manager.handleSuccessfulTask(task0.taskId, directTaskResult)
+
+    // Launch speculative copy of task 1 on exec3
+    clock.advance(1)
+    manager.checkSpeculatableTasks(0)
+    manager.speculatableTasks += 1
+    manager.addPendingTask(1, speculatable = true)
+    val specTask = manager.resourceOffer("exec3", "host3", ANY)._1.get
+    assert(specTask.index === 1)
+    assert(specTask.attemptNumber === 1)
+
+    // Verify reverse index now has speculative task on exec3
+    assert(manager.executorIdToTaskIds("exec3").size === 1)
+    assert(manager.executorIdToTaskIds("exec3").contains(specTask.taskId))
+
+    // Lose exec2 (where original task 1 is running)
+    sched.removeExecutor("exec2")
+    manager.executorLost("exec2", "host2", ExecutorProcessLost())
+
+    // Original task 1 should be failed, speculative task 1 on exec3 should still be running
+    assert(!manager.taskInfos(task1.taskId).running)
+    assert(manager.taskInfos(specTask.taskId).running)
+    assert(manager.runningTasks === 1)
+  }
+
   private def createTaskResult(
       id: Int,
       accumUpdates: Seq[AccumulatorV2[_, _]] = Seq.empty,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR adds a reverse index `executorIdToTaskIds: HashMap[String, OpenHashSet[Long]]` in `TaskSetManager` to efficiently look up tasks by executor ID, replacing O(N) full scans over `taskInfos` in `executorLost()` with O(K) direct lookups (K = tasks per executor).

**Changes:**
- Added `executorIdToTaskIds` field in `TaskSetManager`, populated at task launch in `prepareLaunchingTask()`
- Rewrote the two loops in `executorLost()` to iterate only over tasks on the lost executor via the reverse index

### Why are the changes needed?

In a production Spark job (Spark 3.5.1, dynamic allocation enabled, disable shuffle tracking) with a single stage containing 5 million tasks, we observed that near the end of the stage, the Spark UI showed the last few tasks stuck in "RUNNING" state for **1-2 hours**. 
However, checking executor thread dumps confirmed that **no task threads were actually running** — the tasks had already completed on the executor side, but the Driver had not processed their completion messages.
<img width="2457" height="884" alt="image" src="https://github.com/user-attachments/assets/d001ca27-c297-4777-8b00-25960719570b" />
<img width="4576" height="1854" alt="image" src="https://github.com/user-attachments/assets/503c687c-00a0-41cf-b686-a9ce6f4deaa2" />

CPU profiling of the Driver JVM (5-minute snapshot) revealed that `TaskSetManager.executorLost()` was consuming **99.5%** of all CPU samples, due to O(N) full scans over the `taskInfos` HashMap (N = 5,000,000 entries).
<img width="5086" height="1804" alt="image" src="https://github.com/user-attachments/assets/3a2e76dd-b083-400a-ac99-6296e1abbfff" />

The `executorLost()` method scans the **entire** `taskInfos` map to find tasks on the lost executor:

```scala
// Before: O(N) — scans ALL task attempts to find those on the lost executor
for ((tid, info) <- taskInfos if info.executorId == execId) { ... }
```

The blocking is amplified when the following conditions are present:

1. **Long-tail tasks at stage end** — a few remaining tasks take longer than `spark.dynamicAllocation.executorIdleTimeout` (default 60s) to complete. Most executors have finished their work and sit idle, while these slow tasks are still running.
2. **Batch executor removal** — after the idle timeout is triggered, a large number of RemoveExecutor messages continue to be sent to the DriverEndpoint RPC queue.


After this PR, the same workload (5M tasks, 10K executors, dynamic allocation enabled) no longer exhibits the stall. Execution time reduced from **117 minutes to 45 minutes**. At the end of the Stage, the optimization has eliminated the previous `executorLost` hotspot issue.

| | Before | After |
|---|---|---|
| **Job Timeline** | <img width="1936" height="353" alt="image" src="https://github.com/user-attachments/assets/3f7073e1-1c11-4c52-940a-bf5d76939c12" /> | <img width="1940" height="362" alt="image" src="https://github.com/user-attachments/assets/01ff59fd-d07d-417b-849b-c0a6519daac5" /> |
| **Driver CPU Top Threads (Stage Tail)** | <img width="2758" height="1450" alt="image" src="https://github.com/user-attachments/assets/25f1925b-8d3c-4920-8f90-f0239cb50657" /> | <img width="2506" height="1416" alt="image" src="https://github.com/user-attachments/assets/579b7365-0bc0-487b-bcbd-41cd2bd07ead" /> |


Memory overhead (measured with `jmap -histo:live`):

| Metric | Value |
|---|---|
| Total added memory | **~81 MB** |
| vs `taskInfos` overhead (829 MB) | ~10% |
| vs Driver heap old gen used (9.3 GB) | < 1% |


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Added 2 tests in `TaskSetManagerSuite`

### Was this patch authored or co-authored using generative AI tooling?
No.
