### PR TITLE
[SPARK-56279][CORE][4.1] Enable zero-copy sendfile for FileRegion in native Netty transports

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/protocol/MessageEncoder.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/protocol/MessageEncoder.java
@@ -22,12 +22,14 @@ import java.util.List;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.FileRegion;
 import io.netty.handler.codec.MessageToMessageEncoder;
 
 import org.apache.spark.internal.LogKeys;
 import org.apache.spark.internal.SparkLogger;
 import org.apache.spark.internal.SparkLoggerFactory;
 import org.apache.spark.internal.MDC;
+import org.apache.spark.network.buffer.FileSegmentManagedBuffer;
 
 /**
  * Encoder used by the server side to encode server-to-client responses.
@@ -89,9 +91,24 @@ public final class MessageEncoder extends MessageToMessageEncoder<Message> {
     assert header.writableBytes() == 0;
 
     if (body != null) {
-      // We transfer ownership of the reference on in.body() to MessageWithHeader.
-      // This reference will be freed when MessageWithHeader.deallocate() is called.
-      out.add(new MessageWithHeader(in.body(), header, body, bodyLength));
+      if (body instanceof FileRegion && in.body() instanceof FileSegmentManagedBuffer) {
+        // Emit header and FileRegion as separate objects so that native transports
+        // (EPOLL, KQUEUE) can apply zero-copy sendfile/splice on the FileRegion directly.
+        // When wrapped in MessageWithHeader, native transports fall into a generic
+        // FileRegion.transferTo() fallback that copies data through user-space, bypassing
+        // the optimized sendfile() path.
+        //
+        // This split is only safe when the ManagedBuffer is FileSegmentManagedBuffer,
+        // whose release() is a no-op. Other ManagedBuffer types (e.g.,
+        // BlockManagerManagedBuffer) perform resource cleanup in release() that must be
+        // tied to the write lifecycle via MessageWithHeader.deallocate().
+        out.add(header);
+        out.add(body);
+      } else {
+        // We transfer ownership of the reference on in.body() to MessageWithHeader.
+        // This reference will be freed when MessageWithHeader.deallocate() is called.
+        out.add(new MessageWithHeader(in.body(), header, body, bodyLength));
+      }
     } else {
       out.add(header);
     }

--- a/common/network-common/src/test/java/org/apache/spark/network/protocol/MergedBlockMetaSuccessSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/protocol/MergedBlockMetaSuccessSuite.java
@@ -28,6 +28,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.DefaultFileRegion;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.roaringbitmap.RoaringBitmap;
@@ -70,14 +71,25 @@ public class MergedBlockMetaSuccessSuite {
     when(context.alloc()).thenReturn(ByteBufAllocator.DEFAULT);
 
     MessageEncoder.INSTANCE.encode(context, expectedMeta, out);
-    Assertions.assertEquals(1, out.size());
-    MessageWithHeader msgWithHeader = (MessageWithHeader) out.remove(0);
+    // FileSegmentManagedBuffer.convertToNetty() returns a DefaultFileRegion,
+    // so MessageEncoder splits the output into header ByteBuf + FileRegion.
+    Assertions.assertEquals(2, out.size());
+    Assertions.assertInstanceOf(ByteBuf.class, out.get(0));
+    Assertions.assertInstanceOf(DefaultFileRegion.class, out.get(1));
+    ByteBuf headerBuf = (ByteBuf) out.remove(0);
+    DefaultFileRegion fileRegion = (DefaultFileRegion) out.remove(0);
 
-    ByteArrayWritableChannel writableChannel =
-      new ByteArrayWritableChannel((int) msgWithHeader.count());
-    while (msgWithHeader.transfered() < msgWithHeader.count()) {
-      msgWithHeader.transferTo(writableChannel, msgWithHeader.transfered());
+    int totalLen = headerBuf.readableBytes() + (int) fileRegion.count();
+    ByteArrayWritableChannel writableChannel = new ByteArrayWritableChannel(totalLen);
+    // Write header
+    writableChannel.write(headerBuf.nioBuffer());
+    // Write file region body
+    fileRegion.open();
+    while (fileRegion.transferred() < fileRegion.count()) {
+      fileRegion.transferTo(writableChannel, fileRegion.transferred());
     }
+    fileRegion.release();
+    headerBuf.release();
     ByteBuf messageBuf = Unpooled.wrappedBuffer(writableChannel.getData());
     messageBuf.readLong(); // frame length
     MessageDecoder.INSTANCE.decode(mock(ChannelHandlerContext.class), messageBuf, out);

--- a/core/benchmarks/NettyTransportBenchmark-jdk21-results.txt
+++ b/core/benchmarks/NettyTransportBenchmark-jdk21-results.txt
@@ -6,7 +6,7 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 RPC Latency (1 KB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 KB payload                                        538            552          10          0.0      107614.7       1.0X
+1 KB payload                                        479            503          18          0.0       95759.3       1.0X
 
 
 ================================================================================================
@@ -17,7 +17,7 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 RPC Latency (64 KB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-64 KB payload                                       737            756          12          0.0      147487.1       1.0X
+64 KB payload                                       671            711          24          0.0      134193.1       1.0X
 
 
 ================================================================================================
@@ -28,7 +28,7 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 RPC Latency (1 MB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 MB payload                                        828            946          93          0.0      827804.2       1.0X
+1 MB payload                                        841            869          20          0.0      840764.5       1.0X
 
 
 ================================================================================================
@@ -39,7 +39,7 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 RPC Latency (16 MB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-16 MB payload                                      1364           1422          58          0.0    13641389.0       1.0X
+16 MB payload                                      1216           1343          99          0.0    12156809.2       1.0X
 
 
 ================================================================================================
@@ -50,10 +50,10 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 Concurrent RPC Throughput:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 client(s)                                        1927           2038          98          0.0       96348.3       1.0X
-4 client(s)                                         760            777          15          0.0       37998.2       2.5X
-8 client(s)                                         525            545          18          0.0       26243.9       3.7X
-16 client(s)                                        475            477           2          0.0       23740.8       4.1X
+1 client(s)                                        1910           1939          31          0.0       95483.6       1.0X
+4 client(s)                                         721            753          30          0.0       36054.7       2.6X
+8 client(s)                                         522            530          10          0.0       26080.3       3.7X
+16 client(s)                                        434            448          18          0.0       21696.4       4.4X
 
 
 ================================================================================================
@@ -64,8 +64,8 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 IOMode Comparison:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NIO (8 clients)                                     753            823         115          0.0       37664.7       1.0X
-AUTO (8 clients)                                    838            891          71          0.0       41914.7       0.9X
+NIO (8 clients)                                     757            802          73          0.0       37836.0       1.0X
+AUTO (8 clients)                                    836            841           8          0.0       41783.8       0.9X
 
 
 ================================================================================================
@@ -76,11 +76,11 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 Server Thread Scaling:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-2 server threads                                    475            486          10          0.0       23739.6       1.0X
-4 server threads                                    413            426          22          0.0       20669.4       1.1X
-8 server threads                                    435            452          24          0.0       21760.0       1.1X
-16 server threads                                   437            453          26          0.0       21851.6       1.1X
-32 server threads                                   517            553          59          0.0       25870.9       0.9X
+2 server threads                                    468            483          14          0.0       23408.4       1.0X
+4 server threads                                    399            403           6          0.1       19949.5       1.2X
+8 server threads                                    428            453          32          0.0       21396.6       1.1X
+16 server threads                                   445            472          27          0.0       22236.9       1.1X
+32 server threads                                   477            519          37          0.0       23829.5       1.0X
 
 
 ================================================================================================
@@ -91,9 +91,9 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 Multi-Connection Throughput:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 conn(s), 4 threads                               1678           1771         120          0.0      335512.5       1.0X
-2 conn(s), 4 threads                               1332           1439         102          0.0      266382.3       1.3X
-4 conn(s), 4 threads                               1778           1784           6          0.0      355599.9       0.9X
+1 conn(s), 4 threads                               1692           1756          64          0.0      338440.4       1.0X
+2 conn(s), 4 threads                               1227           1534         274          0.0      245461.7       1.4X
+4 conn(s), 4 threads                               1747           1765          18          0.0      349381.5       1.0X
 
 
 ================================================================================================
@@ -104,9 +104,9 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 Async Write Throughput:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 KB async burst                                     38             52          18          0.1        7668.2       1.0X
-64 KB async burst                                   141            155          22          0.0       28277.2       0.3X
-1 MB async burst                                   1571           1601          46          0.0      314213.1       0.0X
+1 KB async burst                                     57             67           9          0.1       11353.9       1.0X
+64 KB async burst                                   149            159           9          0.0       29737.7       0.4X
+1 MB async burst                                   1316           1417         168          0.0      263248.2       0.0X
 
 
 ================================================================================================
@@ -117,8 +117,8 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 16 MB Block Transfer:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Sequential sends                                    679            896         363          0.0     6790126.3       1.0X
-4-thread parallel sends                             456            460           7          0.0     4563037.9       1.5X
+Sequential sends                                    673           1099         368          0.0     6734864.4       1.0X
+4-thread parallel sends                             430            457          31          0.0     4298940.2       1.6X
 
 
 ================================================================================================
@@ -129,9 +129,9 @@ OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 File-Backed Shuffle Fetch:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NIO, sequential fetch                               387            401          16          0.0     3866419.3       1.0X
-NIO, parallel fetch (4 clients)                     219            220           2          0.0     2192213.7       1.8X
-AUTO, sequential fetch                              388            400          11          0.0     3876821.0       1.0X
-AUTO, parallel fetch (4 clients)                    203            206           5          0.0     2028605.9       1.9X
+NIO, sequential fetch                               382            392          12          0.0     3822462.2       1.0X
+NIO, parallel fetch (4 clients)                     209            223          18          0.0     2086309.5       1.8X
+AUTO, sequential fetch                              372            382          15          0.0     3721206.6       1.0X
+AUTO, parallel fetch (4 clients)                    200            203           4          0.0     1999525.9       1.9X
 
 

--- a/core/benchmarks/NettyTransportBenchmark-jdk21-results.txt
+++ b/core/benchmarks/NettyTransportBenchmark-jdk21-results.txt
@@ -3,10 +3,10 @@ RPC Round-Trip Latency - 1 KB payload (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 RPC Latency (1 KB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 KB payload                                        312            324          14          0.0       62497.5       1.0X
+1 KB payload                                        538            552          10          0.0      107614.7       1.0X
 
 
 ================================================================================================
@@ -14,10 +14,10 @@ RPC Round-Trip Latency - 64 KB payload (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 RPC Latency (64 KB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-64 KB payload                                       435            442           8          0.0       86927.5       1.0X
+64 KB payload                                       737            756          12          0.0      147487.1       1.0X
 
 
 ================================================================================================
@@ -25,10 +25,10 @@ RPC Round-Trip Latency - 1 MB payload (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 RPC Latency (1 MB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 MB payload                                        465            478           8          0.0      465416.7       1.0X
+1 MB payload                                        828            946          93          0.0      827804.2       1.0X
 
 
 ================================================================================================
@@ -36,10 +36,10 @@ RPC Round-Trip Latency - 16 MB payload (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 RPC Latency (16 MB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-16 MB payload                                       800            832          29          0.0     7998535.2       1.0X
+16 MB payload                                      1364           1422          58          0.0    13641389.0       1.0X
 
 
 ================================================================================================
@@ -47,13 +47,13 @@ Concurrent RPC Throughput (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Concurrent RPC Throughput:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 client(s)                                        1264           1270           8          0.0       63217.5       1.0X
-4 client(s)                                         431            438           9          0.0       21569.1       2.9X
-8 client(s)                                         300            307          11          0.1       14983.0       4.2X
-16 client(s)                                        267            274           9          0.1       13371.1       4.7X
+1 client(s)                                        1927           2038          98          0.0       96348.3       1.0X
+4 client(s)                                         760            777          15          0.0       37998.2       2.5X
+8 client(s)                                         525            545          18          0.0       26243.9       3.7X
+16 client(s)                                        475            477           2          0.0       23740.8       4.1X
 
 
 ================================================================================================
@@ -61,11 +61,11 @@ IOMode Comparison (Concurrent Throughput)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 IOMode Comparison:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NIO (8 clients)                                     553            658         151          0.0       27631.8       1.0X
-AUTO (8 clients)                                    490            502          16          0.0       24503.3       1.1X
+NIO (8 clients)                                     753            823         115          0.0       37664.7       1.0X
+AUTO (8 clients)                                    838            891          71          0.0       41914.7       0.9X
 
 
 ================================================================================================
@@ -73,14 +73,14 @@ Server Thread Scaling (IOMode=AUTO, 16 clients)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Server Thread Scaling:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-2 server threads                                    266            275           8          0.1       13285.6       1.0X
-4 server threads                                    236            242           5          0.1       11804.1       1.1X
-8 server threads                                    238            273          31          0.1       11885.5       1.1X
-16 server threads                                   261            276          24          0.1       13028.2       1.0X
-32 server threads                                   260            276          16          0.1       13003.7       1.0X
+2 server threads                                    475            486          10          0.0       23739.6       1.0X
+4 server threads                                    413            426          22          0.0       20669.4       1.1X
+8 server threads                                    435            452          24          0.0       21760.0       1.1X
+16 server threads                                   437            453          26          0.0       21851.6       1.1X
+32 server threads                                   517            553          59          0.0       25870.9       0.9X
 
 
 ================================================================================================
@@ -88,12 +88,12 @@ Multi-Connection Per Peer (IOMode=AUTO, 1MB payload)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Multi-Connection Throughput:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 conn(s), 4 threads                               1730           1754          23          0.0      346078.1       1.0X
-2 conn(s), 4 threads                               1192           1234          41          0.0      238362.5       1.5X
-4 conn(s), 4 threads                               1230           1250          19          0.0      246007.4       1.4X
+1 conn(s), 4 threads                               1678           1771         120          0.0      335512.5       1.0X
+2 conn(s), 4 threads                               1332           1439         102          0.0      266382.3       1.3X
+4 conn(s), 4 threads                               1778           1784           6          0.0      355599.9       0.9X
 
 
 ================================================================================================
@@ -101,12 +101,12 @@ Async Write Pressure (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Async Write Throughput:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 KB async burst                                     45             46           1          0.1        9009.2       1.0X
-64 KB async burst                                   144            209         109          0.0       28863.1       0.3X
-1 MB async burst                                   1675           1721          80          0.0      334900.9       0.0X
+1 KB async burst                                     38             52          18          0.1        7668.2       1.0X
+64 KB async burst                                   141            155          22          0.0       28277.2       0.3X
+1 MB async burst                                   1571           1601          46          0.0      314213.1       0.0X
 
 
 ================================================================================================
@@ -114,11 +114,11 @@ Large Block Transfer Throughput (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 16 MB Block Transfer:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Sequential sends                                    788            813          23          0.0     7875409.8       1.0X
-4-thread parallel sends                             448            457           8          0.0     4480383.9       1.8X
+Sequential sends                                    679            896         363          0.0     6790126.3       1.0X
+4-thread parallel sends                             456            460           7          0.0     4563037.9       1.5X
 
 
 ================================================================================================
@@ -126,12 +126,12 @@ File-Backed Shuffle Block Fetch (NIO vs AUTO, 100x16MB)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 File-Backed Shuffle Fetch:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NIO, sequential fetch                               346            356          14          0.0     3455769.0       1.0X
-NIO, parallel fetch (4 clients)                     209            217          12          0.0     2085147.0       1.7X
-AUTO, sequential fetch                             1304           1326          28          0.0    13042655.6       0.3X
-AUTO, parallel fetch (4 clients)                    489            600          97          0.0     4888981.6       0.7X
+NIO, sequential fetch                               387            401          16          0.0     3866419.3       1.0X
+NIO, parallel fetch (4 clients)                     219            220           2          0.0     2192213.7       1.8X
+AUTO, sequential fetch                              388            400          11          0.0     3876821.0       1.0X
+AUTO, parallel fetch (4 clients)                    203            206           5          0.0     2028605.9       1.9X
 
 

--- a/core/benchmarks/NettyTransportBenchmark-jdk21-results.txt
+++ b/core/benchmarks/NettyTransportBenchmark-jdk21-results.txt
@@ -3,10 +3,10 @@ RPC Round-Trip Latency - 1 KB payload (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-AMD EPYC 7763 64-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 RPC Latency (1 KB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 KB payload                                        479            503          18          0.0       95759.3       1.0X
+1 KB payload                                        331            335           4          0.0       66108.2       1.0X
 
 
 ================================================================================================
@@ -14,10 +14,10 @@ RPC Round-Trip Latency - 64 KB payload (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-AMD EPYC 7763 64-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 RPC Latency (64 KB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-64 KB payload                                       671            711          24          0.0      134193.1       1.0X
+64 KB payload                                       432            445          10          0.0       86379.4       1.0X
 
 
 ================================================================================================
@@ -25,10 +25,10 @@ RPC Round-Trip Latency - 1 MB payload (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-AMD EPYC 7763 64-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 RPC Latency (1 MB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 MB payload                                        841            869          20          0.0      840764.5       1.0X
+1 MB payload                                        455            467           8          0.0      454621.2       1.0X
 
 
 ================================================================================================
@@ -36,10 +36,10 @@ RPC Round-Trip Latency - 16 MB payload (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-AMD EPYC 7763 64-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 RPC Latency (16 MB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-16 MB payload                                      1216           1343          99          0.0    12156809.2       1.0X
+16 MB payload                                       798            802           3          0.0     7982304.4       1.0X
 
 
 ================================================================================================
@@ -47,13 +47,13 @@ Concurrent RPC Throughput (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-AMD EPYC 7763 64-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Concurrent RPC Throughput:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 client(s)                                        1910           1939          31          0.0       95483.6       1.0X
-4 client(s)                                         721            753          30          0.0       36054.7       2.6X
-8 client(s)                                         522            530          10          0.0       26080.3       3.7X
-16 client(s)                                        434            448          18          0.0       21696.4       4.4X
+1 client(s)                                        1246           1287          37          0.0       62282.4       1.0X
+4 client(s)                                         404            419          15          0.0       20185.8       3.1X
+8 client(s)                                         269            297          25          0.1       13440.8       4.6X
+16 client(s)                                        259            268           8          0.1       12953.1       4.8X
 
 
 ================================================================================================
@@ -61,11 +61,11 @@ IOMode Comparison (Concurrent Throughput)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-AMD EPYC 7763 64-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 IOMode Comparison:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NIO (8 clients)                                     757            802          73          0.0       37836.0       1.0X
-AUTO (8 clients)                                    836            841           8          0.0       41783.8       0.9X
+NIO (8 clients)                                     474            485          16          0.0       23677.9       1.0X
+AUTO (8 clients)                                    460            485          28          0.0       22991.0       1.0X
 
 
 ================================================================================================
@@ -73,14 +73,14 @@ Server Thread Scaling (IOMode=AUTO, 16 clients)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-AMD EPYC 7763 64-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Server Thread Scaling:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-2 server threads                                    468            483          14          0.0       23408.4       1.0X
-4 server threads                                    399            403           6          0.1       19949.5       1.2X
-8 server threads                                    428            453          32          0.0       21396.6       1.1X
-16 server threads                                   445            472          27          0.0       22236.9       1.1X
-32 server threads                                   477            519          37          0.0       23829.5       1.0X
+2 server threads                                    276            283           7          0.1       13814.3       1.0X
+4 server threads                                    221            244          22          0.1       11029.7       1.3X
+8 server threads                                    240            260          23          0.1       11986.8       1.2X
+16 server threads                                   248            256           9          0.1       12379.9       1.1X
+32 server threads                                   257            270          15          0.1       12845.1       1.1X
 
 
 ================================================================================================
@@ -88,12 +88,12 @@ Multi-Connection Per Peer (IOMode=AUTO, 1MB payload)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-AMD EPYC 7763 64-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Multi-Connection Throughput:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 conn(s), 4 threads                               1692           1756          64          0.0      338440.4       1.0X
-2 conn(s), 4 threads                               1227           1534         274          0.0      245461.7       1.4X
-4 conn(s), 4 threads                               1747           1765          18          0.0      349381.5       1.0X
+1 conn(s), 4 threads                               1688           1773         127          0.0      337503.3       1.0X
+2 conn(s), 4 threads                               1210           1274          96          0.0      241972.1       1.4X
+4 conn(s), 4 threads                               1140           1147           6          0.0      227969.5       1.5X
 
 
 ================================================================================================
@@ -101,12 +101,12 @@ Async Write Pressure (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-AMD EPYC 7763 64-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Async Write Throughput:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 KB async burst                                     57             67           9          0.1       11353.9       1.0X
-64 KB async burst                                   149            159           9          0.0       29737.7       0.4X
-1 MB async burst                                   1316           1417         168          0.0      263248.2       0.0X
+1 KB async burst                                     46             49           2          0.1        9214.1       1.0X
+64 KB async burst                                   130            138          12          0.0       25985.5       0.4X
+1 MB async burst                                   1598           1602           3          0.0      319655.6       0.0X
 
 
 ================================================================================================
@@ -114,11 +114,11 @@ Large Block Transfer Throughput (IOMode=AUTO)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-AMD EPYC 7763 64-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 16 MB Block Transfer:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Sequential sends                                    673           1099         368          0.0     6734864.4       1.0X
-4-thread parallel sends                             430            457          31          0.0     4298940.2       1.6X
+Sequential sends                                    798            813          13          0.0     7981232.3       1.0X
+4-thread parallel sends                             473            485          10          0.0     4734290.2       1.7X
 
 
 ================================================================================================
@@ -126,12 +126,12 @@ File-Backed Shuffle Block Fetch (NIO vs AUTO, 100x16MB)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
-AMD EPYC 7763 64-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 File-Backed Shuffle Fetch:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NIO, sequential fetch                               382            392          12          0.0     3822462.2       1.0X
-NIO, parallel fetch (4 clients)                     209            223          18          0.0     2086309.5       1.8X
-AUTO, sequential fetch                              372            382          15          0.0     3721206.6       1.0X
-AUTO, parallel fetch (4 clients)                    200            203           4          0.0     1999525.9       1.9X
+NIO, sequential fetch                               353            356           3          0.0     3525033.6       1.0X
+NIO, parallel fetch (4 clients)                     193            231          61          0.0     1931644.9       1.8X
+AUTO, sequential fetch                              347            350           3          0.0     3467489.5       1.0X
+AUTO, parallel fetch (4 clients)                    186            196           8          0.0     1860609.7       1.9X
 
 

--- a/core/benchmarks/NettyTransportBenchmark-results.txt
+++ b/core/benchmarks/NettyTransportBenchmark-results.txt
@@ -6,7 +6,7 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 RPC Latency (1 KB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 KB payload                                        507            520          13          0.0      101304.2       1.0X
+1 KB payload                                        508            533          17          0.0      101559.9       1.0X
 
 
 ================================================================================================
@@ -17,7 +17,7 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 RPC Latency (64 KB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-64 KB payload                                       699            721          21          0.0      139776.4       1.0X
+64 KB payload                                       729            780          30          0.0      145800.9       1.0X
 
 
 ================================================================================================
@@ -28,7 +28,7 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 RPC Latency (1 MB):                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 MB payload                                        862            926          59          0.0      862232.2       1.0X
+1 MB payload                                        837            896          61          0.0      836593.9       1.0X
 
 
 ================================================================================================
@@ -39,7 +39,7 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 RPC Latency (16 MB):                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-16 MB payload                                      1267           1313          54          0.0    12670789.5       1.0X
+16 MB payload                                      1249           1323          52          0.0    12486866.6       1.0X
 
 
 ================================================================================================
@@ -50,10 +50,10 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 Concurrent RPC Throughput:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 client(s)                                        1951           1976          21          0.0       97572.6       1.0X
-4 client(s)                                         663            724          53          0.0       33135.6       2.9X
-8 client(s)                                         489            511          22          0.0       24432.6       4.0X
-16 client(s)                                        453            456           3          0.0       22661.9       4.3X
+1 client(s)                                        2091           2115          21          0.0      104534.5       1.0X
+4 client(s)                                         760            790          26          0.0       37996.5       2.8X
+8 client(s)                                         557            566          10          0.0       27855.0       3.8X
+16 client(s)                                        461            478          26          0.0       23068.9       4.5X
 
 
 ================================================================================================
@@ -64,8 +64,8 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 IOMode Comparison:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NIO (8 clients)                                     756            800          59          0.0       37803.0       1.0X
-AUTO (8 clients)                                    879            894          13          0.0       43947.8       0.9X
+NIO (8 clients)                                     785            864          88          0.0       39253.3       1.0X
+AUTO (8 clients)                                    861            868           6          0.0       43070.4       0.9X
 
 
 ================================================================================================
@@ -76,11 +76,11 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 Server Thread Scaling:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-2 server threads                                    459            472          12          0.0       22963.4       1.0X
-4 server threads                                    392            430          54          0.1       19612.1       1.2X
-8 server threads                                    427            438          17          0.0       21330.4       1.1X
-16 server threads                                   445            456          18          0.0       22247.3       1.0X
-32 server threads                                   457            508          46          0.0       22844.3       1.0X
+2 server threads                                    479            503          24          0.0       23938.2       1.0X
+4 server threads                                    413            429          25          0.0       20659.7       1.2X
+8 server threads                                    455            468          14          0.0       22765.9       1.1X
+16 server threads                                   455            486          34          0.0       22740.7       1.1X
+32 server threads                                   473            513          34          0.0       23672.8       1.0X
 
 
 ================================================================================================
@@ -91,9 +91,9 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 Multi-Connection Throughput:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 conn(s), 4 threads                               1688           1791         155          0.0      337699.8       1.0X
-2 conn(s), 4 threads                               1242           1546         272          0.0      248330.3       1.4X
-4 conn(s), 4 threads                               1625           1687          62          0.0      324991.8       1.0X
+1 conn(s), 4 threads                               1773           1841          62          0.0      354542.2       1.0X
+2 conn(s), 4 threads                               1365           1554         167          0.0      272904.6       1.3X
+4 conn(s), 4 threads                               1655           1694          37          0.0      330985.4       1.1X
 
 
 ================================================================================================
@@ -104,9 +104,9 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 Async Write Throughput:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-1 KB async burst                                     37             49          18          0.1        7305.3       1.0X
-64 KB async burst                                   141            149           7          0.0       28249.7       0.3X
-1 MB async burst                                   1319           1509         165          0.0      263898.9       0.0X
+1 KB async burst                                     73             76           3          0.1       14634.8       1.0X
+64 KB async burst                                   150            159           9          0.0       29915.2       0.5X
+1 MB async burst                                   1337           1462         173          0.0      267363.9       0.1X
 
 
 ================================================================================================
@@ -117,8 +117,8 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 16 MB Block Transfer:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Sequential sends                                    632            825         322          0.0     6319420.9       1.0X
-4-thread parallel sends                             446            451           4          0.0     4461770.8       1.4X
+Sequential sends                                    655           1135         416          0.0     6548597.0       1.0X
+4-thread parallel sends                             452            464          11          0.0     4524357.9       1.4X
 
 
 ================================================================================================
@@ -129,9 +129,9 @@ OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 File-Backed Shuffle Fetch:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-NIO, sequential fetch                               367            376          11          0.0     3665068.0       1.0X
-NIO, parallel fetch (4 clients)                     199            200           1          0.0     1992404.2       1.8X
-AUTO, sequential fetch                             2052           2118          94          0.0    20522297.2       0.2X
-AUTO, parallel fetch (4 clients)                    647            658          13          0.0     6466373.1       0.6X
+NIO, sequential fetch                               373            381           7          0.0     3734242.2       1.0X
+NIO, parallel fetch (4 clients)                     202            210          11          0.0     2024154.0       1.8X
+AUTO, sequential fetch                              366            375           9          0.0     3660147.3       1.0X
+AUTO, parallel fetch (4 clients)                    194            201           9          0.0     1944456.7       1.9X
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR modifies `MessageEncoder` to emit the header `ByteBuf` and `FileRegion` as **separate objects** in the outbound message list when the body is a `FileRegion` backed by `FileSegmentManagedBuffer`, instead of wrapping them together in a `MessageWithHeader`.

Previously, all messages with a body were unconditionally wrapped in `MessageWithHeader`. This caused native transports (EPOLL, KQUEUE) to fall into a generic `FileRegion.transferTo()` fallback path that copies data through user-space, bypassing the optimized `sendfile()` / `splice()` zero-copy path that Netty's native transports provide.

The split is only applied when the `ManagedBuffer` is a `FileSegmentManagedBuffer`, whose `release()` is a no-op, making it safe to emit the `FileRegion` independently of write lifecycle management. Other `ManagedBuffer` types (e.g., `BlockManagerManagedBuffer`) still use the `MessageWithHeader` wrapper because they perform resource cleanup in `release()` that must be tied to `MessageWithHeader.deallocate()`.

### Why are the changes needed?

When using native transports (AUTO/EPOLL on Linux), file-backed shuffle fetch performance was severely degraded compared to NIO mode. The root cause lies in how Netty's native transports dispatch `FileRegion` writes.

In `AbstractEpollStreamChannel.doWriteSingle()` (and the analogous KQueue path), Netty uses an `instanceof` check to choose between two write strategies:

https://github.com/netty/netty/blob/eeb5674526f0b49a142580686a5a9a7147ddadec/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java#L474-L493

```java
} else if (msg instanceof DefaultFileRegion) {
    return writeDefaultFileRegion(in, (DefaultFileRegion) msg);  // → socket.sendFile() (zero-copy)
} else if (msg instanceof FileRegion) {
    return writeFileRegion(in, (FileRegion) msg);                // → region.transferTo() (user-space copy)
}
```

- **`writeDefaultFileRegion()`** calls `socket.sendFile()`, which maps directly to the Linux `sendfile()` syscall — a true zero-copy path where data is transferred from the file page cache to the socket buffer entirely within the kernel, with no user-space copy.

https://github.com/netty/netty/blob/eeb5674526f0b49a142580686a5a9a7147ddadec/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java#L367-L386

```java
    private int writeDefaultFileRegion(ChannelOutboundBuffer in, DefaultFileRegion region) throws Exception {
        final long offset = region.transferred();
        final long regionCount = region.count();
        if (offset >= regionCount) {
            in.remove();
            return 0;
        }

        final long flushedAmount = socket.sendFile(region, region.position(), offset, regionCount - offset);
        if (flushedAmount > 0) {
            in.progress(flushedAmount);
            if (region.transferred() >= regionCount) {
                in.remove();
            }
            return 1;
        } else if (flushedAmount == 0) {
            validateFileRegion(region, offset);
        }
        return WRITE_STATUS_SNDBUF_FULL;
    }
```

- **`writeFileRegion()`** falls back to `region.transferTo(WritableByteChannel)`, which writes data through a `SocketWritableByteChannel` wrapper — effectively a user-space copy path.

https://github.com/netty/netty/blob/eeb5674526f0b49a142580686a5a9a7147ddadec/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java#L402-L420

```java
private int writeFileRegion(ChannelOutboundBuffer in, FileRegion region) throws Exception {
        if (region.transferred() >= region.count()) {
            in.remove();
            return 0;
        }

        if (byteChannel == null) {
            byteChannel = new EpollSocketWritableByteChannel();
        }
        final long flushedAmount = region.transferTo(byteChannel, region.transferred());
        if (flushedAmount > 0) {
            in.progress(flushedAmount);
            if (region.transferred() >= region.count()) {
                in.remove();
            }
            return 1;
        }
        return WRITE_STATUS_SNDBUF_FULL;
    }
```

Spark's `MessageWithHeader extends AbstractFileRegion` (not `DefaultFileRegion`). When `MessageEncoder` wraps a `DefaultFileRegion` body inside `MessageWithHeader`, the resulting object is a generic `FileRegion` from Netty's perspective. This means Netty dispatches it to the `writeFileRegion()` fallback, which calls `MessageWithHeader.transferTo()`:

```java
// MessageWithHeader.java, line 121
if (body instanceof FileRegion fileRegion) {
    writtenBody = fileRegion.transferTo(target, totalBytesTransferred - headerLength);
}
```

Here, even though the inner body is a `DefaultFileRegion`, its `transferTo()` is invoked with a `WritableByteChannel` (not a file descriptor), so the data is read from the file into a user-space buffer and then written to the socket — **the zero-copy opportunity is lost**.

By emitting the `DefaultFileRegion` directly into Netty's outbound buffer (instead of wrapping it in `MessageWithHeader`), Netty's native transport recognizes it via `instanceof DefaultFileRegion` and routes it to `socket.sendFile()`, restoring the zero-copy `sendfile()` path.

**Benchmark results (File-Backed Shuffle Fetch) show dramatic improvement:**

| Scenario | Before (ms) | After (ms) | Improvement |
|---|---|---|---|
| AUTO, sequential fetch (JDK17) | 2052 | 366 | **~5.6x faster** |
| AUTO, parallel fetch (JDK17) | 647 | 194 | **~3.3x faster** |
| AUTO, sequential fetch (JDK21) | 1304 | 347 | **~3.7x faster** |
| AUTO, parallel fetch (JDK21) | 489 | 186  | **~2.6x faster** |

With this fix, AUTO (EPOLL) mode now matches or exceeds NIO performance for file-backed shuffle fetches, achieving the expected ~1.0X relative performance (previously ~0.2X).

### Does this PR introduce _any_ user-facing change?

No. This is an internal optimization to the Netty transport layer. Users benefit from improved shuffle fetch performance when using native transports (the default on Linux) without any configuration changes.

### How was this patch tested?

- Updated `MergedBlockMetaSuccessSuite` to validate the new encoder output format (2 separate objects: `ByteBuf` header + `DefaultFileRegion`, instead of a single `MessageWithHeader`).
- Re-ran `NettyTransportBenchmark` across JDK 17, JDK 21 to confirm the performance improvement. Updated benchmark result files accordingly.


### Was this patch authored or co-authored using generative AI tooling?
Generated-by:  Claude Code 4.6
