### PR TITLE
[SPARK-56219][PS][FOLLOW-UP] Keep legacy groupby idxmax and idxmin skipna=False behavior for pandas 2

### DIFF
--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -2464,11 +2464,13 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         index = self._psdf._internal.index_spark_column_names[0]
         index_spark_type = self._psdf._internal.index_fields[0].spark_type
 
+        pd_version = LooseVersion(pd.__version__)
+
         stat_exprs = []
         for psser, scol in zip(self._agg_columns, self._agg_columns_scols):
             name = psser._internal.data_spark_column_names[0]
 
-            if LooseVersion(pd.__version__) < "3.0.0" or skipna:
+            if pd_version < "3.0.0" or skipna:
                 order_column = scol.desc_nulls_last()
 
                 window = Window.partitionBy(*groupkey_names).orderBy(
@@ -2480,7 +2482,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
                     name,
                     F.when(F.row_number().over(window) == 1, scol_for(sdf, index)).otherwise(None),
                 )
-                if skipna:
+                if pd_version < "2.3.0" or skipna:
                     stat_exprs.append(F.max(scol_for(sdf, name)).alias(name))
                 else:
                     stat_exprs.append(
@@ -2565,22 +2567,25 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         index = self._psdf._internal.index_spark_column_names[0]
         index_spark_type = self._psdf._internal.index_fields[0].spark_type
 
+        pd_version = LooseVersion(pd.__version__)
+
         stat_exprs = []
         for psser, scol in zip(self._agg_columns, self._agg_columns_scols):
             name = psser._internal.data_spark_column_names[0]
 
-            if LooseVersion(pd.__version__) < "3.0.0" or skipna:
+            if pd_version < "3.0.0" or skipna:
                 order_column = scol.asc_nulls_last()
 
                 window = Window.partitionBy(*groupkey_names).orderBy(
                     order_column, NATURAL_ORDER_COLUMN_NAME
                 )
+
                 has_na_name = "__has_na_{}__".format(name)
                 sdf = sdf.withColumn(has_na_name, scol.isNull()).withColumn(
                     name,
                     F.when(F.row_number().over(window) == 1, scol_for(sdf, index)).otherwise(None),
                 )
-                if skipna:
+                if pd_version < "2.3.0" or skipna:
                     stat_exprs.append(F.max(scol_for(sdf, name)).alias(name))
                 else:
                     stat_exprs.append(

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -2477,19 +2477,11 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
                     order_column, NATURAL_ORDER_COLUMN_NAME
                 )
 
-                has_na_name = "__has_na_{}__".format(name)
-                sdf = sdf.withColumn(has_na_name, scol.isNull()).withColumn(
+                sdf = sdf.withColumn(
                     name,
                     F.when(F.row_number().over(window) == 1, scol_for(sdf, index)).otherwise(None),
                 )
-                if pd_version < "2.3.0" or skipna:
-                    stat_exprs.append(F.max(scol_for(sdf, name)).alias(name))
-                else:
-                    stat_exprs.append(
-                        F.when(F.max(scol_for(sdf, has_na_name)), None)
-                        .otherwise(F.max(scol_for(sdf, name)))
-                        .alias(name)
-                    )
+                stat_exprs.append(F.max(scol_for(sdf, name)).alias(name))
             else:
                 # pandas 3 skipna=False: raise on any NA, otherwise return all-missing labels
                 stat_exprs.append(
@@ -2580,19 +2572,11 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
                     order_column, NATURAL_ORDER_COLUMN_NAME
                 )
 
-                has_na_name = "__has_na_{}__".format(name)
-                sdf = sdf.withColumn(has_na_name, scol.isNull()).withColumn(
+                sdf = sdf.withColumn(
                     name,
                     F.when(F.row_number().over(window) == 1, scol_for(sdf, index)).otherwise(None),
                 )
-                if pd_version < "2.3.0" or skipna:
-                    stat_exprs.append(F.max(scol_for(sdf, name)).alias(name))
-                else:
-                    stat_exprs.append(
-                        F.when(F.max(scol_for(sdf, has_na_name)), None)
-                        .otherwise(F.max(scol_for(sdf, name)))
-                        .alias(name)
-                    )
+                stat_exprs.append(F.max(scol_for(sdf, name)).alias(name))
             else:
                 # pandas 3 skipna=False: raise on any NA, otherwise return all-missing labels
                 stat_exprs.append(

--- a/python/pyspark/pandas/tests/groupby/test_index.py
+++ b/python/pyspark/pandas/tests/groupby/test_index.py
@@ -242,23 +242,25 @@ class GroupbyIndexMixin:
             with self.subTest(i=i):
                 psdf = ps.from_pandas(pdf)
                 if LooseVersion(pd.__version__) < "3.0.0":
+                    # pandas-on-Spark preserves the legacy idxmax/idxmin result for skipna=False.
                     self.assert_eq(
-                        pdf.groupby(["a"]).idxmax(skipna=False).sort_index(),
+                        pdf.groupby(["a"]).idxmax().sort_index(),
                         psdf.groupby(["a"]).idxmax(skipna=False).sort_index(),
                     )
                     self.assert_eq(
-                        pdf.groupby(["a"]).idxmin(skipna=False).sort_index(),
+                        pdf.groupby(["a"]).idxmin().sort_index(),
                         psdf.groupby(["a"]).idxmin(skipna=False).sort_index(),
                     )
                     self.assert_eq(
-                        pdf.groupby(["a"])["b"].idxmax(skipna=False).sort_index(),
+                        pdf.groupby(["a"])["b"].idxmax().sort_index(),
                         psdf.groupby(["a"])["b"].idxmax(skipna=False).sort_index(),
                     )
                     self.assert_eq(
-                        pdf.groupby(["a"])["b"].idxmin(skipna=False).sort_index(),
+                        pdf.groupby(["a"])["b"].idxmin().sort_index(),
                         psdf.groupby(["a"])["b"].idxmin(skipna=False).sort_index(),
                     )
                 else:
+                    # pandas 3 raises for skipna=False when NA values are present.
                     with self.assertRaisesRegex(
                         Exception, "idxmax with skipna=False encountered an NA value"
                     ):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of apache/spark#55021.

This PR updates pandas-on-Spark `GroupBy.idxmax` and `GroupBy.idxmin` for `skipna=False` to keep the legacy behavior for all pandas 2 versions.

With this change:

- pandas `< 3.0.0` keeps the legacy `idxmax` and `idxmin` result for `skipna=False`
- pandas `>= 3.0.0` keeps the existing error behavior for NA-containing input

This PR also updates the related test in `python/pyspark/pandas/tests/groupby/test_index.py` to validate the pandas 2 behavior directly instead of relying on pandas 2.2 and 2.3 having the same result.

### Why are the changes needed?

The previous fix split pandas 2.2 and pandas 2.3 behavior for `GroupBy.idxmax(skipna=False)` and `GroupBy.idxmin(skipna=False)` on NA-containing input.

For example:

```python
pdf = pd.DataFrame({"a": [1, 1, 2, 2], "b": [1, None, 3, 4], "c": [4, 3, 2, 1]})
pdf.groupby(["a"]).idxmax(skipna=False).sort_index()
```

In pandas 2.2, this returns:

```python
   b  c
a
1  0  0
2  3  2
```

In pandas 2.3, this returns:

```python
     b  c
a
1  NaN  0
2  3.0  2
```

In pandas 3, this raises `ValueError`.

Instead of matching the pandas 2.2 / 2.3 difference, this PR keeps the legacy pandas 2 behavior across all pandas 2 environments and continues to follow the pandas 3 behavior in pandas 3 environments.

### Does this PR introduce _any_ user-facing change?

Yes.

In pandas-on-Spark with pandas 2.x, `GroupBy.idxmax(skipna=False)` and `GroupBy.idxmin(skipna=False)` on NA-containing groups now consistently keep the legacy result behavior instead of varying with the installed pandas 2 version.

For pandas 3, behavior is unchanged from the current implementation.

### How was this patch tested?

Ran the related pandas-on-Spark regression test in three environments:

- pandas 2.2: `GroupbyIndexTests.test_idxmax_idxmin_skipna_false_with_na`
- pandas 2.3: `GroupbyIndexTests.test_idxmax_idxmin_skipna_false_with_na`
- pandas 3.0: `GroupbyIndexTests.test_idxmax_idxmin_skipna_false_with_na`

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
