### PR TITLE
[SPARK-54938][PYTHON][TEST][FOLLOW-UP] Fix `test_pyarrow_array_type_inference` for pandas >= 3

### DIFF
--- a/python/pyspark/tests/upstream/pyarrow/test_pyarrow_array_type_inference.py
+++ b/python/pyspark/tests/upstream/pyarrow/test_pyarrow_array_type_inference.py
@@ -295,6 +295,10 @@ class PyArrowArrayTypeInferenceTests(unittest.TestCase):
         import numpy as np
         import pandas as pd
         import pyarrow as pa
+        from pyspark.loose_version import LooseVersion
+
+        # pandas >= 3 infers large_string instead of string for object-dtype string Series
+        string_type = pa.large_string() if LooseVersion(pd.__version__) >= "3.0.0" else pa.string()
 
         sg = ZoneInfo("Asia/Singapore")
         la = "America/Los_Angeles"
@@ -315,7 +319,7 @@ class PyArrowArrayTypeInferenceTests(unittest.TestCase):
             (pd.Series([np.inf, 1.0, 2.0]), pa.float64()),
             (pd.Series([-np.inf, 1.0, 2.0]), pa.float64()),
             # String
-            (pd.Series(["a", "b", "c"]), pa.string()),
+            (pd.Series(["a", "b", "c"]), string_type),
             # Boolean
             (pd.Series([True, False, True]), pa.bool_()),
             # Temporal
@@ -356,6 +360,10 @@ class PyArrowArrayTypeInferenceTests(unittest.TestCase):
         import numpy as np
         import pandas as pd
         import pyarrow as pa
+        from pyspark.loose_version import LooseVersion
+
+        # pandas >= 3 uses pyarrow-backed StringDtype, which infers large_string
+        string_type = pa.large_string() if LooseVersion(pd.__version__) >= "3.0.0" else pa.string()
 
         cases = [
             # Integer
@@ -379,8 +387,8 @@ class PyArrowArrayTypeInferenceTests(unittest.TestCase):
             (pd.Series([True, False, True], dtype=pd.BooleanDtype()), pa.bool_()),
             (pd.Series([True, False, None], dtype=pd.BooleanDtype()), pa.bool_()),
             # String
-            (pd.Series(["a", "b", "c"], dtype=pd.StringDtype()), pa.string()),
-            (pd.Series(["a", "b", None], dtype=pd.StringDtype()), pa.string()),
+            (pd.Series(["a", "b", "c"], dtype=pd.StringDtype()), string_type),
+            (pd.Series(["a", "b", None], dtype=pd.StringDtype()), string_type),
         ]
         self._run_inference_tests(cases)
 


### PR DESCRIPTION




<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
pandas 3.x changed default string dtype to use pyarrow-backed storage, causing pa.array() to infer large_string instead of string for string Series. Conditionally expect large_string on pandas >= 3.


### Why are the changes needed?
to resolve failure in https://github.com/apache/spark/actions/runs/23819581811/job/69428367355


### Does this PR introduce _any_ user-facing change?
No, test-only


### How was this patch tested?
manually check

pandas==3.0.1
```
In [3]: import pyarrow as pa

In [4]: import pandas as pd

In [5]: ser = pd.Series(["a", "b", "c"], dtype=pd.StringDtype())

In [6]: pa.array(ser)
Out[6]:
<pyarrow.lib.LargeStringArray object at 0x103455d80>
[
  "a",
  "b",
  "c"
]

In [7]: pa.array(ser, pa.string())
Out[7]:
<pyarrow.lib.StringArray object at 0x1095546a0>
[
  "a",
  "b",
  "c"
]
```

pandas==2.3.3
```
In [7]: ser = pd.Series(["a", "b", "c"], dtype=pd.StringDtype())

In [8]: pa.array(ser)
Out[8]:
<pyarrow.lib.StringArray object at 0x10ae16620>
[
  "a",
  "b",
  "c"
]

In [9]: pa.array(ser, pa.string())
Out[9]:
<pyarrow.lib.StringArray object at 0x10ae14a00>
[
  "a",
  "b",
  "c"
]
```

### Was this patch authored or co-authored using generative AI tooling?
Co-authored-by: Claude code (Opus 4.6)
