### PR TITLE
[SPARK-56245][PS] Fix DataFrame.eval inplace assignment on pandas 3

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -13312,6 +13312,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             nonlocal should_return_series
             nonlocal series_name
             nonlocal should_return_scalar
+            if inplace and LooseVersion(pd.__version__) >= "3.0.0":
+                # pandas 3 can reject inplace eval on a read-only batch frame,
+                # so evaluate against a writable copy.
+                pdf = pdf.copy()
             result_inner = pdf.eval(expr, inplace=inplace)
             if inplace:
                 result_inner = pdf


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates pandas-on-Spark `DataFrame.eval` to make a writable pandas copy before calling `pdf.eval(..., inplace=True)` on pandas 3.

### Why are the changes needed?

With pandas 3, the pandas batch frame used by pandas-on-Spark can be read-only. In that case, inplace expressions such as `psdf.eval("A = B + C", inplace=True)` can fail with:

```
ValueError: Cannot assign expression output to target
```

Copying the batch only for the pandas 3 inplace path keeps the fix minimal and preserves the existing behavior for non-inplace `eval`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing tests should pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
