### PR TITLE
[SPARK-56323][SQL] Propagate ROW FORMAT / STORED AS to v2 catalog in CREATE TABLE LIKE

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
@@ -567,7 +567,7 @@ private[sql] object CatalogV2Util {
    *  - ROW FORMAT SERDE: hive.serde
    *  - SERDEPROPERTIES: add "option." prefix
    */
-  private def convertToProperties(serdeInfo: Option[SerdeInfo]): Map[String, String] = {
+  def convertToProperties(serdeInfo: Option[SerdeInfo]): Map[String, String] = {
     serdeInfo match {
       case Some(s) =>
         s.formatClasses.map { f =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateTableLikeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateTableLikeExec.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
 import org.apache.spark.sql.catalyst.catalog.CatalogUtils
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.SerdeInfo
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Column, Identifier, Table, TableCatalog, TableInfo, V1Table}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
@@ -41,7 +42,8 @@ import org.apache.spark.sql.errors.QueryCompilationErrors
  *
  * The [[TableInfo]] passed to [[TableCatalog.createTableLike]] contains all explicit information
  * for the new table: columns and partitioning copied from the source, constraints copied from
- * the source, user-specified TBLPROPERTIES / LOCATION / USING provider (if given), and
+ * the source, user-specified TBLPROPERTIES / LOCATION / USING provider (if given),
+ * ROW FORMAT / STORED AS converted to hive properties (if given), and
  * [[TableCatalog.PROP_OWNER]] set to the current user. Source table properties are intentionally
  * excluded so that connectors can decide which custom properties to clone via [[sourceTable]].
  */
@@ -51,6 +53,7 @@ case class CreateTableLikeExec(
     sourceTable: Table,
     location: Option[URI],
     provider: Option[String],
+    serdeInfo: Option[SerdeInfo],
     properties: Map[String, String],
     ifNotExists: Boolean) extends LeafV2CommandExec {
 
@@ -93,6 +96,7 @@ case class CreateTableLikeExec(
   private def targetProperties: Map[String, String] =
     CatalogV2Util.withDefaultOwnership(
       properties ++
+        CatalogV2Util.convertToProperties(serdeInfo) ++
         provider.map(TableCatalog.PROP_PROVIDER -> _) ++
         location.map(uri => TableCatalog.PROP_LOCATION -> CatalogUtils.URIToString(uri)))
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -245,7 +245,7 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
     // Views are wrapped in V1Table so the exec can extract schema and provider uniformly.
     case CreateTableLike(
         ResolvedIdentifier(catalog, ident), source,
-        locationStr, provider, _, properties, ifNotExists) =>
+        locationStr, provider, serdeInfo, properties, ifNotExists) =>
       val table = source match {
         case ResolvedTable(_, _, t, _) => t
         case ResolvedPersistentView(_, _, meta) => V1Table(meta)
@@ -258,7 +258,7 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
         else uri
       }
       CreateTableLikeExec(catalog.asTableCatalog, ident, table,
-        location, provider, properties, ifNotExists) :: Nil
+        location, provider, serdeInfo, properties, ifNotExists) :: Nil
 
     case RefreshTable(r: ResolvedTable) =>
       RefreshTableExec(r.catalog, r.identifier, recacheTable(r, includeTimeTravel = true)) :: Nil

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/CreateTableLikeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/CreateTableLikeSuite.scala
@@ -299,6 +299,40 @@ class CreateTableLikeSuite extends DatasourceV2SQLBase {
   }
 
   // -------------------------------------------------------------------------
+  // ROW FORMAT / STORED AS propagation
+  // -------------------------------------------------------------------------
+
+  test("STORED AS is converted to hive.stored-as property for v2 target") {
+    withTable("src", "testcat.dst") {
+      sql("CREATE TABLE src (id bigint) USING parquet")
+      sql("CREATE TABLE testcat.dst LIKE src STORED AS textfile")
+
+      val dst = testCatalog.loadTable(Identifier.of(Array(), "dst"))
+      assert(dst.properties.get("hive.stored-as") === "textfile",
+        "STORED AS should be converted to hive.stored-as property")
+    }
+  }
+
+  test("STORED AS INPUTFORMAT/OUTPUTFORMAT are converted to hive properties for v2 target") {
+    withTable("src", "testcat.dst") {
+      sql("CREATE TABLE src (id bigint) USING parquet")
+      sql(
+        """CREATE TABLE testcat.dst LIKE src
+          |STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'
+          |OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
+          |""".stripMargin)
+
+      val dst = testCatalog.loadTable(Identifier.of(Array(), "dst"))
+      assert(dst.properties.get("hive.input-format") ===
+        "org.apache.hadoop.mapred.TextInputFormat",
+        "INPUTFORMAT should be converted to hive.input-format property")
+      assert(dst.properties.get("hive.output-format") ===
+        "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+        "OUTPUTFORMAT should be converted to hive.output-format property")
+    }
+  }
+
+  // -------------------------------------------------------------------------
   // V1 fallback regression
   // -------------------------------------------------------------------------
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

DataSourceV2Strategy was discarding CreateTableLike.serdeInfo (the parsed ROW FORMAT / STORED AS clauses) with a wildcard pattern. CreateTableLikeExec never received them, so a STORED AS or ROW FORMAT override on a V2 catalog target was silently dropped.

Fix by:
- Exposing CatalogV2Util.convertToProperties so it can be called from the core module (same conversion used by regular CREATE TABLE).
- Adding serdeInfo: Option[SerdeInfo] to CreateTableLikeExec.
- Passing serdeInfo through DataSourceV2Strategy instead of ignoring it.
- Including CatalogV2Util.convertToProperties(serdeInfo) in targetProperties so hive.stored-as / hive.input-format / hive.output-format / hive.serde are set in the TableInfo passed to createTableLike.

Add two tests to CreateTableLikeSuite covering STORED AS and STORED AS INPUTFORMAT/OUTPUTFORMAT for a V2 catalog target.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To fix the issue of not propagating serde into to V2 CREATE TABLE LIKE.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Generated-by: Claude Sonnet 4.6