### PR TITLE
[SPARK-56317][SQL] GetJsonObjectEvaluator should reuse output buffer

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/json/JsonExpressionEvalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/json/JsonExpressionEvalUtils.scala
@@ -369,6 +369,9 @@ case class GetJsonObjectEvaluator(cachedPath: UTF8String) {
   @transient
   private var pathStr: UTF8String = _
 
+  @transient
+  private lazy val outputBuffer = new ByteArrayOutputStream()
+
   def setJson(arg: UTF8String): Unit = {
     jsonStr = arg
   }
@@ -391,14 +394,14 @@ case class GetJsonObjectEvaluator(cachedPath: UTF8String) {
         /* We know the bytes are UTF-8 encoded. Pass a Reader to avoid having Jackson
           detect character encoding which could fail for some malformed strings */
         Utils.tryWithResource(CreateJacksonParser.utf8String(jsonFactory, jsonStr)) { parser =>
-          val output = new ByteArrayOutputStream()
+          outputBuffer.reset()
           val matched = Utils.tryWithResource(
-            jsonFactory.createGenerator(output, JsonEncoding.UTF8)) { generator =>
+            jsonFactory.createGenerator(outputBuffer, JsonEncoding.UTF8)) { generator =>
             parser.nextToken()
             evaluatePath(parser, generator, RawStyle, parsed.get)
           }
           if (matched) {
-            UTF8String.fromBytes(output.toByteArray)
+            UTF8String.fromBytes(outputBuffer.toByteArray)
           } else {
             null
           }


### PR DESCRIPTION
### What changes were proposed in this pull request?
GetJsonObjectEvaluator should reuse output buffer.

### Why are the changes needed?
Currently, GetJsonObjectEvaluator.evaluate() creates a new ByteArrayOutputStream on every invocation. Since the evaluator is reused across rows, this results in unnecessary object allocation and GC pressure. We can reuse the output buffer by promoting it to a class-level lazy val and calling reset() before each use, this is consistent with StructsToJsonEvaluator, which reuses a CharArrayWriter across rows.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing UTs.

### Was this patch authored or co-authored using generative AI tooling?
No.
