### PR TITLE
[SPARK-56339][SQL] Fix BatchScanExec canonicalization to enable ReuseSubquery for DSv2 scans

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
@@ -44,17 +44,22 @@ case class BatchScanExec(
 
   @transient lazy val batch: Batch = if (scan == null) null else scan.toBatch
 
-  // TODO: unify the equal/hashCode implementation for all data source v2 query plans.
+  // SPARK-56339: Use scan-based equality instead of batch-based equality.
+  // V2ScanRelationPushDown creates a separate Scan per DataSourceV2Relation, so each
+  // subquery gets its own Scan -> Batch object. Batch reference equality prevents
+  // ReuseSubquery from detecting identical subquery plans. Scan implementations that
+  // provide content-based equals/hashCode (comparing table path, snapshot version,
+  // schemas, and pushed filters) enable proper deduplication.
   override def equals(other: Any): Boolean = other match {
     case other: BatchScanExec =>
-      this.batch != null && this.batch == other.batch &&
+      this.scan != null && this.scan == other.scan &&
           this.runtimeFilters == other.runtimeFilters &&
           this.keyGroupedPartitioning == other.keyGroupedPartitioning
     case _ =>
       false
   }
 
-  override def hashCode(): Int = Objects.hash(batch, runtimeFilters)
+  override def hashCode(): Int = Objects.hash(scan, runtimeFilters)
 
   @transient override lazy val inputPartitions: Seq[InputPartition] =
     batch.planInputPartitions().toImmutableArraySeq

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
@@ -1101,6 +1101,33 @@ class DataSourceV2Suite extends QueryTest with SharedSparkSession with AdaptiveS
     checkAnswer(query, Row(9, 0))
   }
 
+  test("SPARK-56339: BatchScanExec sameResult uses scan equality for subquery reuse") {
+    // Two BatchScanExec plans from separate queries should be detected as producing
+    // the same result, enabling ReuseSubquery to deduplicate identical subqueries.
+    val df = spark.read.format(classOf[SimpleDataSourceV2].getName).load()
+    df.createOrReplaceTempView("df")
+
+    val plan1 = sql("SELECT * FROM df").queryExecution.executedPlan
+    val plan2 = sql("SELECT * FROM df").queryExecution.executedPlan
+
+    val scans1 = plan1.collect { case b: BatchScanExec => b }
+    val scans2 = plan2.collect { case b: BatchScanExec => b }
+
+    assert(scans1.nonEmpty, "Expected BatchScanExec in plan1")
+    assert(scans2.nonEmpty, "Expected BatchScanExec in plan2")
+
+    val bse1 = scans1.head
+    val bse2 = scans2.head
+
+    // The Scan objects are different references (created by separate
+    // V2ScanRelationPushDown invocations) but have the same content.
+    assert(!(bse1.scan eq bse2.scan),
+      "Scan objects should be different references to test equality semantics")
+    assert(bse1.sameResult(bse2),
+      s"BatchScanExec.sameResult should return true for identical DSv2 scans.\n" +
+      s"scan1.equals(scan2): ${bse1.scan == bse2.scan}")
+  }
+
   test(
     "SPARK-54163: check mergeScalarSubqueries is effective for OrderAndPartitionAwareDataSource"
   ) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Changes `BatchScanExec.equals()` and `hashCode()` to use `scan`-based equality instead of `batch`-based equality. `V2ScanRelationPushDown` creates a separate `Scan` per `DataSourceV2Relation`, so each subquery gets its own `Scan` -> `Batch` object. `Batch` reference equality prevented `ReuseSubquery` from detecting that identical subquery plans produce the same result.

`Scan` implementations that provide content-based `equals`/`hashCode` (comparing table path, snapshot version, schemas, and pushed filters) now enable proper deduplication.

### Why are the changes needed?

When a query contains multiple identical scalar subqueries scanning the same DSv2 table, `ReuseSubquery` should replace duplicates with `ReusedSubqueryExec`. This works for DSv1 (`FileSourceScanExec`) but fails for DSv2 (`BatchScanExec`) because the old `equals()` compared `Batch` objects by reference.

### Does this PR introduce _any_ user-facing change?

No API change. Performance improvement for queries with repeated DSv2 scalar subqueries.

### How was this patch tested?

Added unit test in `DataSourceV2Suite` verifying `BatchScanExec.sameResult()` returns true for two scans of the same table with different `Scan` object references.

### Was this patch authored or co-authored using generative AI tooling?

Yes, co-authored with Claude Code.

