### PR TITLE
[SPARK-54731][SQL] Support Reverse expression to handle BinaryType by performing raw byte-level reversal

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -22501,12 +22501,16 @@ def shuffle(col: "ColumnOrName", seed: Optional[Union[Column, int]] = None) -> C
 @_try_remote_functions
 def reverse(col: "ColumnOrName") -> Column:
     """
-    Collection function: returns a reversed string or an array with elements in reverse order.
+    Collection function: returns a reversed string, a binary value with bytes in reverse order,
+    or an array with elements in reverse order.
 
     .. versionadded:: 1.5.0
 
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
+
+    .. versionchanged:: 4.2.0
+        Added support for binary type.
 
     Parameters
     ----------
@@ -22516,7 +22520,8 @@ def reverse(col: "ColumnOrName") -> Column:
     Returns
     -------
     :class:`~pyspark.sql.Column`
-        A new column that contains a reversed string or an array with elements in reverse order.
+        A new column that contains a reversed string, a binary value with bytes in reverse order,
+        or an array with elements in reverse order.
 
     Examples
     --------
@@ -22543,6 +22548,17 @@ def reverse(col: "ColumnOrName") -> Column:
     |          [1]|
     |           []|
     +-------------+
+
+    Example 3: Reverse binary data
+
+    >>> from pyspark.sql import functions as sf
+    >>> df = spark.createDataFrame([(bytearray(b"\\xCA\\xFE"),)], "data: binary")
+    >>> df.select(sf.hex(sf.reverse(df.data))).show()
+    +------------------+
+    |hex(reverse(data))|
+    +------------------+
+    |              FECA|
+    +------------------+
     """
     return _invoke_function_over_columns("reverse", col)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1343,10 +1343,12 @@ case class Shuffle(child: Expression, randomSeed: Option[Long] = None) extends U
 }
 
 /**
- * Returns a reversed string or an array with reverse order of elements.
+ * Returns a reversed string, a binary value with bytes in reverse order,
+ * or an array with reverse order of elements.
  */
 @ExpressionDescription(
-  usage = "_FUNC_(array) - Returns a reversed string or an array with reverse order of elements.",
+  usage = """_FUNC_(expr) - Returns a reversed string, a binary value with bytes in reverse order,
+    or an array with reverse order of elements.""",
   examples = """
     Examples:
       > SELECT _FUNC_('Spark SQL');
@@ -1358,6 +1360,7 @@ case class Shuffle(child: Expression, randomSeed: Option[Long] = None) extends U
   since = "1.5.0",
   note = """
     Reverse logic for arrays is available since 2.4.0.
+    Reverse logic for binary is available since 4.2.0.
   """
 )
 case class Reverse(child: Expression)
@@ -1365,7 +1368,10 @@ case class Reverse(child: Expression)
   override def nullIntolerant: Boolean = true
   // Input types are utilized by type coercion in ImplicitTypeCasts.
   override def inputTypes: Seq[AbstractDataType] =
-    Seq(TypeCollection(StringTypeWithCollation(supportsTrimCollation = true), ArrayType))
+    Seq(TypeCollection(
+      StringTypeWithCollation(supportsTrimCollation = true),
+      BinaryType,
+      ArrayType))
 
   override def dataType: DataType = child.dataType
 
@@ -1380,17 +1386,36 @@ case class Reverse(child: Expression)
         new GenericArrayData(arrayData.toObjectArray(elementType).reverse)
       }
     case _: StringType => _.asInstanceOf[UTF8String].reverse()
+    case BinaryType => input => input.asInstanceOf[Array[Byte]].reverse
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     nullSafeCodeGen(ctx, ev, c => dataType match {
       case _: StringType => stringCodeGen(ev, c)
+      case BinaryType => binaryCodeGen(ctx, ev, c)
       case _: ArrayType => arrayCodeGen(ctx, ev, c)
     })
   }
 
   private def stringCodeGen(ev: ExprCode, childName: String): String = {
     s"${ev.value} = ($childName).reverse();"
+  }
+
+  private def binaryCodeGen(
+      ctx: CodegenContext, ev: ExprCode, childName: String): String = {
+    val input = ctx.freshName("input")
+    val len = ctx.freshName("len")
+    val result = ctx.freshName("result")
+    val i = ctx.freshName("i")
+    s"""
+       |byte[] $input = (byte[]) $childName;
+       |int $len = $input.length;
+       |byte[] $result = new byte[$len];
+       |for (int $i = 0; $i < $len; $i++) {
+       |  $result[$i] = $input[$len - 1 - $i];
+       |}
+       |${ev.value} = $result;
+     """.stripMargin
   }
 
   private def arrayCodeGen(ctx: CodegenContext, ev: ExprCode, childName: String): String = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1355,6 +1355,8 @@ case class Shuffle(child: Expression, randomSeed: Option[Long] = None) extends U
        LQS krapS
       > SELECT _FUNC_(array(2, 1, 4, 3));
        [3,4,1,2]
+      > SELECT hex(_FUNC_(x'CAFE'));
+       FECA
   """,
   group = "collection_funcs",
   since = "1.5.0",

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -1855,6 +1855,19 @@ class CollectionExpressionsSuite
     checkEvaluation(Reverse(as6), Seq.empty)
     checkEvaluation(Reverse(as7), null)
     checkEvaluation(Reverse(aa), Seq(Seq("e"), Seq("c", "d"), Seq("a", "b")))
+
+    // BinaryType
+    val bb0 = Literal.create(Array[Byte](0xe6.toByte, 0x87.toByte), BinaryType)
+    val bb1 = Literal.create(Array[Byte](), BinaryType)
+    val bb2 = Literal.create(Array[Byte](0xff.toByte), BinaryType)
+    val bb3 = Literal.create(Array[Byte](0x00.toByte, 0x87.toByte), BinaryType)
+    val bb4 = Literal.create(null, BinaryType)
+
+    checkEvaluation(Reverse(bb0), Array[Byte](0x87.toByte, 0xe6.toByte))
+    checkEvaluation(Reverse(bb1), Array[Byte]())
+    checkEvaluation(Reverse(bb2), Array[Byte](0xff.toByte))
+    checkEvaluation(Reverse(bb3), Array[Byte](0x87.toByte, 0x00.toByte))
+    checkEvaluation(Reverse(bb4), null)
   }
 
   test("Array Position") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -2147,6 +2147,36 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
     testString()
   }
 
+  test("reverse function - binary") {
+    val df = Seq(
+      Array[Byte](0xCA.toByte, 0xFE.toByte),
+      Array[Byte](),
+      Array[Byte](0x01.toByte),
+      null
+    ).toDF("b")
+
+    def testBinary(): Unit = {
+      checkAnswer(
+        df.select(reverse($"b")),
+        Seq(
+          Row(Array[Byte](0xFE.toByte, 0xCA.toByte)),
+          Row(Array[Byte]()),
+          Row(Array[Byte](0x01.toByte)),
+          Row(null)))
+      checkAnswer(
+        df.selectExpr("reverse(b)"),
+        Seq(
+          Row(Array[Byte](0xFE.toByte, 0xCA.toByte)),
+          Row(Array[Byte]()),
+          Row(Array[Byte](0x01.toByte)),
+          Row(null)))
+    }
+
+    testBinary()
+    df.cache()
+    testBinary()
+  }
+
   test("reverse function - array for primitive type not containing null") {
     val idfNotContainsNull = Seq(
       Seq(1, 9, 8, 7),
@@ -2240,7 +2270,7 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
         "paramIndex" -> "first",
         "inputSql" -> "\"struct(1, a)\"",
         "inputType" -> "\"STRUCT<col1: INT NOT NULL, col2: STRING NOT NULL>\"",
-        "requiredType" -> "(\"STRING\" or \"ARRAY\")"
+        "requiredType" -> "(\"STRING\" or \"BINARY\" or \"ARRAY\")"
       ),
       queryContext = Array(ExpectedContext("", "", 7, 29, "reverse(struct(1, 'a'))"))
     )
@@ -2255,7 +2285,7 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
         "paramIndex" -> "first",
         "inputSql" -> "\"map(1, a)\"",
         "inputType" -> "\"MAP<INT, STRING>\"",
-        "requiredType" -> "(\"STRING\" or \"ARRAY\")"
+        "requiredType" -> "(\"STRING\" or \"BINARY\" or \"ARRAY\")"
       ),
       queryContext = Array(ExpectedContext("", "", 7, 26, "reverse(map(1, 'a'))"))
     )

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -2175,6 +2175,15 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
     testBinary()
     df.cache()
     testBinary()
+
+    // Verify that reverse preserves BinaryType and does not cast to StringType
+    val resultType = df.select(reverse($"b")).schema.head.dataType
+    assert(resultType === BinaryType,
+      s"reverse on BinaryType column should return BinaryType, but got $resultType")
+    df.createOrReplaceTempView("binary_test")
+    val sqlResultType = spark.sql("SELECT reverse(b) FROM binary_test").schema.head.dataType
+    assert(sqlResultType === BinaryType,
+      s"reverse(b) via SQL should return BinaryType, but got $sqlResultType")
   }
 
   test("reverse function - array for primitive type not containing null") {


### PR DESCRIPTION
### What changes were proposed in this pull request? 
When Spark's `reverse` function is called on a BinaryType column, it previously threw a type mismatch error because BinaryType was not in the accepted input types. This patch adds BinaryType support to the Reverse expression.

The changes:
1. Add BinaryType to the inputTypes TypeCollection in Reverse.
2. Add a BinaryType match case in the interpreted execution path (doReverse) using Scala's Array.reverse.
3. Add a BinaryType match case in the code generation path (doGenCode) with a dedicated binaryCodeGen method that performs byte-level reversal via a for loop.
4. Update @ExpressionDescription to document binary support (since 4.2.0).
5. Update data type mismatch error test expectations to include BINARY in the accepted types.
6. Add end-to-end SQL test for reverse on BinaryType in DataFrameFunctionsSuite covering both interpreted and codegen paths.

### Why are the changes needed?
Without this fix, calling `reverse` on a BinaryType column fails with a type error. This is inconsistent with other Spark functions like `length` and `concat` that already support BinaryType.

### Does this PR introduce _any_ user-facing change?
Yes. The `reverse` function now accepts BinaryType input and returns the byte-reversed binary value. Previously this would throw an AnalysisException.

### How was this patch tested?
- Unit tests in CollectionExpressionsSuite: multi-byte reversal, empty byte array, single byte, byte array containing 0x00, null input.
- End-to-end test in DataFrameFunctionsSuite: reverse on BinaryType column through both interpreted and codegen (cached) paths.
- Updated data type mismatch tests to reflect the new accepted type set.

### Was this patch authored or co-authored using generative AI tooling?
Yes, co-authored with Kiro.