### PR TITLE
[SPARK-56092][SS][CONNECT] Fix NPE in StreamingQueryException.toString() when cause is null

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryException.scala
+++ b/common/utils/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryException.scala
@@ -98,9 +98,15 @@ class StreamingQueryException private[sql](
   override def getMessage: String =
     if (queryDebugString.isEmpty) message else s"${message}\n${queryDebugString}"
 
-  override def toString(): String =
-    s"""${classOf[StreamingQueryException].getName}: ${cause.getMessage}
+  override def toString(): String = {
+    val causeMsg = if (cause != null) {
+      if (cause.getMessage != null) cause.getMessage else s"$message (no cause message)"
+    } else {
+      s"$message (no cause)"
+    }
+    s"""${classOf[StreamingQueryException].getName}: $causeMsg
        |$queryDebugString""".stripMargin
+  }
 
   override def getCondition: String = errorClass
 

--- a/common/utils/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryExceptionSuite.scala
+++ b/common/utils/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryExceptionSuite.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.streaming
+
+import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
+
+class StreamingQueryExceptionSuite extends AnyFunSuite { // scalastyle:ignore funsuite
+
+  test("toString with null cause should not throw NPE") {
+    val exception = new StreamingQueryException(
+      message = "test message",
+      cause = null,
+      errorClass = "TEST_ERROR",
+      messageParameters = Map.empty[String, String])
+
+    val result = exception.toString()
+    assert(result.contains("StreamingQueryException"))
+    assert(result.contains("test message"))
+    assert(result.contains("(no cause)"))
+  }
+
+  test("toString with non-null cause should use cause message") {
+    val cause = new RuntimeException("root cause")
+    val exception = new StreamingQueryException(
+      message = "test message",
+      cause = cause,
+      errorClass = "TEST_ERROR",
+      messageParameters = Map.empty[String, String])
+
+    val result = exception.toString()
+    assert(result.contains("StreamingQueryException"))
+    assert(result.contains("root cause"))
+  }
+
+  test("toString with non-null cause but null cause message") {
+    val cause = new RuntimeException()
+    val exception = new StreamingQueryException(
+      message = "test message",
+      cause = cause,
+      errorClass = "TEST_ERROR",
+      messageParameters = Map.empty[String, String])
+
+    val result = exception.toString()
+    assert(result.contains("StreamingQueryException"))
+    assert(result.contains("test message"))
+    assert(result.contains("(no cause message)"))
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add null safety to StreamingQueryException.toString() to handle cases where cause is null or cause.getMessage is null.

Changes:
- StreamingQueryException.toString(): use Option to guard against both null cause and null cause.getMessage, falling back to message field.
- New StreamingQueryExceptionSuite with tests for null cause, normal cause, and cause with null message.

### Why are the changes needed?
In Spark Connect, GrpcExceptionConverter constructs StreamingQueryException with params.cause.orNull, which passes null when the original cause is unavailable during gRPC deserialization. Calling toString() on such an instance throws NPE because the original code calls cause.getMessage unconditionally.

### Does this PR introduce _any_ user-facing change?
No. Before this fix, calling toString() on a StreamingQueryException with a null cause (e.g. from Spark Connect) would throw an NPE, hiding the actual error message. After this fix, it correctly displays the exception message instead.

### How was this patch tested?
New unit tests in StreamingQueryExceptionSuite covering three scenarios:
- cause is null
- cause is non-null with a message
- cause is non-null but getMessage returns null

### Was this patch authored or co-authored using generative AI tooling? 
Yes, co-authored with Kiro.
