### PR TITLE
[SPARK-56329][PYTHON] Fix all E721 type comparison violations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,6 @@ extend-select = [
 ]
 ignore = [
     "E402", # Module top level import is disabled for optional import check, etc.
-    # TODO
-    "E721", # Use isinstance for type comparison, too many for now.
     "E741", # Ambiguous variables like l, I or O.
 ]
 

--- a/python/pyspark/ml/linalg/__init__.py
+++ b/python/pyspark/ml/linalg/__init__.py
@@ -596,7 +596,7 @@ class SparseVector(Vector):
         assert 1 <= len(args) <= 2, "must pass either 2 or 3 arguments"
         if len(args) == 1:
             pairs = args[0]
-            if type(pairs) == dict:
+            if isinstance(pairs, dict):
                 pairs = pairs.items()
             pairs = cast(Iterable[Tuple[int, float]], sorted(pairs))
             self.indices = np.array([p[0] for p in pairs], dtype=np.int32)

--- a/python/pyspark/ml/param/__init__.py
+++ b/python/pyspark/ml/param/__init__.py
@@ -128,9 +128,9 @@ class TypeConverters:
         """
         Convert a value to a list, if possible.
         """
-        if type(value) == list:
+        if isinstance(value, list):
             return value
-        elif type(value) in [np.ndarray, tuple, range, array.array]:
+        elif isinstance(value, (np.ndarray, tuple, range, array.array)):
             return list(value)
         elif isinstance(value, Vector):
             return list(value.toArray())
@@ -229,7 +229,7 @@ class TypeConverters:
         """
         if isinstance(value, str):
             return value
-        elif type(value) in [np.bytes_, np.str_]:
+        elif isinstance(value, (np.bytes_, np.str_)):
             return str(value)
         else:
             raise TypeError("Could not convert %s to string type" % type(value))
@@ -239,7 +239,7 @@ class TypeConverters:
         """
         Convert a value to a boolean, if possible.
         """
-        if type(value) == bool:
+        if isinstance(value, bool):
             return value
         else:
             raise TypeError("Boolean Param requires value of type bool. Found %s." % type(value))

--- a/python/pyspark/ml/tests/test_param.py
+++ b/python/pyspark/ml/tests/test_param.py
@@ -49,14 +49,14 @@ class ParamTypeConversionTests(PySparkTestCase):
     def test_int(self):
         lr = LogisticRegression(maxIter=5.0)
         self.assertEqual(lr.getMaxIter(), 5)
-        self.assertTrue(type(lr.getMaxIter()) == int)
+        self.assertTrue(isinstance(lr.getMaxIter(), int))
         self.assertRaises(TypeError, lambda: LogisticRegression(maxIter="notAnInt"))
         self.assertRaises(TypeError, lambda: LogisticRegression(maxIter=5.1))
 
     def test_float(self):
         lr = LogisticRegression(tol=1)
         self.assertEqual(lr.getTol(), 1.0)
-        self.assertTrue(type(lr.getTol()) == float)
+        self.assertTrue(isinstance(lr.getTol(), float))
         self.assertRaises(TypeError, lambda: LogisticRegression(tol="notAFloat"))
 
     def test_vector(self):
@@ -78,7 +78,7 @@ class ParamTypeConversionTests(PySparkTestCase):
             tuple(lst),
         ]:
             converted = TypeConverters.toList(lst_like)
-            self.assertEqual(type(converted), list)
+            self.assertIsInstance(converted, list)
             self.assertListEqual(converted, lst)
 
     def test_list_int(self):
@@ -93,21 +93,21 @@ class ParamTypeConversionTests(PySparkTestCase):
         ]:
             vs = VectorSlicer(indices=indices)
             self.assertListEqual(vs.getIndices(), [1, 2])
-            self.assertTrue(all([type(v) == int for v in vs.getIndices()]))
+            self.assertTrue(all([isinstance(v, int) for v in vs.getIndices()]))
         self.assertRaises(TypeError, lambda: VectorSlicer(indices=["a", "b"]))
 
     def test_list_float(self):
         b = Bucketizer(splits=[1, 4])
         self.assertEqual(b.getSplits(), [1.0, 4.0])
-        self.assertTrue(all([type(v) == float for v in b.getSplits()]))
+        self.assertTrue(all([isinstance(v, float) for v in b.getSplits()]))
         self.assertRaises(TypeError, lambda: Bucketizer(splits=["a", 1.0]))
 
     def test_list_list_float(self):
         b = Bucketizer(splitsArray=[[-0.1, 0.5, 3], [-5, 1.5]])
         self.assertEqual(b.getSplitsArray(), [[-0.1, 0.5, 3.0], [-5.0, 1.5]])
-        self.assertTrue(all([type(v) == list for v in b.getSplitsArray()]))
-        self.assertTrue(all([type(v) == float for v in b.getSplitsArray()[0]]))
-        self.assertTrue(all([type(v) == float for v in b.getSplitsArray()[1]]))
+        self.assertTrue(all([isinstance(v, list) for v in b.getSplitsArray()]))
+        self.assertTrue(all([isinstance(v, float) for v in b.getSplitsArray()[0]]))
+        self.assertTrue(all([isinstance(v, float) for v in b.getSplitsArray()[1]]))
         self.assertRaises(TypeError, lambda: Bucketizer(splitsArray=["a", 1.0]))
         self.assertRaises(TypeError, lambda: Bucketizer(splitsArray=[[-5, 1.5], ["a", 1.0]]))
 

--- a/python/pyspark/ml/tests/tuning/test_tuning.py
+++ b/python/pyspark/ml/tests/tuning/test_tuning.py
@@ -203,7 +203,7 @@ class CrossValidatorTests(SparkSessionTestCase, ValidatorTestUtilsMixin):
         paramGrid = ParamGridBuilder().addGrid(lr.regParam, [0.5, 1]).build()
         for param in paramGrid:
             for v in param.values():
-                assert type(v) == float
+                assert isinstance(v, float)
 
     def test_parallel_evaluation(self):
         dataset = self.spark.createDataFrame(

--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -441,7 +441,7 @@ class DenseVector(Vector):
             ...
         AssertionError: dimension mismatch
         """
-        if type(other) == np.ndarray:
+        if isinstance(other, np.ndarray):
             if other.ndim > 1:
                 assert len(self) == other.shape[0], "dimension mismatch"
             return np.dot(self.array, other)
@@ -654,7 +654,7 @@ class SparseVector(Vector):
         assert 1 <= len(args) <= 2, "must pass either 2 or 3 arguments"
         if len(args) == 1:
             pairs = args[0]
-            if type(pairs) == dict:
+            if isinstance(pairs, dict):
                 pairs = pairs.items()
             pairs = cast(Iterable[Tuple[int, float]], sorted(pairs))
             self.indices = np.array([p[0] for p in pairs], dtype=np.int32)

--- a/python/pyspark/mllib/stat/_statistics.py
+++ b/python/pyspark/mllib/stat/_statistics.py
@@ -181,7 +181,7 @@ class Statistics:
         # Check inputs to determine whether a single value or a matrix is needed for output.
         # Since it's legal for users to use the method name as the second argument, we need to
         # check if y is used to specify the method name instead.
-        if type(y) == str:
+        if isinstance(y, str):
             raise TypeError("Use 'method=' to specify method name.")
 
         if not y:

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -14039,7 +14039,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         elif isinstance(key, Series):
             return self.loc[key.astype(bool)]
         elif isinstance(key, slice):
-            if any(type(n) == int or None for n in [key.start, key.stop]):
+            if any(isinstance(n, int) or None for n in [key.start, key.stop]):
                 # Seems like pandas Frame always uses int as positional search when slicing
                 # with ints.
                 return self.iloc[key]

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -434,7 +434,7 @@ class Index(IndexOpsMixin):
         """
         if same_anchor(self, other):
             return True
-        elif type(self) == type(other):
+        elif type(self) is type(other):
             if get_option("compute.ops_on_diff_frames"):
                 # TODO: avoid using default index?
                 with option_context("compute.default_index_type", "distributed-sequence"):
@@ -1467,7 +1467,7 @@ class Index(IndexOpsMixin):
         >>> (s1.index ^ s2.index)
         Index([1, 5], dtype='int64')
         """
-        if type(self) != type(other):
+        if type(self) is not type(other):
             raise NotImplementedError(
                 "Doesn't support symmetric_difference between Index & MultiIndex for now"
             )
@@ -2068,7 +2068,7 @@ class Index(IndexOpsMixin):
         # Check if the `self` and `other` have different index types.
         # 1. `self` is Index, `other` is MultiIndex
         # 2. `self` is MultiIndex, `other` is Index
-        is_index_types_different = isinstance(other, Index) and (type(self) != type(other))
+        is_index_types_different = isinstance(other, Index) and (type(self) is not type(other))
         if is_index_types_different:
             if isinstance(self, MultiIndex):
                 # In case `self` is MultiIndex and `other` is Index,

--- a/python/pyspark/pandas/indexes/multi.py
+++ b/python/pyspark/pandas/indexes/multi.py
@@ -804,7 +804,7 @@ class MultiIndex(Index):
                     (  'lama', 'speed')],
                    )
         """
-        if type(self) != type(other):
+        if type(self) is not type(other):
             raise NotImplementedError(
                 "Doesn't support symmetric_difference between Index & MultiIndex for now"
             )

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -7424,7 +7424,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
     def __getitem__(self, key: Any) -> Any:
         if LooseVersion(pd.__version__) < "3.0.0":
-            treating_keys_as_positions = type(key) == int and not isinstance(
+            treating_keys_as_positions = isinstance(key, int) and not isinstance(
                 self.index.spark.data_type, (IntegerType, LongType)
             )
             if treating_keys_as_positions:
@@ -7439,7 +7439,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             treating_keys_as_positions = False
         try:
             if (
-                isinstance(key, slice) and any(type(n) == int for n in [key.start, key.stop])
+                isinstance(key, slice) and any(isinstance(n, int) for n in [key.start, key.stop])
             ) or treating_keys_as_positions:
                 # Seems like pandas Series always uses int as positional search when slicing
                 # with ints, searches based on index values when the value is int.

--- a/python/pyspark/pandas/tests/test_extension.py
+++ b/python/pyspark/pandas/tests/test_extension.py
@@ -57,7 +57,7 @@ class CustomAccessor:
         return self.item
 
     def check_length(self, col=None):
-        if type(self.obj) == ps.DataFrame or col is not None:
+        if isinstance(self.obj, ps.DataFrame) or col is not None:
             return len(self.obj[col])
         else:
             try:

--- a/python/pyspark/sql/classic/column.py
+++ b/python/pyspark/sql/classic/column.py
@@ -462,7 +462,7 @@ class Column(ParentColumn):
         startPos = enum_to_value(startPos)
         length = enum_to_value(length)
 
-        if type(startPos) != type(length):
+        if type(startPos) is not type(length):
             raise PySparkTypeError(
                 errorClass="NOT_SAME_TYPE",
                 messageParameters={

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -365,7 +365,7 @@ class Column(ParentColumn):
         startPos = enum_to_value(startPos)
         length = enum_to_value(length)
 
-        if type(startPos) != type(length):
+        if type(startPos) is not type(length):
             raise PySparkTypeError(
                 errorClass="NOT_SAME_TYPE",
                 messageParameters={

--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -1044,7 +1044,7 @@ class UnresolvedNamedLambdaVariable(Expression):
 
     @staticmethod
     def fresh_var_name(name: str) -> str:
-        assert isinstance(name, str) and str != ""
+        assert isinstance(name, str) and name != ""
 
         _id: Optional[int] = None
 

--- a/python/pyspark/sql/connect/streaming/readwriter.py
+++ b/python/pyspark/sql/connect/streaming/readwriter.py
@@ -137,7 +137,7 @@ class DataStreamReader(OptionUtils):
         if schema is not None:
             self.schema(schema)
         self.options(**options)
-        if path is not None and (type(path) != str or len(path.strip()) == 0):
+        if path is not None and (not isinstance(path, str) or len(path.strip()) == 0):
             raise PySparkValueError(
                 errorClass="VALUE_NOT_NON_EMPTY_STR",
                 messageParameters={"arg_name": "path", "arg_value": str(path)},
@@ -535,7 +535,7 @@ class DataStreamWriter:
     clusterBy.__doc__ = PySparkDataStreamWriter.clusterBy.__doc__
 
     def queryName(self, queryName: str) -> "DataStreamWriter":
-        if not queryName or type(queryName) != str or len(queryName.strip()) == 0:
+        if not queryName or not isinstance(queryName, str) or len(queryName.strip()) == 0:
             raise PySparkValueError(
                 errorClass="VALUE_NOT_NON_EMPTY_STR",
                 messageParameters={"arg_name": "queryName", "arg_value": str(queryName)},
@@ -583,7 +583,7 @@ class DataStreamWriter:
             )
 
         if processingTime is not None:
-            if type(processingTime) != str or len(processingTime.strip()) == 0:
+            if not isinstance(processingTime, str) or len(processingTime.strip()) == 0:
                 raise PySparkValueError(
                     errorClass="VALUE_NOT_NON_EMPTY_STR",
                     messageParameters={
@@ -602,7 +602,7 @@ class DataStreamWriter:
             self._write_proto.once = True
 
         elif continuous is not None:
-            if type(continuous) != str or len(continuous.strip()) == 0:
+            if not isinstance(continuous, str) or len(continuous.strip()) == 0:
                 raise PySparkValueError(
                     errorClass="VALUE_NOT_NON_EMPTY_STR",
                     messageParameters={"arg_name": "continuous", "arg_value": str(continuous)},
@@ -610,7 +610,7 @@ class DataStreamWriter:
             self._write_proto.continuous_checkpoint_interval = continuous.strip()
 
         elif realTime is not None:
-            if type(realTime) != str or len(realTime.strip()) == 0:
+            if not isinstance(realTime, str) or len(realTime.strip()) == 0:
                 raise PySparkValueError(
                     errorClass="VALUE_NOT_NON_EMPTY_STR",
                     messageParameters={"arg_name": "realTime", "arg_value": str(realTime)},

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -116,38 +116,38 @@ def to_arrow_type(
     """
     import pyarrow as pa
 
-    if type(dt) == BooleanType:
+    if isinstance(dt, BooleanType):
         arrow_type = pa.bool_()
-    elif type(dt) == ByteType:
+    elif isinstance(dt, ByteType):
         arrow_type = pa.int8()
-    elif type(dt) == ShortType:
+    elif isinstance(dt, ShortType):
         arrow_type = pa.int16()
-    elif type(dt) == IntegerType:
+    elif isinstance(dt, IntegerType):
         arrow_type = pa.int32()
-    elif type(dt) == LongType:
+    elif isinstance(dt, LongType):
         arrow_type = pa.int64()
-    elif type(dt) == FloatType:
+    elif isinstance(dt, FloatType):
         arrow_type = pa.float32()
-    elif type(dt) == DoubleType:
+    elif isinstance(dt, DoubleType):
         arrow_type = pa.float64()
-    elif type(dt) == DecimalType:
+    elif isinstance(dt, DecimalType):
         arrow_type = pa.decimal128(dt.precision, dt.scale)
-    elif type(dt) == StringType:
+    elif isinstance(dt, StringType):
         arrow_type = pa.large_string() if prefers_large_types else pa.string()
-    elif type(dt) == BinaryType:
+    elif isinstance(dt, BinaryType):
         arrow_type = pa.large_binary() if prefers_large_types else pa.binary()
-    elif type(dt) == DateType:
+    elif isinstance(dt, DateType):
         arrow_type = pa.date32()
-    elif type(dt) == TimestampType:
+    elif isinstance(dt, TimestampType):
         assert timezone is not None
         arrow_type = pa.timestamp("us", tz=timezone)
-    elif type(dt) == TimestampNTZType:
+    elif isinstance(dt, TimestampNTZType):
         arrow_type = pa.timestamp("us", tz=None)
-    elif type(dt) == DayTimeIntervalType:
+    elif isinstance(dt, DayTimeIntervalType):
         arrow_type = pa.duration("us")
-    elif type(dt) == TimeType:
+    elif isinstance(dt, TimeType):
         arrow_type = pa.time64("ns")
-    elif type(dt) == ArrayType:
+    elif isinstance(dt, ArrayType):
         field = pa.field(
             "element",
             to_arrow_type(
@@ -159,7 +159,7 @@ def to_arrow_type(
             nullable=dt.containsNull,
         )
         arrow_type = pa.list_(field)
-    elif type(dt) == MapType:
+    elif isinstance(dt, MapType):
         key_field = pa.field(
             "key",
             to_arrow_type(
@@ -181,7 +181,7 @@ def to_arrow_type(
             nullable=dt.valueContainsNull,
         )
         arrow_type = pa.map_(key_field, value_field)
-    elif type(dt) == StructType:
+    elif isinstance(dt, StructType):
         field_names = dt.names
         if error_on_duplicated_field_names_in_struct and len(set(field_names)) != len(field_names):
             raise UnsupportedOperationException(
@@ -203,7 +203,7 @@ def to_arrow_type(
             for field in dt
         ]
         arrow_type = pa.struct(fields)
-    elif type(dt) == NullType:
+    elif isinstance(dt, NullType):
         arrow_type = pa.null()
     elif isinstance(dt, UserDefinedType):
         arrow_type = to_arrow_type(
@@ -212,7 +212,7 @@ def to_arrow_type(
             timezone=timezone,
             prefers_large_types=prefers_large_types,
         )
-    elif type(dt) == VariantType:
+    elif isinstance(dt, VariantType):
         fields = [
             pa.field("value", pa.binary(), nullable=False),
             # The metadata field is tagged so we can identify that the arrow struct actually
@@ -220,7 +220,7 @@ def to_arrow_type(
             pa.field("metadata", pa.binary(), nullable=False, metadata={b"variant": b"true"}),
         ]
         arrow_type = pa.struct(fields)
-    elif type(dt) == GeometryType:
+    elif isinstance(dt, GeometryType):
         fields = [
             pa.field("srid", pa.int32(), nullable=False),
             pa.field(
@@ -231,7 +231,7 @@ def to_arrow_type(
             ),
         ]
         arrow_type = pa.struct(fields)
-    elif type(dt) == GeographyType:
+    elif isinstance(dt, GeographyType):
         fields = [
             pa.field("srid", pa.int32(), nullable=False),
             pa.field(
@@ -545,7 +545,7 @@ def _check_arrow_array_timestamps_localize(
     if types.is_timestamp(a.type) and truncate and a.type.unit == "ns":
         a = pc.floor_temporal(a, unit="microsecond")
 
-    if types.is_timestamp(a.type) and a.type.tz is None and type(dt) == TimestampType:
+    if types.is_timestamp(a.type) and a.type.tz is None and isinstance(dt, TimestampType):
         assert timezone is not None
 
         # Only localize timestamps that will become Spark TimestampType columns.
@@ -867,36 +867,36 @@ def _to_corrected_pandas_type(dt: DataType) -> Optional[Any]:
     import numpy as np
     import pandas as pd
 
-    if type(dt) == ByteType:
+    if isinstance(dt, ByteType):
         return np.int8
-    elif type(dt) == ShortType:
+    elif isinstance(dt, ShortType):
         return np.int16
-    elif type(dt) == IntegerType:
+    elif isinstance(dt, IntegerType):
         return np.int32
-    elif type(dt) == LongType:
+    elif isinstance(dt, LongType):
         return np.int64
-    elif type(dt) == FloatType:
+    elif isinstance(dt, FloatType):
         return np.float32
-    elif type(dt) == DoubleType:
+    elif isinstance(dt, DoubleType):
         return np.float64
-    elif type(dt) == BooleanType:
+    elif isinstance(dt, BooleanType):
         return bool
-    elif type(dt) == TimestampType:
+    elif isinstance(dt, TimestampType):
         if LooseVersion(pd.__version__) < "3.0.0":
             return np.dtype("datetime64[ns]")
         else:
             return np.dtype("datetime64[us]")
-    elif type(dt) == TimestampNTZType:
+    elif isinstance(dt, TimestampNTZType):
         if LooseVersion(pd.__version__) < "3.0.0":
             return np.dtype("datetime64[ns]")
         else:
             return np.dtype("datetime64[us]")
-    elif type(dt) == DayTimeIntervalType:
+    elif isinstance(dt, DayTimeIntervalType):
         if LooseVersion(pd.__version__) < "3.0.0":
             return np.dtype("timedelta64[ns]")
         else:
             return np.dtype("timedelta64[us]")
-    elif type(dt) == StringType:
+    elif isinstance(dt, StringType):
         if LooseVersion(pd.__version__) < "3.0.0":
             return None
         else:

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -311,8 +311,8 @@ class DataFrameReader(OptionUtils):
         if isinstance(path, str):
             return self._df(self._jreader.load(path))
         elif path is not None:
-            if type(path) != list:
-                path = [path]  # type: ignore[list-item]
+            if not isinstance(path, list):
+                path = [path]
             assert self._spark._sc._jvm is not None
             return self._df(self._jreader.load(self._spark._sc._jvm.PythonUtils.toSeq(path)))
         else:
@@ -464,7 +464,7 @@ class DataFrameReader(OptionUtils):
         )
         if isinstance(path, str):
             path = [path]
-        if type(path) == list:
+        if isinstance(path, list):
             assert self._spark._sc._jvm is not None
             return self._df(self._jreader.json(self._spark._sc._jvm.PythonUtils.toSeq(path)))
 
@@ -861,7 +861,7 @@ class DataFrameReader(OptionUtils):
         )
         if isinstance(path, str):
             path = [path]
-        if type(path) == list:
+        if isinstance(path, list):
             assert self._spark._sc._jvm is not None
             return self._df(self._jreader.csv(self._spark._sc._jvm.PythonUtils.toSeq(path)))
 
@@ -989,7 +989,7 @@ class DataFrameReader(OptionUtils):
         )
         if isinstance(path, str):
             path = [path]
-        if type(path) == list:
+        if isinstance(path, list):
             assert self._spark._sc._jvm is not None
             return self._df(self._jreader.xml(self._spark._sc._jvm.PythonUtils.toSeq(path)))
 

--- a/python/pyspark/sql/streaming/readwriter.py
+++ b/python/pyspark/sql/streaming/readwriter.py
@@ -349,7 +349,7 @@ class DataStreamReader(OptionUtils):
             self.schema(schema)
         self.options(**options)
         if path is not None:
-            if type(path) != str or len(path.strip()) == 0:
+            if not isinstance(path, str) or len(path.strip()) == 0:
                 raise PySparkValueError(
                     errorClass="VALUE_NOT_NON_EMPTY_STR",
                     messageParameters={"arg_name": "path", "arg_value": str(path)},
@@ -1064,7 +1064,7 @@ class DataStreamWriter:
         >>> time.sleep(3)
         >>> q.stop()
         """
-        if not outputMode or type(outputMode) != str or len(outputMode.strip()) == 0:
+        if not outputMode or not isinstance(outputMode, str) or len(outputMode.strip()) == 0:
             raise PySparkValueError(
                 errorClass="VALUE_NOT_NON_EMPTY_STR",
                 messageParameters={"arg_name": "outputMode", "arg_value": str(outputMode)},
@@ -1324,7 +1324,7 @@ class DataStreamWriter:
         >>> q.name
         'streaming_query'
         """
-        if not queryName or type(queryName) != str or len(queryName.strip()) == 0:
+        if not queryName or not isinstance(queryName, str) or len(queryName.strip()) == 0:
             raise PySparkValueError(
                 errorClass="VALUE_NOT_NON_EMPTY_STR",
                 messageParameters={"arg_name": "queryName", "arg_value": str(queryName)},
@@ -1426,7 +1426,7 @@ class DataStreamWriter:
         jTrigger = None
         assert self._spark._sc._jvm is not None
         if processingTime is not None:
-            if type(processingTime) != str or len(processingTime.strip()) == 0:
+            if not isinstance(processingTime, str) or len(processingTime.strip()) == 0:
                 raise PySparkValueError(
                     errorClass="VALUE_NOT_NON_EMPTY_STR",
                     messageParameters={
@@ -1451,7 +1451,7 @@ class DataStreamWriter:
             ).Once()
 
         elif continuous is not None:
-            if type(continuous) != str or len(continuous.strip()) == 0:
+            if not isinstance(continuous, str) or len(continuous.strip()) == 0:
                 raise PySparkValueError(
                     errorClass="VALUE_NOT_NON_EMPTY_STR",
                     messageParameters={"arg_name": "continuous", "arg_value": str(continuous)},
@@ -1461,7 +1461,7 @@ class DataStreamWriter:
                 self._spark._sc._jvm, "org.apache.spark.sql.streaming.Trigger"
             ).Continuous(interval)
         elif realTime is not None:
-            if type(realTime) != str or len(realTime.strip()) == 0:
+            if not isinstance(realTime, str) or len(realTime.strip()) == 0:
                 raise PySparkValueError(
                     errorClass="VALUE_NOT_NON_EMPTY_STR",
                     messageParameters={"arg_name": "realTime", "arg_value": str(realTime)},

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -574,22 +574,22 @@ class ApplyInPandasTestsMixin:
         pdf = df.toPandas()
 
         def foo1(key, pdf):
-            assert type(key) == tuple
-            assert type(key[0]) == np.int64
+            assert isinstance(key, tuple)
+            assert isinstance(key[0], np.int64)
 
             return pdf.assign(
                 v1=key[0], v2=pdf.v * key[0], v3=pdf.v * pdf.id, v4=pdf.v * pdf.id.mean()
             )
 
         def foo2(key, pdf):
-            assert type(key) == tuple
-            assert type(key[0]) == np.int64
-            assert type(key[1]) == np.int32
+            assert isinstance(key, tuple)
+            assert isinstance(key[0], np.int64)
+            assert isinstance(key[1], np.int32)
 
             return pdf.assign(v1=key[0], v2=key[1], v3=pdf.v * key[0], v4=pdf.v + key[1])
 
         def foo3(key, pdf):
-            assert type(key) == tuple
+            assert isinstance(key, tuple)
             assert len(key) == 0
             return pdf.assign(v1=pdf.v * pdf.id)
 

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -234,9 +234,9 @@ class ScalarPandasUDFTestsMixin:
 
         @pandas_udf("Array<struct<col1:string, col2:long, col3:double>>")
         def return_cols(cols):
-            assert type(cols) == pd.Series
-            assert type(cols[0]) == np.ndarray
-            assert type(cols[0][0]) == dict
+            assert isinstance(cols, pd.Series)
+            assert isinstance(cols[0], np.ndarray)
+            assert isinstance(cols[0][0], dict)
             return cols
 
         df = self.spark.createDataFrame(
@@ -1542,34 +1542,34 @@ class ScalarPandasUDFTestsMixin:
 
         @udf("int")
         def f1(x):
-            assert type(x) == int
+            assert isinstance(x, int)
             return x + 1
 
         @pandas_udf("int")
         def f2_scalar(x):
-            assert type(x) == pd.Series
+            assert isinstance(x, pd.Series)
             return x + 10
 
         @pandas_udf("int", PandasUDFType.SCALAR_ITER)
         def f2_iter(it):
             for x in it:
-                assert type(x) == pd.Series
+                assert isinstance(x, pd.Series)
                 yield x + 10
 
         @udf("int")
         def f3(x):
-            assert type(x) == int
+            assert isinstance(x, int)
             return x + 100
 
         @pandas_udf("int")
         def f4_scalar(x):
-            assert type(x) == pd.Series
+            assert isinstance(x, pd.Series)
             return x + 1000
 
         @pandas_udf("int", PandasUDFType.SCALAR_ITER)
         def f4_iter(it):
             for x in it:
-                assert type(x) == pd.Series
+                assert isinstance(x, pd.Series)
                 yield x + 1000
 
         expected_chained_1 = df.withColumn("f2_f1", df["v"] + 11).collect()
@@ -1667,7 +1667,7 @@ class ScalarPandasUDFTestsMixin:
 
         @udf("int")
         def f1(x):
-            assert type(x) == int
+            assert isinstance(x, int)
             return x + 1
 
         def f2(x):
@@ -1676,13 +1676,13 @@ class ScalarPandasUDFTestsMixin:
 
         @pandas_udf("int")
         def f3s(x):
-            assert type(x) == pd.Series
+            assert isinstance(x, pd.Series)
             return x + 100
 
         @pandas_udf("int", PandasUDFType.SCALAR_ITER)
         def f3i(it):
             for x in it:
-                assert type(x) == pd.Series
+                assert isinstance(x, pd.Series)
                 yield x + 100
 
         expected = (

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_window.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_window.py
@@ -605,7 +605,7 @@ class WindowPandasUDFTestsMixin:
                 mean_udf = pandas_udf(lambda v: value, t, PandasUDFType.GROUPED_AGG)
                 result = df.select(mean_udf(df["v"]).over(w)).first()[0]
                 assert result == Decimal("1.0")
-                assert type(result) == Decimal
+                assert isinstance(result, Decimal)
 
     def test_arrow_cast_str_to_numeric(self):
         df = self.data

--- a/python/pyspark/sql/variant_utils.py
+++ b/python/pyspark/sql/variant_utils.py
@@ -381,7 +381,7 @@ class VariantUtils:
     @classmethod
     def _to_json(cls, value: bytes, metadata: bytes, pos: int, zone_id: str) -> str:
         variant_type = cls._get_type(value, pos)
-        if variant_type == dict:
+        if variant_type is dict:
 
             def handle_object(key_value_pos_list: List[Tuple[str, int]]) -> str:
                 key_value_list = [
@@ -391,7 +391,7 @@ class VariantUtils:
                 return "{" + ",".join(key_value_list) + "}"
 
             return cls._handle_object(value, metadata, pos, handle_object)
-        elif variant_type == array:
+        elif variant_type is array:
 
             def handle_array(value_pos_list: List[int]) -> str:
                 value_list = [
@@ -405,21 +405,21 @@ class VariantUtils:
             value = cls._get_scalar(variant_type, value, metadata, pos, zone_id)
             if value is None:
                 return "null"
-            if type(value) == bool:
+            if isinstance(value, bool):
                 return "true" if value else "false"
-            if type(value) == str:
+            if isinstance(value, str):
                 return json.dumps(value)
-            if type(value) == bytes:
+            if isinstance(value, bytes):
                 # decoding simply converts byte array to string
                 return '"' + base64.b64encode(value).decode("utf-8") + '"'
-            if type(value) == datetime.date or type(value) == datetime.datetime:
+            if isinstance(value, (datetime.date, datetime.datetime)):
                 return '"' + str(value) + '"'
             return str(value)
 
     @classmethod
     def _to_python(cls, value: bytes, metadata: bytes, pos: int) -> Any:
         variant_type = cls._get_type(value, pos)
-        if variant_type == dict:
+        if variant_type is dict:
 
             def handle_object(key_value_pos_list: List[Tuple[str, int]]) -> Dict[str, Any]:
                 key_value_list = [
@@ -429,7 +429,7 @@ class VariantUtils:
                 return dict(key_value_list)
 
             return cls._handle_object(value, metadata, pos, handle_object)
-        elif variant_type == array:
+        elif variant_type is array:
 
             def handle_array(value_pos_list: List[int]) -> List[Any]:
                 value_list = [
@@ -447,21 +447,21 @@ class VariantUtils:
     ) -> Any:
         if isinstance(None, variant_type):
             return None
-        elif variant_type == bool:
+        elif variant_type is bool:
             return cls._get_boolean(value, pos)
-        elif variant_type == int:
+        elif variant_type is int:
             return cls._get_long(value, pos)
-        elif variant_type == str:
+        elif variant_type is str:
             return cls._get_string(value, pos)
-        elif variant_type == float:
+        elif variant_type is float:
             return cls._get_double(value, pos)
-        elif variant_type == decimal.Decimal:
+        elif variant_type is decimal.Decimal:
             return cls._get_decimal(value, pos)
-        elif variant_type == bytes:
+        elif variant_type is bytes:
             return cls._get_binary(value, pos)
-        elif variant_type == datetime.date:
+        elif variant_type is datetime.date:
             return cls._get_date(value, pos)
-        elif variant_type == datetime.datetime:
+        elif variant_type is datetime.datetime:
             return cls._get_timestamp(value, pos, zone_id)
         else:
             raise PySparkValueError(errorClass="MALFORMED_VARIANT", messageParameters={})

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -367,7 +367,7 @@ def wrap_scalar_pandas_udf(f, args_offsets, kwargs_offsets, return_type, runner_
 
     def verify_result_type(result):
         if not hasattr(result, "__len__"):
-            pd_type = "pandas.DataFrame" if type(return_type) == StructType else "pandas.Series"
+            pd_type = "pandas.DataFrame" if isinstance(return_type, StructType) else "pandas.Series"
             raise PySparkTypeError(
                 errorClass="UDF_RETURN_TYPE",
                 messageParameters={
@@ -399,7 +399,7 @@ def wrap_scalar_pandas_udf(f, args_offsets, kwargs_offsets, return_type, runner_
 
 
 def wrap_pandas_batch_iter_udf(f, return_type, runner_conf):
-    iter_type_label = "pandas.DataFrame" if type(return_type) == StructType else "pandas.Series"
+    iter_type_label = "pandas.DataFrame" if isinstance(return_type, StructType) else "pandas.Series"
 
     def verify_result(result):
         if not isinstance(result, Iterator) and not hasattr(result, "__iter__"):
@@ -415,7 +415,7 @@ def wrap_pandas_batch_iter_udf(f, return_type, runner_conf):
     def verify_element(elem):
         import pandas as pd
 
-        if not isinstance(elem, pd.DataFrame if type(return_type) == StructType else pd.Series):
+        if not isinstance(elem, pd.DataFrame if isinstance(return_type, StructType) else pd.Series):
             raise PySparkTypeError(
                 errorClass="UDF_RETURN_TYPE",
                 messageParameters={
@@ -438,7 +438,7 @@ def wrap_pandas_batch_iter_udf(f, return_type, runner_conf):
 def verify_pandas_result(result, return_type, assign_cols_by_name, truncate_return_schema):
     import pandas as pd
 
-    if type(return_type) == StructType:
+    if isinstance(return_type, StructType):
         if not isinstance(result, pd.DataFrame):
             raise PySparkTypeError(
                 errorClass="UDF_RETURN_TYPE",
@@ -2925,9 +2925,9 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             # Legacy coerces String/Binary for Arrow compatibility
             coerce = (
                 str
-                if type(udf_return_type) == StringType
+                if isinstance(udf_return_type, StringType)
                 else bytes
-                if type(udf_return_type) == BinaryType
+                if isinstance(udf_return_type, BinaryType)
                 else None
             )
             udf_infos.append(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix all E721 (`type-comparison`) violations across the PySpark codebase and remove E721 from the `pyproject.toml` ruff ignore list.

### Why are the changes needed?
E721 was ignored in `pyproject.toml` with a TODO comment ("too many for now"). This PR fixes all 78 violations across 24 files so the rule can be enforced going forward.

Changes:
- `type(x) == SomeType` → `isinstance(x, SomeType)`
- `type(x) != SomeType` → `not isinstance(x, SomeType)`
- `type(x) == type(y)` / `type(x) != type(y)` → `type(x) is type(y)` / `type(x) is not type(y)`
- `type(x) in [A, B]` → `isinstance(x, (A, B))`
- `variant_type == dict` → `variant_type is dict` (type-identity comparisons)

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI

### Was this patch authored or co-authored using generative AI tooling?
Co-authored-by: Claude code (Opus 4.6)