### PR TITLE
[SPARK-56341][PYTHON][DOCS] Fix outdated PyArrow minimum version in arrow_pandas.rst

### DIFF
--- a/python/docs/source/tutorial/sql/arrow_pandas.rst
+++ b/python/docs/source/tutorial/sql/arrow_pandas.rst
@@ -443,7 +443,7 @@ working with timestamps in ``pandas_udf``\s to get the best performance, see
 Recommended Pandas and PyArrow Versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For usage with pyspark.sql, the minimum supported versions of Pandas is 2.2.0 and PyArrow is 11.0.0.
+For usage with pyspark.sql, the minimum supported versions of Pandas is 2.2.0 and PyArrow is 18.0.0.
 Higher versions may be used, however, compatibility and data correctness can not be guaranteed and should
 be verified by the user.
 

--- a/python/packaging/classic/setup.py
+++ b/python/packaging/classic/setup.py
@@ -149,6 +149,7 @@ if in_spark:
 # For Arrow, you should also check ./pom.xml and ensure there are no breaking changes in the
 # binary format protocol with the Java version, see ARROW_HOME/format/* for specifications.
 # Also don't forget to update python/docs/source/getting_started/install.rst,
+# python/docs/source/tutorial/sql/arrow_pandas.rst,
 # python/packaging/client/setup.py, and python/packaging/connect/setup.py
 _minimum_pandas_version = "2.2.0"
 _minimum_numpy_version = "1.21"

--- a/python/packaging/client/setup.py
+++ b/python/packaging/client/setup.py
@@ -132,6 +132,7 @@ try:
     # For Arrow, you should also check ./pom.xml and ensure there are no breaking changes in the
     # binary format protocol with the Java version, see ARROW_HOME/format/* for specifications.
     # Also don't forget to update python/docs/source/getting_started/install.rst,
+    # python/docs/source/tutorial/sql/arrow_pandas.rst,
     # python/packaging/classic/setup.py, and python/packaging/connect/setup.py
     _minimum_pandas_version = "2.2.0"
     _minimum_numpy_version = "1.21"

--- a/python/packaging/connect/setup.py
+++ b/python/packaging/connect/setup.py
@@ -85,6 +85,7 @@ try:
     # For Arrow, you should also check ./pom.xml and ensure there are no breaking changes in the
     # binary format protocol with the Java version, see ARROW_HOME/format/* for specifications.
     # Also don't forget to update python/docs/source/getting_started/install.rst,
+    # python/docs/source/tutorial/sql/arrow_pandas.rst,
     # python/packaging/classic/setup.py, and python/packaging/client/setup.py
     _minimum_pandas_version = "2.2.0"
     _minimum_numpy_version = "1.21"


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Updated the minimum PyArrow version from 11.0.0 to 18.0.0 in `python/docs/source/tutorial/sql/arrow_pandas.rst`.
- Added `python/docs/source/tutorial/sql/arrow_pandas.rst` to the version-change reminder comments in `python/packaging/classic/setup.py`, `python/packaging/client/setup.py`, and `python/packaging/connect/setup.py` so this file is not missed in future version bumps.

### Why are the changes needed?

The documentation in `arrow_pandas.rst` still states the minimum PyArrow version is 11.0.0, but it was raised to 18.0.0 in SPARK-51334. The setup.py reminder comments also do not reference this doc file, which is why it was missed.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Documentation-only change; no tests needed.

### Was this patch authored or co-authored using generative AI tooling?

No.