### PR TITLE
[SPARK-56032][SQL][TESTS][FOLLOWUP] Use `DayTimeIntervalType` in FilterExec CSE codegen test to fix non-ansi mode failure

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution
 
+import java.time.Duration
+
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.MapPartitionsWithEvaluatorRDD
 import org.apache.spark.sql.{Dataset, QueryTest, Row, SaveMode}
@@ -30,7 +32,7 @@ import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNes
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{DayTimeIntervalType, IntegerType, StringType, StructField, StructType}
 
 // Disable AQE because the WholeStageCodegenExec is added when running QueryStageExec
 class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
@@ -948,12 +950,20 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
 
   test("SPARK-56032: subexpression elimination in FilterExec codegen") {
     val schema = StructType(Seq(
-      StructField("a", IntegerType, nullable = true),
-      StructField("b", IntegerType, nullable = true)))
+      StructField("a", DayTimeIntervalType(), nullable = true),
+      StructField("b", DayTimeIntervalType(), nullable = true)))
     val data = spark.sparkContext.parallelize(Seq(
-      Row(1, 5), Row(null, 3), Row(4, null), Row(5, 6), Row(7, 8), Row(2, 3)))
+      Row(Duration.ofDays(1), Duration.ofDays(5)),
+      Row(null, Duration.ofDays(3)),
+      Row(Duration.ofDays(4), null),
+      Row(Duration.ofDays(5), Duration.ofDays(6)),
+      Row(Duration.ofDays(7), Duration.ofDays(8)),
+      Row(Duration.ofDays(2), Duration.ofDays(3))))
 
-    val expected = Seq(Row(1, 5), Row(5, 6), Row(2, 3))
+    val expected = Seq(
+      Row(Duration.ofDays(1), Duration.ofDays(5)),
+      Row(Duration.ofDays(5), Duration.ofDays(6)),
+      Row(Duration.ofDays(2), Duration.ofDays(3)))
 
     Seq("1", Int.MaxValue.toString).foreach { splitThreshold =>
       def testFilterCSE(cseEnabled: Boolean): String = {
@@ -964,7 +974,8 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
           SQLConf.CODEGEN_METHOD_SPLIT_THRESHOLD.key -> splitThreshold) {
           val df = spark.createDataFrame(data, schema)
           val filtered = df.where(
-            "a IS NOT NULL AND (a + b) > 3 AND (a + b) < 15 AND (a + b) != 10")
+            "a IS NOT NULL AND (a + b) > INTERVAL '3' DAY " +
+              "AND (a + b) < INTERVAL '15' DAY AND (a + b) != INTERVAL '10' DAY")
           val plan = filtered.queryExecution.executedPlan
           assert(plan.exists(_.isInstanceOf[WholeStageCodegenExec]),
             "Filter should be in whole-stage codegen")


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR changes the  test case "SPARK-56032: subexpression elimination in FilterExec codegen" to use `DayTimeIntervalType` instead of `IntegerType`, making the test pass in both ansi and non-ansi modes.


### Why are the changes needed?
To fix non-ansi daily test failed:
- https://github.com/apache/spark/actions/runs/23520761957/job/68463530273

```
- SPARK-56032: subexpression elimination in FilterExec codegen *** FAILED *** (139 milliseconds)
[info]   0 was not less than 0 CSE should reduce repeated evaluation (splitThreshold=1): addExact appears 0 times with CSE vs 0 times without (WholeStageCodegenSuite.scala:982)
[info]   org.scalatest.exceptions.TestFailedException:
[info]   at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
[info]   at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:471)
[info]   at org.scalatest.Assertions$.newAssertionFailedException(Assertions.scala:1231)
[info]   at org.scalatest.Assertions$AssertionsHelper.macroAssert(Assertions.scala:1295)
[info]   at org.apache.spark.sql.execution.WholeStageCodegenSuite.$anonfun$new$163(WholeStageCodegenSuite.scala:982)
[info]   at scala.collection.immutable.List.foreach(List.scala:323)
[info]   at org.apache.spark.sql.execution.WholeStageCodegenSuite.$anonfun$new$162(WholeStageCodegenSuite.scala:958)
[info]   at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
[info]   at org.apache.spark.sql.catalyst.SQLConfHelper.withSQLConf(SQLConfHelper.scala:54)
[info]   at org.apache.spark.sql.catalyst.SQLConfHelper.withSQLConf$(SQLConfHelper.scala:38)
[info]   at org.apache.spark.sql.execution.WholeStageCodegenSuite.org$apache$spark$sql$test$SQLTestUtilsBase$$super$withSQLConf(WholeStageCodegenSuite.scala:36)
[info]   at org.apache.spark.sql.test.SQLTestUtilsBase.withSQLConf(SQLTestUtils.scala:255)
[info]   at org.apache.spark.sql.test.SQLTestUtilsBase.withSQLConf$(SQLTestUtils.scala:253)
[info]   at org.apache.spark.sql.execution.WholeStageCodegenSuite.withSQLConf(WholeStageCodegenSuite.scala:36)
[info]   at org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecutionSuite.$anonfun$test$3(AdaptiveTestUtils.scala:65)
[info]   at org.scalatest.enablers.Timed$$anon$1.timeoutAfter(Timed.scala:127)
[info]   at org.scalatest.concurrent.TimeLimits$.failAfterImpl(TimeLimits.scala:282)
[info]   at org.scalatest.concurrent.TimeLimits.failAfter(TimeLimits.scala:231)
[info]   at org.scalatest.concurrent.TimeLimits.failAfter$(TimeLimits.scala:230)
[info]   at org.apache.spark.SparkFunSuite.failAfter(SparkFunSuite.scala:30)
[info]   at org.apache.spark.SparkFunSuite.$anonfun$test$2(SparkFunSuite.scala:41)
[info]   at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
[info]   at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:22)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:20)
[info]   at org.scalatest.funsuite.AnyFunSuiteLike$$anon$1.apply(AnyFunSuiteLike.scala:226)
[info]   at org.apache.spark.SparkTestSuite.withFixture(SparkTestSuite.scala:175)
[info]   at org.apache.spark.SparkTestSuite.withFixture$(SparkTestSuite.scala:169)
[info]   at org.apache.spark.SparkFunSuite.withFixture(SparkFunSuite.scala:30)
[info]   at org.scalatest.funsuite.AnyFunSuiteLike.invokeWithFixture$1(AnyFunSuiteLike.scala:224)
```

The test verifies CSE  in `FilterExec` codegen by counting occurrences of `addExact` in the generated code. However,
for `IntegerType`, `addExact` is only generated when `failOnError=true`(ansi mode). In non-ansi mode, integer addition produces inline `eval1 + eval2` with no `addExact` call, causing both CSE and non-CSE counts to be 0 and the assertion `0 < 0` to fail.

`DayTimeIntervalType` is an `AnsiIntervalType` whose codegen unconditionally routes through `IntervalMathUtils.addExact()` regardless of ANSI mode (see `BinaryArithmetic.doGenCode`, the `_: AnsiIntervalType` branch). This makes `addExact` a reliable marker for counting in all configurations.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass Github Actions
- Manual check:

```
SPARK_ANSI_SQL_MODE=false build/sbt 'sql/testOnly org.apache.spark.sql.execution.WholeStageCodegenSuite'

[info] Run completed in 15 seconds, 371 milliseconds.
[info] Total number of tests run: 37
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 37, failed 0, canceled 0, ignored 3, pending 0
[info] All tests passed.
```




### Was this patch authored or co-authored using generative AI tooling?
No
