### PR TITLE
[SPARK-56258][SQL] Make MetricUtils.stringValue lenient for unknown metric types

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/MetricUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/MetricUtils.scala
@@ -22,10 +22,10 @@ import java.util.{Arrays, Locale}
 
 import scala.concurrent.duration._
 
-import org.apache.spark.SparkException
+import org.apache.spark.internal.Logging
 import org.apache.spark.util.Utils
 
-private[spark] object MetricUtils {
+private[spark] object MetricUtils extends Logging {
 
   val SUM_METRIC: String = "sum"
   val SIZE_METRIC: String = "size"
@@ -82,7 +82,9 @@ private[spark] object MetricUtils {
       } else if (metricsType == NS_TIMING_METRIC) {
         duration => Utils.msDurationToString(duration.nanos.toMillis)
       } else {
-        throw SparkException.internalError(s"unexpected metrics type: $metricsType")
+        logDebug(s"unexpected metrics type: $metricsType")
+        val numberFormat = NumberFormat.getIntegerInstance(Locale.US)
+        v: Long => s"[unknown] ${numberFormat.format(v)}"
       }
 
       val validValues = values.filter(_ >= 0)

--- a/core/src/test/scala/org/apache/spark/util/MetricUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/MetricUtilsSuite.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+import org.apache.spark.SparkFunSuite
+
+class MetricUtilsSuite extends SparkFunSuite {
+
+  test("stringValue with unknown metric type falls back gracefully") {
+    val values = Array(100L, 200L, 300L)
+    val maxMetrics = Array(300L, 2L, 0L, 5L) // value, stageId, attemptId, taskId
+    val result = MetricUtils.stringValue("customType", values, maxMetrics)
+    assert(result.contains("[unknown]"))
+    assert(result.contains("(stage 2.0: task 5)"))
+  }
+
+  test("stringValue with unknown metric type and single value") {
+    val values = Array(42L)
+    val result = MetricUtils.stringValue("customType", values, Array.empty[Long])
+    assert(result == "[unknown] 42")
+  }
+
+  test("stringValue with known metric types still works") {
+    // sum
+    val sumResult = MetricUtils.stringValue("sum", Array(100L, 200L), Array.empty[Long])
+    assert(sumResult == "300")
+
+    // size
+    val sizeResult = MetricUtils.stringValue("size", Array(1024L), Array.empty[Long])
+    assert(sizeResult == "1024.0 B")
+
+    // timing
+    val timingResult = MetricUtils.stringValue("timing", Array(500L), Array.empty[Long])
+    assert(timingResult == "500 ms")
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace `SparkException.internalError` with best-effort rendering for unknown metric types in `MetricUtils.stringValue`.

For unknown types, the formatter now:
- Logs at `DEBUG` level for developer tracing
- Formats values as `[unknown] N` with `NumberFormat` thousand separators
- Continues to compute sum/min/med/max statistics like other types

### Why are the changes needed?

A crash at UI rendering time is worse than showing a degraded metric. The current `throw` is over-defensive for a display function. This also enables downstream projects (Gluten, Comet) to define custom metric types without Spark core throwing at display time.

### Does this PR introduce _any_ user-facing change?

Yes — unknown metric types now display as `[unknown] 1,234,567` instead of crashing the SQL execution page.

### How was this patch tested?

Compilation verified.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot (Claude Opus 4.6)