### PR TITLE
[SPARK-55109][SQL] Enhance RaiseError to generate valid SQL

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -100,9 +100,12 @@ case class RaiseError(errorClass: Expression, errorParms: Expression, dataType: 
   override def sql: String = {
     // When constructed from the single-argument form (just an error message string),
     // output only the original message to produce valid, roundtrippable SQL.
-    errorParms match {
-      case CreateMap(Seq(Literal(key, _), msg), _)
-        if key != null && key.toString == "errorMessage" =>
+    (errorClass, errorParms) match {
+      case (Literal(cls, _), CreateMap(Seq(Literal(key, _), msg), _))
+        if cls != null &&
+          (cls.toString == "USER_RAISED_EXCEPTION" ||
+            cls.toString == "_LEGACY_ERROR_USER_RAISED_EXCEPTION") &&
+          key != null && key.toString == "errorMessage" =>
         s"$prettyName(${msg.sql})"
       case _ =>
         super.sql

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -97,6 +97,18 @@ case class RaiseError(errorClass: Expression, errorParms: Expression, dataType: 
 
   override def prettyName: String = "raise_error"
 
+  override def sql: String = {
+    // When constructed from the single-argument form (just an error message string),
+    // output only the original message to produce valid, roundtrippable SQL.
+    errorParms match {
+      case CreateMap(Seq(Literal(key, _), msg), _)
+        if key != null && key.toString == "errorMessage" =>
+        s"$prettyName(${msg.sql})"
+      case _ =>
+        super.sql
+    }
+  }
+
   override def eval(input: InternalRow): Any = {
     val error = errorClass.eval(input).asInstanceOf[UTF8String]
     val parms: MapData = errorParms.eval(input).asInstanceOf[MapData]

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MiscExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MiscExpressionsSuite.scala
@@ -55,8 +55,14 @@ class MiscExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     )
   }
 
-  test("SPARK-55109: RaiseError.sql should produce valid single-argument form") {
+  test("SPARK-55109: RaiseError.sql uses single-argument form only for known error classes") {
     assert(RaiseError(Literal("error!")).sql === "raise_error('error!')")
+
+    // A custom errorClass should NOT produce the single-argument form
+    val customError = RaiseError(
+      Literal("CUSTOM_ERROR"),
+      CreateMap(Seq(Literal("errorMessage"), Literal("error!"))))
+    assert(customError.sql === "raise_error('CUSTOM_ERROR', map('errorMessage', 'error!'))")
   }
 
   test("uuid") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MiscExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MiscExpressionsSuite.scala
@@ -55,6 +55,10 @@ class MiscExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     )
   }
 
+  test("SPARK-55109: RaiseError.sql should produce valid single-argument form") {
+    assert(RaiseError(Literal("error!")).sql === "raise_error('error!')")
+  }
+
   test("uuid") {
     checkEvaluation(Length(Uuid(Some(0))), 36)
     val r = new Random()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix RaiseError.sql: [[SPARK-55109] RaiseError(xyz).sql is broken in 4.0](https://issues.apache.org/jira/browse/SPARK-55109)

Repro:

import org.apache.spark.sql.catalyst.expressions.{Literal, RaiseError}
println(RaiseError(Literal("error!")).sql)
 
3.5 generates valid SQL:
 
raise_error('error!')
 
4.0:
raise_error('USER_RAISED_EXCEPTION', map('errorMessage', 'error!')) 


### Why are the changes needed?
To fix the regression in 4.0

### Does this PR introduce _any_ user-facing change?
Bug fix, now it generates valid SQL.

### How was this patch tested?
New unit test.

<img width="785" height="546" alt="image" src="https://github.com/user-attachments/assets/5929d48c-7b11-430d-8e7a-627ad8c50a11" />
<img width="416" height="139" alt="image" src="https://github.com/user-attachments/assets/7f2cf0a3-3ecf-47db-b2c3-abef5b2be408" />


### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Github Copilot v1.0.14-0