### PR TITLE
[SPARK-56120][PYTHON][TEST] Add ASV micro-benchmarks for SQL_WINDOW_AGG_ARROW_UDF

### DIFF
--- a/python/benchmarks/bench_eval_type.py
+++ b/python/benchmarks/bench_eval_type.py
@@ -147,11 +147,18 @@ class MockProtocolWriter:
         write_udf: Callable[[io.BufferedIOBase], None],
         write_data: Callable[[io.BufferedIOBase], None],
         buf: io.BufferedIOBase,
+        runner_conf: dict[str, str] | None = None,
     ) -> None:
         """Write the full worker binary stream: preamble + command + data + end."""
         cls.write_preamble(buf)
         write_int(eval_type, buf)
-        write_int(0, buf)  # RunnerConf  (0 key-value pairs)
+        if runner_conf:
+            write_int(len(runner_conf), buf)
+            for k, v in runner_conf.items():
+                cls.write_utf8(k, buf)
+                cls.write_utf8(v, buf)
+        else:
+            write_int(0, buf)  # RunnerConf  (0 key-value pairs)
         write_int(0, buf)  # EvalConf    (0 key-value pairs)
         write_udf(buf)
         write_data(buf)
@@ -969,4 +976,88 @@ class ScalarArrowIterUDFTimeBench(_ScalarArrowIterBenchMixin, _TimeBenchBase):
 
 
 class ScalarArrowIterUDFPeakmemBench(_ScalarArrowIterBenchMixin, _PeakmemBenchBase):
+    pass
+
+
+# -- SQL_WINDOW_AGG_ARROW_UDF ------------------------------------------------
+# UDF receives ``pa.Array`` columns for the entire window partition, returns scalar.
+
+
+class _WindowAggArrowBenchMixin:
+    """Provides _write_scenario for SQL_WINDOW_AGG_ARROW_UDF."""
+
+    def _window_agg_arrow_sum(col):
+        """Sum a single Arrow column."""
+        import pyarrow.compute as pc
+
+        return pc.sum(col).as_py()
+
+    def _window_agg_arrow_mean_multi(col0, col1):
+        """Mean of two Arrow columns combined."""
+        import pyarrow.compute as pc
+
+        return (pc.mean(col0).as_py() or 0) + (pc.mean(col1).as_py() or 0)
+
+    def _build_scenarios():
+        """Build scenarios for SQL_WINDOW_AGG_ARROW_UDF.
+
+        Returns a dict mapping scenario name to ``(groups, schema)``.
+        """
+        scenarios = {}
+
+        for name, (num_groups, rows_per_group, n_cols) in {
+            "few_groups_sm": (50, 5_000, 5),
+            "few_groups_lg": (50, 50_000, 5),
+            "many_groups_sm": (2_000, 500, 5),
+            "many_groups_lg": (500, 10_000, 5),
+            "wide_cols": (200, 5_000, 20),
+        }.items():
+            groups, schema = MockDataFactory.make_batch_groups(
+                num_groups=num_groups,
+                num_rows=rows_per_group,
+                num_cols=n_cols,
+                spark_type_pool=MockDataFactory.NUMERIC_TYPES,
+                batch_size=rows_per_group,
+            )
+            scenarios[name] = (groups, schema)
+
+        return scenarios
+
+    _scenarios = _build_scenarios()
+    _udfs = {
+        "sum_udf": _window_agg_arrow_sum,
+        "mean_multi_udf": _window_agg_arrow_mean_multi,
+    }
+    params = [list(_scenarios), list(_udfs)]
+    param_names = ["scenario", "udf"]
+
+    def _write_scenario(self, scenario, udf_name, buf):
+        groups, _schema = self._scenarios[scenario]
+        udf_func = self._udfs[udf_name]
+
+        # sum_udf uses 1 arg, mean_multi_udf uses 2 args
+        if "multi" in udf_name:
+            arg_offsets = [0, 1]
+        else:
+            arg_offsets = [0]
+
+        return_type = DoubleType()
+
+        def write_udf(b):
+            MockProtocolWriter.write_udf_payload(udf_func, return_type, arg_offsets, b)
+
+        MockProtocolWriter.write_worker_input(
+            PythonEvalType.SQL_WINDOW_AGG_ARROW_UDF,
+            write_udf,
+            lambda b: MockProtocolWriter.write_grouped_data_payload(groups, num_dfs=1, buf=b),
+            buf,
+            runner_conf={"window_bound_types": "unbounded"},
+        )
+
+
+class WindowAggArrowUDFTimeBench(_WindowAggArrowBenchMixin, _TimeBenchBase):
+    pass
+
+
+class WindowAggArrowUDFPeakmemBench(_WindowAggArrowBenchMixin, _PeakmemBenchBase):
     pass


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add ASV micro-benchmarks for `SQL_WINDOW_AGG_ARROW_UDF`.

Also adds optional `runner_conf` parameter to `MockProtocolWriter.write_worker_input` for passing configuration like `window_bound_types`.

### Why are the changes needed?

Part of [SPARK-55724](https://issues.apache.org/jira/browse/SPARK-55724). Establishes performance baselines before refactoring this eval type.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```
./python/asv run --python=same -b "WindowAggArrow" -a repeat=3 --show-stderr
```

```
··· ================ ============ ================
    --                            udf             
    ---------------- -----------------------------
        scenario       sum_udf     mean_multi_udf 
    ================ ============ ================
     few_groups_sm    11.3±0.3ms     9.85±0.1ms   
     few_groups_lg    45.7±0.1ms     44.4±0.1ms   
     many_groups_sm    317±4ms        273±5ms     
     many_groups_lg    177±2ms        158±1ms     
       wide_cols       85.1±1ms      83.2±0.7ms   
    ================ ============ ================
```

```
··· ================ ========= ================
    --                          udf            
    ---------------- --------------------------
        scenario      sum_udf   mean_multi_udf 
    ================ ========= ================
     few_groups_sm      468M         467M      
     few_groups_lg      492M         490M      
     many_groups_sm     474M         473M      
     many_groups_lg     505M         503M      
       wide_cols        478M         477M      
    ================ ========= ================
```

### Was this patch authored or co-authored using generative AI tooling?

No.