### PR TITLE
[SPARK-56350][SQL] Skip ColumnarToRow for Arrow-backed input to Python UDFs

### DIFF
--- a/python/pyspark/sql/tests/pandas/bench_arrow_columnar_udf.py
+++ b/python/pyspark/sql/tests/pandas/bench_arrow_columnar_udf.py
@@ -49,7 +49,6 @@ import pandas as pd
 
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import pandas_udf, col
-from pyspark.sql.types import DoubleType
 
 
 ARROW_SOURCE = "org.apache.spark.sql.execution.python.ArrowBackedDataSourceV2"

--- a/python/pyspark/sql/tests/pandas/bench_arrow_columnar_udf.py
+++ b/python/pyspark/sql/tests/pandas/bench_arrow_columnar_udf.py
@@ -67,15 +67,15 @@ def create_spark():
     )
 
 
-def timed_collect(df, warmup=2, iterations=5):
-    """Collect a DataFrame multiple times, returning per-iteration timings."""
+def timed_run(df, warmup=2, iterations=5):
+    """Run a DataFrame with noop sink, returning per-iteration timings."""
     for _ in range(warmup):
-        df.collect()
+        df.write.format("noop").mode("overwrite").save()
 
     times = []
     for _ in range(iterations):
         start = time.perf_counter()
-        df.collect()
+        df.write.format("noop").mode("overwrite").save()
         elapsed = time.perf_counter() - start
         times.append(elapsed)
     return times
@@ -116,50 +116,44 @@ def main():
     print(f"  rows={args.rows}  partitions={args.partitions}  iterations={args.iterations}")
     print()
 
-    # A minimal scalar Arrow UDF -- isolates data transfer overhead.
-    @pandas_udf(DoubleType())
-    def add_udf(id_col: pd.Series, val_col: pd.Series) -> pd.Series:
-        return id_col + val_col
+    # Identity UDF -- returns input as-is to minimize Python-side cost
+    # and isolate JVM data transfer overhead.
+    @pandas_udf("string")
+    def identity_udf(data: pd.Series) -> pd.Series:
+        return data
 
-    # ----- Source 1: Arrow-backed columnar DSv2 -----
-    arrow_df = (
-        spark.read.format(ARROW_SOURCE)
-        .option("numRows", str(args.rows))
-        .option("numPartitions", str(args.partitions))
-        .load()
-        .select(add_udf(col("id"), col("value")))
-    )
+    conf_key = "spark.sql.execution.arrow.pythonUDF.columnarInput.enabled"
 
-    # ----- Source 2: Row-based (spark.range) -----
-    row_df = (
-        spark.range(args.rows)
-        .repartition(args.partitions)
-        .selectExpr(
-            "CAST(id AS INT) AS id",
-            "CONCAT('row_', CAST(id AS STRING)) AS name",
-            "CAST(id AS DOUBLE) * 0.1 AS value",
+    def make_df():
+        return (
+            spark.read.format(ARROW_SOURCE)
+            .option("numRows", str(args.rows))
+            .option("numPartitions", str(args.partitions))
+            .load()
+            .select(col("id"), col("name"), col("value"), col("data"), identity_udf(col("data")))
         )
-        .select(add_udf(col("id"), col("value")))
-    )
 
-    # Print physical plans for verification.
+    # ----- Benchmark 1: Arrow columnar (config=true) -----
+    spark.conf.set(conf_key, "true")
+    arrow_df = make_df()
     print("--- Physical Plan: Arrow columnar source ---")
     arrow_df.explain()
     print()
-    print("--- Physical Plan: Row-based source ---")
-    row_df.explain()
-    print()
-
-    # ----- Run benchmarks -----
     print("--- Results ---")
     print()
-
-    arrow_times = timed_collect(arrow_df, iterations=args.iterations)
+    arrow_times = timed_run(arrow_df, iterations=args.iterations)
     arrow_avg = print_stats("Arrow columnar (direct FieldVector extraction)", arrow_times)
     print()
 
-    row_times = timed_collect(row_df, iterations=args.iterations)
+    # ----- Benchmark 2: Row-based with ColumnarToRow (config=false) -----
+    spark.conf.set(conf_key, "false")
+    row_df = make_df()
+    print("--- Physical Plan: Row-based (ColumnarToRow) source ---")
+    row_df.explain()
+    print()
+    row_times = timed_run(row_df, iterations=args.iterations)
     row_avg = print_stats("Row-based (ColumnarToRow + ArrowWriter)", row_times)
+    spark.conf.set(conf_key, "true")
     print()
 
     if arrow_avg > 0:

--- a/python/pyspark/sql/tests/pandas/bench_arrow_columnar_udf.py
+++ b/python/pyspark/sql/tests/pandas/bench_arrow_columnar_udf.py
@@ -1,0 +1,178 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Benchmark: Arrow columnar vs row-based input for scalar Arrow Python UDFs.
+
+Compares end-to-end execution time of applying a scalar pandas_udf to data
+from two sources:
+
+1. ArrowBackedDataSourceV2 -- produces ColumnarBatch with ArrowColumnVector.
+   ArrowEvalPythonExec extracts Arrow FieldVectors directly via the columnar
+   path (no ColumnarToRow conversion).
+
+2. spark.range() -- produces row-based data.
+   ArrowEvalPythonExec uses the standard path: InternalRow -> ArrowWriter.
+
+The UDF does minimal computation (addition) so the benchmark isolates
+the data transfer overhead between JVM and Python.
+
+Usage:
+    cd $SPARK_HOME
+    python python/pyspark/sql/tests/pandas/bench_arrow_columnar_udf.py \
+        [--rows N] [--iterations N] [--partitions N]
+"""
+
+import argparse
+import sys
+import os
+import time
+
+# Allow running from the Spark root directory.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../../.."))
+
+import pandas as pd
+
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import pandas_udf, col
+from pyspark.sql.types import DoubleType
+
+
+ARROW_SOURCE = (
+    "org.apache.spark.sql.execution.python.ArrowBackedDataSourceV2"
+)
+
+
+def create_spark():
+    return (
+        SparkSession.builder
+        .master("local[1]")
+        .appName("ArrowColumnarUDFBenchmark")
+        .config("spark.sql.execution.arrow.pyspark.enabled", "true")
+        .config("spark.python.worker.reuse", "true")
+        .config("spark.ui.enabled", "false")
+        .config("spark.sql.shuffle.partitions", "1")
+        .getOrCreate()
+    )
+
+
+def timed_collect(df, warmup=2, iterations=5):
+    """Collect a DataFrame multiple times, returning per-iteration timings."""
+    for _ in range(warmup):
+        df.collect()
+
+    times = []
+    for _ in range(iterations):
+        start = time.perf_counter()
+        df.collect()
+        elapsed = time.perf_counter() - start
+        times.append(elapsed)
+    return times
+
+
+def print_stats(label, times):
+    avg = sum(times) / len(times)
+    mn = min(times)
+    mx = max(times)
+    print(f"  {label}")
+    print(f"    avg = {avg * 1000:8.1f} ms   "
+          f"min = {mn * 1000:8.1f} ms   "
+          f"max = {mx * 1000:8.1f} ms   "
+          f"({len(times)} iterations)")
+    return avg
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark Arrow columnar vs row-based Python UDF input")
+    parser.add_argument("--rows", type=int, default=500_000,
+                        help="Number of rows (default: 500000)")
+    parser.add_argument("--iterations", type=int, default=5,
+                        help="Timed iterations (default: 5)")
+    parser.add_argument("--partitions", type=int, default=1,
+                        help="Number of partitions (default: 1)")
+    args = parser.parse_args()
+
+    spark = create_spark()
+
+    print("=" * 70)
+    print("Arrow Columnar vs Row-Based Input for Scalar Arrow Python UDF")
+    print("=" * 70)
+    print(f"  rows={args.rows}  partitions={args.partitions}  "
+          f"iterations={args.iterations}")
+    print()
+
+    # A minimal scalar Arrow UDF -- isolates data transfer overhead.
+    @pandas_udf(DoubleType())
+    def add_udf(id_col: pd.Series, val_col: pd.Series) -> pd.Series:
+        return id_col + val_col
+
+    # ----- Source 1: Arrow-backed columnar DSv2 -----
+    arrow_df = (
+        spark.read
+        .format(ARROW_SOURCE)
+        .option("numRows", str(args.rows))
+        .option("numPartitions", str(args.partitions))
+        .load()
+        .select(add_udf(col("id"), col("value")))
+    )
+
+    # ----- Source 2: Row-based (spark.range) -----
+    row_df = (
+        spark.range(args.rows)
+        .repartition(args.partitions)
+        .selectExpr(
+            "CAST(id AS INT) AS id",
+            "CONCAT('row_', CAST(id AS STRING)) AS name",
+            "CAST(id AS DOUBLE) * 0.1 AS value",
+        )
+        .select(add_udf(col("id"), col("value")))
+    )
+
+    # Print physical plans for verification.
+    print("--- Physical Plan: Arrow columnar source ---")
+    arrow_df.explain()
+    print()
+    print("--- Physical Plan: Row-based source ---")
+    row_df.explain()
+    print()
+
+    # ----- Run benchmarks -----
+    print("--- Results ---")
+    print()
+
+    arrow_times = timed_collect(arrow_df, iterations=args.iterations)
+    arrow_avg = print_stats(
+        "Arrow columnar (direct FieldVector extraction)", arrow_times)
+    print()
+
+    row_times = timed_collect(row_df, iterations=args.iterations)
+    row_avg = print_stats(
+        "Row-based (ColumnarToRow + ArrowWriter)", row_times)
+    print()
+
+    if arrow_avg > 0:
+        speedup = row_avg / arrow_avg
+        faster = "faster" if speedup > 1.0 else "slower"
+        print(f"  Speedup: {speedup:.2f}x ({faster} with Arrow columnar)")
+    print()
+
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/pyspark/sql/tests/pandas/bench_arrow_columnar_udf.py
+++ b/python/pyspark/sql/tests/pandas/bench_arrow_columnar_udf.py
@@ -52,15 +52,12 @@ from pyspark.sql.functions import pandas_udf, col
 from pyspark.sql.types import DoubleType
 
 
-ARROW_SOURCE = (
-    "org.apache.spark.sql.execution.python.ArrowBackedDataSourceV2"
-)
+ARROW_SOURCE = "org.apache.spark.sql.execution.python.ArrowBackedDataSourceV2"
 
 
 def create_spark():
     return (
-        SparkSession.builder
-        .master("local[1]")
+        SparkSession.builder.master("local[1]")
         .appName("ArrowColumnarUDFBenchmark")
         .config("spark.sql.execution.arrow.pyspark.enabled", "true")
         .config("spark.python.worker.reuse", "true")
@@ -123,8 +120,7 @@ def main():
 
     # ----- Source 1: Arrow-backed columnar DSv2 -----
     arrow_df = (
-        spark.read
-        .format(ARROW_SOURCE)
+        spark.read.format(ARROW_SOURCE)
         .option("numRows", str(args.rows))
         .option("numPartitions", str(args.partitions))
         .load()
@@ -156,13 +152,11 @@ def main():
     print()
 
     arrow_times = timed_collect(arrow_df, iterations=args.iterations)
-    arrow_avg = print_stats(
-        "Arrow columnar (direct FieldVector extraction)", arrow_times)
+    arrow_avg = print_stats("Arrow columnar (direct FieldVector extraction)", arrow_times)
     print()
 
     row_times = timed_collect(row_df, iterations=args.iterations)
-    row_avg = print_stats(
-        "Row-based (ColumnarToRow + ArrowWriter)", row_times)
+    row_avg = print_stats("Row-based (ColumnarToRow + ArrowWriter)", row_times)
     print()
 
     if arrow_avg > 0:

--- a/python/pyspark/sql/tests/pandas/bench_arrow_columnar_udf.py
+++ b/python/pyspark/sql/tests/pandas/bench_arrow_columnar_udf.py
@@ -86,22 +86,26 @@ def print_stats(label, times):
     mn = min(times)
     mx = max(times)
     print(f"  {label}")
-    print(f"    avg = {avg * 1000:8.1f} ms   "
-          f"min = {mn * 1000:8.1f} ms   "
-          f"max = {mx * 1000:8.1f} ms   "
-          f"({len(times)} iterations)")
+    print(
+        f"    avg = {avg * 1000:8.1f} ms   "
+        f"min = {mn * 1000:8.1f} ms   "
+        f"max = {mx * 1000:8.1f} ms   "
+        f"({len(times)} iterations)"
+    )
     return avg
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Benchmark Arrow columnar vs row-based Python UDF input")
-    parser.add_argument("--rows", type=int, default=500_000,
-                        help="Number of rows (default: 500000)")
-    parser.add_argument("--iterations", type=int, default=5,
-                        help="Timed iterations (default: 5)")
-    parser.add_argument("--partitions", type=int, default=1,
-                        help="Number of partitions (default: 1)")
+        description="Benchmark Arrow columnar vs row-based Python UDF input"
+    )
+    parser.add_argument(
+        "--rows", type=int, default=500_000, help="Number of rows (default: 500000)"
+    )
+    parser.add_argument("--iterations", type=int, default=5, help="Timed iterations (default: 5)")
+    parser.add_argument(
+        "--partitions", type=int, default=1, help="Number of partitions (default: 1)"
+    )
     args = parser.parse_args()
 
     spark = create_spark()
@@ -109,8 +113,7 @@ def main():
     print("=" * 70)
     print("Arrow Columnar vs Row-Based Input for Scalar Arrow Python UDF")
     print("=" * 70)
-    print(f"  rows={args.rows}  partitions={args.partitions}  "
-          f"iterations={args.iterations}")
+    print(f"  rows={args.rows}  partitions={args.partitions}  iterations={args.iterations}")
     print()
 
     # A minimal scalar Arrow UDF -- isolates data transfer overhead.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4420,6 +4420,18 @@ object SQLConf {
       .intConf
       .createWithDefault(3)
 
+  val ARROW_PYSPARK_UDF_COLUMNAR_INPUT_ENABLED =
+    buildConf("spark.sql.execution.arrow.pythonUDF.columnarInput.enabled")
+      .doc("When true, Arrow-based Python UDFs (pandas UDFs) can accept " +
+        "columnar input directly from DataSource V2 connectors that " +
+        "produce Arrow-backed ColumnarBatch, bypassing the " +
+        "ColumnarToRow and ArrowWriter conversion. This optimization " +
+        "reduces data transfer overhead between the JVM and Python " +
+        "worker processes.")
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val ARROW_TRANSFORM_WITH_STATE_IN_PYSPARK_MAX_STATE_RECORDS_PER_BATCH =
     buildConf("spark.sql.execution.arrow.transformWithStateInPySpark.maxStateRecordsPerBatch")
       .doc("When using TransformWithState in PySpark (both Python Row and Pandas), limit " +
@@ -8007,6 +8019,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def arrowCompressionCodec: String = getConf(ARROW_EXECUTION_COMPRESSION_CODEC)
 
   def arrowZstdCompressionLevel: Int = getConf(ARROW_EXECUTION_ZSTD_COMPRESSION_LEVEL)
+
+  def arrowPySparkUDFColumnarInputEnabled: Boolean =
+    getConf(ARROW_PYSPARK_UDF_COLUMNAR_INPUT_ENABLED)
 
   def arrowTransformWithStateInPySparkMaxStateRecordsPerBatch: Int =
     getConf(ARROW_TRANSFORM_WITH_STATE_IN_PYSPARK_MAX_STATE_RECORDS_PER_BATCH)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4428,7 +4428,7 @@ object SQLConf {
         "ColumnarToRow and ArrowWriter conversion. This optimization " +
         "reduces data transfer overhead between the JVM and Python " +
         "worker processes.")
-      .version("4.1.0")
+      .version("4.2.0")
       .booleanConf
       .createWithDefault(true)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4429,6 +4429,7 @@ object SQLConf {
         "This optimization reduces data transfer overhead between " +
         "the JVM and Python worker processes.")
       .version("4.2.0")
+      .withBindingPolicy(ConfigBindingPolicy.SESSION)
       .booleanConf
       .createWithDefault(true)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4423,11 +4423,11 @@ object SQLConf {
   val ARROW_PYSPARK_UDF_COLUMNAR_INPUT_ENABLED =
     buildConf("spark.sql.execution.arrow.pythonUDF.columnarInput.enabled")
       .doc("When true, Arrow-based Python UDFs (pandas UDFs) can accept " +
-        "columnar input directly from DataSource V2 connectors that " +
-        "produce Arrow-backed ColumnarBatch, bypassing the " +
-        "ColumnarToRow and ArrowWriter conversion. This optimization " +
-        "reduces data transfer overhead between the JVM and Python " +
-        "worker processes.")
+        "columnar input directly from upstream operators that produce " +
+        "Arrow-backed ColumnarBatch (e.g., DataSource V2 connectors), " +
+        "bypassing the ColumnarToRow and ArrowWriter conversion. " +
+        "This optimization reduces data transfer overhead between " +
+        "the JVM and Python worker processes.")
       .version("4.2.0")
       .booleanConf
       .createWithDefault(true)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -100,8 +100,14 @@ case class ArrowEvalPythonExec(
 
   override protected def doExecute(): RDD[InternalRow] = {
     if (child.supportsColumnar) {
-      // Columnar path: delegate to doExecuteColumnar, flatten to rows.
-      doExecuteColumnar().flatMap(_.rowIterator().asScala)
+      // Columnar path: delegate to doExecuteColumnar, flatten to
+      // UnsafeRow. ColumnarBatchRow from rowIterator() is NOT
+      // UnsafeRow, and downstream operators (e.g., outer
+      // EvalPythonExec) may cast to UnsafeRow.
+      doExecuteColumnar().mapPartitionsInternal { batchIter =>
+        val toUnsafe = UnsafeProjection.create(schema)
+        batchIter.flatMap(_.rowIterator().asScala.map(toUnsafe))
+      }
     } else {
       // Row-based path: unchanged.
       super.doExecute()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -95,7 +95,10 @@ case class ArrowEvalPythonExec(
   // accept columnar input to avoid the ColumnarToRow -> ArrowWriter round-trip.
   // The Arrow FieldVectors are extracted directly from ArrowColumnVector and
   // serialized to IPC, bypassing the row-based ArrowWriter conversion.
-  override def supportsColumnar: Boolean = child.supportsColumnar
+  override def supportsColumnar: Boolean =
+    child.supportsColumnar && conf.getConfString(
+      "spark.sql.execution.arrow.pythonUDF.columnarInput.enabled",
+      "true").toBoolean
   override def supportsRowBased: Boolean = true
 
   override protected def doExecute(): RDD[InternalRow] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -21,6 +21,7 @@ import scala.jdk.CollectionConverters._
 
 import org.apache.spark.{JobArtifactSet, SparkException, TaskContext}
 import org.apache.spark.api.python.{ChainedPythonFunctions, PythonEvalType}
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.errors.QueryExecutionErrors
@@ -88,6 +89,42 @@ case class ArrowEvalPythonExec(
         session.sessionUUID
     }
   }
+
+  // When the child supports columnar output (e.g., Arrow-backed DSv2 connectors),
+  // accept columnar input to avoid the ColumnarToRow -> ArrowWriter round-trip.
+  override def supportsColumnar: Boolean = child.supportsColumnar
+  override def supportsRowBased: Boolean = true
+
+  override protected def doExecute(): RDD[InternalRow] = {
+    if (child.supportsColumnar) {
+      // Columnar path: process ColumnarBatch directly, potentially extracting
+      // Arrow FieldVectors without row conversion.
+      val inputRDD = child.executeColumnar()
+      if (conf.usePartitionEvaluator) {
+        inputRDD.mapPartitionsWithEvaluator(columnarEvaluatorFactory)
+      } else {
+        inputRDD.mapPartitionsWithIndexInternal { (index, iter) =>
+          columnarEvaluatorFactory.createEvaluator().eval(index, iter)
+        }
+      }
+    } else {
+      // Row-based path: unchanged.
+      super.doExecute()
+    }
+  }
+
+  private lazy val columnarEvaluatorFactory = new ColumnarArrowEvalPythonEvaluatorFactory(
+    child.output,
+    udfs,
+    output,
+    conf.arrowMaxRecordsPerBatch,
+    evalType,
+    conf.sessionLocalTimeZone,
+    conf.arrowUseLargeVarTypes,
+    ArrowPythonRunner.getPythonRunnerConfMap(conf),
+    pythonMetrics,
+    jobArtifactUUID,
+    sessionUUID)
 
   override protected def evaluatorFactory: EvalPythonEvaluatorFactory = {
     new ArrowEvalPythonEvaluatorFactory(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -25,8 +25,8 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.execution.{RowToColumnarEvaluatorFactory, SparkPlan}
-import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
 import org.apache.spark.sql.types.{StructType, UserDefinedType}
 import org.apache.spark.sql.types.DataType.equalsIgnoreCompatibleCollation
@@ -100,39 +100,21 @@ case class ArrowEvalPythonExec(
 
   override protected def doExecute(): RDD[InternalRow] = {
     if (child.supportsColumnar) {
-      // Columnar path: read ColumnarBatch from child, send Arrow vectors
-      // directly to Python when possible.
-      val inputRDD = child.executeColumnar()
-      if (conf.usePartitionEvaluator) {
-        inputRDD.mapPartitionsWithEvaluator(columnarEvaluatorFactory)
-      } else {
-        inputRDD.mapPartitionsWithIndexInternal { (index, iter) =>
-          columnarEvaluatorFactory.createEvaluator().eval(index, iter)
-        }
-      }
+      // Columnar path: delegate to doExecuteColumnar, flatten to rows.
+      doExecuteColumnar().flatMap(_.rowIterator().asScala)
     } else {
       // Row-based path: unchanged.
       super.doExecute()
     }
   }
 
-  // Required because supportsColumnar = true. Converts row output to
-  // columnar batches so upstream columnar consumers can read from us.
   override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
-    val numInputRows = longMetric("numOutputRows")
-    val numOutputBatches =
-      SQLMetrics.createMetric(sparkContext, "number of output batches")
-    val evaluatorFactory = new RowToColumnarEvaluatorFactory(
-      conf.offHeapColumnVectorEnabled,
-      conf.columnBatchSize,
-      schema,
-      numInputRows,
-      numOutputBatches)
+    val inputRDD = child.executeColumnar()
     if (conf.usePartitionEvaluator) {
-      doExecute().mapPartitionsWithEvaluator(evaluatorFactory)
+      inputRDD.mapPartitionsWithEvaluator(columnarEvaluatorFactory)
     } else {
-      doExecute().mapPartitionsWithIndexInternal { (index, rowIter) =>
-        evaluatorFactory.createEvaluator().eval(index, rowIter)
+      inputRDD.mapPartitionsWithIndexInternal { (index, iter) =>
+        columnarEvaluatorFactory.createEvaluator().eval(index, iter)
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -93,27 +93,26 @@ case class ArrowEvalPythonExec(
 
   // When the child supports columnar output (e.g., Arrow-backed DSv2 connectors),
   // accept columnar input to avoid the ColumnarToRow -> ArrowWriter round-trip.
+  // The Arrow FieldVectors are extracted directly from ArrowColumnVector and
+  // serialized to IPC, bypassing the row-based ArrowWriter conversion.
   override def supportsColumnar: Boolean = child.supportsColumnar
   override def supportsRowBased: Boolean = true
 
   override protected def doExecute(): RDD[InternalRow] = {
     if (child.supportsColumnar) {
-      // Columnar path: produce ColumnarBatch via doExecuteColumnar(), then flatten to rows.
-      doExecuteColumnar().flatMap(_.rowIterator().asScala)
+      // Columnar path: read ColumnarBatch from child, send Arrow vectors
+      // directly to Python when possible.
+      val inputRDD = child.executeColumnar()
+      if (conf.usePartitionEvaluator) {
+        inputRDD.mapPartitionsWithEvaluator(columnarEvaluatorFactory)
+      } else {
+        inputRDD.mapPartitionsWithIndexInternal { (index, iter) =>
+          columnarEvaluatorFactory.createEvaluator().eval(index, iter)
+        }
+      }
     } else {
       // Row-based path: unchanged.
       super.doExecute()
-    }
-  }
-
-  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
-    val inputRDD = child.executeColumnar()
-    if (conf.usePartitionEvaluator) {
-      inputRDD.mapPartitionsWithEvaluator(columnarEvaluatorFactory)
-    } else {
-      inputRDD.mapPartitionsWithIndexInternal { (index, iter) =>
-        columnarEvaluatorFactory.createEvaluator().eval(index, iter)
-      }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -98,7 +98,6 @@ case class ArrowEvalPythonExec(
   override protected def doExecute(): RDD[InternalRow] = {
     if (child.supportsColumnar) {
       // Columnar path: produce ColumnarBatch via doExecuteColumnar(), then flatten to rows.
-      // This mirrors DBR's approach in ArrowEvalPythonExec.doExecute().
       doExecuteColumnar().flatMap(_.rowIterator().asScala)
     } else {
       // Row-based path: unchanged.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -97,19 +97,23 @@ case class ArrowEvalPythonExec(
 
   override protected def doExecute(): RDD[InternalRow] = {
     if (child.supportsColumnar) {
-      // Columnar path: process ColumnarBatch directly, potentially extracting
-      // Arrow FieldVectors without row conversion.
-      val inputRDD = child.executeColumnar()
-      if (conf.usePartitionEvaluator) {
-        inputRDD.mapPartitionsWithEvaluator(columnarEvaluatorFactory)
-      } else {
-        inputRDD.mapPartitionsWithIndexInternal { (index, iter) =>
-          columnarEvaluatorFactory.createEvaluator().eval(index, iter)
-        }
-      }
+      // Columnar path: produce ColumnarBatch via doExecuteColumnar(), then flatten to rows.
+      // This mirrors DBR's approach in ArrowEvalPythonExec.doExecute().
+      doExecuteColumnar().flatMap(_.rowIterator().asScala)
     } else {
       // Row-based path: unchanged.
       super.doExecute()
+    }
+  }
+
+  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
+    val inputRDD = child.executeColumnar()
+    if (conf.usePartitionEvaluator) {
+      inputRDD.mapPartitionsWithEvaluator(columnarEvaluatorFactory)
+    } else {
+      inputRDD.mapPartitionsWithIndexInternal { (index, iter) =>
+        columnarEvaluatorFactory.createEvaluator().eval(index, iter)
+      }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -25,11 +25,12 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.execution.{RowToColumnarEvaluatorFactory, SparkPlan}
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
 import org.apache.spark.sql.types.{StructType, UserDefinedType}
 import org.apache.spark.sql.types.DataType.equalsIgnoreCompatibleCollation
+import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
  * Grouped a iterator into batches.
@@ -112,6 +113,27 @@ case class ArrowEvalPythonExec(
     } else {
       // Row-based path: unchanged.
       super.doExecute()
+    }
+  }
+
+  // Required because supportsColumnar = true. Converts row output to
+  // columnar batches so upstream columnar consumers can read from us.
+  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
+    val numInputRows = longMetric("numOutputRows")
+    val numOutputBatches =
+      SQLMetrics.createMetric(sparkContext, "number of output batches")
+    val evaluatorFactory = new RowToColumnarEvaluatorFactory(
+      conf.offHeapColumnVectorEnabled,
+      conf.columnBatchSize,
+      schema,
+      numInputRows,
+      numOutputBatches)
+    if (conf.usePartitionEvaluator) {
+      doExecute().mapPartitionsWithEvaluator(evaluatorFactory)
+    } else {
+      doExecute().mapPartitionsWithIndexInternal { (index, rowIter) =>
+        evaluatorFactory.createEvaluator().eval(index, rowIter)
+      }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -118,12 +118,16 @@ case class ArrowEvalPythonExec(
   // Required because supportsColumnar = true. Wraps doExecute() row
   // output into ColumnarBatch for upstream columnar consumers.
   override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
+    val numInputRows =
+      SQLMetrics.createMetric(sparkContext, "number of input rows")
+    val numOutputBatches =
+      SQLMetrics.createMetric(sparkContext, "number of output batches")
     val evaluatorFactory = new RowToColumnarEvaluatorFactory(
       conf.offHeapColumnVectorEnabled,
       conf.columnBatchSize,
       schema,
-      longMetric("numOutputRows"),
-      SQLMetrics.createMetric(sparkContext, "number of output batches"))
+      numInputRows,
+      numOutputBatches)
     if (conf.usePartitionEvaluator) {
       doExecute().mapPartitionsWithEvaluator(evaluatorFactory)
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
 import org.apache.spark.sql.types.{StructType, UserDefinedType}
 import org.apache.spark.sql.types.DataType.equalsIgnoreCompatibleCollation
+import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
  * Grouped a iterator into batches.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -25,8 +25,8 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.execution.{RowToColumnarEvaluatorFactory, SparkPlan}
-import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
 import org.apache.spark.sql.types.{StructType, UserDefinedType}
 import org.apache.spark.sql.types.DataType.equalsIgnoreCompatibleCollation
@@ -100,55 +100,39 @@ case class ArrowEvalPythonExec(
 
   override protected def doExecute(): RDD[InternalRow] = {
     if (child.supportsColumnar) {
-      // Columnar path: process ColumnarBatch input directly.
-      val inputRDD = child.executeColumnar()
-      if (conf.usePartitionEvaluator) {
-        inputRDD.mapPartitionsWithEvaluator(columnarEvaluatorFactory)
-      } else {
-        inputRDD.mapPartitionsWithIndexInternal { (index, iter) =>
-          columnarEvaluatorFactory.createEvaluator().eval(index, iter)
-        }
-      }
+      // Columnar path: delegate to doExecuteColumnar, flatten to rows.
+      doExecuteColumnar().flatMap(_.rowIterator().asScala)
     } else {
       // Row-based path: unchanged.
       super.doExecute()
     }
   }
 
-  // Required because supportsColumnar = true. Wraps doExecute() row
-  // output into ColumnarBatch for upstream columnar consumers.
   override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
-    val numInputRows =
-      SQLMetrics.createMetric(sparkContext, "number of input rows")
-    val numOutputBatches =
-      SQLMetrics.createMetric(sparkContext, "number of output batches")
-    val evaluatorFactory = new RowToColumnarEvaluatorFactory(
-      conf.offHeapColumnVectorEnabled,
-      conf.columnBatchSize,
-      schema,
-      numInputRows,
-      numOutputBatches)
+    val inputRDD = child.executeColumnar()
     if (conf.usePartitionEvaluator) {
-      doExecute().mapPartitionsWithEvaluator(evaluatorFactory)
+      inputRDD.mapPartitionsWithEvaluator(columnarEvaluatorFactory)
     } else {
-      doExecute().mapPartitionsWithIndexInternal { (index, iter) =>
-        evaluatorFactory.createEvaluator().eval(index, iter)
+      inputRDD.mapPartitionsWithIndexInternal { (index, iter) =>
+        columnarEvaluatorFactory.createEvaluator().eval(index, iter)
       }
     }
   }
 
-  private lazy val columnarEvaluatorFactory = new ColumnarArrowEvalPythonEvaluatorFactory(
-    child.output,
-    udfs,
-    output,
-    conf.arrowMaxRecordsPerBatch,
-    evalType,
-    conf.sessionLocalTimeZone,
-    conf.arrowUseLargeVarTypes,
-    ArrowPythonRunner.getPythonRunnerConfMap(conf),
-    pythonMetrics,
-    jobArtifactUUID,
-    sessionUUID)
+  private lazy val columnarEvaluatorFactory =
+    new ColumnarArrowEvalPythonEvaluatorFactory(
+      child.output,
+      udfs,
+      output,
+      StructType.fromAttributes(output),
+      conf.arrowMaxRecordsPerBatch,
+      evalType,
+      conf.sessionLocalTimeZone,
+      conf.arrowUseLargeVarTypes,
+      ArrowPythonRunner.getPythonRunnerConfMap(conf),
+      pythonMetrics,
+      jobArtifactUUID,
+      sessionUUID)
 
   override protected def evaluatorFactory: EvalPythonEvaluatorFactory = {
     new ArrowEvalPythonEvaluatorFactory(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -30,7 +30,6 @@ import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
 import org.apache.spark.sql.types.{StructType, UserDefinedType}
 import org.apache.spark.sql.types.DataType.equalsIgnoreCompatibleCollation
-import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
  * Grouped a iterator into batches.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -96,9 +96,7 @@ case class ArrowEvalPythonExec(
   // The Arrow FieldVectors are extracted directly from ArrowColumnVector and
   // serialized to IPC, bypassing the row-based ArrowWriter conversion.
   override def supportsColumnar: Boolean =
-    child.supportsColumnar && conf.getConfString(
-      "spark.sql.execution.arrow.pythonUDF.columnarInput.enabled",
-      "true").toBoolean
+    child.supportsColumnar && conf.arrowPySparkUDFColumnarInputEnabled
   override def supportsRowBased: Boolean = true
 
   override protected def doExecute(): RDD[InternalRow] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -124,7 +124,7 @@ case class ArrowEvalPythonExec(
       child.output,
       udfs,
       output,
-      StructType.fromAttributes(output),
+      output.toStructType,
       conf.arrowMaxRecordsPerBatch,
       evalType,
       conf.sessionLocalTimeZone,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -25,8 +25,8 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.execution.{RowToColumnarEvaluatorFactory, SparkPlan}
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
 import org.apache.spark.sql.types.{StructType, UserDefinedType}
 import org.apache.spark.sql.types.DataType.equalsIgnoreCompatibleCollation
@@ -100,21 +100,35 @@ case class ArrowEvalPythonExec(
 
   override protected def doExecute(): RDD[InternalRow] = {
     if (child.supportsColumnar) {
-      // Columnar path: delegate to doExecuteColumnar, flatten to rows.
-      doExecuteColumnar().flatMap(_.rowIterator().asScala)
+      // Columnar path: process ColumnarBatch input directly.
+      val inputRDD = child.executeColumnar()
+      if (conf.usePartitionEvaluator) {
+        inputRDD.mapPartitionsWithEvaluator(columnarEvaluatorFactory)
+      } else {
+        inputRDD.mapPartitionsWithIndexInternal { (index, iter) =>
+          columnarEvaluatorFactory.createEvaluator().eval(index, iter)
+        }
+      }
     } else {
       // Row-based path: unchanged.
       super.doExecute()
     }
   }
 
+  // Required because supportsColumnar = true. Wraps doExecute() row
+  // output into ColumnarBatch for upstream columnar consumers.
   override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
-    val inputRDD = child.executeColumnar()
+    val evaluatorFactory = new RowToColumnarEvaluatorFactory(
+      conf.offHeapColumnVectorEnabled,
+      conf.columnBatchSize,
+      schema,
+      longMetric("numOutputRows"),
+      SQLMetrics.createMetric(sparkContext, "number of output batches"))
     if (conf.usePartitionEvaluator) {
-      inputRDD.mapPartitionsWithEvaluator(columnarEvaluatorFactory)
+      doExecute().mapPartitionsWithEvaluator(evaluatorFactory)
     } else {
-      inputRDD.mapPartitionsWithIndexInternal { (index, iter) =>
-        columnarEvaluatorFactory.createEvaluator().eval(index, iter)
+      doExecute().mapPartitionsWithIndexInternal { (index, iter) =>
+        evaluatorFactory.createEvaluator().eval(index, iter)
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowEvalPythonEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowEvalPythonEvaluatorFactory.scala
@@ -45,11 +45,6 @@ import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
  * When UDF inputs contain complex expressions (not simple column references),
  * the UDF inputs are serialized via the row-based ArrowWriter fallback, but
  * pass-through columns are still kept in columnar format.
- *
- * Note: DBR handles complex expressions by inserting a Project node upstream
- * (via PhotonStageCompiler.extractUDFInputsIntoProject) to pre-evaluate them.
- * A similar physical plan rule could be added to OSS Spark in the future to
- * eliminate the fallback path.
  */
 private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
     childOutput: Seq[Attribute],
@@ -184,6 +179,12 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
     /**
      * Fallback path: UDF inputs contain complex expressions. Convert to rows for
      * UDF input serialization, but still keep pass-through columns in columnar format.
+     *
+     * TODO: Add a physical plan rule that inserts a ProjectExec before
+     *   ArrowEvalPythonExec to pre-evaluate complex UDF input expressions into
+     *   simple column references. This would eliminate this fallback entirely,
+     *   allowing the fully columnar evalColumnar() path to always be used when
+     *   the child supports columnar output.
      */
     private def evalRowFallback(
         inputIter: Iterator[ColumnarBatch],

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowEvalPythonEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowEvalPythonEvaluatorFactory.scala
@@ -16,35 +16,42 @@
  */
 package org.apache.spark.sql.execution.python
 
-import java.util.ArrayDeque
+import java.io.File
 
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 
-import org.apache.spark.{PartitionEvaluator, PartitionEvaluatorFactory, TaskContext}
+import org.apache.spark.{PartitionEvaluator, PartitionEvaluatorFactory, SparkEnv, TaskContext}
 import org.apache.spark.api.python.ChainedPythonFunctions
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
 import org.apache.spark.sql.types.{DataType, StructField, StructType, UserDefinedType}
 import org.apache.spark.sql.types.DataType.equalsIgnoreCompatibleCollation
-import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.Utils
 
 /**
- * Evaluator factory for Arrow Python UDFs that processes [[ColumnarBatch]] input
- * and produces [[ColumnarBatch]] output, staying fully in columnar format.
+ * Evaluator factory for Arrow Python UDFs that processes [[ColumnarBatch]] input.
  *
  * When UDF inputs are simple column references and the batch is Arrow-backed,
- * this avoids the columnar-to-row-to-columnar round-trip entirely:
- * - UDF input columns: extracted as Arrow FieldVectors and sent directly via IPC.
- * - Pass-through columns: kept as ColumnVector references (no row conversion).
- * - Output: pass-through ColumnVectors + UDF result ColumnVectors combined into
- *   a new [[ColumnarBatch]].
+ * the UDF input columns are extracted as Arrow FieldVectors and sent directly
+ * via IPC, bypassing the ArrowWriter row-by-row conversion.
+ *
+ * Pass-through columns (child columns that are not UDF inputs) are buffered
+ * as rows in [[HybridRowQueue]] and joined with UDF results row by row, since
+ * the Python worker does not preserve input batch boundaries.
  *
  * When UDF inputs contain complex expressions (not simple column references),
- * the UDF inputs are serialized via the row-based ArrowWriter fallback, but
- * pass-through columns are still kept in columnar format.
+ * the UDF inputs are serialized via the row-based ArrowWriter fallback.
+ *
+ * TODO: Add a physical plan rule that inserts a ProjectExec before
+ *   ArrowEvalPythonExec to pre-evaluate complex UDF input expressions into
+ *   simple column references. This would eliminate the fallback path,
+ *   allowing the direct Arrow path to always be used when the child
+ *   supports columnar output.
  */
 private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
     childOutput: Seq[Attribute],
@@ -58,20 +65,21 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
     pythonMetrics: Map[String, SQLMetric],
     jobArtifactUUID: Option[String],
     sessionUUID: Option[String])
-  extends PartitionEvaluatorFactory[ColumnarBatch, ColumnarBatch] {
+  extends PartitionEvaluatorFactory[ColumnarBatch, InternalRow] {
 
-  override def createEvaluator(): PartitionEvaluator[ColumnarBatch, ColumnarBatch] =
+  override def createEvaluator(): PartitionEvaluator[ColumnarBatch, InternalRow] =
     new ColumnarArrowEvalPythonPartitionEvaluator
 
   private class ColumnarArrowEvalPythonPartitionEvaluator
-      extends PartitionEvaluator[ColumnarBatch, ColumnarBatch] {
+      extends PartitionEvaluator[ColumnarBatch, InternalRow] {
 
     private def collectFunctions(
         udf: PythonUDF): ((ChainedPythonFunctions, Long), Seq[Expression]) = {
       udf.children match {
         case Seq(u: PythonUDF) =>
           val ((chained, _), children) = collectFunctions(u)
-          ((ChainedPythonFunctions(chained.funcs ++ Seq(udf.func)), udf.resultId.id), children)
+          ((ChainedPythonFunctions(chained.funcs ++ Seq(udf.func)), udf.resultId.id),
+            children)
         case children =>
           assert(children.forall(!_.exists(_.isInstanceOf[PythonUDF])))
           ((ChainedPythonFunctions(Seq(udf.func)), udf.resultId.id), udf.children)
@@ -80,13 +88,20 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
 
     override def eval(
         partitionIndex: Int,
-        iters: Iterator[ColumnarBatch]*): Iterator[ColumnarBatch] = {
+        iters: Iterator[ColumnarBatch]*): Iterator[InternalRow] = {
       val inputIter = iters.head
       val context = TaskContext.get()
 
+      // Buffer input rows for joining with UDF output (same as EvalPythonEvaluatorFactory).
+      val queue = HybridRowQueue(
+        context.taskMemoryManager(),
+        new File(Utils.getLocalDir(SparkEnv.get.conf)),
+        childOutput.length)
+      context.addTaskCompletionListener[Unit] { _ => queue.close() }
+
       val (pyFuncs, inputs) = udfs.map(collectFunctions).unzip
 
-      // Flatten all UDF arguments and build argMetas (same as EvalPythonEvaluatorFactory).
+      // Flatten all UDF arguments and build argMetas.
       val allInputs = new ArrayBuffer[Expression]
       val dataTypes = new ArrayBuffer[DataType]
       val argMetas = inputs.map { input =>
@@ -109,35 +124,74 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
         StructField(s"_$i", dt)
       }.toArray)
 
-      val outputTypes = output.drop(childOutput.length).map(_.dataType.transformRecursively {
-        case udt: UserDefinedType[_] => udt.sqlType
-      })
-
-      // Queue to buffer pass-through columns from input batches.
-      // Each entry is (ColumnVector[], numRows) corresponding to one input ColumnarBatch.
-      val passThruQueue = new ArrayDeque[(Array[ColumnVector], Int)]()
+      val outputTypes = output.drop(childOutput.length).map(
+        _.dataType.transformRecursively {
+          case udt: UserDefinedType[_] => udt.sqlType
+        })
 
       // Try to resolve all UDF inputs as simple column references.
       val inputColumnIndices = resolveColumnIndices(allInputs.toSeq)
 
+      val unsafeProj = UnsafeProjection.create(childOutput, childOutput)
+
       val resultIter = if (inputColumnIndices.isDefined) {
-        evalColumnar(
-          inputIter, context, pyFuncs, argMetas, udfInputSchema,
-          inputColumnIndices.get, passThruQueue)
+        // Columnar path: send Arrow FieldVectors directly to Python.
+        // Buffer rows in queue for result joining.
+        val bufferedIter = inputIter.map { batch =>
+          batch.rowIterator().asScala.foreach { row =>
+            queue.add(unsafeProj(row).copy())
+          }
+          batch
+        }
+
+        val pyRunner = new ColumnarArrowPythonWithNamedArgumentRunner(
+          pyFuncs, evalType, argMetas, udfInputSchema,
+          sessionLocalTimeZone, largeVarTypes, pythonRunnerConf,
+          pythonMetrics, jobArtifactUUID, sessionUUID,
+          inputColumnIndices.get)
+
+        pyRunner.compute(bufferedIter, context.partitionId(), context)
       } else {
-        evalRowFallback(
-          inputIter, context, pyFuncs, argMetas, allInputs.toSeq,
-          udfInputSchema, passThruQueue)
+        // Fallback: complex expressions, convert to rows for UDF input.
+        val projection = MutableProjection.create(allInputs.toSeq, childOutput)
+        projection.initialize(context.partitionId())
+
+        val projectedRowIter = inputIter.flatMap { batch =>
+          batch.rowIterator().asScala
+        }.map { inputRow =>
+          queue.add(unsafeProj(inputRow).copy())
+          projection(inputRow)
+        }
+
+        val batchIter = Iterator(projectedRowIter)
+        val pyRunner = new ArrowPythonWithNamedArgumentRunner(
+          pyFuncs, evalType, argMetas, udfInputSchema,
+          sessionLocalTimeZone, largeVarTypes, pythonRunnerConf,
+          pythonMetrics, jobArtifactUUID, sessionUUID
+        ) with BatchedPythonArrowInput
+
+        pyRunner.compute(batchIter, context.partitionId(), context)
       }
 
-      combineResults(resultIter, outputTypes, passThruQueue)
+      // Join UDF results with buffered input rows.
+      val joined = new JoinedRow
+      val resultProj = UnsafeProjection.create(output, output)
+
+      resultIter.flatMap { batch =>
+        val actualDataTypes = (0 until batch.numCols()).map(
+          i => batch.column(i).dataType())
+        if (!equalsIgnoreCompatibleCollation(outputTypes, actualDataTypes)) {
+          throw QueryExecutionErrors.arrowDataTypeMismatchError(
+            "pandas_udf()", outputTypes, actualDataTypes)
+        }
+        batch.rowIterator.asScala
+      }.map { outputRow =>
+        resultProj(joined(queue.remove(), outputRow))
+      }
     }
 
-    /**
-     * Try to resolve all UDF input expressions as simple column references in childOutput.
-     * Returns Some(indices) if all are AttributeReferences; None otherwise.
-     */
-    private def resolveColumnIndices(allInputs: Seq[Expression]): Option[Array[Int]] = {
+    private def resolveColumnIndices(
+        allInputs: Seq[Expression]): Option[Array[Int]] = {
       val indices = allInputs.map {
         case attr: AttributeReference =>
           val idx = childOutput.indexWhere(_.exprId == attr.exprId)
@@ -146,109 +200,6 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
           return None
       }
       Some(indices.toArray)
-    }
-
-    /**
-     * Columnar path: extract Arrow vectors directly from ColumnarBatch and send to Python.
-     * Pass-through columns are kept as ColumnVector references -- no row conversion.
-     */
-    private def evalColumnar(
-        inputIter: Iterator[ColumnarBatch],
-        context: TaskContext,
-        pyFuncs: Seq[(ChainedPythonFunctions, Long)],
-        argMetas: Array[Array[ArgumentMetadata]],
-        udfInputSchema: StructType,
-        columnIndices: Array[Int],
-        passThruQueue: ArrayDeque[(Array[ColumnVector], Int)]): Iterator[ColumnarBatch] = {
-
-      // Wrap iterator: save pass-through columns, then pass batch to runner.
-      val bufferedIter = inputIter.map { batch =>
-        val passThruCols = childOutput.indices.map(i => batch.column(i)).toArray
-        passThruQueue.add((passThruCols, batch.numRows()))
-        batch
-      }
-
-      val pyRunner = new ColumnarArrowPythonWithNamedArgumentRunner(
-        pyFuncs, evalType, argMetas, udfInputSchema, sessionLocalTimeZone,
-        largeVarTypes, pythonRunnerConf, pythonMetrics, jobArtifactUUID,
-        sessionUUID, columnIndices)
-
-      pyRunner.compute(bufferedIter, context.partitionId(), context)
-    }
-
-    /**
-     * Fallback path: UDF inputs contain complex expressions. Convert to rows for
-     * UDF input serialization, but still keep pass-through columns in columnar format.
-     *
-     * TODO: Add a physical plan rule that inserts a ProjectExec before
-     *   ArrowEvalPythonExec to pre-evaluate complex UDF input expressions into
-     *   simple column references. This would eliminate this fallback entirely,
-     *   allowing the fully columnar evalColumnar() path to always be used when
-     *   the child supports columnar output.
-     */
-    private def evalRowFallback(
-        inputIter: Iterator[ColumnarBatch],
-        context: TaskContext,
-        pyFuncs: Seq[(ChainedPythonFunctions, Long)],
-        argMetas: Array[Array[ArgumentMetadata]],
-        allInputs: Seq[Expression],
-        udfInputSchema: StructType,
-        passThruQueue: ArrayDeque[(Array[ColumnVector], Int)]): Iterator[ColumnarBatch] = {
-
-      val projection = MutableProjection.create(allInputs, childOutput)
-      projection.initialize(context.partitionId())
-
-      // Convert ColumnarBatch to rows for UDF input, save pass-through columns.
-      val projectedRowIter = inputIter.flatMap { batch =>
-        val passThruCols = childOutput.indices.map(i => batch.column(i)).toArray
-        passThruQueue.add((passThruCols, batch.numRows()))
-        batch.rowIterator().asScala.map(projection)
-      }
-
-      val batchIter = Iterator(projectedRowIter)
-      val pyRunner = new ArrowPythonWithNamedArgumentRunner(
-        pyFuncs, evalType, argMetas, udfInputSchema, sessionLocalTimeZone,
-        largeVarTypes, pythonRunnerConf, pythonMetrics, jobArtifactUUID,
-        sessionUUID) with BatchedPythonArrowInput
-
-      pyRunner.compute(batchIter, context.partitionId(), context)
-    }
-
-    /**
-     * Combine pass-through columns with UDF result columns into output ColumnarBatches.
-     *
-     * For scalar Arrow UDFs, Python preserves batch boundaries: one input batch
-     * produces one output batch with the same number of rows. This method pops
-     * pass-through columns from the queue and combines them with UDF result columns.
-     */
-    private def combineResults(
-        resultIter: Iterator[ColumnarBatch],
-        outputTypes: Seq[DataType],
-        passThruQueue: ArrayDeque[(Array[ColumnVector], Int)]): Iterator[ColumnarBatch] = {
-
-      resultIter.map { resultBatch =>
-        val actualDataTypes = (0 until resultBatch.numCols()).map(
-          i => resultBatch.column(i).dataType())
-        if (!equalsIgnoreCompatibleCollation(outputTypes, actualDataTypes)) {
-          throw QueryExecutionErrors.arrowDataTypeMismatchError(
-            "pandas_udf()", outputTypes, actualDataTypes)
-        }
-
-        val numResultRows = resultBatch.numRows()
-        val resultCols = (0 until resultBatch.numCols()).map(
-          i => resultBatch.column(i)).toArray
-
-        // Pop the corresponding pass-through columns.
-        val (passThruCols, passThruRows) = passThruQueue.poll()
-        assert(passThruRows == numResultRows,
-          s"Batch size mismatch: pass-through has $passThruRows rows " +
-          s"but UDF result has $numResultRows rows. " +
-          s"This can happen when Arrow output batch slicing is enabled.")
-
-        // Combine: [pass-through columns | UDF result columns]
-        val allCols = passThruCols ++ resultCols
-        new ColumnarBatch(allCols, numResultRows)
-      }
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowEvalPythonEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowEvalPythonEvaluatorFactory.scala
@@ -16,15 +16,13 @@
  */
 package org.apache.spark.sql.execution.python
 
-import java.io.File
 import java.util.ArrayDeque
 
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 
-import org.apache.spark.{PartitionEvaluator, PartitionEvaluatorFactory, SparkEnv, TaskContext}
+import org.apache.spark.{PartitionEvaluator, PartitionEvaluatorFactory, TaskContext}
 import org.apache.spark.api.python.ChainedPythonFunctions
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -32,32 +30,32 @@ import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
 import org.apache.spark.sql.types.{DataType, StructField, StructType, UserDefinedType}
 import org.apache.spark.sql.types.DataType.equalsIgnoreCompatibleCollation
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
-import org.apache.spark.util.Utils
 
 /**
- * Evaluator factory for Arrow Python UDFs that processes [[ColumnarBatch]] input.
+ * Evaluator factory for Arrow Python UDFs that processes [[ColumnarBatch]]
+ * input and produces [[ColumnarBatch]] output, fully columnar end-to-end.
  *
- * Two execution paths:
+ * Both execution paths maintain 1:1 batch correspondence with Python,
+ * enabling columnar pass-through column combining:
  *
  * 1. '''Columnar path''' (all UDF inputs are simple column references):
- *    UDF input columns are extracted as Arrow FieldVectors and sent directly
- *    via IPC. Pass-through columns are kept as [[ColumnVector]] references and
- *    combined with UDF results at the columnar level. This works because each
- *    input [[ColumnarBatch]] is sent as one Arrow IPC RecordBatch, the Python
- *    worker processes scalar UDFs batch-by-batch preserving 1:1 correspondence,
- *    and the default output batch config does not do slicing (both
- *    maxRecordsPerOutputBatch and maxBytesPerOutputBatch default to -1).
+ *    Arrow FieldVectors are extracted directly from [[ArrowColumnVector]]
+ *    and serialized to IPC. Each [[ColumnarBatch]] becomes one IPC
+ *    RecordBatch.
  *
  * 2. '''Row fallback path''' (UDF inputs contain complex expressions):
- *    Falls back to row-based ArrowWriter for UDF input serialization and
- *    [[HybridRowQueue]] for pass-through column buffering, since
- *    [[BatchedPythonArrowInput]] re-batches rows and breaks batch boundaries.
+ *    Rows are extracted via [[MutableProjection]] and sent using
+ *    [[BasicPythonArrowInput]] (NOT [[BatchedPythonArrowInput]]), where
+ *    each [[ColumnarBatch]]'s rows form one inner iterator that becomes
+ *    one IPC RecordBatch. This preserves 1:1 batch correspondence.
+ *
+ * In both paths, pass-through columns are kept as [[ColumnVector]]
+ * references and combined with UDF result columns at the columnar level.
  *
  * TODO: Add a physical plan rule that inserts a ProjectExec before
- *   ArrowEvalPythonExec to pre-evaluate complex UDF input expressions into
- *   simple column references. This would eliminate the fallback path,
- *   allowing the direct Arrow path to always be used when the child
- *   supports columnar output.
+ *   ArrowEvalPythonExec to pre-evaluate complex UDF input expressions
+ *   into simple column references. This would eliminate the row fallback
+ *   path entirely.
  */
 private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
     childOutput: Seq[Attribute],
@@ -71,30 +69,31 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
     pythonMetrics: Map[String, SQLMetric],
     jobArtifactUUID: Option[String],
     sessionUUID: Option[String])
-  extends PartitionEvaluatorFactory[ColumnarBatch, InternalRow] {
+  extends PartitionEvaluatorFactory[ColumnarBatch, ColumnarBatch] {
 
-  override def createEvaluator(): PartitionEvaluator[ColumnarBatch, InternalRow] =
+  override def createEvaluator(): PartitionEvaluator[ColumnarBatch, ColumnarBatch] =
     new ColumnarArrowEvalPythonPartitionEvaluator
 
   private class ColumnarArrowEvalPythonPartitionEvaluator
-      extends PartitionEvaluator[ColumnarBatch, InternalRow] {
+      extends PartitionEvaluator[ColumnarBatch, ColumnarBatch] {
 
     private def collectFunctions(
         udf: PythonUDF): ((ChainedPythonFunctions, Long), Seq[Expression]) = {
       udf.children match {
         case Seq(u: PythonUDF) =>
           val ((chained, _), children) = collectFunctions(u)
-          ((ChainedPythonFunctions(chained.funcs ++ Seq(udf.func)), udf.resultId.id),
-            children)
+          ((ChainedPythonFunctions(chained.funcs ++ Seq(udf.func)),
+            udf.resultId.id), children)
         case children =>
           assert(children.forall(!_.exists(_.isInstanceOf[PythonUDF])))
-          ((ChainedPythonFunctions(Seq(udf.func)), udf.resultId.id), udf.children)
+          ((ChainedPythonFunctions(Seq(udf.func)),
+            udf.resultId.id), udf.children)
       }
     }
 
     override def eval(
         partitionIndex: Int,
-        iters: Iterator[ColumnarBatch]*): Iterator[InternalRow] = {
+        iters: Iterator[ColumnarBatch]*): Iterator[ColumnarBatch] = {
       val inputIter = iters.head
       val context = TaskContext.get()
 
@@ -106,11 +105,13 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
       val argMetas = inputs.map { input =>
         input.map { e =>
           val (key, value) = e match {
-            case NamedArgumentExpression(key, value) => (Some(key), value)
+            case NamedArgumentExpression(key, value) =>
+              (Some(key), value)
             case _ => (None, e)
           }
           if (allInputs.exists(_.semanticEquals(value))) {
-            ArgumentMetadata(allInputs.indexWhere(_.semanticEquals(value)), key)
+            ArgumentMetadata(
+              allInputs.indexWhere(_.semanticEquals(value)), key)
           } else {
             allInputs += value
             dataTypes += value.dataType
@@ -119,53 +120,48 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
         }.toArray
       }.toArray
 
-      val udfInputSchema = StructType(dataTypes.zipWithIndex.map { case (dt, i) =>
-        StructField(s"_$i", dt)
-      }.toArray)
+      val udfInputSchema = StructType(
+        dataTypes.zipWithIndex.map { case (dt, i) =>
+          StructField(s"_$i", dt)
+        }.toArray)
 
       val outputTypes = output.drop(childOutput.length).map(
         _.dataType.transformRecursively {
           case udt: UserDefinedType[_] => udt.sqlType
         })
 
+      // Queue to buffer pass-through columns per input batch.
+      val passThruQueue = new ArrayDeque[(Array[ColumnVector], Int)]()
+
       // Try to resolve all UDF inputs as simple column references.
       val inputColumnIndices = resolveColumnIndices(allInputs.toSeq)
 
-      if (inputColumnIndices.isDefined) {
+      val resultIter = if (inputColumnIndices.isDefined) {
         evalColumnar(inputIter, context, pyFuncs, argMetas,
-          udfInputSchema, outputTypes, inputColumnIndices.get)
+          udfInputSchema, inputColumnIndices.get, passThruQueue)
       } else {
         evalRowFallback(inputIter, context, pyFuncs, argMetas,
-          allInputs.toSeq, udfInputSchema, outputTypes)
+          allInputs.toSeq, udfInputSchema, passThruQueue)
       }
+
+      combineResults(resultIter, outputTypes, passThruQueue)
     }
 
-    /**
-     * Try to resolve all UDF input expressions as simple column references
-     * in childOutput. Returns Some(indices) if all are AttributeReferences;
-     * None otherwise.
-     */
     private def resolveColumnIndices(
         allInputs: Seq[Expression]): Option[Array[Int]] = {
       val indices = allInputs.map {
         case attr: AttributeReference =>
           val idx = childOutput.indexWhere(_.exprId == attr.exprId)
           if (idx >= 0) idx else return None
-        case _ =>
-          return None
+        case _ => return None
       }
       Some(indices.toArray)
     }
 
     /**
-     * Columnar path: send Arrow FieldVectors directly to Python.
-     * Pass-through columns are kept as ColumnVector references and combined
-     * with UDF results at the columnar level (1:1 batch correspondence).
-     *
-     * This works because:
-     * - ColumnarArrowPythonInput sends one IPC RecordBatch per ColumnarBatch
-     * - Python scalar UDF worker processes batch-by-batch (one in, one out)
-     * - Default output batch config does not do slicing (both defaults = -1)
+     * Columnar path: extract Arrow FieldVectors directly from
+     * ColumnarBatch and send to Python. Each ColumnarBatch becomes
+     * one IPC RecordBatch (1:1 batch correspondence).
      */
     private def evalColumnar(
         inputIter: Iterator[ColumnarBatch],
@@ -173,12 +169,9 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
         pyFuncs: Seq[(ChainedPythonFunctions, Long)],
         argMetas: Array[Array[ArgumentMetadata]],
         udfInputSchema: StructType,
-        outputTypes: Seq[DataType],
-        columnIndices: Array[Int]): Iterator[InternalRow] = {
-
-      // Queue pass-through columns per batch for columnar combining.
-      val passThruQueue = new ArrayDeque[(Array[ColumnVector], Int)]()
-
+        columnIndices: Array[Int],
+        passThruQueue: ArrayDeque[(Array[ColumnVector], Int)]
+    ): Iterator[ColumnarBatch] = {
       val bufferedIter = inputIter.map { batch =>
         val passThruCols = childOutput.indices.map(
           i => batch.column(i)).toArray
@@ -191,43 +184,19 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
         sessionLocalTimeZone, largeVarTypes, pythonRunnerConf,
         pythonMetrics, jobArtifactUUID, sessionUUID, columnIndices)
 
-      val resultIter = pyRunner.compute(
-        bufferedIter, context.partitionId(), context)
-
-      // Combine pass-through columns with UDF results at columnar level,
-      // then flatten to rows.
-      resultIter.flatMap { resultBatch =>
-        validateOutputTypes(resultBatch, outputTypes)
-
-        val numRows = resultBatch.numRows()
-        val resultCols = (0 until resultBatch.numCols()).map(
-          i => resultBatch.column(i)).toArray
-
-        val (passThruCols, passThruRows) = passThruQueue.poll()
-        assert(passThruRows == numRows,
-          s"Batch size mismatch: pass-through has $passThruRows rows " +
-          s"but UDF result has $numRows rows.")
-
-        // Combine: [pass-through columns | UDF result columns]
-        val combined = new ColumnarBatch(
-          passThruCols ++ resultCols, numRows)
-        combined.rowIterator().asScala
-      }
+      pyRunner.compute(bufferedIter, context.partitionId(), context)
     }
 
     /**
-     * Fallback path: UDF inputs contain complex expressions that cannot be
-     * resolved to simple column indices. Uses row-based ArrowWriter for UDF
-     * input serialization and HybridRowQueue for pass-through buffering.
+     * Row fallback path: UDF inputs contain complex expressions.
+     * Rows are extracted via MutableProjection and sent using
+     * BasicPythonArrowInput (NOT BatchedPythonArrowInput) so that
+     * each ColumnarBatch's rows form one inner iterator = one IPC
+     * RecordBatch, preserving 1:1 batch correspondence.
      *
-     * This path uses BatchedPythonArrowInput which re-batches rows according
-     * to maxRecordsPerBatch, breaking the original ColumnarBatch boundaries.
-     * Therefore columnar pass-through combining is not possible.
-     *
-     * TODO: Add a physical plan rule that inserts a ProjectExec before
-     *   ArrowEvalPythonExec to pre-evaluate complex UDF input expressions
-     *   into simple column references. This would eliminate this fallback
-     *   entirely.
+     * TODO: Add a physical plan rule that inserts a ProjectExec
+     *   before ArrowEvalPythonExec to pre-evaluate complex UDF input
+     *   expressions. This would eliminate this fallback entirely.
      */
     private def evalRowFallback(
         inputIter: Iterator[ColumnarBatch],
@@ -236,54 +205,61 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
         argMetas: Array[Array[ArgumentMetadata]],
         allInputs: Seq[Expression],
         udfInputSchema: StructType,
-        outputTypes: Seq[DataType]): Iterator[InternalRow] = {
-
-      val queue = HybridRowQueue(
-        context.taskMemoryManager(),
-        new File(Utils.getLocalDir(SparkEnv.get.conf)),
-        childOutput.length)
-      context.addTaskCompletionListener[Unit] { _ => queue.close() }
-
+        passThruQueue: ArrayDeque[(Array[ColumnVector], Int)]
+    ): Iterator[ColumnarBatch] = {
       val projection = MutableProjection.create(allInputs, childOutput)
       projection.initialize(context.partitionId())
 
-      val unsafeProj = UnsafeProjection.create(childOutput, childOutput)
-
-      val projectedRowIter = inputIter.flatMap { batch =>
-        batch.rowIterator().asScala
-      }.map { inputRow =>
-        queue.add(unsafeProj(inputRow).copy())
-        projection(inputRow)
+      // Each ColumnarBatch's projected rows become one inner iterator.
+      // BasicPythonArrowInput sends each inner iterator as one IPC
+      // RecordBatch, maintaining 1:1 batch correspondence with the
+      // pass-through queue.
+      val batchIter = inputIter.map { batch =>
+        val passThruCols = childOutput.indices.map(
+          i => batch.column(i)).toArray
+        passThruQueue.add((passThruCols, batch.numRows()))
+        batch.rowIterator().asScala.map(projection(_))
       }
 
-      val batchIter = Iterator(projectedRowIter)
       val pyRunner = new ArrowPythonWithNamedArgumentRunner(
         pyFuncs, evalType, argMetas, udfInputSchema,
         sessionLocalTimeZone, largeVarTypes, pythonRunnerConf,
         pythonMetrics, jobArtifactUUID, sessionUUID
-      ) with BatchedPythonArrowInput
+      ) with BasicPythonArrowInput
 
-      val resultIter = pyRunner.compute(
-        batchIter, context.partitionId(), context)
-
-      val joined = new JoinedRow
-      val resultProj = UnsafeProjection.create(output, output)
-
-      resultIter.flatMap { batch =>
-        validateOutputTypes(batch, outputTypes)
-        batch.rowIterator.asScala
-      }.map { outputRow =>
-        resultProj(joined(queue.remove(), outputRow))
-      }
+      pyRunner.compute(batchIter, context.partitionId(), context)
     }
 
-    private def validateOutputTypes(
-        batch: ColumnarBatch, outputTypes: Seq[DataType]): Unit = {
-      val actualDataTypes = (0 until batch.numCols()).map(
-        i => batch.column(i).dataType())
-      if (!equalsIgnoreCompatibleCollation(outputTypes, actualDataTypes)) {
-        throw QueryExecutionErrors.arrowDataTypeMismatchError(
-          "pandas_udf()", outputTypes, actualDataTypes)
+    /**
+     * Combine pass-through columns with UDF result columns.
+     * Both evalColumnar and evalRowFallback maintain 1:1 batch
+     * correspondence, so each result batch matches one pass-through
+     * entry in the queue.
+     */
+    private def combineResults(
+        resultIter: Iterator[ColumnarBatch],
+        outputTypes: Seq[DataType],
+        passThruQueue: ArrayDeque[(Array[ColumnVector], Int)]
+    ): Iterator[ColumnarBatch] = {
+      resultIter.map { resultBatch =>
+        val actualDataTypes = (0 until resultBatch.numCols()).map(
+          i => resultBatch.column(i).dataType())
+        if (!equalsIgnoreCompatibleCollation(
+            outputTypes, actualDataTypes)) {
+          throw QueryExecutionErrors.arrowDataTypeMismatchError(
+            "pandas_udf()", outputTypes, actualDataTypes)
+        }
+
+        val numRows = resultBatch.numRows()
+        val resultCols = (0 until resultBatch.numCols()).map(
+          i => resultBatch.column(i)).toArray
+
+        val (passThruCols, passThruRows) = passThruQueue.poll()
+        assert(passThruRows == numRows,
+          s"Batch size mismatch: pass-through has $passThruRows " +
+          s"rows but UDF result has $numRows rows.")
+
+        new ColumnarBatch(passThruCols ++ resultCols, numRows)
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowEvalPythonEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowEvalPythonEvaluatorFactory.scala
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.python
+
+import java.io.File
+
+import scala.collection.mutable.ArrayBuffer
+import scala.jdk.CollectionConverters._
+
+import org.apache.spark.{PartitionEvaluator, PartitionEvaluatorFactory, SparkEnv, TaskContext}
+import org.apache.spark.api.python.ChainedPythonFunctions
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
+import org.apache.spark.sql.types.{DataType, StructField, StructType, UserDefinedType}
+import org.apache.spark.sql.types.DataType.equalsIgnoreCompatibleCollation
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.Utils
+
+/**
+ * Evaluator factory for Arrow Python UDFs that processes [[ColumnarBatch]] input directly.
+ *
+ * When UDF inputs are simple column references and the batch is Arrow-backed,
+ * this avoids the columnar-to-row-to-columnar round-trip by extracting Arrow
+ * FieldVectors directly from [[ArrowColumnVector]] columns.
+ *
+ * When UDF inputs contain complex expressions (not simple column references),
+ * falls back to converting ColumnarBatch to rows and delegating to the existing
+ * row-based [[ArrowEvalPythonEvaluatorFactory]].
+ */
+private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
+    childOutput: Seq[Attribute],
+    udfs: Seq[PythonUDF],
+    output: Seq[Attribute],
+    batchSize: Int,
+    evalType: Int,
+    sessionLocalTimeZone: String,
+    largeVarTypes: Boolean,
+    pythonRunnerConf: Map[String, String],
+    pythonMetrics: Map[String, SQLMetric],
+    jobArtifactUUID: Option[String],
+    sessionUUID: Option[String])
+  extends PartitionEvaluatorFactory[ColumnarBatch, InternalRow] {
+
+  override def createEvaluator(): PartitionEvaluator[ColumnarBatch, InternalRow] =
+    new ColumnarArrowEvalPythonPartitionEvaluator
+
+  private class ColumnarArrowEvalPythonPartitionEvaluator
+      extends PartitionEvaluator[ColumnarBatch, InternalRow] {
+
+    /** Collect chained Python functions and their children (same as EvalPythonEvaluatorFactory). */
+    private def collectFunctions(
+        udf: PythonUDF): ((ChainedPythonFunctions, Long), Seq[Expression]) = {
+      udf.children match {
+        case Seq(u: PythonUDF) =>
+          val ((chained, _), children) = collectFunctions(u)
+          ((ChainedPythonFunctions(chained.funcs ++ Seq(udf.func)), udf.resultId.id), children)
+        case children =>
+          assert(children.forall(!_.exists(_.isInstanceOf[PythonUDF])))
+          ((ChainedPythonFunctions(Seq(udf.func)), udf.resultId.id), udf.children)
+      }
+    }
+
+    override def eval(
+        partitionIndex: Int,
+        iters: Iterator[ColumnarBatch]*): Iterator[InternalRow] = {
+      val inputIter = iters.head
+      val context = TaskContext.get()
+
+      // Buffer input rows to combine with UDF output later (same as EvalPythonEvaluatorFactory).
+      val queue = HybridRowQueue(
+        context.taskMemoryManager(),
+        new File(Utils.getLocalDir(SparkEnv.get.conf)),
+        childOutput.length)
+      context.addTaskCompletionListener[Unit] { _ => queue.close() }
+
+      val (pyFuncs, inputs) = udfs.map(collectFunctions).unzip
+
+      // Flatten all UDF arguments and build argMetas (same as EvalPythonEvaluatorFactory).
+      val allInputs = new ArrayBuffer[Expression]
+      val dataTypes = new ArrayBuffer[DataType]
+      val argMetas = inputs.map { input =>
+        input.map { e =>
+          val (key, value) = e match {
+            case NamedArgumentExpression(key, value) => (Some(key), value)
+            case _ => (None, e)
+          }
+          if (allInputs.exists(_.semanticEquals(value))) {
+            ArgumentMetadata(allInputs.indexWhere(_.semanticEquals(value)), key)
+          } else {
+            allInputs += value
+            dataTypes += value.dataType
+            ArgumentMetadata(allInputs.length - 1, key)
+          }
+        }.toArray
+      }.toArray
+
+      val udfInputSchema = StructType(dataTypes.zipWithIndex.map { case (dt, i) =>
+        StructField(s"_$i", dt)
+      }.toArray)
+
+      // Try to resolve all UDF inputs as simple column references.
+      val inputColumnIndices = resolveColumnIndices(allInputs.toSeq)
+
+      if (inputColumnIndices.isDefined) {
+        // Columnar path: all UDF inputs are simple column references.
+        evalColumnar(
+          inputIter, context, queue, pyFuncs, argMetas,
+          udfInputSchema, inputColumnIndices.get)
+      } else {
+        // Fallback: complex expressions exist, convert to rows.
+        evalRowFallback(
+          inputIter, context, queue, pyFuncs, argMetas, allInputs.toSeq,
+          udfInputSchema)
+      }
+    }
+
+    /**
+     * Try to resolve all UDF input expressions as simple column references in childOutput.
+     * Returns Some(indices) if all are AttributeReferences; None otherwise.
+     */
+    private def resolveColumnIndices(allInputs: Seq[Expression]): Option[Array[Int]] = {
+      val indices = allInputs.map {
+        case attr: AttributeReference =>
+          val idx = childOutput.indexWhere(_.exprId == attr.exprId)
+          if (idx >= 0) idx else return None
+        case _ =>
+          return None
+      }
+      Some(indices.toArray)
+    }
+
+    /**
+     * Columnar path: extract Arrow vectors directly from ColumnarBatch and send to Python.
+     */
+    private def evalColumnar(
+        inputIter: Iterator[ColumnarBatch],
+        context: TaskContext,
+        queue: HybridRowQueue,
+        pyFuncs: Seq[(ChainedPythonFunctions, Long)],
+        argMetas: Array[Array[ArgumentMetadata]],
+        udfInputSchema: StructType,
+        columnIndices: Array[Int]): Iterator[InternalRow] = {
+
+      val unsafeProj = UnsafeProjection.create(childOutput, childOutput)
+
+      // Wrap iterator: buffer rows in queue, then pass batch to runner.
+      val bufferedIter = inputIter.map { batch =>
+        val rowIter = batch.rowIterator().asScala
+        while (rowIter.hasNext) {
+          queue.add(unsafeProj(rowIter.next()).copy())
+        }
+        batch
+      }
+
+      val pyRunner = new ColumnarArrowPythonWithNamedArgumentRunner(
+        pyFuncs,
+        evalType,
+        argMetas,
+        udfInputSchema,
+        sessionLocalTimeZone,
+        largeVarTypes,
+        pythonRunnerConf,
+        pythonMetrics,
+        jobArtifactUUID,
+        sessionUUID,
+        columnIndices)
+
+      val outputTypes = output.drop(childOutput.length).map(_.dataType.transformRecursively {
+        case udt: UserDefinedType[_] => udt.sqlType
+      })
+
+      val columnarBatchIter = pyRunner.compute(bufferedIter, context.partitionId(), context)
+
+      val joined = new JoinedRow
+      val resultProj = UnsafeProjection.create(output, output)
+
+      columnarBatchIter.flatMap { batch =>
+        val actualDataTypes = (0 until batch.numCols()).map(i => batch.column(i).dataType())
+        if (!equalsIgnoreCompatibleCollation(outputTypes, actualDataTypes)) {
+          throw QueryExecutionErrors.arrowDataTypeMismatchError(
+            "pandas_udf()", outputTypes, actualDataTypes)
+        }
+        batch.rowIterator.asScala
+      }.map { outputRow =>
+        resultProj(joined(queue.remove(), outputRow))
+      }
+    }
+
+    /**
+     * Fallback path: convert ColumnarBatch to rows and use existing row-based evaluation.
+     * Used when UDF inputs contain complex expressions that cannot be resolved to
+     * simple column indices.
+     */
+    private def evalRowFallback(
+        inputIter: Iterator[ColumnarBatch],
+        context: TaskContext,
+        queue: HybridRowQueue,
+        pyFuncs: Seq[(ChainedPythonFunctions, Long)],
+        argMetas: Array[Array[ArgumentMetadata]],
+        allInputs: Seq[Expression],
+        udfInputSchema: StructType): Iterator[InternalRow] = {
+
+      val projection = MutableProjection.create(allInputs, childOutput)
+      projection.initialize(context.partitionId())
+
+      val outputTypes = output.drop(childOutput.length).map(_.dataType.transformRecursively {
+        case udt: UserDefinedType[_] => udt.sqlType
+      })
+
+      // Convert ColumnarBatch to rows, buffer + project.
+      val unsafeProj = UnsafeProjection.create(childOutput, childOutput)
+      val projectedRowIter = inputIter.flatMap { batch =>
+        batch.rowIterator().asScala
+      }.map { inputRow =>
+        queue.add(unsafeProj(inputRow).copy())
+        projection(inputRow)
+      }
+
+      val batchIter = Iterator(projectedRowIter)
+
+      val pyRunner = new ArrowPythonWithNamedArgumentRunner(
+        pyFuncs,
+        evalType,
+        argMetas,
+        udfInputSchema,
+        sessionLocalTimeZone,
+        largeVarTypes,
+        pythonRunnerConf,
+        pythonMetrics,
+        jobArtifactUUID,
+        sessionUUID) with BatchedPythonArrowInput
+      val columnarBatchIter = pyRunner.compute(batchIter, context.partitionId(), context)
+
+      val joined = new JoinedRow
+      val resultProj = UnsafeProjection.create(output, output)
+
+      columnarBatchIter.flatMap { batch =>
+        val actualDataTypes = (0 until batch.numCols()).map(i => batch.column(i).dataType())
+        if (!equalsIgnoreCompatibleCollation(outputTypes, actualDataTypes)) {
+          throw QueryExecutionErrors.arrowDataTypeMismatchError(
+            "pandas_udf()", outputTypes, actualDataTypes)
+        }
+        batch.rowIterator.asScala
+      }.map { outputRow =>
+        resultProj(joined(queue.remove(), outputRow))
+      }
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowEvalPythonEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowEvalPythonEvaluatorFactory.scala
@@ -16,33 +16,40 @@
  */
 package org.apache.spark.sql.execution.python
 
-import java.io.File
+import java.util.ArrayDeque
 
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 
-import org.apache.spark.{PartitionEvaluator, PartitionEvaluatorFactory, SparkEnv, TaskContext}
+import org.apache.spark.{PartitionEvaluator, PartitionEvaluatorFactory, TaskContext}
 import org.apache.spark.api.python.ChainedPythonFunctions
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
 import org.apache.spark.sql.types.{DataType, StructField, StructType, UserDefinedType}
 import org.apache.spark.sql.types.DataType.equalsIgnoreCompatibleCollation
-import org.apache.spark.sql.vectorized.ColumnarBatch
-import org.apache.spark.util.Utils
+import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 
 /**
- * Evaluator factory for Arrow Python UDFs that processes [[ColumnarBatch]] input directly.
+ * Evaluator factory for Arrow Python UDFs that processes [[ColumnarBatch]] input
+ * and produces [[ColumnarBatch]] output, staying fully in columnar format.
  *
  * When UDF inputs are simple column references and the batch is Arrow-backed,
- * this avoids the columnar-to-row-to-columnar round-trip by extracting Arrow
- * FieldVectors directly from [[ArrowColumnVector]] columns.
+ * this avoids the columnar-to-row-to-columnar round-trip entirely:
+ * - UDF input columns: extracted as Arrow FieldVectors and sent directly via IPC.
+ * - Pass-through columns: kept as ColumnVector references (no row conversion).
+ * - Output: pass-through ColumnVectors + UDF result ColumnVectors combined into
+ *   a new [[ColumnarBatch]].
  *
  * When UDF inputs contain complex expressions (not simple column references),
- * falls back to converting ColumnarBatch to rows and delegating to the existing
- * row-based [[ArrowEvalPythonEvaluatorFactory]].
+ * the UDF inputs are serialized via the row-based ArrowWriter fallback, but
+ * pass-through columns are still kept in columnar format.
+ *
+ * Note: DBR handles complex expressions by inserting a Project node upstream
+ * (via PhotonStageCompiler.extractUDFInputsIntoProject) to pre-evaluate them.
+ * A similar physical plan rule could be added to OSS Spark in the future to
+ * eliminate the fallback path.
  */
 private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
     childOutput: Seq[Attribute],
@@ -56,15 +63,14 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
     pythonMetrics: Map[String, SQLMetric],
     jobArtifactUUID: Option[String],
     sessionUUID: Option[String])
-  extends PartitionEvaluatorFactory[ColumnarBatch, InternalRow] {
+  extends PartitionEvaluatorFactory[ColumnarBatch, ColumnarBatch] {
 
-  override def createEvaluator(): PartitionEvaluator[ColumnarBatch, InternalRow] =
+  override def createEvaluator(): PartitionEvaluator[ColumnarBatch, ColumnarBatch] =
     new ColumnarArrowEvalPythonPartitionEvaluator
 
   private class ColumnarArrowEvalPythonPartitionEvaluator
-      extends PartitionEvaluator[ColumnarBatch, InternalRow] {
+      extends PartitionEvaluator[ColumnarBatch, ColumnarBatch] {
 
-    /** Collect chained Python functions and their children (same as EvalPythonEvaluatorFactory). */
     private def collectFunctions(
         udf: PythonUDF): ((ChainedPythonFunctions, Long), Seq[Expression]) = {
       udf.children match {
@@ -79,16 +85,9 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
 
     override def eval(
         partitionIndex: Int,
-        iters: Iterator[ColumnarBatch]*): Iterator[InternalRow] = {
+        iters: Iterator[ColumnarBatch]*): Iterator[ColumnarBatch] = {
       val inputIter = iters.head
       val context = TaskContext.get()
-
-      // Buffer input rows to combine with UDF output later (same as EvalPythonEvaluatorFactory).
-      val queue = HybridRowQueue(
-        context.taskMemoryManager(),
-        new File(Utils.getLocalDir(SparkEnv.get.conf)),
-        childOutput.length)
-      context.addTaskCompletionListener[Unit] { _ => queue.close() }
 
       val (pyFuncs, inputs) = udfs.map(collectFunctions).unzip
 
@@ -115,20 +114,28 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
         StructField(s"_$i", dt)
       }.toArray)
 
+      val outputTypes = output.drop(childOutput.length).map(_.dataType.transformRecursively {
+        case udt: UserDefinedType[_] => udt.sqlType
+      })
+
+      // Queue to buffer pass-through columns from input batches.
+      // Each entry is (ColumnVector[], numRows) corresponding to one input ColumnarBatch.
+      val passThruQueue = new ArrayDeque[(Array[ColumnVector], Int)]()
+
       // Try to resolve all UDF inputs as simple column references.
       val inputColumnIndices = resolveColumnIndices(allInputs.toSeq)
 
-      if (inputColumnIndices.isDefined) {
-        // Columnar path: all UDF inputs are simple column references.
+      val resultIter = if (inputColumnIndices.isDefined) {
         evalColumnar(
-          inputIter, context, queue, pyFuncs, argMetas,
-          udfInputSchema, inputColumnIndices.get)
+          inputIter, context, pyFuncs, argMetas, udfInputSchema,
+          inputColumnIndices.get, passThruQueue)
       } else {
-        // Fallback: complex expressions exist, convert to rows.
         evalRowFallback(
-          inputIter, context, queue, pyFuncs, argMetas, allInputs.toSeq,
-          udfInputSchema)
+          inputIter, context, pyFuncs, argMetas, allInputs.toSeq,
+          udfInputSchema, passThruQueue)
       }
+
+      combineResults(resultIter, outputTypes, passThruQueue)
     }
 
     /**
@@ -148,118 +155,98 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
 
     /**
      * Columnar path: extract Arrow vectors directly from ColumnarBatch and send to Python.
+     * Pass-through columns are kept as ColumnVector references -- no row conversion.
      */
     private def evalColumnar(
         inputIter: Iterator[ColumnarBatch],
         context: TaskContext,
-        queue: HybridRowQueue,
         pyFuncs: Seq[(ChainedPythonFunctions, Long)],
         argMetas: Array[Array[ArgumentMetadata]],
         udfInputSchema: StructType,
-        columnIndices: Array[Int]): Iterator[InternalRow] = {
+        columnIndices: Array[Int],
+        passThruQueue: ArrayDeque[(Array[ColumnVector], Int)]): Iterator[ColumnarBatch] = {
 
-      val unsafeProj = UnsafeProjection.create(childOutput, childOutput)
-
-      // Wrap iterator: buffer rows in queue, then pass batch to runner.
+      // Wrap iterator: save pass-through columns, then pass batch to runner.
       val bufferedIter = inputIter.map { batch =>
-        val rowIter = batch.rowIterator().asScala
-        while (rowIter.hasNext) {
-          queue.add(unsafeProj(rowIter.next()).copy())
-        }
+        val passThruCols = childOutput.indices.map(i => batch.column(i)).toArray
+        passThruQueue.add((passThruCols, batch.numRows()))
         batch
       }
 
       val pyRunner = new ColumnarArrowPythonWithNamedArgumentRunner(
-        pyFuncs,
-        evalType,
-        argMetas,
-        udfInputSchema,
-        sessionLocalTimeZone,
-        largeVarTypes,
-        pythonRunnerConf,
-        pythonMetrics,
-        jobArtifactUUID,
-        sessionUUID,
-        columnIndices)
+        pyFuncs, evalType, argMetas, udfInputSchema, sessionLocalTimeZone,
+        largeVarTypes, pythonRunnerConf, pythonMetrics, jobArtifactUUID,
+        sessionUUID, columnIndices)
 
-      val outputTypes = output.drop(childOutput.length).map(_.dataType.transformRecursively {
-        case udt: UserDefinedType[_] => udt.sqlType
-      })
-
-      val columnarBatchIter = pyRunner.compute(bufferedIter, context.partitionId(), context)
-
-      val joined = new JoinedRow
-      val resultProj = UnsafeProjection.create(output, output)
-
-      columnarBatchIter.flatMap { batch =>
-        val actualDataTypes = (0 until batch.numCols()).map(i => batch.column(i).dataType())
-        if (!equalsIgnoreCompatibleCollation(outputTypes, actualDataTypes)) {
-          throw QueryExecutionErrors.arrowDataTypeMismatchError(
-            "pandas_udf()", outputTypes, actualDataTypes)
-        }
-        batch.rowIterator.asScala
-      }.map { outputRow =>
-        resultProj(joined(queue.remove(), outputRow))
-      }
+      pyRunner.compute(bufferedIter, context.partitionId(), context)
     }
 
     /**
-     * Fallback path: convert ColumnarBatch to rows and use existing row-based evaluation.
-     * Used when UDF inputs contain complex expressions that cannot be resolved to
-     * simple column indices.
+     * Fallback path: UDF inputs contain complex expressions. Convert to rows for
+     * UDF input serialization, but still keep pass-through columns in columnar format.
      */
     private def evalRowFallback(
         inputIter: Iterator[ColumnarBatch],
         context: TaskContext,
-        queue: HybridRowQueue,
         pyFuncs: Seq[(ChainedPythonFunctions, Long)],
         argMetas: Array[Array[ArgumentMetadata]],
         allInputs: Seq[Expression],
-        udfInputSchema: StructType): Iterator[InternalRow] = {
+        udfInputSchema: StructType,
+        passThruQueue: ArrayDeque[(Array[ColumnVector], Int)]): Iterator[ColumnarBatch] = {
 
       val projection = MutableProjection.create(allInputs, childOutput)
       projection.initialize(context.partitionId())
 
-      val outputTypes = output.drop(childOutput.length).map(_.dataType.transformRecursively {
-        case udt: UserDefinedType[_] => udt.sqlType
-      })
-
-      // Convert ColumnarBatch to rows, buffer + project.
-      val unsafeProj = UnsafeProjection.create(childOutput, childOutput)
+      // Convert ColumnarBatch to rows for UDF input, save pass-through columns.
       val projectedRowIter = inputIter.flatMap { batch =>
-        batch.rowIterator().asScala
-      }.map { inputRow =>
-        queue.add(unsafeProj(inputRow).copy())
-        projection(inputRow)
+        val passThruCols = childOutput.indices.map(i => batch.column(i)).toArray
+        passThruQueue.add((passThruCols, batch.numRows()))
+        batch.rowIterator().asScala.map(projection)
       }
 
       val batchIter = Iterator(projectedRowIter)
-
       val pyRunner = new ArrowPythonWithNamedArgumentRunner(
-        pyFuncs,
-        evalType,
-        argMetas,
-        udfInputSchema,
-        sessionLocalTimeZone,
-        largeVarTypes,
-        pythonRunnerConf,
-        pythonMetrics,
-        jobArtifactUUID,
+        pyFuncs, evalType, argMetas, udfInputSchema, sessionLocalTimeZone,
+        largeVarTypes, pythonRunnerConf, pythonMetrics, jobArtifactUUID,
         sessionUUID) with BatchedPythonArrowInput
-      val columnarBatchIter = pyRunner.compute(batchIter, context.partitionId(), context)
 
-      val joined = new JoinedRow
-      val resultProj = UnsafeProjection.create(output, output)
+      pyRunner.compute(batchIter, context.partitionId(), context)
+    }
 
-      columnarBatchIter.flatMap { batch =>
-        val actualDataTypes = (0 until batch.numCols()).map(i => batch.column(i).dataType())
+    /**
+     * Combine pass-through columns with UDF result columns into output ColumnarBatches.
+     *
+     * For scalar Arrow UDFs, Python preserves batch boundaries: one input batch
+     * produces one output batch with the same number of rows. This method pops
+     * pass-through columns from the queue and combines them with UDF result columns.
+     */
+    private def combineResults(
+        resultIter: Iterator[ColumnarBatch],
+        outputTypes: Seq[DataType],
+        passThruQueue: ArrayDeque[(Array[ColumnVector], Int)]): Iterator[ColumnarBatch] = {
+
+      resultIter.map { resultBatch =>
+        val actualDataTypes = (0 until resultBatch.numCols()).map(
+          i => resultBatch.column(i).dataType())
         if (!equalsIgnoreCompatibleCollation(outputTypes, actualDataTypes)) {
           throw QueryExecutionErrors.arrowDataTypeMismatchError(
             "pandas_udf()", outputTypes, actualDataTypes)
         }
-        batch.rowIterator.asScala
-      }.map { outputRow =>
-        resultProj(joined(queue.remove(), outputRow))
+
+        val numResultRows = resultBatch.numRows()
+        val resultCols = (0 until resultBatch.numCols()).map(
+          i => resultBatch.column(i)).toArray
+
+        // Pop the corresponding pass-through columns.
+        val (passThruCols, passThruRows) = passThruQueue.poll()
+        assert(passThruRows == numResultRows,
+          s"Batch size mismatch: pass-through has $passThruRows rows " +
+          s"but UDF result has $numResultRows rows. " +
+          s"This can happen when Arrow output batch slicing is enabled.")
+
+        // Combine: [pass-through columns | UDF result columns]
+        val allCols = passThruCols ++ resultCols
+        new ColumnarBatch(allCols, numResultRows)
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowEvalPythonEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowEvalPythonEvaluatorFactory.scala
@@ -16,46 +16,51 @@
  */
 package org.apache.spark.sql.execution.python
 
+import java.io.File
 import java.util.ArrayDeque
 
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 
-import org.apache.spark.{PartitionEvaluator, PartitionEvaluatorFactory, TaskContext}
+import org.apache.spark.{PartitionEvaluator, PartitionEvaluatorFactory, SparkEnv, TaskContext}
 import org.apache.spark.api.python.ChainedPythonFunctions
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
 import org.apache.spark.sql.types.{DataType, StructField, StructType, UserDefinedType}
 import org.apache.spark.sql.types.DataType.equalsIgnoreCompatibleCollation
-import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch, ColumnVector}
+import org.apache.spark.util.Utils
 
 /**
  * Evaluator factory for Arrow Python UDFs that processes [[ColumnarBatch]]
- * input and produces [[ColumnarBatch]] output, fully columnar end-to-end.
+ * input and produces [[InternalRow]] output.
  *
- * Both execution paths maintain 1:1 batch correspondence with Python,
- * enabling columnar pass-through column combining:
+ * Three execution paths based on input characteristics:
  *
- * 1. '''Columnar path''' (all UDF inputs are simple column references):
- *    Arrow FieldVectors are extracted directly from [[ArrowColumnVector]]
- *    and serialized to IPC. Each [[ColumnarBatch]] becomes one IPC
- *    RecordBatch.
+ * 1. '''Arrow columnar path''' (UDF inputs are simple column refs AND
+ *    columns are [[ArrowColumnVector]]): Arrow FieldVectors are extracted
+ *    directly and serialized to IPC. Pass-through columns are kept as
+ *    [[ColumnVector]] references (safe because Arrow vectors are
+ *    independently allocated per batch, not reused). Output is produced
+ *    by columnar combining then flatMap to rows.
  *
- * 2. '''Row fallback path''' (UDF inputs contain complex expressions):
+ * 2. '''Non-Arrow columnar path''' (UDF inputs are simple column refs
+ *    BUT columns are NOT [[ArrowColumnVector]]): Non-Arrow columnar
+ *    readers (Parquet vectorized, InMemoryTableScan) reuse ColumnVector
+ *    objects across batches, so storing references is unsafe. Uses
+ *    [[HybridRowQueue]] for pass-through buffering. UDF inputs still
+ *    benefit from [[ColumnarArrowPythonInput]]'s row-by-row fallback.
+ *
+ * 3. '''Row fallback path''' (UDF inputs contain complex expressions):
  *    Rows are extracted via [[MutableProjection]] and sent using
- *    [[BasicPythonArrowInput]] (NOT [[BatchedPythonArrowInput]]), where
- *    each [[ColumnarBatch]]'s rows form one inner iterator that becomes
- *    one IPC RecordBatch. This preserves 1:1 batch correspondence.
- *
- * In both paths, pass-through columns are kept as [[ColumnVector]]
- * references and combined with UDF result columns at the columnar level.
+ *    [[BasicPythonArrowInput]]. Uses [[HybridRowQueue]] for pass-through.
  *
  * TODO: Add a physical plan rule that inserts a ProjectExec before
  *   ArrowEvalPythonExec to pre-evaluate complex UDF input expressions
- *   into simple column references. This would eliminate the row fallback
- *   path entirely.
+ *   into simple column references. This would eliminate path 3.
  */
 private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
     childOutput: Seq[Attribute],
@@ -69,13 +74,13 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
     pythonMetrics: Map[String, SQLMetric],
     jobArtifactUUID: Option[String],
     sessionUUID: Option[String])
-  extends PartitionEvaluatorFactory[ColumnarBatch, ColumnarBatch] {
+  extends PartitionEvaluatorFactory[ColumnarBatch, InternalRow] {
 
-  override def createEvaluator(): PartitionEvaluator[ColumnarBatch, ColumnarBatch] =
+  override def createEvaluator(): PartitionEvaluator[ColumnarBatch, InternalRow] =
     new ColumnarArrowEvalPythonPartitionEvaluator
 
   private class ColumnarArrowEvalPythonPartitionEvaluator
-      extends PartitionEvaluator[ColumnarBatch, ColumnarBatch] {
+      extends PartitionEvaluator[ColumnarBatch, InternalRow] {
 
     private def collectFunctions(
         udf: PythonUDF): ((ChainedPythonFunctions, Long), Seq[Expression]) = {
@@ -93,13 +98,12 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
 
     override def eval(
         partitionIndex: Int,
-        iters: Iterator[ColumnarBatch]*): Iterator[ColumnarBatch] = {
+        iters: Iterator[ColumnarBatch]*): Iterator[InternalRow] = {
       val inputIter = iters.head
       val context = TaskContext.get()
 
       val (pyFuncs, inputs) = udfs.map(collectFunctions).unzip
 
-      // Flatten all UDF arguments and build argMetas.
       val allInputs = new ArrayBuffer[Expression]
       val dataTypes = new ArrayBuffer[DataType]
       val argMetas = inputs.map { input =>
@@ -130,21 +134,28 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
           case udt: UserDefinedType[_] => udt.sqlType
         })
 
-      // Queue to buffer pass-through columns per input batch.
-      val passThruQueue = new ArrayDeque[(Array[ColumnVector], Int)]()
-
-      // Try to resolve all UDF inputs as simple column references.
       val inputColumnIndices = resolveColumnIndices(allInputs.toSeq)
 
-      val resultIter = if (inputColumnIndices.isDefined) {
-        evalColumnar(inputIter, context, pyFuncs, argMetas,
-          udfInputSchema, inputColumnIndices.get, passThruQueue)
-      } else {
-        evalRowFallback(inputIter, context, pyFuncs, argMetas,
-          allInputs.toSeq, udfInputSchema, passThruQueue)
+      // Peek at the first batch to determine if Arrow-backed.
+      // Arrow vectors are independently allocated per batch (safe to
+      // store references). Non-Arrow vectors (Parquet, InMemory) are
+      // reused across batches (unsafe to store references).
+      val peekIter = new PeekableIterator(inputIter)
+      val isArrow = peekIter.peek().exists { batch =>
+        batch.numCols() > 0 &&
+          batch.column(0).isInstanceOf[ArrowColumnVector]
       }
 
-      combineResults(resultIter, outputTypes, passThruQueue)
+      if (inputColumnIndices.isDefined && isArrow) {
+        // Path 1: Arrow columnar -- full optimization.
+        evalArrowColumnar(peekIter, context, pyFuncs, argMetas,
+          udfInputSchema, outputTypes, inputColumnIndices.get)
+      } else {
+        // Path 2 & 3: non-Arrow or complex expressions -- row queue.
+        evalWithRowQueue(peekIter, context, pyFuncs, argMetas,
+          allInputs.toSeq, udfInputSchema, outputTypes,
+          inputColumnIndices)
+      }
     }
 
     private def resolveColumnIndices(
@@ -159,19 +170,23 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
     }
 
     /**
-     * Columnar path: extract Arrow FieldVectors directly from
-     * ColumnarBatch and send to Python. Each ColumnarBatch becomes
-     * one IPC RecordBatch (1:1 batch correspondence).
+     * Path 1: Arrow columnar. ColumnVector references are safe because
+     * Arrow vectors are independently allocated per batch. Combines
+     * pass-through columns with UDF results at the columnar level,
+     * then flattens to rows.
      */
-    private def evalColumnar(
+    private def evalArrowColumnar(
         inputIter: Iterator[ColumnarBatch],
         context: TaskContext,
         pyFuncs: Seq[(ChainedPythonFunctions, Long)],
         argMetas: Array[Array[ArgumentMetadata]],
         udfInputSchema: StructType,
-        columnIndices: Array[Int],
-        passThruQueue: ArrayDeque[(Array[ColumnVector], Int)]
-    ): Iterator[ColumnarBatch] = {
+        outputTypes: Seq[DataType],
+        columnIndices: Array[Int]): Iterator[InternalRow] = {
+
+      val passThruQueue =
+        new ArrayDeque[(Array[ColumnVector], Int)]()
+
       val bufferedIter = inputIter.map { batch =>
         val passThruCols = childOutput.indices.map(
           i => batch.column(i)).toArray
@@ -182,85 +197,137 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
       val pyRunner = new ColumnarArrowPythonWithNamedArgumentRunner(
         pyFuncs, evalType, argMetas, udfInputSchema,
         sessionLocalTimeZone, largeVarTypes, pythonRunnerConf,
-        pythonMetrics, jobArtifactUUID, sessionUUID, columnIndices)
+        pythonMetrics, jobArtifactUUID, sessionUUID,
+        columnIndices)
 
-      pyRunner.compute(bufferedIter, context.partitionId(), context)
+      val resultIter = pyRunner.compute(
+        bufferedIter, context.partitionId(), context)
+
+      resultIter.flatMap { resultBatch =>
+        validateOutputTypes(resultBatch, outputTypes)
+        val numRows = resultBatch.numRows()
+        val resultCols = (0 until resultBatch.numCols()).map(
+          i => resultBatch.column(i)).toArray
+        val (passThruCols, passThruRows) = passThruQueue.poll()
+        assert(passThruRows == numRows,
+          s"Batch size mismatch: pass-through has $passThruRows " +
+            s"rows but UDF result has $numRows rows.")
+        val combined = new ColumnarBatch(
+          passThruCols ++ resultCols, numRows)
+        combined.rowIterator().asScala
+      }
     }
 
     /**
-     * Row fallback path: UDF inputs contain complex expressions.
-     * Rows are extracted via MutableProjection and sent using
-     * BasicPythonArrowInput (NOT BatchedPythonArrowInput) so that
-     * each ColumnarBatch's rows form one inner iterator = one IPC
-     * RecordBatch, preserving 1:1 batch correspondence.
-     *
-     * TODO: Add a physical plan rule that inserts a ProjectExec
-     *   before ArrowEvalPythonExec to pre-evaluate complex UDF input
-     *   expressions. This would eliminate this fallback entirely.
+     * Paths 2 & 3: non-Arrow columnar or complex expressions.
+     * Uses HybridRowQueue for pass-through because non-Arrow columnar
+     * readers reuse ColumnVector objects across batches.
      */
-    private def evalRowFallback(
+    private def evalWithRowQueue(
         inputIter: Iterator[ColumnarBatch],
         context: TaskContext,
         pyFuncs: Seq[(ChainedPythonFunctions, Long)],
         argMetas: Array[Array[ArgumentMetadata]],
         allInputs: Seq[Expression],
         udfInputSchema: StructType,
-        passThruQueue: ArrayDeque[(Array[ColumnVector], Int)]
-    ): Iterator[ColumnarBatch] = {
-      val projection = MutableProjection.create(allInputs, childOutput)
-      projection.initialize(context.partitionId())
+        outputTypes: Seq[DataType],
+        inputColumnIndices: Option[Array[Int]]
+    ): Iterator[InternalRow] = {
 
-      // Each ColumnarBatch's projected rows become one inner iterator.
-      // BasicPythonArrowInput sends each inner iterator as one IPC
-      // RecordBatch, maintaining 1:1 batch correspondence with the
-      // pass-through queue.
-      val batchIter = inputIter.map { batch =>
-        val passThruCols = childOutput.indices.map(
-          i => batch.column(i)).toArray
-        passThruQueue.add((passThruCols, batch.numRows()))
-        batch.rowIterator().asScala.map(projection(_))
+      val queue = HybridRowQueue(
+        context.taskMemoryManager(),
+        new File(Utils.getLocalDir(SparkEnv.get.conf)),
+        childOutput.length)
+      context.addTaskCompletionListener[Unit] { _ => queue.close() }
+
+      val unsafeProj = UnsafeProjection.create(
+        childOutput, childOutput)
+
+      val resultIter = if (inputColumnIndices.isDefined) {
+        // Path 2: simple column refs, non-Arrow vectors.
+        val bufferedIter = inputIter.map { batch =>
+          batch.rowIterator().asScala.foreach { row =>
+            queue.add(unsafeProj(row).copy())
+          }
+          batch
+        }
+        val pyRunner =
+          new ColumnarArrowPythonWithNamedArgumentRunner(
+            pyFuncs, evalType, argMetas, udfInputSchema,
+            sessionLocalTimeZone, largeVarTypes, pythonRunnerConf,
+            pythonMetrics, jobArtifactUUID, sessionUUID,
+            inputColumnIndices.get)
+        pyRunner.compute(
+          bufferedIter, context.partitionId(), context)
+      } else {
+        // Path 3: complex expressions.
+        val projection = MutableProjection.create(
+          allInputs, childOutput)
+        projection.initialize(context.partitionId())
+        val batchIter = inputIter.map { batch =>
+          batch.rowIterator().asScala.map { row =>
+            queue.add(unsafeProj(row).copy())
+            projection(row)
+          }
+        }
+        val pyRunner = new ArrowPythonWithNamedArgumentRunner(
+          pyFuncs, evalType, argMetas, udfInputSchema,
+          sessionLocalTimeZone, largeVarTypes, pythonRunnerConf,
+          pythonMetrics, jobArtifactUUID, sessionUUID
+        ) with BasicPythonArrowInput
+        pyRunner.compute(
+          batchIter, context.partitionId(), context)
       }
 
-      val pyRunner = new ArrowPythonWithNamedArgumentRunner(
-        pyFuncs, evalType, argMetas, udfInputSchema,
-        sessionLocalTimeZone, largeVarTypes, pythonRunnerConf,
-        pythonMetrics, jobArtifactUUID, sessionUUID
-      ) with BasicPythonArrowInput
+      val joined = new JoinedRow
+      val resultProj = UnsafeProjection.create(output, output)
 
-      pyRunner.compute(batchIter, context.partitionId(), context)
+      resultIter.flatMap { batch =>
+        validateOutputTypes(batch, outputTypes)
+        batch.rowIterator.asScala
+      }.map { outputRow =>
+        resultProj(joined(queue.remove(), outputRow))
+      }
     }
 
-    /**
-     * Combine pass-through columns with UDF result columns.
-     * Both evalColumnar and evalRowFallback maintain 1:1 batch
-     * correspondence, so each result batch matches one pass-through
-     * entry in the queue.
-     */
-    private def combineResults(
-        resultIter: Iterator[ColumnarBatch],
-        outputTypes: Seq[DataType],
-        passThruQueue: ArrayDeque[(Array[ColumnVector], Int)]
-    ): Iterator[ColumnarBatch] = {
-      resultIter.map { resultBatch =>
-        val actualDataTypes = (0 until resultBatch.numCols()).map(
-          i => resultBatch.column(i).dataType())
-        if (!equalsIgnoreCompatibleCollation(
-            outputTypes, actualDataTypes)) {
-          throw QueryExecutionErrors.arrowDataTypeMismatchError(
-            "pandas_udf()", outputTypes, actualDataTypes)
-        }
-
-        val numRows = resultBatch.numRows()
-        val resultCols = (0 until resultBatch.numCols()).map(
-          i => resultBatch.column(i)).toArray
-
-        val (passThruCols, passThruRows) = passThruQueue.poll()
-        assert(passThruRows == numRows,
-          s"Batch size mismatch: pass-through has $passThruRows " +
-          s"rows but UDF result has $numRows rows.")
-
-        new ColumnarBatch(passThruCols ++ resultCols, numRows)
+    private def validateOutputTypes(
+        batch: ColumnarBatch, outputTypes: Seq[DataType]): Unit = {
+      val actualDataTypes = (0 until batch.numCols()).map(
+        i => batch.column(i).dataType())
+      if (!equalsIgnoreCompatibleCollation(
+          outputTypes, actualDataTypes)) {
+        throw QueryExecutionErrors.arrowDataTypeMismatchError(
+          "pandas_udf()", outputTypes, actualDataTypes)
       }
+    }
+  }
+}
+
+/** Iterator wrapper that allows peeking at the first element. */
+private[python] class PeekableIterator[T](underlying: Iterator[T])
+    extends Iterator[T] {
+  private var peeked: Option[T] = None
+  private var peekedDone = false
+
+  def peek(): Option[T] = {
+    if (!peekedDone) {
+      peeked = if (underlying.hasNext) Some(underlying.next())
+               else None
+      peekedDone = true
+    }
+    peeked
+  }
+
+  override def hasNext: Boolean =
+    peeked.isDefined || underlying.hasNext
+
+  override def next(): T = {
+    if (peeked.isDefined) {
+      val v = peeked.get
+      peeked = None
+      v
+    } else {
+      underlying.next()
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowEvalPythonEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowEvalPythonEvaluatorFactory.scala
@@ -27,16 +27,17 @@ import org.apache.spark.api.python.ChainedPythonFunctions
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.execution.RowToColumnConverter
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
+import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector
 import org.apache.spark.sql.types.{DataType, StructField, StructType, UserDefinedType}
 import org.apache.spark.sql.types.DataType.equalsIgnoreCompatibleCollation
 import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch, ColumnVector}
 import org.apache.spark.util.Utils
 
 /**
- * Evaluator factory for Arrow Python UDFs that processes [[ColumnarBatch]]
- * input and produces [[InternalRow]] output.
+ * Evaluator factory for Arrow Python UDFs: ColumnarBatch in, ColumnarBatch out.
  *
  * Three execution paths based on input characteristics:
  *
@@ -44,19 +45,19 @@ import org.apache.spark.util.Utils
  *    columns are [[ArrowColumnVector]]): Arrow FieldVectors are extracted
  *    directly and serialized to IPC. Pass-through columns are kept as
  *    [[ColumnVector]] references (safe because Arrow vectors are
- *    independently allocated per batch, not reused). Output is produced
- *    by columnar combining then flatMap to rows.
+ *    independently allocated per batch). Output is produced by columnar
+ *    combining: passThruCols ++ resultCols -> ColumnarBatch.
  *
  * 2. '''Non-Arrow columnar path''' (UDF inputs are simple column refs
  *    BUT columns are NOT [[ArrowColumnVector]]): Non-Arrow columnar
  *    readers (Parquet vectorized, InMemoryTableScan) reuse ColumnVector
- *    objects across batches, so storing references is unsafe. Uses
- *    [[HybridRowQueue]] for pass-through buffering. UDF inputs still
- *    benefit from [[ColumnarArrowPythonInput]]'s row-by-row fallback.
+ *    objects across batches. Uses [[HybridRowQueue]] for pass-through
+ *    buffering and converts joined rows back to [[ColumnarBatch]].
  *
  * 3. '''Row fallback path''' (UDF inputs contain complex expressions):
  *    Rows are extracted via [[MutableProjection]] and sent using
- *    [[BasicPythonArrowInput]]. Uses [[HybridRowQueue]] for pass-through.
+ *    [[BasicPythonArrowInput]]. Uses [[HybridRowQueue]] for pass-through
+ *    and converts joined rows back to [[ColumnarBatch]].
  *
  * TODO: Add a physical plan rule that inserts a ProjectExec before
  *   ArrowEvalPythonExec to pre-evaluate complex UDF input expressions
@@ -66,6 +67,7 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
     childOutput: Seq[Attribute],
     udfs: Seq[PythonUDF],
     output: Seq[Attribute],
+    outputSchema: StructType,
     batchSize: Int,
     evalType: Int,
     sessionLocalTimeZone: String,
@@ -74,23 +76,27 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
     pythonMetrics: Map[String, SQLMetric],
     jobArtifactUUID: Option[String],
     sessionUUID: Option[String])
-  extends PartitionEvaluatorFactory[ColumnarBatch, InternalRow] {
+  extends PartitionEvaluatorFactory[ColumnarBatch, ColumnarBatch] {
 
-  override def createEvaluator(): PartitionEvaluator[ColumnarBatch, InternalRow] =
+  override def createEvaluator()
+      : PartitionEvaluator[ColumnarBatch, ColumnarBatch] =
     new ColumnarArrowEvalPythonPartitionEvaluator
 
   private class ColumnarArrowEvalPythonPartitionEvaluator
-      extends PartitionEvaluator[ColumnarBatch, InternalRow] {
+      extends PartitionEvaluator[ColumnarBatch, ColumnarBatch] {
 
     private def collectFunctions(
-        udf: PythonUDF): ((ChainedPythonFunctions, Long), Seq[Expression]) = {
+        udf: PythonUDF
+    ): ((ChainedPythonFunctions, Long), Seq[Expression]) = {
       udf.children match {
         case Seq(u: PythonUDF) =>
           val ((chained, _), children) = collectFunctions(u)
-          ((ChainedPythonFunctions(chained.funcs ++ Seq(udf.func)),
+          ((ChainedPythonFunctions(
+            chained.funcs ++ Seq(udf.func)),
             udf.resultId.id), children)
         case children =>
-          assert(children.forall(!_.exists(_.isInstanceOf[PythonUDF])))
+          assert(children.forall(
+            !_.exists(_.isInstanceOf[PythonUDF])))
           ((ChainedPythonFunctions(Seq(udf.func)),
             udf.resultId.id), udf.children)
       }
@@ -98,7 +104,8 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
 
     override def eval(
         partitionIndex: Int,
-        iters: Iterator[ColumnarBatch]*): Iterator[InternalRow] = {
+        iters: Iterator[ColumnarBatch]*
+    ): Iterator[ColumnarBatch] = {
       val inputIter = iters.head
       val context = TaskContext.get()
 
@@ -136,10 +143,7 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
 
       val inputColumnIndices = resolveColumnIndices(allInputs.toSeq)
 
-      // Peek at the first batch to determine if Arrow-backed.
-      // Arrow vectors are independently allocated per batch (safe to
-      // store references). Non-Arrow vectors (Parquet, InMemory) are
-      // reused across batches (unsafe to store references).
+      // Peek at first batch to check if Arrow-backed.
       val peekIter = new PeekableIterator(inputIter)
       val isArrow = peekIter.peek().exists { batch =>
         batch.numCols() > 0 &&
@@ -151,7 +155,7 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
         evalArrowColumnar(peekIter, context, pyFuncs, argMetas,
           udfInputSchema, outputTypes, inputColumnIndices.get)
       } else {
-        // Path 2 & 3: non-Arrow or complex expressions -- row queue.
+        // Path 2 & 3: non-Arrow or complex expressions.
         evalWithRowQueue(peekIter, context, pyFuncs, argMetas,
           allInputs.toSeq, udfInputSchema, outputTypes,
           inputColumnIndices)
@@ -170,10 +174,9 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
     }
 
     /**
-     * Path 1: Arrow columnar. ColumnVector references are safe because
-     * Arrow vectors are independently allocated per batch. Combines
-     * pass-through columns with UDF results at the columnar level,
-     * then flattens to rows.
+     * Path 1: Arrow columnar. ColumnVector references are safe
+     * because Arrow vectors are independently allocated per batch.
+     * Combines pass-through + UDF result columns into ColumnarBatch.
      */
     private def evalArrowColumnar(
         inputIter: Iterator[ColumnarBatch],
@@ -182,7 +185,7 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
         argMetas: Array[Array[ArgumentMetadata]],
         udfInputSchema: StructType,
         outputTypes: Seq[DataType],
-        columnIndices: Array[Int]): Iterator[InternalRow] = {
+        columnIndices: Array[Int]): Iterator[ColumnarBatch] = {
 
       val passThruQueue =
         new ArrayDeque[(Array[ColumnVector], Int)]()
@@ -203,25 +206,23 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
       val resultIter = pyRunner.compute(
         bufferedIter, context.partitionId(), context)
 
-      resultIter.flatMap { resultBatch =>
+      resultIter.map { resultBatch =>
         validateOutputTypes(resultBatch, outputTypes)
         val numRows = resultBatch.numRows()
         val resultCols = (0 until resultBatch.numCols()).map(
           i => resultBatch.column(i)).toArray
         val (passThruCols, passThruRows) = passThruQueue.poll()
         assert(passThruRows == numRows,
-          s"Batch size mismatch: pass-through has $passThruRows " +
-            s"rows but UDF result has $numRows rows.")
-        val combined = new ColumnarBatch(
-          passThruCols ++ resultCols, numRows)
-        combined.rowIterator().asScala
+          s"Batch size mismatch: pass-through has " +
+            s"$passThruRows rows but UDF result has $numRows rows.")
+        new ColumnarBatch(passThruCols ++ resultCols, numRows)
       }
     }
 
     /**
-     * Paths 2 & 3: non-Arrow columnar or complex expressions.
-     * Uses HybridRowQueue for pass-through because non-Arrow columnar
-     * readers reuse ColumnVector objects across batches.
+     * Paths 2 & 3: non-Arrow or complex expressions.
+     * Uses HybridRowQueue for pass-through, joins rows, then
+     * converts back to ColumnarBatch via RowToColumnConverter.
      */
     private def evalWithRowQueue(
         inputIter: Iterator[ColumnarBatch],
@@ -232,7 +233,7 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
         udfInputSchema: StructType,
         outputTypes: Seq[DataType],
         inputColumnIndices: Option[Array[Int]]
-    ): Iterator[InternalRow] = {
+    ): Iterator[ColumnarBatch] = {
 
       val queue = HybridRowQueue(
         context.taskMemoryManager(),
@@ -282,22 +283,51 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
       val joined = new JoinedRow
       val resultProj = UnsafeProjection.create(output, output)
 
-      resultIter.flatMap { batch =>
+      val rowIter = resultIter.flatMap { batch =>
         validateOutputTypes(batch, outputTypes)
         batch.rowIterator.asScala
       }.map { outputRow =>
         resultProj(joined(queue.remove(), outputRow))
       }
+
+      // Convert joined rows back to ColumnarBatch.
+      rowsToColumnarBatches(rowIter, context)
     }
 
     private def validateOutputTypes(
-        batch: ColumnarBatch, outputTypes: Seq[DataType]): Unit = {
-      val actualDataTypes = (0 until batch.numCols()).map(
+        batch: ColumnarBatch,
+        outputTypes: Seq[DataType]): Unit = {
+      val actual = (0 until batch.numCols()).map(
         i => batch.column(i).dataType())
-      if (!equalsIgnoreCompatibleCollation(
-          outputTypes, actualDataTypes)) {
+      if (!equalsIgnoreCompatibleCollation(outputTypes, actual)) {
         throw QueryExecutionErrors.arrowDataTypeMismatchError(
-          "pandas_udf()", outputTypes, actualDataTypes)
+          "pandas_udf()", outputTypes, actual)
+      }
+    }
+
+    /** Convert Iterator[InternalRow] to Iterator[ColumnarBatch]. */
+    private def rowsToColumnarBatches(
+        rowIter: Iterator[InternalRow],
+        context: TaskContext): Iterator[ColumnarBatch] = {
+      val converters = new RowToColumnConverter(outputSchema)
+      val vectors = OnHeapColumnVector
+        .allocateColumns(batchSize, outputSchema).toSeq
+      val cb = new ColumnarBatch(vectors.toArray)
+      context.addTaskCompletionListener[Unit] { _ => cb.close() }
+
+      new Iterator[ColumnarBatch] {
+        override def hasNext: Boolean = rowIter.hasNext
+        override def next(): ColumnarBatch = {
+          cb.setNumRows(0)
+          vectors.foreach(_.reset())
+          var count = 0
+          while (count < batchSize && rowIter.hasNext) {
+            converters.convert(rowIter.next(), vectors.toArray)
+            count += 1
+          }
+          cb.setNumRows(count)
+          cb
+        }
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowEvalPythonEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowEvalPythonEvaluatorFactory.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.execution.python
 
 import java.io.File
+import java.util.ArrayDeque
 
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
@@ -30,22 +31,27 @@ import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
 import org.apache.spark.sql.types.{DataType, StructField, StructType, UserDefinedType}
 import org.apache.spark.sql.types.DataType.equalsIgnoreCompatibleCollation
-import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 import org.apache.spark.util.Utils
 
 /**
  * Evaluator factory for Arrow Python UDFs that processes [[ColumnarBatch]] input.
  *
- * When UDF inputs are simple column references and the batch is Arrow-backed,
- * the UDF input columns are extracted as Arrow FieldVectors and sent directly
- * via IPC, bypassing the ArrowWriter row-by-row conversion.
+ * Two execution paths:
  *
- * Pass-through columns (child columns that are not UDF inputs) are buffered
- * as rows in [[HybridRowQueue]] and joined with UDF results row by row, since
- * the Python worker does not preserve input batch boundaries.
+ * 1. '''Columnar path''' (all UDF inputs are simple column references):
+ *    UDF input columns are extracted as Arrow FieldVectors and sent directly
+ *    via IPC. Pass-through columns are kept as [[ColumnVector]] references and
+ *    combined with UDF results at the columnar level. This works because each
+ *    input [[ColumnarBatch]] is sent as one Arrow IPC RecordBatch, the Python
+ *    worker processes scalar UDFs batch-by-batch preserving 1:1 correspondence,
+ *    and the default output batch config does not do slicing (both
+ *    maxRecordsPerOutputBatch and maxBytesPerOutputBatch default to -1).
  *
- * When UDF inputs contain complex expressions (not simple column references),
- * the UDF inputs are serialized via the row-based ArrowWriter fallback.
+ * 2. '''Row fallback path''' (UDF inputs contain complex expressions):
+ *    Falls back to row-based ArrowWriter for UDF input serialization and
+ *    [[HybridRowQueue]] for pass-through column buffering, since
+ *    [[BatchedPythonArrowInput]] re-batches rows and breaks batch boundaries.
  *
  * TODO: Add a physical plan rule that inserts a ProjectExec before
  *   ArrowEvalPythonExec to pre-evaluate complex UDF input expressions into
@@ -92,13 +98,6 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
       val inputIter = iters.head
       val context = TaskContext.get()
 
-      // Buffer input rows for joining with UDF output (same as EvalPythonEvaluatorFactory).
-      val queue = HybridRowQueue(
-        context.taskMemoryManager(),
-        new File(Utils.getLocalDir(SparkEnv.get.conf)),
-        childOutput.length)
-      context.addTaskCompletionListener[Unit] { _ => queue.close() }
-
       val (pyFuncs, inputs) = udfs.map(collectFunctions).unzip
 
       // Flatten all UDF arguments and build argMetas.
@@ -132,64 +131,20 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
       // Try to resolve all UDF inputs as simple column references.
       val inputColumnIndices = resolveColumnIndices(allInputs.toSeq)
 
-      val unsafeProj = UnsafeProjection.create(childOutput, childOutput)
-
-      val resultIter = if (inputColumnIndices.isDefined) {
-        // Columnar path: send Arrow FieldVectors directly to Python.
-        // Buffer rows in queue for result joining.
-        val bufferedIter = inputIter.map { batch =>
-          batch.rowIterator().asScala.foreach { row =>
-            queue.add(unsafeProj(row).copy())
-          }
-          batch
-        }
-
-        val pyRunner = new ColumnarArrowPythonWithNamedArgumentRunner(
-          pyFuncs, evalType, argMetas, udfInputSchema,
-          sessionLocalTimeZone, largeVarTypes, pythonRunnerConf,
-          pythonMetrics, jobArtifactUUID, sessionUUID,
-          inputColumnIndices.get)
-
-        pyRunner.compute(bufferedIter, context.partitionId(), context)
+      if (inputColumnIndices.isDefined) {
+        evalColumnar(inputIter, context, pyFuncs, argMetas,
+          udfInputSchema, outputTypes, inputColumnIndices.get)
       } else {
-        // Fallback: complex expressions, convert to rows for UDF input.
-        val projection = MutableProjection.create(allInputs.toSeq, childOutput)
-        projection.initialize(context.partitionId())
-
-        val projectedRowIter = inputIter.flatMap { batch =>
-          batch.rowIterator().asScala
-        }.map { inputRow =>
-          queue.add(unsafeProj(inputRow).copy())
-          projection(inputRow)
-        }
-
-        val batchIter = Iterator(projectedRowIter)
-        val pyRunner = new ArrowPythonWithNamedArgumentRunner(
-          pyFuncs, evalType, argMetas, udfInputSchema,
-          sessionLocalTimeZone, largeVarTypes, pythonRunnerConf,
-          pythonMetrics, jobArtifactUUID, sessionUUID
-        ) with BatchedPythonArrowInput
-
-        pyRunner.compute(batchIter, context.partitionId(), context)
-      }
-
-      // Join UDF results with buffered input rows.
-      val joined = new JoinedRow
-      val resultProj = UnsafeProjection.create(output, output)
-
-      resultIter.flatMap { batch =>
-        val actualDataTypes = (0 until batch.numCols()).map(
-          i => batch.column(i).dataType())
-        if (!equalsIgnoreCompatibleCollation(outputTypes, actualDataTypes)) {
-          throw QueryExecutionErrors.arrowDataTypeMismatchError(
-            "pandas_udf()", outputTypes, actualDataTypes)
-        }
-        batch.rowIterator.asScala
-      }.map { outputRow =>
-        resultProj(joined(queue.remove(), outputRow))
+        evalRowFallback(inputIter, context, pyFuncs, argMetas,
+          allInputs.toSeq, udfInputSchema, outputTypes)
       }
     }
 
+    /**
+     * Try to resolve all UDF input expressions as simple column references
+     * in childOutput. Returns Some(indices) if all are AttributeReferences;
+     * None otherwise.
+     */
     private def resolveColumnIndices(
         allInputs: Seq[Expression]): Option[Array[Int]] = {
       val indices = allInputs.map {
@@ -200,6 +155,136 @@ private[python] class ColumnarArrowEvalPythonEvaluatorFactory(
           return None
       }
       Some(indices.toArray)
+    }
+
+    /**
+     * Columnar path: send Arrow FieldVectors directly to Python.
+     * Pass-through columns are kept as ColumnVector references and combined
+     * with UDF results at the columnar level (1:1 batch correspondence).
+     *
+     * This works because:
+     * - ColumnarArrowPythonInput sends one IPC RecordBatch per ColumnarBatch
+     * - Python scalar UDF worker processes batch-by-batch (one in, one out)
+     * - Default output batch config does not do slicing (both defaults = -1)
+     */
+    private def evalColumnar(
+        inputIter: Iterator[ColumnarBatch],
+        context: TaskContext,
+        pyFuncs: Seq[(ChainedPythonFunctions, Long)],
+        argMetas: Array[Array[ArgumentMetadata]],
+        udfInputSchema: StructType,
+        outputTypes: Seq[DataType],
+        columnIndices: Array[Int]): Iterator[InternalRow] = {
+
+      // Queue pass-through columns per batch for columnar combining.
+      val passThruQueue = new ArrayDeque[(Array[ColumnVector], Int)]()
+
+      val bufferedIter = inputIter.map { batch =>
+        val passThruCols = childOutput.indices.map(
+          i => batch.column(i)).toArray
+        passThruQueue.add((passThruCols, batch.numRows()))
+        batch
+      }
+
+      val pyRunner = new ColumnarArrowPythonWithNamedArgumentRunner(
+        pyFuncs, evalType, argMetas, udfInputSchema,
+        sessionLocalTimeZone, largeVarTypes, pythonRunnerConf,
+        pythonMetrics, jobArtifactUUID, sessionUUID, columnIndices)
+
+      val resultIter = pyRunner.compute(
+        bufferedIter, context.partitionId(), context)
+
+      // Combine pass-through columns with UDF results at columnar level,
+      // then flatten to rows.
+      resultIter.flatMap { resultBatch =>
+        validateOutputTypes(resultBatch, outputTypes)
+
+        val numRows = resultBatch.numRows()
+        val resultCols = (0 until resultBatch.numCols()).map(
+          i => resultBatch.column(i)).toArray
+
+        val (passThruCols, passThruRows) = passThruQueue.poll()
+        assert(passThruRows == numRows,
+          s"Batch size mismatch: pass-through has $passThruRows rows " +
+          s"but UDF result has $numRows rows.")
+
+        // Combine: [pass-through columns | UDF result columns]
+        val combined = new ColumnarBatch(
+          passThruCols ++ resultCols, numRows)
+        combined.rowIterator().asScala
+      }
+    }
+
+    /**
+     * Fallback path: UDF inputs contain complex expressions that cannot be
+     * resolved to simple column indices. Uses row-based ArrowWriter for UDF
+     * input serialization and HybridRowQueue for pass-through buffering.
+     *
+     * This path uses BatchedPythonArrowInput which re-batches rows according
+     * to maxRecordsPerBatch, breaking the original ColumnarBatch boundaries.
+     * Therefore columnar pass-through combining is not possible.
+     *
+     * TODO: Add a physical plan rule that inserts a ProjectExec before
+     *   ArrowEvalPythonExec to pre-evaluate complex UDF input expressions
+     *   into simple column references. This would eliminate this fallback
+     *   entirely.
+     */
+    private def evalRowFallback(
+        inputIter: Iterator[ColumnarBatch],
+        context: TaskContext,
+        pyFuncs: Seq[(ChainedPythonFunctions, Long)],
+        argMetas: Array[Array[ArgumentMetadata]],
+        allInputs: Seq[Expression],
+        udfInputSchema: StructType,
+        outputTypes: Seq[DataType]): Iterator[InternalRow] = {
+
+      val queue = HybridRowQueue(
+        context.taskMemoryManager(),
+        new File(Utils.getLocalDir(SparkEnv.get.conf)),
+        childOutput.length)
+      context.addTaskCompletionListener[Unit] { _ => queue.close() }
+
+      val projection = MutableProjection.create(allInputs, childOutput)
+      projection.initialize(context.partitionId())
+
+      val unsafeProj = UnsafeProjection.create(childOutput, childOutput)
+
+      val projectedRowIter = inputIter.flatMap { batch =>
+        batch.rowIterator().asScala
+      }.map { inputRow =>
+        queue.add(unsafeProj(inputRow).copy())
+        projection(inputRow)
+      }
+
+      val batchIter = Iterator(projectedRowIter)
+      val pyRunner = new ArrowPythonWithNamedArgumentRunner(
+        pyFuncs, evalType, argMetas, udfInputSchema,
+        sessionLocalTimeZone, largeVarTypes, pythonRunnerConf,
+        pythonMetrics, jobArtifactUUID, sessionUUID
+      ) with BatchedPythonArrowInput
+
+      val resultIter = pyRunner.compute(
+        batchIter, context.partitionId(), context)
+
+      val joined = new JoinedRow
+      val resultProj = UnsafeProjection.create(output, output)
+
+      resultIter.flatMap { batch =>
+        validateOutputTypes(batch, outputTypes)
+        batch.rowIterator.asScala
+      }.map { outputRow =>
+        resultProj(joined(queue.remove(), outputRow))
+      }
+    }
+
+    private def validateOutputTypes(
+        batch: ColumnarBatch, outputTypes: Seq[DataType]): Unit = {
+      val actualDataTypes = (0 until batch.numCols()).map(
+        i => batch.column(i).dataType())
+      if (!equalsIgnoreCompatibleCollation(outputTypes, actualDataTypes)) {
+        throw QueryExecutionErrors.arrowDataTypeMismatchError(
+          "pandas_udf()", outputTypes, actualDataTypes)
+      }
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowPythonInput.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowPythonInput.scala
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.python
+
+import java.io.DataOutputStream
+import java.nio.channels.Channels
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.arrow.vector.{FieldVector, VectorSchemaRoot, VectorUnloader}
+import org.apache.arrow.vector.ipc.ArrowStreamWriter
+import org.apache.arrow.vector.ipc.WriteChannel
+import org.apache.arrow.vector.ipc.message.MessageSerializer
+
+import org.apache.spark.api.python.BasePythonRunner
+import org.apache.spark.sql.execution.arrow.ArrowWriter
+import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch}
+
+/**
+ * A trait that can be mixed-in with [[BasePythonRunner]] to send Arrow-backed
+ * [[ColumnarBatch]] data to Python via Arrow IPC, bypassing the row-based conversion.
+ *
+ * When the batch's columns are [[ArrowColumnVector]], the underlying Arrow
+ * [[FieldVector]]s are extracted directly and serialized via [[VectorUnloader]]
+ * and [[MessageSerializer]] -- no data copy of vector buffers occurs.
+ *
+ * When the batch's columns are NOT [[ArrowColumnVector]], falls back to iterating
+ * rows and writing via [[ArrowWriter]] (same as the existing row-based path).
+ */
+private[python] trait ColumnarArrowPythonInput
+    extends PythonArrowInput[ColumnarBatch] {
+  self: BasePythonRunner[ColumnarBatch, _] =>
+
+  /**
+   * Column indices to select from each [[ColumnarBatch]] for UDF input.
+   * Set by the evaluator factory based on UDF argument resolution.
+   */
+  protected def inputColumnIndices: Array[Int]
+
+  // Lazy-initialized ArrowWriter for the fallback (non-Arrow) path.
+  // Uses the pre-allocated `root` from PythonArrowInput.
+  private lazy val arrowWriter: ArrowWriter = ArrowWriter.create(root)
+  private lazy val unloader: VectorUnloader = new VectorUnloader(root, true, codec, true)
+
+  protected def writeNextBatchToArrowStream(
+      root: VectorSchemaRoot,
+      writer: ArrowStreamWriter,
+      dataOut: DataOutputStream,
+      inputIterator: Iterator[ColumnarBatch]): Boolean = {
+    if (inputIterator.hasNext) {
+      val batch = inputIterator.next()
+      val startData = dataOut.size()
+
+      if (isArrowBacked(batch)) {
+        writeArrowDirect(batch, dataOut)
+      } else {
+        writeRowByRow(batch, dataOut)
+      }
+
+      val deltaData = dataOut.size() - startData
+      pythonMetrics("pythonDataSent") += deltaData
+      true
+    } else {
+      super[PythonArrowInput].close()
+      false
+    }
+  }
+
+  /**
+   * Check whether all selected columns in the batch are Arrow-backed.
+   */
+  private def isArrowBacked(batch: ColumnarBatch): Boolean = {
+    inputColumnIndices.forall(i => batch.column(i).isInstanceOf[ArrowColumnVector])
+  }
+
+  /**
+   * Arrow-direct path: extract FieldVectors from ArrowColumnVector, wrap in a
+   * temporary VectorSchemaRoot, and serialize via VectorUnloader + MessageSerializer.
+   * No copy of vector data occurs -- VectorSchemaRoot.of() is a lightweight wrapper.
+   */
+  private def writeArrowDirect(batch: ColumnarBatch, dataOut: DataOutputStream): Unit = {
+    val selectedVectors = inputColumnIndices.map { i =>
+      batch.column(i).asInstanceOf[ArrowColumnVector]
+        .getValueVector.asInstanceOf[FieldVector]
+    }
+    val batchRoot = VectorSchemaRoot.of(selectedVectors: _*)
+    batchRoot.setRowCount(batch.numRows())
+
+    val batchUnloader = new VectorUnloader(batchRoot, true, codec, true)
+    val recordBatch = batchUnloader.getRecordBatch()
+    try {
+      val writeChannel = new WriteChannel(Channels.newChannel(dataOut))
+      MessageSerializer.serialize(writeChannel, recordBatch)
+    } finally {
+      recordBatch.close()
+    }
+    // Do NOT close batchRoot or selectedVectors -- they are owned by the upstream batch.
+  }
+
+  /**
+   * Fallback path: iterate rows from the ColumnarBatch and write via ArrowWriter,
+   * same as the existing row-based path. No performance regression compared to
+   * ColumnarToRow + ArrowWriter.
+   */
+  private def writeRowByRow(batch: ColumnarBatch, dataOut: DataOutputStream): Unit = {
+    val selectedBatch = selectColumns(batch)
+    val rowIter = selectedBatch.rowIterator().asScala
+    while (rowIter.hasNext) {
+      arrowWriter.write(rowIter.next())
+    }
+    arrowWriter.finish()
+
+    val recordBatch = unloader.getRecordBatch()
+    try {
+      val writeChannel = new WriteChannel(Channels.newChannel(dataOut))
+      MessageSerializer.serialize(writeChannel, recordBatch)
+    } finally {
+      recordBatch.close()
+    }
+    arrowWriter.reset()
+  }
+
+  /**
+   * Select only the UDF input columns from the batch, producing a new ColumnarBatch
+   * with only those columns.
+   */
+  private def selectColumns(batch: ColumnarBatch): ColumnarBatch = {
+    val selectedColumns = inputColumnIndices.map(i => batch.column(i))
+    val selected = new ColumnarBatch(selectedColumns, batch.numRows())
+    selected
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowPythonRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ColumnarArrowPythonRunner.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.python
+
+import java.io.DataOutputStream
+
+import org.apache.spark.api.python._
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+/**
+ * Arrow Python runner that accepts [[ColumnarBatch]] input directly instead of
+ * [[Iterator[InternalRow]]]. When the batch's columns are Arrow-backed, the underlying
+ * Arrow FieldVectors are extracted and serialized to Arrow IPC without row conversion.
+ *
+ * This is the columnar counterpart of [[ArrowPythonWithNamedArgumentRunner]].
+ */
+private[python] class ColumnarArrowPythonWithNamedArgumentRunner(
+    funcs: Seq[(ChainedPythonFunctions, Long)],
+    evalType: Int,
+    argMetas: Array[Array[ArgumentMetadata]],
+    override protected val schema: StructType,
+    override protected val timeZoneId: String,
+    override protected val largeVarTypes: Boolean,
+    pythonRunnerConf: Map[String, String],
+    override val pythonMetrics: Map[String, SQLMetric],
+    jobArtifactUUID: Option[String],
+    sessionUUID: Option[String],
+    override protected val inputColumnIndices: Array[Int])
+  extends BaseArrowPythonRunner[ColumnarBatch, ColumnarBatch](
+    funcs, evalType, argMetas.map(_.map(_.offset)), schema, timeZoneId, largeVarTypes,
+    pythonMetrics, jobArtifactUUID, sessionUUID)
+  with ColumnarArrowPythonInput
+  with BasicPythonArrowOutput {
+
+  override protected def runnerConf: Map[String, String] = super.runnerConf ++ pythonRunnerConf
+
+  override protected def writeUDF(dataOut: DataOutputStream): Unit = {
+    if (evalType == PythonEvalType.SQL_ARROW_BATCHED_UDF) {
+      PythonWorkerUtils.writeUTF(schema.json, dataOut)
+    }
+    PythonUDFRunner.writeUDFs(dataOut, funcs, argMetas)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowBackedDataSourceV2.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowBackedDataSourceV2.scala
@@ -21,7 +21,8 @@ import java.util
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector._
 
-import org.apache.spark.sql.connector.catalog.{Table, TableCapability, TableProvider}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.catalog.{SupportsRead, Table, TableCapability, TableProvider}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.connector.read._
 import org.apache.spark.sql.types._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowBackedDataSourceV2.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowBackedDataSourceV2.scala
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.python
+
+import java.util
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector._
+
+import org.apache.spark.sql.connector.catalog.{Table, TableCapability, TableProvider}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.connector.read._
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.util.ArrowUtils
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch, ColumnVector}
+
+/**
+ * A test-only DataSource V2 implementation that produces Arrow-backed
+ * [[ColumnarBatch]]es (with [[ArrowColumnVector]] columns).
+ *
+ * Used for testing and benchmarking the columnar Arrow Python UDF path
+ * that bypasses ColumnarToRow conversion.
+ *
+ * Schema: (id INT, name STRING, value DOUBLE)
+ * Data: configurable number of rows (default 10000), split across partitions.
+ *
+ * Usage:
+ * {{{
+ *   spark.read
+ *     .format("org.apache.spark.sql.execution.python.ArrowBackedDataSourceV2")
+ *     .option("numRows", "10000")
+ *     .option("numPartitions", "2")
+ *     .load()
+ * }}}
+ */
+class ArrowBackedDataSourceV2 extends TableProvider {
+
+  override def inferSchema(options: CaseInsensitiveStringMap): StructType = {
+    ArrowBackedDataSourceV2.SCHEMA
+  }
+
+  override def getTable(
+      schema: StructType,
+      partitioning: Array[Transform],
+      properties: util.Map[String, String]): Table = {
+    val options = new CaseInsensitiveStringMap(properties)
+    new ArrowBackedTable(options)
+  }
+}
+
+object ArrowBackedDataSourceV2 {
+  val SCHEMA: StructType = new StructType()
+    .add("id", IntegerType, nullable = false)
+    .add("name", StringType, nullable = true)
+    .add("value", DoubleType, nullable = true)
+
+  val DEFAULT_NUM_ROWS: Int = 10000
+  val DEFAULT_NUM_PARTITIONS: Int = 2
+  val BATCH_SIZE: Int = 1024
+}
+
+/** Table that supports batch read with columnar output. */
+private class ArrowBackedTable(options: CaseInsensitiveStringMap)
+    extends Table with SupportsRead {
+
+  override def name(): String = "ArrowBackedTestTable"
+
+  override def schema(): StructType = ArrowBackedDataSourceV2.SCHEMA
+
+  override def capabilities(): util.Set[TableCapability] = {
+    util.EnumSet.of(TableCapability.BATCH_READ)
+  }
+
+  override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
+    new ArrowBackedScanBuilder(this.options)
+  }
+}
+
+/** Scan builder / Scan / Batch implementation. */
+private class ArrowBackedScanBuilder(options: CaseInsensitiveStringMap)
+    extends ScanBuilder with Scan with Batch {
+
+  private val numRows =
+    options.getInt("numRows", ArrowBackedDataSourceV2.DEFAULT_NUM_ROWS)
+  private val numPartitions =
+    options.getInt("numPartitions", ArrowBackedDataSourceV2.DEFAULT_NUM_PARTITIONS)
+
+  override def build(): Scan = this
+
+  override def toBatch: Batch = this
+
+  override def readSchema(): StructType = ArrowBackedDataSourceV2.SCHEMA
+
+  override def planInputPartitions(): Array[InputPartition] = {
+    val rowsPerPartition = numRows / numPartitions
+    (0 until numPartitions).map { i =>
+      val start = i * rowsPerPartition
+      val end = if (i == numPartitions - 1) numRows else start + rowsPerPartition
+      ArrowPartition(start, end): InputPartition
+    }.toArray
+  }
+
+  override def createReaderFactory(): PartitionReaderFactory = {
+    new ArrowBackedReaderFactory()
+  }
+}
+
+private case class ArrowPartition(start: Int, end: Int) extends InputPartition
+
+/** Factory that produces Arrow-backed columnar readers. */
+private class ArrowBackedReaderFactory extends PartitionReaderFactory {
+
+  override def supportColumnarReads(partition: InputPartition): Boolean = true
+
+  override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
+    throw new UnsupportedOperationException(
+      "ArrowBackedDataSourceV2 only supports columnar reads")
+  }
+
+  override def createColumnarReader(
+      partition: InputPartition): PartitionReader[ColumnarBatch] = {
+    val ArrowPartition(start, end) = partition
+    new ArrowBackedPartitionReader(start, end)
+  }
+}
+
+/**
+ * Partition reader that produces Arrow-backed [[ColumnarBatch]]es.
+ *
+ * Each batch contains up to [[ArrowBackedDataSourceV2.BATCH_SIZE]] rows with:
+ * - id (INT): sequential integer starting from partition start
+ * - name (STRING): "row_<id>"
+ * - value (DOUBLE): id * 0.1
+ */
+private class ArrowBackedPartitionReader(start: Int, end: Int)
+    extends PartitionReader[ColumnarBatch] {
+
+  private val batchSize = ArrowBackedDataSourceV2.BATCH_SIZE
+  private var current = start
+  private var currentBatch: ColumnarBatch = _
+  private var allocator: BufferAllocator = _
+
+  override def next(): Boolean = {
+    // Close previous batch's resources
+    closeCurrent()
+
+    if (current >= end) return false
+
+    val count = math.min(batchSize, end - current)
+
+    allocator = ArrowUtils.rootAllocator.newChildAllocator(
+      s"arrow-test-reader-$start", 0, Long.MaxValue)
+
+    // Create Arrow vectors
+    val idVector = createIntVector(allocator, "id", count)
+    val nameVector = createStringVector(allocator, "name", count)
+    val valueVector = createDoubleVector(allocator, "value", count)
+
+    // Wrap in ArrowColumnVector
+    val columns: Array[ColumnVector] = Array(
+      new ArrowColumnVector(idVector),
+      new ArrowColumnVector(nameVector),
+      new ArrowColumnVector(valueVector))
+
+    currentBatch = new ColumnarBatch(columns, count)
+    current += count
+    true
+  }
+
+  override def get(): ColumnarBatch = currentBatch
+
+  override def close(): Unit = closeCurrent()
+
+  private def closeCurrent(): Unit = {
+    if (currentBatch != null) {
+      currentBatch.close()
+      currentBatch = null
+    }
+    if (allocator != null) {
+      allocator.close()
+      allocator = null
+    }
+  }
+
+  private def createIntVector(
+      alloc: BufferAllocator, name: String, count: Int): IntVector = {
+    val field = ArrowUtils.toArrowField(name, IntegerType, nullable = false, null)
+    val vector = field.createVector(alloc).asInstanceOf[IntVector]
+    vector.allocateNew(count)
+    (0 until count).foreach { i =>
+      vector.setSafe(i, current + i)
+    }
+    vector.setValueCount(count)
+    vector
+  }
+
+  private def createStringVector(
+      alloc: BufferAllocator, name: String, count: Int): VarCharVector = {
+    val field = ArrowUtils.toArrowField(name, StringType, nullable = true, null)
+    val vector = field.createVector(alloc).asInstanceOf[VarCharVector]
+    vector.allocateNew()
+    (0 until count).foreach { i =>
+      val bytes = s"row_${current + i}".getBytes("UTF-8")
+      vector.setSafe(i, bytes, 0, bytes.length)
+    }
+    vector.setValueCount(count)
+    vector
+  }
+
+  private def createDoubleVector(
+      alloc: BufferAllocator, name: String, count: Int): Float8Vector = {
+    val field = ArrowUtils.toArrowField(name, DoubleType, nullable = true, null)
+    val vector = field.createVector(alloc).asInstanceOf[Float8Vector]
+    vector.allocateNew(count)
+    (0 until count).foreach { i =>
+      vector.setSafe(i, (current + i) * 0.1)
+    }
+    vector.setValueCount(count)
+    vector
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowBackedDataSourceV2.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowBackedDataSourceV2.scala
@@ -69,6 +69,7 @@ object ArrowBackedDataSourceV2 {
     .add("id", IntegerType, nullable = false)
     .add("name", StringType, nullable = true)
     .add("value", DoubleType, nullable = true)
+    .add("data", StringType, nullable = true)
 
   val DEFAULT_NUM_ROWS: Int = 10000
   val DEFAULT_NUM_PARTITIONS: Int = 2
@@ -116,21 +117,48 @@ private class ArrowBackedScanBuilder(options: CaseInsensitiveStringMap)
     }.toArray
   }
 
+  private val columnar =
+    options.getBoolean("columnar", true)
+
   override def createReaderFactory(): PartitionReaderFactory = {
-    new ArrowBackedReaderFactory()
+    new ArrowBackedReaderFactory(columnar)
   }
 }
 
-private case class ArrowPartition(start: Int, end: Int) extends InputPartition
+private case class ArrowPartition(start: Int, end: Int)
+    extends InputPartition
 
-/** Factory that produces Arrow-backed columnar readers. */
-private class ArrowBackedReaderFactory extends PartitionReaderFactory {
+/**
+ * Factory that produces Arrow-backed readers.
+ *
+ * @param columnar if true, returns columnar ColumnarBatch output
+ *   (supportsColumnarReads = true). If false, returns row-based
+ *   InternalRow output by iterating the ColumnarBatch row by row.
+ *   This allows benchmarking the same data source with and without
+ *   the columnar optimization.
+ */
+private class ArrowBackedReaderFactory(columnar: Boolean)
+    extends PartitionReaderFactory {
 
-  override def supportColumnarReads(partition: InputPartition): Boolean = true
+  override def supportColumnarReads(
+      partition: InputPartition): Boolean = columnar
 
-  override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
-    throw new UnsupportedOperationException(
-      "ArrowBackedDataSourceV2 only supports columnar reads")
+  override def createReader(
+      partition: InputPartition): PartitionReader[InternalRow] = {
+    val ArrowPartition(start, end) = partition
+    val inner = new ArrowBackedPartitionReader(start, end)
+    // Wrap columnar reader as row reader.
+    new PartitionReader[InternalRow] {
+      private var rowIter: java.util.Iterator[InternalRow] = _
+      override def next(): Boolean = {
+        if (rowIter != null && rowIter.hasNext) return true
+        if (!inner.next()) return false
+        rowIter = inner.get().rowIterator()
+        rowIter.hasNext
+      }
+      override def get(): InternalRow = rowIter.next()
+      override def close(): Unit = inner.close()
+    }
   }
 
   override def createColumnarReader(
@@ -154,48 +182,51 @@ private class ArrowBackedPartitionReader(start: Int, end: Int)
   private val batchSize = ArrowBackedDataSourceV2.BATCH_SIZE
   private var current = start
   private var currentBatch: ColumnarBatch = _
-  private var allocator: BufferAllocator = _
+
+  // Single allocator for the entire partition reader lifetime.
+  // Arrow vectors from earlier batches may still be referenced by
+  // downstream operators (e.g., pass-through column queue), so we
+  // must NOT close the allocator until the reader itself is closed.
+  private val allocator: BufferAllocator =
+    ArrowUtils.rootAllocator.newChildAllocator(
+      s"arrow-test-reader-$start", 0, Long.MaxValue)
+
+  // Track all batches so we can close them in close().
+  private val allBatches =
+    new java.util.ArrayList[ColumnarBatch]()
 
   override def next(): Boolean = {
-    // Close previous batch's resources
-    closeCurrent()
-
     if (current >= end) return false
 
     val count = math.min(batchSize, end - current)
-
-    allocator = ArrowUtils.rootAllocator.newChildAllocator(
-      s"arrow-test-reader-$start", 0, Long.MaxValue)
 
     // Create Arrow vectors
     val idVector = createIntVector(allocator, "id", count)
     val nameVector = createStringVector(allocator, "name", count)
     val valueVector = createDoubleVector(allocator, "value", count)
+    val dataVector = createLongStringVector(
+      allocator, "data", count)
 
     // Wrap in ArrowColumnVector
     val columns: Array[ColumnVector] = Array(
       new ArrowColumnVector(idVector),
       new ArrowColumnVector(nameVector),
-      new ArrowColumnVector(valueVector))
+      new ArrowColumnVector(valueVector),
+      new ArrowColumnVector(dataVector))
 
     currentBatch = new ColumnarBatch(columns, count)
+    allBatches.add(currentBatch)
     current += count
     true
   }
 
   override def get(): ColumnarBatch = currentBatch
 
-  override def close(): Unit = closeCurrent()
-
-  private def closeCurrent(): Unit = {
-    if (currentBatch != null) {
-      currentBatch.close()
-      currentBatch = null
-    }
-    if (allocator != null) {
-      allocator.close()
-      allocator = null
-    }
+  override def close(): Unit = {
+    allBatches.forEach(_.close())
+    allBatches.clear()
+    currentBatch = null
+    allocator.close()
   }
 
   private def createIntVector(
@@ -230,6 +261,35 @@ private class ArrowBackedPartitionReader(start: Int, end: Int)
     vector.allocateNew(count)
     (0 until count).foreach { i =>
       vector.setSafe(i, (current + i) * 0.1)
+    }
+    vector.setValueCount(count)
+    vector
+  }
+
+  // Random long strings (~200 chars each) to stress ArrowWriter's
+  // per-element VarChar serialization overhead.
+  private val rng = new java.util.Random(42)
+  private def randomString(len: Int): String = {
+    val sb = new java.lang.StringBuilder(len)
+    var i = 0
+    while (i < len) {
+      sb.append(('a' + rng.nextInt(26)).toChar)
+      i += 1
+    }
+    sb.toString
+  }
+
+  private def createLongStringVector(
+      alloc: BufferAllocator, name: String,
+      count: Int): VarCharVector = {
+    val field = ArrowUtils.toArrowField(
+      name, StringType, nullable = true, null)
+    val vector = field.createVector(alloc)
+      .asInstanceOf[VarCharVector]
+    vector.allocateNew()
+    (0 until count).foreach { i =>
+      val bytes = randomString(100).getBytes("UTF-8")
+      vector.setSafe(i, bytes, 0, bytes.length)
     }
     vector.setValueCount(count)
     vector

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
@@ -60,7 +60,11 @@ class ArrowColumnarPythonUDFSuite extends QueryTest with SharedSparkSession {
       registerTestUDF(pandasUDF, spark)
 
       val df = readArrowSource()
-      val result = df.selectExpr("arrow_test_udf(id)")
+      // Select all columns to avoid column pruning inserting a
+      // ProjectExec (which does not support columnar) between the
+      // scan and ArrowEvalPythonExec.
+      val result = df.selectExpr(
+        "id", "name", "value", "arrow_test_udf(id) as udf_id")
       val plan = result.queryExecution.executedPlan
 
       // ArrowEvalPythonExec should be present.
@@ -68,14 +72,12 @@ class ArrowColumnarPythonUDFSuite extends QueryTest with SharedSparkSession {
       assert(arrowExecs.nonEmpty,
         s"Expected ArrowEvalPythonExec in plan:\n$plan")
 
-      // No ColumnarToRowExec should be between the scan and
-      // ArrowEvalPythonExec.
+      // The direct child of ArrowEvalPythonExec should support
+      // columnar (the scan), with no ColumnarToRowExec in between.
       val arrowExec = arrowExecs.head
-      val columnarToRows = collectNodes[ColumnarToRowExec](arrowExec)
-      assert(columnarToRows.isEmpty,
-        "ColumnarToRowExec should not be present under " +
-          s"ArrowEvalPythonExec when reading from Arrow-backed source:" +
-          s"\n$plan")
+      assert(arrowExec.child.supportsColumnar,
+        "ArrowEvalPythonExec child should support columnar " +
+          s"when reading from Arrow-backed source:\n$plan")
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.execution.{ColumnarToRowExec, SparkPlan}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.StringType
 
 /**
  * End-to-end tests for the Arrow columnar Python UDF input path.
@@ -47,17 +48,20 @@ class ArrowColumnarPythonUDFSuite extends QueryTest with SharedSparkSession {
 
   private def collectNodes[T <: SparkPlan](
       plan: SparkPlan)(implicit tag: reflect.ClassTag[T]): Seq[T] = {
-    plan.collect { case p if tag.runtimeClass.isInstance(p) => p.asInstanceOf[T] }
+    plan.collect {
+      case p if tag.runtimeClass.isInstance(p) => p.asInstanceOf[T]
+    }
   }
 
   test("Arrow-backed source: no ColumnarToRowExec before ArrowEvalPythonExec") {
     assume(shouldTestPandasUDFs)
     withSQLConf(SQLConf.ARROW_PYSPARK_EXECUTION_ENABLED.key -> "true") {
-      val pandasUDF = TestScalarPandasUDF(name = "arrow_test_udf")
+      val pandasUDF = TestScalarPandasUDF(
+        name = "arrow_test_udf", returnType = Some(StringType))
       registerTestUDF(pandasUDF, spark)
 
       val df = readArrowSource()
-      val result = df.select(col("id"), pandasUDF(col("id")))
+      val result = df.selectExpr("arrow_test_udf(id)")
       val plan = result.queryExecution.executedPlan
 
       // ArrowEvalPythonExec should be present.
@@ -65,30 +69,34 @@ class ArrowColumnarPythonUDFSuite extends QueryTest with SharedSparkSession {
       assert(arrowExecs.nonEmpty,
         s"Expected ArrowEvalPythonExec in plan:\n$plan")
 
-      // No ColumnarToRowExec should be between the scan and ArrowEvalPythonExec.
-      val columnarToRows = collectNodes[ColumnarToRowExec](plan)
+      // No ColumnarToRowExec should be between the scan and
+      // ArrowEvalPythonExec.
+      val arrowExec = arrowExecs.head
+      val columnarToRows = collectNodes[ColumnarToRowExec](arrowExec)
       assert(columnarToRows.isEmpty,
-        s"ColumnarToRowExec should not be present when reading from " +
-          s"Arrow-backed source:\n$plan")
+        "ColumnarToRowExec should not be present under " +
+          s"ArrowEvalPythonExec when reading from Arrow-backed source:" +
+          s"\n$plan")
     }
   }
 
   test("Arrow-backed source: correctness of scalar pandas UDF") {
     assume(shouldTestPandasUDFs)
     withSQLConf(SQLConf.ARROW_PYSPARK_EXECUTION_ENABLED.key -> "true") {
-      val pandasUDF = TestScalarPandasUDF(name = "arrow_str_udf")
+      val pandasUDF = TestScalarPandasUDF(
+        name = "arrow_str_udf", returnType = Some(StringType))
       registerTestUDF(pandasUDF, spark)
 
       val df = readArrowSource(numRows = 10)
       // The test pandas UDF converts input to string.
-      val result = df.select(col("id"), pandasUDF(col("id")))
+      val result = df.selectExpr("id", "arrow_str_udf(id) as udf_id")
       val rows = result.collect()
 
       assert(rows.length == 10)
       rows.zipWithIndex.foreach { case (row, i) =>
         assert(row.getInt(0) == i, s"id mismatch at row $i")
-        // The pandas UDF converts to string.
-        assert(row.getString(1) == i.toString, s"UDF result mismatch at row $i")
+        assert(row.getString(1) == i.toString,
+          s"UDF result mismatch at row $i")
       }
     }
   }
@@ -96,16 +104,16 @@ class ArrowColumnarPythonUDFSuite extends QueryTest with SharedSparkSession {
   test("Arrow-backed source: multiple UDF columns") {
     assume(shouldTestPandasUDFs)
     withSQLConf(SQLConf.ARROW_PYSPARK_EXECUTION_ENABLED.key -> "true") {
-      val udf1 = TestScalarPandasUDF(name = "arrow_udf1")
-      val udf2 = TestScalarPandasUDF(name = "arrow_udf2")
+      val udf1 = TestScalarPandasUDF(
+        name = "arrow_udf1", returnType = Some(StringType))
+      val udf2 = TestScalarPandasUDF(
+        name = "arrow_udf2", returnType = Some(StringType))
       registerTestUDF(udf1, spark)
       registerTestUDF(udf2, spark)
 
       val df = readArrowSource(numRows = 10)
-      val result = df.select(
-        col("id"),
-        udf1(col("id")),
-        udf2(col("name")))
+      val result = df.selectExpr(
+        "id", "arrow_udf1(id) as u1", "arrow_udf2(name) as u2")
       val rows = result.collect()
 
       assert(rows.length == 10)
@@ -117,29 +125,35 @@ class ArrowColumnarPythonUDFSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("Arrow-backed source: supportsColumnar is true") {
+  test("Arrow-backed source: scan supportsColumnar is true") {
     val df = readArrowSource()
     val plan = df.queryExecution.executedPlan
-    assert(plan.supportsColumnar,
-      s"Arrow-backed source should support columnar output:\n$plan")
+    // The top-level plan may be ColumnarToRowExec (for Spark's row output),
+    // but the scan underneath should support columnar.
+    val scans = plan.collect {
+      case p if p.supportsColumnar => p
+    }
+    assert(scans.nonEmpty,
+      s"Arrow-backed source should have a columnar-capable scan:\n$plan")
   }
 
-  test("Row-based source: ColumnarToRowExec is present (baseline)") {
+  test("Row-based source: child does not support columnar (baseline)") {
     assume(shouldTestPandasUDFs)
     withSQLConf(SQLConf.ARROW_PYSPARK_EXECUTION_ENABLED.key -> "true") {
-      val pandasUDF = TestScalarPandasUDF(name = "row_test_udf")
+      val pandasUDF = TestScalarPandasUDF(
+        name = "row_test_udf", returnType = Some(StringType))
       registerTestUDF(pandasUDF, spark)
 
       // spark.range does not produce Arrow-backed columnar output.
       val df = spark.range(100).toDF("id")
-      val result = df.select(pandasUDF(col("id")))
+      val result = df.selectExpr("row_test_udf(id)")
       val plan = result.queryExecution.executedPlan
 
-      // Row-based source should NOT have the columnar optimization.
       val arrowExecs = collectNodes[ArrowEvalPythonExec](plan)
       arrowExecs.foreach { exec =>
         assert(!exec.child.supportsColumnar,
-          s"Row-based source child should not support columnar:\n$plan")
+          "Row-based source child should not support columnar:" +
+            s"\n$plan")
       }
     }
   }
@@ -147,11 +161,12 @@ class ArrowColumnarPythonUDFSuite extends QueryTest with SharedSparkSession {
   test("Arrow-backed source: multiple partitions") {
     assume(shouldTestPandasUDFs)
     withSQLConf(SQLConf.ARROW_PYSPARK_EXECUTION_ENABLED.key -> "true") {
-      val pandasUDF = TestScalarPandasUDF(name = "arrow_multi_part_udf")
+      val pandasUDF = TestScalarPandasUDF(
+        name = "arrow_mp_udf", returnType = Some(StringType))
       registerTestUDF(pandasUDF, spark)
 
       val df = readArrowSource(numRows = 100, numPartitions = 4)
-      val result = df.select(col("id"), pandasUDF(col("id")))
+      val result = df.selectExpr("id", "arrow_mp_udf(id) as udf_id")
       val rows = result.collect().sortBy(_.getInt(0))
 
       assert(rows.length == 100)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
@@ -64,7 +64,8 @@ class ArrowColumnarPythonUDFSuite extends QueryTest with SharedSparkSession {
       // ProjectExec (which does not support columnar) between the
       // scan and ArrowEvalPythonExec.
       val result = df.selectExpr(
-        "id", "name", "value", "arrow_test_udf(id) as udf_id")
+        "id", "name", "value", "data",
+        "arrow_test_udf(id) as udf_id")
       val plan = result.queryExecution.executedPlan
 
       // ArrowEvalPythonExec should be present.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.python
 
 import org.apache.spark.sql.{IntegratedUDFTestUtils, QueryTest}
-import org.apache.spark.sql.execution.{ColumnarToRowExec, SparkPlan}
+import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StringType

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution.python
 
 import org.apache.spark.sql.{IntegratedUDFTestUtils, QueryTest}
 import org.apache.spark.sql.execution.{ColumnarToRowExec, SparkPlan}
-import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StringType

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.python
 
-import org.apache.spark.sql.{IntegratedUDFTestUtils, QueryTest, Row}
+import org.apache.spark.sql.{IntegratedUDFTestUtils, QueryTest}
 import org.apache.spark.sql.execution.{ColumnarToRowExec, SparkPlan}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.python
+
+import org.apache.spark.sql.{IntegratedUDFTestUtils, QueryTest, Row}
+import org.apache.spark.sql.execution.{ColumnarToRowExec, SparkPlan}
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * End-to-end tests for the Arrow columnar Python UDF input path.
+ *
+ * Verifies that when reading from an Arrow-backed DataSource V2 connector,
+ * ArrowEvalPythonExec uses the columnar path (no ColumnarToRowExec) and
+ * produces correct results.
+ */
+class ArrowColumnarPythonUDFSuite extends QueryTest with SharedSparkSession {
+
+  import IntegratedUDFTestUtils._
+
+  private val arrowSource =
+    "org.apache.spark.sql.execution.python.ArrowBackedDataSourceV2"
+
+  private def readArrowSource(numRows: Int = 100, numPartitions: Int = 1) = {
+    spark.read
+      .format(arrowSource)
+      .option("numRows", numRows.toString)
+      .option("numPartitions", numPartitions.toString)
+      .load()
+  }
+
+  private def collectNodes[T <: SparkPlan](
+      plan: SparkPlan)(implicit tag: reflect.ClassTag[T]): Seq[T] = {
+    plan.collect { case p if tag.runtimeClass.isInstance(p) => p.asInstanceOf[T] }
+  }
+
+  test("Arrow-backed source: no ColumnarToRowExec before ArrowEvalPythonExec") {
+    assume(shouldTestPandasUDFs)
+    withSQLConf(SQLConf.ARROW_PYSPARK_EXECUTION_ENABLED.key -> "true") {
+      val pandasUDF = TestScalarPandasUDF(name = "arrow_test_udf")
+      registerTestUDF(pandasUDF, spark)
+
+      val df = readArrowSource()
+      val result = df.select(col("id"), pandasUDF(col("id")))
+      val plan = result.queryExecution.executedPlan
+
+      // ArrowEvalPythonExec should be present.
+      val arrowExecs = collectNodes[ArrowEvalPythonExec](plan)
+      assert(arrowExecs.nonEmpty,
+        s"Expected ArrowEvalPythonExec in plan:\n$plan")
+
+      // No ColumnarToRowExec should be between the scan and ArrowEvalPythonExec.
+      val columnarToRows = collectNodes[ColumnarToRowExec](plan)
+      assert(columnarToRows.isEmpty,
+        s"ColumnarToRowExec should not be present when reading from " +
+          s"Arrow-backed source:\n$plan")
+    }
+  }
+
+  test("Arrow-backed source: correctness of scalar pandas UDF") {
+    assume(shouldTestPandasUDFs)
+    withSQLConf(SQLConf.ARROW_PYSPARK_EXECUTION_ENABLED.key -> "true") {
+      val pandasUDF = TestScalarPandasUDF(name = "arrow_str_udf")
+      registerTestUDF(pandasUDF, spark)
+
+      val df = readArrowSource(numRows = 10)
+      // The test pandas UDF converts input to string.
+      val result = df.select(col("id"), pandasUDF(col("id")))
+      val rows = result.collect()
+
+      assert(rows.length == 10)
+      rows.zipWithIndex.foreach { case (row, i) =>
+        assert(row.getInt(0) == i, s"id mismatch at row $i")
+        // The pandas UDF converts to string.
+        assert(row.getString(1) == i.toString, s"UDF result mismatch at row $i")
+      }
+    }
+  }
+
+  test("Arrow-backed source: multiple UDF columns") {
+    assume(shouldTestPandasUDFs)
+    withSQLConf(SQLConf.ARROW_PYSPARK_EXECUTION_ENABLED.key -> "true") {
+      val udf1 = TestScalarPandasUDF(name = "arrow_udf1")
+      val udf2 = TestScalarPandasUDF(name = "arrow_udf2")
+      registerTestUDF(udf1, spark)
+      registerTestUDF(udf2, spark)
+
+      val df = readArrowSource(numRows = 10)
+      val result = df.select(
+        col("id"),
+        udf1(col("id")),
+        udf2(col("name")))
+      val rows = result.collect()
+
+      assert(rows.length == 10)
+      rows.zipWithIndex.foreach { case (row, i) =>
+        assert(row.getInt(0) == i)
+        assert(row.getString(1) == i.toString)
+        assert(row.getString(2) == s"row_$i")
+      }
+    }
+  }
+
+  test("Arrow-backed source: supportsColumnar is true") {
+    val df = readArrowSource()
+    val plan = df.queryExecution.executedPlan
+    assert(plan.supportsColumnar,
+      s"Arrow-backed source should support columnar output:\n$plan")
+  }
+
+  test("Row-based source: ColumnarToRowExec is present (baseline)") {
+    assume(shouldTestPandasUDFs)
+    withSQLConf(SQLConf.ARROW_PYSPARK_EXECUTION_ENABLED.key -> "true") {
+      val pandasUDF = TestScalarPandasUDF(name = "row_test_udf")
+      registerTestUDF(pandasUDF, spark)
+
+      // spark.range does not produce Arrow-backed columnar output.
+      val df = spark.range(100).toDF("id")
+      val result = df.select(pandasUDF(col("id")))
+      val plan = result.queryExecution.executedPlan
+
+      // Row-based source should NOT have the columnar optimization.
+      val arrowExecs = collectNodes[ArrowEvalPythonExec](plan)
+      arrowExecs.foreach { exec =>
+        assert(!exec.child.supportsColumnar,
+          s"Row-based source child should not support columnar:\n$plan")
+      }
+    }
+  }
+
+  test("Arrow-backed source: multiple partitions") {
+    assume(shouldTestPandasUDFs)
+    withSQLConf(SQLConf.ARROW_PYSPARK_EXECUTION_ENABLED.key -> "true") {
+      val pandasUDF = TestScalarPandasUDF(name = "arrow_multi_part_udf")
+      registerTestUDF(pandasUDF, spark)
+
+      val df = readArrowSource(numRows = 100, numPartitions = 4)
+      val result = df.select(col("id"), pandasUDF(col("id")))
+      val rows = result.collect().sortBy(_.getInt(0))
+
+      assert(rows.length == 100)
+      rows.zipWithIndex.foreach { case (row, i) =>
+        assert(row.getInt(0) == i)
+        assert(row.getString(1) == i.toString)
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds a columnar execution path to ArrowEvalPythonExec that allows Arrow-backed ColumnarBatch input (e.g., from DataSource V2 connectors that produce ArrowColumnVector columns) to be serialized directly to Arrow IPC for Python UDF evaluation, bypassing the existing ColumnarToRow → ArrowWriter round-trip.

Specifically:

  - ArrowEvalPythonExec now declares supportsColumnar = child.supportsColumnar and supportsRowBased = true, so Spark's transition rules no longer insert ColumnarToRowExec when the child supports columnar output.
  - A new doExecuteColumnar() method produces RDD[ColumnarBatch] where each output batch combines pass-through columns (kept as ColumnVector references without row conversion) with UDF result columns from Python.
  - doExecute() delegates to doExecuteColumnar().flatMap(_.rowIterator()) when the child supports columnar, and falls back to the existing row-based path otherwise.
  - A new ColumnarArrowPythonInput trait detects ArrowColumnVector columns at runtime and extracts the underlying Arrow FieldVectors directly via VectorSchemaRoot.of() + VectorUnloader for zero-copy IPC serialization. Non-Arrow ColumnarBatch inputs fall back to row-by-row ArrowWriter.
  - When UDF inputs contain complex expressions (not simple column references), the evaluator falls back to row-based projection for UDF input serialization while still keeping pass-through columns in columnar format.

Benchmark:

| Scenario | Rows | String Length | UDF | Sink | Arrow Columnar (ms) | Row-based (ms) | Speedup |
|---|---|---|---|---|---|---|---|
| string concat | 2M | 200 chars | `name + data` | noop | 2086 | 2401 | **1.15x** |
| string identity | 1M | 1000 chars | `return data` | noop | 4506 | 4839 | **1.07x** |
| string identity | 2M | 200 chars | `return data` | noop | 2118 | 2324 | **1.10x** |
| string identity | 10M | 100 chars | `return data` | noop | 6067 | 7124 | **1.17x** |
| string identity | 20M | 100 chars | `return data` | noop | 11917 | 14106 | **1.18x** |

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When a Spark operator produces Arrow-backed ColumnarBatch (e.g., connectors that read columnar formats like Parquet into Arrow vectors), the current execution path for Arrow Python UDFs performs a wasteful columnar → row → columnar round-trip: ColumnarToRowExec converts the columnar data to InternalRow, then ArrowWriter converts each row back to Arrow columnar format for IPC serialization to the Python worker.

This round-trip is expensive due to per-row virtual dispatch, type conversion, null checking, and poor cache locality in ArrowWriter.write(). Since the data is already in Arrow format, the conversion is entirely unnecessary.

With this change, Arrow FieldVectors are extracted directly from ArrowColumnVector and serialized to IPC via VectorUnloader — skipping both ColumnarToRowExec and ArrowWriter. Pass-through columns are kept as ColumnVector references throughout, avoiding row materialization entirely in the fully columnar path.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Generated-by: Claude Opus 4.6
