### PR TITLE
[SPARK-56319][SQL] ShuffleExternalSorter should reuse write buffer

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/sort/ShuffleExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/ShuffleExternalSorter.java
@@ -122,6 +122,13 @@ final class ShuffleExternalSorter extends MemoryConsumer implements ShuffleCheck
   // Checksum calculator for each partition. Empty when shuffle checksum disabled.
   private final Checksum[] partitionChecksums;
 
+  // Small writes to DiskBlockObjectWriter will be fairly inefficient. Since there doesn't seem to
+  // be an API to directly transfer bytes from managed memory to the disk writer, we buffer
+  // data through a byte array. This array does not need to be large enough to hold a single
+  // record;
+  // Lazily allocated on the first call to writeSortedFile() and reused across spills.
+  private byte[] writeBuffer;
+
   ShuffleExternalSorter(
       TaskMemoryManager memoryManager,
       BlockManager blockManager,
@@ -199,12 +206,6 @@ final class ShuffleExternalSorter extends MemoryConsumer implements ShuffleCheck
       writeMetricsToUse = new ShuffleWriteMetrics();
     }
 
-    // Small writes to DiskBlockObjectWriter will be fairly inefficient. Since there doesn't seem to
-    // be an API to directly transfer bytes from managed memory to the disk writer, we buffer
-    // data through a byte array. This array does not need to be large enough to hold a single
-    // record;
-    final byte[] writeBuffer = new byte[diskWriteBufferSize];
-
     // Because this output will be read during shuffle, its compression codec must be controlled by
     // spark.shuffle.compress instead of spark.shuffle.spill.compress, so we need to use
     // createTempShuffleBlock here; see SPARK-3426 for more details.
@@ -219,6 +220,10 @@ final class ShuffleExternalSorter extends MemoryConsumer implements ShuffleCheck
     // OutputStream methods), but DiskBlockObjectWriter still calls some methods on it. To work
     // around this, we pass a dummy no-op serializer.
     final SerializerInstance ser = DummySerializerInstance.INSTANCE;
+
+    if (writeBuffer == null) {
+      writeBuffer = new byte[diskWriteBufferSize];
+    }
 
     int currentPartition = -1;
     final FileSegment committedSegment;


### PR DESCRIPTION
### What changes were proposed in this pull request?
[SPARK-56319] ShuffleExternalSorter should reuse write buffer

### Why are the changes needed?
In ShuffleExternalSorter, the writeSortedFile() method allocates a new byte[] of diskWriteBufferSize (default 1 MB) on every invocation. This method is called once per spill and once more for the final file write, so in a spill-heavy shuffle task the same 1 MB array is allocated and discarded repeatedly, adding unnecessary GC pressure.

This PR promotes the write buffer to a lazily-initialized instance field so that it is allocated on the first call to writeSortedFile() and reused across subsequent spills. Lazy initialization ensures that the buffer is not allocated until it is actually needed, so tasks that insert no records (and therefore never call into the write path) pay no extra cost.



### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing UTs.

### Was this patch authored or co-authored using generative AI tooling?
No.
