### PR TITLE
[SPARK-56333][SQL] Use multiset intersection for NATURAL JOIN column matching

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3626,9 +3626,8 @@ class Analyzer(
       case j @ Join(left, right, NaturalJoin(joinType), condition, hint)
           if j.resolvedExceptNatural =>
         // find common column names from both sides
-        val joinNames = left.output.map(_.name).distinct.filter { leftName =>
-          right.output.map(_.name).exists(resolver(leftName, _))
-        }
+        val joinNames = NaturalAndUsingJoinResolution.canonicalizedIntersect(
+            left.output.map(_.name), right.output.map(_.name))
         val project = commonNaturalJoinProcessing(
           left, right, joinType, joinNames, condition, hint)
         j.getTagValue(LogicalPlan.PLAN_ID_TAG)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/NaturalAndUsingJoinResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/NaturalAndUsingJoinResolution.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
+import scala.collection.mutable
+
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.expressions.{
   Alias,
@@ -80,6 +82,30 @@ object NaturalAndUsingJoinResolution extends DataTypeErrorsBase with SQLConfHelp
       joinType
     )
     (output, hiddenOutput, newCondition)
+  }
+
+  /**
+   * Computes a multiset intersection of two name sequences, respecting case sensitivity.
+   * Preserves multiplicity: each name appears min(left count, right count) times.
+   */
+  def canonicalizedIntersect(
+      leftNames: Seq[String],
+      rightNames: Seq[String]): Seq[String] = {
+    val rightNameCounts = mutable.HashMap[String, Int]()
+    for (name <- rightNames) {
+      val key = conf.canonicalize(name)
+      rightNameCounts(key) = rightNameCounts.getOrElse(key, 0) + 1
+    }
+    leftNames.filter { leftName =>
+      val key = conf.canonicalize(leftName)
+      val count = rightNameCounts.getOrElse(key, 0)
+      if (count > 0) {
+        rightNameCounts(key) = count - 1
+        true
+      } else {
+        false
+      }
+    }
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/JoinResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/JoinResolver.scala
@@ -370,7 +370,10 @@ class JoinResolver(resolver: Resolver, expressionResolver: ExpressionResolver)
   private def getJoinNamesForNaturalJoin(
       leftNameScope: NameScope,
       rightNameScope: NameScope): Seq[String] = {
-    leftNameScope.output.map(_.name).intersect(rightNameScope.output.map(_.name))
+    NaturalAndUsingJoinResolution.canonicalizedIntersect(
+      leftNameScope.output.map(_.name),
+      rightNameScope.output.map(_.name)
+    )
   }
 
   /**

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/natural-join.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/natural-join.sql.out
@@ -692,3 +692,31 @@ Project [ID#x]
       +- SubqueryAlias t2
          +- Project [1 AS id#x]
             +- OneRowRelation
+
+
+-- !query
+SELECT * FROM (SELECT 1 AS c1, 2 AS c1, 3 AS c2) NATURAL JOIN (SELECT 1 AS c1, 2 AS c1, 3 AS c2)
+-- !query analysis
+Project [c1#x, c1#x, c2#x, c1#x, c1#x]
++- Project [c1#x, c1#x, c2#x, c1#x, c1#x]
+   +- Join Inner, (((c1#x = c1#x) AND (c1#x = c1#x)) AND (c2#x = c2#x))
+      :- SubqueryAlias __auto_generated_subquery_name
+      :  +- Project [1 AS c1#x, 2 AS c1#x, 3 AS c2#x]
+      :     +- OneRowRelation
+      +- SubqueryAlias __auto_generated_subquery_name
+         +- Project [1 AS c1#x, 2 AS c1#x, 3 AS c2#x]
+            +- OneRowRelation
+
+
+-- !query
+SELECT * FROM (SELECT 1 AS c1, 2 AS c1, 3 AS c2) NATURAL JOIN (SELECT 1 AS c1, 3 AS c2)
+-- !query analysis
+Project [c1#x, c2#x, c1#x]
++- Project [c1#x, c2#x, c1#x]
+   +- Join Inner, ((c1#x = c1#x) AND (c2#x = c2#x))
+      :- SubqueryAlias __auto_generated_subquery_name
+      :  +- Project [1 AS c1#x, 2 AS c1#x, 3 AS c2#x]
+      :     +- OneRowRelation
+      +- SubqueryAlias __auto_generated_subquery_name
+         +- Project [1 AS c1#x, 3 AS c2#x]
+            +- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/inputs/natural-join.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/natural-join.sql
@@ -77,3 +77,7 @@ SELECT * FROM nt1 natural join nt2 join nt3 on nt2.k = nt3.k;
 SELECT nt1.*, nt2.*, nt3.*, nt4.* FROM nt1 natural join nt2 natural join nt3 natural join nt4;
 
 SELECT * FROM (SELECT 1 AS ID) t1 NATURAL JOIN (SELECT 1 AS id) t2;
+
+SELECT * FROM (SELECT 1 AS c1, 2 AS c1, 3 AS c2) NATURAL JOIN (SELECT 1 AS c1, 2 AS c1, 3 AS c2);
+
+SELECT * FROM (SELECT 1 AS c1, 2 AS c1, 3 AS c2) NATURAL JOIN (SELECT 1 AS c1, 3 AS c2);

--- a/sql/core/src/test/resources/sql-tests/results/natural-join.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/natural-join.sql.out
@@ -348,3 +348,19 @@ SELECT * FROM (SELECT 1 AS ID) t1 NATURAL JOIN (SELECT 1 AS id) t2
 struct<ID:int>
 -- !query output
 1
+
+
+-- !query
+SELECT * FROM (SELECT 1 AS c1, 2 AS c1, 3 AS c2) NATURAL JOIN (SELECT 1 AS c1, 2 AS c1, 3 AS c2)
+-- !query schema
+struct<c1:int,c1:int,c2:int,c1:int,c1:int>
+-- !query output
+1	1	3	2	2
+
+
+-- !query
+SELECT * FROM (SELECT 1 AS c1, 2 AS c1, 3 AS c2) NATURAL JOIN (SELECT 1 AS c1, 3 AS c2)
+-- !query schema
+struct<c1:int,c2:int,c1:int>
+-- !query output
+1	3	2


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Replace `distinct.filter(resolver)` with a multiset intersection (`canonicalizedIntersect`) when computing common columns for NATURAL JOIN. This preserves duplicate column multiplicity (each name appears `min(left count, right count)` times) instead of deduplicating.


### Why are the changes needed?
`distinct` drops duplicate column names, so `NATURAL JOIN` between relations with repeated column names (e.g., c1, c1, c2) silently loses join conditions. The multiset approach matches `Seq.intersect` semantics while still respecting `spark.sql.caseSensitive`.

Now `NATURAL JOIN` behaves in the same way as before https://github.com/apache/spark/pull/54858 except it now respects caseSensitive conf.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
New golden file tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
