### PR TITLE
[SPARK-56280][SS] normalize NaN and +/-0.0 in streaming dedupe node

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -525,7 +525,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
     /**
      * If any dedup key is a floating-point type, wraps the physical child in a ProjectExec that
      * normalizes NaN and -0.0 so that semantically equal values produce identical UnsafeRow bytes
-     * in the state store. This mirrors the aggregate key normalization at lines 600-608.
+     * in the state store.
      */
     private def maybeNormalizeFloatingPointKeys(
         keys: Seq[Attribute], child: LogicalPlan): SparkPlan = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -51,6 +51,7 @@ import org.apache.spark.sql.execution.streaming.runtime.{StreamingExecutionRelat
 import org.apache.spark.sql.execution.streaming.sources.MemoryPlan
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.OutputMode
+import org.apache.spark.sql.types.{DoubleType, FloatType}
 
 /**
  * Converts a logical plan into zero or more SparkPlans.  This API is exposed for experimenting
@@ -511,12 +512,42 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
   object StreamingDeduplicationStrategy extends Strategy {
     override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
       case Deduplicate(keys, child) if child.isStreaming =>
-        StreamingDeduplicateExec(keys, planLater(child)) :: Nil
+        StreamingDeduplicateExec(
+          keys, maybeNormalizeFloatingPointKeys(keys, child)) :: Nil
 
       case DeduplicateWithinWatermark(keys, child) if child.isStreaming =>
-        StreamingDeduplicateWithinWatermarkExec(keys, planLater(child)) :: Nil
+        StreamingDeduplicateWithinWatermarkExec(
+          keys, maybeNormalizeFloatingPointKeys(keys, child)) :: Nil
 
       case _ => Nil
+    }
+
+    /**
+     * If any dedup key is a floating-point type, wraps the physical child in a ProjectExec that
+     * normalizes NaN and -0.0 so that semantically equal values produce identical UnsafeRow bytes
+     * in the state store. This mirrors the aggregate key normalization at lines 600-608.
+     */
+    private def maybeNormalizeFloatingPointKeys(
+        keys: Seq[Attribute], child: LogicalPlan): SparkPlan = {
+      val physicalChild = planLater(child)
+      val needsNormalization = keys.exists(k =>
+        k.dataType == FloatType || k.dataType == DoubleType)
+      if (needsNormalization) {
+        val normalizedProjectList = child.output.map { attr =>
+          if (keys.exists(_.exprId == attr.exprId) &&
+              (attr.dataType == FloatType || attr.dataType == DoubleType)) {
+            NormalizeFloatingNumbers.normalize(attr) match {
+              case a: NamedExpression => a
+              case other => Alias(other, attr.name)(exprId = attr.exprId)
+            }
+          } else {
+            attr
+          }
+        }
+        execution.ProjectExec(normalizedProjectList, physicalChild)
+      } else {
+        physicalChild
+      }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -511,42 +511,12 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
   object StreamingDeduplicationStrategy extends Strategy {
     override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
       case Deduplicate(keys, child) if child.isStreaming =>
-        StreamingDeduplicateExec(
-          keys, maybeNormalizeFloatingPointKeys(keys, child)) :: Nil
+        StreamingDeduplicateExec(keys, planLater(child)) :: Nil
 
       case DeduplicateWithinWatermark(keys, child) if child.isStreaming =>
-        StreamingDeduplicateWithinWatermarkExec(
-          keys, maybeNormalizeFloatingPointKeys(keys, child)) :: Nil
+        StreamingDeduplicateWithinWatermarkExec(keys, planLater(child)) :: Nil
 
       case _ => Nil
-    }
-
-    /**
-     * If any dedup key contains a floating-point type (including nested types), wraps the physical
-     * child in a ProjectExec that normalizes NaN and -0.0 so that semantically equal values produce
-     * identical UnsafeRow bytes in the state store.
-     *
-     * Note that the streaming dedupe node does not support map-typed keys, althoug the
-     * `NormalizeFloatingNumbers` helper does.
-     */
-    private def maybeNormalizeFloatingPointKeys(
-        keys: Seq[Attribute], child: LogicalPlan): SparkPlan = {
-      val physicalChild = planLater(child)
-      val normalizedProjectList = child.output.map { attr =>
-        if (keys.exists(_.exprId == attr.exprId)) {
-          NormalizeFloatingNumbers.normalize(attr) match {
-            case a: Attribute => a
-            case other => Alias(other, attr.name)(exprId = attr.exprId)
-          }
-        } else {
-          attr
-        }
-      }
-      if (normalizedProjectList.exists(!_.isInstanceOf[Attribute])) {
-        execution.ProjectExec(normalizedProjectList, physicalChild)
-      } else {
-        physicalChild
-      }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -51,7 +51,6 @@ import org.apache.spark.sql.execution.streaming.runtime.{StreamingExecutionRelat
 import org.apache.spark.sql.execution.streaming.sources.MemoryPlan
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.OutputMode
-import org.apache.spark.sql.types.{DoubleType, FloatType}
 
 /**
  * Converts a logical plan into zero or more SparkPlans.  This API is exposed for experimenting
@@ -523,27 +522,27 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
     }
 
     /**
-     * If any dedup key is a floating-point type, wraps the physical child in a ProjectExec that
-     * normalizes NaN and -0.0 so that semantically equal values produce identical UnsafeRow bytes
-     * in the state store.
+     * If any dedup key contains a floating-point type (including nested types), wraps the physical
+     * child in a ProjectExec that normalizes NaN and -0.0 so that semantically equal values produce
+     * identical UnsafeRow bytes in the state store.
+     *
+     * Note that the streaming dedupe node does not support map-typed keys, althoug the
+     * `NormalizeFloatingNumbers` helper does.
      */
     private def maybeNormalizeFloatingPointKeys(
         keys: Seq[Attribute], child: LogicalPlan): SparkPlan = {
       val physicalChild = planLater(child)
-      val needsNormalization = keys.exists(k =>
-        k.dataType == FloatType || k.dataType == DoubleType)
-      if (needsNormalization) {
-        val normalizedProjectList = child.output.map { attr =>
-          if (keys.exists(_.exprId == attr.exprId) &&
-              (attr.dataType == FloatType || attr.dataType == DoubleType)) {
-            NormalizeFloatingNumbers.normalize(attr) match {
-              case a: NamedExpression => a
-              case other => Alias(other, attr.name)(exprId = attr.exprId)
-            }
-          } else {
-            attr
+      val normalizedProjectList = child.output.map { attr =>
+        if (keys.exists(_.exprId == attr.exprId)) {
+          NormalizeFloatingNumbers.normalize(attr) match {
+            case a: Attribute => a
+            case other => Alias(other, attr.name)(exprId = attr.exprId)
           }
+        } else {
+          attr
         }
+      }
+      if (normalizedProjectList.exists(!_.isInstanceOf[Attribute])) {
         execution.ProjectExec(normalizedProjectList, physicalChild)
       } else {
         physicalChild

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/statefulOperators.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
+import org.apache.spark.sql.catalyst.optimizer.NormalizeFloatingNumbers
 import org.apache.spark.sql.catalyst.plans.logical.EventTimeWatermark
 import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, Distribution, Partitioning}
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes._
@@ -1336,7 +1337,10 @@ abstract class BaseStreamingDeduplicateExec
       session.sessionState,
       Some(session.streams.stateStoreCoordinator),
       extraOptions = extraOptionOnStateStore) { (store, iter) =>
-      val getKey = GenerateUnsafeProjection.generate(keyExpressions, child.output)
+      // Normalize NaN and -0.0 in floating-point key values so that semantically equal
+      // values produce identical UnsafeRow bytes.
+      val getKey = GenerateUnsafeProjection.generate(
+        keyExpressions.map(NormalizeFloatingNumbers.normalize), child.output)
       val numOutputRows = longMetric("numOutputRows")
       val numUpdatedStateRows = longMetric("numUpdatedStateRows")
       val allUpdatesTimeMs = longMetric("allUpdatesTimeMs")

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationSuite.scala
@@ -60,6 +60,50 @@ class StreamingDeduplicationSuite extends StateStoreMetricsTest
     )
   }
 
+  test("different NaN bit patterns should be deduplicated") {
+    val inputData = MemoryStream[(Float, Int)]
+    val result = inputData.toDS().toDF("value", "id").dropDuplicates("value")
+
+    // Canonical quiet NaN (0x7fc00000) and non-canonical signaling NaN (0x7f800001).
+    val canonicalNaN = java.lang.Float.intBitsToFloat(0x7fc00000)
+    val nonCanonicalNaN = java.lang.Float.intBitsToFloat(0x7f800001)
+    assert(java.lang.Float.isNaN(canonicalNaN) && java.lang.Float.isNaN(nonCanonicalNaN))
+    assert(java.lang.Float.floatToRawIntBits(canonicalNaN) !=
+      java.lang.Float.floatToRawIntBits(nonCanonicalNaN))
+
+    testStream(result, Append)(
+      AddData(inputData, (canonicalNaN, 1)),
+      CheckLastBatch((canonicalNaN, 1)),
+      assertNumStateRows(total = 1, updated = 1),
+
+      // Non-canonical NaN should be treated as a duplicate of canonical NaN
+      AddData(inputData, (nonCanonicalNaN, 2)),
+      CheckLastBatch(),
+      assertNumStateRows(total = 1, updated = 0),
+
+      // Only the first NaN row should be in the complete output
+      CheckAnswer((canonicalNaN, 1))
+    )
+  }
+
+  test("negative zero and positive zero should be deduplicated") {
+    val inputData = MemoryStream[(Float, Int)]
+    val result = inputData.toDS().toDF("value", "id").dropDuplicates("value")
+
+    testStream(result, Append)(
+      AddData(inputData, (0.0f, 1)),
+      CheckLastBatch((0.0f, 1)),
+      assertNumStateRows(total = 1, updated = 1),
+
+      // -0.0f should be treated as a duplicate of 0.0f
+      AddData(inputData, (-0.0f, 2)),
+      CheckLastBatch(),
+      assertNumStateRows(total = 1, updated = 0),
+
+      CheckAnswer((0.0f, 1))
+    )
+  }
+
   test("deduplicate with some columns") {
     val inputData = MemoryStream[(String, Int)]
     val result = inputData.toDS().dropDuplicates("_1")

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationSuite.scala
@@ -60,6 +60,27 @@ class StreamingDeduplicationSuite extends StateStoreMetricsTest
     )
   }
 
+  test("same NaN bit patterns should be treated as duplicates") {
+    val inputData = MemoryStream[(Float, Int)]
+    val result = inputData.toDS().toDF("value", "id").dropDuplicates("value")
+
+    val canonicalNaN = java.lang.Float.intBitsToFloat(0x7fc00000)
+    val otherNan = java.lang.Float.intBitsToFloat(0x7fc00000)
+    assert(java.lang.Float.isNaN(canonicalNaN) && java.lang.Float.isNaN(otherNan))
+    assert(java.lang.Float.floatToRawIntBits(canonicalNaN) ==
+      java.lang.Float.floatToRawIntBits(otherNan))
+
+    testStream(result, Append)(
+      AddData(inputData, (canonicalNaN, 1)),
+      CheckLastBatch((canonicalNaN, 1)),
+      assertNumStateRows(total = 1, updated = 1),
+      AddData(inputData, (otherNan, 2)),
+      CheckLastBatch(),
+      assertNumStateRows(total = 1, updated = 0),
+      CheckAnswer((canonicalNaN, 1))
+    )
+  }
+
   test("different NaN bit patterns should be deduplicated") {
     val inputData = MemoryStream[(Float, Int)]
     val result = inputData.toDS().toDF("value", "id").dropDuplicates("value")

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationSuite.scala
@@ -60,52 +60,61 @@ class StreamingDeduplicationSuite extends StateStoreMetricsTest
     )
   }
 
-  test("same NaN bit patterns should be treated as duplicates") {
+  // Canonical quiet NaN and a non-canonical NaN with a different bit pattern.
+  // Both are NaN, but they have distinct raw bit representations.
+  private val canonicalNaN = java.lang.Float.intBitsToFloat(0x7fc00000)
+  private val nonCanonicalNaN = java.lang.Float.intBitsToFloat(0x7f800001)
+  assert(java.lang.Float.isNaN(canonicalNaN) && java.lang.Float.isNaN(nonCanonicalNaN),
+    "Both values must be NaN")
+  assert(java.lang.Float.floatToRawIntBits(canonicalNaN) !=
+    java.lang.Float.floatToRawIntBits(nonCanonicalNaN),
+    "The two NaN values must have different bit patterns")
+
+  test("same NaN bit pattern should be deduplicated") {
     val inputData = MemoryStream[(Float, Int)]
     val result = inputData.toDS().toDF("value", "id").dropDuplicates("value")
-
-    val canonicalNaN = java.lang.Float.intBitsToFloat(0x7fc00000)
-    val otherNan = java.lang.Float.intBitsToFloat(0x7fc00000)
-    assert(java.lang.Float.isNaN(canonicalNaN) && java.lang.Float.isNaN(otherNan))
-    assert(java.lang.Float.floatToRawIntBits(canonicalNaN) ==
-      java.lang.Float.floatToRawIntBits(otherNan))
-
-    testStream(result, Append)(
-      AddData(inputData, (canonicalNaN, 1)),
-      CheckLastBatch((canonicalNaN, 1)),
-      assertNumStateRows(total = 1, updated = 1),
-      AddData(inputData, (otherNan, 2)),
-      CheckLastBatch(),
-      assertNumStateRows(total = 1, updated = 0),
-      CheckAnswer((canonicalNaN, 1))
-    )
-  }
-
-  test("different NaN bit patterns should be deduplicated") {
-    val inputData = MemoryStream[(Float, Int)]
-    val result = inputData.toDS().toDF("value", "id").dropDuplicates("value")
-
-    // Canonical quiet NaN (0x7fc00000) and non-canonical signaling NaN (0x7f800001).
-    val canonicalNaN = java.lang.Float.intBitsToFloat(0x7fc00000)
-    val nonCanonicalNaN = java.lang.Float.intBitsToFloat(0x7f800001)
-    assert(java.lang.Float.isNaN(canonicalNaN) && java.lang.Float.isNaN(nonCanonicalNaN))
-    assert(java.lang.Float.floatToRawIntBits(canonicalNaN) !=
-      java.lang.Float.floatToRawIntBits(nonCanonicalNaN))
 
     testStream(result, Append)(
       AddData(inputData, (canonicalNaN, 1)),
       CheckLastBatch((canonicalNaN, 1)),
       assertNumStateRows(total = 1, updated = 1),
 
-      // Non-canonical NaN should be treated as a duplicate of canonical NaN
-      AddData(inputData, (nonCanonicalNaN, 2)),
+      AddData(inputData, (canonicalNaN, 2)),
       CheckLastBatch(),
       assertNumStateRows(total = 1, updated = 0),
 
-      // Only the first NaN row should be in the complete output
       CheckAnswer((canonicalNaN, 1))
     )
   }
+
+  /**
+   * Tests that different NaN bit patterns are deduplicated for a given key type.
+   * `buildKey` transforms the base DataFrame (columns: f, id) to add a "key" column.
+   */
+  private def testNaNDedup(keyDesc: String, buildKey: DataFrame => DataFrame): Unit = {
+    test(s"NaN normalization in dedup key: $keyDesc") {
+      val inputData = MemoryStream[(Float, Int)]
+      val base = inputData.toDS().toDF("f", "id")
+      val result = buildKey(base).dropDuplicates("key").select("f", "id")
+
+      testStream(result, Append)(
+        AddData(inputData, (canonicalNaN, 1)),
+        CheckLastBatch((canonicalNaN, 1)),
+        assertNumStateRows(total = 1, updated = 1),
+
+        // Non-canonical NaN should be treated as a duplicate
+        AddData(inputData, (nonCanonicalNaN, 2)),
+        CheckLastBatch(),
+        assertNumStateRows(total = 1, updated = 0),
+
+        CheckAnswer((canonicalNaN, 1))
+      )
+    }
+  }
+
+  testNaNDedup("scalar float", _.withColumn("key", col("f")))
+  testNaNDedup("struct containing float", _.withColumn("key", struct(col("f"))))
+  testNaNDedup("array containing float", _.withColumn("key", array(col("f"))))
 
   test("negative zero and positive zero should be deduplicated") {
     val inputData = MemoryStream[(Float, Int)]
@@ -116,7 +125,6 @@ class StreamingDeduplicationSuite extends StateStoreMetricsTest
       CheckLastBatch((0.0f, 1)),
       assertNumStateRows(total = 1, updated = 1),
 
-      // -0.0f should be treated as a duplicate of 0.0f
       AddData(inputData, (-0.0f, 2)),
       CheckLastBatch(),
       assertNumStateRows(total = 1, updated = 0),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

title - adds a project operator before the streaming dedupe node when any of the keys are double/floats

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

if two NaNs have different bits, but are both NaN, they won't be deduplicated. They should be deduplicated.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

yes - NaNs with different bit patterns are now deduplicated/considered duplicates.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
adde UT

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: claude 2.1.88 (Claude Code)