### PR TITLE
[SPARK-56300][K8S] Add Java-friendly factory method to `KubernetesDriverSpec`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesDriverSpec.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesDriverSpec.scala
@@ -16,6 +16,10 @@
  */
 package org.apache.spark.deploy.k8s
 
+import java.util.{List => JList, Map => JMap}
+
+import scala.jdk.CollectionConverters._
+
 import io.fabric8.kubernetes.api.model.HasMetadata
 
 import org.apache.spark.annotation.{DeveloperApi, Since, Unstable}
@@ -34,3 +38,20 @@ case class KubernetesDriverSpec(
     driverPreKubernetesResources: Seq[HasMetadata],
     driverKubernetesResources: Seq[HasMetadata],
     systemProperties: Map[String, String])
+
+@Unstable
+@DeveloperApi
+object KubernetesDriverSpec {
+  @Since("4.2.0")
+  def create(
+      pod: SparkPod,
+      driverPreKubernetesResources: JList[HasMetadata],
+      driverKubernetesResources: JList[HasMetadata],
+      systemProperties: JMap[String, String]): KubernetesDriverSpec = {
+    KubernetesDriverSpec(
+      pod,
+      driverPreKubernetesResources.asScala.toSeq,
+      driverKubernetesResources.asScala.toSeq,
+      systemProperties.asScala.toMap)
+  }
+}

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesDriverSpecSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesDriverSpecSuite.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.k8s
+
+import java.util.{Arrays, HashMap}
+
+import io.fabric8.kubernetes.api.model.{ContainerBuilder, HasMetadata, PodBuilder, SecretBuilder}
+
+import org.apache.spark.SparkFunSuite
+
+class KubernetesDriverSpecSuite extends SparkFunSuite {
+
+  private val POD = new PodBuilder()
+    .withNewMetadata().withName("driver").endMetadata()
+    .withNewSpec().endSpec()
+    .build()
+  private val CONTAINER = new ContainerBuilder().withName("driver-container").build()
+  private val SPARK_POD = SparkPod(POD, CONTAINER)
+
+  test("create from Java collections") {
+    val secret = new SecretBuilder()
+      .withNewMetadata().withName("test-secret").endMetadata()
+      .build()
+    val preResources = Arrays.asList[HasMetadata](secret)
+    val resources = Arrays.asList[HasMetadata](secret)
+    val props = new HashMap[String, String]()
+    props.put("spark.key1", "value1")
+    props.put("spark.key2", "value2")
+
+    val spec = KubernetesDriverSpec.create(SPARK_POD, preResources, resources, props)
+
+    assert(spec.pod === SPARK_POD)
+    assert(spec.driverPreKubernetesResources.length === 1)
+    assert(spec.driverPreKubernetesResources.head === secret)
+    assert(spec.driverKubernetesResources.length === 1)
+    assert(spec.driverKubernetesResources.head === secret)
+    assert(spec.systemProperties === Map("spark.key1" -> "value1", "spark.key2" -> "value2"))
+  }
+
+  test("create from empty Java collections") {
+    val preResources = Arrays.asList[HasMetadata]()
+    val resources = Arrays.asList[HasMetadata]()
+    val props = new HashMap[String, String]()
+
+    val spec = KubernetesDriverSpec.create(SPARK_POD, preResources, resources, props)
+
+    assert(spec.pod === SPARK_POD)
+    assert(spec.driverPreKubernetesResources.isEmpty)
+    assert(spec.driverKubernetesResources.isEmpty)
+    assert(spec.systemProperties.isEmpty)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a Java-friendly `create` factory method to `KubernetesDriverSpec` companion object that accepts `java.util.List` and `java.util.Map` instead of Scala `Seq` and `Map`.

### Why are the changes needed?

`KubernetesDriverSpec` is a `@DeveloperApi` public class used by external projects such as the `Apache Spark K8s Operator`. Since it exposes Scala collection types (`Seq[HasMetadata]`, `Map[String, String]`), Java callers must manually convert Java collections to Scala equivalents. The new `create` method provides a convenient entry point for Java users.

### Does this PR introduce _any_ user-facing change?

No behavior change because this is a new additional API.

### How was this patch tested?

Pass the CIs with newly added test suite.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)