### PR TITLE
[SPARK-56275][K8S] Set appProtocol on spark-connect service port

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStep.scala
@@ -92,6 +92,7 @@ private[spark] class DriverServiceFeatureStep(
           .withName(SPARK_CONNECT_SERVER_PORT_NAME)
           .withPort(driverSparkConnectServerPort)
           .withNewTargetPort(driverSparkConnectServerPort)
+          .withAppProtocol("grpc")
           .endPort()
         .endSpec()
       .build()

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStepSuite.scala
@@ -266,5 +266,6 @@ class DriverServiceFeatureStepSuite extends SparkFunSuite {
     assert(driverServicePorts(2).getTargetPort.getIntVal === drierUIPort)
     assert(driverServicePorts(3).getPort.intValue() === driverConnectServerPort)
     assert(driverServicePorts(3).getTargetPort.getIntVal === driverConnectServerPort)
+    assert(driverServicePorts(3).getAppProtocol === "grpc")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Set `appProtocol` to `"grpc"` on the `spark-connect` service port in `DriverServiceFeatureStep`.

### Why are the changes needed?

Without `appProtocol: grpc`, service meshes (e.g. Istio, Linkerd) treat gRPC traffic as opaque TCP. This prevents L7-aware load balancing, protocol-specific retries, and proper gRPC health checking for Spark Connect sessions.

This change is limited to the `spark-connect` port because gRPC is unambiguous regardless of SSL configuration. Other ports (HTTP-based) are left untouched since their protocol depends on `spark.ssl.*` settings.

### Does this PR introduce _any_ user-facing change?

No. The `appProtocol` field is advisory and has no effect in environments without a service mesh.

### How was this patch tested?

Updated `DriverServiceFeatureStepSuite.verifyService()` to assert that the `spark-connect` port has `appProtocol: "grpc"`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.6