### PR TITLE
[SPARK-54986][DOCS] Document return types for aggregate functions

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -1643,6 +1643,15 @@ def sum(col: "ColumnOrName") -> Column:
     :class:`~pyspark.sql.Column`
         the column for computed results.
 
+    Notes
+    -----
+    - Null values are ignored during the computation.
+    - The return type depends on the input:
+      :class:`~pyspark.sql.types.LongType` for integral inputs,
+      :class:`~pyspark.sql.types.DecimalType` for decimal inputs,
+      :class:`~pyspark.sql.types.DoubleType` for other numeric inputs, or an interval type
+      for interval inputs.
+
     Examples
     --------
     Example 1: Calculating the sum of values in a column
@@ -1701,6 +1710,14 @@ def avg(col: "ColumnOrName") -> Column:
     :class:`~pyspark.sql.Column`
         the column for computed results.
 
+    Notes
+    -----
+    - Null values are ignored during the computation.
+    - The return type depends on the input:
+      :class:`~pyspark.sql.types.DoubleType` for numeric inputs,
+      :class:`~pyspark.sql.types.DecimalType` for decimal inputs, or an interval type
+      for interval inputs.
+
     Examples
     --------
     Example 1: Calculating the average age
@@ -1748,6 +1765,14 @@ def mean(col: "ColumnOrName") -> Column:
     -------
     :class:`~pyspark.sql.Column`
         the column for computed results.
+
+    Notes
+    -----
+    - Null values are ignored during the computation.
+    - The return type depends on the input:
+      :class:`~pyspark.sql.types.DoubleType` for numeric inputs,
+      :class:`~pyspark.sql.types.DecimalType` for decimal inputs, or an interval type
+      for interval inputs.
 
     Examples
     --------
@@ -4250,6 +4275,12 @@ def stddev(col: "ColumnOrName") -> Column:
     :class:`~pyspark.sql.Column`
         standard deviation of given column.
 
+    Notes
+    -----
+    - Null values are ignored during the computation.
+    - The result is always a :class:`~pyspark.sql.types.DoubleType` column,
+      regardless of the input column type.
+
     Examples
     --------
     >>> import pyspark.sql.functions as sf
@@ -4288,6 +4319,12 @@ def std(col: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.variance`
     :meth:`pyspark.sql.functions.skewness`
     :meth:`pyspark.sql.functions.kurtosis`
+
+    Notes
+    -----
+    - Null values are ignored during the computation.
+    - The result is always a :class:`~pyspark.sql.types.DoubleType` column,
+      regardless of the input column type.
 
     Examples
     --------
@@ -4330,6 +4367,12 @@ def stddev_samp(col: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.stddev_pop`
     :meth:`pyspark.sql.functions.var_samp`
 
+    Notes
+    -----
+    - Null values are ignored during the computation.
+    - The result is always a :class:`~pyspark.sql.types.DoubleType` column,
+      regardless of the input column type.
+
     Examples
     --------
     >>> import pyspark.sql.functions as sf
@@ -4370,6 +4413,12 @@ def stddev_pop(col: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.stddev`
     :meth:`pyspark.sql.functions.stddev_samp`
     :meth:`pyspark.sql.functions.var_pop`
+
+    Notes
+    -----
+    - Null values are ignored during the computation.
+    - The result is always a :class:`~pyspark.sql.types.DoubleType` column,
+      regardless of the input column type.
 
     Examples
     --------
@@ -4412,6 +4461,12 @@ def variance(col: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.skewness`
     :meth:`pyspark.sql.functions.kurtosis`
 
+    Notes
+    -----
+    - Null values are ignored during the computation.
+    - The result is always a :class:`~pyspark.sql.types.DoubleType` column,
+      regardless of the input column type.
+
     Examples
     --------
     >>> from pyspark.sql import functions as sf
@@ -4453,6 +4508,12 @@ def var_samp(col: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.var_pop`
     :meth:`pyspark.sql.functions.std_samp`
 
+    Notes
+    -----
+    - Null values are ignored during the computation.
+    - The result is always a :class:`~pyspark.sql.types.DoubleType` column,
+      regardless of the input column type.
+
     Examples
     --------
     >>> from pyspark.sql import functions as sf
@@ -4492,6 +4553,12 @@ def var_pop(col: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.variance`
     :meth:`pyspark.sql.functions.var_samp`
     :meth:`pyspark.sql.functions.std_pop`
+
+    Notes
+    -----
+    - Null values are ignored during the computation.
+    - The result is always a :class:`~pyspark.sql.types.DoubleType` column,
+      regardless of the input column type.
 
     Examples
     --------
@@ -5777,6 +5844,12 @@ def skewness(col: "ColumnOrName") -> Column:
     :class:`~pyspark.sql.Column`
         skewness of given column.
 
+    Notes
+    -----
+    - Null values are ignored during the computation.
+    - The result is always a :class:`~pyspark.sql.types.DoubleType` column,
+      regardless of the input column type.
+
     Examples
     --------
     >>> from pyspark.sql import functions as sf
@@ -5817,6 +5890,12 @@ def kurtosis(col: "ColumnOrName") -> Column:
     :meth:`pyspark.sql.functions.stddev`
     :meth:`pyspark.sql.functions.variance`
     :meth:`pyspark.sql.functions.skewness`
+
+    Notes
+    -----
+    - Null values are ignored during the computation.
+    - The result is always a :class:`~pyspark.sql.types.DoubleType` column,
+      regardless of the input column type.
 
     Examples
     --------
@@ -6751,6 +6830,12 @@ def corr(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     :class:`~pyspark.sql.Column`
         Pearson Correlation Coefficient of these two column values.
 
+    Notes
+    -----
+    - Null values are ignored during the computation.
+    - The result is always a :class:`~pyspark.sql.types.DoubleType` column,
+      regardless of the input column type.
+
     Examples
     --------
     >>> from pyspark.sql import functions as sf
@@ -6793,6 +6878,12 @@ def covar_pop(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     --------
     :meth:`pyspark.sql.functions.covar_samp`
 
+    Notes
+    -----
+    - Null values are ignored during the computation.
+    - The result is always a :class:`~pyspark.sql.types.DoubleType` column,
+      regardless of the input column type.
+
     Examples
     --------
     >>> from pyspark.sql import functions as sf
@@ -6834,6 +6925,12 @@ def covar_samp(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     See Also
     --------
     :meth:`pyspark.sql.functions.covar_pop`
+
+    Notes
+    -----
+    - Null values are ignored during the computation.
+    - The result is always a :class:`~pyspark.sql.types.DoubleType` column,
+      regardless of the input column type.
 
     Examples
     --------


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added `Notes` sections to PySpark docstrings for 15 aggregate functions in `python/pyspark/sql/functions/builtin.py`, documenting their return data types:

- **Always `DoubleType`**: `stddev`, `std`, `stddev_samp`, `stddev_pop`, `variance`, `var_samp`, `var_pop`, `skewness`, `kurtosis`, `corr`, `covar_pop`, `covar_samp`
- **Input-dependent**: `avg`/`mean` (`DoubleType` for numeric, `DecimalType` for decimal, interval type for interval inputs) and `sum` (`LongType` for integral, `DecimalType` for decimal, `DoubleType` for other numeric, interval type for interval inputs)

The return type information was confirmed from the Scala implementations: `CentralMomentAgg`, `Average`, `Sum`, `PearsonCorrelation`, and `Covariance` in `sql/catalyst/.../expressions/aggregate/`.

The `Notes` section style follows the existing pattern used by `max` and `min` in the same file, which already document null/NaN handling behavior.

### Why are the changes needed?

The PySpark API docs for these aggregate functions don't document their return data types. Users have to read the Scala source code (e.g., `CentralMomentAgg.scala`) to discover that functions like `stddev` always return `DoubleType` regardless of input type, or that `sum` returns `LongType` for integer inputs. This information should be readily available in the Python docstrings.

See: https://github.com/apache/spark/issues/54986

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only change.

### How was this patch tested?

Documentation-only change. Verified that all docstrings follow valid NumPy-style RST formatting consistent with existing `Notes` sections (e.g., `max`, `min`) in the same file. Return type claims were cross-checked against the Scala source implementations.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude.ai/code) using Claude Opus 4.6