### PR TITLE
[SPARK-56347][TEST] Fix TOCTOU race in DockerJDBCIntegrationSuite port allocation

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.net.ServerSocket
 import java.sql.{Connection, DriverManager}
 import java.util.Properties
 import java.util.concurrent.TimeUnit
@@ -120,12 +119,7 @@ abstract class DockerJDBCIntegrationSuite
 
   private var docker: DockerClient = _
   // Configure networking (necessary for boot2docker / Docker Machine)
-  protected lazy val externalPort: Int = {
-    val sock = new ServerSocket(0)
-    val port = sock.getLocalPort
-    sock.close()
-    port
-  }
+  protected var externalPort: Int = -1
   private var container: CreateContainerResponse = _
   private var pulled: Boolean = false
   protected var jdbcUrl: String = _
@@ -181,7 +175,7 @@ abstract class DockerJDBCIntegrationSuite
         .newHostConfig()
         .withNetworkMode("bridge")
         .withPrivileged(db.privileged)
-        .withPortBindings(PortBinding.parse(s"$externalPort:${db.jdbcPort}"))
+        .withPortBindings(PortBinding.parse(s"0:${db.jdbcPort}"))
 
       if (db.usesIpc) {
         hostConfig.withIpcMode("host")
@@ -209,6 +203,10 @@ abstract class DockerJDBCIntegrationSuite
         val response = docker.inspectContainerCmd(container.getId).exec()
         assert(response.getState.getRunning)
       }
+      // Resolve the actual port assigned by Docker to avoid TOCTOU race conditions
+      externalPort = docker.inspectContainerCmd(container.getId).exec()
+        .getNetworkSettings.getPorts.getBindings
+        .get(ExposedPort.tcp(db.jdbcPort)).head.getHostPortSpec.toInt
       jdbcUrl = db.getJdbcUrl(dockerIp, externalPort)
       sleepBeforeTesting()
       var conn: Connection = null

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
@@ -125,7 +125,6 @@ abstract class DockerJDBCIntegrationSuite
   protected var jdbcUrl: String = _
 
   override def beforeAll(): Unit = runIfTestsEnabled(s"Prepare for ${this.getClass.getName}") {
-    super.beforeAll()
     try {
       val config = DefaultDockerClientConfig.createDefaultConfigBuilder.build
       val httpClient = new ZerodepDockerHttpClient.Builder()
@@ -207,6 +206,8 @@ abstract class DockerJDBCIntegrationSuite
       externalPort = docker.inspectContainerCmd(container.getId).exec()
         .getNetworkSettings.getPorts.getBindings
         .get(ExposedPort.tcp(db.jdbcPort)).head.getHostPortSpec.toInt
+      // Initialize SparkSession after port is known so sparkConf can read the correct url
+      super.beforeAll()
       jdbcUrl = db.getJdbcUrl(dockerIp, externalPort)
       sleepBeforeTesting()
       var conn: Connection = null

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2NamespaceSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2NamespaceSuite.scala
@@ -38,7 +38,7 @@ import org.apache.spark.tags.DockerTest
 @DockerTest
 class DB2NamespaceSuite extends DockerJDBCIntegrationSuite with V2JDBCNamespaceTest {
   override val db = new DB2DatabaseOnDocker
-  val map = new CaseInsensitiveStringMap(
+  lazy val map = new CaseInsensitiveStringMap(
     Map("url" -> db.getJdbcUrl(dockerIp, externalPort),
       "driver" -> "com.ibm.db2.jcc.DB2Driver").asJava)
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerNamespaceSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerNamespaceSuite.scala
@@ -36,11 +36,14 @@ import org.apache.spark.tags.DockerTest
 @DockerTest
 class MsSqlServerNamespaceSuite extends DockerJDBCIntegrationSuite with V2JDBCNamespaceTest {
   override val db = new MsSQLServerDatabaseOnDocker
-  val map = new CaseInsensitiveStringMap(
+  lazy val map = new CaseInsensitiveStringMap(
     Map("url" -> db.getJdbcUrl(dockerIp, externalPort),
       "driver" -> "com.microsoft.sqlserver.jdbc.SQLServerDriver").asJava)
 
-  catalog.initialize("mssql", map)
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    catalog.initialize("mssql", map)
+  }
 
   override def dataPreparation(conn: Connection): Unit = {}
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLNamespaceSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLNamespaceSuite.scala
@@ -38,11 +38,14 @@ import org.apache.spark.tags.DockerTest
 class MySQLNamespaceSuite extends DockerJDBCIntegrationSuite with V2JDBCNamespaceTest {
   override val db = new MySQLDatabaseOnDocker
 
-  val map = new CaseInsensitiveStringMap(
+  lazy val map = new CaseInsensitiveStringMap(
     Map("url" -> db.getJdbcUrl(dockerIp, externalPort),
       "driver" -> "com.mysql.cj.jdbc.Driver").asJava)
 
-  catalog.initialize("mysql", map)
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    catalog.initialize("mysql", map)
+  }
 
   override def dataPreparation(conn: Connection): Unit = {}
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleNamespaceSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleNamespaceSuite.scala
@@ -59,11 +59,14 @@ class OracleNamespaceSuite extends DockerJDBCIntegrationSuite with V2JDBCNamespa
 
   override val db = new OracleDatabaseOnDocker
 
-  val map = new CaseInsensitiveStringMap(
+  lazy val map = new CaseInsensitiveStringMap(
     Map("url" -> db.getJdbcUrl(dockerIp, externalPort),
       "driver" -> "oracle.jdbc.OracleDriver").asJava)
 
-  catalog.initialize("system", map)
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    catalog.initialize("system", map)
+  }
 
   override def dataPreparation(conn: Connection): Unit = {}
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresNamespaceSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresNamespaceSuite.scala
@@ -36,11 +36,14 @@ import org.apache.spark.tags.DockerTest
 class PostgresNamespaceSuite extends DockerJDBCIntegrationSuite with V2JDBCNamespaceTest {
   override val db = new PostgresDatabaseOnDocker
 
-  val map = new CaseInsensitiveStringMap(
+  lazy val map = new CaseInsensitiveStringMap(
     Map("url" -> db.getJdbcUrl(dockerIp, externalPort),
       "driver" -> "org.postgresql.Driver").asJava)
 
-  catalog.initialize("postgresql", map)
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    catalog.initialize("postgresql", map)
+  }
 
   override def dataPreparation(conn: Connection): Unit = {}
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/join/MsSqlServerJoinPushdownIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/join/MsSqlServerJoinPushdownIntegrationSuite.scala
@@ -38,7 +38,7 @@ class MsSqlServerJoinPushdownIntegrationSuite
     with JDBCV2JoinPushdownIntegrationSuiteBase {
   override val db = new MsSQLServerDatabaseOnDocker
 
-  override val url = db.getJdbcUrl(dockerIp, externalPort)
+  override lazy val url = db.getJdbcUrl(dockerIp, externalPort)
 
   override val jdbcDialect: JdbcDialect = MsSqlServerDialect()
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/join/MySQLJoinPushdownIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/join/MySQLJoinPushdownIntegrationSuite.scala
@@ -37,7 +37,7 @@ class MySQLJoinPushdownIntegrationSuite
     with JDBCV2JoinPushdownIntegrationSuiteBase {
   override val db = new MySQLDatabaseOnDocker
 
-  override val url = db.getJdbcUrl(dockerIp, externalPort)
+  override lazy val url = db.getJdbcUrl(dockerIp, externalPort)
 
   override val jdbcDialect: JdbcDialect = MySQLDialect()
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/join/OracleJoinPushdownIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/join/OracleJoinPushdownIntegrationSuite.scala
@@ -70,7 +70,7 @@ class OracleJoinPushdownIntegrationSuite
 
   override val db = new OracleDatabaseOnDocker
 
-  override val url = db.getJdbcUrl(dockerIp, externalPort)
+  override lazy val url = db.getJdbcUrl(dockerIp, externalPort)
 
   override val jdbcDialect: JdbcDialect = OracleDialect()
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/join/PostgresJoinPushdownIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/join/PostgresJoinPushdownIntegrationSuite.scala
@@ -36,7 +36,7 @@ class PostgresJoinPushdownIntegrationSuite
     with JDBCV2JoinPushdownIntegrationSuiteBase {
   override val db = new PostgresDatabaseOnDocker
 
-  override val url = db.getJdbcUrl(dockerIp, externalPort)
+  override lazy val url = db.getJdbcUrl(dockerIp, externalPort)
 
   override val jdbcDialect: JdbcDialect = PostgresDialect()
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Docker integration tests fail in CI when running multiple >20 instances of same test on same machine. The suite aborts in `beforeAll` with `address already in use` before any test executes.

Root cause is a TOCTOU race: `ServerSocket(0)` finds a free port, closes the socket, then passes the port to Docker later. Between close and Docker bind, another parallel test grabs the same port.

- Use Docker port 0 (auto-assign) instead of pre-allocating via `ServerSocket(0)`, eliminating the TOCTOU entirely
- Resolve the actual Docker-assigned port after container startup via `resolvedMappedPort` / `inspectContainer`
- Change `port` declarations from `val` to `def` in test base traits and subclasses so they read the resolved port at access time

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Avoiding flakiness in tests.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
The change is test itself.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes.