### PR TITLE
[SPARK-56306][SQL] Fix collation-aware PIVOT

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PivotFirst.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PivotFirst.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.trees.BinaryLike
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.{GenericArrayData, TypeUtils}
-import org.apache.spark.sql.catalyst.util.UnsafeRowUtils
 import org.apache.spark.sql.types._
 
 object PivotFirst {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PivotFirst.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PivotFirst.scala
@@ -87,25 +87,21 @@ case class PivotFirst(
 
   override val dataType: DataType = ArrayType(valueDataType)
 
-  val pivotIndex: Map[Any, Int] = {
-    val dt = pivotColumn.dataType
-    if (UnsafeRowUtils.isBinaryStable(dt) &&
-        dt.isInstanceOf[AtomicType]) {
-      HashMap(pivotColumnValues.zipWithIndex: _*)
-    } else {
-      TreeMap(pivotColumnValues.zipWithIndex: _*)(
-        TypeUtils.getInterpretedOrdering(dt))
-    }
-  }
-
   private val usesTreeMap: Boolean =
     !UnsafeRowUtils.isBinaryStable(pivotColumn.dataType) ||
       !pivotColumn.dataType.isInstanceOf[AtomicType]
 
-  // Null-safe lookup into pivotIndex. When pivotIndex is a TreeMap
-  // its comparison-based lookup throws NPE on null keys. Return -1
-  // for null on the TreeMap path since null can never be a valid
-  // pivot value in a TreeMap (insertion would also NPE).
+  val pivotIndex: Map[Any, Int] = if (usesTreeMap) {
+    TreeMap(pivotColumnValues.zipWithIndex: _*)(
+      TypeUtils.getInterpretedOrdering(pivotColumn.dataType))
+  } else {
+    HashMap(pivotColumnValues.zipWithIndex: _*)
+  }
+
+  // Null-safe lookup into pivotIndex. When pivotIndex is a TreeMap, its comparison-based lookup 
+  // throws NPE on null keys. Returning -1 for null is safe on the TreeMap path because null can
+  // never be a TreeMap key (insertion would also NPE), so it can never match any pivot value.
+  // Otherwise, pivotIndex is a HashMap that handles null keys safely via hash-based lookup.
   private def findPivotIndex(key: Any): Int = key match {
     case null if usesTreeMap => -1
     case _ => pivotIndex.getOrElse(key, -1)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PivotFirst.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PivotFirst.scala
@@ -86,9 +86,7 @@ case class PivotFirst(
 
   override val dataType: DataType = ArrayType(valueDataType)
 
-  private val usesTreeMap: Boolean =
-    !TypeUtils.typeWithProperEquals(pivotColumn.dataType) ||
-      !pivotColumn.dataType.isInstanceOf[AtomicType]
+  private val usesTreeMap: Boolean = !TypeUtils.typeWithProperEquals(pivotColumn.dataType)
 
   val pivotIndex: Map[Any, Int] = if (usesTreeMap) {
     TreeMap(pivotColumnValues.zipWithIndex: _*)(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PivotFirst.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PivotFirst.scala
@@ -88,7 +88,7 @@ case class PivotFirst(
   override val dataType: DataType = ArrayType(valueDataType)
 
   private val usesTreeMap: Boolean =
-    !UnsafeRowUtils.isBinaryStable(pivotColumn.dataType) ||
+    !TypeUtils.typeWithProperEquals(pivotColumn.dataType) ||
       !pivotColumn.dataType.isInstanceOf[AtomicType]
 
   val pivotIndex: Map[Any, Int] = if (usesTreeMap) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PivotFirst.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PivotFirst.scala
@@ -97,7 +97,7 @@ case class PivotFirst(
     HashMap(pivotColumnValues.zipWithIndex: _*)
   }
 
-  // Null-safe lookup into pivotIndex. When pivotIndex is a TreeMap, its comparison-based lookup 
+  // Null-safe lookup into pivotIndex. When pivotIndex is a TreeMap, its comparison-based lookup
   // throws NPE on null keys. Returning -1 for null is safe on the TreeMap path because null can
   // never be a TreeMap key (insertion would also NPE), so it can never match any pivot value.
   // Otherwise, pivotIndex is a HashMap that handles null keys safely via hash-based lookup.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PivotFirst.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PivotFirst.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.trees.BinaryLike
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.{GenericArrayData, TypeUtils}
+import org.apache.spark.sql.catalyst.util.UnsafeRowUtils
 import org.apache.spark.sql.types._
 
 object PivotFirst {
@@ -86,20 +87,27 @@ case class PivotFirst(
 
   override val dataType: DataType = ArrayType(valueDataType)
 
-  val pivotIndex: Map[Any, Int] = if (pivotColumn.dataType.isInstanceOf[AtomicType]) {
-    HashMap(pivotColumnValues.zipWithIndex: _*)
-  } else {
-    TreeMap(pivotColumnValues.zipWithIndex: _*)(
-      TypeUtils.getInterpretedOrdering(pivotColumn.dataType))
+  val pivotIndex: Map[Any, Int] = {
+    val dt = pivotColumn.dataType
+    if (UnsafeRowUtils.isBinaryStable(dt) &&
+        dt.isInstanceOf[AtomicType]) {
+      HashMap(pivotColumnValues.zipWithIndex: _*)
+    } else {
+      TreeMap(pivotColumnValues.zipWithIndex: _*)(
+        TypeUtils.getInterpretedOrdering(dt))
+    }
   }
 
-  // Null-safe lookup into pivotIndex. For atomic types, pivotIndex is a HashMap which
-  // handles null keys safely via hash-based lookup. For non-atomic types, pivotIndex is a TreeMap
-  // whose comparison-based lookup throws NPE on null keys. Returning -1 for null is safe on the
-  // TreeMap path because null can never be a TreeMap key (insertion would also NPE), so it can
-  // never match any pivot value.
+  private val usesTreeMap: Boolean =
+    !UnsafeRowUtils.isBinaryStable(pivotColumn.dataType) ||
+      !pivotColumn.dataType.isInstanceOf[AtomicType]
+
+  // Null-safe lookup into pivotIndex. When pivotIndex is a TreeMap
+  // its comparison-based lookup throws NPE on null keys. Return -1
+  // for null on the TreeMap path since null can never be a valid
+  // pivot value in a TreeMap (insertion would also NPE).
   private def findPivotIndex(key: Any): Int = key match {
-    case null if !pivotColumn.dataType.isInstanceOf[AtomicType] => -1
+    case null if usesTreeMap => -1
     case _ => pivotIndex.getOrElse(key, -1)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
@@ -426,8 +426,10 @@ class DataFramePivotSuite extends QueryTest with SharedSparkSession {
   }
 
   test("pivot with explicit values under UNICODE_CI collation") {
+    // scalastyle:off nonascii
     val precomposed = "\u00FCber"  // über (precomposed)
     val decomposed = "u\u0308ber" // über (decomposed)
+    // scalastyle:on nonascii
     withTable("uci_pivot") {
       sql(
         """CREATE TABLE uci_pivot (

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
@@ -397,4 +397,81 @@ class DataFramePivotSuite extends QueryTest with SharedSparkSession {
         Row(500, 200))
     }
   }
+
+  test("pivot with explicit values under UTF8_LCASE collation") {
+    withTable("lcase_pivot") {
+      sql(
+        """CREATE TABLE lcase_pivot (
+          |  quarter STRING COLLATE UTF8_LCASE,
+          |  course STRING,
+          |  earnings INT
+          |) USING PARQUET""".stripMargin)
+      sql(
+        """INSERT INTO lcase_pivot VALUES
+          |  ('q1', 'dotNET', 10000),
+          |  ('q2', 'dotNET', 15000),
+          |  ('q1', 'Java',   20000),
+          |  ('q2', 'Java',   30000)""".stripMargin)
+
+      checkAnswer(
+        sql(
+          """SELECT * FROM lcase_pivot
+            |PIVOT (
+            |  SUM(earnings)
+            |  FOR quarter IN ('Q1' AS Q1, 'Q2' AS Q2)
+            |)""".stripMargin),
+        Row("dotNET", 10000, 15000) ::
+          Row("Java", 20000, 30000) :: Nil)
+    }
+  }
+
+  test("pivot with explicit values under UNICODE_CI collation") {
+    val precomposed = "\u00FCber"  // über (precomposed)
+    val decomposed = "u\u0308ber" // über (decomposed)
+    withTable("uci_pivot") {
+      sql(
+        """CREATE TABLE uci_pivot (
+          |  key STRING COLLATE UNICODE_CI,
+          |  amount INT
+          |) USING PARQUET""".stripMargin)
+      sql(s"INSERT INTO uci_pivot VALUES ('$precomposed', 100)")
+      sql(s"INSERT INTO uci_pivot VALUES ('$decomposed', 200)")
+      sql("INSERT INTO uci_pivot VALUES ('other', 50)")
+
+      checkAnswer(
+        sql(
+          s"""SELECT * FROM uci_pivot
+             |PIVOT (
+             |  SUM(amount) FOR key IN (
+             |    '$precomposed' AS uber,
+             |    'other' AS other
+             |  )
+             |)""".stripMargin),
+        Row(300, 50))
+    }
+  }
+
+  test("pivot with null collated string column should not NPE") {
+    withTable("lcase_null_pivot") {
+      sql(
+        """CREATE TABLE lcase_null_pivot (
+          |  key STRING COLLATE UTF8_LCASE,
+          |  amount INT
+          |) USING PARQUET""".stripMargin)
+      sql(
+        """INSERT INTO lcase_null_pivot VALUES
+          |  ('a', 10),
+          |  (NULL, 20),
+          |  ('b', 30)""".stripMargin)
+
+      checkAnswer(
+        sql(
+          """SELECT * FROM lcase_null_pivot
+            |PIVOT (
+            |  SUM(amount)
+            |  FOR key IN ('a' AS a, 'b' AS b)
+            |)""".stripMargin),
+        Row(10, 30))
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR fixes PivotFirst to respect pivot value collation. Below is a minimalistic repro for the bug:

```
from pyspark.sql import SparkSession

spark = SparkSession.builder.appName("PivotCollationTest").getOrCreate()

data = [(1, "SALES", 100), (1, "sales", 50)]
df = spark.createDataFrame(data, ["emp_id", "dept", "amount"])
df.createOrReplaceTempView("df")

COLLATED = "(SELECT emp_id, COLLATE(dept, 'UTF8_LCASE') AS dept, amount FROM df)"

print("Pivot with 'SALES' - expects 150, gets 150")
spark.sql(f"""
    SELECT * FROM {COLLATED}
    PIVOT (SUM(amount) FOR dept IN ('SALES'))
""").show()

print("Pivot with 'sales' - expects 150, gets NULL")
spark.sql(f"""
    SELECT * FROM {COLLATED}
    PIVOT (SUM(amount) FOR dept IN ('sales'))
""").show()

spark.stop()
```

Given the `UTF8_LCASE` collation, both PIVOT queries should return a `SUM(amount)` of 150. However, since Scala's ImmutableHashMap does a byte-level comparison of the keys in `pivotIndex` with incoming `pivotColumn` values, `SUM(amount)` for `'SALES'` returns `150` and `NULL` for `sales`. This is because the HashMap does a byte-by-byte comparison between `'sales'` and the resolved group-key (`'SALES'`).

The fix is to fall back to `TreeMap` (already used on nested types) for non-binary-stable string types (e.g., `UTF8_LCASE`, `UNICODE_CI`).


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

There is currently a correctness bug. `PIVOT` compares atomic strings at the byte level, completely ignoring specified collation and silently returning `NULL`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, collation-aware pivot values will now adhere to the specified collation. This will result in fewer false negative pivot column value matches and more meaningful results.

### How was this patch tested?
<!--
If tests were added, s ay they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests testing `UTF8_LCASE` and `UNICODE_CI` collation with nulls.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: claude-4.6-opus-high
