### PR TITLE
[SPARK-56279][CORE] Enable zero-copy sendfile for FileRegion in native Netty transports

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/MessageEncoder.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/MessageEncoder.java
@@ -22,12 +22,14 @@ import java.util.List;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.FileRegion;
 import io.netty.handler.codec.MessageToMessageEncoder;
 
 import org.apache.spark.internal.LogKeys;
 import org.apache.spark.internal.SparkLogger;
 import org.apache.spark.internal.SparkLoggerFactory;
 import org.apache.spark.internal.MDC;
+import org.apache.spark.network.buffer.FileSegmentManagedBuffer;
 
 /**
  * Encoder used by the server side to encode server-to-client responses.
@@ -89,9 +91,24 @@ public final class MessageEncoder extends MessageToMessageEncoder<Message> {
     assert header.writableBytes() == 0;
 
     if (body != null) {
-      // We transfer ownership of the reference on in.body() to MessageWithHeader.
-      // This reference will be freed when MessageWithHeader.deallocate() is called.
-      out.add(new MessageWithHeader(in.body(), header, body, bodyLength));
+      if (body instanceof FileRegion && in.body() instanceof FileSegmentManagedBuffer) {
+        // Emit header and FileRegion as separate objects so that native transports
+        // (EPOLL, KQUEUE) can apply zero-copy sendfile/splice on the FileRegion directly.
+        // When wrapped in MessageWithHeader, native transports fall into a generic
+        // FileRegion.transferTo() fallback that copies data through user-space, bypassing
+        // the optimized sendfile() path.
+        //
+        // This split is only safe when the ManagedBuffer is FileSegmentManagedBuffer,
+        // whose release() is a no-op. Other ManagedBuffer types (e.g.,
+        // BlockManagerManagedBuffer) perform resource cleanup in release() that must be
+        // tied to the write lifecycle via MessageWithHeader.deallocate().
+        out.add(header);
+        out.add(body);
+      } else {
+        // We transfer ownership of the reference on in.body() to MessageWithHeader.
+        // This reference will be freed when MessageWithHeader.deallocate() is called.
+        out.add(new MessageWithHeader(in.body(), header, body, bodyLength));
+      }
     } else {
       out.add(header);
     }

--- a/common/network-common/src/test/java/org/apache/spark/network/protocol/MergedBlockMetaSuccessSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/protocol/MergedBlockMetaSuccessSuite.java
@@ -28,6 +28,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.DefaultFileRegion;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.roaringbitmap.RoaringBitmap;
@@ -70,14 +71,25 @@ public class MergedBlockMetaSuccessSuite {
     when(context.alloc()).thenReturn(ByteBufAllocator.DEFAULT);
 
     MessageEncoder.INSTANCE.encode(context, expectedMeta, out);
-    Assertions.assertEquals(1, out.size());
-    MessageWithHeader msgWithHeader = (MessageWithHeader) out.remove(0);
+    // FileSegmentManagedBuffer.convertToNetty() returns a DefaultFileRegion,
+    // so MessageEncoder splits the output into header ByteBuf + FileRegion.
+    Assertions.assertEquals(2, out.size());
+    Assertions.assertInstanceOf(ByteBuf.class, out.get(0));
+    Assertions.assertInstanceOf(DefaultFileRegion.class, out.get(1));
+    ByteBuf headerBuf = (ByteBuf) out.remove(0);
+    DefaultFileRegion fileRegion = (DefaultFileRegion) out.remove(0);
 
-    ByteArrayWritableChannel writableChannel =
-      new ByteArrayWritableChannel((int) msgWithHeader.count());
-    while (msgWithHeader.transfered() < msgWithHeader.count()) {
-      msgWithHeader.transferTo(writableChannel, msgWithHeader.transfered());
+    int totalLen = headerBuf.readableBytes() + (int) fileRegion.count();
+    ByteArrayWritableChannel writableChannel = new ByteArrayWritableChannel(totalLen);
+    // Write header
+    writableChannel.write(headerBuf.nioBuffer());
+    // Write file region body
+    fileRegion.open();
+    while (fileRegion.transferred() < fileRegion.count()) {
+      fileRegion.transferTo(writableChannel, fileRegion.transferred());
     }
+    fileRegion.release();
+    headerBuf.release();
     ByteBuf messageBuf = Unpooled.wrappedBuffer(writableChannel.getData());
     messageBuf.readLong(); // frame length
     MessageDecoder.INSTANCE.decode(mock(ChannelHandlerContext.class), messageBuf, out);

--- a/core/benchmarks/NettyTransportBenchmark-jdk21-results.txt
+++ b/core/benchmarks/NettyTransportBenchmark-jdk21-results.txt
@@ -6,7 +6,7 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 RPC Latency (1 KB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 KB payload                                        493            539          31          0.0       98616.6       1.0X
+1 KB payload                                        495            512          13          0.0       99079.2       1.0X
 
 
 ================================================================================================
@@ -17,7 +17,7 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 RPC Latency (64 KB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-64 KB payload                                       737            758          18          0.0      147330.6       1.0X
+64 KB payload                                       690            715          15          0.0      138099.8       1.0X
 
 
 ================================================================================================
@@ -28,7 +28,7 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 RPC Latency (1 MB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 MB payload                                        829            899          90          0.0      828572.3       1.0X
+1 MB payload                                        884            944          57          0.0      883906.3       1.0X
 
 
 ================================================================================================
@@ -39,7 +39,7 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 RPC Latency (16 MB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-16 MB payload                                      1271           1351          72          0.0    12713142.1       1.0X
+16 MB payload                                      1275           1303          22          0.0    12752225.6       1.0X
 
 
 ================================================================================================
@@ -50,10 +50,10 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 Concurrent RPC Throughput:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 client(s)                                        1936           2030          85          0.0       96813.3       1.0X
-4 client(s)                                         726            748          32          0.0       36305.7       2.7X
-8 client(s)                                         548            550           1          0.0       27417.0       3.5X
-16 client(s)                                        445            458          14          0.0       22238.6       4.4X
+1 client(s)                                        1883           1927          46          0.0       94151.5       1.0X
+4 client(s)                                         726            742          16          0.0       36282.9       2.6X
+8 client(s)                                         523            530           9          0.0       26136.4       3.6X
+16 client(s)                                        424            437          12          0.0       21221.7       4.4X
 
 
 ================================================================================================
@@ -64,8 +64,8 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 IOMode Comparison:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NIO (8 clients)                                     792            803          19          0.0       39590.9       1.0X
-AUTO (8 clients)                                    835            851          16          0.0       41747.2       0.9X
+NIO (8 clients)                                     811            829          17          0.0       40567.8       1.0X
+AUTO (8 clients)                                    848            874          45          0.0       42380.6       1.0X
 
 
 ================================================================================================
@@ -76,11 +76,11 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 Server Thread Scaling:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-2 server threads                                    481            491          12          0.0       24050.8       1.0X
-4 server threads                                    391            413          29          0.1       19537.1       1.2X
-8 server threads                                    416            434          15          0.0       20819.9       1.2X
-16 server threads                                   449            473          26          0.0       22455.0       1.1X
-32 server threads                                   461            499          33          0.0       23043.3       1.0X
+2 server threads                                    465            477          15          0.0       23261.5       1.0X
+4 server threads                                    386            397          14          0.1       19278.9       1.2X
+8 server threads                                    415            431          21          0.0       20738.6       1.1X
+16 server threads                                   435            472          34          0.0       21760.2       1.1X
+32 server threads                                   479            497          28          0.0       23925.6       1.0X
 
 
 ================================================================================================
@@ -91,9 +91,9 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 Multi-Connection Throughput:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 conn(s), 4 threads                               1601           1667         108          0.0      320283.2       1.0X
-2 conn(s), 4 threads                               1189           1505         274          0.0      237803.7       1.3X
-4 conn(s), 4 threads                               1754           1793          34          0.0      350832.7       0.9X
+1 conn(s), 4 threads                               1853           2013         167          0.0      370521.8       1.0X
+2 conn(s), 4 threads                               1557           1588          28          0.0      311449.1       1.2X
+4 conn(s), 4 threads                               1756           1822          57          0.0      351214.2       1.1X
 
 
 ================================================================================================
@@ -104,9 +104,9 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 Async Write Throughput:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 KB async burst                                     37             40           3          0.1        7439.9       1.0X
-64 KB async burst                                   145            155          13          0.0       29093.7       0.3X
-1 MB async burst                                   1539           1571          33          0.0      307765.1       0.0X
+1 KB async burst                                     34             48          21          0.1        6745.3       1.0X
+64 KB async burst                                   163            167           6          0.0       32507.6       0.2X
+1 MB async burst                                   1512           1574          75          0.0      302329.1       0.0X
 
 
 ================================================================================================
@@ -117,8 +117,8 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 16 MB Block Transfer:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Sequential sends                                    627            834         304          0.0     6267294.2       1.0X
-4-thread parallel sends                             452            457           7          0.0     4520142.4       1.4X
+Sequential sends                                    658           1087         373          0.0     6575971.7       1.0X
+4-thread parallel sends                             419            477          88          0.0     4187438.8       1.6X
 
 
 ================================================================================================
@@ -129,9 +129,9 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 File-Backed Shuffle Fetch:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NIO, sequential fetch                               370            384          13          0.0     3700370.3       1.0X
-NIO, parallel fetch (4 clients)                     205            213           7          0.0     2054174.4       1.8X
-AUTO, sequential fetch                             2093           2189          85          0.0    20929166.7       0.2X
-AUTO, parallel fetch (4 clients)                    677            787         113          0.0     6769621.7       0.5X
+NIO, sequential fetch                               366            372           9          0.0     3655386.3       1.0X
+NIO, parallel fetch (4 clients)                     200            211          11          0.0     2002026.0       1.8X
+AUTO, sequential fetch                              360            369          13          0.0     3600497.3       1.0X
+AUTO, parallel fetch (4 clients)                    204            206           2          0.0     2041001.7       1.8X
 
 

--- a/core/benchmarks/NettyTransportBenchmark-jdk25-results.txt
+++ b/core/benchmarks/NettyTransportBenchmark-jdk25-results.txt
@@ -6,7 +6,7 @@ OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 RPC Latency (1 KB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 KB payload                                        507            531          17          0.0      101431.1       1.0X
+1 KB payload                                        483            514          20          0.0       96640.5       1.0X
 
 
 ================================================================================================
@@ -17,7 +17,7 @@ OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 RPC Latency (64 KB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-64 KB payload                                       620            652          24          0.0      123934.0       1.0X
+64 KB payload                                       638            661          16          0.0      127507.5       1.0X
 
 
 ================================================================================================
@@ -28,7 +28,7 @@ OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 RPC Latency (1 MB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 MB payload                                        434            469          42          0.0      433901.5       1.0X
+1 MB payload                                        495            519          21          0.0      494963.5       1.0X
 
 
 ================================================================================================
@@ -39,7 +39,7 @@ OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 RPC Latency (16 MB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-16 MB payload                                       719            727          13          0.0     7186630.4       1.0X
+16 MB payload                                       667            700          26          0.0     6668529.6       1.0X
 
 
 ================================================================================================
@@ -50,10 +50,10 @@ OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 Concurrent RPC Throughput:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 client(s)                                        2050           2094          67          0.0      102521.6       1.0X
-4 client(s)                                         711            727          20          0.0       35571.3       2.9X
-8 client(s)                                         518            527          10          0.0       25876.1       4.0X
-16 client(s)                                        447            451           4          0.0       22360.0       4.6X
+1 client(s)                                        1856           1904          45          0.0       92800.7       1.0X
+4 client(s)                                         736            751          22          0.0       36787.4       2.5X
+8 client(s)                                         513            532          16          0.0       25658.3       3.6X
+16 client(s)                                        447            453           7          0.0       22327.2       4.2X
 
 
 ================================================================================================
@@ -64,8 +64,8 @@ OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 IOMode Comparison:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NIO (8 clients)                                     720            780          64          0.0       36000.0       1.0X
-AUTO (8 clients)                                    684            689           6          0.0       34189.4       1.1X
+NIO (8 clients)                                     715            731          15          0.0       35748.6       1.0X
+AUTO (8 clients)                                    679            724          40          0.0       33953.2       1.1X
 
 
 ================================================================================================
@@ -76,11 +76,11 @@ OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 Server Thread Scaling:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-2 server threads                                    460            474          18          0.0       22994.7       1.0X
-4 server threads                                    391            410          27          0.1       19564.8       1.2X
-8 server threads                                    411            418          11          0.0       20566.8       1.1X
-16 server threads                                   456            475          28          0.0       22789.9       1.0X
-32 server threads                                   464            497          30          0.0       23223.7       1.0X
+2 server threads                                    468            483          15          0.0       23387.8       1.0X
+4 server threads                                    410            429          19          0.0       20484.6       1.1X
+8 server threads                                    433            438           6          0.0       21665.3       1.1X
+16 server threads                                   452            459           6          0.0       22611.9       1.0X
+32 server threads                                   463            500          34          0.0       23146.1       1.0X
 
 
 ================================================================================================
@@ -91,9 +91,9 @@ OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 Multi-Connection Throughput:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 conn(s), 4 threads                               1963           2003          42          0.0      392657.6       1.0X
-2 conn(s), 4 threads                               1185           1332         138          0.0      237065.8       1.7X
-4 conn(s), 4 threads                               1060           1083          22          0.0      211942.7       1.9X
+1 conn(s), 4 threads                               1920           1987          86          0.0      384003.1       1.0X
+2 conn(s), 4 threads                               1305           1551         227          0.0      261002.4       1.5X
+4 conn(s), 4 threads                               1111           1143          46          0.0      222294.1       1.7X
 
 
 ================================================================================================
@@ -104,9 +104,9 @@ OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 Async Write Throughput:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 KB async burst                                     37             58          19          0.1        7331.0       1.0X
-64 KB async burst                                   147            163          20          0.0       29303.0       0.3X
-1 MB async burst                                   1384           1455         121          0.0      276842.9       0.0X
+1 KB async burst                                     64             66           2          0.1       12844.2       1.0X
+64 KB async burst                                   182            183           1          0.0       36387.3       0.4X
+1 MB async burst                                   1453           1528         103          0.0      290589.8       0.0X
 
 
 ================================================================================================
@@ -117,8 +117,8 @@ OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 16 MB Block Transfer:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Sequential sends                                    679            685           5          0.0     6793339.7       1.0X
-4-thread parallel sends                             365            370           4          0.0     3653257.9       1.9X
+Sequential sends                                    694            722          33          0.0     6942386.8       1.0X
+4-thread parallel sends                             391            395           7          0.0     3905094.7       1.8X
 
 
 ================================================================================================
@@ -129,9 +129,9 @@ OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 File-Backed Shuffle Fetch:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NIO, sequential fetch                               369            390          24          0.0     3689959.5       1.0X
-NIO, parallel fetch (4 clients)                     200            208           7          0.0     2001935.5       1.8X
-AUTO, sequential fetch                             1918           1994          80          0.0    19179875.5       0.2X
-AUTO, parallel fetch (4 clients)                    652            730         116          0.0     6517014.3       0.6X
+NIO, sequential fetch                               411            419          13          0.0     4112689.7       1.0X
+NIO, parallel fetch (4 clients)                     213            214           1          0.0     2131475.4       1.9X
+AUTO, sequential fetch                              411            416           4          0.0     4112489.8       1.0X
+AUTO, parallel fetch (4 clients)                    196            199           3          0.0     1956986.8       2.1X
 
 

--- a/core/benchmarks/NettyTransportBenchmark-results.txt
+++ b/core/benchmarks/NettyTransportBenchmark-results.txt
@@ -6,7 +6,7 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 RPC Latency (1 KB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 KB payload                                        463            477          13          0.0       92568.3       1.0X
+1 KB payload                                        444            472          20          0.0       88867.8       1.0X
 
 
 ================================================================================================
@@ -17,7 +17,7 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 RPC Latency (64 KB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-64 KB payload                                       680            695          12          0.0      136004.3       1.0X
+64 KB payload                                       715            742          25          0.0      143088.4       1.0X
 
 
 ================================================================================================
@@ -28,7 +28,7 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 RPC Latency (1 MB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 MB payload                                        822            895          52          0.0      822087.0       1.0X
+1 MB payload                                        875            902          23          0.0      874524.5       1.0X
 
 
 ================================================================================================
@@ -39,7 +39,7 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 RPC Latency (16 MB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-16 MB payload                                      1230           1306          58          0.0    12295430.0       1.0X
+16 MB payload                                      1327           1390          61          0.0    13268791.8       1.0X
 
 
 ================================================================================================
@@ -50,10 +50,10 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 Concurrent RPC Throughput:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 client(s)                                        1830           1881          49          0.0       91498.8       1.0X
-4 client(s)                                         717            730          11          0.0       35831.2       2.6X
-8 client(s)                                         502            514          13          0.0       25122.4       3.6X
-16 client(s)                                        442            453          10          0.0       22114.2       4.1X
+1 client(s)                                        1823           1969         127          0.0       91128.9       1.0X
+4 client(s)                                         768            783          20          0.0       38389.3       2.4X
+8 client(s)                                         512            536          23          0.0       25603.3       3.6X
+16 client(s)                                        459            464           5          0.0       22970.0       4.0X
 
 
 ================================================================================================
@@ -64,8 +64,8 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 IOMode Comparison:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NIO (8 clients)                                     772            837          75          0.0       38575.1       1.0X
-AUTO (8 clients)                                    862            896          30          0.0       43107.0       0.9X
+NIO (8 clients)                                     792            840          41          0.0       39614.4       1.0X
+AUTO (8 clients)                                    867            885          19          0.0       43371.9       0.9X
 
 
 ================================================================================================
@@ -76,11 +76,11 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 Server Thread Scaling:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-2 server threads                                    448            460          14          0.0       22384.7       1.0X
-4 server threads                                    396            398           2          0.1       19794.4       1.1X
-8 server threads                                    411            422          11          0.0       20525.4       1.1X
-16 server threads                                   470            478           9          0.0       23488.2       1.0X
-32 server threads                                   461            498          34          0.0       23049.9       1.0X
+2 server threads                                    496            502          10          0.0       24789.3       1.0X
+4 server threads                                    405            424          32          0.0       20234.7       1.2X
+8 server threads                                    421            450          27          0.0       21025.0       1.2X
+16 server threads                                   443            458          26          0.0       22142.6       1.1X
+32 server threads                                   455            515          52          0.0       22727.6       1.1X
 
 
 ================================================================================================
@@ -91,9 +91,9 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 Multi-Connection Throughput:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 conn(s), 4 threads                               1642           1740          96          0.0      328480.9       1.0X
-2 conn(s), 4 threads                               1390           1588         172          0.0      278078.4       1.2X
-4 conn(s), 4 threads                               1667           1724          50          0.0      333315.0       1.0X
+1 conn(s), 4 threads                               1702           1871         152          0.0      340467.9       1.0X
+2 conn(s), 4 threads                               1278           1540         227          0.0      255638.3       1.3X
+4 conn(s), 4 threads                               1736           1768          36          0.0      347180.2       1.0X
 
 
 ================================================================================================
@@ -104,9 +104,9 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 Async Write Throughput:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 KB async burst                                     59             66           6          0.1       11860.0       1.0X
-64 KB async burst                                   147            167          23          0.0       29498.4       0.4X
-1 MB async burst                                   1375           1555         166          0.0      275081.9       0.0X
+1 KB async burst                                     72            137         112          0.1       14336.3       1.0X
+64 KB async burst                                   147            161          13          0.0       29489.6       0.5X
+1 MB async burst                                   1412           1479          59          0.0      282361.9       0.1X
 
 
 ================================================================================================
@@ -117,8 +117,8 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 16 MB Block Transfer:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Sequential sends                                    662            891         330          0.0     6616920.9       1.0X
-4-thread parallel sends                             438            497          88          0.0     4380966.0       1.5X
+Sequential sends                                    670            895         358          0.0     6695791.0       1.0X
+4-thread parallel sends                             436            451          17          0.0     4358412.5       1.5X
 
 
 ================================================================================================
@@ -129,9 +129,9 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 File-Backed Shuffle Fetch:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NIO, sequential fetch                               380            385           5          0.0     3802737.0       1.0X
-NIO, parallel fetch (4 clients)                     212            214           3          0.0     2118790.3       1.8X
-AUTO, sequential fetch                             2075           2093          16          0.0    20751127.3       0.2X
-AUTO, parallel fetch (4 clients)                    676            814         129          0.0     6757222.9       0.6X
+NIO, sequential fetch                               384            386           3          0.0     3844405.1       1.0X
+NIO, parallel fetch (4 clients)                     209            217           9          0.0     2091358.0       1.8X
+AUTO, sequential fetch                              362            372          14          0.0     3615964.2       1.1X
+AUTO, parallel fetch (4 clients)                    202            209           6          0.0     2022433.8       1.9X
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR modifies `MessageEncoder` to emit the header `ByteBuf` and `FileRegion` as **separate objects** in the outbound message list when the body is a `FileRegion` backed by `FileSegmentManagedBuffer`, instead of wrapping them together in a `MessageWithHeader`.

Previously, all messages with a body were unconditionally wrapped in `MessageWithHeader`. This caused native transports (EPOLL, KQUEUE) to fall into a generic `FileRegion.transferTo()` fallback path that copies data through user-space, bypassing the optimized `sendfile()` / `splice()` zero-copy path that Netty's native transports provide.

The split is only applied when the `ManagedBuffer` is a `FileSegmentManagedBuffer`, whose `release()` is a no-op, making it safe to emit the `FileRegion` independently of write lifecycle management. Other `ManagedBuffer` types (e.g., `BlockManagerManagedBuffer`) still use the `MessageWithHeader` wrapper because they perform resource cleanup in `release()` that must be tied to `MessageWithHeader.deallocate()`.

### Why are the changes needed?

When using native transports (AUTO/EPOLL on Linux), file-backed shuffle fetch performance was severely degraded compared to NIO mode. The root cause lies in how Netty's native transports dispatch `FileRegion` writes.

In `AbstractEpollStreamChannel.doWriteSingle()` (and the analogous KQueue path), Netty uses an `instanceof` check to choose between two write strategies:

https://github.com/netty/netty/blob/eeb5674526f0b49a142580686a5a9a7147ddadec/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java#L474-L493

```java
} else if (msg instanceof DefaultFileRegion) {
    return writeDefaultFileRegion(in, (DefaultFileRegion) msg);  // → socket.sendFile() (zero-copy)
} else if (msg instanceof FileRegion) {
    return writeFileRegion(in, (FileRegion) msg);                // → region.transferTo() (user-space copy)
}
```

- **`writeDefaultFileRegion()`** calls `socket.sendFile()`, which maps directly to the Linux `sendfile()` syscall — a true zero-copy path where data is transferred from the file page cache to the socket buffer entirely within the kernel, with no user-space copy.

https://github.com/netty/netty/blob/eeb5674526f0b49a142580686a5a9a7147ddadec/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java#L367-L386

```java
    private int writeDefaultFileRegion(ChannelOutboundBuffer in, DefaultFileRegion region) throws Exception {
        final long offset = region.transferred();
        final long regionCount = region.count();
        if (offset >= regionCount) {
            in.remove();
            return 0;
        }

        final long flushedAmount = socket.sendFile(region, region.position(), offset, regionCount - offset);
        if (flushedAmount > 0) {
            in.progress(flushedAmount);
            if (region.transferred() >= regionCount) {
                in.remove();
            }
            return 1;
        } else if (flushedAmount == 0) {
            validateFileRegion(region, offset);
        }
        return WRITE_STATUS_SNDBUF_FULL;
    }
```

- **`writeFileRegion()`** falls back to `region.transferTo(WritableByteChannel)`, which writes data through a `SocketWritableByteChannel` wrapper — effectively a user-space copy path.

https://github.com/netty/netty/blob/eeb5674526f0b49a142580686a5a9a7147ddadec/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java#L402-L420

```java
private int writeFileRegion(ChannelOutboundBuffer in, FileRegion region) throws Exception {
        if (region.transferred() >= region.count()) {
            in.remove();
            return 0;
        }

        if (byteChannel == null) {
            byteChannel = new EpollSocketWritableByteChannel();
        }
        final long flushedAmount = region.transferTo(byteChannel, region.transferred());
        if (flushedAmount > 0) {
            in.progress(flushedAmount);
            if (region.transferred() >= region.count()) {
                in.remove();
            }
            return 1;
        }
        return WRITE_STATUS_SNDBUF_FULL;
    }
```

Spark's `MessageWithHeader extends AbstractFileRegion` (not `DefaultFileRegion`). When `MessageEncoder` wraps a `DefaultFileRegion` body inside `MessageWithHeader`, the resulting object is a generic `FileRegion` from Netty's perspective. This means Netty dispatches it to the `writeFileRegion()` fallback, which calls `MessageWithHeader.transferTo()`:

```java
// MessageWithHeader.java, line 121
if (body instanceof FileRegion fileRegion) {
    writtenBody = fileRegion.transferTo(target, totalBytesTransferred - headerLength);
}
```

Here, even though the inner body is a `DefaultFileRegion`, its `transferTo()` is invoked with a `WritableByteChannel` (not a file descriptor), so the data is read from the file into a user-space buffer and then written to the socket — **the zero-copy opportunity is lost**.

By emitting the `DefaultFileRegion` directly into Netty's outbound buffer (instead of wrapping it in `MessageWithHeader`), Netty's native transport recognizes it via `instanceof DefaultFileRegion` and routes it to `socket.sendFile()`, restoring the zero-copy `sendfile()` path.

**Benchmark results (File-Backed Shuffle Fetch) show dramatic improvement:**

| Scenario | Before (ms) | After (ms) | Improvement |
|---|---|---|---|
| AUTO, sequential fetch (JDK17) | 2075 | 362 | **~5.7x faster** |
| AUTO, parallel fetch (JDK17) | 676 | 202 | **~3.3x faster** |
| AUTO, sequential fetch (JDK21) | 2093 | 360 | **~5.8x faster** |
| AUTO, parallel fetch (JDK21) | 677 | 204 | **~3.3x faster** |
| AUTO, sequential fetch (JDK25) | 1918 | 411 | **~4.7x faster** |
| AUTO, parallel fetch (JDK25) | 652 | 196 | **~3.3x faster** |

With this fix, AUTO (EPOLL) mode now matches or exceeds NIO performance for file-backed shuffle fetches, achieving the expected ~1.0X relative performance (previously ~0.2X).

### Does this PR introduce _any_ user-facing change?

No. This is an internal optimization to the Netty transport layer. Users benefit from improved shuffle fetch performance when using native transports (the default on Linux) without any configuration changes.

### How was this patch tested?

- Updated `MergedBlockMetaSuccessSuite` to validate the new encoder output format (2 separate objects: `ByteBuf` header + `DefaultFileRegion`, instead of a single `MessageWithHeader`).
- Re-ran `NettyTransportBenchmark` across JDK 17, JDK 21, and JDK 25 to confirm the performance improvement. Updated benchmark result files accordingly.


### Was this patch authored or co-authored using generative AI tooling?
Generated-by:  Claude Code 4.6
