### PR TITLE
[SPARK-56298] Enable `spark.master.rest.virtualThread.enabled` by default

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2061,7 +2061,7 @@ package object config {
       .doc("If true, Spark master tries to use Java 21 virtual thread for REST API.")
       .version("4.0.0")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   private[spark] val MASTER_UI_PORT = ConfigBuilder("spark.master.ui.port")
     .version("1.1.0")

--- a/docs/core-migration-guide.md
+++ b/docs/core-migration-guide.md
@@ -24,6 +24,8 @@ license: |
 
 ## Upgrading from Core 4.1 to 4.2
 
+- Since Spark 4.2, Spark Master REST API uses Java 21 virtual threads by default when running on Java 21 or later. To restore the legacy behavior, you can set `spark.master.rest.virtualThread.enabled` to `false`.
+
 - Since Spark 4.2, Spark will allocate executor pods with a batch size of `20`. To restore the legacy behavior, you can set `spark.kubernetes.allocation.batch.size` to `10`.
 
 - Since Spark 4.2, Spark configures a `NetworkPolicy` by default so that executor pods only accept ingress traffic from the driver and peer executors within the same job. To disable this and restore the legacy behavior, set `spark.kubernetes.driver.pod.excludedFeatureSteps` to `org.apache.spark.deploy.k8s.features.NetworkPolicyFeatureStep`.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes the default value of `spark.master.rest.virtualThread.enabled` from `false` to `true`.

### Why are the changes needed?

Since Apache Spark 4.0.0 introduced this feature, we have been using this on Java 21+.
- https://github.com/apache/spark/pull/48923

The runtime guard (`Utils.isJavaVersionAtLeast21`) already exists in `RestSubmissionServer`, so enabling this by default is safe:
- On Java 17: no behavior change (virtual threads are not activated)
- On Java 21+: virtual threads are automatically used for the Master REST API, improving scalability

### Does this PR introduce _any_ user-facing change?

Yes. On Java 21+, the Spark Master REST API server now uses virtual threads by default. The migration guide is updated. To restore the previous behavior, set `spark.master.rest.virtualThread.enabled` to `false`.

### How was this patch tested?

Pass the existing tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.6 with 1M context)