### PR TITLE
[SPARK-55969][SQL][3.5][FOLLOW-UP][TESTS] Update `SQLQueryTestSuite` golden files

### DIFF
--- a/sql/core/src/test/resources/sql-tests/analyzer-results/linear-regression.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/linear-regression.sql.out
@@ -415,7 +415,7 @@ SELECT regr_r2(k, x) FROM testRegression where k=2
 Aggregate [regr_r2(cast(k#x as double), cast(x#x as double)) AS regr_r2(k, x)#x]
 +- Filter (k#x = 2)
    +- SubqueryAlias testregression
-      +- View (`testRegression`, [k#x, y#x, x#x])
+      +- View (`testRegression`, [k#x,y#x,x#x])
          +- Project [cast(k#x as int) AS k#x, cast(y#x as int) AS y#x, cast(x#x as int) AS x#x]
             +- Project [k#x, y#x, x#x]
                +- SubqueryAlias testRegression
@@ -428,7 +428,7 @@ SELECT regr_r2(y, k) FROM testRegression where k=2
 Aggregate [regr_r2(cast(y#x as double), cast(k#x as double)) AS regr_r2(y, k)#x]
 +- Filter (k#x = 2)
    +- SubqueryAlias testregression
-      +- View (`testRegression`, [k#x, y#x, x#x])
+      +- View (`testRegression`, [k#x,y#x,x#x])
          +- Project [cast(k#x as int) AS k#x, cast(y#x as int) AS y#x, cast(x#x as int) AS x#x]
             +- Project [k#x, y#x, x#x]
                +- SubqueryAlias testRegression


### PR DESCRIPTION
### What changes were proposed in this pull request?

Regenerate related golden files after https://github.com/apache/spark/pull/54901.

### Why are the changes needed?

3.5 PRs (like https://github.com/apache/spark/pull/55167) currently fail with:
```
[info] - linear-regression.sql_analyzer_test *** FAILED *** (142 milliseconds)
[info]   linear-regression.sql_analyzer_test
[info]   Expected "...stRegression`, [k#x,[ y#x, ]x#x])
[info]            +- Pr...", but got "...stRegression`, [k#x,[y#x,]x#x])
[info]            +- Pr..." Result did not match for query #33
[info]   SELECT regr_r2(k, x) FROM testRegression where k=2 (SQLQueryTestSuite.scala:876)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.