### PR TITLE
[SPARK-54986][PYSPARK][DOCS] Document return type (DoubleType) for aggregate functions

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -4248,7 +4248,7 @@ def stddev(col: "ColumnOrName") -> Column:
     Returns
     -------
     :class:`~pyspark.sql.Column`
-        standard deviation of given column.
+        A new column of DoubleType representing the standard deviation of the given column.
 
     Examples
     --------
@@ -4321,7 +4321,7 @@ def stddev_samp(col: "ColumnOrName") -> Column:
     Returns
     -------
     :class:`~pyspark.sql.Column`
-        standard deviation of given column.
+        A new column of DoubleType representing the standard deviation of the given column.
 
     See Also
     --------
@@ -4362,7 +4362,7 @@ def stddev_pop(col: "ColumnOrName") -> Column:
     Returns
     -------
     :class:`~pyspark.sql.Column`
-        standard deviation of given column.
+        A new column of DoubleType representing the standard deviation of the given column.
 
     See Also
     --------
@@ -4402,7 +4402,7 @@ def variance(col: "ColumnOrName") -> Column:
     Returns
     -------
     :class:`~pyspark.sql.Column`
-        variance of given column.
+        A new column of DoubleType representing the variance of the given column.
 
     See Also
     --------
@@ -4445,7 +4445,7 @@ def var_samp(col: "ColumnOrName") -> Column:
     Returns
     -------
     :class:`~pyspark.sql.Column`
-        variance of given column.
+        A new column of DoubleType representing the variance of the given column.
 
     See Also
     --------
@@ -4485,7 +4485,7 @@ def var_pop(col: "ColumnOrName") -> Column:
     Returns
     -------
     :class:`~pyspark.sql.Column`
-        variance of given column.
+        A new column of DoubleType representing the variance of the given column.
 
     See Also
     --------


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the PySpark API documentation to explicitly mention the return type of aggregate functions such as `stddev`, `stddev_samp`, `stddev_pop`, `variance`, `var_samp`, and `var_pop`.

From inspecting the underlying implementation in `CentralMomentAgg.scala`, these functions return `DoubleType` regardless of input column type. However, this was not clearly documented in the PySpark function docstrings.

This PR adds explicit mention of `DoubleType` in the return section of the relevant functions in `builtin.py`.

---

### Why are the changes needed?

Currently, the return type of these aggregate functions is not clearly documented, which may confuse users.

Adding this improves documentation clarity and aligns PySpark docs with actual implementation.

---

### Does this PR introduce any user-facing change?

No. This is a documentation-only change.

---

### How was this patch tested?

Documentation change only. Verified consistency with implementation in `CentralMomentAgg.scala`.