### PR TITLE
[SPARK-56243][SS] Throw detailed error on malformed Kafka record timestamps

### DIFF
--- a/connector/kafka-0-10-sql/src/main/resources/error/kafka-error-conditions.json
+++ b/connector/kafka-0-10-sql/src/main/resources/error/kafka-error-conditions.json
@@ -120,5 +120,13 @@
     "message" : [
       "The specified start <offsetType> <startOffset> is greater than the end <offsetType> <endOffset> for topic <topic> partition <partition>."
     ]
+  },
+  "KAFKA_MALFORMED_RECORD_TIMESTAMP" : {
+    "message": [
+      "Record at topic <topic> partition <partition> offset <offset> has timestamp value <timestamp> that overflows when converting to Spark's microsecond-precision TimestampType.",
+      "Kafka record timestamps must be in milliseconds since epoch per the Kafka protocol. The provided value suggests the producer may be writing timestamps in microseconds or nanoseconds instead.",
+      "Ensure the Kafka producer sets the ProducerRecord timestamp in milliseconds."
+    ],
+    "sqlState": "22008"
   }
 }

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaExceptions.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaExceptions.scala
@@ -178,6 +178,25 @@ object KafkaExceptions {
         "assignedPartitions" -> assignedPartitions.toString))
   }
 
+  def kafkaMalformedRecordTimestamp(
+      topic: String,
+      partition: Int,
+      offset: Long,
+      timestamp: Long,
+      cause: Throwable
+  ): KafkaIllegalStateException = {
+    new KafkaIllegalStateException(
+      errorClass = "KAFKA_MALFORMED_RECORD_TIMESTAMP",
+      messageParameters = Map(
+        "topic" -> topic,
+        "partition" -> partition.toString,
+        "offset" -> offset.toString,
+        "timestamp" -> timestamp.toString
+      ),
+      cause = cause
+    )
+  }
+
   def nullTopicInData(): KafkaIllegalStateException = {
     new KafkaIllegalStateException(
       errorClass = "KAFKA_NULL_TOPIC_IN_DATA",

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaRecordToRowConverter.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaRecordToRowConverter.scala
@@ -39,13 +39,13 @@ private[kafka010] class KafkaRecordToRowConverter {
   val toInternalRowWithoutHeaders: Record => InternalRow =
     (cr: Record) => InternalRow(
       cr.key, cr.value, UTF8String.fromString(cr.topic), cr.partition, cr.offset,
-      DateTimeUtils.fromJavaTimestamp(new Timestamp(cr.timestamp)), cr.timestampType.id
+      parseTimestamp(cr), cr.timestampType.id
     )
 
   val toInternalRowWithHeaders: Record => InternalRow =
     (cr: Record) => InternalRow(
       cr.key, cr.value, UTF8String.fromString(cr.topic), cr.partition, cr.offset,
-      DateTimeUtils.fromJavaTimestamp(new Timestamp(cr.timestamp)), cr.timestampType.id,
+      parseTimestamp(cr), cr.timestampType.id,
       if (cr.headers.iterator().hasNext) {
         new GenericArrayData(cr.headers.iterator().asScala
           .map(header =>
@@ -89,5 +89,20 @@ private[kafka010] object KafkaRecordToRowConverter {
 
   def kafkaSchema(includeHeaders: Boolean): StructType = {
     if (includeHeaders) schemaWithHeaders else schemaWithoutHeaders
+  }
+
+  private def parseTimestamp(cr: Record): Long = {
+    try {
+      DateTimeUtils.fromJavaTimestamp(new Timestamp(cr.timestamp))
+    } catch {
+      case e: ArithmeticException =>
+        throw KafkaExceptions.kafkaMalformedRecordTimestamp(
+          cr.topic(),
+          cr.partition(),
+          cr.offset(),
+          cr.timestamp(),
+          e
+        )
+    }
   }
 }

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -1589,6 +1589,36 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase with 
       q.stop()
     }
   }
+
+  test("SPARK-56243: malformed record timestamp throws detailed error") {
+    val topic = newTopic()
+    testUtils.createTopic(topic, partitions = 1)
+
+    // Nanosecond-precision timestamp that overflows millis-to-micros conversion
+    val nanoTimestamp = 1712345678123456789L
+    val record = new RecordBuilder(topic, "value").partition(0).timestamp(nanoTimestamp).build()
+    testUtils.sendMessages(Seq(record))
+
+    val kafka = spark
+      .readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+      .option("subscribe", topic)
+      .option("startingOffsets", "earliest")
+      .load()
+
+    testStream(kafka)(
+      StartStream(),
+      ExpectFailure[KafkaIllegalStateException](e => {
+        val ex = e.asInstanceOf[KafkaIllegalStateException]
+        assert(ex.getCondition === "KAFKA_MALFORMED_RECORD_TIMESTAMP")
+        assert(ex.getSqlState === "22008")
+        assert(ex.getMessage.contains(topic))
+        assert(ex.getMessage.contains(nanoTimestamp.toString))
+        assert(ex.getCause.isInstanceOf[ArithmeticException])
+      })
+    )
+  }
 }
 
 abstract class KafkaMicroBatchV1SourceSuite extends KafkaMicroBatchSourceSuiteBase {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Throw a detailed `KAFKA_MALFORMED_RECORD_TIMESTAMP` message when a record has a malformed or incorrect precision timestamp.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Some users may use custom producers which set the timestamp to an incorrect precision level than what is expected by Kafka. Upon hitting this issue, they would get a generic arithmetic overflow error.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, it introduces a new error message, however there is no other behavioral change.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
N/A

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
