### PR TITLE
[SPARK-52965][BUILD] Upgrade gRPC to 1.76.0 on branch-4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@
     <!-- Version used in Connect -->
     <connect.guava.version>33.4.0-jre</connect.guava.version>
     <guava.failureaccess.version>1.0.2</guava.failureaccess.version>
-    <io.grpc.version>1.67.1</io.grpc.version>
+    <io.grpc.version>1.76.0</io.grpc.version>
     <mima.version>1.1.4</mima.version>
     <tomcat.annotations.api.version>6.0.53</tomcat.annotations.api.version>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade gRPC from 1.67.1 to 1.76.0 on branch-4.0.

### Why are the changes needed?

gRPC 1.67.1 contains a version detection mechanism in `GrpcHttp2ConnectionHandler`
that uses `io.netty.util.Version.identify()` to determine the Netty version and
conditionally enable `NettyAdaptiveCumulator` for Netty < 4.1.111.

In environments where the classpath contains multiple JARs with
`META-INF/io.netty.versions.properties` (e.g., Hive client libraries bundling
old Netty), `Properties.load()` merges entries from all JARs and the last-loaded
value wins. This causes `Version.identify()` to report an incorrect (old) Netty
version, activating `NettyAdaptiveCumulator` on Netty 4.1.118 where it is
incompatible — resulting in `INTERNAL: Encountered end-of-stream mid-frame`.

gRPC 1.76.0 includes grpc/grpc-java#12390 which removes the `Version.identify()`
based detection entirely and unconditionally disables `NettyAdaptiveCumulator`,
fixing this class of issues.

**Verification:**
- Confirmed `usingPre4_1_111_Netty = true` in the affected environment via
  jshell (with Hive client JARs in classpath)
- Confirmed `usingPre4_1_111_Netty = false` without Hive client JARs
- Cherry-picked only grpc/grpc-java@70b7249da onto 1.75.0 → error resolved
- Removing `/opt/hive/lib/*` from classpath with gRPC 1.67.1 → error resolved

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Tested on a Spark Connect server deployment with the following configurations:
  - gRPC 1.67.1 (error), 1.75.0 (error), 1.76.0 (resolved), 1.76.3 (resolved)
  - gRPC 1.75.0 + cherry-pick of grpc-java#12390 (resolved)
  - gRPC 1.67.1 with Hive classpath excluded (resolved)
- Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.