### PR TITLE
[SPARK-56242][PYTHON][TESTS] Add a test to ensure no 3rd party libraries are imported for "import pyspark"

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -492,6 +492,7 @@ pyspark_core = Module(
         "pyspark.tests.test_conf",
         "pyspark.tests.test_context",
         "pyspark.tests.test_daemon",
+        "pyspark.tests.test_import_spark",
         "pyspark.tests.test_join",
         "pyspark.tests.test_memory_profiler",
         "pyspark.tests.test_pin_thread",

--- a/python/pyspark/tests/test_import_spark.py
+++ b/python/pyspark/tests/test_import_spark.py
@@ -1,0 +1,69 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import subprocess
+import sys
+import unittest
+
+
+class ImportSparkTest(unittest.TestCase):
+    def test_import_spark_libraries(self):
+        """
+        We want to ensure "import pyspark" is fast. It matters when we spawn
+        workers and it provides a good user experience.
+
+        It's difficult to compare the exact time, for this test, we test if any
+        unnecessary 3rd party libraries are imported. We only expect py4j to
+        be imported when we do "import pyspark".
+        """
+        ALLOWED_PACKAGES = set(sys.stdlib_module_names) | set(["py4j"])
+
+        stdout = subprocess.check_output(
+            ["python", "-X", "importtime", "-c", "import pyspark"],
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        # reverse the lines to follow the dependency order
+        # the first line is the header so we skip it
+        lines = reversed(stdout.split("\n")[1:])
+        module_lines = [line.split("|")[-1] for line in lines if line.strip()]
+        skip_indentation = None
+        for module_line in module_lines:
+            module = module_line.lstrip()
+            indentation = len(module_line) - len(module)
+            if skip_indentation is not None:
+                if indentation > skip_indentation:
+                    continue
+                else:
+                    skip_indentation = None
+
+            if module.startswith("pyspark"):
+                continue
+
+            package = module.split(".")[0]
+            if package in ALLOWED_PACKAGES:
+                skip_indentation = indentation
+            else:
+                self.fail(
+                    f"Unexpected 3rd party package '{package}' imported during 'import pyspark'"
+                )
+
+
+if __name__ == "__main__":
+    from pyspark.testing import main
+
+    main()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

A new test is added. The new test runs `python -X importtime -c "import pyspark"` to get the import dependency and checks whether 3rd party libraries are imported.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

2 weeks ago `import pyspark` takes 200+ms, now it's 60ms - most of it because we lazy loaded `memory_profiler`. Make `import pyspark` fast is important for user experience. It's also critical for our worker spawn time. The only way to keep it fast is to add a test to check against it.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Test passed locally.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.