### PR TITLE
[SPARK-56154][SQL] Preserve ENUM logical annotation through Parquet read-write

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
@@ -177,16 +177,30 @@ class ParquetToSparkSchemaConverter(
       val convertedField = convertField(field, fieldReadType)
       val fieldName = fieldFromReadSchema.map(_.name).getOrElse(field.getType.getName)
 
+      val enumTypeMetadata = field match {
+        case p: PrimitiveColumnIO
+          if Option(p.getType.getLogicalTypeAnnotation)
+            .exists(_.isInstanceOf[EnumLogicalTypeAnnotation]) =>
+          new MetadataBuilder()
+            .putString(ParquetSchemaConverter.PARQUET_LOGICAL_TYPE_KEY,
+              ParquetSchemaConverter.PARQUET_ENUM_TYPE)
+            .build()
+        case _ => Metadata.empty
+      }
+
       field.getType.getRepetition match {
         case OPTIONAL | REQUIRED =>
           val nullable = field.getType.getRepetition == OPTIONAL
-          (StructField(fieldName, convertedField.sparkType, nullable = nullable),
+          (StructField(fieldName, convertedField.sparkType, nullable = nullable,
+              metadata = enumTypeMetadata),
               convertedField)
 
         case REPEATED =>
           // A repeated field that is neither contained by a `LIST`- or `MAP`-annotated group nor
           // annotated by `LIST` or `MAP` should be interpreted as a required list of required
           // elements where the element type is the type of the field.
+          // ENUM metadata is not propagated for REPEATED fields because the write path
+          // cannot round-trip it back to the element's logical type within ArrayType.
           val arrayType = ArrayType(convertedField.sparkType, containsNull = false)
           (StructField(fieldName, arrayType, nullable = false),
               ParquetColumn(arrayType, None, convertedField.repetitionLevel - 1,
@@ -674,8 +688,15 @@ class SparkToParquetSchemaConverter(
         Types.primitive(DOUBLE, repetition).named(field.name)
 
       case _: StringType =>
-        Types.primitive(BINARY, repetition)
-          .as(LogicalTypeAnnotation.stringType()).named(field.name)
+        val logicalType =
+          if (field.metadata.contains(ParquetSchemaConverter.PARQUET_LOGICAL_TYPE_KEY) &&
+              field.metadata.getString(ParquetSchemaConverter.PARQUET_LOGICAL_TYPE_KEY) ==
+                ParquetSchemaConverter.PARQUET_ENUM_TYPE) {
+            LogicalTypeAnnotation.enumType()
+          } else {
+            LogicalTypeAnnotation.stringType()
+          }
+        Types.primitive(BINARY, repetition).as(logicalType).named(field.name)
 
       case geom: GeometryType =>
         Types.primitive(BINARY, repetition)
@@ -921,6 +942,11 @@ class SparkToParquetSchemaConverter(
 
 private[sql] object ParquetSchemaConverter {
   val SPARK_PARQUET_SCHEMA_NAME = "spark_schema"
+
+  // Internal metadata to preserve Parquet logical type annotations (e.g., ENUM)
+  // through read-write roundtrips. See SPARK-56154.
+  val PARQUET_LOGICAL_TYPE_KEY = "__PARQUET_LOGICAL_TYPE"
+  val PARQUET_ENUM_TYPE = "ENUM"
 
   val EMPTY_MESSAGE: MessageType =
     Types.buildMessage().named(ParquetSchemaConverter.SPARK_PARQUET_SCHEMA_NAME)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -1887,6 +1887,183 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
       }
     }
   }
+
+  test("ENUM logical annotation roundtrip preservation") {
+    val enumSchema = MessageTypeParser.parseMessageType(
+      """message test {
+        |  optional binary suit (ENUM);
+        |}""".stripMargin)
+
+    withTempDir { dir =>
+      val inputPath = new Path(dir.getAbsolutePath, "input")
+      val writer = createParquetWriter(enumSchema, inputPath)
+      try {
+        val factory = new SimpleGroupFactory(enumSchema)
+        writer.write(factory.newGroup().append("suit", "HEARTS"))
+        writer.write(factory.newGroup().append("suit", "SPADES"))
+      } finally {
+        writer.close()
+      }
+
+      val df = spark.read.parquet(inputPath.toString)
+      assert(df.schema("suit").metadata.contains(
+        ParquetSchemaConverter.PARQUET_LOGICAL_TYPE_KEY))
+      assert(df.schema("suit").metadata.getString(
+        ParquetSchemaConverter.PARQUET_LOGICAL_TYPE_KEY) ==
+        ParquetSchemaConverter.PARQUET_ENUM_TYPE)
+
+      val outputPath = new Path(dir.getAbsolutePath, "output")
+      df.write.parquet(outputPath.toString)
+
+      val hadoopConf = spark.sessionState.newHadoopConf()
+      // scalastyle:off FileSystemGet
+      val outputFiles = FileSystem.get(hadoopConf).listStatus(outputPath)
+        .filter(_.getPath.getName.endsWith(".parquet"))
+      // scalastyle:on FileSystemGet
+      assert(outputFiles.nonEmpty, "Expected at least one Parquet file in output")
+
+      val reader = ParquetFileReader.open(
+        org.apache.parquet.hadoop.util.HadoopInputFile.fromPath(
+          outputFiles.head.getPath, hadoopConf))
+      try {
+        val outputSchema = reader.getFooter.getFileMetaData.getSchema
+        val suitField = outputSchema.getFields.get(0)
+        val annotation = suitField.asPrimitiveType().getLogicalTypeAnnotation
+        assert(annotation.toString == "ENUM",
+          s"Expected ENUM annotation but got: $annotation")
+      } finally {
+        reader.close()
+      }
+    }
+  }
+
+  test("plain StringType column writes as STRING not ENUM") {
+    withTempDir { dir =>
+      val df = Seq("hello", "world").toDF("name")
+      assert(!df.schema("name").metadata.contains(
+        ParquetSchemaConverter.PARQUET_LOGICAL_TYPE_KEY))
+
+      val outputPath = new Path(dir.getAbsolutePath, "output")
+      df.write.parquet(outputPath.toString)
+
+      val hadoopConf = spark.sessionState.newHadoopConf()
+      // scalastyle:off FileSystemGet
+      val outputFiles = FileSystem.get(hadoopConf).listStatus(outputPath)
+        .filter(_.getPath.getName.endsWith(".parquet"))
+      // scalastyle:on FileSystemGet
+      assert(outputFiles.nonEmpty)
+
+      val reader = ParquetFileReader.open(
+        org.apache.parquet.hadoop.util.HadoopInputFile.fromPath(
+          outputFiles.head.getPath, hadoopConf))
+      try {
+        val outputSchema = reader.getFooter.getFileMetaData.getSchema
+        val nameField = outputSchema.getFields.get(0)
+        val annotation = nameField.asPrimitiveType().getLogicalTypeAnnotation
+        assert(annotation.toString == "STRING",
+          s"Expected STRING annotation but got: $annotation")
+      } finally {
+        reader.close()
+      }
+    }
+  }
+
+  test("REQUIRED ENUM field roundtrip preservation") {
+    val enumSchema = MessageTypeParser.parseMessageType(
+      """message test {
+        |  required binary color (ENUM);
+        |}""".stripMargin)
+
+    withTempDir { dir =>
+      val inputPath = new Path(dir.getAbsolutePath, "input")
+      val writer = createParquetWriter(enumSchema, inputPath)
+      try {
+        val factory = new SimpleGroupFactory(enumSchema)
+        writer.write(factory.newGroup().append("color", "RED"))
+        writer.write(factory.newGroup().append("color", "BLUE"))
+      } finally {
+        writer.close()
+      }
+
+      val df = spark.read.parquet(inputPath.toString)
+      assert(df.schema("color").metadata.getString(
+        ParquetSchemaConverter.PARQUET_LOGICAL_TYPE_KEY) ==
+        ParquetSchemaConverter.PARQUET_ENUM_TYPE)
+
+      val outputPath = new Path(dir.getAbsolutePath, "output")
+      df.write.parquet(outputPath.toString)
+
+      val hadoopConf = spark.sessionState.newHadoopConf()
+      // scalastyle:off FileSystemGet
+      val outputFiles = FileSystem.get(hadoopConf).listStatus(outputPath)
+        .filter(_.getPath.getName.endsWith(".parquet"))
+      // scalastyle:on FileSystemGet
+
+      val reader = ParquetFileReader.open(
+        org.apache.parquet.hadoop.util.HadoopInputFile.fromPath(
+          outputFiles.head.getPath, hadoopConf))
+      try {
+        val outputSchema = reader.getFooter.getFileMetaData.getSchema
+        val colorField = outputSchema.getFields.get(0)
+        assert(colorField.asPrimitiveType().getLogicalTypeAnnotation.toString == "ENUM",
+          "REQUIRED ENUM annotation should be preserved")
+      } finally {
+        reader.close()
+      }
+    }
+  }
+
+  test("mixed ENUM and STRING columns in same schema") {
+    val mixedSchema = MessageTypeParser.parseMessageType(
+      """message test {
+        |  optional binary suit (ENUM);
+        |  optional binary name (STRING);
+        |}""".stripMargin)
+
+    withTempDir { dir =>
+      val inputPath = new Path(dir.getAbsolutePath, "input")
+      val writer = createParquetWriter(mixedSchema, inputPath)
+      try {
+        val factory = new SimpleGroupFactory(mixedSchema)
+        writer.write(factory.newGroup().append("suit", "HEARTS").append("name", "Alice"))
+        writer.write(factory.newGroup().append("suit", "SPADES").append("name", "Bob"))
+      } finally {
+        writer.close()
+      }
+
+      val df = spark.read.parquet(inputPath.toString)
+      assert(df.schema("suit").metadata.contains(
+        ParquetSchemaConverter.PARQUET_LOGICAL_TYPE_KEY))
+      assert(!df.schema("name").metadata.contains(
+        ParquetSchemaConverter.PARQUET_LOGICAL_TYPE_KEY))
+
+      val outputPath = new Path(dir.getAbsolutePath, "output")
+      df.write.parquet(outputPath.toString)
+
+      val hadoopConf = spark.sessionState.newHadoopConf()
+      // scalastyle:off FileSystemGet
+      val outputFiles = FileSystem.get(hadoopConf).listStatus(outputPath)
+        .filter(_.getPath.getName.endsWith(".parquet"))
+      // scalastyle:on FileSystemGet
+
+      val reader = ParquetFileReader.open(
+        org.apache.parquet.hadoop.util.HadoopInputFile.fromPath(
+          outputFiles.head.getPath, hadoopConf))
+      try {
+        val outputSchema = reader.getFooter.getFileMetaData.getSchema
+        val suitAnnotation = outputSchema.getFields.get(0)
+          .asPrimitiveType().getLogicalTypeAnnotation
+        val nameAnnotation = outputSchema.getFields.get(1)
+          .asPrimitiveType().getLogicalTypeAnnotation
+        assert(suitAnnotation.toString == "ENUM",
+          s"ENUM column should stay ENUM but got: $suitAnnotation")
+        assert(nameAnnotation.toString == "STRING",
+          s"STRING column should stay STRING but got: $nameAnnotation")
+      } finally {
+        reader.close()
+      }
+    }
+  }
 }
 
 class JobCommitFailureParquetOutputCommitter(outputPath: Path, context: TaskAttemptContext)


### PR DESCRIPTION
### What changes were proposed in this pull request?

When Spark reads a Parquet file containing BINARY(ENUM) columns, the ENUM logical type annotation is lost and written back as BINARY(STRING). This patch preserves the ENUM annotation through read-write roundtrips by storing it in StructField metadata.

The changes:
1. In ParquetToSparkSchemaConverter (read path): detect EnumLogicalTypeAnnotation on PrimitiveColumnIO and store a metadata tag on the StructField. This applies to OPTIONAL and REQUIRED fields. REPEATED ENUM is intentionally not supported because the write path cannot propagate element-level metadata through ArrayType conversion.
2. In SparkToParquetSchemaConverter (write path): when writing StringType columns, check for the ENUM metadata tag and emit LogicalTypeAnnotation.enumType() instead of stringType().
3. Extract hardcoded metadata key/value strings into constants (PARQUET_LOGICAL_TYPE_KEY, PARQUET_ENUM_TYPE) in the ParquetSchemaConverter companion object. The metadata key uses the __ prefix convention for internal metadata.

### Why are the changes needed?

Without this fix, Parquet files with ENUM-annotated columns lose their annotation after a Spark read-write cycle. This breaks downstream systems that depend on the ENUM annotation (e.g., Avro ecosystem tooling), causes schema inconsistency in data pipelines, and fails schema validation in schema registry scenarios.

### Does this PR introduce _any_ user-facing change?

Yes. Parquet ENUM logical type annotations are now preserved when reading and writing Parquet files through Spark. Previously, all StringType columns were written as BINARY(STRING) regardless of the original annotation.

### How was this patch tested?

- Roundtrip test: creates a Parquet file with BINARY(ENUM) schema, reads with Spark, verifies metadata tag, writes back, and verifies the output file retains the ENUM annotation.
- REQUIRED ENUM test: verifies roundtrip preservation for required (non-nullable) ENUM fields.
- Mixed columns test: verifies ENUM and STRING columns coexist correctly in the same schema without interference.
- Negative test: verifies that plain StringType columns without ENUM metadata continue to write as BINARY(STRING).

### Was this patch authored or co-authored using generative AI tooling?

Yes, co-authored with Kiro.