### PR TITLE
[SPARK-56327][PYTHON][TESTS] Fix grouped map pandas tests for pandas 3

### DIFF
--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -120,7 +120,11 @@ class ApplyInPandasTestsMixin:
                 float=pdf.float * 2,
                 double=pdf.double * 2,
                 decim=pdf.decim * 2,
-                bool=False if pdf.bool else True,
+                bool=(
+                    (False if pdf.bool else True)
+                    if LooseVersion(pd.__version__) < "3.0.0"
+                    else (~pdf.bool)
+                ),
                 str=pdf.str + "there",
                 array=pdf.array,
                 bin=pdf.bin,
@@ -139,7 +143,11 @@ class ApplyInPandasTestsMixin:
                 float=pdf.float * 2,
                 double=pdf.double * 2,
                 decim=pdf.decim * 2,
-                bool=False if pdf.bool else True,
+                bool=(
+                    (False if pdf.bool else True)
+                    if LooseVersion(pd.__version__) < "3.0.0"
+                    else (~pdf.bool)
+                ),
                 str=pdf.str + "there",
                 array=pdf.array,
                 bin=pdf.bin,
@@ -159,7 +167,11 @@ class ApplyInPandasTestsMixin:
                 float=pdf.float * 2,
                 double=pdf.double * 2,
                 decim=pdf.decim * 2,
-                bool=False if pdf.bool else True,
+                bool=(
+                    (False if pdf.bool else True)
+                    if LooseVersion(pd.__version__) < "3.0.0"
+                    else (~pdf.bool)
+                ),
                 str=pdf.str + "there",
                 array=pdf.array,
                 bin=pdf.bin,
@@ -170,7 +182,15 @@ class ApplyInPandasTestsMixin:
         )
 
         result1 = df.groupby("id").apply(udf1).sort("id").toPandas()
-        expected1 = df.toPandas().groupby("id").apply(udf1.func).reset_index(drop=True)
+
+        pdf = df.toPandas()
+        if LooseVersion(pd.__version__) < "3.0.0":
+            grouped_pdf = pdf.groupby("id")
+        else:
+            # pandas 3+ GroupBy.apply drops grouping columns when grouped by
+            # the same DataFrame column, so use a copied Series instead.
+            grouped_pdf = pdf.groupby(pdf.id.copy())
+        expected1 = grouped_pdf.apply(udf1.func).reset_index(drop=True)
 
         result2 = df.groupby("id").apply(udf2).sort("id").toPandas()
         expected2 = expected1
@@ -196,7 +216,16 @@ class ApplyInPandasTestsMixin:
         udf = pandas_udf(lambda pdf: pdf, output_schema, PandasUDFType.GROUPED_MAP)
 
         result = df.groupby("id").apply(udf).sort("id").toPandas()
-        expected = df.toPandas().groupby("id").apply(udf.func).reset_index(drop=True)
+
+        pdf = df.toPandas()
+        if LooseVersion(pd.__version__) < "3.0.0":
+            grouped_pdf = pdf.groupby("id", as_index=False)
+        else:
+            # pandas 3+ GroupBy.apply drops grouping columns when grouped by
+            # the same DataFrame column, so use a copied Series instead.
+            grouped_pdf = pdf.groupby(pdf.id.copy(), as_index=False)
+        expected = grouped_pdf.apply(udf.func).reset_index(drop=True)
+
         assert_frame_equal(expected, result)
 
     def test_register_grouped_map_udf(self):
@@ -226,7 +255,16 @@ class ApplyInPandasTestsMixin:
             return pdf.assign(v1=pdf.v * pdf.id * 1.0, v2=pdf.v + pdf.id)
 
         result = df.groupby("id").apply(foo).sort("id").toPandas()
-        expected = df.toPandas().groupby("id").apply(foo.func).reset_index(drop=True)
+
+        pdf = df.toPandas()
+        if LooseVersion(pd.__version__) < "3.0.0":
+            grouped_pdf = pdf.groupby("id")
+        else:
+            # pandas 3+ GroupBy.apply drops grouping columns when grouped by
+            # the same DataFrame column, so use a copied Series instead.
+            grouped_pdf = pdf.groupby(pdf.id.copy())
+        expected = grouped_pdf.apply(foo.func).reset_index(drop=True)
+
         assert_frame_equal(expected, result)
 
     def test_coerce(self):
@@ -235,7 +273,13 @@ class ApplyInPandasTestsMixin:
         foo = pandas_udf(lambda pdf: pdf, "id long, v double", PandasUDFType.GROUPED_MAP)
 
         result = df.groupby("id").apply(foo).sort("id").toPandas()
-        expected = df.toPandas().groupby("id").apply(foo.func).reset_index(drop=True)
+
+        pdf = df.toPandas()
+        if LooseVersion(pd.__version__) < "3.0.0":
+            grouped_pdf = pdf.groupby("id")
+        else:
+            grouped_pdf = pdf.groupby(pdf.id.copy())
+        expected = grouped_pdf.apply(foo.func).reset_index(drop=True)
         expected = expected.assign(v=expected.v.astype("float64"))
         assert_frame_equal(expected, result)
 
@@ -418,7 +462,16 @@ class ApplyInPandasTestsMixin:
         )
 
         result = df.groupby("id").apply(foo_udf).sort("id").toPandas()
-        expected = df.toPandas().groupby("id").apply(foo_udf.func).reset_index(drop=True)
+
+        pdf = df.toPandas()
+        if LooseVersion(pd.__version__) < "3.0.0":
+            grouped_pdf = pdf.groupby("id")
+        else:
+            # pandas 3+ GroupBy.apply drops grouping columns when grouped by
+            # the same DataFrame column, so use a copied Series instead.
+            grouped_pdf = pdf.groupby(pdf.id.copy())
+        expected = grouped_pdf.apply(foo_udf.func).reset_index(drop=True)
+
         assert_frame_equal(expected, result)
 
     def test_wrong_return_type(self):
@@ -552,9 +605,14 @@ class ApplyInPandasTestsMixin:
 
         # Test groupby column
         result1 = df.groupby("id").apply(udf1).sort("id", "v").toPandas()
+        if LooseVersion(pd.__version__) < "3.0.0":
+            grouped_pdf = pdf.groupby("id", as_index=False)
+        else:
+            # pandas 3+ GroupBy.apply drops grouping columns when grouped by
+            # the same DataFrame column, so use a copied Series instead.
+            grouped_pdf = pdf.groupby(pdf.id.copy(), as_index=False)
         expected1 = (
-            pdf.groupby("id", as_index=False)
-            .apply(lambda x: udf1.func((x.id.iloc[0],), x))
+            grouped_pdf.apply(lambda x: udf1.func((x.id.iloc[0],), x))
             .sort_values(["id", "v"])
             .reset_index(drop=True)
         )
@@ -572,9 +630,14 @@ class ApplyInPandasTestsMixin:
 
         # Test complex groupby
         result3 = df.groupby(df.id, df.v % 2).apply(udf2).sort("id", "v").toPandas()
+        if LooseVersion(pd.__version__) < "3.0.0":
+            grouped_pdf = pdf.groupby([pdf.id, pdf.v % 2], as_index=False)
+        else:
+            # pandas 3+ GroupBy.apply drops grouping columns when grouped by
+            # the same DataFrame column, so copy the id grouper instead.
+            grouped_pdf = pdf.groupby([pdf.id.copy(), pdf.v % 2], as_index=False)
         expected3 = (
-            pdf.groupby([pdf.id, pdf.v % 2], as_index=False)
-            .apply(
+            grouped_pdf.apply(
                 lambda x: udf2.func(
                     (
                         x.id.iloc[0],
@@ -606,7 +669,14 @@ class ApplyInPandasTestsMixin:
 
         df = self.data
         grouped_df = df.groupby("id")
-        grouped_pdf = df.toPandas().groupby("id", as_index=False)
+
+        pdf = df.toPandas()
+        if LooseVersion(pd.__version__) < "3.0.0":
+            grouped_pdf = pdf.groupby("id", as_index=False)
+        else:
+            # pandas 3+ GroupBy.apply drops grouping columns when grouped by
+            # the same DataFrame column, so use a copied Series instead.
+            grouped_pdf = pdf.groupby(pdf.id.copy(), as_index=False)
 
         # Function returns a pdf with required column names, but order could be arbitrary using dict
         def change_col_order(pdf):
@@ -1415,8 +1485,15 @@ class ApplyInPandasTestsMixin:
             return pdf.assign(v1=pdf.v * pdf.id * 1.0)
 
         df = self.data
+
         pdf = df.toPandas()
-        expected = pdf.groupby("id", as_index=False).apply(foo.func).reset_index(drop=True)
+        if LooseVersion(pd.__version__) < "3.0.0":
+            grouped_pdf = pdf.groupby("id", as_index=False)
+        else:
+            # pandas 3+ GroupBy.apply drops grouping columns when grouped by
+            # the same DataFrame column, so use a copied Series instead.
+            grouped_pdf = pdf.groupby(pdf.id.copy(), as_index=False)
+        expected = grouped_pdf.apply(foo.func).reset_index(drop=True)
 
         for codec in ["none", "zstd", "lz4"]:
             with self.subTest(compressionCodec=codec):

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -278,6 +278,8 @@ class ApplyInPandasTestsMixin:
         if LooseVersion(pd.__version__) < "3.0.0":
             grouped_pdf = pdf.groupby("id")
         else:
+            # pandas 3+ GroupBy.apply drops grouping columns when grouped by
+            # the same DataFrame column, so use a copied Series instead.
             grouped_pdf = pdf.groupby(pdf.id.copy())
         expected = grouped_pdf.apply(foo.func).reset_index(drop=True)
         expected = expected.assign(v=expected.v.astype("float64"))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates `python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py` for pandas 3 behavior in grouped map pandas UDF tests.

The changes are:
- update the expected boolean inversion in `test_supported_types` to use `~pdf.bool` on pandas 3 while keeping the existing behavior on older pandas versions
- update several pandas-side expected-value paths to avoid grouping directly by the same in-DataFrame column on pandas 3
- use copied groupers such as `pdf.id.copy()` so the grouped pandas input still keeps the grouping columns while preserving the original grouping semantics
- add comments explaining why the pandas 3 branch uses copied groupers

### Why are the changes needed?

In pandas 3, `GroupBy.apply` drops grouping columns when the grouping key is the same DataFrame column. These tests build expected results by applying the Python function to pandas-grouped data, so the previous expectations no longer match the grouped map input shape seen by Spark in cases that rely on grouping columns remaining present.

The boolean expectation also needs a pandas-3-specific branch because the old scalar-style inversion logic does not match the pandas 3 object being operated on in these tests.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Updated the related tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
