### PR TITLE
[SPARK-49793][PYTHON][TESTS] Reenable test_caching for predict_batch_udf

### DIFF
--- a/python/pyspark/ml/tests/test_functions.py
+++ b/python/pyspark/ml/tests/test_functions.py
@@ -18,7 +18,6 @@ import unittest
 
 import numpy as np
 
-from pyspark.loose_version import LooseVersion
 from pyspark.ml.linalg import DenseVector
 from pyspark.ml.functions import array_to_vector, vector_to_array, predict_batch_udf
 from pyspark.sql.functions import array, struct, col
@@ -67,6 +66,11 @@ class ArrayVectorConversionTests(ArrayVectorConversionTestsMixin, ReusedSQLTestC
 
 
 class PredictBatchUDFTestsMixin:
+    @classmethod
+    def master(cls):
+        # test_caching requires all the workload to be executed on the same worker
+        return "local[1]"
+
     def setUp(self):
         import pandas as pd
 
@@ -225,10 +229,6 @@ class PredictBatchUDFTestsMixin:
         batch_sizes = preds["preds"].to_numpy()
         self.assertTrue(all(batch_sizes <= batch_size))
 
-    # TODO(SPARK-49793): enable the test below
-    @unittest.skipIf(
-        LooseVersion(np.__version__) >= LooseVersion("2"), "Caching does not work with numpy 2"
-    )
     def test_caching(self):
         def make_predict_fn():
             # emulate loading a model, this should only be invoked once (per worker process)
@@ -241,7 +241,8 @@ class PredictBatchUDFTestsMixin:
 
         identity = predict_batch_udf(make_predict_fn, return_type=DoubleType(), batch_size=5)
 
-        # results should be the same
+        # Notice that we can't rely on a consistent partition to worker assignment, so we need to
+        # run all the workload on the same worker to ensure the same results.
         df1 = self.df.withColumn("preds", identity(struct("a"))).toPandas()
         df2 = self.df.withColumn("preds", identity(struct("a"))).toPandas()
         self.assertTrue(df1.equals(df2))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Set the worker number of `PredictBatchUDFTestsMixin` to `1` and reenable `test_caching`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The previous test is fundamentally flaky because it requires a strict partition to worker mapping for two jobs. It's never about numpy2 vs numpy1, it's the partition strategy and timing requirements. Each worker will have its own predict UDF and the only way this works is to make sure two calls of `self.df.withColumn("preds", identity(struct("a"))).toPandas()` are partitioned and assigned to the workers in the exact same way.

Some of our CIs are failing https://github.com/apache/spark/actions/runs/23589024473/job/68689585748 (other CIs are not impacted because the test was disabled for numpy>=2.0).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Locally it passed, waiting for CI.