### PR TITLE
[SPARK-55076][SQL] Add legacy config for MySQL unsigned TINYINT type …

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
@@ -27,7 +27,7 @@ import scala.util.Using
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.ShortType
+import org.apache.spark.sql.types.{ByteType, ShortType}
 import org.apache.spark.tags.DockerTest
 
 /**
@@ -179,6 +179,22 @@ class MySQLIntegrationSuite extends SharedJDBCIntegrationSuite {
       assert(rows.getBoolean(7) === false)
     } else {
       assert(rows.getShort(7) === 0)
+    }
+  }
+
+  test("SPARK-55076: Legacy config for unsigned TINYINT mapping") {
+    // Default behavior: unsigned TINYINT -> ShortType
+    val df = spark.read.jdbc(jdbcUrl, "unsigned_numbers", new Properties)
+    assert(df.schema("tiny").dataType === ShortType)
+    assert(df.head().getShort(0) === 255)
+
+    // Legacy behavior: unsigned TINYINT -> ByteType
+    withSQLConf(
+      SQLConf.LEGACY_MYSQL_UNSIGNED_TINYINT_MAPPING_ENABLED.key -> "true") {
+      val legacyDf = spark.read.jdbc(jdbcUrl, "unsigned_numbers", new Properties)
+      assert(legacyDf.schema("tiny").dataType === ByteType)
+      // 255 unsigned overflows to -1 as signed byte
+      assert(legacyDf.head().getByte(0) === -1.toByte)
     }
   }
 

--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -26,6 +26,7 @@ license: |
 
 - Since Spark 4.2, Spark enables order-independent checksums for shuffle outputs by default to detect data inconsistencies during indeterminate shuffle stage retries. If a checksum mismatch is detected, Spark rolls back and re-executes all succeeding stages that depend on the shuffle output. If rolling back is not possible for some succeeding stages, the job will fail. To restore the previous behavior, set `spark.sql.shuffle.orderIndependentChecksum.enabled` and `spark.sql.shuffle.orderIndependentChecksum.enableFullRetryOnMismatch` to `false`.
 - Since Spark 4.2, support for Derby JDBC datasource is deprecated.
+- Since Spark 4.2, a new configuration `spark.sql.legacy.mysql.unsignedTinyIntMapping.enabled` is available. When set to `true`, MySQL TINYINT UNSIGNED is mapped to ByteType (same as signed TINYINT), which may cause overflow for values outside [-128, 127]. The default (`false`) maps it to ShortType to accommodate the full unsigned range [0, 255].
 
 ## Upgrading from Spark SQL 4.0 to 4.1
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5787,6 +5787,17 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val LEGACY_MYSQL_UNSIGNED_TINYINT_MAPPING_ENABLED =
+    buildConf("spark.sql.legacy.mysql.unsignedTinyIntMapping.enabled")
+      .internal()
+      .doc("When true, MySQL TINYINT UNSIGNED is mapped to ByteType (same as signed TINYINT), " +
+        "which may cause overflow for values outside [-128, 127]. " +
+        "When false (default), it is mapped to ShortType to accommodate the full " +
+        "unsigned range [0, 255].")
+      .version("4.2.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val LEGACY_ORACLE_TIMESTAMP_MAPPING_ENABLED =
     buildConf("spark.sql.legacy.oracle.timestampMapping.enabled")
       .internal()
@@ -7583,6 +7594,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def legacyMySqlTimestampNTZMappingEnabled: Boolean =
     getConf(LEGACY_MYSQL_TIMESTAMPNTZ_MAPPING_ENABLED)
+
+  def legacyMySqlUnsignedTinyIntMappingEnabled: Boolean =
+    getConf(LEGACY_MYSQL_UNSIGNED_TINYINT_MAPPING_ENABLED)
 
   def legacyOracleTimestampMappingEnabled: Boolean =
     getConf(LEGACY_ORACLE_TIMESTAMP_MAPPING_ENABLED)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -167,7 +167,8 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper with No
         // scalastyle:on line.size.limit
         Some(StringType)
       case Types.TINYINT =>
-        if (md.build().getBoolean("isSigned")) {
+        if (md.build().getBoolean("isSigned") ||
+            conf.legacyMySqlUnsignedTinyIntMappingEnabled) {
           Some(ByteType)
         } else {
           Some(ShortType)

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -940,6 +940,11 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     metadata.putBoolean("isSigned", value = false)
     assert(mySqlDialect.getCatalystType(java.sql.Types.TINYINT, "TINYINT", 1, metadata) ===
       Some(ShortType))
+    withSQLConf(SQLConf.LEGACY_MYSQL_UNSIGNED_TINYINT_MAPPING_ENABLED.key -> "true") {
+      metadata.putBoolean("isSigned", value = false)
+      assert(mySqlDialect.getCatalystType(java.sql.Types.TINYINT, "TINYINT", 1, metadata) ===
+        Some(ByteType))
+    }
     assert(mySqlDialect.getCatalystType(java.sql.Types.REAL, "FLOAT", 1, metadata) ===
       Some(DoubleType))
     assert(mySqlDialect.getCatalystType(java.sql.Types.FLOAT, "FLOAT", 1, metadata) ===


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a new legacy configuration option `spark.sql.legacy.mysql.unsignedTinyIntMapping.enabled` to control how MySQL TINYINT UNSIGNED columns are mapped to Spark types.

- When `false` (default): unsigned TINYINT is mapped to `ShortType` (range [0, 255]) — this is the existing behavior since SPARK-47435.
- When `true`: unsigned TINYINT is mapped to `ByteType` (same as signed TINYINT), reverting to pre-SPARK-47435 behavior.

Changes:
1. Added `LEGACY_MYSQL_UNSIGNED_TINYINT_MAPPING_ENABLED` config in `SQLConf`
2. Modified `MySQLDialect.getCatalystType` to check the config for the `Types.TINYINT` case
3. Added unit test in `JDBCSuite` and integration test in `MySQLIntegrationSuite`
4. Added migration guide entry for Spark 4.1 → 4.2

### Why are the changes needed?

The core feature (unsigned TINYINT → `ShortType`) already exists in OSS Spark since SPARK-47435. However, there is no user-facing configuration option to revert this behavior. Users who depend on the old `ByteType` mapping (e.g., for schema compatibility with downstream systems) need a way to opt out of the `ShortType` mapping. This follows the same legacy escape hatch pattern used by other MySQL JDBC type mapping configs (`spark.sql.legacy.mysql.bitArrayMapping.enabled`, `spark.sql.legacy.mysql.timestampNTZMapping.enabled`).

### Does this PR introduce _any_ user-facing change?

No change to default behavior. A new internal configuration `spark.sql.legacy.mysql.unsignedTinyIntMapping.enabled` is added. When set to `true`, MySQL TINYINT UNSIGNED columns are read as `ByteType` instead of the default `ShortType`, which may cause overflow for values outside [-128, 127].

### How was this patch tested?

- Unit test added in `JDBCSuite.scala`: validates that `MySQLDialect.getCatalystType` returns `ByteType` for unsigned TINYINT when the legacy config is enabled.
- Integration test added in `MySQLIntegrationSuite.scala`: validates both default (`ShortType`, value 255) and legacy (`ByteType`, value overflows to -1) behaviors against a real MySQL instance.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)