### PR TITLE
[SPARK-56260][INFRA] Pin third-party GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -423,7 +423,7 @@ jobs:
           **/target/surefire-reports/*.xml
     - name: Test Summary
       if: always()
-      uses: test-summary/action@v2
+      uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2
       with:
         paths: |
           **/target/test-reports/*.xml
@@ -679,7 +679,7 @@ jobs:
         fi
     - name: Upload coverage to Codecov
       if: fromJSON(inputs.envs).PYSPARK_CODECOV == 'true'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
       env:
         CODECOV_TOKEN: ${{ secrets.codecov_token }}
       with:
@@ -690,7 +690,7 @@ jobs:
     - name: Upload test results to Codecov
       env: ${{ fromJSON(inputs.envs) }}
       if: fromJSON(inputs.envs).PYSPARK_CODECOV == 'true'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
       with:
         report_type: 'test_results'
         files: '**/target/test-reports/*.xml'
@@ -708,7 +708,7 @@ jobs:
           **/target/surefire-reports/*.xml
     - name: Test Summary
       if: always()
-      uses: test-summary/action@v2
+      uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2
       with:
         paths: |
           **/target/test-reports/*.xml
@@ -799,7 +799,7 @@ jobs:
           **/target/surefire-reports/*.xml
     - name: Test Summary
       if: always()
-      uses: test-summary/action@v2
+      uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2
       with:
         paths: |
           **/target/test-reports/*.xml
@@ -824,15 +824,15 @@ jobs:
         git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
         git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
     - name: Install Buf
-      uses: bufbuild/buf-setup-action@v1
+      uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Protocol Buffers Linter
-      uses: bufbuild/buf-lint-action@v1
+      uses: bufbuild/buf-lint-action@06f9dd823d873146471cfaaf108a993fe00e5325 # v1
       with:
         input: core/src/main/protobuf
     - name: Breaking change detection against branch-4.0
-      uses: bufbuild/buf-breaking-action@v1
+      uses: bufbuild/buf-breaking-action@c57b3d842a5c3f3b454756ef65305a50a587c5ba # v1
       with:
         input: sql/connect/common/src/main
         against: 'https://github.com/apache/spark.git#branch=branch-4.0,subdir=sql/connect/common/src/main'
@@ -1324,7 +1324,7 @@ jobs:
           **/target/surefire-reports/*.xml
     - name: Test Summary
       if: always()
-      uses: test-summary/action@v2
+      uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2
       with:
         paths: |
           **/target/test-reports/*.xml
@@ -1400,7 +1400,7 @@ jobs:
           **/target/surefire-reports/*.xml
     - name: Test Summary
       if: always()
-      uses: test-summary/action@v2
+      uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2
       with:
         paths: |
           **/target/test-reports/*.xml
@@ -1464,7 +1464,7 @@ jobs:
           sudo apt update
           sudo apt-get install r-base
       - name: Start Minikube
-        uses: medyagh/setup-minikube@v0.0.21
+        uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
         with:
           kubernetes-version: "1.35.0"
           # GitHub Actions limit 4C/16G, limit to 2C/6G for better resource statistic

--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -52,7 +52,7 @@ jobs:
         distribution: zulu
         java-version: 17
     - name: Install R 4.4.3
-      uses: r-lib/actions/setup-r@v2
+      uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
       with:
         r-version: 4.4.3
     - name: Install R dependencies

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -66,7 +66,7 @@ jobs:
             'pandas-stubs==1.2.0.53' 'grpcio==1.76.0' 'grpcio-status==1.76.0' 'protobuf==6.33.5' 'grpc-stubs==1.24.11' 'googleapis-common-protos-stubs==2.2.0' \
             'sphinxcontrib-applehelp==1.0.4' 'sphinxcontrib-devhelp==1.0.2' 'sphinxcontrib-htmlhelp==2.0.1' 'sphinxcontrib-qthelp==1.0.3' 'sphinxcontrib-serializinghtml==1.1.5'
       - name: Install Ruby for documentation generation
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@4dc28cf14d77b0afa6832d9765ac422dbf0dfedd # v1
         with:
           ruby-version: '3.3'
           bundler-cache: true


### PR DESCRIPTION
### What changes were proposed in this pull request?

Pin all third-party GitHub Actions in CI workflows to specific commit SHA versions instead of mutable version tags. A version comment is added alongside each SHA for maintainability.

Actions pinned:

| Action | Before | Pinned SHA | Apache Allowlist |
|---|---|---|---|
| `bufbuild/buf-setup-action` | `@v1` | `a47c93e0...` | `*: keep: true` |
| `bufbuild/buf-lint-action` | `@v1` | `06f9dd82...` | `*: keep: true` |
| `bufbuild/buf-breaking-action` | `@v1` | `c57b3d84...` | `*: keep: true` |
| `codecov/codecov-action` | `@v5` | `75cd1169...` | `*: keep: true` |
| `medyagh/setup-minikube` | `@v0.0.21` | `e9e035a8...` | `*: keep: true` |
| `r-lib/actions/setup-r` | `@v2` | `6f6e5bc6...` | `*: keep: true` |
| `ruby/setup-ruby` | `@v1` | `4dc28cf1...` | `*: keep: true` |
| `test-summary/action` | `@v2` | `31493c76...` | `*: keep: true` |

All actions are verified to be on the [Apache infrastructure-actions allowlist](https://github.com/apache/infrastructure-actions/blob/main/actions.yml).

### Why are the changes needed?

Pinning actions to commit SHAs is a [security best practice recommended by GitHub](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) to prevent supply chain attacks via compromised action tags.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

No functional changes - only CI workflow action references are updated.

### Was this patch authored or co-authored using generative AI tooling?

No