### PR TITLE
[SPARK-56328][SQL] Fix inline table collation handling for INSERT VALUES and DEFAULT COLLATION

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveInlineTables.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveInlineTables.scala
@@ -18,8 +18,9 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.catalyst.expressions.EvalHelper
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoStatement, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.CurrentOrigin
 import org.apache.spark.sql.catalyst.trees.TreePattern.INLINE_TABLE_EVAL
 import org.apache.spark.sql.catalyst.util.EvaluateUnresolvedInlineTable
 
@@ -29,6 +30,16 @@ import org.apache.spark.sql.catalyst.util.EvaluateUnresolvedInlineTable
 object ResolveInlineTables extends Rule[LogicalPlan] with EvalHelper {
   override def apply(plan: LogicalPlan): LogicalPlan = {
     plan.resolveOperatorsWithPruning(_.containsPattern(INLINE_TABLE_EVAL), ruleId) {
+      // For INSERT, ignore collation differences in inline table columns since the INSERT
+      // coercion will cast to the target column's collation.
+      case i @ InsertIntoStatement(_, _, _, table: UnresolvedInlineTable, _, _, _, _, _)
+          if table.expressionsResolved =>
+        // Preserve the inline table's origin so error messages point to the VALUES clause,
+        // not the INSERT statement.
+        CurrentOrigin.withOrigin(table.origin) {
+          i.copy(query = EvaluateUnresolvedInlineTable
+            .evaluateUnresolvedInlineTable(table, ignoreCollation = true))
+        }
       case table: UnresolvedInlineTable if table.expressionsResolved =>
         EvaluateUnresolvedInlineTable.evaluateUnresolvedInlineTable(table)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveInlineTables.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveInlineTables.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.catalyst.expressions.EvalHelper
-import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoStatement, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoStatement, LogicalPlan, OverwriteByExpression}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.CurrentOrigin
 import org.apache.spark.sql.catalyst.trees.TreePattern.INLINE_TABLE_EVAL
@@ -32,12 +32,18 @@ object ResolveInlineTables extends Rule[LogicalPlan] with EvalHelper {
     plan.resolveOperatorsWithPruning(_.containsPattern(INLINE_TABLE_EVAL), ruleId) {
       // For INSERT, ignore collation differences in inline table columns since the INSERT
       // coercion will cast to the target column's collation.
+      // Preserve the inline table's origin so error messages point to the VALUES clause,
+      // not the INSERT statement.
       case i @ InsertIntoStatement(_, _, _, table: UnresolvedInlineTable, _, _, _, _, _)
           if table.expressionsResolved =>
-        // Preserve the inline table's origin so error messages point to the VALUES clause,
-        // not the INSERT statement.
         CurrentOrigin.withOrigin(table.origin) {
           i.copy(query = EvaluateUnresolvedInlineTable
+            .evaluateUnresolvedInlineTable(table, ignoreCollation = true))
+        }
+      case w @ OverwriteByExpression(_, _, table: UnresolvedInlineTable, _, _, _, _, _)
+          if table.expressionsResolved =>
+        CurrentOrigin.withOrigin(table.origin) {
+          w.copy(query = EvaluateUnresolvedInlineTable
             .evaluateUnresolvedInlineTable(table, ignoreCollation = true))
         }
       case table: UnresolvedInlineTable if table.expressionsResolved =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2867,12 +2867,66 @@ class AstBuilder extends DataTypeAstBuilder
     }
 
     val unresolvedTable = UnresolvedInlineTable(aliases, rows.toSeq)
-    val table = if (conf.getConf(SQLConf.EAGER_EVAL_OF_UNRESOLVED_INLINE_TABLE_ENABLED)) {
-      EvaluateUnresolvedInlineTable.evaluate(unresolvedTable)
+    val table = if (canEagerlyEvaluateInlineTable(ctx, unresolvedTable)) {
+      EvaluateUnresolvedInlineTable.evaluate(
+        unresolvedTable, ignoreCollation = isInlineTableInsideInsertValuesClause(ctx))
     } else {
       unresolvedTable
     }
     table.optionalMap(ctx.tableAlias.strictIdentifier)(aliasPlan)
+  }
+
+  /**
+   * Returns whether we can eagerly evaluate the given inline table at parse time.
+   *
+   * Eager evaluation is not allowed if the config is disabled, or if the inline table is part of
+   * a `CREATE TABLE/VIEW` statement and contains non-collated string literals or default string
+   * producing built-in functions (e.g., `current_database()`). In those cases, the default
+   * collation of the object must be applied to the string literals. Since default collation is
+   * applied during analysis, the inline table cannot be eagerly evaluated.
+   */
+  private def canEagerlyEvaluateInlineTable(
+      ctx: InlineTableContext, table: UnresolvedInlineTable): Boolean = {
+    def isDefaultCollationApplicable: Boolean = {
+      isInsideCreateObjectWithDefaultCollationSupport(ctx) &&
+        ApplyDefaultCollation.needsResolution(table.expressions)
+    }
+
+    conf.getConf(SQLConf.EAGER_EVAL_OF_UNRESOLVED_INLINE_TABLE_ENABLED) &&
+      !isDefaultCollationApplicable
+  }
+
+  // Checks if the VALUES clause is directly part of an INSERT statement (e.g.,
+  // `INSERT INTO t VALUES (...)`) by walking up the parser context tree. Returns false if a
+  // FROM clause is found first, meaning the VALUES is inside a subquery.
+  private def isInlineTableInsideInsertValuesClause(ctx: InlineTableContext): Boolean = {
+    var currentContext: ParserRuleContext = ctx
+    while (currentContext != null) {
+      currentContext match {
+        case _: InsertIntoTableContext | _: InsertOverwriteTableContext |
+             _: InsertIntoReplaceUsingContext =>
+          return true
+        case _: FromClauseContext =>
+          return false
+        case _ =>
+          currentContext = currentContext.getParent
+      }
+    }
+    false
+  }
+
+  private def isInsideCreateObjectWithDefaultCollationSupport(
+      ctx: ParserRuleContext): Boolean = {
+    var currentContext = ctx
+    while (currentContext != null) {
+      currentContext match {
+        case _: CreateTableContext | _: ReplaceTableContext | _: CreateViewContext =>
+          return true
+        case _ =>
+          currentContext = currentContext.getParent
+      }
+    }
+    false
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2880,10 +2880,10 @@ class AstBuilder extends DataTypeAstBuilder
    * Returns whether we can eagerly evaluate the given inline table at parse time.
    *
    * Eager evaluation is not allowed if the config is disabled, or if the inline table is part of
-   * a `CREATE TABLE/VIEW` statement and contains non-collated string literals or default string
-   * producing built-in functions (e.g., `current_database()`). In those cases, the default
-   * collation of the object must be applied to the string literals. Since default collation is
-   * applied during analysis, the inline table cannot be eagerly evaluated.
+   * a `CREATE TABLE/VIEW` statement and contains expressions that need default collation
+   * resolution (e.g., string literals or casts to string types). In those cases, the default
+   * collation of the object must be applied during analysis, so the inline table cannot be
+   * eagerly evaluated.
    */
   private def canEagerlyEvaluateInlineTable(
       ctx: InlineTableContext, table: UnresolvedInlineTable): Boolean = {
@@ -2898,14 +2898,20 @@ class AstBuilder extends DataTypeAstBuilder
 
   // Checks if the VALUES clause is directly part of an INSERT statement (e.g.,
   // `INSERT INTO t VALUES (...)`) by walking up the parser context tree. Returns false if a
-  // FROM clause is found first, meaning the VALUES is inside a subquery.
+  // FROM clause is found first, meaning the VALUES is inside a subquery
+  // (e.g., `INSERT INTO t SELECT * FROM VALUES (...) AS T`).
   private def isInlineTableInsideInsertValuesClause(ctx: InlineTableContext): Boolean = {
     var currentContext: ParserRuleContext = ctx
     while (currentContext != null) {
       currentContext match {
-        case _: InsertIntoTableContext | _: InsertOverwriteTableContext |
-             _: InsertIntoReplaceUsingContext =>
-          return true
+        case c: SingleInsertQueryContext =>
+          c.insertInto() match {
+            case _: InsertIntoTableContext | _: InsertOverwriteTableContext |
+                 _: InsertIntoReplaceUsingContext | _: InsertIntoReplaceBooleanCondContext =>
+              return true
+            case _ =>
+              return false
+          }
         case _: FromClauseContext =>
           return false
         case _ =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/EvaluateUnresolvedInlineTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/EvaluateUnresolvedInlineTable.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.trees.TreePattern.CURRENT_LIKE
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.TypeUtils.{toSQLExpr, toSQLId}
-import org.apache.spark.sql.types.{StructField, StructType}
+import org.apache.spark.sql.types.{StringHelper, StringType, StructField, StructType}
 
 /**
  * Utility object used to replace [[UnresolvedInlineTable]] with [[ResolvedInlineTable]] or
@@ -36,13 +36,17 @@ import org.apache.spark.sql.types.{StructField, StructType}
 object EvaluateUnresolvedInlineTable extends SQLConfHelper
   with AliasHelper with EvalHelper with CastSupport {
 
-  def evaluate(plan: UnresolvedInlineTable): LogicalPlan =
-    if (plan.expressionsResolved) evaluateUnresolvedInlineTable(plan) else plan
+  def evaluate(
+      plan: UnresolvedInlineTable,
+      ignoreCollation: Boolean = false): LogicalPlan =
+    if (plan.expressionsResolved) evaluateUnresolvedInlineTable(plan, ignoreCollation) else plan
 
-  def evaluateUnresolvedInlineTable(table: UnresolvedInlineTable): LogicalPlan = {
+  def evaluateUnresolvedInlineTable(
+      table: UnresolvedInlineTable,
+      ignoreCollation: Boolean = false): LogicalPlan = {
     validateInputDimension(table)
     validateInputEvaluable(table)
-    val resolvedTable = findCommonTypesAndCast(table)
+    val resolvedTable = findCommonTypesAndCast(table, ignoreCollation)
     earlyEvalIfPossible(resolvedTable)
   }
 
@@ -106,11 +110,23 @@ object EvaluateUnresolvedInlineTable extends SQLConfHelper
    *
    * This is package visible for unit testing.
    */
-  def findCommonTypesAndCast(table: UnresolvedInlineTable): ResolvedInlineTable = {
+  def findCommonTypesAndCast(
+      table: UnresolvedInlineTable,
+      ignoreCollation: Boolean = false): ResolvedInlineTable = {
     // For each column, traverse all the values and find a common data type and nullability.
     val (fields, columns) = table.rows.transpose.zip(table.names).map { case (column, name) =>
       val inputTypes = column.map(_.dataType)
-      val tpe = TypeCoercion.findWiderTypeWithoutStringPromotion(inputTypes).getOrElse {
+      // In INSERT INTO ... VALUES, collations are ignored because the target table's column
+      // collation takes precedence - the INSERT coercion will cast each value to the target
+      // column's type, including collation.
+      val strippedInputTypes = if (ignoreCollation) {
+        inputTypes.map(_.transformRecursively {
+          case st: StringType => StringHelper.removeCollation(st)
+        })
+      } else {
+        inputTypes
+      }
+      val tpe = TypeCoercion.findWiderTypeWithoutStringPromotion(strippedInputTypes).getOrElse {
         table.failAnalysis(
           errorClass = "INVALID_INLINE_TABLE.INCOMPATIBLE_TYPES_IN_INLINE_TABLE",
           messageParameters = Map("colName" -> toSQLId(name)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
@@ -2479,4 +2479,182 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
       )
     }
   }
+
+  test("INSERT VALUES with NULLs into collated columns") {
+    Seq(true, false).foreach { eagerEval =>
+      withSQLConf(
+        SQLConf.EAGER_EVAL_OF_UNRESOLVED_INLINE_TABLE_ENABLED.key -> eagerEval.toString) {
+        withTable("t") {
+          sql("CREATE TABLE t (c1 STRING COLLATE UTF8_LCASE, c2 STRING COLLATE UTF8_LCASE)")
+          sql("INSERT INTO t VALUES ('a', NULL), (NULL, NULL)")
+          checkAnswer(
+            sql("SELECT * FROM t"),
+            Seq(Row("a", null), Row(null, null))
+          )
+        }
+      }
+    }
+  }
+
+  test("INSERT VALUES with DEFAULT into collated columns") {
+    Seq(true, false).foreach { eagerEval =>
+      withSQLConf(
+        SQLConf.EAGER_EVAL_OF_UNRESOLVED_INLINE_TABLE_ENABLED.key -> eagerEval.toString) {
+        withTable("t") {
+          sql("CREATE TABLE t (c1 STRING COLLATE UTF8_LCASE, c2 STRING COLLATE UTF8_LCASE)")
+          sql("INSERT INTO t VALUES ('a', DEFAULT), (DEFAULT, DEFAULT)")
+          checkAnswer(
+            sql("SELECT * FROM t"),
+            Seq(Row("a", null), Row(null, null))
+          )
+        }
+      }
+    }
+  }
+
+  test("INSERT VALUES with explicit conflicting collations") {
+    Seq(true, false).foreach { eagerEval =>
+      withSQLConf(
+        SQLConf.EAGER_EVAL_OF_UNRESOLVED_INLINE_TABLE_ENABLED.key -> eagerEval.toString) {
+        withTable("t") {
+          sql("CREATE TABLE t (c1 STRING COLLATE UTF8_LCASE)")
+          sql("INSERT INTO t VALUES ('a' COLLATE UTF8_LCASE), ('b' COLLATE UNICODE)")
+          checkAnswer(
+            sql("SELECT * FROM t"),
+            Seq(Row("a"), Row("b"))
+          )
+        }
+      }
+    }
+  }
+
+  test("INSERT VALUES with mixed collations and NULLs") {
+    Seq(true, false).foreach { eagerEval =>
+      withSQLConf(
+        SQLConf.EAGER_EVAL_OF_UNRESOLVED_INLINE_TABLE_ENABLED.key -> eagerEval.toString) {
+        withTable("t") {
+          sql(
+            """CREATE TABLE t (
+              |  c1 STRING COLLATE UTF8_LCASE,
+              |  c2 STRING COLLATE UNICODE
+              |)""".stripMargin)
+          sql("INSERT INTO t VALUES ('hello', 'world'), (NULL, NULL)")
+          checkAnswer(
+            sql("SELECT * FROM t"),
+            Seq(Row("hello", "world"), Row(null, null))
+          )
+        }
+      }
+    }
+  }
+
+  test("INSERT OVERWRITE VALUES with collated columns") {
+    Seq(true, false).foreach { eagerEval =>
+      withSQLConf(
+        SQLConf.EAGER_EVAL_OF_UNRESOLVED_INLINE_TABLE_ENABLED.key -> eagerEval.toString) {
+        withTable("t") {
+          sql("CREATE TABLE t (c1 STRING COLLATE UTF8_LCASE)")
+          sql("INSERT INTO t VALUES ('x')")
+          sql("INSERT OVERWRITE t VALUES ('a' COLLATE UTF8_LCASE), ('b' COLLATE UNICODE)")
+          checkAnswer(
+            sql("SELECT * FROM t"),
+            Seq(Row("a"), Row("b"))
+          )
+        }
+      }
+    }
+  }
+
+  test("INSERT VALUES with nested collated types") {
+    Seq(true, false).foreach { eagerEval =>
+      withSQLConf(
+        SQLConf.EAGER_EVAL_OF_UNRESOLVED_INLINE_TABLE_ENABLED.key -> eagerEval.toString) {
+        withTable("t") {
+          sql("CREATE TABLE t (c1 ARRAY<STRING COLLATE UTF8_LCASE>)")
+          sql("INSERT INTO t VALUES (array('a', 'b')), (array('c'))")
+          checkAnswer(
+            sql("SELECT * FROM t"),
+            Seq(Row(Seq("a", "b")), Row(Seq("c")))
+          )
+        }
+      }
+    }
+  }
+
+  test("collation stripping for type resolution must not affect expression evaluation") {
+    Seq(true, false).foreach { eagerEval =>
+      withSQLConf(
+        SQLConf.EAGER_EVAL_OF_UNRESOLVED_INLINE_TABLE_ENABLED.key -> eagerEval.toString) {
+        withTable("t") {
+          sql("CREATE TABLE t (c1 BOOLEAN)")
+          sql("INSERT INTO t VALUES ('a' COLLATE UTF8_LCASE = 'A')")
+          checkAnswer(sql("SELECT * FROM t"), Row(true))
+        }
+      }
+    }
+  }
+
+  test("INSERT SELECT FROM VALUES with conflicting collations should fail") {
+    Seq(true, false).foreach { eagerEval =>
+      withSQLConf(
+        SQLConf.EAGER_EVAL_OF_UNRESOLVED_INLINE_TABLE_ENABLED.key -> eagerEval.toString) {
+        withTable("t") {
+          sql("CREATE TABLE t (c1 STRING COLLATE UTF8_LCASE)")
+          checkError(
+            exception = intercept[AnalysisException] {
+              sql(
+                """INSERT INTO t
+                  |SELECT * FROM VALUES
+                  |  ('a' COLLATE UTF8_LCASE), ('b' COLLATE UNICODE) AS T(c1)""".stripMargin)
+            },
+            condition = "INVALID_INLINE_TABLE.INCOMPATIBLE_TYPES_IN_INLINE_TABLE",
+            parameters = Map("colName" -> "`c1`"),
+            queryContext = Array(ExpectedContext(
+              "VALUES\n  ('a' COLLATE UTF8_LCASE), ('b' COLLATE UNICODE) AS T(c1)"))
+          )
+        }
+      }
+    }
+  }
+
+  test("standalone SELECT VALUES with conflicting collations should fail") {
+    Seq(true, false).foreach { eagerEval =>
+      withSQLConf(
+        SQLConf.EAGER_EVAL_OF_UNRESOLVED_INLINE_TABLE_ENABLED.key -> eagerEval.toString) {
+        checkError(
+          exception = intercept[AnalysisException] {
+            sql(
+              "SELECT * FROM VALUES ('a' COLLATE UTF8_LCASE), ('b' COLLATE UNICODE) AS T(c1)")
+          },
+          condition = "INVALID_INLINE_TABLE.INCOMPATIBLE_TYPES_IN_INLINE_TABLE",
+          parameters = Map("colName" -> "`c1`"),
+          queryContext = Array(ExpectedContext(
+            "VALUES ('a' COLLATE UTF8_LCASE), ('b' COLLATE UNICODE) AS T(c1)"))
+        )
+      }
+    }
+  }
+
+  test("CTAS with conflicting collations in VALUES should fail") {
+    Seq(true, false).foreach { eagerEval =>
+      withSQLConf(
+        SQLConf.EAGER_EVAL_OF_UNRESOLVED_INLINE_TABLE_ENABLED.key -> eagerEval.toString) {
+        withTable("t") {
+          checkError(
+            exception = intercept[AnalysisException] {
+              sql(
+                """CREATE TABLE t AS
+                  |SELECT * FROM VALUES
+                  |  ('a' COLLATE UTF8_LCASE), ('b' COLLATE UNICODE) AS T(c1)""".stripMargin)
+            },
+            condition = "INVALID_INLINE_TABLE.INCOMPATIBLE_TYPES_IN_INLINE_TABLE",
+            parameters = Map("colName" -> "`c1`"),
+            queryContext = Array(ExpectedContext(
+              "VALUES\n  ('a' COLLATE UTF8_LCASE), ('b' COLLATE UNICODE) AS T(c1)"))
+          )
+        }
+      }
+    }
+  }
+
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
@@ -2528,6 +2528,25 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  test("INSERT VALUES with CAST to conflicting collated string types") {
+    Seq(true, false).foreach { eagerEval =>
+      withSQLConf(
+        SQLConf.EAGER_EVAL_OF_UNRESOLVED_INLINE_TABLE_ENABLED.key -> eagerEval.toString) {
+        withTable("t") {
+          sql("CREATE TABLE t (c1 STRING COLLATE UTF8_LCASE)")
+          sql(
+            """INSERT INTO t VALUES
+              |  (CAST('a' AS STRING COLLATE UTF8_LCASE)),
+              |  (CAST('b' AS STRING COLLATE UNICODE))""".stripMargin)
+          checkAnswer(
+            sql("SELECT * FROM t"),
+            Seq(Row("a"), Row("b"))
+          )
+        }
+      }
+    }
+  }
+
   test("INSERT VALUES with mixed collations and NULLs") {
     Seq(true, false).foreach { eagerEval =>
       withSQLConf(
@@ -2558,6 +2577,25 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
           sql("INSERT OVERWRITE t VALUES ('a' COLLATE UTF8_LCASE), ('b' COLLATE UNICODE)")
           checkAnswer(
             sql("SELECT * FROM t"),
+            Seq(Row("a"), Row("b"))
+          )
+        }
+      }
+    }
+  }
+
+  test("INSERT REPLACE WHERE VALUES with collated columns") {
+    Seq(true, false).foreach { eagerEval =>
+      withSQLConf(
+        SQLConf.EAGER_EVAL_OF_UNRESOLVED_INLINE_TABLE_ENABLED.key -> eagerEval.toString) {
+        withTable("testcat.t") {
+          sql("CREATE TABLE testcat.t (c1 STRING COLLATE UTF8_LCASE)")
+          sql("INSERT INTO testcat.t VALUES ('x')")
+          sql(
+            """INSERT INTO testcat.t REPLACE WHERE c1 = 'x'
+              |  VALUES ('a' COLLATE UTF8_LCASE), ('b' COLLATE UNICODE)""".stripMargin)
+          checkAnswer(
+            sql("SELECT * FROM testcat.t"),
             Seq(Row("a"), Row("b"))
           )
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
@@ -2592,7 +2592,7 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
           sql("CREATE TABLE testcat.t (c1 STRING COLLATE UTF8_LCASE)")
           sql("INSERT INTO testcat.t VALUES ('x')")
           sql(
-            """INSERT INTO testcat.t REPLACE WHERE c1 = 'x'
+            """INSERT INTO testcat.t REPLACE WHERE TRUE
               |  VALUES ('a' COLLATE UTF8_LCASE), ('b' COLLATE UNICODE)""".stripMargin)
           checkAnswer(
             sql("SELECT * FROM testcat.t"),
@@ -2690,6 +2690,23 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
             queryContext = Array(ExpectedContext(
               "VALUES\n  ('a' COLLATE UTF8_LCASE), ('b' COLLATE UNICODE) AS T(c1)"))
           )
+        }
+      }
+    }
+  }
+
+  test("CTAS with DEFAULT COLLATION and plain string literals in inline table") {
+    Seq(true, false).foreach { eagerEval =>
+      withSQLConf(
+        SQLConf.EAGER_EVAL_OF_UNRESOLVED_INLINE_TABLE_ENABLED.key -> eagerEval.toString) {
+        withTable("t") {
+          sql(
+            """CREATE TABLE t DEFAULT COLLATION UTF8_LCASE AS
+              |SELECT * FROM VALUES ('a'), ('b') AS T(c1) WHERE c1 = 'A'
+              |""".stripMargin)
+          checkAnswer(sql("SELECT COUNT(*) FROM t"), Seq(Row(1)))
+          checkAnswer(sql("SELECT DISTINCT COLLATION(c1) FROM t"),
+            Row(s"${fullyQualifiedPrefix}UTF8_LCASE"))
         }
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes two related issues with how collations interact with inline tables (VALUES clauses):

**1. Eager evaluation bypasses DEFAULT COLLATION for CREATE TABLE/VIEW**

Inline tables are eagerly evaluated during parsing for performance. But when inside `CREATE TABLE ... DEFAULT COLLATION UTF8_LCASE AS SELECT * FROM VALUES ('a') AS T(c1)`, the default collation must be applied to string literals during analysis. Since eager evaluation happens before analysis, the collation was lost.

The fix adds `canEagerlyEvaluateInlineTable` which prevents eager evaluation when the inline table is inside a CREATE TABLE/VIEW statement and contains expressions that need default collation resolution (e.g., string literals or casts to string types).

**2. INSERT INTO VALUES fails with INCOMPATIBLE_TYPES_IN_INLINE_TABLE for collated columns**

When using `INSERT INTO ... VALUES` with collated columns, the inline table resolution could fail because values in the same column end up with different collations. This happens when:
- `ResolveColumnDefaultInCommandInputQuery` resolves `DEFAULT` to a typed null with the target column's collation, which differs from other literals' collation
- Explicit `COLLATE` or `CAST` to collated string types on values produces mismatched collations across rows

The fix adds an `ignoreCollation` parameter to `EvaluateUnresolvedInlineTable` that strips collations from input types before finding the common type. This is safe for INSERT because the INSERT coercion will cast each value to the target column's type, including collation.

The collation stripping is applied only when the inline table is the direct VALUES clause of an INSERT statement:
- **Parser path**: `isInlineTableInsideInsertValuesClause` walks up the parser context tree to `SingleInsertQueryContext` and inspects its `insertInto()` child to detect `INSERT INTO t VALUES (...)`. This is necessary because in the ANTLR grammar (`singleInsertQuery: insertInto query`), the `insertInto` context and the `query` context (containing `InlineTableContext`) are siblings, not ancestor-descendant. Returns false if a `FromClauseContext` is encountered first, meaning the VALUES is inside a subquery (e.g., `INSERT INTO t SELECT * FROM VALUES (...) AS T`).
- **Analyzer path**: `ResolveInlineTables` pattern-matches `InsertIntoStatement` and `OverwriteByExpression` (from `INSERT REPLACE WHERE`) with a direct `UnresolvedInlineTable` query child.

Standalone `SELECT * FROM VALUES (...)` and CTAS with conflicting explicit collations continue to fail as expected.

### Why are the changes needed?

Without this fix:

```sql
-- Fails: DEFAULT COLLATION not applied to inline table literals
CREATE TABLE t DEFAULT COLLATION UTF8_LCASE AS
  SELECT * FROM VALUES ('a'), ('b') AS T(c1) WHERE c1 = 'A';
-- Column c1 gets UTF8_BINARY instead of UTF8_LCASE

-- Fails: INCOMPATIBLE_TYPES_IN_INLINE_TABLE
CREATE TABLE t (c1 STRING COLLATE UTF8_LCASE, c2 STRING COLLATE UTF8_LCASE);
INSERT INTO t VALUES ('a', DEFAULT), (DEFAULT, DEFAULT);

-- Fails at parse time with eager eval: CAST bakes collation into StringType
CREATE TABLE t (c1 STRING COLLATE UTF8_LCASE);
INSERT INTO t VALUES (CAST('a' AS STRING COLLATE UTF8_LCASE)), (CAST('b' AS STRING COLLATE UNICODE));
```

### Does this PR introduce _any_ user-facing change?

Yes.
- `CREATE TABLE/VIEW ... DEFAULT COLLATION ... AS SELECT * FROM VALUES (...)` now correctly applies the default collation to inline table literals.
- `INSERT INTO ... VALUES` with collated columns now succeeds in cases that previously failed with `INCOMPATIBLE_TYPES_IN_INLINE_TABLE`.

### How was this patch tested?

New tests in `CollationSuite` covering both eager and non-eager evaluation paths (`EAGER_EVAL_OF_UNRESOLVED_INLINE_TABLE_ENABLED = true/false`):
- INSERT VALUES with NULLs, DEFAULT, explicit conflicting collations, mixed collations, nested types (ARRAY)
- INSERT OVERWRITE with collated values
- INSERT REPLACE WHERE with collated values (V2 table)
- INSERT VALUES with CAST to conflicting collated string types (exercises parser-level `ignoreCollation` since CAST bakes collation into StringType at parse time)
- Collation stripping does not affect expression evaluation
- Negative tests: standalone SELECT VALUES, INSERT SELECT FROM VALUES, and CTAS with conflicting collations still fail

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code