### PR TITLE
[SPARK-56346][SQL] Use PartitionPredicate in DSV2 Metadata Only Delete

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryPartitionPredicateDeleteTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryPartitionPredicateDeleteTable.scala
@@ -84,7 +84,7 @@ class InMemoryPartitionPredicateDeleteTable(
       candidateKeys
     }
 
-    // Handle data predicates (simulate data source with data column statistics)
+    // Handle data predicates (simulate a data source handling data filters with data statistics)
     if (dataStdPreds.isEmpty) {
       dataMap --= keysToProcess
     } else {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryPartitionPredicateDeleteTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryPartitionPredicateDeleteTable.scala
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.catalog
+
+import java.util
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.MultipartIdentifierHelper
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.connector.expressions.filter.{PartitionPredicate, Predicate}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.ArrayImplicits._
+
+/**
+ * In-memory table that supports row-level operations and accepts [[PartitionPredicate]]s
+ * in V2 [[canDeleteWhere]]/[[deleteWhere]] for metadata-only deletes.
+ *
+ * Contains some knobs to control acceptance of various partition and data predicates.
+ */
+class InMemoryPartitionPredicateDeleteTable(
+    name: String,
+    schema: StructType,
+    partitioning: Array[Transform],
+    properties: util.Map[String, String])
+  extends InMemoryRowLevelOperationTable(name, schema, partitioning, properties) {
+
+  private val acceptPartitionPredicates: Boolean =
+    properties.getOrDefault(
+      InMemoryPartitionPredicateDeleteTable.AcceptPartitionPredicatesKey, "true").toBoolean
+
+  private val acceptDataPredicates: Boolean =
+    properties.getOrDefault(
+      InMemoryPartitionPredicateDeleteTable.AcceptDataPredicatesKey, "false").toBoolean
+
+  private val partPaths = partCols.map(_.mkString(".")).toSet
+
+  private def refsOnlyPartCols(p: Predicate): Boolean =
+    p.references().forall(ref => partPaths.contains(ref.fieldNames().mkString(".")))
+
+  override def canDeleteWhere(predicates: Array[Predicate]): Boolean = {
+    predicates.forall {
+      case _: PartitionPredicate => acceptPartitionPredicates
+      case p =>
+        InMemoryTableWithV2Filter.supportsPredicates(Array(p)) &&
+          (acceptDataPredicates || refsOnlyPartCols(p))
+    }
+  }
+
+  override def deleteWhere(predicates: Array[Predicate]): Unit = dataMap.synchronized {
+    val (partPreds, standardPreds) = predicates.partition(_.isInstanceOf[PartitionPredicate])
+    val (partStdPreds, dataStdPreds) = standardPreds.partition(refsOnlyPartCols)
+
+    val candidateKeys = if (partStdPreds.nonEmpty) {
+      InMemoryTableWithV2Filter.filtersToKeys(
+        dataMap.keys, partCols.map(_.toSeq.quoted).toImmutableArraySeq, partStdPreds)
+    } else {
+      dataMap.keys
+    }
+
+    // Handle partition predicates.
+    val keysToProcess = if (partPreds.nonEmpty) {
+      val pArr = partPreds.map(_.asInstanceOf[PartitionPredicate])
+      candidateKeys.filter { key =>
+        val partRow = PartitionInternalRow(key.toArray)
+        pArr.forall(_.eval(partRow))
+      }
+    } else {
+      candidateKeys
+    }
+
+    // Handle data predicates (simulate data source with data column statistics)
+    if (dataStdPreds.isEmpty) {
+      dataMap --= keysToProcess
+    } else {
+      for (key <- keysToProcess.toSeq) {
+        dataMap.get(key).foreach { splits =>
+          val filtered = splits.map { buffered =>
+            val kept = new BufferedRows(key, buffered.schema)
+            buffered.rows
+              .filterNot(rowMatchesAll(_, dataStdPreds, buffered.schema))
+              .foreach(kept.withRow)
+            kept
+          }
+          if (filtered.forall(_.rows.isEmpty)) {
+            dataMap.remove(key)
+          } else {
+            dataMap.update(key, filtered)
+          }
+        }
+      }
+    }
+  }
+
+  private def rowMatchesAll(
+      row: InternalRow,
+      preds: Array[Predicate],
+      rowSchema: StructType): Boolean = {
+    val resolve: String => Any = colName => {
+      val idx = rowSchema.fieldIndex(colName)
+      row.get(idx, rowSchema(idx).dataType)
+    }
+    preds.forall(
+      InMemoryTableWithV2Filter.evalPredicate(_, resolve))
+  }
+}
+
+object InMemoryPartitionPredicateDeleteTable {
+  private[catalog] val AcceptPartitionPredicatesKey = "accept-partition-predicates"
+  private[catalog] val AcceptDataPredicatesKey = "accept-data-predicates"
+}
+
+class InMemoryPartitionPredicateDeleteCatalog extends InMemoryTableCatalog {
+  import CatalogV2Implicits._
+
+  override def createTable(ident: Identifier, tableInfo: TableInfo): Table = {
+    if (tables.containsKey(ident)) {
+      throw new TableAlreadyExistsException(ident.asMultipartIdentifier)
+    }
+
+    InMemoryTableCatalog.maybeSimulateFailedTableCreation(tableInfo.properties)
+
+    val tableName = s"$name.${ident.quoted}"
+    val schema = CatalogV2Util.v2ColumnsToStructType(tableInfo.columns)
+    val table = new InMemoryPartitionPredicateDeleteTable(
+      tableName, schema, tableInfo.partitions, tableInfo.properties)
+    tables.put(ident, table)
+    namespaces.putIfAbsent(ident.namespace.toList, Map())
+    table
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithV2Filter.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithV2Filter.scala
@@ -140,31 +140,36 @@ object InMemoryTableWithV2Filter {
       partitionNames: Seq[String],
       filters: Array[Predicate]): Iterable[Seq[Any]] = {
     keys.filter { partValues =>
-      filters.flatMap(splitAnd).forall {
-        case p: Predicate if p.name().equals("=") =>
-          p.children()(1).asInstanceOf[LiteralValue[_]].value ==
-            InMemoryBaseTable.extractValue(p.children()(0).toString, partitionNames, partValues)
-        case p: Predicate if p.name().equals("<=>") =>
-          val attrVal = InMemoryBaseTable
-            .extractValue(p.children()(0).toString, partitionNames, partValues)
-          val value = p.children()(1).asInstanceOf[LiteralValue[_]].value
-          if (attrVal == null && value == null) {
-            true
-          } else if (attrVal == null || value == null) {
-            false
-          } else {
-            value == attrVal
-          }
-        case p: Predicate if p.name().equals("IS_NULL") =>
-          val attr = p.children()(0).toString
-          null == InMemoryBaseTable.extractValue(attr, partitionNames, partValues)
-        case p: Predicate if p.name().equals("IS_NOT_NULL") =>
-          val attr = p.children()(0).toString
-          null != InMemoryBaseTable.extractValue(attr, partitionNames, partValues)
-        case p: Predicate if p.name().equals("ALWAYS_TRUE") => true
-        case f =>
-          throw new IllegalArgumentException(s"Unsupported filter type: $f")
-      }
+      val resolve: String => Any = attr =>
+        InMemoryBaseTable.extractValue(attr, partitionNames, partValues)
+      filters.flatMap(splitAnd).forall(evalPredicate(_, resolve))
+    }
+  }
+
+  /**
+   * Evaluates a single V2 predicate by resolving column values through the
+   * given function. Supports =, <=>, IS_NULL, IS_NOT_NULL, and ALWAYS_TRUE.
+   */
+  def evalPredicate(
+      pred: Predicate,
+      resolveValue: String => Any): Boolean = {
+    lazy val attr = pred.children()(0).toString
+    pred.name() match {
+      case "=" =>
+        resolveValue(attr) ==
+          pred.children()(1).asInstanceOf[LiteralValue[_]].value
+      case "<=>" =>
+        val attrVal = resolveValue(attr)
+        val litVal =
+          pred.children()(1).asInstanceOf[LiteralValue[_]].value
+        (attrVal == null && litVal == null) ||
+          (attrVal != null && litVal != null && attrVal == litVal)
+      case "IS_NULL" => resolveValue(attr) == null
+      case "IS_NOT_NULL" => resolveValue(attr) != null
+      case "ALWAYS_TRUE" => true
+      case other =>
+        throw new IllegalArgumentException(
+          s"Unsupported filter type: $other")
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/OptimizeMetadataOnlyDeleteFromTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/OptimizeMetadataOnlyDeleteFromTable.scala
@@ -45,10 +45,15 @@ object OptimizeMetadataOnlyDeleteFromTable extends Rule[LogicalPlan] with Predic
           val normalizedPredicates = DataSourceStrategy.normalizeExprs(predicates, relation.output)
           val filtersOpt = tryTranslateToV2(normalizedPredicates)
           if (filtersOpt.exists(table.canDeleteWhere)) {
+            logDebug(s"Switching to delete with filters: " +
+              s"${filtersOpt.get.mkString("[", ", ", "]")}")
             DeleteFromTableWithFilters(relation, filtersOpt.get.toImmutableArraySeq)
           } else {
             tryDeleteWithPartitionPredicates(table, relation, normalizedPredicates)
-              .getOrElse(rowLevelPlan)
+              .getOrElse {
+                logDebug(s"Falling back to row-level delete on ${relation.table.name()}")
+                rowLevelPlan
+              }
           }
 
         case _: TruncatableTable if cond == TrueLiteral =>
@@ -93,6 +98,8 @@ object OptimizeMetadataOnlyDeleteFromTable extends Rule[LogicalPlan] with Predic
       combined = partPredicates.toArray ++ dataV2Filters
       if table.canDeleteWhere(combined)
     } yield {
+      logDebug(s"Switching to delete with PartitionPredicate filters: " +
+        s"${combined.mkString("[", ", ", "]")}")
       DeleteFromTableWithFilters(relation, combined.toImmutableArraySeq)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/OptimizeMetadataOnlyDeleteFromTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/OptimizeMetadataOnlyDeleteFromTable.scala
@@ -64,16 +64,6 @@ object OptimizeMetadataOnlyDeleteFromTable extends Rule[LogicalPlan] with Predic
       }
   }
 
-  private def toDataSourceV2Filters(predicates: Seq[Expression]): Array[Predicate] = {
-    predicates.flatMap { p =>
-      val filter = DataSourceV2Strategy.translateFilterV2(p)
-      if (filter.isEmpty) {
-        logDebug(s"Cannot translate expression to data source filter: $p")
-      }
-      filter
-    }.toArray
-  }
-
   /**
    * Attempts to convert partition-column filters to [[PartitionPredicate]]s and
    * combine them with translated V2 data filters for a metadata-only delete. (See SPARK-55596)
@@ -106,7 +96,13 @@ object OptimizeMetadataOnlyDeleteFromTable extends Rule[LogicalPlan] with Predic
 
   /** Translates all expressions to V2 filters, or returns [[None]] if any fail. */
   private def tryTranslateToV2(predicates: Seq[Expression]): Option[Array[Predicate]] = {
-    val filters = toDataSourceV2Filters(predicates)
+    val filters = predicates.flatMap { p =>
+      val filter = DataSourceV2Strategy.translateFilterV2(p)
+      if (filter.isEmpty) {
+        logDebug(s"Cannot translate expression to data source filter: $p")
+      }
+      filter
+    }.toArray
     Option.when(filters.length == predicates.size)(filters)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/OptimizeMetadataOnlyDeleteFromTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/OptimizeMetadataOnlyDeleteFromTable.scala
@@ -43,13 +43,12 @@ object OptimizeMetadataOnlyDeleteFromTable extends Rule[LogicalPlan] with Predic
         case table: SupportsDeleteV2 if !SubqueryExpression.hasSubquery(cond) =>
           val predicates = splitConjunctivePredicates(cond)
           val normalizedPredicates = DataSourceStrategy.normalizeExprs(predicates, relation.output)
-          val filters = toDataSourceV2Filters(normalizedPredicates)
-          val allPredicatesTranslated = normalizedPredicates.size == filters.length
-          if (allPredicatesTranslated && table.canDeleteWhere(filters)) {
-            logDebug(s"Switching to delete with filters: ${filters.mkString("[", ", ", "]")}")
-            DeleteFromTableWithFilters(relation, filters.toImmutableArraySeq)
+          val filtersOpt = tryTranslateToV2(normalizedPredicates)
+          if (filtersOpt.exists(table.canDeleteWhere)) {
+            DeleteFromTableWithFilters(relation, filtersOpt.get.toImmutableArraySeq)
           } else {
-            rowLevelPlan
+            tryDeleteWithPartitionPredicates(table, relation, normalizedPredicates)
+              .getOrElse(rowLevelPlan)
           }
 
         case _: TruncatableTable if cond == TrueLiteral =>
@@ -68,6 +67,40 @@ object OptimizeMetadataOnlyDeleteFromTable extends Rule[LogicalPlan] with Predic
       }
       filter
     }.toArray
+  }
+
+  /**
+   * Attempts to convert partition-column filters to [[PartitionPredicate]]s and
+   * combine them with translated V2 data filters for a metadata-only delete. (See SPARK-55596)
+   *
+   * Returns [[Some]] with the plan if the table accepts the combined predicates,
+   * or [[None]] if partition predicates cannot be created or the table rejects them.
+   */
+  private def tryDeleteWithPartitionPredicates(
+      table: SupportsDeleteV2,
+      relation: DataSourceV2Relation,
+      normalizedPredicates: Seq[Expression]): Option[LogicalPlan] = {
+    for {
+      partitionFields <- PushDownUtils.getPartitionPredicateSchema(relation)
+      flattenedFilters = PushDownUtils.flattenNestedPartitionFilters(
+        normalizedPredicates, partitionFields).keys.toSeq
+      (candidatePredicates, remainingFilters) =
+        PushDownUtils.createPartitionPredicates(flattenedFilters, partitionFields)
+      // None if no partition predicates created
+      partPredicates <- Option.when(candidatePredicates.nonEmpty)(candidatePredicates)
+      // None if any remaining filter cannot be translated to V2
+      dataV2Filters <- tryTranslateToV2(remainingFilters)
+      combined = partPredicates.toArray ++ dataV2Filters
+      if table.canDeleteWhere(combined)
+    } yield {
+      DeleteFromTableWithFilters(relation, combined.toImmutableArraySeq)
+    }
+  }
+
+  /** Translates all expressions to V2 filters, or returns [[None]] if any fail. */
+  private def tryTranslateToV2(predicates: Seq[Expression]): Option[Array[Predicate]] = {
+    val filters = toDataSourceV2Filters(predicates)
+    Option.when(filters.length == predicates.size)(filters)
   }
 
   private object RewrittenRowLevelCommand {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -149,7 +149,7 @@ object PushDownUtils extends Logging {
         case _ => None
       }
       if (fields.length == transforms.length) {
-        Some(fields.toSeq).filter(_.nonEmpty)
+        Some(fields.toSeq)
       } else {
         None
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -149,7 +149,7 @@ object PushDownUtils extends Logging {
         case _ => None
       }
       if (fields.length == transforms.length) {
-        Some(fields.toSeq)
+        Some(fields.toSeq).filter(_.nonEmpty)
       } else {
         None
       }
@@ -178,6 +178,32 @@ object PushDownUtils extends Logging {
   }
 
   /**
+   * Separates partition filters from data filters and converts pushable partition
+   * filters to [[PartitionPredicateImpl]] instances.
+   *
+   * Callers must first flatten nested partition field references via
+   * [[flattenNestedPartitionFilters]] with [[ExprId]] matching the [[PartitionPredicateField]]s.
+   *
+   * @param flattenedFilters Catalyst filter expressions with partition field references
+   *                         already flattened.
+   * @param partitionFields Partition field metadata.
+   * @return a pair of (created partition predicates, remaining filters not converted).
+   */
+  private[v2] def createPartitionPredicates(
+      flattenedFilters: Seq[Expression],
+      partitionFields: Seq[PartitionPredicateField])
+  : (Seq[PartitionPredicateImpl], Seq[Expression]) = {
+    val partitionAttributes = partitionFields.map(_.attrRef)
+    val (partFilters, nonPartitionFilters) =
+      DataSourceUtils.getPartitionFiltersAndDataFilters(partitionAttributes, flattenedFilters)
+    val (pushable, nonPushable) = partFilters.partition(isPushablePartitionFilter)
+    val (partitionPredicates, errorPartitionPredicates) = pushable.partitionMap { e =>
+      PartitionPredicateImpl(e, partitionFields).toLeft(e)
+    }
+    (partitionPredicates, nonPartitionFilters ++ nonPushable ++ errorPartitionPredicates)
+  }
+
+  /**
    * If the scan supports iterative filtering, infer additional partition filters,
    * convert these and unused partition filters to PartitionPredicates,
    * and push them down in another pass. (See SPARK-55596)
@@ -186,22 +212,15 @@ object PushDownUtils extends Logging {
       scanBuilder: SupportsPushDownV2Filters,
       partitionFields: Seq[PartitionPredicateField],
       remainingFilters: Seq[Expression]): Seq[Expression] = {
-    val normalizedToOriginal = normalizeNestedPartitionFilters(remainingFilters, partitionFields)
-    val normalized = normalizedToOriginal.keys.toSeq
-    val partitionAttributes = partitionFields.map(_.attrRef)
-    // may infer additional partition filters
-    val (partFilters, nonPartitionFilters) =
-      DataSourceUtils.getPartitionFiltersAndDataFilters(partitionAttributes, normalized)
-    val (pushable, nonPushable) = partFilters.partition(isPushablePartitionFilter)
-    val (partitionPredicates, errorPartitionPredicates) = pushable.partitionMap { e =>
-      PartitionPredicateImpl(e, partitionFields).toLeft(e)
-    }
-    val rejectedPartitionFilters = scanBuilder.pushPredicates(partitionPredicates.toArray).map {
+    val flattenedToOriginal = flattenNestedPartitionFilters(remainingFilters, partitionFields)
+    val flattened = flattenedToOriginal.keys.toSeq
+    val (partPredicates, remaining) = createPartitionPredicates(flattened, partitionFields)
+    val rejectedPartitionFilters = scanBuilder.pushPredicates(partPredicates.toArray).map {
       p => p.asInstanceOf[PartitionPredicateImpl].expression
     }.toSeq
-    (nonPartitionFilters ++ nonPushable ++ errorPartitionPredicates ++ rejectedPartitionFilters)
-      .filter(normalizedToOriginal.contains)
-      .map(normalizedToOriginal)
+    (remaining ++ rejectedPartitionFilters)
+      .filter(flattenedToOriginal.contains)
+      .map(flattenedToOriginal)
   }
 
   private def isPushablePartitionFilter(f: Expression) =
@@ -218,9 +237,9 @@ object PushDownUtils extends Logging {
    * (identity transform on a nested field), the analyzer produces
    * `GetStructField(attr("s"), "tz")`. This method replaces that chain with `attr("s.tz")`.
    *
-   * Returns a map from normalized expression to original.
+   * Returns a map from flattened expression to original.
    */
-  private def normalizeNestedPartitionFilters(
+  private[v2] def flattenNestedPartitionFilters(
       filters: Seq[Expression],
       partitionFields: Seq[PartitionPredicateField])
   : Map[Expression, Expression] = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2EnhancedDeleteFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2EnhancedDeleteFilterSuite.scala
@@ -29,7 +29,8 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.util.QueryExecutionListener
 
 /**
- * Tests for metadata-only delete optimization using second-pass PartitionPredicate (see SPARK-55596).
+ * Tests for metadata-only delete optimization using second-pass
+ * PartitionPredicate (see SPARK-55596).
  */
 class DataSourceV2EnhancedDeleteFilterSuite
   extends QueryTest with SharedSparkSession {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2EnhancedDeleteFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2EnhancedDeleteFilterSuite.scala
@@ -1,0 +1,370 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.connector.catalog.InMemoryPartitionPredicateDeleteCatalog
+import org.apache.spark.sql.connector.expressions.PartitionFieldReference
+import org.apache.spark.sql.connector.expressions.filter.PartitionPredicate
+import org.apache.spark.sql.execution.{QueryExecution, SparkPlan}
+import org.apache.spark.sql.execution.datasources.v2.{DeleteFromTableExec, ReplaceDataExec, WriteDeltaExec}
+import org.apache.spark.sql.functions.udf
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.util.QueryExecutionListener
+
+/**
+ * Tests for metadata-only delete optimization using second-pass PartitionPredicate (see SPARK-55596).
+ */
+class DataSourceV2EnhancedDeleteFilterSuite
+  extends QueryTest with SharedSparkSession {
+
+  private val v2Source = classOf[FakeV2ProviderWithCustomSchema].getName
+  private val catalogName = "ppd_cat"
+  private val deleteTableName = s"$catalogName.t"
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(s"spark.sql.catalog.$catalogName",
+      classOf[InMemoryPartitionPredicateDeleteCatalog].getName)
+
+  // '=' on a partition column is accepted by canDeleteWhere in the first pass.
+  test("first pass accepted: partition column filter") {
+    withTable(deleteTableName) {
+      sql(s"CREATE TABLE $deleteTableName (pk INT, dep STRING, salary INT) " +
+        s"USING $v2Source PARTITIONED BY (dep)")
+      sql(s"INSERT INTO $deleteTableName VALUES " +
+        "(1, 'hr', 100), (2, 'hr', 200), (3, 'software', 300)")
+
+      assertDeleteWithFilters(
+        s"DELETE FROM $deleteTableName WHERE dep = 'hr'",
+        expectedNumConditions = 1)
+
+      checkAnswer(
+        sql(s"SELECT * FROM $deleteTableName"),
+        Row(3, "software", 300) :: Nil)
+    }
+  }
+
+  // '=' on a data column is accepted by canDeleteWhere in the first pass
+  // when accept-data-predicates is enabled; row-level filtering applies.
+  test("first pass accepted: data column filter") {
+    withTable(deleteTableName) {
+      sql(s"CREATE TABLE $deleteTableName (pk INT, dep STRING, salary INT) " +
+        s"USING $v2Source PARTITIONED BY (dep) " +
+        "TBLPROPERTIES('accept-data-predicates' = 'true')")
+      sql(s"INSERT INTO $deleteTableName VALUES " +
+        "(1, 'hr', 100), (2, 'hr', 200), (3, 'software', 300)")
+
+      assertDeleteWithFilters(
+        s"DELETE FROM $deleteTableName WHERE salary = 100",
+        expectedNumConditions = 1)
+
+      checkAnswer(
+        sql(s"SELECT * FROM $deleteTableName"),
+        Seq(Row(2, "hr", 200), Row(3, "software", 300)))
+    }
+  }
+
+  // IN is rejected by canDeleteWhere; second pass converts it
+  // to a PartitionPredicate which is accepted.
+  test("first pass rejected, second pass accepted: partition predicate") {
+    withTable(deleteTableName) {
+      sql(s"CREATE TABLE $deleteTableName (pk INT, dep STRING, salary INT) " +
+        s"USING $v2Source PARTITIONED BY (dep)")
+      sql(s"INSERT INTO $deleteTableName VALUES " +
+        "(1, 'hr', 100), (2, 'software', 200), (3, 'marketing', 300)")
+
+      assertDeleteWithFilters(
+        s"DELETE FROM $deleteTableName WHERE dep IN ('hr', 'software')",
+        expectedNumConditions = 1,
+        expectedNumPartitionPredicates = 1,
+        expectedOrdinalsPerPredicate = Seq(Array(0)),
+        expectedPartitionFieldNames = Array("dep"))
+
+      checkAnswer(
+        sql(s"SELECT * FROM $deleteTableName"),
+        Row(3, "marketing", 300) :: Nil)
+    }
+  }
+
+  // STARTS_WITH on partition column rejected in first pass; second pass
+  // creates a PartitionPredicate for it. '=' on data column translates
+  // to V2. Table accepts both (accept-data-predicates=true).
+  test("first pass rejected, second pass accepted: mixed partition + data") {
+    withTable(deleteTableName) {
+      sql(s"CREATE TABLE $deleteTableName (pk INT, dep STRING, salary INT) " +
+        s"USING $v2Source PARTITIONED BY (dep) " +
+        "TBLPROPERTIES('accept-data-predicates' = 'true')")
+      sql(s"INSERT INTO $deleteTableName VALUES " +
+        "(1, 'hr', 100), (2, 'hr', 200), (3, 'software', 300)")
+
+      assertDeleteWithFilters(
+        s"DELETE FROM $deleteTableName " +
+          "WHERE dep LIKE 'h%' AND salary = 100",
+        expectedNumConditions = 2,
+        expectedNumPartitionPredicates = 1,
+        expectedOrdinalsPerPredicate = Seq(Array(0)),
+        expectedPartitionFieldNames = Array("dep"))
+
+      checkAnswer(
+        sql(s"SELECT * FROM $deleteTableName"),
+        Seq(Row(2, "hr", 200), Row(3, "software", 300)))
+    }
+  }
+
+  // UDF referencing non-contiguous partition columns (p0, p2);
+  // untranslatable to V2, wrapped as PartitionPredicate in second pass.
+  test("second pass accepted: UDF on non-contiguous partition columns") {
+    withTable(deleteTableName) {
+      sql(s"CREATE TABLE $deleteTableName " +
+        "(data STRING, p0 STRING, p1 STRING, p2 STRING) " +
+        s"USING $v2Source PARTITIONED BY (p0, p1, p2)")
+      sql(s"INSERT INTO $deleteTableName VALUES " +
+        "('d1', 'a', 'y', 'x'), ('d2', 'b', 'y', 'z'), " +
+        "('d3', 'a', 'z', 'z')")
+
+      spark.udf.register("my_concat",
+        udf((s1: String, s2: String) => s1 + s2))
+
+      assertDeleteWithFilters(
+        s"DELETE FROM $deleteTableName " +
+          "WHERE my_concat(p0, p2) = 'ax'",
+        expectedNumConditions = 1,
+        expectedNumPartitionPredicates = 1,
+        expectedOrdinalsPerPredicate = Seq(Array(0, 2)),
+        expectedPartitionFieldNames = Array("p0", "p1", "p2"))
+
+      checkAnswer(
+        sql(s"SELECT * FROM $deleteTableName"),
+        Seq(Row("d2", "b", "y", "z"),
+          Row("d3", "a", "z", "z")))
+    }
+  }
+
+  // Two separate partition filters on different columns (p0, p2) each
+  // become their own PartitionPredicate; ordinals [0] and [2].
+  test("second pass accepted: multiple PartitionPredicates") {
+    withTable(deleteTableName) {
+      sql(s"CREATE TABLE $deleteTableName " +
+        "(data STRING, p0 STRING, p1 STRING, p2 STRING) " +
+        s"USING $v2Source PARTITIONED BY (p0, p1, p2)")
+      sql(s"INSERT INTO $deleteTableName VALUES " +
+        "('d1', 'a', 'y', 'x'), ('d2', 'b', 'y', 'z'), " +
+        "('d3', 'a', 'z', 'z')")
+
+      assertDeleteWithFilters(
+        s"DELETE FROM $deleteTableName " +
+          "WHERE p0 IN ('a', 'b') AND p2 LIKE 'x%'",
+        expectedNumConditions = 2,
+        expectedNumPartitionPredicates = 2,
+        expectedOrdinalsPerPredicate =
+          Seq(Array(0), Array(2)),
+        expectedPartitionFieldNames =
+          Array("p0", "p1", "p2"))
+
+      checkAnswer(
+        sql(s"SELECT * FROM $deleteTableName"),
+        Seq(Row("d2", "b", "y", "z"),
+          Row("d3", "a", "z", "z")))
+    }
+  }
+
+  // Table property disables PartitionPredicate acceptance;
+  // both passes rejected, falls back to row-level operation.
+  test("first and second pass rejected: table rejects all") {
+    withTable(deleteTableName) {
+      sql(s"CREATE TABLE $deleteTableName (pk INT, dep STRING, salary INT) " +
+        s"USING $v2Source PARTITIONED BY (dep) " +
+        "TBLPROPERTIES('accept-partition-predicates' = 'false')")
+      sql(s"INSERT INTO $deleteTableName VALUES " +
+        "(1, 'hr', 100), (2, 'software', 200), (3, 'marketing', 300)")
+
+      assertDeleteWithRowLevel(
+        s"DELETE FROM $deleteTableName WHERE dep IN ('hr', 'software')")
+
+      checkAnswer(
+        sql(s"SELECT * FROM $deleteTableName"),
+        Row(3, "marketing", 300) :: Nil)
+    }
+  }
+
+  // First pass fails because table configured to reject data-column predicate.
+  // Second pass skipped because no partition predicates can be created from a data filter
+  // and the table configured to reject data filters.
+  test("second pass skipped: data-only filter") {
+    withTable(deleteTableName) {
+      sql(s"CREATE TABLE $deleteTableName (pk INT, dep STRING, salary INT) " +
+        s"USING $v2Source PARTITIONED BY (dep)")
+      sql(s"INSERT INTO $deleteTableName VALUES " +
+        "(1, 'hr', 100), (2, 'hr', 200), (3, 'software', 300)")
+
+      assertDeleteWithRowLevel(
+        s"DELETE FROM $deleteTableName WHERE salary = 100")
+
+      checkAnswer(
+        sql(s"SELECT * FROM $deleteTableName"),
+        Seq(Row(2, "hr", 200), Row(3, "software", 300)))
+    }
+  }
+
+  // Partition predicate created for IN, but remaining data filter
+  // causes canDeleteWhere to reject the combined predicates;
+  // falls back to row-level operation.
+  test("second pass rejected: successful partition predicate but rejected data filter") {
+    withTable(deleteTableName) {
+      sql(s"CREATE TABLE $deleteTableName (pk INT, dep STRING, salary INT) " +
+        s"USING $v2Source PARTITIONED BY (dep)")
+      sql(s"INSERT INTO $deleteTableName VALUES " +
+        "(1, 'hr', 100), (2, 'hr', 200), (3, 'software', 300)")
+
+      assertDeleteWithRowLevel(
+        s"DELETE FROM $deleteTableName WHERE dep IN ('hr') AND salary = 100")
+
+      checkAnswer(
+        sql(s"SELECT * FROM $deleteTableName"),
+        Seq(Row(2, "hr", 200), Row(3, "software", 300)))
+    }
+  }
+
+  private def executeAndKeepPlan(func: => Unit): SparkPlan = {
+    var executedPlan: SparkPlan = null
+
+    val listener = new QueryExecutionListener {
+      override def onSuccess(
+          funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
+        executedPlan = qe.executedPlan
+      }
+      override def onFailure(
+          funcName: String, qe: QueryExecution, exception: Exception): Unit = {}
+    }
+    spark.listenerManager.register(listener)
+
+    try {
+      func
+      sparkContext.listenerBus.waitUntilEmpty()
+    } finally {
+      spark.listenerManager.unregister(listener)
+    }
+
+    assert(executedPlan != null,
+      "QueryExecutionListener did not capture the executed plan")
+    executedPlan
+  }
+
+  /**
+   * @param expectedOrdinalsPerPredicate one entry per expected
+   *   PartitionPredicate, each listing the ordinals that predicate
+   *   should reference, in the order they appear in the plan.
+   */
+  private def assertDeleteWithFilters(
+      query: String,
+      expectedNumConditions: Int,
+      expectedNumPartitionPredicates: Int = 0,
+      expectedOrdinalsPerPredicate: Seq[Array[Int]] = Seq.empty,
+      expectedPartitionFieldNames: Array[String] = Array.empty
+  ): Unit = {
+    val plan = executeAndKeepPlan { sql(query) }
+    val exec = plan match {
+      case d: DeleteFromTableExec => d
+      case other =>
+        fail("Expected DeleteFromTableExec but got: " +
+          other.getClass.getSimpleName)
+    }
+    val conds = exec.condition
+    assert(conds.length === expectedNumConditions,
+      s"Expected $expectedNumConditions condition(s), " +
+        s"got ${conds.length}: " +
+        conds.mkString("[", ", ", "]"))
+
+    val partPreds = conds.collect {
+      case p: PartitionPredicate => p
+    }
+    assert(partPreds.length === expectedNumPartitionPredicates,
+      s"Expected $expectedNumPartitionPredicates " +
+        s"PartitionPredicate(s), got ${partPreds.length}: " +
+        conds.mkString("[", ", ", "]"))
+
+    if (partPreds.nonEmpty && partPreds.length < conds.length) {
+      val lastPartIdx = conds.lastIndexWhere(
+        _.isInstanceOf[PartitionPredicate])
+      val firstNonPartIdx = conds.indexWhere(
+        c => !c.isInstanceOf[PartitionPredicate])
+      assert(lastPartIdx < firstNonPartIdx,
+        "PartitionPredicates should precede non-partition " +
+          "predicates: " + conds.mkString("[", ", ", "]"))
+    }
+
+    assertPartitionFieldReferences(
+      partPreds, expectedOrdinalsPerPredicate,
+      expectedPartitionFieldNames)
+  }
+
+  private def assertPartitionFieldReferences(
+      partPreds: Array[PartitionPredicate],
+      expectedOrdinalsPerPredicate: Seq[Array[Int]],
+      expectedPartitionFieldNames: Array[String]): Unit = {
+    if (expectedOrdinalsPerPredicate.isEmpty) return
+    val names = expectedPartitionFieldNames
+
+    assert(partPreds.length === expectedOrdinalsPerPredicate.size,
+      s"Predicate count ${partPreds.length} != " +
+        s"expected ${expectedOrdinalsPerPredicate.size}")
+
+    partPreds.zip(expectedOrdinalsPerPredicate).foreach {
+      case (p, expectedOrdinals) =>
+        val refs = p.references()
+        val ordinals = refs.map(
+          _.asInstanceOf[PartitionFieldReference].ordinal()).sorted
+        assert(
+          ordinals.sameElements(expectedOrdinals.sorted),
+          s"Expected ordinals " +
+            expectedOrdinals.sorted.mkString("[", ", ", "]") +
+            s", got ${ordinals.mkString("[", ", ", "]")}")
+
+        refs.foreach { ref =>
+          assert(ref.isInstanceOf[PartitionFieldReference],
+            "Expected PartitionFieldReference, " +
+              s"got ${ref.getClass.getName}")
+          val partRef =
+            ref.asInstanceOf[PartitionFieldReference]
+          assert(partRef.fieldNames().nonEmpty,
+            s"ordinal=${partRef.ordinal()} " +
+              "has empty fieldNames")
+          assert(partRef.ordinal() < names.length,
+            s"ordinal=${partRef.ordinal()} out of range " +
+              s"for ${names.length} field name(s)")
+          val expected = names(partRef.ordinal())
+          val actual = partRef.fieldNames().mkString(".")
+          assert(actual === expected,
+            s"ordinal=${partRef.ordinal()}: expected " +
+              s"'$expected', got '$actual'")
+        }
+    }
+  }
+
+  private def assertDeleteWithRowLevel(query: String): Unit = {
+    val plan = executeAndKeepPlan { sql(query) }
+    plan match {
+      case _: ReplaceDataExec => // expected
+      case _: WriteDeltaExec => // expected
+      case other =>
+        fail("Expected ReplaceDataExec or WriteDeltaExec " +
+          s"but got: ${other.getClass.getSimpleName}")
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

When `OptimizeMetadataOnlyDeleteFromTable` fails to translate all delete predicates to standard V2 filters, it now falls back to a second pass that converts partition-column filters to `PartitionPredicate`s (reusing the SPARK-55596 infrastructure), translates any remaining data-column filters to standard V2 predicates, and combines them for `table.canDeleteWhere`. This mirrors the two-pass approach already used for scan filter pushdown in `PushDownUtils.pushPartitionPredicates`.

### Why are the changes needed?

Currently, `OptimizeMetadataOnlyDeleteFromTable` only attempts to translate all delete predicates to standard V2 filters. If any predicate cannot be translated (e.g. complex expressions on partition columns), the optimization falls back to an expensive row-level delete even though the table could accept the predicates as `PartitionPredicate`s. This change enables the metadata-only delete path in more cases by leveraging the `PartitionPredicate` infrastructure introduced in SPARK-55596.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New test suite `DataSourceV2EnhancedDeleteFilterSuite` with 9 test cases covering: first-pass accept, second-pass accept/reject, mixed partition+data filters, UDF on non-contiguous partition columns, multiple PartitionPredicates, and row-level fallback. Existing suites verified for no regressions: `DataSourceV2EnhancedPartitionFilterSuite`, `GroupBasedDeleteFromTableSuite`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Cursor agent mode)