### PR TITLE
[SPARK-56342][PYTHON] Tighten type hints for refactored eval type functions in worker.py

### DIFF
--- a/python/pyspark/sql/pandas/_typing/__init__.pyi
+++ b/python/pyspark/sql/pandas/_typing/__init__.pyi
@@ -69,7 +69,7 @@ ArrowGroupedAggUDFType = Literal[252]
 ArrowWindowAggUDFType = Literal[253]
 ArrowGroupedAggIterUDFType = Literal[254]
 
-# Arrow stream types for worker.py read_udfs() func signatures.
+# Arrow stream types
 # A single group of Arrow batches (e.g., one key group in groupBy).
 GroupedBatch = Iterator[pyarrow.RecordBatch]
 # A pair of groups for cogroup operations (e.g., cogroupBy).

--- a/python/pyspark/sql/pandas/_typing/__init__.pyi
+++ b/python/pyspark/sql/pandas/_typing/__init__.pyi
@@ -72,7 +72,7 @@ ArrowGroupedAggIterUDFType = Literal[254]
 # Arrow stream types
 # A single group of Arrow batches (e.g., one key group in groupBy).
 GroupedBatch = Iterator[pyarrow.RecordBatch]
-# A pair of groups for cogroup operations (e.g., cogroupBy).
+# A group of two relations for cogroup operations (e.g., cogroupBy).
 CoGroupedBatch = Tuple[Iterator[pyarrow.RecordBatch], Iterator[pyarrow.RecordBatch]]
 
 class ArrowVariadicScalarToScalarFunction(Protocol):

--- a/python/pyspark/sql/pandas/_typing/__init__.pyi
+++ b/python/pyspark/sql/pandas/_typing/__init__.pyi
@@ -69,6 +69,12 @@ ArrowGroupedAggUDFType = Literal[252]
 ArrowWindowAggUDFType = Literal[253]
 ArrowGroupedAggIterUDFType = Literal[254]
 
+# Arrow stream types for worker.py read_udfs() func signatures.
+# A single group of Arrow batches (e.g., one key group in groupBy).
+GroupedBatch = Iterator[pyarrow.RecordBatch]
+# A pair of groups for cogroup operations (e.g., cogroupBy).
+CoGroupedBatch = Tuple[Iterator[pyarrow.RecordBatch], Iterator[pyarrow.RecordBatch]]
+
 class ArrowVariadicScalarToScalarFunction(Protocol):
     def __call__(self, *_: pyarrow.Array) -> pyarrow.Array: ...
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2700,7 +2700,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             prefers_large_types=runner_conf.use_large_var_types,
         )
 
-        def func(split_index: int, data: Iterator["GroupedBatch"]) -> Iterator[pa.RecordBatch]:
+        def grouped_func(split_index: int, data: Iterator["GroupedBatch"]) -> Iterator[pa.RecordBatch]:
             for group in data:
                 batch_list = list(group)
                 if not batch_list:
@@ -2725,7 +2725,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
                 yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 
         # profiling is not supported for UDF
-        return func, None, ser, ser
+        return grouped_func, None, ser, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_AGG_ARROW_ITER_UDF:
         import pyarrow as pa
@@ -2743,7 +2743,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             args = tuple(batch.column(o) for o in args_offsets)
             return args[0] if len(args) == 1 else args
 
-        def func(split_index: int, data: Iterator["GroupedBatch"]) -> Iterator[pa.RecordBatch]:
+        def grouped_func(split_index: int, data: Iterator["GroupedBatch"]) -> Iterator[pa.RecordBatch]:
             for group in data:
                 batch_iter = map(extract_args, group)
                 result = udf_func(batch_iter)
@@ -2754,7 +2754,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
                 yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 
         # profiling is not supported for UDF
-        return func, None, ser, ser
+        return grouped_func, None, ser, ser
 
     if eval_type == PythonEvalType.SQL_WINDOW_AGG_ARROW_UDF:
         import pyarrow as pa
@@ -2769,7 +2769,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             prefers_large_types=runner_conf.use_large_var_types,
         )
 
-        def func(split_index: int, data: Iterator["GroupedBatch"]) -> Iterator[pa.RecordBatch]:
+        def grouped_func(split_index: int, data: Iterator["GroupedBatch"]) -> Iterator[pa.RecordBatch]:
             for group in data:
                 batch_list = list(group)
                 if not batch_list:
@@ -2820,7 +2820,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
                 yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 
         # profiling is not supported for UDF
-        return func, None, ser, ser
+        return grouped_func, None, ser, ser
 
     if (
         eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2700,7 +2700,9 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             prefers_large_types=runner_conf.use_large_var_types,
         )
 
-        def grouped_func(split_index: int, data: Iterator["GroupedBatch"]) -> Iterator[pa.RecordBatch]:
+        def grouped_func(
+            split_index: int, data: Iterator["GroupedBatch"]
+        ) -> Iterator[pa.RecordBatch]:
             for group in data:
                 batch_list = list(group)
                 if not batch_list:
@@ -2743,7 +2745,9 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             args = tuple(batch.column(o) for o in args_offsets)
             return args[0] if len(args) == 1 else args
 
-        def grouped_func(split_index: int, data: Iterator["GroupedBatch"]) -> Iterator[pa.RecordBatch]:
+        def grouped_func(
+            split_index: int, data: Iterator["GroupedBatch"]
+        ) -> Iterator[pa.RecordBatch]:
             for group in data:
                 batch_iter = map(extract_args, group)
                 result = udf_func(batch_iter)
@@ -2769,7 +2773,9 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             prefers_large_types=runner_conf.use_large_var_types,
         )
 
-        def grouped_func(split_index: int, data: Iterator["GroupedBatch"]) -> Iterator[pa.RecordBatch]:
+        def grouped_func(
+            split_index: int, data: Iterator["GroupedBatch"]
+        ) -> Iterator[pa.RecordBatch]:
             for group in data:
                 batch_list = list(group)
                 if not batch_list:

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -26,7 +26,10 @@ import time
 import inspect
 import itertools
 import json
-from typing import Any, Callable, Iterable, Iterator, Optional, Tuple, Union
+from typing import Any, Callable, Iterable, Iterator, Optional, Tuple, TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    from pyspark.sql.pandas._typing import GroupedBatch, CoGroupedBatch
 
 from pyspark.accumulators import (
     SpecialAccumulatorIds,
@@ -2573,12 +2576,14 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
         assert num_udfs == 1, "One MAP_ARROW_ITER UDF expected here."
         udf_func: Callable[[Iterator[pa.RecordBatch]], Iterator[pa.RecordBatch]] = udfs[0][0]
 
-        def func(split_index: int, batches: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
+        def func(
+            split_index: int, data: Iterator[pa.RecordBatch]
+        ) -> Iterator[pa.RecordBatch]:
             """Apply mapInArrow UDF"""
 
             # Pre-processing
             input_batches: Iterator[pa.RecordBatch] = map(
-                ArrowBatchTransformer.flatten_struct, batches
+                ArrowBatchTransformer.flatten_struct, data
             )
 
             # invoke the UDF
@@ -2601,15 +2606,17 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             prefers_large_types=runner_conf.use_large_var_types,
         )
 
-        def func(split_index: int, batches: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
+        def func(
+            split_index: int, data: Iterator[pa.RecordBatch]
+        ) -> Iterator[pa.RecordBatch]:
             """Apply scalar Arrow UDFs"""
 
-            for input_batch in batches:
+            for batch in data:
                 output_batch = pa.RecordBatch.from_arrays(
                     [
                         udf_func(
-                            *[input_batch.column(o) for o in args_offsets],
-                            **{k: input_batch.column(v) for k, v in kwargs_offsets.items()},
+                            *[batch.column(o) for o in args_offsets],
+                            **{k: batch.column(v) for k, v in kwargs_offsets.items()},
                         )
                         for udf_func, args_offsets, kwargs_offsets, _ in udfs
                     ],
@@ -2618,7 +2625,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
                 output_batch = ArrowBatchTransformer.enforce_schema(
                     output_batch, combined_arrow_schema
                 )
-                verify_scalar_result(output_batch, input_batch.num_rows)
+                verify_scalar_result(output_batch, batch.num_rows)
                 yield output_batch
 
         # profiling is not supported for UDF
@@ -2635,7 +2642,9 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             return_type, timezone="UTC", prefers_large_types=runner_conf.use_large_var_types
         )
 
-        def func(split_index: int, batches: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
+        def func(
+            split_index: int, data: Iterator[pa.RecordBatch]
+        ) -> Iterator[pa.RecordBatch]:
             """Apply scalar Arrow iterator UDF"""
 
             num_input_rows = 0
@@ -2647,7 +2656,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
                 return args[0] if len(args) == 1 else args
 
             # Extract args from input batches (streaming)
-            args_iter = map(extract_args, batches)
+            args_iter = map(extract_args, data)
 
             # Call UDF and verify result type (iterator of pa.Array)
             verified_iter = verify_result(pa.Array)(udf_func(args_iter))
@@ -2697,9 +2706,11 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             prefers_large_types=runner_conf.use_large_var_types,
         )
 
-        def func(split_index: int, batches: Iterator[Any]) -> Iterator[pa.RecordBatch]:
-            for group_batches in batches:
-                batch_list = list(group_batches)
+        def func(
+            split_index: int, data: Iterator["GroupedBatch"]
+        ) -> Iterator[pa.RecordBatch]:
+            for group in data:
+                batch_list = list(group)
                 if not batch_list:
                     continue
                 if hasattr(pa, "concat_batches"):
@@ -2740,9 +2751,11 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             args = tuple(batch.column(o) for o in args_offsets)
             return args[0] if len(args) == 1 else args
 
-        def func(split_index: int, batches: Iterator[Any]) -> Iterator[pa.RecordBatch]:
-            for group_batches in batches:
-                batch_iter = map(extract_args, group_batches)
+        def func(
+            split_index: int, data: Iterator["GroupedBatch"]
+        ) -> Iterator[pa.RecordBatch]:
+            for group in data:
+                batch_iter = map(extract_args, group)
                 result = udf_func(batch_iter)
                 # Drain remaining batches to maintain stream position
                 for _ in batch_iter:
@@ -2766,9 +2779,11 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             prefers_large_types=runner_conf.use_large_var_types,
         )
 
-        def func(split_index: int, batches: Iterator[Any]) -> Iterator[pa.RecordBatch]:
-            for group_batches in batches:
-                batch_list = list(group_batches)
+        def func(
+            split_index: int, data: Iterator["GroupedBatch"]
+        ) -> Iterator[pa.RecordBatch]:
+            for group in data:
+                batch_list = list(group)
                 if not batch_list:
                     continue
                 if hasattr(pa, "concat_batches"):

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -29,7 +29,7 @@ import json
 from typing import Any, Callable, Iterable, Iterator, Optional, Tuple, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
-    from pyspark.sql.pandas._typing import GroupedBatch, CoGroupedBatch
+    from pyspark.sql.pandas._typing import GroupedBatch
 
 from pyspark.accumulators import (
     SpecialAccumulatorIds,

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2576,9 +2576,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
         assert num_udfs == 1, "One MAP_ARROW_ITER UDF expected here."
         udf_func: Callable[[Iterator[pa.RecordBatch]], Iterator[pa.RecordBatch]] = udfs[0][0]
 
-        def func(
-            split_index: int, data: Iterator[pa.RecordBatch]
-        ) -> Iterator[pa.RecordBatch]:
+        def func(split_index: int, data: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
             """Apply mapInArrow UDF"""
 
             # Pre-processing
@@ -2606,9 +2604,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             prefers_large_types=runner_conf.use_large_var_types,
         )
 
-        def func(
-            split_index: int, data: Iterator[pa.RecordBatch]
-        ) -> Iterator[pa.RecordBatch]:
+        def func(split_index: int, data: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
             """Apply scalar Arrow UDFs"""
 
             for batch in data:
@@ -2642,9 +2638,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             return_type, timezone="UTC", prefers_large_types=runner_conf.use_large_var_types
         )
 
-        def func(
-            split_index: int, data: Iterator[pa.RecordBatch]
-        ) -> Iterator[pa.RecordBatch]:
+        def func(split_index: int, data: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
             """Apply scalar Arrow iterator UDF"""
 
             num_input_rows = 0
@@ -2706,9 +2700,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             prefers_large_types=runner_conf.use_large_var_types,
         )
 
-        def func(
-            split_index: int, data: Iterator["GroupedBatch"]
-        ) -> Iterator[pa.RecordBatch]:
+        def func(split_index: int, data: Iterator["GroupedBatch"]) -> Iterator[pa.RecordBatch]:
             for group in data:
                 batch_list = list(group)
                 if not batch_list:
@@ -2751,9 +2743,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             args = tuple(batch.column(o) for o in args_offsets)
             return args[0] if len(args) == 1 else args
 
-        def func(
-            split_index: int, data: Iterator["GroupedBatch"]
-        ) -> Iterator[pa.RecordBatch]:
+        def func(split_index: int, data: Iterator["GroupedBatch"]) -> Iterator[pa.RecordBatch]:
             for group in data:
                 batch_iter = map(extract_args, group)
                 result = udf_func(batch_iter)
@@ -2779,9 +2769,7 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             prefers_large_types=runner_conf.use_large_var_types,
         )
 
-        def func(
-            split_index: int, data: Iterator["GroupedBatch"]
-        ) -> Iterator[pa.RecordBatch]:
+        def func(split_index: int, data: Iterator["GroupedBatch"]) -> Iterator[pa.RecordBatch]:
             for group in data:
                 batch_list = list(group)
                 if not batch_list:

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2877,8 +2877,8 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             with ThreadPoolExecutor(max_workers=runner_conf.arrow_concurrency_level) as pool:
                 return list(pool.map(lambda row: udf_func(*row), rows))
 
-        def func(split_index: int, batches: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
-            for input_batch in batches:
+        def func(split_index: int, data: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
+            for input_batch in data:
                 num_rows = input_batch.num_rows
 
                 # --- Input: Arrow -> Python columns ---
@@ -2962,8 +2962,8 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             with ThreadPoolExecutor(max_workers=runner_conf.arrow_concurrency_level) as pool:
                 return list(pool.map(lambda row: udf_func(*row), rows))
 
-        def func(split_index: int, batches: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
-            for input_batch in batches:
+        def func(split_index: int, data: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
+            for input_batch in data:
                 # --- Input: Arrow -> pandas columns ---
                 pandas_columns = ArrowBatchTransformer.to_pandas(
                     input_batch,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Tighten the type hints for `def func` signatures in `read_udfs()` for eval types that have been refactored to be self-contained. Specifically:

- Replace `Iterator[Any]` with `Iterator["GroupedBatch"]` for grouped eval types (`SQL_GROUPED_AGG_ARROW_UDF`, `SQL_GROUPED_AGG_ARROW_ITER_UDF`, `SQL_WINDOW_AGG_ARROW_UDF`)
- Rename the `batches` parameter to `data` across all refactored eval types for consistency, since the same call site passes either a flat stream or grouped stream
- Use `for batch in data` for flat streams and `for group in data` for grouped streams
- Define `GroupedBatch` and `CoGroupedBatch` type aliases in `pyspark.sql.pandas._typing`

### Why are the changes needed?

After refactoring eval types to be self-contained in `read_udfs()`, the `def func` signatures used `Iterator[Any]` for grouped eval types, losing type information. Tightening these hints improves readability and enables better static analysis.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.