### PR TITLE
[SPARK-48275][SQL][DOCS] Improve array_sort default comparator documentation

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -8788,9 +8788,13 @@ object functions {
   def get(column: Column, index: Column): Column = Column.fn("get", column, index)
 
   /**
-   * Sorts the input array in ascending order. The elements of the input array must be orderable.
-   * NaN is greater than any non-NaN elements for double/float type. Null elements will be placed
-   * at the end of the returned array.
+   * Sorts the input array in ascending order. Null elements will be placed at the end of the
+   * returned array. NaN is greater than any non-NaN elements for double/float type.
+   *
+   * The elements of the input array must be orderable. For example, when the array elements are
+   * structs, the default comparator compares the struct fields in schema order. Therefore, all
+   * fields in the struct must be orderable. If the default comparator does not support the input
+   * type, you can specify a custom comparator.
    *
    * @group collection_funcs
    * @since 2.4.0


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR improves the Scaladoc for `array_sort` by clarifying the behavior of the default comparator, especially for struct elements.

### Why are the changes needed?

The current documentation says that array elements must be orderable, but does not explain how the default comparator behaves for structs or why arrays of structs with unorderable fields can fail.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Built the affected module locally with:

`./build/mvn -pl sql/api -am -DskipTests package`

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: ChatGPT GPT-5.4 Thinking