### PR TITLE
[SPARK-56307][BUILD] Upgrade `log4j` to 2.25.4

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -182,11 +182,11 @@ lapack/3.1.1//lapack-3.1.1.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.16.0//libthrift-0.16.0.jar
-log4j-1.2-api/2.25.3//log4j-1.2-api-2.25.3.jar
-log4j-api/2.25.3//log4j-api-2.25.3.jar
-log4j-core/2.25.3//log4j-core-2.25.3.jar
-log4j-layout-template-json/2.25.3//log4j-layout-template-json-2.25.3.jar
-log4j-slf4j2-impl/2.25.3//log4j-slf4j2-impl-2.25.3.jar
+log4j-1.2-api/2.25.4//log4j-1.2-api-2.25.4.jar
+log4j-api/2.25.4//log4j-api-2.25.4.jar
+log4j-core/2.25.4//log4j-core-2.25.4.jar
+log4j-layout-template-json/2.25.4//log4j-layout-template-json-2.25.4.jar
+log4j-slf4j2-impl/2.25.4//log4j-slf4j2-impl-2.25.4.jar
 lz4-java/1.10.4//lz4-java-1.10.4.jar
 metrics-core/4.2.37//metrics-core-4.2.37.jar
 metrics-graphite/4.2.37//metrics-graphite-4.2.37.jar

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.9.1</asm.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <log4j.version>2.25.3</log4j.version>
+    <log4j.version>2.25.4</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.4.3</hadoop.version>
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades Apache Log4j to 2.25.4.

### Why are the changes needed?

To bring in the latest bug fixes from Log4j 2.25.4, which includes fixes for configuration inconsistencies and formatting issues across several layouts.
- https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.25.4

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.6)