### PR TITLE
[SPARK-52351][SQL] Fix T prefix detection after whitespace trimming in stringToTimestamp

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkDateTimeUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkDateTimeUtils.scala
@@ -466,7 +466,8 @@ trait SparkDateTimeUtils {
   /**
    * Trims and parses a given UTF8 timestamp string to the corresponding timestamp segments, time
    * zone id and whether it is just time without a date. value. The return type is [[Option]] in
-   * order to distinguish between 0L and null. The following formats are allowed:
+   * order to distinguish between 0L and null. Leading and trailing whitespace and ISO control
+   * characters are trimmed before parsing. The following formats are allowed:
    *
    * `[+-]yyyy*` `[+-]yyyy*-[m]m` `[+-]yyyy*-[m]m-[d]d` `[+-]yyyy*-[m]m-[d]d `
    * `[+-]yyyy*-[m]m-[d]d [h]h:[m]m:[s]s.[ms][ms][ms][us][us][us][zone_id]`
@@ -509,7 +510,8 @@ trait SparkDateTimeUtils {
     var currentSegmentValue = 0
     var currentSegmentDigits = 0
     val bytes = s.getBytes
-    var j = getTrimmedStart(bytes)
+    val trimmedStart = getTrimmedStart(bytes)
+    var j = trimmedStart
     val strEndTrimmed = getTrimmedEnd(j, bytes)
 
     if (j == strEndTrimmed) {
@@ -527,7 +529,7 @@ trait SparkDateTimeUtils {
       val b = bytes(j)
       val parsedValue = b - '0'.toByte
       if (parsedValue < 0 || parsedValue > 9) {
-        if (j == 0 && b == 'T') {
+        if (j == trimmedStart && b == 'T') {
           justTime = true
           i += 3
         } else if (i < 2) {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -302,6 +302,28 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
       checkStringToTimestamp("T18:12:15.12312 UTC+07:30", expected)
       checkStringToTimestamp("T18:12:15.12312+0730", expected)
 
+      // Leading whitespace with T prefix
+      expected = Option(time(23, 17, 50, zid = zid))
+      checkStringToTimestamp(" T23:17:50", expected)
+      checkStringToTimestamp("  T23:17:50", expected)
+      expected = Option(time(12, 0, 0, zid = zid))
+      checkStringToTimestamp("  T12:00:00", expected)
+      expected = Option(time(9, 30, 0, zid = zid))
+      checkStringToTimestamp("\tT09:30:00", expected)
+
+      // Leading whitespace with T prefix and time zone
+      zoneId = getZoneId("+07:30")
+      expected = Option(time(18, 12, 15, 123120, zid = zoneId))
+      checkStringToTimestamp(" T18:12:15.12312+7:30", expected)
+      checkStringToTimestamp("  T18:12:15.12312+0730", expected)
+      checkStringToTimestamp(" T18:12:15.12312 UTC+07:30", expected)
+
+      // Leading whitespace with year sign
+      expected = Option(date(10000, 1, 1, zid = zid))
+      checkStringToTimestamp(" +10000-01-01", expected)
+      expected = Option(date(-1, 1, 1, zid = zid))
+      checkStringToTimestamp("  -0001-01-01", expected)
+
       zoneId = getZoneId("+07:30")
       expected = Option(time(18, 12, 15, 123120, zid = zoneId))
       checkStringToTimestamp("18:12:15.12312+7:30", expected)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix T prefix detection in parseTimestampString after whitespace trimming. The condition used hardcoded j == 0 instead of comparing against the trimmed start index, causing T-prefixed time strings with leading whitespace (e.g. " T23:17:50") to fail parsing.

### Why are the changes needed?
Without this fix, timestamp strings like " T23:17:50" with leading whitespace before the T prefix are not parsed correctly, returning None instead of the expected timestamp.

### Does this PR introduce _any_ user-facing change?
Yes. T-prefixed time strings with leading whitespace are now parsed correctly.

### How was this patch tested?
Added test cases for:
- Leading whitespace with T prefix
- Leading whitespace with T prefix and time zone
- Leading whitespace with year sign (+/-)

### Was this patch authored or co-authored using generative AI tooling? 
Yes, co-authored with Kiro.