### PR TITLE
[SPARK-56246][INFRA][4.0] Pin pandas to version 2.2.3 in docs Docker image

### DIFF
--- a/dev/spark-test-image/docs/Dockerfile
+++ b/dev/spark-test-image/docs/Dockerfile
@@ -85,7 +85,7 @@ RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9
 # See 'ipython_genutils' in SPARK-38517
 # See 'docutils<0.18.0' in SPARK-39421
 RUN python3.9 -m pip install 'sphinx==4.5.0' mkdocs 'pydata_sphinx_theme>=0.13' sphinx-copybutton nbsphinx numpydoc jinja2 markupsafe 'pyzmq<24.0.0' \
-  ipython ipython_genutils sphinx_plotly_directive 'numpy>=1.20.0' pyarrow pandas 'plotly>=4.8' 'docutils<0.18.0' \
+  ipython ipython_genutils sphinx_plotly_directive 'numpy>=1.20.0' pyarrow 'pandas==2.2.3' 'plotly>=4.8' 'docutils<0.18.0' \
   'flake8==3.9.0' 'mypy==1.8.0' 'pytest==7.1.3' 'pytest-mypy-plugins==1.9.3' 'black==23.12.1' \
   'pandas-stubs==1.2.0.53' 'grpcio==1.67.0' 'grpcio-status==1.67.0' 'protobuf==5.29.1' 'grpc-stubs==1.24.11' 'googleapis-common-protos-stubs==2.2.0' \
   'sphinxcontrib-applehelp==1.0.4' 'sphinxcontrib-devhelp==1.0.2' 'sphinxcontrib-htmlhelp==2.0.1' 'sphinxcontrib-qthelp==1.0.3' 'sphinxcontrib-serializinghtml==1.1.5' \


### PR DESCRIPTION
### What changes were proposed in this pull request?

Pin `pandas==2.2.3` in the docs Docker image (`dev/spark-test-image/docs/Dockerfile`).

### Why are the changes needed?

The docs Docker image installs pandas without a version pin. When pandas 2.3.3 was released, the documentation build started failing because `supported_api_gen.py` requires an exact match with pandas 2.2.3:

```
ImportError: Warning: pandas 2.2.3 is required; your version is 2.3.3
```

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

CI should pass with the pinned version.

### Was this patch authored or co-authored using generative AI tooling?

No