### PR TITLE
[SPARK-56286][PYTHON] Add DataFrame.dataQuality API for column profiling

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -3380,6 +3380,188 @@ class DataFrame:
         """
         ...
 
+    def dataQuality(self) -> "DataFrame":
+        """Profiles column-level and dataset-level data quality metrics.
+
+        This method returns one row per input column plus one synthetic
+        ``__dataset__`` row containing overall dataset completeness metrics.
+        The resulting :class:`DataFrame` includes null counts, null ratios,
+        distinct counts, min/max, mode, and numeric statistics such as mean,
+        standard deviation, and median.
+
+        Notes
+        -----
+        This function is meant for exploratory data analysis, as we make no
+        guarantee about the backward compatibility of the schema of the resulting
+        :class:`DataFrame`.
+
+        .. versionadded:: 4.1.0
+
+        Returns
+        -------
+        :class:`DataFrame`
+            A new DataFrame that profiles the input DataFrame.
+
+        Examples
+        --------
+        >>> df = spark.createDataFrame(
+        ...     [(1, 10.0, "ok"), (2, None, "ok"), (None, 30.0, None)],
+        ...     ["id", "score", "status"],
+        ... )
+        >>> df.dataQuality().select("column", "null_count", "mean", "median").show()
+        +-----------+----------+----+------+
+        |     column|null_count|mean|median|
+        +-----------+----------+----+------+
+        |         id|         1| 1.5|   1.0|
+        |      score|         1|20.0|  10.0|
+        |     status|         1|NULL|  NULL|
+        |__dataset__|         3|NULL|  NULL|
+        +-----------+----------+----+------+
+        """
+        from pyspark.sql import functions as F
+        from pyspark.sql.types import (
+            DoubleType,
+            FloatType,
+            LongType,
+            NumericType,
+            StringType,
+            StructField,
+            StructType,
+        )
+
+        def _is_missing(column_name: str, data_type: Any) -> Column:
+            column = F.col(column_name)
+            if isinstance(data_type, (DoubleType, FloatType)):
+                return column.isNull() | F.isnan(column)
+            return column.isNull()
+
+        fields = list(self.schema.fields)
+        agg_exprs: List[Column] = [F.count("*").alias("__row_count")]
+
+        for idx, field in enumerate(fields):
+            missing = _is_missing(field.name, field.dataType)
+            valid_as_string = F.when(~missing, F.col(field.name).cast("string"))
+
+            agg_exprs.extend(
+                [
+                    F.sum(F.when(missing, 1).otherwise(0)).cast("long").alias(
+                        f"__null_count_{idx}"
+                    ),
+                    F.sum(F.when(~missing, 1).otherwise(0)).cast("long").alias(
+                        f"__non_null_count_{idx}"
+                    ),
+                    F.countDistinct(valid_as_string).cast("long").alias(f"__distinct_count_{idx}"),
+                    F.min(valid_as_string).alias(f"__min_{idx}"),
+                    F.max(valid_as_string).alias(f"__max_{idx}"),
+                ]
+            )
+
+            if isinstance(field.dataType, NumericType):
+                valid_numeric = F.when(~missing, F.col(field.name))
+                agg_exprs.extend(
+                    [
+                        F.avg(valid_numeric).cast("double").alias(f"__mean_{idx}"),
+                        F.stddev(valid_numeric).cast("double").alias(f"__stddev_{idx}"),
+                        F.percentile_approx(valid_numeric, 0.5, 10000)
+                        .cast("double")
+                        .alias(f"__median_{idx}"),
+                    ]
+                )
+
+        profile = self.agg(*agg_exprs).first()
+        assert profile is not None
+
+        row_count = int(profile["__row_count"])
+        column_count = len(fields)
+        rows: List[Tuple[Any, ...]] = []
+        total_null_count = 0
+        total_non_null_count = 0
+
+        for idx, field in enumerate(fields):
+            null_count = int(profile[f"__null_count_{idx}"])
+            non_null_count = int(profile[f"__non_null_count_{idx}"])
+            total_null_count += null_count
+            total_non_null_count += non_null_count
+
+            mode_row = (
+                self.where(~_is_missing(field.name, field.dataType))
+                .groupBy(F.col(field.name).cast("string").alias("value"))
+                .count()
+                .orderBy(F.desc("count"), F.asc("value"))
+                .first()
+            )
+            mode = None if mode_row is None else mode_row["value"]
+
+            mean = profile[f"__mean_{idx}"] if isinstance(field.dataType, NumericType) else None
+            stddev = (
+                profile[f"__stddev_{idx}"] if isinstance(field.dataType, NumericType) else None
+            )
+            median = (
+                profile[f"__median_{idx}"] if isinstance(field.dataType, NumericType) else None
+            )
+
+            rows.append(
+                (
+                    field.name,
+                    field.dataType.simpleString(),
+                    row_count,
+                    1,
+                    row_count,
+                    non_null_count,
+                    null_count,
+                    float(null_count) / row_count if row_count else 0.0,
+                    int(profile[f"__distinct_count_{idx}"]),
+                    mean,
+                    stddev,
+                    median,
+                    profile[f"__min_{idx}"],
+                    profile[f"__max_{idx}"],
+                    mode,
+                )
+            )
+
+        total_cells = row_count * column_count
+        rows.append(
+            (
+                "__dataset__",
+                "dataset",
+                row_count,
+                column_count,
+                total_cells,
+                total_non_null_count,
+                total_null_count,
+                float(total_null_count) / total_cells if total_cells else 0.0,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+        )
+
+        schema = StructType(
+            [
+                StructField("column", StringType(), False),
+                StructField("data_type", StringType(), False),
+                StructField("row_count", LongType(), False),
+                StructField("column_count", LongType(), False),
+                StructField("total_cells", LongType(), False),
+                StructField("non_null_count", LongType(), False),
+                StructField("null_count", LongType(), False),
+                StructField("null_ratio", DoubleType(), False),
+                StructField("distinct_count", LongType(), True),
+                StructField("mean", DoubleType(), True),
+                StructField("stddev", DoubleType(), True),
+                StructField("median", DoubleType(), True),
+                StructField("min", StringType(), True),
+                StructField("max", StringType(), True),
+                StructField("mode", StringType(), True),
+            ]
+        )
+        return self.sparkSession.createDataFrame(rows, schema=schema)
+
     @overload
     def head(self) -> Optional[Row]: ...
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -3444,12 +3444,12 @@ class DataFrame:
 
             agg_exprs.extend(
                 [
-                    F.sum(F.when(missing, 1).otherwise(0)).cast("long").alias(
-                        f"__null_count_{idx}"
-                    ),
-                    F.sum(F.when(~missing, 1).otherwise(0)).cast("long").alias(
-                        f"__non_null_count_{idx}"
-                    ),
+                    F.sum(F.when(missing, 1).otherwise(0))
+                    .cast("long")
+                    .alias(f"__null_count_{idx}"),
+                    F.sum(F.when(~missing, 1).otherwise(0))
+                    .cast("long")
+                    .alias(f"__non_null_count_{idx}"),
                     F.countDistinct(valid_as_string).cast("long").alias(f"__distinct_count_{idx}"),
                     F.min(valid_as_string).alias(f"__min_{idx}"),
                     F.max(valid_as_string).alias(f"__max_{idx}"),
@@ -3493,12 +3493,8 @@ class DataFrame:
             mode = None if mode_row is None else mode_row["value"]
 
             mean = profile[f"__mean_{idx}"] if isinstance(field.dataType, NumericType) else None
-            stddev = (
-                profile[f"__stddev_{idx}"] if isinstance(field.dataType, NumericType) else None
-            )
-            median = (
-                profile[f"__median_{idx}"] if isinstance(field.dataType, NumericType) else None
-            )
+            stddev = profile[f"__stddev_{idx}"] if isinstance(field.dataType, NumericType) else None
+            median = profile[f"__median_{idx}"] if isinstance(field.dataType, NumericType) else None
 
             rows.append(
                 (

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -204,6 +204,62 @@ class DataFrameTestsMixin:
         pydoc.render_doc(df.foo)
         pydoc.render_doc(df.take(1))
 
+    def test_data_quality(self):
+        df = self.spark.createDataFrame(
+            [
+                (1, 10.0, "x"),
+                (2, None, "x"),
+                (None, 30.0, None),
+                (2, 20.0, "y"),
+                (3, float("nan"), "x"),
+            ],
+            ["id", "score", "label"],
+        )
+
+        rows = {row["column"]: row.asDict(recursive=True) for row in df.dataQuality().collect()}
+
+        self.assertEqual(set(rows.keys()), {"id", "score", "label", "__dataset__"})
+
+        id_row = rows["id"]
+        self.assertEqual(id_row["data_type"], "bigint")
+        self.assertEqual(id_row["row_count"], 5)
+        self.assertEqual(id_row["column_count"], 1)
+        self.assertEqual(id_row["total_cells"], 5)
+        self.assertEqual(id_row["non_null_count"], 4)
+        self.assertEqual(id_row["null_count"], 1)
+        self.assertAlmostEqual(id_row["null_ratio"], 0.2)
+        self.assertEqual(id_row["distinct_count"], 3)
+        self.assertAlmostEqual(id_row["mean"], 2.0)
+        self.assertAlmostEqual(id_row["median"], 2.0)
+        self.assertEqual(id_row["min"], "1")
+        self.assertEqual(id_row["max"], "3")
+        self.assertEqual(id_row["mode"], "2")
+
+        score_row = rows["score"]
+        self.assertEqual(score_row["non_null_count"], 3)
+        self.assertEqual(score_row["null_count"], 2)
+        self.assertAlmostEqual(score_row["mean"], 20.0)
+        self.assertAlmostEqual(score_row["median"], 20.0)
+        self.assertEqual(score_row["min"], "10.0")
+        self.assertEqual(score_row["max"], "30.0")
+
+        label_row = rows["label"]
+        self.assertEqual(label_row["non_null_count"], 4)
+        self.assertEqual(label_row["null_count"], 1)
+        self.assertEqual(label_row["distinct_count"], 2)
+        self.assertIsNone(label_row["mean"])
+        self.assertEqual(label_row["mode"], "x")
+
+        dataset_row = rows["__dataset__"]
+        self.assertEqual(dataset_row["data_type"], "dataset")
+        self.assertEqual(dataset_row["row_count"], 5)
+        self.assertEqual(dataset_row["column_count"], 3)
+        self.assertEqual(dataset_row["total_cells"], 15)
+        self.assertEqual(dataset_row["non_null_count"], 11)
+        self.assertEqual(dataset_row["null_count"], 4)
+        self.assertAlmostEqual(dataset_row["null_ratio"], 4.0 / 15.0)
+        self.assertIsNone(dataset_row["mean"])
+
     def test_drop(self):
         df = self.spark.createDataFrame([("A", 50, "Y"), ("B", 60, "Y")], ["name", "age", "active"])
         self.assertEqual(df.drop("active").columns, ["name", "age"])


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a new PySpark `DataFrame.dataQuality()` API for exploratory dataset profiling.

The new method returns a DataFrame with one row per input column and one synthetic `__dataset__` row for overall dataset-level completeness metrics. The output includes `row_count`, `column_count`, `total_cells`, `non_null_count`, `null_count`, `null_ratio`, `distinct_count`, `min`, `max`, and `mode`. For numeric columns, it also includes `mean`, `stddev`, and `median`.

This PR also adds PySpark unit test coverage for the new API, including null handling, `NaN` handling for floating-point columns, numeric profiling, categorical mode, and overall dataset metrics.

### Why are the changes needed?

PySpark currently provides `describe()` and `summary()`, but there is no built-in API focused on practical data quality profiling.

A common early step in exploratory analysis is understanding completeness and basic quality characteristics of a dataset, such as null distribution, distinct values, central tendency, and per-column summary metrics. Today, users typically have to compose several custom aggregations to gather this information. This change makes that workflow easier and more discoverable through a single DataFrame API.

### Does this PR introduce _any_ user-facing change?

Yes.

This PR introduces a new PySpark API:

```python
df.dataQuality()
```

Example:

```python
df = spark.createDataFrame(
    [(1, 10.0, "ok"), (2, None, "ok"), (None, 30.0, None)],
    ["id", "score", "status"],
)

df.dataQuality().show()
```

This allows users to retrieve column-level and dataset-level quality metrics directly from a DataFrame without composing multiple manual aggregations.

### How was this patch tested?

Added a new PySpark test in `python/pyspark/sql/tests/test_dataframe.py`.

The test covers:

- per-column null and non-null counts
- dataset-level completeness metrics
- distinct counts
- mean and median for numeric columns
- mode for categorical columns
- `NaN` handling for floating-point columns

I also verified that the modified Python files compile successfully with:

```bash
python -m py_compile python/pyspark/sql/dataframe.py python/pyspark/sql/tests/test_dataframe.py
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)