### PR TITLE
[SPARK-56345][PYTHON][TESTS] Use `pd.Series.__name__` in Arrow UDF type-hint test

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_udf_typehints.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_udf_typehints.py
@@ -452,7 +452,7 @@ class ArrowUDFTypeHintsTests(ReusedSQLTestCase):
 
         with self.assertRaisesRegex(
             Exception,
-            "Unsupported signature:.*pandas.core.series.Series.",
+            f"Unsupported signature:.*{pd.Series.__name__}.",
         ):
 
             @arrow_udf("long")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates `python/pyspark/sql/tests/arrow/test_arrow_udf_typehints.py` to make the negative Arrow UDF type-hint assertion build the expected error pattern from `pd.Series.__name__` instead of hard-coding `pandas.core.series.Series`.

The change is limited to the test expectation in `ArrowUDFTypeHintsTests.test_negative_with_pandas_udf`.

### Why are the changes needed?

The previous assertion depended on a hard-coded fully qualified pandas type name. Building the expected pattern from `pd.Series.__name__` makes the test less coupled to a specific pandas type string representation while still checking that an unsupported pandas `Series` signature is rejected.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Updated the related test expectation.

### Was this patch authored or co-authored using generative AI tooling?

No.
