### PR TITLE
[SPARK-56240][CORE][TESTS] Add `NettyTransportBenchmark` for Netty transport layer performance evaluation

### DIFF
--- a/core/benchmarks/NettyTransportBenchmark-jdk21-results.txt
+++ b/core/benchmarks/NettyTransportBenchmark-jdk21-results.txt
@@ -1,0 +1,137 @@
+================================================================================================
+RPC Round-Trip Latency - 1 KB payload (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+RPC Latency (1 KB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+1 KB payload                                        335            342           7          0.0       66911.4       1.0X
+
+
+================================================================================================
+RPC Round-Trip Latency - 64 KB payload (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+RPC Latency (64 KB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+64 KB payload                                       448            460          10          0.0       89657.2       1.0X
+
+
+================================================================================================
+RPC Round-Trip Latency - 1 MB payload (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+RPC Latency (1 MB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+1 MB payload                                        471            479           9          0.0      470636.9       1.0X
+
+
+================================================================================================
+RPC Round-Trip Latency - 16 MB payload (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+RPC Latency (16 MB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+16 MB payload                                       841            849           7          0.0     8407092.8       1.0X
+
+
+================================================================================================
+Concurrent RPC Throughput (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Concurrent RPC Throughput:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+1 client(s)                                        1294           1314          25          0.0       64708.3       1.0X
+4 client(s)                                         427            439          10          0.0       21360.8       3.0X
+8 client(s)                                         314            320           7          0.1       15676.1       4.1X
+16 client(s)                                        272            279           8          0.1       13589.0       4.8X
+
+
+================================================================================================
+IOMode Comparison (Concurrent Throughput)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+IOMode Comparison:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+NIO (8 clients)                                     516            589          93          0.0       25825.0       1.0X
+AUTO (8 clients)                                    490            500          17          0.0       24505.4       1.1X
+
+
+================================================================================================
+Server Thread Scaling (IOMode=AUTO, 16 clients)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Server Thread Scaling:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+2 server threads                                    286            295          14          0.1       14310.4       1.0X
+4 server threads                                    242            255          13          0.1       12112.0       1.2X
+8 server threads                                    252            270          23          0.1       12589.5       1.1X
+16 server threads                                   275            287          21          0.1       13745.1       1.0X
+32 server threads                                   271            287          14          0.1       13561.4       1.1X
+
+
+================================================================================================
+Multi-Connection Per Peer (IOMode=AUTO, 1MB payload)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Multi-Connection Throughput:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+1 conn(s), 4 threads                               1775           1832          77          0.0      354929.4       1.0X
+2 conn(s), 4 threads                               1183           1247          85          0.0      236554.9       1.5X
+4 conn(s), 4 threads                               1234           1270          38          0.0      246700.6       1.4X
+
+
+================================================================================================
+Async Write Pressure (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Async Write Throughput:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+1 KB async burst                                     45             49           4          0.1        9065.0       1.0X
+64 KB async burst                                   138            162          26          0.0       27506.3       0.3X
+1 MB async burst                                   1725           1782          86          0.0      344925.8       0.0X
+
+
+================================================================================================
+Large Block Transfer Throughput (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+16 MB Block Transfer:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Sequential sends                                    870            895          22          0.0     8701927.9       1.0X
+4-thread parallel sends                             506            512           6          0.0     5055321.9       1.7X
+
+
+================================================================================================
+File-Backed Shuffle Block Fetch (NIO vs AUTO, 100x16MB)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+File-Backed Shuffle Fetch:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+NIO, sequential fetch                               397            411          11          0.0     3974586.8       1.0X
+NIO, parallel fetch (4 clients)                     212            216           6          0.0     2124732.6       1.9X
+AUTO, sequential fetch                             1380           1585         307          0.0    13797686.8       0.3X
+AUTO, parallel fetch (4 clients)                    627            712         110          0.0     6269026.1       0.6X
+
+

--- a/core/benchmarks/NettyTransportBenchmark-jdk21-results.txt
+++ b/core/benchmarks/NettyTransportBenchmark-jdk21-results.txt
@@ -3,10 +3,10 @@ RPC Round-Trip Latency - 1 KB payload (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 RPC Latency (1 KB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 KB payload                                        334            346          11          0.0       66847.1       1.0X
+1 KB payload                                        493            539          31          0.0       98616.6       1.0X
 
 
 ================================================================================================
@@ -14,10 +14,10 @@ RPC Round-Trip Latency - 64 KB payload (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 RPC Latency (64 KB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-64 KB payload                                       443            458          13          0.0       88561.5       1.0X
+64 KB payload                                       737            758          18          0.0      147330.6       1.0X
 
 
 ================================================================================================
@@ -25,10 +25,10 @@ RPC Round-Trip Latency - 1 MB payload (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 RPC Latency (1 MB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 MB payload                                        490            492           1          0.0      489845.9       1.0X
+1 MB payload                                        829            899          90          0.0      828572.3       1.0X
 
 
 ================================================================================================
@@ -36,10 +36,10 @@ RPC Round-Trip Latency - 16 MB payload (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 RPC Latency (16 MB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-16 MB payload                                       855            868          16          0.0     8553120.7       1.0X
+16 MB payload                                      1271           1351          72          0.0    12713142.1       1.0X
 
 
 ================================================================================================
@@ -47,13 +47,13 @@ Concurrent RPC Throughput (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Concurrent RPC Throughput:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 client(s)                                        1297           1329          45          0.0       64836.3       1.0X
-4 client(s)                                         421            432          11          0.0       21064.1       3.1X
-8 client(s)                                         306            316           9          0.1       15323.1       4.2X
-16 client(s)                                        263            276          11          0.1       13170.0       4.9X
+1 client(s)                                        1936           2030          85          0.0       96813.3       1.0X
+4 client(s)                                         726            748          32          0.0       36305.7       2.7X
+8 client(s)                                         548            550           1          0.0       27417.0       3.5X
+16 client(s)                                        445            458          14          0.0       22238.6       4.4X
 
 
 ================================================================================================
@@ -61,11 +61,11 @@ IOMode Comparison (Concurrent Throughput)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 IOMode Comparison:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NIO (8 clients)                                     578            614          40          0.0       28919.3       1.0X
-AUTO (8 clients)                                    472            497          22          0.0       23617.2       1.2X
+NIO (8 clients)                                     792            803          19          0.0       39590.9       1.0X
+AUTO (8 clients)                                    835            851          16          0.0       41747.2       0.9X
 
 
 ================================================================================================
@@ -73,14 +73,14 @@ Server Thread Scaling (IOMode=AUTO, 16 clients)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Server Thread Scaling:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-2 server threads                                    281            284           3          0.1       14045.0       1.0X
-4 server threads                                    252            256           7          0.1       12608.2       1.1X
-8 server threads                                    239            251          13          0.1       11934.1       1.2X
-16 server threads                                   256            272          28          0.1       12775.4       1.1X
-32 server threads                                   265            280          13          0.1       13258.5       1.1X
+2 server threads                                    481            491          12          0.0       24050.8       1.0X
+4 server threads                                    391            413          29          0.1       19537.1       1.2X
+8 server threads                                    416            434          15          0.0       20819.9       1.2X
+16 server threads                                   449            473          26          0.0       22455.0       1.1X
+32 server threads                                   461            499          33          0.0       23043.3       1.0X
 
 
 ================================================================================================
@@ -88,12 +88,12 @@ Multi-Connection Per Peer (IOMode=AUTO, 1MB payload)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Multi-Connection Throughput:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 conn(s), 4 threads                               1917           1971          66          0.0      383371.3       1.0X
-2 conn(s), 4 threads                               1331           1364          31          0.0      266122.0       1.4X
-4 conn(s), 4 threads                               1235           1287          57          0.0      247060.8       1.6X
+1 conn(s), 4 threads                               1601           1667         108          0.0      320283.2       1.0X
+2 conn(s), 4 threads                               1189           1505         274          0.0      237803.7       1.3X
+4 conn(s), 4 threads                               1754           1793          34          0.0      350832.7       0.9X
 
 
 ================================================================================================
@@ -101,12 +101,12 @@ Async Write Pressure (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Async Write Throughput:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 KB async burst                                     27             34          10          0.2        5478.6       1.0X
-64 KB async burst                                   138            146          12          0.0       27543.0       0.2X
-1 MB async burst                                   1717           1822         166          0.0      343390.6       0.0X
+1 KB async burst                                     37             40           3          0.1        7439.9       1.0X
+64 KB async burst                                   145            155          13          0.0       29093.7       0.3X
+1 MB async burst                                   1539           1571          33          0.0      307765.1       0.0X
 
 
 ================================================================================================
@@ -114,11 +114,11 @@ Large Block Transfer Throughput (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 16 MB Block Transfer:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Sequential sends                                    868            912          38          0.0     8683882.3       1.0X
-4-thread parallel sends                             502            509           7          0.0     5016951.6       1.7X
+Sequential sends                                    627            834         304          0.0     6267294.2       1.0X
+4-thread parallel sends                             452            457           7          0.0     4520142.4       1.4X
 
 
 ================================================================================================
@@ -126,12 +126,12 @@ File-Backed Shuffle Block Fetch (NIO vs AUTO, 100x16MB)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 File-Backed Shuffle Fetch:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NIO, sequential fetch                               388            464         114          0.0     3880925.3       1.0X
-NIO, parallel fetch (4 clients)                     212            216           6          0.0     2115103.2       1.8X
-AUTO, sequential fetch                             1400           1457          95          0.0    14001963.1       0.3X
-AUTO, parallel fetch (4 clients)                    548            619          64          0.0     5478120.0       0.7X
+NIO, sequential fetch                               370            384          13          0.0     3700370.3       1.0X
+NIO, parallel fetch (4 clients)                     205            213           7          0.0     2054174.4       1.8X
+AUTO, sequential fetch                             2093           2189          85          0.0    20929166.7       0.2X
+AUTO, parallel fetch (4 clients)                    677            787         113          0.0     6769621.7       0.5X
 
 

--- a/core/benchmarks/NettyTransportBenchmark-jdk21-results.txt
+++ b/core/benchmarks/NettyTransportBenchmark-jdk21-results.txt
@@ -6,7 +6,7 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 RPC Latency (1 KB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 KB payload                                        335            342           7          0.0       66911.4       1.0X
+1 KB payload                                        334            346          11          0.0       66847.1       1.0X
 
 
 ================================================================================================
@@ -17,7 +17,7 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 RPC Latency (64 KB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-64 KB payload                                       448            460          10          0.0       89657.2       1.0X
+64 KB payload                                       443            458          13          0.0       88561.5       1.0X
 
 
 ================================================================================================
@@ -28,7 +28,7 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 RPC Latency (1 MB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 MB payload                                        471            479           9          0.0      470636.9       1.0X
+1 MB payload                                        490            492           1          0.0      489845.9       1.0X
 
 
 ================================================================================================
@@ -39,7 +39,7 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 RPC Latency (16 MB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-16 MB payload                                       841            849           7          0.0     8407092.8       1.0X
+16 MB payload                                       855            868          16          0.0     8553120.7       1.0X
 
 
 ================================================================================================
@@ -50,10 +50,10 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Concurrent RPC Throughput:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 client(s)                                        1294           1314          25          0.0       64708.3       1.0X
-4 client(s)                                         427            439          10          0.0       21360.8       3.0X
-8 client(s)                                         314            320           7          0.1       15676.1       4.1X
-16 client(s)                                        272            279           8          0.1       13589.0       4.8X
+1 client(s)                                        1297           1329          45          0.0       64836.3       1.0X
+4 client(s)                                         421            432          11          0.0       21064.1       3.1X
+8 client(s)                                         306            316           9          0.1       15323.1       4.2X
+16 client(s)                                        263            276          11          0.1       13170.0       4.9X
 
 
 ================================================================================================
@@ -64,8 +64,8 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 IOMode Comparison:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NIO (8 clients)                                     516            589          93          0.0       25825.0       1.0X
-AUTO (8 clients)                                    490            500          17          0.0       24505.4       1.1X
+NIO (8 clients)                                     578            614          40          0.0       28919.3       1.0X
+AUTO (8 clients)                                    472            497          22          0.0       23617.2       1.2X
 
 
 ================================================================================================
@@ -76,11 +76,11 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Server Thread Scaling:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-2 server threads                                    286            295          14          0.1       14310.4       1.0X
-4 server threads                                    242            255          13          0.1       12112.0       1.2X
-8 server threads                                    252            270          23          0.1       12589.5       1.1X
-16 server threads                                   275            287          21          0.1       13745.1       1.0X
-32 server threads                                   271            287          14          0.1       13561.4       1.1X
+2 server threads                                    281            284           3          0.1       14045.0       1.0X
+4 server threads                                    252            256           7          0.1       12608.2       1.1X
+8 server threads                                    239            251          13          0.1       11934.1       1.2X
+16 server threads                                   256            272          28          0.1       12775.4       1.1X
+32 server threads                                   265            280          13          0.1       13258.5       1.1X
 
 
 ================================================================================================
@@ -91,9 +91,9 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Multi-Connection Throughput:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 conn(s), 4 threads                               1775           1832          77          0.0      354929.4       1.0X
-2 conn(s), 4 threads                               1183           1247          85          0.0      236554.9       1.5X
-4 conn(s), 4 threads                               1234           1270          38          0.0      246700.6       1.4X
+1 conn(s), 4 threads                               1917           1971          66          0.0      383371.3       1.0X
+2 conn(s), 4 threads                               1331           1364          31          0.0      266122.0       1.4X
+4 conn(s), 4 threads                               1235           1287          57          0.0      247060.8       1.6X
 
 
 ================================================================================================
@@ -104,9 +104,9 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Async Write Throughput:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 KB async burst                                     45             49           4          0.1        9065.0       1.0X
-64 KB async burst                                   138            162          26          0.0       27506.3       0.3X
-1 MB async burst                                   1725           1782          86          0.0      344925.8       0.0X
+1 KB async burst                                     27             34          10          0.2        5478.6       1.0X
+64 KB async burst                                   138            146          12          0.0       27543.0       0.2X
+1 MB async burst                                   1717           1822         166          0.0      343390.6       0.0X
 
 
 ================================================================================================
@@ -117,8 +117,8 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 16 MB Block Transfer:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Sequential sends                                    870            895          22          0.0     8701927.9       1.0X
-4-thread parallel sends                             506            512           6          0.0     5055321.9       1.7X
+Sequential sends                                    868            912          38          0.0     8683882.3       1.0X
+4-thread parallel sends                             502            509           7          0.0     5016951.6       1.7X
 
 
 ================================================================================================
@@ -129,9 +129,9 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 File-Backed Shuffle Fetch:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NIO, sequential fetch                               397            411          11          0.0     3974586.8       1.0X
-NIO, parallel fetch (4 clients)                     212            216           6          0.0     2124732.6       1.9X
-AUTO, sequential fetch                             1380           1585         307          0.0    13797686.8       0.3X
-AUTO, parallel fetch (4 clients)                    627            712         110          0.0     6269026.1       0.6X
+NIO, sequential fetch                               388            464         114          0.0     3880925.3       1.0X
+NIO, parallel fetch (4 clients)                     212            216           6          0.0     2115103.2       1.8X
+AUTO, sequential fetch                             1400           1457          95          0.0    14001963.1       0.3X
+AUTO, parallel fetch (4 clients)                    548            619          64          0.0     5478120.0       0.7X
 
 

--- a/core/benchmarks/NettyTransportBenchmark-jdk25-results.txt
+++ b/core/benchmarks/NettyTransportBenchmark-jdk25-results.txt
@@ -1,0 +1,137 @@
+================================================================================================
+RPC Round-Trip Latency - 1 KB payload (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+RPC Latency (1 KB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+1 KB payload                                        507            531          17          0.0      101431.1       1.0X
+
+
+================================================================================================
+RPC Round-Trip Latency - 64 KB payload (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+RPC Latency (64 KB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+64 KB payload                                       620            652          24          0.0      123934.0       1.0X
+
+
+================================================================================================
+RPC Round-Trip Latency - 1 MB payload (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+RPC Latency (1 MB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+1 MB payload                                        434            469          42          0.0      433901.5       1.0X
+
+
+================================================================================================
+RPC Round-Trip Latency - 16 MB payload (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+RPC Latency (16 MB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+16 MB payload                                       719            727          13          0.0     7186630.4       1.0X
+
+
+================================================================================================
+Concurrent RPC Throughput (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+Concurrent RPC Throughput:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+1 client(s)                                        2050           2094          67          0.0      102521.6       1.0X
+4 client(s)                                         711            727          20          0.0       35571.3       2.9X
+8 client(s)                                         518            527          10          0.0       25876.1       4.0X
+16 client(s)                                        447            451           4          0.0       22360.0       4.6X
+
+
+================================================================================================
+IOMode Comparison (Concurrent Throughput)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+IOMode Comparison:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+NIO (8 clients)                                     720            780          64          0.0       36000.0       1.0X
+AUTO (8 clients)                                    684            689           6          0.0       34189.4       1.1X
+
+
+================================================================================================
+Server Thread Scaling (IOMode=AUTO, 16 clients)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+Server Thread Scaling:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+2 server threads                                    460            474          18          0.0       22994.7       1.0X
+4 server threads                                    391            410          27          0.1       19564.8       1.2X
+8 server threads                                    411            418          11          0.0       20566.8       1.1X
+16 server threads                                   456            475          28          0.0       22789.9       1.0X
+32 server threads                                   464            497          30          0.0       23223.7       1.0X
+
+
+================================================================================================
+Multi-Connection Per Peer (IOMode=AUTO, 1MB payload)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+Multi-Connection Throughput:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+1 conn(s), 4 threads                               1963           2003          42          0.0      392657.6       1.0X
+2 conn(s), 4 threads                               1185           1332         138          0.0      237065.8       1.7X
+4 conn(s), 4 threads                               1060           1083          22          0.0      211942.7       1.9X
+
+
+================================================================================================
+Async Write Pressure (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+Async Write Throughput:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+1 KB async burst                                     37             58          19          0.1        7331.0       1.0X
+64 KB async burst                                   147            163          20          0.0       29303.0       0.3X
+1 MB async burst                                   1384           1455         121          0.0      276842.9       0.0X
+
+
+================================================================================================
+Large Block Transfer Throughput (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+16 MB Block Transfer:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Sequential sends                                    679            685           5          0.0     6793339.7       1.0X
+4-thread parallel sends                             365            370           4          0.0     3653257.9       1.9X
+
+
+================================================================================================
+File-Backed Shuffle Block Fetch (NIO vs AUTO, 100x16MB)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+File-Backed Shuffle Fetch:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+NIO, sequential fetch                               369            390          24          0.0     3689959.5       1.0X
+NIO, parallel fetch (4 clients)                     200            208           7          0.0     2001935.5       1.8X
+AUTO, sequential fetch                             1918           1994          80          0.0    19179875.5       0.2X
+AUTO, parallel fetch (4 clients)                    652            730         116          0.0     6517014.3       0.6X
+
+

--- a/core/benchmarks/NettyTransportBenchmark-results.txt
+++ b/core/benchmarks/NettyTransportBenchmark-results.txt
@@ -1,0 +1,137 @@
+================================================================================================
+RPC Round-Trip Latency - 1 KB payload (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+RPC Latency (1 KB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+1 KB payload                                        463            477          13          0.0       92568.3       1.0X
+
+
+================================================================================================
+RPC Round-Trip Latency - 64 KB payload (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+RPC Latency (64 KB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+64 KB payload                                       680            695          12          0.0      136004.3       1.0X
+
+
+================================================================================================
+RPC Round-Trip Latency - 1 MB payload (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+RPC Latency (1 MB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+1 MB payload                                        822            895          52          0.0      822087.0       1.0X
+
+
+================================================================================================
+RPC Round-Trip Latency - 16 MB payload (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+RPC Latency (16 MB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+16 MB payload                                      1230           1306          58          0.0    12295430.0       1.0X
+
+
+================================================================================================
+Concurrent RPC Throughput (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+Concurrent RPC Throughput:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+1 client(s)                                        1830           1881          49          0.0       91498.8       1.0X
+4 client(s)                                         717            730          11          0.0       35831.2       2.6X
+8 client(s)                                         502            514          13          0.0       25122.4       3.6X
+16 client(s)                                        442            453          10          0.0       22114.2       4.1X
+
+
+================================================================================================
+IOMode Comparison (Concurrent Throughput)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+IOMode Comparison:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+NIO (8 clients)                                     772            837          75          0.0       38575.1       1.0X
+AUTO (8 clients)                                    862            896          30          0.0       43107.0       0.9X
+
+
+================================================================================================
+Server Thread Scaling (IOMode=AUTO, 16 clients)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+Server Thread Scaling:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+2 server threads                                    448            460          14          0.0       22384.7       1.0X
+4 server threads                                    396            398           2          0.1       19794.4       1.1X
+8 server threads                                    411            422          11          0.0       20525.4       1.1X
+16 server threads                                   470            478           9          0.0       23488.2       1.0X
+32 server threads                                   461            498          34          0.0       23049.9       1.0X
+
+
+================================================================================================
+Multi-Connection Per Peer (IOMode=AUTO, 1MB payload)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+Multi-Connection Throughput:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+1 conn(s), 4 threads                               1642           1740          96          0.0      328480.9       1.0X
+2 conn(s), 4 threads                               1390           1588         172          0.0      278078.4       1.2X
+4 conn(s), 4 threads                               1667           1724          50          0.0      333315.0       1.0X
+
+
+================================================================================================
+Async Write Pressure (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+Async Write Throughput:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+1 KB async burst                                     59             66           6          0.1       11860.0       1.0X
+64 KB async burst                                   147            167          23          0.0       29498.4       0.4X
+1 MB async burst                                   1375           1555         166          0.0      275081.9       0.0X
+
+
+================================================================================================
+Large Block Transfer Throughput (IOMode=AUTO)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+16 MB Block Transfer:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Sequential sends                                    662            891         330          0.0     6616920.9       1.0X
+4-thread parallel sends                             438            497          88          0.0     4380966.0       1.5X
+
+
+================================================================================================
+File-Backed Shuffle Block Fetch (NIO vs AUTO, 100x16MB)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
+AMD EPYC 7763 64-Core Processor
+File-Backed Shuffle Fetch:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+NIO, sequential fetch                               380            385           5          0.0     3802737.0       1.0X
+NIO, parallel fetch (4 clients)                     212            214           3          0.0     2118790.3       1.8X
+AUTO, sequential fetch                             2075           2093          16          0.0    20751127.3       0.2X
+AUTO, parallel fetch (4 clients)                    676            814         129          0.0     6757222.9       0.6X
+
+

--- a/core/src/test/scala/org/apache/spark/network/NettyTransportBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/network/NettyTransportBenchmark.scala
@@ -1,0 +1,743 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network
+
+import java.io.{File, RandomAccessFile}
+import java.nio.ByteBuffer
+import java.util.concurrent.{CountDownLatch, Semaphore, TimeUnit}
+import java.util.concurrent.atomic.AtomicLong
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
+import org.apache.spark.network.buffer.{FileSegmentManagedBuffer, ManagedBuffer}
+import org.apache.spark.network.client._
+import org.apache.spark.network.server._
+import org.apache.spark.network.util._
+
+/**
+ * Benchmark for Spark's Netty transport layer.
+ *
+ * All suites measure performance through the actual Spark transport pipeline
+ * (TransportServer + TransportClientFactory + TransportContext).
+ *
+ * Suite overview:
+ *   1. RPC Latency            - driver-executor RPC overhead at different payload sizes
+ *   2. Concurrent Throughput  - multi-executor pressure on the transport layer
+ *   3. IOMode Comparison      - NIO vs native transport (AUTO selects EPOLL/KQUEUE)
+ *   4. Server Thread Scaling  - validates MAX_DEFAULT_NETTY_THREADS=8 cap
+ *   5. Multi-Connection       - numConnectionsPerPeer=1 vs 2 vs 4
+ *   6. Async Write Pressure   - fire-and-forget RPCs to saturate the write path
+ *   7. Large Block Transfer   - shuffle-like 16MB block transfers (in-memory payload)
+ *   8. File-Backed Shuffle    - ChunkFetch from disk, NIO vs AUTO (EPOLL sendfile bypass detection)
+ *
+ * {{{
+ *   To run this benchmark:
+ *   1. without sbt: bin/spark-submit --class <this class> <spark core test jar>
+ *   2. build/sbt "core/Test/runMain <this class>"
+ *   3. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "core/Test/runMain <this class>"
+ *      Results will be written to "benchmarks/NettyTransportBenchmark-results.txt".
+ * }}}
+ */
+object NettyTransportBenchmark extends BenchmarkBase {
+
+  private val SMALL_PAYLOAD = 1024              // 1 KB
+  private val MEDIUM_PAYLOAD = 64 * 1024        // 64 KB
+  private val LARGE_PAYLOAD = 1024 * 1024       // 1 MB
+  private val XLARGE_PAYLOAD = 16 * 1024 * 1024 // 16 MB
+
+  private val RPC_ITERS = 5000
+  private val THROUGHPUT_ITERS = 20000
+
+  // Fixed 8-byte ACK response, avoids heap allocation proportional to payload.
+  private val ACK_BYTES = Array[Byte](0, 0, 0, 0, 0, 0, 0, 1)
+
+  private def createEchoRpcHandler(): RpcHandler = new RpcHandler {
+    override def receive(
+        client: TransportClient,
+        message: ByteBuffer,
+        callback: RpcResponseCallback): Unit = {
+      callback.onSuccess(ByteBuffer.wrap(ACK_BYTES))
+    }
+    override def getStreamManager: StreamManager = new OneForOneStreamManager()
+  }
+
+  private def createConf(
+      ioMode: String,
+      serverThreads: Int = 4,
+      clientThreads: Int = 4,
+      extraConf: Map[String, String] = Map.empty): TransportConf = {
+    val configMap = (Map(
+      "spark.shuffle.io.mode" -> ioMode,
+      "spark.shuffle.io.serverThreads" -> serverThreads.toString,
+      "spark.shuffle.io.clientThreads" -> clientThreads.toString
+    ) ++ extraConf).asJava
+    new TransportConf("shuffle", new MapConfigProvider(configMap))
+  }
+
+  /**
+   * Sets up a TransportServer + TransportClientFactory, runs fn, then tears down.
+   */
+  private def withTransport(conf: TransportConf)(
+      fn: (TransportClientFactory, Int) => Unit): Unit = {
+    val context = new TransportContext(conf, createEchoRpcHandler())
+    val server = context.createServer()
+    val clientFactory = context.createClientFactory()
+    try {
+      fn(clientFactory, server.getPort)
+    } finally {
+      clientFactory.close()
+      server.close()
+      context.close()
+    }
+  }
+
+  private def withTransport(ioMode: String)(
+      fn: (TransportClientFactory, Int) => Unit): Unit = {
+    withTransport(createConf(ioMode))(fn)
+  }
+
+  /**
+   * Sends a synchronous RPC. Throws on failure to prevent silent result corruption.
+   */
+  private def sendRpcSync(
+      client: TransportClient,
+      payload: Array[Byte],
+      timeoutMs: Long = 30000): Unit = {
+    val latch = new CountDownLatch(1)
+    @volatile var error: Throwable = null
+    client.sendRpc(ByteBuffer.wrap(payload), new RpcResponseCallback {
+      override def onSuccess(response: ByteBuffer): Unit = latch.countDown()
+      override def onFailure(e: Throwable): Unit = {
+        error = e
+        latch.countDown()
+      }
+    })
+    if (!latch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
+      throw new RuntimeException("RPC timed out")
+    }
+    if (error != null) {
+      throw new RuntimeException("RPC failed", error)
+    }
+  }
+
+  /**
+   * Fires RPCs asynchronously and waits for all to complete.
+   * Returns (successCount, failCount).
+   */
+  private def sendRpcsAsync(
+      client: TransportClient,
+      payload: Array[Byte],
+      count: Int): (Long, Long) = {
+    val successCount = new AtomicLong(0)
+    val failCount = new AtomicLong(0)
+    val latch = new CountDownLatch(count)
+    var i = 0
+    while (i < count) {
+      client.sendRpc(ByteBuffer.wrap(payload), new RpcResponseCallback {
+        override def onSuccess(response: ByteBuffer): Unit = {
+          successCount.incrementAndGet()
+          latch.countDown()
+        }
+        override def onFailure(e: Throwable): Unit = {
+          failCount.incrementAndGet()
+          latch.countDown()
+        }
+      })
+      i += 1
+    }
+    latch.await(120, TimeUnit.SECONDS)
+    (successCount.get(), failCount.get())
+  }
+
+  /**
+   * Creates N independent (non-pooled) connections to the server.
+   * Uses createUnmanagedClient to bypass TransportClientFactory's connection pool,
+   * which defaults to numConnectionsPerPeer=1 and would return the same client.
+   */
+  private def createClients(
+      factory: TransportClientFactory,
+      port: Int,
+      count: Int): Seq[TransportClient] = {
+    (0 until count).map(_ => factory.createUnmanagedClient("localhost", port))
+  }
+
+  // ==================== Benchmark Suites ====================
+
+  /**
+   * Suite 1: RPC Round-Trip Latency at different payload sizes.
+   * Each size is a separate Benchmark so valuesPerIteration and Rate are accurate.
+   */
+  private def rpcLatencyBenchmark(): Unit = {
+    val ioMode = detectIOMode()
+
+    Seq(
+      ("1 KB", SMALL_PAYLOAD, RPC_ITERS),
+      ("64 KB", MEDIUM_PAYLOAD, RPC_ITERS),
+      ("1 MB", LARGE_PAYLOAD, RPC_ITERS / 5),
+      ("16 MB", XLARGE_PAYLOAD, RPC_ITERS / 50)
+    ).foreach { case (sizeLabel, payloadSize, iters) =>
+      runBenchmark(s"RPC Round-Trip Latency - $sizeLabel payload (IOMode=$ioMode)") {
+        withTransport(ioMode) { (clientFactory, port) =>
+          val client = clientFactory.createUnmanagedClient("localhost", port)
+          val payload = new Array[Byte](payloadSize)
+
+          val benchmark = new Benchmark(
+            s"RPC Latency ($sizeLabel)",
+            iters.toLong,
+            minNumIters = 3,
+            output = output)
+
+          benchmark.addTimerCase(s"$sizeLabel payload", numIters = 5) { timer =>
+            sendRpcSync(client, payload) // warm up
+
+            timer.startTiming()
+            var i = 0
+            while (i < iters) {
+              sendRpcSync(client, payload)
+              i += 1
+            }
+            timer.stopTiming()
+          }
+
+          benchmark.run()
+          client.close()
+        }
+      }
+    }
+  }
+
+  /**
+   * Suite 2: Concurrent RPC throughput with 1-16 independent connections.
+   * Uses createUnmanagedClient so each "client" is a distinct TCP connection.
+   */
+  private def concurrentThroughputBenchmark(): Unit = {
+    val ioMode = detectIOMode()
+
+    runBenchmark(s"Concurrent RPC Throughput (IOMode=$ioMode)") {
+      withTransport(ioMode) { (clientFactory, port) =>
+        val payload = new Array[Byte](SMALL_PAYLOAD)
+        val totalMessages = THROUGHPUT_ITERS.toLong
+
+        val benchmark = new Benchmark(
+          "Concurrent RPC Throughput",
+          totalMessages,
+          minNumIters = 3,
+          output = output)
+
+        Seq(1, 4, 8, 16).foreach { numThreads =>
+          benchmark.addTimerCase(s"$numThreads client(s)", numIters = 3) { timer =>
+            val messagesPerThread = (totalMessages / numThreads).toInt
+            val latch = new CountDownLatch(numThreads)
+            val clients = createClients(clientFactory, port, numThreads)
+
+            clients.foreach(c => sendRpcSync(c, payload))
+
+            timer.startTiming()
+
+            clients.foreach { client =>
+              val t = new Thread(() => {
+                try {
+                  var i = 0
+                  while (i < messagesPerThread) {
+                    sendRpcSync(client, payload)
+                    i += 1
+                  }
+                } finally {
+                  latch.countDown()
+                }
+              })
+              t.setDaemon(true)
+              t.start()
+            }
+
+            latch.await(120, TimeUnit.SECONDS)
+            timer.stopTiming()
+            clients.foreach(_.close())
+          }
+        }
+
+        benchmark.run()
+      }
+    }
+  }
+
+  /**
+   * Suite 3: IOMode Comparison (NIO vs AUTO).
+   * AUTO selects the best native transport via NettyUtils.createEventLoop
+   * (EPOLL on Linux, KQUEUE on macOS, NIO fallback), so comparing NIO vs AUTO
+   * shows the benefit of native transport without needing manual probing.
+   * Uses concurrent load (8 clients) to amplify transport-level differences.
+   */
+  private def ioModeComparisonBenchmark(): Unit = {
+    val payload = new Array[Byte](MEDIUM_PAYLOAD)
+    val totalMessages = THROUGHPUT_ITERS.toLong
+    val numClients = 8
+
+    runBenchmark("IOMode Comparison (Concurrent Throughput)") {
+      val benchmark = new Benchmark(
+        "IOMode Comparison",
+        totalMessages,
+        minNumIters = 3,
+        output = output)
+
+      Seq("NIO", "AUTO").foreach { mode =>
+        benchmark.addTimerCase(s"$mode ($numClients clients)", numIters = 3) { timer =>
+          withTransport(mode) { (clientFactory, port) =>
+            val messagesPerClient = (totalMessages / numClients).toInt
+            val latch = new CountDownLatch(numClients)
+            val clients = createClients(clientFactory, port, numClients)
+
+            clients.foreach(c => sendRpcSync(c, payload))
+
+            timer.startTiming()
+
+            clients.foreach { client =>
+              val t = new Thread(() => {
+                try {
+                  var i = 0
+                  while (i < messagesPerClient) {
+                    sendRpcSync(client, payload)
+                    i += 1
+                  }
+                } finally {
+                  latch.countDown()
+                }
+              })
+              t.setDaemon(true)
+              t.start()
+            }
+
+            latch.await(120, TimeUnit.SECONDS)
+            timer.stopTiming()
+            clients.foreach(_.close())
+          }
+        }
+      }
+
+      benchmark.run()
+    }
+  }
+
+  /**
+   * Suite 4: Server thread scaling (2-32 threads) under 16-client load.
+   * Shows whether raising MAX_DEFAULT_NETTY_THREADS=8 helps.
+   */
+  private def serverThreadScalingBenchmark(): Unit = {
+    val ioMode = detectIOMode()
+    val numClients = 16
+    val totalMessages = THROUGHPUT_ITERS.toLong
+    val payload = new Array[Byte](SMALL_PAYLOAD)
+
+    runBenchmark(s"Server Thread Scaling (IOMode=$ioMode, $numClients clients)") {
+      val benchmark = new Benchmark(
+        "Server Thread Scaling",
+        totalMessages,
+        minNumIters = 3,
+        output = output)
+
+      Seq(2, 4, 8, 16, 32).foreach { serverThreads =>
+        benchmark.addTimerCase(s"$serverThreads server threads", numIters = 3) { timer =>
+          val conf = createConf(ioMode, serverThreads = serverThreads)
+          withTransport(conf) { (clientFactory, port) =>
+            val messagesPerClient = (totalMessages / numClients).toInt
+            val latch = new CountDownLatch(numClients)
+            val clients = createClients(clientFactory, port, numClients)
+
+            clients.foreach(c => sendRpcSync(c, payload))
+
+            timer.startTiming()
+
+            clients.foreach { client =>
+              val t = new Thread(() => {
+                try {
+                  var i = 0
+                  while (i < messagesPerClient) {
+                    sendRpcSync(client, payload)
+                    i += 1
+                  }
+                } finally {
+                  latch.countDown()
+                }
+              })
+              t.setDaemon(true)
+              t.start()
+            }
+
+            latch.await(120, TimeUnit.SECONDS)
+            timer.stopTiming()
+            clients.foreach(_.close())
+          }
+        }
+      }
+
+      benchmark.run()
+    }
+  }
+
+  /**
+   * Suite 5: Multi-connection per peer (1 vs 2 vs 4 connections, 4 sender threads).
+   * Uses createUnmanagedClient to ensure genuinely distinct TCP connections.
+   */
+  private def multiConnectionBenchmark(): Unit = {
+    val ioMode = detectIOMode()
+    val payload = new Array[Byte](LARGE_PAYLOAD) // 1MB
+    val numSenderThreads = 4
+    val totalMessages = THROUGHPUT_ITERS / 4
+
+    runBenchmark(s"Multi-Connection Per Peer (IOMode=$ioMode, 1MB payload)") {
+      withTransport(ioMode) { (clientFactory, port) =>
+        val benchmark = new Benchmark(
+          "Multi-Connection Throughput",
+          totalMessages.toLong,
+          minNumIters = 3,
+          output = output)
+
+        Seq(1, 2, 4).foreach { numConns =>
+          benchmark.addTimerCase(
+              s"$numConns conn(s), $numSenderThreads threads", numIters = 3) { timer =>
+            val messagesPerThread = totalMessages / numSenderThreads
+            val clients = createClients(clientFactory, port, numConns)
+            clients.foreach(c => sendRpcSync(c, payload))
+
+            val latch = new CountDownLatch(numSenderThreads)
+
+            timer.startTiming()
+            (0 until numSenderThreads).foreach { idx =>
+              val client = clients(idx % numConns)
+              val t = new Thread(() => {
+                try {
+                  var i = 0
+                  while (i < messagesPerThread) {
+                    sendRpcSync(client, payload)
+                    i += 1
+                  }
+                } finally {
+                  latch.countDown()
+                }
+              })
+              t.setDaemon(true)
+              t.start()
+            }
+            latch.await(120, TimeUnit.SECONDS)
+            timer.stopTiming()
+            clients.foreach(_.close())
+          }
+        }
+
+        benchmark.run()
+      }
+    }
+  }
+
+  /**
+   * Suite 6: Async write pressure - fire-and-forget RPCs to saturate the write path.
+   * Reports failure count to detect backpressure effects.
+   */
+  private def asyncWritePressureBenchmark(): Unit = {
+    val ioMode = detectIOMode()
+    val asyncBatchSize = 5000
+
+    runBenchmark(s"Async Write Pressure (IOMode=$ioMode)") {
+      withTransport(ioMode) { (clientFactory, port) =>
+        val benchmark = new Benchmark(
+          "Async Write Throughput",
+          asyncBatchSize.toLong,
+          minNumIters = 3,
+          output = output)
+
+        Seq(
+          ("1 KB async burst", SMALL_PAYLOAD),
+          ("64 KB async burst", MEDIUM_PAYLOAD),
+          ("1 MB async burst", LARGE_PAYLOAD)
+        ).foreach { case (name, payloadSize) =>
+          val payload = new Array[Byte](payloadSize)
+
+          benchmark.addTimerCase(name, numIters = 3) { timer =>
+            val client = clientFactory.createUnmanagedClient("localhost", port)
+            sendRpcSync(client, payload)
+
+            timer.startTiming()
+            val (success, fail) = sendRpcsAsync(client, payload, asyncBatchSize)
+            timer.stopTiming()
+
+            if (fail > 0) {
+              // scalastyle:off println
+              println(s"    $name: $success ok, $fail failed (backpressure)")
+              // scalastyle:on println
+            }
+            client.close()
+          }
+        }
+
+        benchmark.run()
+      }
+    }
+  }
+
+  /**
+   * Suite 7: Large block transfer (16MB), sequential and 4-thread parallel.
+   */
+  private def largeBlockTransferBenchmark(): Unit = {
+    val ioMode = detectIOMode()
+    val numBlocks = 100
+
+    runBenchmark(s"Large Block Transfer Throughput (IOMode=$ioMode)") {
+      withTransport(ioMode) { (clientFactory, port) =>
+        val payload = new Array[Byte](XLARGE_PAYLOAD)
+
+        val benchmark = new Benchmark(
+          "16 MB Block Transfer",
+          numBlocks.toLong,
+          minNumIters = 3,
+          output = output)
+
+        benchmark.addTimerCase("Sequential sends", numIters = 3) { timer =>
+          val client = clientFactory.createUnmanagedClient("localhost", port)
+          sendRpcSync(client, payload)
+
+          timer.startTiming()
+          var i = 0
+          while (i < numBlocks) {
+            sendRpcSync(client, payload)
+            i += 1
+          }
+          timer.stopTiming()
+          client.close()
+        }
+
+        benchmark.addTimerCase("4-thread parallel sends", numIters = 3) { timer =>
+          val numThreads = 4
+          val blocksPerThread = numBlocks / numThreads
+          val clients = createClients(clientFactory, port, numThreads)
+          clients.foreach(c => sendRpcSync(c, payload))
+
+          timer.startTiming()
+          val latch = new CountDownLatch(numThreads)
+          clients.foreach { c =>
+            val t = new Thread(() => {
+              try {
+                var i = 0
+                while (i < blocksPerThread) {
+                  sendRpcSync(c, payload)
+                  i += 1
+                }
+              } finally {
+                latch.countDown()
+              }
+            })
+            t.setDaemon(true)
+            t.start()
+          }
+          latch.await(120, TimeUnit.SECONDS)
+          timer.stopTiming()
+          clients.foreach(_.close())
+        }
+
+        benchmark.run()
+      }
+    }
+  }
+
+  /**
+   * Suite 8: File-Backed Shuffle Block Fetch via ChunkFetch.
+   *
+   * Writes temp files to disk, serves them as FileSegmentManagedBuffer via StreamManager,
+   * and fetches them using client.fetchChunk(). This exercises the DefaultFileRegion
+   * zero-copy sendfile/splice path.
+   *
+   * Compares NIO vs AUTO to verify that native transports (EPOLL/KQUEUE) use sendfile()
+   * for file-backed transfers. AUTO should be equal to or faster than NIO.
+   */
+  private def fileBackedShuffleBenchmark(): Unit = {
+    val numFiles = 100
+    val fileSize = 16 * 1024 * 1024 // 16 MB per file
+
+    // Create temp shuffle files
+    val tmpDir = new File(System.getProperty("java.io.tmpdir"), "spark-bench-shuffle")
+    tmpDir.mkdirs()
+    val files = (0 until numFiles).map { idx =>
+      val f = new File(tmpDir, s"shuffle-$idx.data")
+      f.deleteOnExit()
+      val raf = new RandomAccessFile(f, "rw")
+      try {
+        val chunk = new Array[Byte](1024 * 1024)
+        var written = 0
+        while (written < fileSize) {
+          val toWrite = math.min(chunk.length, fileSize - written)
+          raf.write(chunk, 0, toWrite)
+          written += toWrite
+        }
+      } finally {
+        raf.close()
+      }
+      f
+    }
+
+    try {
+      runBenchmark(s"File-Backed Shuffle Block Fetch (NIO vs AUTO, ${numFiles}x16MB)") {
+        val benchmark = new Benchmark(
+          "File-Backed Shuffle Fetch",
+          numFiles.toLong,
+          minNumIters = 3,
+          output = output)
+
+        Seq("NIO", "AUTO").foreach { mode =>
+          benchmark.addTimerCase(s"$mode, sequential fetch", numIters = 3) { timer =>
+            val conf = createConf(mode)
+            val streamManager = createFileStreamManager(conf, files)
+            val rpcHandler = createStreamRpcHandler(streamManager)
+            val context = new TransportContext(conf, rpcHandler)
+            val server = context.createServer()
+            val clientFactory = context.createClientFactory()
+            try {
+              val client = clientFactory.createUnmanagedClient("localhost", server.getPort)
+              fetchChunksSync(client, streamId = 0, chunkIndices = Seq(0))
+
+              timer.startTiming()
+              fetchChunksSync(client, streamId = 0, chunkIndices = 0 until numFiles)
+              timer.stopTiming()
+              client.close()
+            } finally {
+              clientFactory.close()
+              server.close()
+              context.close()
+            }
+          }
+
+          benchmark.addTimerCase(s"$mode, parallel fetch (4 clients)", numIters = 3) { timer =>
+            val conf = createConf(mode)
+            val streamManager = createFileStreamManager(conf, files)
+            val rpcHandler = createStreamRpcHandler(streamManager)
+            val context = new TransportContext(conf, rpcHandler)
+            val server = context.createServer()
+            val clientFactory = context.createClientFactory()
+            try {
+              val port = server.getPort
+              val numThreads = 4
+              val chunksPerThread = numFiles / numThreads
+              val clients = createClients(clientFactory, port, numThreads)
+              clients.foreach(c => fetchChunksSync(c, streamId = 0, chunkIndices = Seq(0)))
+
+              timer.startTiming()
+              val latch = new CountDownLatch(numThreads)
+              (0 until numThreads).foreach { threadIdx =>
+                val client = clients(threadIdx)
+                val startChunk = threadIdx * chunksPerThread
+                val endChunk = startChunk + chunksPerThread
+                val t = new Thread(() => {
+                  try {
+                    fetchChunksSync(
+                      client, streamId = 0, chunkIndices = startChunk until endChunk)
+                  } finally {
+                    latch.countDown()
+                  }
+                })
+                t.setDaemon(true)
+                t.start()
+              }
+              latch.await(120, TimeUnit.SECONDS)
+              timer.stopTiming()
+              clients.foreach(_.close())
+            } finally {
+              clientFactory.close()
+              server.close()
+              context.close()
+            }
+          }
+        }
+
+        benchmark.run()
+      }
+    } finally {
+      files.foreach(_.delete())
+      tmpDir.delete()
+    }
+  }
+
+  private def createFileStreamManager(
+      conf: TransportConf, files: Seq[File]): StreamManager = {
+    new StreamManager {
+      override def getChunk(streamId: Long, chunkIndex: Int): ManagedBuffer = {
+        new FileSegmentManagedBuffer(conf, files(chunkIndex), 0, files(chunkIndex).length())
+      }
+    }
+  }
+
+  private def createStreamRpcHandler(streamManager: StreamManager): RpcHandler = {
+    new RpcHandler {
+      override def receive(
+          client: TransportClient,
+          message: ByteBuffer,
+          callback: RpcResponseCallback): Unit = {
+        throw new UnsupportedOperationException()
+      }
+      override def getStreamManager: StreamManager = streamManager
+    }
+  }
+
+  // ==================== Helpers ====================
+
+  /** AUTO mode safely falls back to NIO if native .so is unavailable. */
+  private def detectIOMode(): String = "AUTO"
+
+  /**
+   * Fetches chunks synchronously via ChunkFetchRequest and waits for all to complete.
+   * The buffer is NOT retained or released here -- TransportResponseHandler releases
+   * it after the callback returns.
+   */
+  private def fetchChunksSync(
+      client: TransportClient,
+      streamId: Long,
+      chunkIndices: Seq[Int]): Unit = {
+    val sem = new Semaphore(0)
+    @volatile var error: Throwable = null
+    val callback = new ChunkReceivedCallback {
+      override def onSuccess(chunkIndex: Int, buffer: ManagedBuffer): Unit = {
+        sem.release()
+      }
+      override def onFailure(chunkIndex: Int, e: Throwable): Unit = {
+        error = e
+        sem.release()
+      }
+    }
+    chunkIndices.foreach { idx =>
+      client.fetchChunk(streamId, idx, callback)
+    }
+    if (!sem.tryAcquire(chunkIndices.size, 120, TimeUnit.SECONDS)) {
+      throw new RuntimeException("ChunkFetch timed out")
+    }
+    if (error != null) {
+      throw new RuntimeException("ChunkFetch failed", error)
+    }
+  }
+
+  // ==================== Main ====================
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    rpcLatencyBenchmark()
+    concurrentThroughputBenchmark()
+    ioModeComparisonBenchmark()
+    serverThreadScalingBenchmark()
+    multiConnectionBenchmark()
+    asyncWritePressureBenchmark()
+    largeBlockTransferBenchmark()
+    fileBackedShuffleBenchmark()
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to add `NettyTransportBenchmark` for Netty transport layer performance evaluation.

### Why are the changes needed?
For Spark, Netty is a crucial third-party component. Adding a micro-benchmark test facilitates: 

1. verifying performance during subsequent Netty upgrades; 
2. validating performance after changes to relevant code in Spark.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Pass Github Actions

### Was this patch authored or co-authored using generative AI tooling?
Generated-by:  Claude Code 4.6
