### PR TITLE
[SPARK-56250][SQL] Remove confusing defensive code in SortExec.rowSorter and add warning comment

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
@@ -62,6 +62,9 @@ case class SortExec(
     "peakMemory" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory"),
     "spillSize" -> SQLMetrics.createSizeMetric(sparkContext, "spill size"))
 
+  // WARNING: This is a shared mutable var on the SortExec instance. Do not access it from
+  // multiple threads concurrently — Spark operators are not thread-safe and one task's sorter
+  // could overwrite another's, causing a race condition.
   private[sql] var rowSorter: UnsafeExternalRowSorter = _
 
   /**
@@ -191,13 +194,13 @@ case class SortExec(
   }
 
   /**
-   * In SortExec, we overwrites cleanupResources to close UnsafeExternalRowSorter.
+   * In SortExec, we overwrite cleanupResources to close UnsafeExternalRowSorter.
+   * There's possible for rowSorter to be null here, for example, in the scenario of empty iterator
+   * in the current task, the downstream physical node (like SortMergeJoinExec) will trigger
+   * cleanupResources before rowSorter is initialized in createSorter.
    */
   override protected[sql] def cleanupResources(): Unit = {
     if (rowSorter != null) {
-      // There's possible for rowSorter is null here, for example, in the scenario of empty
-      // iterator in the current task, the downstream physical node(like SortMergeJoinExec) will
-      // trigger cleanupResources before rowSorter initialized in createSorter.
       rowSorter.cleanupResources()
     }
     super.cleanupResources()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
@@ -63,7 +63,7 @@ case class SortExec(
     "spillSize" -> SQLMetrics.createSizeMetric(sparkContext, "spill size"))
 
   // WARNING: This is a shared mutable var on the SortExec instance. Do not access it from
-  // multiple threads concurrently — Spark operators do not guarantee thread-safety and one
+  // multiple threads concurrently - Spark operators do not guarantee thread-safety and one
   // task's sorter could overwrite another's, causing a race condition.
   private[sql] var rowSorter: UnsafeExternalRowSorter = _
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
@@ -62,13 +62,9 @@ case class SortExec(
     "peakMemory" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory"),
     "spillSize" -> SQLMetrics.createSizeMetric(sparkContext, "spill size"))
 
-  // Each task thread has its own UnsafeExternalRowSorter instance stored here.
-  // Using a stable lazy val (rather than a reassigned var) ensures that the ThreadLocal
-  // object itself is never replaced: concurrent tasks on different threads each get their
-  // own independent slot in the same ThreadLocal, so one task can never observe or clobber
-  // another task's sorter reference.
-  @transient private[sql] lazy val rowSorter: ThreadLocal[UnsafeExternalRowSorter] =
-    new ThreadLocal[UnsafeExternalRowSorter]()
+  // Each task has its own instance of UnsafeExternalRowSorter. It is created in the
+  // createSorter method and stored in a ThreadLocal variable.
+  private[sql] var rowSorter: ThreadLocal[UnsafeExternalRowSorter] = _
 
   /**
    * This method gets invoked only once for each SortExec instance to initialize an
@@ -77,6 +73,8 @@ case class SortExec(
    * should make it public.
    */
   def createSorter(): UnsafeExternalRowSorter = {
+    rowSorter = new ThreadLocal[UnsafeExternalRowSorter]()
+
     val ordering = RowOrdering.create(sortOrder, output)
 
     // The comparator for comparing prefix
@@ -198,13 +196,13 @@ case class SortExec(
   }
 
   /**
-   * In SortExec, we overwrite cleanupResources to close UnsafeExternalRowSorter.
-   * There's possible for rowSorter to be null here, for example, in the scenario of empty iterator
-   * in the current task, the downstream physical node (like SortMergeJoinExec) will trigger
-   * cleanupResources before rowSorter is initialized in createSorter.
+   * In SortExec, we overwrites cleanupResources to close UnsafeExternalRowSorter.
    */
   override protected[sql] def cleanupResources(): Unit = {
-    if (rowSorter.get() != null) {
+    if (rowSorter != null && rowSorter.get() != null) {
+      // There's possible for rowSorter is null here, for example, in the scenario of empty
+      // iterator in the current task, the downstream physical node(like SortMergeJoinExec) will
+      // trigger cleanupResources before rowSorter initialized in createSorter.
       rowSorter.get().cleanupResources()
     }
     super.cleanupResources()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
@@ -63,8 +63,8 @@ case class SortExec(
     "spillSize" -> SQLMetrics.createSizeMetric(sparkContext, "spill size"))
 
   // WARNING: This is a shared mutable var on the SortExec instance. Do not access it from
-  // multiple threads concurrently — Spark operators are not thread-safe and one task's sorter
-  // could overwrite another's, causing a race condition.
+  // multiple threads concurrently — Spark operators do not guarantee thread-safety and one
+  // task's sorter could overwrite another's, causing a race condition.
   private[sql] var rowSorter: UnsafeExternalRowSorter = _
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
@@ -62,9 +62,7 @@ case class SortExec(
     "peakMemory" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory"),
     "spillSize" -> SQLMetrics.createSizeMetric(sparkContext, "spill size"))
 
-  // Each task has its own instance of UnsafeExternalRowSorter. It is created in the
-  // createSorter method and stored in a ThreadLocal variable.
-  private[sql] var rowSorter: ThreadLocal[UnsafeExternalRowSorter] = _
+  private[sql] var rowSorter: UnsafeExternalRowSorter = _
 
   /**
    * This method gets invoked only once for each SortExec instance to initialize an
@@ -73,8 +71,6 @@ case class SortExec(
    * should make it public.
    */
   def createSorter(): UnsafeExternalRowSorter = {
-    rowSorter = new ThreadLocal[UnsafeExternalRowSorter]()
-
     val ordering = RowOrdering.create(sortOrder, output)
 
     // The comparator for comparing prefix
@@ -99,14 +95,13 @@ case class SortExec(
     }
 
     val pageSize = SparkEnv.get.memoryManager.pageSizeBytes
-    val newRowSorter = UnsafeExternalRowSorter.create(
+    rowSorter = UnsafeExternalRowSorter.create(
       schema, ordering, prefixComparator, prefixComputer, pageSize, canUseRadixSort)
 
     if (testSpillFrequency > 0) {
-      newRowSorter.setTestSpillFrequency(testSpillFrequency)
+      rowSorter.setTestSpillFrequency(testSpillFrequency)
     }
-    rowSorter.set(newRowSorter)
-    rowSorter.get()
+    rowSorter
   }
 
   protected override def doExecute(): RDD[InternalRow] = {
@@ -199,11 +194,11 @@ case class SortExec(
    * In SortExec, we overwrites cleanupResources to close UnsafeExternalRowSorter.
    */
   override protected[sql] def cleanupResources(): Unit = {
-    if (rowSorter != null && rowSorter.get() != null) {
+    if (rowSorter != null) {
       // There's possible for rowSorter is null here, for example, in the scenario of empty
       // iterator in the current task, the downstream physical node(like SortMergeJoinExec) will
       // trigger cleanupResources before rowSorter initialized in createSorter.
-      rowSorter.get().cleanupResources()
+      rowSorter.cleanupResources()
     }
     super.cleanupResources()
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

[SPARK-52609](https://issues.apache.org/jira/browse/SPARK-52609) added some defensive code to SortExec. The defensive has some issues and was fixed by [SPARK-56203](https://issues.apache.org/jira/browse/SPARK-56203).

But actually the defensive code is not for Spark itself but to guard multithreading access to SortExec that isn't an issue to Spark itself. The defensive code could easily confuse others. After rethinking about it, it might be better to revert it and add some warning comment.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To simplify the code and reduce confusion.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Generated-by: Claude Sonnet 4.6