### PR TITLE
[SPARK-56251][SQL] Add default fetchSize for postgres to avoid loading all data in memory

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -160,8 +160,6 @@ class JDBCOptions(
      """.stripMargin
   )
 
-  val fetchSize = parameters.getOrElse(JDBC_BATCH_FETCH_SIZE, "0").toInt
-
   // ------------------------------------------------------------
   // Optional parameters only for writing
   // ------------------------------------------------------------

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -160,6 +160,8 @@ class JDBCOptions(
      """.stripMargin
   )
 
+  val fetchSize = parameters.getOrElse(JDBC_BATCH_FETCH_SIZE, "0").toInt
+
   // ------------------------------------------------------------
   // Optional parameters only for writing
   // ------------------------------------------------------------

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -343,9 +343,7 @@ class JDBCRDD(
     logInfo(log"Generated JDBC query to fetch data: ${MDC(SQL_TEXT, sqlText)}")
     stmt = conn.prepareStatement(sqlText,
         ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
-    val effectiveFetchSize =
-      if (options.fetchSize > 0) options.fetchSize else dialect.defaultFetchSize
-    stmt.setFetchSize(effectiveFetchSize)
+    stmt.setFetchSize(dialect.effectiveFetchSize(options))
     stmt.setQueryTimeout(options.queryTimeout)
 
     rs = SQLMetrics.withTimingNs(queryExecutionTimeMetric) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -343,7 +343,9 @@ class JDBCRDD(
     logInfo(log"Generated JDBC query to fetch data: ${MDC(SQL_TEXT, sqlText)}")
     stmt = conn.prepareStatement(sqlText,
         ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
-    stmt.setFetchSize(options.fetchSize)
+    val effectiveFetchSize =
+      if (options.fetchSize > 0) options.fetchSize else dialect.defaultFetchSize
+    stmt.setFetchSize(effectiveFetchSize)
     stmt.setQueryTimeout(options.queryTimeout)
 
     rs = SQLMetrics.withTimingNs(queryExecutionTimeMetric) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -343,7 +343,7 @@ class JDBCRDD(
     logInfo(log"Generated JDBC query to fetch data: ${MDC(SQL_TEXT, sqlText)}")
     stmt = conn.prepareStatement(sqlText,
         ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
-    stmt.setFetchSize(dialect.effectiveFetchSize(options))
+    stmt.setFetchSize(dialect.getFetchSize(options))
     stmt.setQueryTimeout(options.queryTimeout)
 
     rs = SQLMetrics.withTimingNs(queryExecutionTimeMetric) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
@@ -17,8 +17,9 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.sql.SQLException
+import java.sql.{Connection, SQLException}
 
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 import org.apache.spark.sql.types.{DataType, MetadataBuilder}
 
 /**
@@ -82,5 +83,15 @@ private class AggregatedDialect(dialects: List[JdbcDialect])
       table: String,
       cascade: Option[Boolean] = isCascadingTruncateTable()): String = {
     dialects.head.getTruncateQuery(table, cascade)
+  }
+
+  override def defaultFetchSize: Int = dialects.head.defaultFetchSize
+
+  override def effectiveFetchSize(options: JDBCOptions): Int = {
+    dialects.head.effectiveFetchSize(options)
+  }
+
+  override def beforeFetch(connection: Connection, options: JDBCOptions): Unit = {
+    dialects.head.beforeFetch(connection, options)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
@@ -85,8 +85,6 @@ private class AggregatedDialect(dialects: List[JdbcDialect])
     dialects.head.getTruncateQuery(table, cascade)
   }
 
-  override def defaultFetchSize: Int = dialects.head.defaultFetchSize
-
   override def effectiveFetchSize(options: JDBCOptions): Int = {
     dialects.head.effectiveFetchSize(options)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/AggregatedDialect.scala
@@ -85,8 +85,8 @@ private class AggregatedDialect(dialects: List[JdbcDialect])
     dialects.head.getTruncateQuery(table, cascade)
   }
 
-  override def effectiveFetchSize(options: JDBCOptions): Int = {
-    dialects.head.effectiveFetchSize(options)
+  override def getFetchSize(options: JDBCOptions): Int = {
+    dialects.head.getFetchSize(options)
   }
 
   override def beforeFetch(connection: Connection, options: JDBCOptions): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -345,6 +345,18 @@ abstract class JdbcDialect extends Serializable with Logging {
   def defaultFetchSize: Int = 0
 
   /**
+   * Returns the effective fetch size considering the user-specified option and the dialect default.
+   * If the user explicitly sets a fetchSize (including 0), that value is used.
+   * Otherwise, the dialect's [[defaultFetchSize]] is used as fallback.
+   */
+  def effectiveFetchSize(options: JDBCOptions): Int = {
+    options.parameters.get(JDBCOptions.JDBC_BATCH_FETCH_SIZE) match {
+      case Some(v) => v.toInt
+      case None => defaultFetchSize
+    }
+  }
+
+  /**
    * Override connection specific properties to run before a select is made.  This is in place to
    * allow dialects that need special treatment to optimize behavior.
    * @param connection The connection object

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -337,6 +337,14 @@ abstract class JdbcDialect extends Serializable with Logging {
   }
 
   /**
+   * Returns the default number of rows to fetch per round trip when reading from the JDBC source.
+   * A value of 0 means the JDBC driver's default fetch size will be used.
+   * Dialects can override this to provide a sensible default, e.g. to avoid loading all rows
+   * into memory at once.
+   */
+  def defaultFetchSize: Int = 0
+
+  /**
    * Override connection specific properties to run before a select is made.  This is in place to
    * allow dialects that need special treatment to optimize behavior.
    * @param connection The connection object

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -338,7 +338,7 @@ abstract class JdbcDialect extends Serializable with Logging {
 
   /**
    * Returns the effective fetch size for reading from the JDBC source.
-   * By default, returns the user-specified fetchSize from [[JDBCOptions]].
+   * By default, returns the user-specified fetchSize from JDBCOptions.
    * Dialects can override this to provide a sensible default when the user does not
    * explicitly set the fetchSize option.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -342,7 +342,8 @@ abstract class JdbcDialect extends Serializable with Logging {
    * Dialects can override this to provide a sensible default when the user does not
    * explicitly set the fetchSize option.
    */
-  def effectiveFetchSize(options: JDBCOptions): Int = options.fetchSize
+  @Since("4.2.0")
+  def getFetchSize(options: JDBCOptions): Int = options.fetchSize
 
   /**
    * Override connection specific properties to run before a select is made.  This is in place to

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -337,24 +337,12 @@ abstract class JdbcDialect extends Serializable with Logging {
   }
 
   /**
-   * Returns the default number of rows to fetch per round trip when reading from the JDBC source.
-   * A value of 0 means the JDBC driver's default fetch size will be used.
-   * Dialects can override this to provide a sensible default, e.g. to avoid loading all rows
-   * into memory at once.
+   * Returns the effective fetch size for reading from the JDBC source.
+   * By default, returns the user-specified fetchSize from [[JDBCOptions]].
+   * Dialects can override this to provide a sensible default when the user does not
+   * explicitly set the fetchSize option.
    */
-  def defaultFetchSize: Int = 0
-
-  /**
-   * Returns the effective fetch size considering the user-specified option and the dialect default.
-   * If the user explicitly sets a fetchSize (including 0), that value is used.
-   * Otherwise, the dialect's [[defaultFetchSize]] is used as fallback.
-   */
-  def effectiveFetchSize(options: JDBCOptions): Int = {
-    options.parameters.get(JDBCOptions.JDBC_BATCH_FETCH_SIZE) match {
-      case Some(v) => v.toInt
-      case None => defaultFetchSize
-    }
-  }
+  def effectiveFetchSize(options: JDBCOptions): Int = options.fetchSize
 
   /**
    * Override connection specific properties to run before a select is made.  This is in place to

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -191,6 +191,11 @@ private case class PostgresDialect()
     }
   }
 
+  // The default fetch size for PostgreSQL to avoid loading all rows into memory at once,
+  // which can cause executor OOM. PostgreSQL JDBC driver fetches all rows by default when
+  // fetchSize is 0.
+  override val defaultFetchSize: Int = 1000
+
   override def beforeFetch(connection: Connection, properties: Map[String, String]): Unit = {
     super.beforeFetch(connection, properties)
 
@@ -200,7 +205,9 @@ private case class PostgresDialect()
     //
     // See: https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor
     //
-    if (properties.getOrElse(JDBCOptions.JDBC_BATCH_FETCH_SIZE, "0").toInt > 0) {
+    val userFetchSize = properties.get(JDBCOptions.JDBC_BATCH_FETCH_SIZE).map(_.toInt)
+    val effectiveFetchSize = userFetchSize.getOrElse(defaultFetchSize)
+    if (effectiveFetchSize > 0) {
       connection.setAutoCommit(false)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -196,8 +196,8 @@ private case class PostgresDialect()
   // fetchSize is 0.
   override val defaultFetchSize: Int = 1000
 
-  override def beforeFetch(connection: Connection, properties: Map[String, String]): Unit = {
-    super.beforeFetch(connection, properties)
+  override def beforeFetch(connection: Connection, options: JDBCOptions): Unit = {
+    super.beforeFetch(connection, options)
 
     // According to the postgres jdbc documentation we need to be in autocommit=false if we actually
     // want to have fetchsize be non 0 (all the rows).  This allows us to not have to cache all the
@@ -205,9 +205,7 @@ private case class PostgresDialect()
     //
     // See: https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor
     //
-    val userFetchSize = properties.get(JDBCOptions.JDBC_BATCH_FETCH_SIZE).map(_.toInt)
-    val effectiveFetchSize = userFetchSize.getOrElse(defaultFetchSize)
-    if (effectiveFetchSize > 0) {
+    if (effectiveFetchSize(options) > 0) {
       connection.setAutoCommit(false)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -196,11 +196,11 @@ private case class PostgresDialect()
   // the user does not explicitly set the fetchSize option.
   private val POSTGRES_DEFAULT_FETCH_SIZE = 1000
 
-  override def effectiveFetchSize(options: JDBCOptions): Int = {
+  override def getFetchSize(options: JDBCOptions): Int = {
     options.parameters.get(JDBCOptions.JDBC_BATCH_FETCH_SIZE) match {
       case Some(v) => v.toInt
       case None =>
-        logWarning(s"No fetchSize option set for PostgreSQL JDBC read. " +
+        logInfo(s"No fetchSize option set for PostgreSQL JDBC read. " +
           s"Defaulting to $POSTGRES_DEFAULT_FETCH_SIZE to avoid loading all rows into memory. " +
           s"Set the 'fetchsize' option explicitly to override this behavior.")
         POSTGRES_DEFAULT_FETCH_SIZE
@@ -216,7 +216,7 @@ private case class PostgresDialect()
     //
     // See: https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor
     //
-    if (effectiveFetchSize(options) > 0) {
+    if (getFetchSize(options) > 0) {
       connection.setAutoCommit(false)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -191,10 +191,21 @@ private case class PostgresDialect()
     }
   }
 
-  // The default fetch size for PostgreSQL to avoid loading all rows into memory at once,
-  // which can cause executor OOM. PostgreSQL JDBC driver fetches all rows by default when
-  // fetchSize is 0.
-  override val defaultFetchSize: Int = 1000
+  // PostgreSQL JDBC driver fetches all rows into memory by default (fetchSize=0),
+  // which can cause executor OOM. Override to use 1000 as a sensible default when
+  // the user does not explicitly set the fetchSize option.
+  private val POSTGRES_DEFAULT_FETCH_SIZE = 1000
+
+  override def effectiveFetchSize(options: JDBCOptions): Int = {
+    options.parameters.get(JDBCOptions.JDBC_BATCH_FETCH_SIZE) match {
+      case Some(v) => v.toInt
+      case None =>
+        logWarning(s"No fetchSize option set for PostgreSQL JDBC read. " +
+          s"Defaulting to $POSTGRES_DEFAULT_FETCH_SIZE to avoid loading all rows into memory. " +
+          s"Set the 'fetchsize' option explicitly to override this behavior.")
+        POSTGRES_DEFAULT_FETCH_SIZE
+    }
+  }
 
   override def beforeFetch(connection: Connection, options: JDBCOptions): Unit = {
     super.beforeFetch(connection, options)

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -531,7 +531,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("Dialect defaultFetchSize is applied when user does not specify fetchsize") {
+  test("SPARK-56251: Dialect defaultFetchSize is applied when user does not specify fetchsize") {
     @volatile var capturedFetchSize: Int = -1
 
     val testDialect = new JdbcDialect {
@@ -555,7 +555,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("User-specified fetchsize takes precedence over dialect defaultFetchSize") {
+  test("SPARK-56251: User-specified fetchsize takes precedence over dialect defaultFetchSize") {
     @volatile var capturedFetchSize: Int = -1
 
     val testDialect = new JdbcDialect {

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -531,6 +531,50 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     }
   }
 
+  test("Dialect defaultFetchSize is applied when user does not specify fetchsize") {
+    val testDialect = new JdbcDialect {
+      override def canHandle(url: String): Boolean = url.startsWith("jdbc:h2")
+      override val defaultFetchSize: Int = 100
+    }
+
+    JdbcDialects.registerDialect(testDialect)
+    try {
+      // Read without specifying fetchsize - dialect's defaultFetchSize should be used
+      val df = spark.read.jdbc(urlWithUserAndPass, "TEST.PEOPLE", new Properties())
+      assert(df.collect().length === 3)
+
+      // Verify the dialect resolves the correct effective fetchSize
+      val options = new JDBCOptions(Map(
+        "url" -> urlWithUserAndPass, "dbtable" -> "TEST.PEOPLE"))
+      assert(testDialect.effectiveFetchSize(options) === 100)
+    } finally {
+      JdbcDialects.unregisterDialect(testDialect)
+    }
+  }
+
+  test("User-specified fetchsize takes precedence over dialect defaultFetchSize") {
+    val testDialect = new JdbcDialect {
+      override def canHandle(url: String): Boolean = url.startsWith("jdbc:h2")
+      override val defaultFetchSize: Int = 100
+    }
+
+    JdbcDialects.registerDialect(testDialect)
+    try {
+      val properties = new Properties()
+      properties.setProperty(JDBCOptions.JDBC_BATCH_FETCH_SIZE, "42")
+      val df = spark.read.jdbc(urlWithUserAndPass, "TEST.PEOPLE", properties)
+      assert(df.collect().length === 3)
+
+      // Verify the dialect resolves user-specified value over default
+      val options = new JDBCOptions(Map(
+        "url" -> urlWithUserAndPass, "dbtable" -> "TEST.PEOPLE",
+        JDBCOptions.JDBC_BATCH_FETCH_SIZE -> "42"))
+      assert(testDialect.effectiveFetchSize(options) === 42)
+    } finally {
+      JdbcDialects.unregisterDialect(testDialect)
+    }
+  }
+
   test("Partitioning via JDBCPartitioningInfo API") {
     val df = spark.read.jdbc(urlWithUserAndPass, "TEST.PEOPLE", "THEID", 0, 4, 3, new Properties())
     checkNumPartitions(df, expectedNumPartitions = 3)

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -532,30 +532,40 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
   }
 
   test("Dialect defaultFetchSize is applied when user does not specify fetchsize") {
+    @volatile var capturedFetchSize: Int = -1
+
     val testDialect = new JdbcDialect {
       override def canHandle(url: String): Boolean = url.startsWith("jdbc:h2")
       override val defaultFetchSize: Int = 100
+      override def effectiveFetchSize(options: JDBCOptions): Int = {
+        val result = super.effectiveFetchSize(options)
+        capturedFetchSize = result
+        result
+      }
     }
 
     JdbcDialects.registerDialect(testDialect)
     try {
-      // Read without specifying fetchsize - dialect's defaultFetchSize should be used
       val df = spark.read.jdbc(urlWithUserAndPass, "TEST.PEOPLE", new Properties())
       assert(df.collect().length === 3)
-
-      // Verify the dialect resolves the correct effective fetchSize
-      val options = new JDBCOptions(Map(
-        "url" -> urlWithUserAndPass, "dbtable" -> "TEST.PEOPLE"))
-      assert(testDialect.effectiveFetchSize(options) === 100)
+      assert(capturedFetchSize === 100,
+        s"Expected effectiveFetchSize to return 100 (dialect default), got $capturedFetchSize")
     } finally {
       JdbcDialects.unregisterDialect(testDialect)
     }
   }
 
   test("User-specified fetchsize takes precedence over dialect defaultFetchSize") {
+    @volatile var capturedFetchSize: Int = -1
+
     val testDialect = new JdbcDialect {
       override def canHandle(url: String): Boolean = url.startsWith("jdbc:h2")
       override val defaultFetchSize: Int = 100
+      override def effectiveFetchSize(options: JDBCOptions): Int = {
+        val result = super.effectiveFetchSize(options)
+        capturedFetchSize = result
+        result
+      }
     }
 
     JdbcDialects.registerDialect(testDialect)
@@ -564,12 +574,8 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       properties.setProperty(JDBCOptions.JDBC_BATCH_FETCH_SIZE, "42")
       val df = spark.read.jdbc(urlWithUserAndPass, "TEST.PEOPLE", properties)
       assert(df.collect().length === 3)
-
-      // Verify the dialect resolves user-specified value over default
-      val options = new JDBCOptions(Map(
-        "url" -> urlWithUserAndPass, "dbtable" -> "TEST.PEOPLE",
-        JDBCOptions.JDBC_BATCH_FETCH_SIZE -> "42"))
-      assert(testDialect.effectiveFetchSize(options) === 42)
+      assert(capturedFetchSize === 42,
+        s"Expected effectiveFetchSize to return 42 (user-specified), got $capturedFetchSize")
     } finally {
       JdbcDialects.unregisterDialect(testDialect)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -531,12 +531,12 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-56251: Dialect effectiveFetchSize is applied when user does not specify fetchsize") {
+  test("SPARK-56251: Dialect getFetchSize is applied when user does not specify fetchsize") {
     @volatile var capturedFetchSize: Int = -1
 
     val testDialect = new JdbcDialect {
       override def canHandle(url: String): Boolean = url.startsWith("jdbc:h2")
-      override def effectiveFetchSize(options: JDBCOptions): Int = {
+      override def getFetchSize(options: JDBCOptions): Int = {
         val result = options.parameters.get(JDBCOptions.JDBC_BATCH_FETCH_SIZE) match {
           case Some(v) => v.toInt
           case None => 100
@@ -551,18 +551,18 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       val df = spark.read.jdbc(urlWithUserAndPass, "TEST.PEOPLE", new Properties())
       assert(df.collect().length === 3)
       assert(capturedFetchSize === 100,
-        s"Expected effectiveFetchSize to return 100 (dialect default), got $capturedFetchSize")
+        s"Expected getFetchSize to return 100 (dialect default), got $capturedFetchSize")
     } finally {
       JdbcDialects.unregisterDialect(testDialect)
     }
   }
 
-  test("SPARK-56251: User-specified fetchsize takes precedence over dialect effectiveFetchSize") {
+  test("SPARK-56251: User-specified fetchsize takes precedence over dialect getFetchSize") {
     @volatile var capturedFetchSize: Int = -1
 
     val testDialect = new JdbcDialect {
       override def canHandle(url: String): Boolean = url.startsWith("jdbc:h2")
-      override def effectiveFetchSize(options: JDBCOptions): Int = {
+      override def getFetchSize(options: JDBCOptions): Int = {
         val result = options.parameters.get(JDBCOptions.JDBC_BATCH_FETCH_SIZE) match {
           case Some(v) => v.toInt
           case None => 100
@@ -579,7 +579,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       val df = spark.read.jdbc(urlWithUserAndPass, "TEST.PEOPLE", properties)
       assert(df.collect().length === 3)
       assert(capturedFetchSize === 42,
-        s"Expected effectiveFetchSize to return 42 (user-specified), got $capturedFetchSize")
+        s"Expected getFetchSize to return 42 (user-specified), got $capturedFetchSize")
     } finally {
       JdbcDialects.unregisterDialect(testDialect)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -532,7 +532,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SPARK-56251: Dialect getFetchSize is applied when user does not specify fetchsize") {
-    @volatile var capturedFetchSize: Int = -1
+    JDBCSuite.capturedFetchSize = -1
 
     val testDialect = new JdbcDialect {
       override def canHandle(url: String): Boolean = url.startsWith("jdbc:h2")
@@ -541,7 +541,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
           case Some(v) => v.toInt
           case None => 100
         }
-        capturedFetchSize = result
+        JDBCSuite.capturedFetchSize = result
         result
       }
     }
@@ -550,15 +550,16 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     try {
       val df = spark.read.jdbc(urlWithUserAndPass, "TEST.PEOPLE", new Properties())
       assert(df.collect().length === 3)
-      assert(capturedFetchSize === 100,
-        s"Expected getFetchSize to return 100 (dialect default), got $capturedFetchSize")
+      assert(JDBCSuite.capturedFetchSize === 100,
+        s"Expected getFetchSize to return 100 (dialect default), " +
+          s"got ${JDBCSuite.capturedFetchSize}")
     } finally {
       JdbcDialects.unregisterDialect(testDialect)
     }
   }
 
   test("SPARK-56251: User-specified fetchsize takes precedence over dialect getFetchSize") {
-    @volatile var capturedFetchSize: Int = -1
+    JDBCSuite.capturedFetchSize = -1
 
     val testDialect = new JdbcDialect {
       override def canHandle(url: String): Boolean = url.startsWith("jdbc:h2")
@@ -567,7 +568,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
           case Some(v) => v.toInt
           case None => 100
         }
-        capturedFetchSize = result
+        JDBCSuite.capturedFetchSize = result
         result
       }
     }
@@ -578,8 +579,9 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       properties.setProperty(JDBCOptions.JDBC_BATCH_FETCH_SIZE, "42")
       val df = spark.read.jdbc(urlWithUserAndPass, "TEST.PEOPLE", properties)
       assert(df.collect().length === 3)
-      assert(capturedFetchSize === 42,
-        s"Expected getFetchSize to return 42 (user-specified), got $capturedFetchSize")
+      assert(JDBCSuite.capturedFetchSize === 42,
+        s"Expected getFetchSize to return 42 (user-specified), " +
+          s"got ${JDBCSuite.capturedFetchSize}")
     } finally {
       JdbcDialects.unregisterDialect(testDialect)
     }
@@ -2363,4 +2365,10 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       )
     }
   }
+}
+
+object JDBCSuite {
+  // SPARK-56251: Spark tasks use deserialized dialect instances, so closure-captured variables
+  // from the test method won't be updated. Use a companion object singleton to pass values instead.
+  @volatile var capturedFetchSize: Int = -1
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -531,14 +531,16 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-56251: Dialect defaultFetchSize is applied when user does not specify fetchsize") {
+  test("SPARK-56251: Dialect effectiveFetchSize is applied when user does not specify fetchsize") {
     @volatile var capturedFetchSize: Int = -1
 
     val testDialect = new JdbcDialect {
       override def canHandle(url: String): Boolean = url.startsWith("jdbc:h2")
-      override val defaultFetchSize: Int = 100
       override def effectiveFetchSize(options: JDBCOptions): Int = {
-        val result = super.effectiveFetchSize(options)
+        val result = options.parameters.get(JDBCOptions.JDBC_BATCH_FETCH_SIZE) match {
+          case Some(v) => v.toInt
+          case None => 100
+        }
         capturedFetchSize = result
         result
       }
@@ -555,14 +557,16 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-56251: User-specified fetchsize takes precedence over dialect defaultFetchSize") {
+  test("SPARK-56251: User-specified fetchsize takes precedence over dialect effectiveFetchSize") {
     @volatile var capturedFetchSize: Int = -1
 
     val testDialect = new JdbcDialect {
       override def canHandle(url: String): Boolean = url.startsWith("jdbc:h2")
-      override val defaultFetchSize: Int = 100
       override def effectiveFetchSize(options: JDBCOptions): Int = {
-        val result = super.effectiveFetchSize(options)
+        val result = options.parameters.get(JDBCOptions.JDBC_BATCH_FETCH_SIZE) match {
+          case Some(v) => v.toInt
+          case None => 100
+        }
         capturedFetchSize = result
         result
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
@@ -38,6 +38,30 @@ class PostgresDialectSuite extends SparkFunSuite with MockitoSugar {
     ) ++ extraOptions)
   }
 
+  test("beforeFetch sets autoCommit=false with lowercase fetchsize") {
+    val conn = mock[Connection]
+    dialect.beforeFetch(conn, createJDBCOptions(Map("fetchsize" -> "100")))
+    verify(conn).setAutoCommit(false)
+  }
+
+  test("beforeFetch sets autoCommit=false with camelCase fetchSize") {
+    val conn = mock[Connection]
+    dialect.beforeFetch(conn, createJDBCOptions(Map("fetchSize" -> "100")))
+    verify(conn).setAutoCommit(false)
+  }
+
+  test("beforeFetch sets autoCommit=false with uppercase FETCHSIZE") {
+    val conn = mock[Connection]
+    dialect.beforeFetch(conn, createJDBCOptions(Map("FETCHSIZE" -> "100")))
+    verify(conn).setAutoCommit(false)
+  }
+
+  test("beforeFetch does not set autoCommit when fetchSize is 0") {
+    val conn = mock[Connection]
+    dialect.beforeFetch(conn, createJDBCOptions(Map("fetchsize" -> "0")))
+    verify(conn, never()).setAutoCommit(false)
+  }
+
   test("effectiveFetchSize: returns user-specified value when set") {
     assert(dialect.effectiveFetchSize(createJDBCOptions(Map("fetchsize" -> "500"))) === 500)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
@@ -18,9 +18,8 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.sql.{Connection, PreparedStatement, ResultSet}
+import java.sql.Connection
 
-import org.mockito.ArgumentMatchers.{anyInt, anyString}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 
@@ -62,26 +61,19 @@ class PostgresDialectSuite extends SparkFunSuite with MockitoSugar {
     verify(conn, never()).setAutoCommit(false)
   }
 
-  test("effectiveFetchSize: returns user-specified value when set") {
+  test("SPARK-56251: effectiveFetchSize: returns user-specified value when set") {
     assert(dialect.effectiveFetchSize(createJDBCOptions(Map("fetchsize" -> "500"))) === 500)
   }
 
-  test("effectiveFetchSize: returns 0 when user explicitly sets 0") {
+  test("SPARK-56251: effectiveFetchSize: returns 0 when user explicitly sets 0") {
     assert(dialect.effectiveFetchSize(createJDBCOptions(Map("fetchsize" -> "0"))) === 0)
   }
 
-  test("effectiveFetchSize: returns defaultFetchSize (1000) when not set") {
+  test("SPARK-56251: effectiveFetchSize: returns defaultFetchSize (1000) when not set") {
     assert(dialect.effectiveFetchSize(createJDBCOptions(Map.empty)) === 1000)
   }
 
-  test("effectiveFetchSize: is case-insensitive for option key") {
-    Seq("fetchsize", "fetchSize", "FETCHSIZE").foreach { key =>
-      assert(dialect.effectiveFetchSize(createJDBCOptions(Map(key -> "200"))) === 200,
-        s"Failed for key: $key")
-    }
-  }
-
-  test("effectiveFetchSize: base dialect returns 0 when not set") {
+  test("SPARK-56251: effectiveFetchSize: base dialect returns 0 when not set") {
     val baseDialect = new JdbcDialect {
       override def canHandle(url: String): Boolean = true
     }
@@ -89,54 +81,10 @@ class PostgresDialectSuite extends SparkFunSuite with MockitoSugar {
     assert(baseDialect.effectiveFetchSize(createJDBCOptions(Map.empty)) === 0)
   }
 
-  /**
-   * Simulates the JDBCRDD.compute() call sequence to verify that beforeFetch (connection setup)
-   * and effectiveFetchSize (statement setup) work correctly together.
-   *
-   * In JDBCRDD.compute():
-   *   1. dialect.beforeFetch(conn, options)      -- sets autoCommit=false for Postgres
-   *   2. conn.prepareStatement(...)
-   *   3. stmt.setFetchSize(dialect.effectiveFetchSize(options))
-   */
-  private def simulateJdbcRead(options: JDBCOptions): (Connection, PreparedStatement) = {
+  test("SPARK-56251: beforeFetch sets autoCommit=false when using default fetchSize") {
     val conn = mock[Connection]
-    val stmt = mock[PreparedStatement]
-    val rs = mock[ResultSet]
-    when(conn.prepareStatement(anyString(), anyInt(), anyInt())).thenReturn(stmt)
-    when(stmt.executeQuery()).thenReturn(rs)
-    when(rs.next()).thenReturn(false)
-
-    // Simulate JDBCRDD.compute() sequence
-    dialect.beforeFetch(conn, options)
-    stmt.setFetchSize(dialect.effectiveFetchSize(options))
-    stmt.executeQuery()
-
-    (conn, stmt)
-  }
-
-  test("JDBCRDD compute simulation: no fetchSize specified uses dialect default") {
-    val options = createJDBCOptions(Map.empty)
-    val (conn, stmt) = simulateJdbcRead(options)
-
-    val order = inOrder(conn, stmt)
-    order.verify(conn).setAutoCommit(false)
-    order.verify(stmt).setFetchSize(1000)
-  }
-
-  test("JDBCRDD compute simulation: explicit fetchSize overrides dialect default") {
-    val options = createJDBCOptions(Map("fetchsize" -> "50"))
-    val (conn, stmt) = simulateJdbcRead(options)
-
-    val order = inOrder(conn, stmt)
-    order.verify(conn).setAutoCommit(false)
-    order.verify(stmt).setFetchSize(50)
-  }
-
-  test("JDBCRDD compute simulation: explicit fetchSize=0 disables cursor fetching") {
-    val options = createJDBCOptions(Map("fetchsize" -> "0"))
-    val (conn, stmt) = simulateJdbcRead(options)
-
-    verify(conn, never()).setAutoCommit(false)
-    verify(stmt).setFetchSize(0)
+    // No explicit fetchsize - should use defaultFetchSize (1000) and set autoCommit=false
+    dialect.beforeFetch(conn, createJDBCOptions(Map.empty))
+    verify(conn).setAutoCommit(false)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
@@ -18,8 +18,9 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.sql.Connection
+import java.sql.{Connection, PreparedStatement, ResultSet}
 
+import org.mockito.ArgumentMatchers.{anyInt, anyString}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 
@@ -37,57 +38,81 @@ class PostgresDialectSuite extends SparkFunSuite with MockitoSugar {
     ) ++ extraOptions)
   }
 
-  test("beforeFetch sets autoCommit=false with lowercase fetchsize") {
-    val conn = mock[Connection]
-    dialect.beforeFetch(conn, createJDBCOptions(Map("fetchsize" -> "100")))
-    verify(conn).setAutoCommit(false)
-  }
-
-  test("beforeFetch sets autoCommit=false with camelCase fetchSize") {
-    val conn = mock[Connection]
-    dialect.beforeFetch(conn, createJDBCOptions(Map("fetchSize" -> "100")))
-    verify(conn).setAutoCommit(false)
-  }
-
-  test("beforeFetch sets autoCommit=false with uppercase FETCHSIZE") {
-    val conn = mock[Connection]
-    dialect.beforeFetch(conn, createJDBCOptions(Map("FETCHSIZE" -> "100")))
-    verify(conn).setAutoCommit(false)
-  }
-
-  test("beforeFetch does not set autoCommit when fetchSize is explicitly 0") {
-    val conn = mock[Connection]
-    dialect.beforeFetch(conn, createJDBCOptions(Map("fetchsize" -> "0")))
-    verify(conn, never()).setAutoCommit(false)
-  }
-
-  test("defaultFetchSize returns 1000") {
-    assert(dialect.defaultFetchSize === 1000)
-  }
-
-  test("beforeFetch sets autoCommit=false when using default fetchSize") {
-    val conn = mock[Connection]
-    // No explicit fetchsize - should use defaultFetchSize (1000) and set autoCommit=false
-    dialect.beforeFetch(conn, createJDBCOptions(Map.empty))
-    verify(conn).setAutoCommit(false)
-  }
-
-  test("effectiveFetchSize returns user-specified value when set") {
+  test("effectiveFetchSize: returns user-specified value when set") {
     assert(dialect.effectiveFetchSize(createJDBCOptions(Map("fetchsize" -> "500"))) === 500)
   }
 
-  test("effectiveFetchSize returns 0 when user explicitly sets 0") {
+  test("effectiveFetchSize: returns 0 when user explicitly sets 0") {
     assert(dialect.effectiveFetchSize(createJDBCOptions(Map("fetchsize" -> "0"))) === 0)
   }
 
-  test("effectiveFetchSize returns defaultFetchSize when not set") {
+  test("effectiveFetchSize: returns defaultFetchSize (1000) when not set") {
     assert(dialect.effectiveFetchSize(createJDBCOptions(Map.empty)) === 1000)
   }
 
-  test("base dialect effectiveFetchSize returns 0 when not set") {
+  test("effectiveFetchSize: is case-insensitive for option key") {
+    Seq("fetchsize", "fetchSize", "FETCHSIZE").foreach { key =>
+      assert(dialect.effectiveFetchSize(createJDBCOptions(Map(key -> "200"))) === 200,
+        s"Failed for key: $key")
+    }
+  }
+
+  test("effectiveFetchSize: base dialect returns 0 when not set") {
     val baseDialect = new JdbcDialect {
       override def canHandle(url: String): Boolean = true
     }
+    assert(baseDialect.defaultFetchSize === 0)
     assert(baseDialect.effectiveFetchSize(createJDBCOptions(Map.empty)) === 0)
+  }
+
+  /**
+   * Simulates the JDBCRDD.compute() call sequence to verify that beforeFetch (connection setup)
+   * and effectiveFetchSize (statement setup) work correctly together.
+   *
+   * In JDBCRDD.compute():
+   *   1. dialect.beforeFetch(conn, options)      -- sets autoCommit=false for Postgres
+   *   2. conn.prepareStatement(...)
+   *   3. stmt.setFetchSize(dialect.effectiveFetchSize(options))
+   */
+  private def simulateJdbcRead(options: JDBCOptions): (Connection, PreparedStatement) = {
+    val conn = mock[Connection]
+    val stmt = mock[PreparedStatement]
+    val rs = mock[ResultSet]
+    when(conn.prepareStatement(anyString(), anyInt(), anyInt())).thenReturn(stmt)
+    when(stmt.executeQuery()).thenReturn(rs)
+    when(rs.next()).thenReturn(false)
+
+    // Simulate JDBCRDD.compute() sequence
+    dialect.beforeFetch(conn, options)
+    stmt.setFetchSize(dialect.effectiveFetchSize(options))
+    stmt.executeQuery()
+
+    (conn, stmt)
+  }
+
+  test("JDBCRDD compute simulation: no fetchSize specified uses dialect default") {
+    val options = createJDBCOptions(Map.empty)
+    val (conn, stmt) = simulateJdbcRead(options)
+
+    val order = inOrder(conn, stmt)
+    order.verify(conn).setAutoCommit(false)
+    order.verify(stmt).setFetchSize(1000)
+  }
+
+  test("JDBCRDD compute simulation: explicit fetchSize overrides dialect default") {
+    val options = createJDBCOptions(Map("fetchsize" -> "50"))
+    val (conn, stmt) = simulateJdbcRead(options)
+
+    val order = inOrder(conn, stmt)
+    order.verify(conn).setAutoCommit(false)
+    order.verify(stmt).setFetchSize(50)
+  }
+
+  test("JDBCRDD compute simulation: explicit fetchSize=0 disables cursor fetching") {
+    val options = createJDBCOptions(Map("fetchsize" -> "0"))
+    val (conn, stmt) = simulateJdbcRead(options)
+
+    verify(conn, never()).setAutoCommit(false)
+    verify(stmt).setFetchSize(0)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
@@ -28,6 +28,8 @@ import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 
 class PostgresDialectSuite extends SparkFunSuite with MockitoSugar {
 
+  private val dialect = PostgresDialect()
+
   private def createJDBCOptions(extraOptions: Map[String, String]): JDBCOptions = {
     new JDBCOptions(Map(
       "url" -> "jdbc:postgresql://localhost:5432/test",
@@ -37,42 +39,55 @@ class PostgresDialectSuite extends SparkFunSuite with MockitoSugar {
 
   test("beforeFetch sets autoCommit=false with lowercase fetchsize") {
     val conn = mock[Connection]
-    val dialect = PostgresDialect()
     dialect.beforeFetch(conn, createJDBCOptions(Map("fetchsize" -> "100")))
     verify(conn).setAutoCommit(false)
   }
 
   test("beforeFetch sets autoCommit=false with camelCase fetchSize") {
     val conn = mock[Connection]
-    val dialect = PostgresDialect()
     dialect.beforeFetch(conn, createJDBCOptions(Map("fetchSize" -> "100")))
     verify(conn).setAutoCommit(false)
   }
 
   test("beforeFetch sets autoCommit=false with uppercase FETCHSIZE") {
     val conn = mock[Connection]
-    val dialect = PostgresDialect()
     dialect.beforeFetch(conn, createJDBCOptions(Map("FETCHSIZE" -> "100")))
     verify(conn).setAutoCommit(false)
   }
 
-  test("beforeFetch does not set autoCommit when fetchSize is 0") {
+  test("beforeFetch does not set autoCommit when fetchSize is explicitly 0") {
     val conn = mock[Connection]
-    val dialect = PostgresDialect()
     dialect.beforeFetch(conn, createJDBCOptions(Map("fetchsize" -> "0")))
     verify(conn, never()).setAutoCommit(false)
   }
 
   test("defaultFetchSize returns 1000") {
-    val dialect = PostgresDialect()
     assert(dialect.defaultFetchSize === 1000)
   }
 
   test("beforeFetch sets autoCommit=false when using default fetchSize") {
     val conn = mock[Connection]
-    val dialect = PostgresDialect()
-    // No explicit fetchsize - should still set autoCommit=false due to defaultFetchSize
+    // No explicit fetchsize - should use defaultFetchSize (1000) and set autoCommit=false
     dialect.beforeFetch(conn, createJDBCOptions(Map.empty))
     verify(conn).setAutoCommit(false)
+  }
+
+  test("effectiveFetchSize returns user-specified value when set") {
+    assert(dialect.effectiveFetchSize(createJDBCOptions(Map("fetchsize" -> "500"))) === 500)
+  }
+
+  test("effectiveFetchSize returns 0 when user explicitly sets 0") {
+    assert(dialect.effectiveFetchSize(createJDBCOptions(Map("fetchsize" -> "0"))) === 0)
+  }
+
+  test("effectiveFetchSize returns defaultFetchSize when not set") {
+    assert(dialect.effectiveFetchSize(createJDBCOptions(Map.empty)) === 1000)
+  }
+
+  test("base dialect effectiveFetchSize returns 0 when not set") {
+    val baseDialect = new JdbcDialect {
+      override def canHandle(url: String): Boolean = true
+    }
+    assert(baseDialect.effectiveFetchSize(createJDBCOptions(Map.empty)) === 0)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
@@ -62,4 +62,17 @@ class PostgresDialectSuite extends SparkFunSuite with MockitoSugar {
     dialect.beforeFetch(conn, createJDBCOptions(Map("fetchsize" -> "0")))
     verify(conn, never()).setAutoCommit(false)
   }
+
+  test("defaultFetchSize returns 1000") {
+    val dialect = PostgresDialect()
+    assert(dialect.defaultFetchSize === 1000)
+  }
+
+  test("beforeFetch sets autoCommit=false when using default fetchSize") {
+    val conn = mock[Connection]
+    val dialect = PostgresDialect()
+    // No explicit fetchsize - should still set autoCommit=false due to defaultFetchSize
+    dialect.beforeFetch(conn, createJDBCOptions(Map.empty))
+    verify(conn).setAutoCommit(false)
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
@@ -61,15 +61,15 @@ class PostgresDialectSuite extends SparkFunSuite with MockitoSugar {
     verify(conn, never()).setAutoCommit(false)
   }
 
-  test("SPARK-56251: effectiveFetchSize: returns 1000 when not set (Postgres default)") {
-    assert(dialect.effectiveFetchSize(createJDBCOptions(Map.empty)) === 1000)
+  test("SPARK-56251: getFetchSize: returns 1000 when not set (Postgres default)") {
+    assert(dialect.getFetchSize(createJDBCOptions(Map.empty)) === 1000)
   }
 
-  test("SPARK-56251: effectiveFetchSize: base dialect returns 0 when not set") {
+  test("SPARK-56251: getFetchSize: base dialect returns 0 when not set") {
     val baseDialect = new JdbcDialect {
       override def canHandle(url: String): Boolean = true
     }
-    assert(baseDialect.effectiveFetchSize(createJDBCOptions(Map.empty)) === 0)
+    assert(baseDialect.getFetchSize(createJDBCOptions(Map.empty)) === 0)
   }
 
   test("SPARK-56251: beforeFetch sets autoCommit=false when using default fetchSize") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
@@ -61,15 +61,7 @@ class PostgresDialectSuite extends SparkFunSuite with MockitoSugar {
     verify(conn, never()).setAutoCommit(false)
   }
 
-  test("SPARK-56251: effectiveFetchSize: returns user-specified value when set") {
-    assert(dialect.effectiveFetchSize(createJDBCOptions(Map("fetchsize" -> "500"))) === 500)
-  }
-
-  test("SPARK-56251: effectiveFetchSize: returns 0 when user explicitly sets 0") {
-    assert(dialect.effectiveFetchSize(createJDBCOptions(Map("fetchsize" -> "0"))) === 0)
-  }
-
-  test("SPARK-56251: effectiveFetchSize: returns defaultFetchSize (1000) when not set") {
+  test("SPARK-56251: effectiveFetchSize: returns 1000 when not set (Postgres default)") {
     assert(dialect.effectiveFetchSize(createJDBCOptions(Map.empty)) === 1000)
   }
 
@@ -77,13 +69,12 @@ class PostgresDialectSuite extends SparkFunSuite with MockitoSugar {
     val baseDialect = new JdbcDialect {
       override def canHandle(url: String): Boolean = true
     }
-    assert(baseDialect.defaultFetchSize === 0)
     assert(baseDialect.effectiveFetchSize(createJDBCOptions(Map.empty)) === 0)
   }
 
   test("SPARK-56251: beforeFetch sets autoCommit=false when using default fetchSize") {
     val conn = mock[Connection]
-    // No explicit fetchsize - should use defaultFetchSize (1000) and set autoCommit=false
+    // No explicit fetchsize - should use Postgres default (1000) and set autoCommit=false
     dialect.beforeFetch(conn, createJDBCOptions(Map.empty))
     verify(conn).setAutoCommit(false)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds a default `fetchSize` of 1000 for the PostgreSQL JDBC dialect to prevent loading entire tables into memory when no explicit `fetchSize` is specified by the user.

The changes include:

1. **`JdbcDialect`**: Added `getFetchSize(options)` method that returns `options.fetchSize` by default. Dialects can override this to provide a sensible default when the user does not explicitly set the `fetchsize` option.
2. **`PostgresDialect`**: Overrides `getFetchSize` to return 1000 when the user hasn't set `fetchsize`, and updates `beforeFetch` to use `getFetchSize()` for the `autoCommit` decision. Also logs an info message when the default is applied.
3. **`AggregatedDialect`**: Delegates `getFetchSize` and `beforeFetch` to `dialects.head`, consistent with how other methods (e.g., `quoteIdentifier`, `getTruncateQuery`) are delegated.
4. **`JDBCRDD`**: Uses `dialect.getFetchSize(options)` instead of `options.fetchSize` for `stmt.setFetchSize()`.

### Why are the changes needed?
By default, the PostgreSQL JDBC driver loads **all rows** into memory when `fetchSize` is 0 (the Spark default). Without partitioning information, a single task may load the entire table into memory, which can easily cause executor OOM.

Unlike most JDBC drivers, PostgreSQL requires both `fetchSize > 0` **and** `autoCommit = false` to enable cursor-based fetching (see [PostgreSQL JDBC documentation](https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor)). Setting a sensible default fetch size of 1000 enables cursor-based row batching automatically, preventing the driver from buffering the entire result set.

Users can still override the default by explicitly setting the `fetchsize` option (including `fetchsize=0` to restore the old behavior).

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
UTs added.
Manually verified the behavior for Postgres.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code v2.1.87
