### PR TITLE
 [SPARK-56330][CORE] Add TaskInterruptListener to TaskContext for interrupt notifications

### DIFF
--- a/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala
@@ -213,6 +213,11 @@ class BarrierTaskContext private[spark] (
     this
   }
 
+  override def addTaskInterruptListener(listener: TaskInterruptListener): this.type = {
+    taskContext.addTaskInterruptListener(listener)
+    this
+  }
+
   override def stageId(): Int = taskContext.stageId()
 
   override def stageAttemptNumber(): Int = taskContext.stageAttemptNumber()

--- a/core/src/main/scala/org/apache/spark/TaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContext.scala
@@ -186,7 +186,7 @@ abstract class TaskContext extends Serializable {
 
   /**
    * Adds a listener to be executed when the task is interrupted (Scala closure form).
-   * Behavior matches [[addTaskInterruptListener]] with a [[TaskInterruptListener]].
+   * Behavior matches `addTaskInterruptListener` with TaskInterruptListener.
    */
   def addTaskInterruptListener(f: (TaskContext, String) => Unit): TaskContext = {
     addTaskInterruptListener(new TaskInterruptListener {

--- a/core/src/main/scala/org/apache/spark/TaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContext.scala
@@ -172,13 +172,28 @@ abstract class TaskContext extends Serializable {
   /**
    * Adds a listener to be executed when the task is interrupted.
    *
+   * Adding a listener to an already interrupted task will result in that listener being called
+   * immediately.
+   *
    * There are no ordering guarantees for task interrupt listeners. Listeners are guaranteed to
    * execute sequentially with other task completion, failure, or interrupt listeners. Listeners may
    * be invoked concurrently with the task itself.
    *
-   * Exceptions thrown by the listener will result in failure of the task.
+   * Exceptions thrown by the listener will mark the task as failed; they are not propagated from
+   * `markInterrupted` (for example when interruption is delivered on the executor kill thread).
    */
   def addTaskInterruptListener(listener: TaskInterruptListener): TaskContext
+
+  /**
+   * Adds a listener to be executed when the task is interrupted (Scala closure form).
+   * Behavior matches [[addTaskInterruptListener]] with a [[TaskInterruptListener]].
+   */
+  def addTaskInterruptListener(f: (TaskContext, String) => Unit): TaskContext = {
+    addTaskInterruptListener(new TaskInterruptListener {
+      override def onTaskInterrupted(context: TaskContext, reason: String): Unit =
+        f(context, reason)
+    })
+  }
 
   /** Runs a task with this context, ensuring failure and completion listeners get triggered. */
   private[spark] def runTaskWithListeners[T](task: Task[T]): T = {

--- a/core/src/main/scala/org/apache/spark/TaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContext.scala
@@ -27,7 +27,7 @@ import org.apache.spark.metrics.source.Source
 import org.apache.spark.resource.ResourceInformation
 import org.apache.spark.scheduler.Task
 import org.apache.spark.shuffle.FetchFailedException
-import org.apache.spark.util.{AccumulatorV2, TaskCompletionListener, TaskFailureListener}
+import org.apache.spark.util.{AccumulatorV2, TaskCompletionListener, TaskFailureListener, TaskInterruptListener}
 
 
 object TaskContext {
@@ -168,6 +168,17 @@ abstract class TaskContext extends Serializable {
       override def onTaskFailure(context: TaskContext, error: Throwable): Unit = f(context, error)
     })
   }
+
+  /**
+   * Adds a listener to be executed when the task is interrupted.
+   *
+   * There are no ordering guarantees for task interrupt listeners. Listeners are guaranteed to
+   * execute sequentially with other task completion, failure, or interrupt listeners. Listeners may
+   * be invoked concurrently with the task itself.
+   *
+   * Exceptions thrown by the listener will result in failure of the task.
+   */
+  def addTaskInterruptListener(listener: TaskInterruptListener): TaskContext
 
   /** Runs a task with this context, ensuring failure and completion listeners get triggered. */
   private[spark] def runTaskWithListeners[T](task: Task[T]): T = {

--- a/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
@@ -188,7 +188,14 @@ private[spark] class TaskContextImpl(
   private def invokeTaskInterruptListeners(reason: String, error: Throwable): Unit = {
     // It is safe to access the reference to `onInterruptCallbacks` without holding the TaskContext
     // lock. `invokeListeners()` acquires the lock before accessing the contents.
-    invokeListeners(onInterruptCallbacks, "TaskInterruptListener", Option(error)) {
+    // Do not call `markTaskFailed` per listener here: the first failure would win in
+    // `failureCauseOpt` and mask the aggregate `TaskCompletionListenerException` that
+    // `markInterrupted` records after swallowing the thrown exception (SPARK-56330).
+    invokeListeners(
+      onInterruptCallbacks,
+      "TaskInterruptListener",
+      Option(error),
+      markTaskFailedOnListenerError = false) {
       _.onTaskInterrupted(this, reason)
     }
   }
@@ -196,7 +203,8 @@ private[spark] class TaskContextImpl(
   private def invokeListeners[T](
       listeners: Stack[T],
       name: String,
-      error: Option[Throwable])(
+      error: Option[Throwable],
+      markTaskFailedOnListenerError: Boolean = true)(
       callback: T => Unit): Unit = {
     // This method is subject to two constraints:
     //
@@ -239,7 +247,8 @@ private[spark] class TaskContextImpl(
         callback(listener)
       } catch {
         case e: Throwable =>
-          // A listener failed. Temporarily clear the listenerInvocationThread and markTaskFailed.
+          // A listener failed. For completion/failure listeners, temporarily clear
+          // listenerInvocationThread and markTaskFailed so nested TaskContext calls can run.
           //
           // One of the following cases applies (#3 being the interesting one):
           //
@@ -273,15 +282,20 @@ private[spark] class TaskContextImpl(
           //    failed, and now another completion listener has failed. Then our call to
           //    [[markTaskFailed]] here will have no effect and we simply resume running the
           //    remaining completion handlers.
-          try {
-            listenerInvocationThread = None
-            markTaskFailed(e)
-          } catch {
-            case t: Throwable => e.addSuppressed(t)
-          } finally {
-            synchronized {
-              if (listenerInvocationThread.isEmpty) {
-                listenerInvocationThread = Some(Thread.currentThread())
+          //
+          // Task interrupt listeners skip per-listener [[markTaskFailed]]; see
+          // [[invokeTaskInterruptListeners]].
+          if (markTaskFailedOnListenerError) {
+            try {
+              listenerInvocationThread = None
+              markTaskFailed(e)
+            } catch {
+              case t: Throwable => e.addSuppressed(t)
+            } finally {
+              synchronized {
+                if (listenerInvocationThread.isEmpty) {
+                  listenerInvocationThread = Some(Thread.currentThread())
+                }
               }
             }
           }
@@ -303,9 +317,10 @@ private[spark] class TaskContextImpl(
       invokeTaskInterruptListeners(reason, new TaskKilledException(reason))
     } catch {
       case e: TaskCompletionListenerException =>
-        // SPARK-56330: Listener failures already called `markTaskFailed`; do not propagate
-        // to the executor kill / RPC thread.
+        // SPARK-56330: Do not propagate to the executor kill / RPC thread; record the aggregate
+        // failure for the task (not the first listener exception only).
         logError(log"Exception(s) in TaskInterruptListener(s) after task was interrupted", e)
+        markTaskFailed(e)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
@@ -172,7 +172,11 @@ private[spark] class TaskContextImpl(
   private def invokeTaskCompletionListeners(error: Option[Throwable]): Unit = {
     // It is safe to access the reference to `onCompleteCallbacks` without holding the TaskContext
     // lock. `invokeListeners()` acquires the lock before accessing the contents.
-    invokeListeners(onCompleteCallbacks, "TaskCompletionListener", error) {
+    invokeListeners(
+      onCompleteCallbacks,
+      "TaskCompletionListener",
+      error,
+      markTaskFailedOnListenerError = true) {
       _.onTaskCompletion(this)
     }
   }
@@ -180,7 +184,11 @@ private[spark] class TaskContextImpl(
   private def invokeTaskFailureListeners(error: Throwable): Unit = {
     // It is safe to access the reference to `onFailureCallbacks` without holding the TaskContext
     // lock. `invokeListeners()` acquires the lock before accessing the contents.
-    invokeListeners(onFailureCallbacks, "TaskFailureListener", Option(error)) {
+    invokeListeners(
+      onFailureCallbacks,
+      "TaskFailureListener",
+      Option(error),
+      markTaskFailedOnListenerError = true) {
       _.onTaskFailure(this, error)
     }
   }
@@ -204,7 +212,7 @@ private[spark] class TaskContextImpl(
       listeners: Stack[T],
       name: String,
       error: Option[Throwable],
-      markTaskFailedOnListenerError: Boolean = true)(
+      markTaskFailedOnListenerError: Boolean)(
       callback: T => Unit): Unit = {
     // This method is subject to two constraints:
     //

--- a/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
@@ -73,6 +73,9 @@ private[spark] class TaskContextImpl(
   /** List of callback functions to execute when the task fails. */
   @transient private val onFailureCallbacks = new Stack[TaskFailureListener]
 
+  /** List of callback functions to execute when the task is interrupted. */
+  @transient private val onInterruptCallbacks = new Stack[TaskInterruptListener]
+
   /**
    * The thread currently executing task completion or failure listeners, if any.
    *
@@ -126,6 +129,20 @@ private[spark] class TaskContextImpl(
     this
   }
 
+  override def addTaskInterruptListener(listener: TaskInterruptListener): this.type = {
+    synchronized {
+      // If there is already a thread invoking listeners, adding the new listener to
+      // `onInterruptCallbacks` will cause that thread to execute the new listener, and the call to
+      // `invokeTaskInterruptListeners()` below will be a no-op.
+      //
+      // If there is no such thread, the call to `invokeTaskInterruptListeners()` below will execute
+      // all listeners, including the new listener.
+      onInterruptCallbacks.push(listener)
+      reasonIfKilled
+    }.foreach(reason => invokeTaskInterruptListeners(new TaskKilledException(reason)))
+    this
+  }
+
   override def resourcesJMap(): java.util.Map[String, ResourceInformation] = {
     resources.asJava
   }
@@ -163,6 +180,14 @@ private[spark] class TaskContextImpl(
     // lock. `invokeListeners()` acquires the lock before accessing the contents.
     invokeListeners(onFailureCallbacks, "TaskFailureListener", Option(error)) {
       _.onTaskFailure(this, error)
+    }
+  }
+
+  private def invokeTaskInterruptListeners(error: Throwable): Unit = {
+    // It is safe to access the reference to `onInterruptCallbacks` without holding the TaskContext
+    // lock. `invokeListeners()` acquires the lock before accessing the contents.
+    invokeListeners(onInterruptCallbacks, "TaskInterruptListener", Option(error)) {
+      _.onTaskInterrupted(this)
     }
   }
 
@@ -272,6 +297,7 @@ private[spark] class TaskContextImpl(
 
   private[spark] override def markInterrupted(reason: String): Unit = {
     reasonIfKilled = Some(reason)
+    invokeTaskInterruptListeners(new TaskKilledException(reason))
   }
 
   private[spark] override def killTaskIfInterrupted(): Unit = {

--- a/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
@@ -77,7 +77,7 @@ private[spark] class TaskContextImpl(
   @transient private val onInterruptCallbacks = new Stack[TaskInterruptListener]
 
   /**
-   * The thread currently executing task completion or failure listeners, if any.
+   * The thread currently executing task completion, failure, or interrupt listeners, if any.
    *
    * `invokeListeners()` uses this to ensure listeners are called sequentially.
    */
@@ -139,7 +139,9 @@ private[spark] class TaskContextImpl(
       // all listeners, including the new listener.
       onInterruptCallbacks.push(listener)
       reasonIfKilled
-    }.foreach(reason => invokeTaskInterruptListeners(new TaskKilledException(reason)))
+    }.foreach { reason =>
+      invokeTaskInterruptListeners(reason, new TaskKilledException(reason))
+    }
     this
   }
 
@@ -183,11 +185,11 @@ private[spark] class TaskContextImpl(
     }
   }
 
-  private def invokeTaskInterruptListeners(error: Throwable): Unit = {
+  private def invokeTaskInterruptListeners(reason: String, error: Throwable): Unit = {
     // It is safe to access the reference to `onInterruptCallbacks` without holding the TaskContext
     // lock. `invokeListeners()` acquires the lock before accessing the contents.
     invokeListeners(onInterruptCallbacks, "TaskInterruptListener", Option(error)) {
-      _.onTaskInterrupted(this)
+      _.onTaskInterrupted(this, reason)
     }
   }
 
@@ -297,7 +299,14 @@ private[spark] class TaskContextImpl(
 
   private[spark] override def markInterrupted(reason: String): Unit = {
     reasonIfKilled = Some(reason)
-    invokeTaskInterruptListeners(new TaskKilledException(reason))
+    try {
+      invokeTaskInterruptListeners(reason, new TaskKilledException(reason))
+    } catch {
+      case e: TaskCompletionListenerException =>
+        // SPARK-56330: Listener failures already called `markTaskFailed`; do not propagate
+        // to the executor kill / RPC thread.
+        logError(log"Exception(s) in TaskInterruptListener(s) after task was interrupted", e)
+    }
   }
 
   private[spark] override def killTaskIfInterrupted(): Unit = {

--- a/core/src/main/scala/org/apache/spark/TaskKilledException.scala
+++ b/core/src/main/scala/org/apache/spark/TaskKilledException.scala
@@ -24,6 +24,6 @@ import org.apache.spark.annotation.DeveloperApi
  * Exception thrown when a task is explicitly killed (i.e., task failure is expected).
  */
 @DeveloperApi
-class TaskKilledException(val reason: String) extends RuntimeException {
+class TaskKilledException(val reason: String) extends RuntimeException(reason) {
   def this() = this("unknown reason")
 }

--- a/core/src/main/scala/org/apache/spark/util/taskListeners.scala
+++ b/core/src/main/scala/org/apache/spark/util/taskListeners.scala
@@ -48,9 +48,6 @@ trait TaskFailureListener extends EventListener {
  * :: DeveloperApi ::
  *
  * Listener providing a callback function to invoke when a task's execution is interrupted.
- *
- * @param context the task context
- * @param reason the kill / interrupt reason
  */
 @DeveloperApi
 trait TaskInterruptListener extends EventListener {

--- a/core/src/main/scala/org/apache/spark/util/taskListeners.scala
+++ b/core/src/main/scala/org/apache/spark/util/taskListeners.scala
@@ -48,10 +48,13 @@ trait TaskFailureListener extends EventListener {
  * :: DeveloperApi ::
  *
  * Listener providing a callback function to invoke when a task's execution is interrupted.
+ *
+ * @param context the task context
+ * @param reason the kill / interrupt reason (same string as in [[org.apache.spark.TaskKilledException]])
  */
 @DeveloperApi
 trait TaskInterruptListener extends EventListener {
-  def onTaskInterrupted(context: TaskContext): Unit
+  def onTaskInterrupted(context: TaskContext, reason: String): Unit
 }
 
 

--- a/core/src/main/scala/org/apache/spark/util/taskListeners.scala
+++ b/core/src/main/scala/org/apache/spark/util/taskListeners.scala
@@ -44,6 +44,16 @@ trait TaskFailureListener extends EventListener {
   def onTaskFailure(context: TaskContext, error: Throwable): Unit
 }
 
+/**
+ * :: DeveloperApi ::
+ *
+ * Listener providing a callback function to invoke when a task's execution is interrupted.
+ */
+@DeveloperApi
+trait TaskInterruptListener extends EventListener {
+  def onTaskInterrupted(context: TaskContext): Unit
+}
+
 
 /**
  * Exception thrown when there is an exception in executing the callback in TaskCompletionListener.

--- a/core/src/main/scala/org/apache/spark/util/taskListeners.scala
+++ b/core/src/main/scala/org/apache/spark/util/taskListeners.scala
@@ -50,7 +50,7 @@ trait TaskFailureListener extends EventListener {
  * Listener providing a callback function to invoke when a task's execution is interrupted.
  *
  * @param context the task context
- * @param reason the kill / interrupt reason (same string as in [[org.apache.spark.TaskKilledException]])
+ * @param reason the kill / interrupt reason
  */
 @DeveloperApi
 trait TaskInterruptListener extends EventListener {

--- a/core/src/test/java/test/org/apache/spark/JavaTaskContextCompileCheck.java
+++ b/core/src/test/java/test/org/apache/spark/JavaTaskContextCompileCheck.java
@@ -81,7 +81,7 @@ public class JavaTaskContextCompileCheck {
 
   static class JavaTaskInterruptListenerImpl implements TaskInterruptListener {
     @Override
-    public void onTaskInterrupted(TaskContext context) {
+    public void onTaskInterrupted(TaskContext context, String reason) {
     }
   }
 

--- a/core/src/test/java/test/org/apache/spark/JavaTaskContextCompileCheck.java
+++ b/core/src/test/java/test/org/apache/spark/JavaTaskContextCompileCheck.java
@@ -23,6 +23,7 @@ import org.apache.spark.TaskContext;
 import org.apache.spark.resource.ResourceInformation;
 import org.apache.spark.util.TaskCompletionListener;
 import org.apache.spark.util.TaskFailureListener;
+import org.apache.spark.util.TaskInterruptListener;
 
 /**
  * Something to make sure that TaskContext can be used in Java.
@@ -37,6 +38,7 @@ public class JavaTaskContextCompileCheck {
 
     tc.addTaskCompletionListener(new JavaTaskCompletionListenerImpl());
     tc.addTaskFailureListener(new JavaTaskFailureListenerImpl());
+    tc.addTaskInterruptListener(new JavaTaskInterruptListenerImpl());
 
     tc.attemptNumber();
     tc.partitionId();
@@ -74,6 +76,12 @@ public class JavaTaskContextCompileCheck {
   static class JavaTaskFailureListenerImpl implements TaskFailureListener {
     @Override
     public void onTaskFailure(TaskContext context, Throwable error) {
+    }
+  }
+
+  static class JavaTaskInterruptListenerImpl implements TaskInterruptListener {
+    @Override
+    public void onTaskInterrupted(TaskContext context) {
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskContextSuite.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable.ArrayBuffer
 
-import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfter
 
@@ -154,26 +154,49 @@ class TaskContextSuite extends SparkFunSuite with BeforeAndAfter with LocalSpark
     val context = TaskContext.empty()
     val listener = mock(classOf[TaskInterruptListener])
     context.addTaskInterruptListener(new TaskInterruptListener {
-      override def onTaskInterrupted(context: TaskContext): Unit =
+      override def onTaskInterrupted(context: TaskContext, reason: String): Unit =
         throw new Exception("exception in listener1")
     })
     context.addTaskInterruptListener(listener)
     context.addTaskInterruptListener(new TaskInterruptListener {
-      override def onTaskInterrupted(context: TaskContext): Unit =
+      override def onTaskInterrupted(context: TaskContext, reason: String): Unit =
         throw new Exception("exception in listener3")
     })
 
-    val e = intercept[TaskCompletionListenerException] {
-      context.markInterrupted("test interrupt")
-    }
+    // Interrupt listener failures mark the task failed but are not thrown from `markInterrupted`
+    // (kill / RPC thread must not see TaskCompletionListenerException).
+    context.markInterrupted("test interrupt")
+    assert(context.isFailed())
 
-    // Make sure listener 2 was called.
-    verify(listener, times(1)).onTaskInterrupted(any())
+    verify(listener, times(1)).onTaskInterrupted(any(), mockitoEq("test interrupt"))
 
-    // also need to check failure in TaskInterruptListener does not mask earlier exception
+    val taskFailure = context.getTaskFailure.get
+    assert(taskFailure.isInstanceOf[TaskCompletionListenerException])
+    val e = taskFailure.asInstanceOf[TaskCompletionListenerException]
     assert(e.getMessage.contains("exception in listener1"))
     assert(e.getMessage.contains("exception in listener3"))
     assert(e.getMessage.contains("test interrupt"))
+  }
+
+  test("immediately call an interrupt listener if the context is already interrupted") {
+    var invocations = 0
+    var lastReason: String = null
+    val context = TaskContext.empty()
+    context.markInterrupted("already interrupted")
+    context.addTaskInterruptListener(new TaskInterruptListener {
+      override def onTaskInterrupted(context: TaskContext, reason: String): Unit = {
+        invocations += 1
+        lastReason = reason
+      }
+    })
+    assert(invocations == 1)
+    assert(lastReason == "already interrupted")
+    context.addTaskInterruptListener(new TaskInterruptListener {
+      override def onTaskInterrupted(context: TaskContext, reason: String): Unit = {
+        invocations += 1
+      }
+    })
+    assert(invocations == 2)
   }
 
   test("FailureListener throws after task body fails") {

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskContextSuite.scala
@@ -150,6 +150,32 @@ class TaskContextSuite extends SparkFunSuite with BeforeAndAfter with LocalSpark
     assert(e.getMessage.contains("exception in task"))
   }
 
+  test("all TaskInterruptListeners should be called even if some fail") {
+    val context = TaskContext.empty()
+    val listener = mock(classOf[TaskInterruptListener])
+    context.addTaskInterruptListener(new TaskInterruptListener {
+      override def onTaskInterrupted(context: TaskContext): Unit =
+        throw new Exception("exception in listener1")
+    })
+    context.addTaskInterruptListener(listener)
+    context.addTaskInterruptListener(new TaskInterruptListener {
+      override def onTaskInterrupted(context: TaskContext): Unit =
+        throw new Exception("exception in listener3")
+    })
+
+    val e = intercept[TaskCompletionListenerException] {
+      context.markInterrupted("test interrupt")
+    }
+
+    // Make sure listener 2 was called.
+    verify(listener, times(1)).onTaskInterrupted(any())
+
+    // also need to check failure in TaskInterruptListener does not mask earlier exception
+    assert(e.getMessage.contains("exception in listener1"))
+    assert(e.getMessage.contains("exception in listener3"))
+    assert(e.getMessage.contains("test interrupt"))
+  }
+
   test("FailureListener throws after task body fails") {
     val context = TaskContext.empty()
     val listenerCalls = ArrayBuffer.empty[String]

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -53,7 +53,9 @@ object MimaExcludes {
     // [SPARK-55793][CORE] Add multiple log directories support to SHS
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.status.api.v1.ApplicationAttemptInfo.apply"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.status.api.v1.ApplicationAttemptInfo.copy"),
-    ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.status.api.v1.ApplicationAttemptInfo$")
+    ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.status.api.v1.ApplicationAttemptInfo$"),
+    // [SPARK-56330][CORE] Add TaskInterruptListener to TaskContext for interrupt notifications
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.TaskContext.addTaskInterruptListener")
   )
 
   // Exclude rules for 4.1.x from 4.0.0


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added `TaskInterruptListener`, a new listener type that fires immediately when a task is interrupted via `markInterrupted`. The new listener follows the same invocation model as `TaskCompletionListener` and `TaskFailureListener` - all listeners run sequentially, exceptions in individual listeners don't suppress other listeners, and listener exceptions cause task failure.                                

Also fixes `TaskKilledException` to pass the cancellation reason to the `RuntimeException` constructor, so `getMessage()` no longer returns `null`.

### Why are the changes needed?                                                                                                                               
The polling-based cancellation API (`killTaskIfInterrupted`) cannot support push-style reactions to task interruption. Components that block on I/O or hold locks have no way to react immediately when cancellation is signalled without implementing their own polling thread. `TaskInterruptListener` closes this gap by providing a callback that fires synchronously when `markInterrupted` is called.

### Does this PR introduce _any_ user-facing change?
Yes. Adds a new `@DeveloperApi` listener interface `TaskInterruptListener` and a corresponding `addTaskInterruptListener` method on `TaskContext`. Also fixes `TaskKilledException#getMessage()` to return the actual reason string rather than `null`.

### How was this patch tested?                                                                        
Added a `TaskContextSuite` test that verifies all registered `TaskInterruptListener`s are invoked even when some throw exceptions, and that the interrupt reason is propagated into the resulting `TaskCompletionListenerException` message. Added Java interop coverage in `JavaTaskContextCompileCheck`.

### Was this patch authored or co-authored using generative AI tooling?                                                                                       
No.