### PR TITLE
[SPARK-56270][PYTHON] Fix type hints and import issue for find_spark_home

### DIFF
--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -37,9 +37,6 @@ disable_error_code = misc
 [mypy-pyspark.daemon]
 disallow_untyped_defs = False
 
-[mypy-pyspark.find_spark_home]
-disallow_untyped_defs = False
-
 [mypy-pyspark._globals]
 disallow_untyped_defs = False
 

--- a/python/pyspark/find_spark_home.py
+++ b/python/pyspark/find_spark_home.py
@@ -24,13 +24,13 @@ import os
 import sys
 
 
-def _find_spark_home():
+def _find_spark_home() -> str:
     """Find the SPARK_HOME."""
     # If the environment has SPARK_HOME set trust it.
     if "SPARK_HOME" in os.environ:
         return os.environ["SPARK_HOME"]
 
-    def is_spark_home(path):
+    def is_spark_home(path: str) -> bool:
         """Takes a path and returns true if the provided path could be a reasonable SPARK_HOME"""
         return os.path.isfile(os.path.join(path, "bin/spark-submit")) and (
             os.path.isdir(os.path.join(path, "jars"))
@@ -52,19 +52,16 @@ def _find_spark_home():
         ]
 
     # Add the path of the PySpark module if it exists
-    import_error_raised = False
     from importlib.util import find_spec
 
-    try:
-        module_home = os.path.dirname(find_spec("pyspark").origin)
+    spec = find_spec("pyspark")
+    if spec is not None and spec.origin is not None:
+        module_home = os.path.dirname(spec.origin)
         paths.append(os.path.join(module_home, spark_dist_dir))
         paths.append(module_home)
         # If we are installed in edit mode also look two dirs up
         # Downloading different versions are not supported in edit mode.
         paths.append(os.path.join(module_home, "../../"))
-    except ImportError:
-        # Not pip installed no worries
-        import_error_raised = True
 
     # Normalize the paths
     paths = [os.path.abspath(p) for p in paths]
@@ -73,21 +70,20 @@ def _find_spark_home():
         return next(path for path in paths if is_spark_home(path))
     except StopIteration:
         print("Could not find valid SPARK_HOME while searching {0}".format(paths), file=sys.stderr)
-        if import_error_raised:
-            print(
-                "\nDid you install PySpark via a package manager such as pip or Conda? If so,\n"
-                "PySpark was not found in your Python environment. It is possible your\n"
-                "Python environment does not properly bind with your package manager.\n"
-                "\nPlease check your default 'python' and if you set PYSPARK_PYTHON and/or\n"
-                "PYSPARK_DRIVER_PYTHON environment variables, and see if you can import\n"
-                "PySpark, for example, 'python -c 'import pyspark'.\n"
-                "\nIf you cannot import, you can install by using the Python executable directly,\n"
-                "for example, 'python -m pip install pyspark [--user]'. Otherwise, you can also\n"
-                "explicitly set the Python executable, that has PySpark installed, to\n"
-                "PYSPARK_PYTHON or PYSPARK_DRIVER_PYTHON environment variables, for example,\n"
-                "'PYSPARK_PYTHON=python3 pyspark'.\n",
-                file=sys.stderr,
-            )
+        print(
+            "\nDid you install PySpark via a package manager such as pip or Conda? If so,\n"
+            "PySpark was not found in your Python environment. It is possible your\n"
+            "Python environment does not properly bind with your package manager.\n"
+            "\nPlease check your default 'python' and if you set PYSPARK_PYTHON and/or\n"
+            "PYSPARK_DRIVER_PYTHON environment variables, and see if you can import\n"
+            "PySpark, for example, 'python -c 'import pyspark'.\n"
+            "\nIf you cannot import, you can install by using the Python executable directly,\n"
+            "for example, 'python -m pip install pyspark [--user]'. Otherwise, you can also\n"
+            "explicitly set the Python executable, that has PySpark installed, to\n"
+            "PYSPARK_PYTHON or PYSPARK_DRIVER_PYTHON environment variables, for example,\n"
+            "'PYSPARK_PYTHON=python3 pyspark'.\n",
+            file=sys.stderr,
+        )
         sys.exit(-1)
 
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

* Remove the type hint ignore for `find_spark_home` module and fill in the type hints
* Remove the `ImportError` check and `import_error_raised` related logic

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

There's no reason we can't type hint this module so I just did it.

For the import part, it's impossible to trigger that path because `find_spec("pyspark")` will never trigger `ImportError`. It either returns a spec or `None`. I searched the history and the first time it was introduced was in https://github.com/apache/spark/pull/15659 . There were 2 branches and the one for python2 actually will trigger the `ImportError`. The python3 branch won't work but it might just be ignored.

In https://github.com/apache/spark/pull/28152 we added `import_error_raised` check and extra messages, but we only tested in python2, which would trigger that message. I confirmed that the message won't be printed if we can't find `pyspark`.

Now we print the message if we can't find `SPARK_HOME`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Locally confirmed the message will be printed if `pyspark` can't be imported. Lint also passed locally.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.