### PR TITLE
[SPARK-55729][SPARK-55630][SS][FOLLOWUP] Fix failing test due to dependencies of two changes

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceChangeDataReadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceChangeDataReadSuite.scala
@@ -73,7 +73,7 @@ class RocksDBWithChangelogCheckpointStateDataSourceChangeDataReaderSuite extends
         //   partition_id)
         // In V4 inner join, the matched flag on the other side is not updated as an
         // optimization (since the matched flag is only needed for outer/semi joins).
-        // Therefore, only "append" records appear — no "update" records.
+        // Therefore, only "append" records appear -- no "update" records.
         checkAnswer(keyWithTsToValuesDf, Seq(
           Row(0L, "append", Row(2, evtTime(2)), Row(2, ts(2), false), 4),
           Row(0L, "append", Row(4, evtTime(4)), Row(4, ts(4), false), 2),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceChangeDataReadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceChangeDataReadSuite.scala
@@ -71,19 +71,15 @@ class RocksDBWithChangelogCheckpointStateDataSourceChangeDataReaderSuite extends
         //   key: (field0: Int, __event_time: Long),
         //   value: (leftId: Int, leftTime: Timestamp, matched: Boolean),
         //   partition_id)
-        // Each entry first appears as "append" with matched=false, then an "update"
-        // with matched=true once the join finds a match on the right side.
+        // In V4 inner join, the matched flag on the other side is not updated as an
+        // optimization (since the matched flag is only needed for outer/semi joins).
+        // Therefore, only "append" records appear — no "update" records.
         checkAnswer(keyWithTsToValuesDf, Seq(
           Row(0L, "append", Row(2, evtTime(2)), Row(2, ts(2), false), 4),
-          Row(0L, "update", Row(2, evtTime(2)), Row(2, ts(2), true), 4),
           Row(0L, "append", Row(4, evtTime(4)), Row(4, ts(4), false), 2),
-          Row(0L, "update", Row(4, evtTime(4)), Row(4, ts(4), true), 2),
           Row(1L, "append", Row(6, evtTime(6)), Row(6, ts(6), false), 4),
-          Row(1L, "update", Row(6, evtTime(6)), Row(6, ts(6), true), 4),
           Row(1L, "append", Row(8, evtTime(8)), Row(8, ts(8), false), 3),
-          Row(1L, "update", Row(8, evtTime(8)), Row(8, ts(8), true), 3),
-          Row(1L, "append", Row(10, evtTime(10)), Row(10, ts(10), false), 2),
-          Row(1L, "update", Row(10, evtTime(10)), Row(10, ts(10), true), 2)
+          Row(1L, "append", Row(10, evtTime(10)), Row(10, ts(10), false), 2)
         ))
 
         val tsWithKeyDf = spark.read.format("statestore")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix the failing test introduced in SPARK-55729 due to the fact SPARK-55630 changes the behavior but misses to reflect the change to the test.

### Why are the changes needed?

The new commit broke the test introduced by old commit.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI will follow.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude 4.6 Opus