### PR TITLE
[SPARK-56248][PYTHON][SS] Optimize python stateful processor serialization to skip unnecessary list/dict/row construction.

### DIFF
--- a/python/pyspark/sql/streaming/stateful_processor_api_client.py
+++ b/python/pyspark/sql/streaming/stateful_processor_api_client.py
@@ -516,7 +516,7 @@ class StatefulProcessorApiClient:
                 else:
                     return v
 
-            converted = [normalize_value(v) for v in data]
+            converted = tuple(normalize_value(v) for v in data)
         else:
             converted = data
 

--- a/python/pyspark/sql/streaming/stateful_processor_api_client.py
+++ b/python/pyspark/sql/streaming/stateful_processor_api_client.py
@@ -518,12 +518,9 @@ class StatefulProcessorApiClient:
 
             converted = [normalize_value(v) for v in data]
         else:
-            converted = list(data)
+            converted = data
 
-        field_names = [f.name for f in schema.fields]
-        row_value = Row(**dict(zip(field_names, converted)))
-
-        return self.pickleSer.dumps(schema.toInternal(row_value))
+        return self.pickleSer.dumps(schema.toInternal(converted))
 
     def _deserialize_from_bytes(self, value: bytes) -> Any:
         return self.pickleSer.loads(value)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Eliminate per-call Row(**dict(zip(...))) construction in _serialize_to_bytes, pass normalized tuples directly to schema.toInternal which handles them by index

To better explain the removal of `Row` usage: 
- The positional ordering is retained because Row was constructed purely positionally:
    - Row.new stores values in insertion order ([link](https://github.com/jiateoh/spark/blob/615af5d154d1b15b26dfde3cc3441550eac5a615/python/pyspark/sql/types.py#L3547)). [This is also noted in the change notes since 3.0.0](https://github.com/jiateoh/spark/blob/615af5d154d1b15b26dfde3cc3441550eac5a615/python/pyspark/sql/types.py#L3492)
    - `dict(zip(...))` preserves insertion order in python 3.7+ (dicts preserve insertion order)
    - Inputs to `zip` are field_names, assumed to be same-ordered as the `converted` input data which is derived from the original input tuple in the same order.
- `Row` is a tuple subclass, so it always hit [Schema.toInternal](https://github.com/jiateoh/spark/blob/615af5d154d1b15b26dfde3cc3441550eac5a615/python/pyspark/sql/types.py#L1763)'s tuple/list positional branch.  Replacing it with the input tuple or a converted list will execute the same Schema.toInternal branch as before.

The result is that the extra list, zip, dict, and Row construction is no longer necessary: the end result remains equivalent to the input to the entire `Row(**dict(zip(...)))` sequence: a positionally-ordered tuple/list

AI-assisted + human reviewed/updated

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is a code cleanup/performance optimization. Original code has unnecessary operations that are executed for every row, including: rebuilding closures, extracting field names, building intermediate lists + dicts, and constructing Row objects (which sort by field unnecessarily). These can all add minor overhead while having no effect on the underlying usage.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Code (Claude Opus 4.6)