### PR TITLE
[SPARK-56295][PYTHON] Add Java error classes to Python side

### DIFF
--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -15,14 +15,42 @@
 # limitations under the License.
 #
 
+import glob
 import json
 import importlib.resources
+import os
+import zipfile
+from pyspark.find_spark_home import _find_spark_home
 
 # Note: Though we call them "error classes" here, the proper name is "error conditions",
 #   hence why the name of the JSON file is different.
 #   For more information, please see: https://issues.apache.org/jira/browse/SPARK-46810
 #   This discrepancy will be resolved as part of: https://issues.apache.org/jira/browse/SPARK-47429
-ERROR_CLASSES_JSON = (
-    importlib.resources.files("pyspark.errors").joinpath("error-conditions.json").read_text()
-)
-ERROR_CLASSES_MAP = json.loads(ERROR_CLASSES_JSON)
+
+
+def get_error_classes():
+    python_error_classes_json = (
+        importlib.resources.files("pyspark.errors").joinpath("error-conditions.json").read_text()
+    )
+    python_error_classes_map = json.loads(python_error_classes_json)
+
+    # We load the Java error classes from the jars so Python recognizes them too
+    java_error_classes_map = {}
+    spark_home = _find_spark_home()
+
+    # Released spark packages have the jars in SPARK_HOME/jars, and development builds have them
+    # in assembly/target
+    for bin_dir in ("jars", "assembly/target/scala-*/jars"):
+        bin_path = os.path.join(spark_home, bin_dir)
+        jars = glob.glob(os.path.join(bin_path, "spark-common-utils_*.jar"))
+        if jars:
+            with zipfile.ZipFile(jars[0]) as zf:
+                with zf.open("error/error-conditions.json") as f:
+                    java_error_classes_json = f.read().decode("utf-8")
+                    java_error_classes_map = json.loads(java_error_classes_json)
+                    break
+
+    return java_error_classes_map | python_error_classes_map
+
+
+ERROR_CLASSES_MAP = get_error_classes()

--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -28,7 +28,7 @@ from pyspark.find_spark_home import _find_spark_home
 #   This discrepancy will be resolved as part of: https://issues.apache.org/jira/browse/SPARK-47429
 
 
-def get_error_classes():
+def get_error_classes() -> dict[str, dict]:
     python_error_classes_json = (
         importlib.resources.files("pyspark.errors").joinpath("error-conditions.json").read_text()
     )

--- a/python/pyspark/errors/tests/test_errors.py
+++ b/python/pyspark/errors/tests/test_errors.py
@@ -16,19 +16,23 @@
 # limitations under the License.
 #
 
+import importlib.resources
 import json
 import unittest
 
 from pyspark.errors import PySparkRuntimeError, PySparkValueError
-from pyspark.errors.error_classes import ERROR_CLASSES_JSON
 from pyspark.errors.utils import ErrorClassesReader
 
 
 class ErrorsTest(unittest.TestCase):
     def test_error_classes_sorted(self):
         # Test error classes is sorted alphabetically
-        error_reader = ErrorClassesReader()
-        error_class_names = list(error_reader.error_info_map.keys())
+        ERROR_CLASSES_JSON = (
+            importlib.resources.files("pyspark.errors")
+            .joinpath("error-conditions.json")
+            .read_text()
+        )
+        error_class_names = list(json.loads(ERROR_CLASSES_JSON).keys())
         for i in range(len(error_class_names) - 1):
             self.assertTrue(
                 error_class_names[i] < error_class_names[i + 1],
@@ -47,6 +51,12 @@ class ErrorsTest(unittest.TestCase):
                 self.assertTrue(name not in error_classes_json, f"Duplicate error class: {name}")
                 error_classes_json[name] = message
             return error_classes_json
+
+        ERROR_CLASSES_JSON = (
+            importlib.resources.files("pyspark.errors")
+            .joinpath("error-conditions.json")
+            .read_text()
+        )
 
         json.loads(ERROR_CLASSES_JSON, object_pairs_hook=detect_duplication)
 
@@ -107,6 +117,11 @@ class ErrorsTest(unittest.TestCase):
         )
         subclass_map = error_reader.error_info_map["TEST_ERROR_WITH_SUB_CLASS"]["sub_class"]
         self.assertEqual(breaking_change_info2, subclass_map["SUBCLASS"]["breaking_change_info"])
+
+    def test_java_error_classes(self):
+        error_reader = ErrorClassesReader()
+        msg = error_reader.get_error_message("AGGREGATE_OUT_OF_MEMORY", {})
+        self.assertEqual(msg, "No enough memory for aggregation")
 
     def test_sqlstate(self):
         error = PySparkRuntimeError(errorClass="APPLICATION_NAME_NOT_SET", messageParameters={})

--- a/python/pyspark/errors_doc_gen.py
+++ b/python/pyspark/errors_doc_gen.py
@@ -1,6 +1,6 @@
+import importlib.resources
+import json
 import re
-
-from pyspark.errors.error_classes import ERROR_CLASSES_MAP
 
 
 def generate_errors_doc(output_rst_file_path: str) -> None:
@@ -47,7 +47,13 @@ When writing PySpark errors, developers must use an error class from the list. I
 """
     with open(output_rst_file_path, "w") as f:
         f.write(header + "\n\n")
-        for error_key, error_details in ERROR_CLASSES_MAP.items():
+        python_error_classes_json = (
+            importlib.resources.files("pyspark.errors")
+            .joinpath("error-conditions.json")
+            .read_text()
+        )
+        python_error_classes_map = json.loads(python_error_classes_json)
+        for error_key, error_details in python_error_classes_map.items():
             f.write(error_key + "\n")
             # The length of the error class name and underline must be the same
             # to satisfy the RST format.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Include Java side error classes in Python so python can generate consistent error messages as Java with the same error class + message parameters.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently we have two separate `error-conditions.json` files, for Python and Java. I think it's historical reason that we can't easily load Java's json on Python so we created a Python specific one. The issue is that two files are unsynced. It's possible that we want to raise the same error on both Python and Java, and we either need to create a new error class on Python json file or forget to do that and break message generation.

Ideally we should have a single source of truth, which is achievable now by merging every existing Python error classes into Java one. But there could be unexpected consequences and it's difficult to split them back once it's merged. Moreover, the Python file contains some python-specific error classes which may not fit into the java file.

As a compromise, we keep the Python file and load the Java file from Python. We keep the current structure and make it more flexible. In the future, if we have a clear plan of which way we should go, we can always eliminate the Python json file.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

A new test is added to test Python can raise Java-specific error class.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.