### PR TITLE
[SPARK-56303][K8S] Add Java-friendly factory methods to `JavaMainAppResource`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/MainAppResource.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/MainAppResource.scala
@@ -42,6 +42,19 @@ case class JavaMainAppResource(primaryResource: Option[String])
 
 @Stable
 @DeveloperApi
+@Since("4.2.0")
+object JavaMainAppResource {
+  /** Java-friendly factory: creates with a specific resource path. */
+  def of(primaryResource: String): JavaMainAppResource =
+    JavaMainAppResource(Some(primaryResource))
+
+  /** Java-friendly factory: creates with no resource (uses spark-internal). */
+  def create(): JavaMainAppResource =
+    JavaMainAppResource(None)
+}
+
+@Stable
+@DeveloperApi
 @Since("2.4.0")
 case class PythonMainAppResource(primaryResource: String)
   extends MainAppResource with NonJVMResource

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverCommandFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverCommandFeatureStepSuite.scala
@@ -112,6 +112,27 @@ class DriverCommandFeatureStepSuite extends SparkFunSuite {
       mainResource, "5", "7", "9"))
   }
 
+  test("SPARK-56303: java resource with Java-friendly factory methods") {
+    val mainResource = "local:/main.jar"
+    val spec1 = applyFeatureStep(
+      JavaMainAppResource.of(mainResource),
+      appArgs = Array("5", "7"))
+    assert(spec1.pod.container.getArgs.asScala === List(
+      "driver",
+      "--properties-file", SPARK_CONF_PATH,
+      "--class", KubernetesTestConf.MAIN_CLASS,
+      mainResource, "5", "7"))
+
+    val spec2 = applyFeatureStep(
+      JavaMainAppResource.create(),
+      appArgs = Array("5", "7"))
+    assert(spec2.pod.container.getArgs.asScala === List(
+      "driver",
+      "--properties-file", SPARK_CONF_PATH,
+      "--class", KubernetesTestConf.MAIN_CLASS,
+      "spark-internal", "5", "7"))
+  }
+
   test("SPARK-25355: java resource args with proxy-user") {
     val mainResource = "local:/main.jar"
     val spec = applyFeatureStep(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a companion object to `JavaMainAppResource` with Java-friendly factory methods:
- `JavaMainAppResource.of(primaryResource)` — creates with a specific resource path
- `JavaMainAppResource.create()` — creates with no resource (uses spark-internal)

### Why are the changes needed?

The new factory methods allow Java callers to simply write:

```java
JavaMainAppResource res = JavaMainAppResource.of("path/to/jar");
JavaMainAppResource empty = JavaMainAppResource.create();
```

while the existing Scala API remains unchanged.

### Does this PR introduce _any_ user-facing change?

Yes. New public factory methods are added to `JavaMainAppResource` for Java interoperability. No existing behavior is changed.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code