### PR TITLE
[SPARK-56355][SQL] Improve join stats estimation when equi-join keys lack column statistics

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/JoinEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/JoinEstimation.scala
@@ -173,6 +173,12 @@ case class JoinEstimation(join: Join) extends Logging {
    * estimated by ndv of join key A.k1 and B.k1, card2 is the cardinality estimated by histograms
    * of join key A.k2 and B.k2, then the result cardinality would be min(card1, card2).
    *
+   * When equi-join keys exist but lack column statistics (e.g. under AQE where ExchangeQueryStageExec
+   * only provides sizeInBytes and rowCount), falling back to a cartesian product T(A) * T(B) would
+   * significantly overestimate the result size. In this case we assume V(A.k) ~= T(A) and
+   * V(B.k) ~= T(B) (i.e. join keys are approximately unique on each side), and use max(T(A), T(B))
+   * as a reasonable conservative estimate of the result cardinality.
+   *
    * @param keyPairs pairs of join keys
    *
    * @return join cardinality, and column stats for join keys after the join
@@ -182,7 +188,12 @@ case class JoinEstimation(join: Join) extends Logging {
       keyPairs: Seq[(AttributeReference, AttributeReference)],
       leftSideUniqueness: Boolean,
       rightSideUniqueness: Boolean): (BigInt, AttributeMap[ColumnStat]) = {
-    // If there's no column stats available for join keys, estimate as cartesian product.
+    if (keyPairs.isEmpty) {
+      // No column stats available for join keys. Use max(T(A), T(B)) instead of the
+      // cartesian product T(A) * T(B), which would otherwise cause severe overestimation
+      // in downstream joins and aggregations.
+      return (leftStats.rowCount.get.max(rightStats.rowCount.get), AttributeMap.empty)
+    }
     var joinCard: BigInt = (leftSideUniqueness, rightSideUniqueness) match {
       case (true, true) => leftStats.rowCount.get.min(rightStats.rowCount.get)
       case (true, false) => rightStats.rowCount.get

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/BasicStatsEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/BasicStatsEstimationSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.analysis.ResolvedNamespace
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeMap, AttributeReference, Literal, SortOrder}
-import org.apache.spark.sql.catalyst.plans.{Inner, PlanTest}
+import org.apache.spark.sql.catalyst.plans.{Inner, LeftOuter, PlanTest}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.connector.catalog.SupportsNamespaces
 import org.apache.spark.sql.internal.SQLConf
@@ -376,6 +376,40 @@ test("range with invalid long value") {
       join,
       expectedStatsCboOn = Statistics(4871880, Some(tableRowCnt), join.stats.attributeStats),
       expectedStatsCboOff = Statistics(sizeInBytes = 4059900 * 2))
+  }
+
+  test("SPARK-56355: equi-join estimation without column stats should not use cartesian product") {
+    val leftKey = attr("left_key")
+    val rightKey = attr("right_key")
+
+    val leftRowCount = 1000
+    val rightRowCount = 500
+    val leftSize = leftRowCount * (8 + 4)
+    val rightSize = rightRowCount * (8 + 4)
+
+    val left = StatsTestPlan(
+      outputList = Seq(leftKey),
+      rowCount = leftRowCount,
+      attributeStats = AttributeMap(Nil),
+      size = Some(leftSize))
+
+    val right = StatsTestPlan(
+      outputList = Seq(rightKey),
+      rowCount = rightRowCount,
+      attributeStats = AttributeMap(Nil),
+      size = Some(rightSize))
+
+    val expectedOutputRows = leftRowCount
+    val expectedSizeInBytes = expectedOutputRows * (8 + 4 + 4)
+
+    Seq(Inner, LeftOuter).foreach { joinType =>
+      val join = Join(left, right, joinType, Some(leftKey === rightKey), JoinHint.NONE)
+
+      checkStats(
+        join,
+        expectedStatsCboOn = Statistics(expectedSizeInBytes, Some(expectedOutputRows)),
+        expectedStatsCboOff = Statistics(leftSize * rightSize))
+    }
   }
 
   test("row size and column stats estimation for sort") {

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/explain.txt
@@ -7,329 +7,332 @@
             +- Exchange (44)
                +- * HashAggregate (43)
                   +- * Project (42)
-                     +- * BroadcastHashJoin Inner BuildRight (41)
-                        :- * Project (29)
-                        :  +- * SortMergeJoin Inner (28)
-                        :     :- * Sort (21)
-                        :     :  +- Exchange (20)
-                        :     :     +- * Project (19)
-                        :     :        +- * SortMergeJoin Inner (18)
-                        :     :           :- * Sort (12)
-                        :     :           :  +- Exchange (11)
-                        :     :           :     +- * Project (10)
-                        :     :           :        +- * BroadcastHashJoin Inner BuildRight (9)
-                        :     :           :           :- * Project (4)
-                        :     :           :           :  +- * Filter (3)
-                        :     :           :           :     +- * ColumnarToRow (2)
-                        :     :           :           :        +- Scan parquet spark_catalog.default.store_sales (1)
-                        :     :           :           +- BroadcastExchange (8)
-                        :     :           :              +- * Filter (7)
-                        :     :           :                 +- * ColumnarToRow (6)
-                        :     :           :                    +- Scan parquet spark_catalog.default.item (5)
-                        :     :           +- * Sort (17)
-                        :     :              +- Exchange (16)
-                        :     :                 +- * Filter (15)
-                        :     :                    +- * ColumnarToRow (14)
-                        :     :                       +- Scan parquet spark_catalog.default.customer (13)
-                        :     +- * Sort (27)
-                        :        +- Exchange (26)
-                        :           +- * Project (25)
-                        :              +- * Filter (24)
-                        :                 +- * ColumnarToRow (23)
-                        :                    +- Scan parquet spark_catalog.default.store_returns (22)
-                        +- BroadcastExchange (40)
-                           +- * Project (39)
-                              +- * BroadcastHashJoin Inner BuildLeft (38)
-                                 :- BroadcastExchange (34)
-                                 :  +- * Project (33)
-                                 :     +- * Filter (32)
-                                 :        +- * ColumnarToRow (31)
-                                 :           +- Scan parquet spark_catalog.default.store (30)
+                     +- * SortMergeJoin Inner (41)
+                        :- * Sort (34)
+                        :  +- Exchange (33)
+                        :     +- * Project (32)
+                        :        +- * SortMergeJoin Inner (31)
+                        :           :- * Sort (18)
+                        :           :  +- Exchange (17)
+                        :           :     +- * Project (16)
+                        :           :        +- * BroadcastHashJoin Inner BuildLeft (15)
+                        :           :           :- BroadcastExchange (11)
+                        :           :           :  +- * Project (10)
+                        :           :           :     +- * BroadcastHashJoin Inner BuildLeft (9)
+                        :           :           :        :- BroadcastExchange (5)
+                        :           :           :        :  +- * Project (4)
+                        :           :           :        :     +- * Filter (3)
+                        :           :           :        :        +- * ColumnarToRow (2)
+                        :           :           :        :           +- Scan parquet spark_catalog.default.store (1)
+                        :           :           :        +- * Filter (8)
+                        :           :           :           +- * ColumnarToRow (7)
+                        :           :           :              +- Scan parquet spark_catalog.default.customer_address (6)
+                        :           :           +- * Filter (14)
+                        :           :              +- * ColumnarToRow (13)
+                        :           :                 +- Scan parquet spark_catalog.default.customer (12)
+                        :           +- * Sort (30)
+                        :              +- Exchange (29)
+                        :                 +- * Project (28)
+                        :                    +- * BroadcastHashJoin Inner BuildRight (27)
+                        :                       :- * Project (22)
+                        :                       :  +- * Filter (21)
+                        :                       :     +- * ColumnarToRow (20)
+                        :                       :        +- Scan parquet spark_catalog.default.store_sales (19)
+                        :                       +- BroadcastExchange (26)
+                        :                          +- * Filter (25)
+                        :                             +- * ColumnarToRow (24)
+                        :                                +- Scan parquet spark_catalog.default.item (23)
+                        +- * Sort (40)
+                           +- Exchange (39)
+                              +- * Project (38)
                                  +- * Filter (37)
                                     +- * ColumnarToRow (36)
-                                       +- Scan parquet spark_catalog.default.customer_address (35)
+                                       +- Scan parquet spark_catalog.default.store_returns (35)
 
 
-(1) Scan parquet spark_catalog.default.store_sales
-Output [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store_sales]
-PushedFilters: [IsNotNull(ss_ticket_number), IsNotNull(ss_item_sk), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk)]
-ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_net_paid:decimal(7,2)>
-
-(2) ColumnarToRow [codegen id : 2]
-Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
-
-(3) Filter [codegen id : 2]
-Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
-Condition : ((((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#1], xxhash64(ss_store_sk#3, 42)))
-
-(4) Project [codegen id : 2]
-Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5]
-Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
-
-(5) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#8, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_color), EqualTo(i_color,pale                ), IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
-
-(6) ColumnarToRow [codegen id : 1]
-Input [6]: [i_item_sk#8, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
-
-(7) Filter [codegen id : 1]
-Input [6]: [i_item_sk#8, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
-Condition : ((isnotnull(i_color#11) AND (i_color#11 = pale                )) AND isnotnull(i_item_sk#8))
-
-(8) BroadcastExchange
-Input [6]: [i_item_sk#8, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
-
-(9) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#8]
-Join type: Inner
-Join condition: None
-
-(10) Project [codegen id : 2]
-Output [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
-Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_item_sk#8, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
-
-(11) Exchange
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
-Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(12) Sort [codegen id : 3]
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
-Arguments: [ss_customer_sk#2 ASC NULLS FIRST], false, 0
-
-(13) Scan parquet spark_catalog.default.customer
-Output [4]: [c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_birth_country)]
-ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string,c_birth_country:string>
-
-(14) ColumnarToRow [codegen id : 4]
-Input [4]: [c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
-
-(15) Filter [codegen id : 4]
-Input [4]: [c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
-Condition : (isnotnull(c_customer_sk#14) AND isnotnull(c_birth_country#17))
-
-(16) Exchange
-Input [4]: [c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
-Arguments: hashpartitioning(c_customer_sk#14, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(17) Sort [codegen id : 5]
-Input [4]: [c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
-Arguments: [c_customer_sk#14 ASC NULLS FIRST], false, 0
-
-(18) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_customer_sk#2]
-Right keys [1]: [c_customer_sk#14]
-Join type: Inner
-Join condition: None
-
-(19) Project [codegen id : 6]
-Output [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17]
-Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
-
-(20) Exchange
-Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17]
-Arguments: hashpartitioning(ss_ticket_number#4, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(21) Sort [codegen id : 7]
-Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17]
-Arguments: [ss_ticket_number#4 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST], false, 0
-
-(22) Scan parquet spark_catalog.default.store_returns
-Output [3]: [sr_item_sk#18, sr_ticket_number#19, sr_returned_date_sk#20]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store_returns]
-PushedFilters: [IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
-ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int>
-
-(23) ColumnarToRow [codegen id : 8]
-Input [3]: [sr_item_sk#18, sr_ticket_number#19, sr_returned_date_sk#20]
-
-(24) Filter [codegen id : 8]
-Input [3]: [sr_item_sk#18, sr_ticket_number#19, sr_returned_date_sk#20]
-Condition : (isnotnull(sr_ticket_number#19) AND isnotnull(sr_item_sk#18))
-
-(25) Project [codegen id : 8]
-Output [2]: [sr_item_sk#18, sr_ticket_number#19]
-Input [3]: [sr_item_sk#18, sr_ticket_number#19, sr_returned_date_sk#20]
-
-(26) Exchange
-Input [2]: [sr_item_sk#18, sr_ticket_number#19]
-Arguments: hashpartitioning(sr_ticket_number#19, sr_item_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(27) Sort [codegen id : 9]
-Input [2]: [sr_item_sk#18, sr_ticket_number#19]
-Arguments: [sr_ticket_number#19 ASC NULLS FIRST, sr_item_sk#18 ASC NULLS FIRST], false, 0
-
-(28) SortMergeJoin [codegen id : 12]
-Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
-Right keys [2]: [sr_ticket_number#19, sr_item_sk#18]
-Join type: Inner
-Join condition: None
-
-(29) Project [codegen id : 12]
-Output [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17]
-Input [14]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17, sr_item_sk#18, sr_ticket_number#19]
-
-(30) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#21, s_store_name#22, s_market_id#23, s_state#24, s_zip#25]
+(1) Scan parquet spark_catalog.default.store
+Output [5]: [s_store_sk#1, s_store_name#2, s_market_id#3, s_state#4, s_zip#5]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
 
-(31) ColumnarToRow [codegen id : 10]
-Input [5]: [s_store_sk#21, s_store_name#22, s_market_id#23, s_state#24, s_zip#25]
+(2) ColumnarToRow [codegen id : 1]
+Input [5]: [s_store_sk#1, s_store_name#2, s_market_id#3, s_state#4, s_zip#5]
 
-(32) Filter [codegen id : 10]
-Input [5]: [s_store_sk#21, s_store_name#22, s_market_id#23, s_state#24, s_zip#25]
-Condition : (((isnotnull(s_market_id#23) AND (s_market_id#23 = 8)) AND isnotnull(s_store_sk#21)) AND isnotnull(s_zip#25))
+(3) Filter [codegen id : 1]
+Input [5]: [s_store_sk#1, s_store_name#2, s_market_id#3, s_state#4, s_zip#5]
+Condition : (((isnotnull(s_market_id#3) AND (s_market_id#3 = 8)) AND isnotnull(s_store_sk#1)) AND isnotnull(s_zip#5))
 
-(33) Project [codegen id : 10]
-Output [4]: [s_store_sk#21, s_store_name#22, s_state#24, s_zip#25]
-Input [5]: [s_store_sk#21, s_store_name#22, s_market_id#23, s_state#24, s_zip#25]
+(4) Project [codegen id : 1]
+Output [4]: [s_store_sk#1, s_store_name#2, s_state#4, s_zip#5]
+Input [5]: [s_store_sk#1, s_store_name#2, s_market_id#3, s_state#4, s_zip#5]
 
-(34) BroadcastExchange
-Input [4]: [s_store_sk#21, s_store_name#22, s_state#24, s_zip#25]
-Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=7]
+(5) BroadcastExchange
+Input [4]: [s_store_sk#1, s_store_name#2, s_state#4, s_zip#5]
+Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=1]
 
-(35) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#26, ca_zip#27, ca_country#28]
+(6) Scan parquet spark_catalog.default.customer_address
+Output [3]: [ca_state#6, ca_zip#7, ca_country#8]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
-(36) ColumnarToRow
-Input [3]: [ca_state#26, ca_zip#27, ca_country#28]
+(7) ColumnarToRow
+Input [3]: [ca_state#6, ca_zip#7, ca_country#8]
 
-(37) Filter
-Input [3]: [ca_state#26, ca_zip#27, ca_country#28]
-Condition : (isnotnull(ca_country#28) AND isnotnull(ca_zip#27))
+(8) Filter
+Input [3]: [ca_state#6, ca_zip#7, ca_country#8]
+Condition : (isnotnull(ca_country#8) AND isnotnull(ca_zip#7))
 
-(38) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [s_zip#25]
-Right keys [1]: [ca_zip#27]
+(9) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [s_zip#5]
+Right keys [1]: [ca_zip#7]
 Join type: Inner
 Join condition: None
 
-(39) Project [codegen id : 11]
-Output [5]: [s_store_sk#21, s_store_name#22, s_state#24, ca_state#26, ca_country#28]
-Input [7]: [s_store_sk#21, s_store_name#22, s_state#24, s_zip#25, ca_state#26, ca_zip#27, ca_country#28]
+(10) Project [codegen id : 2]
+Output [5]: [s_store_sk#1, s_store_name#2, s_state#4, ca_state#6, ca_country#8]
+Input [7]: [s_store_sk#1, s_store_name#2, s_state#4, s_zip#5, ca_state#6, ca_zip#7, ca_country#8]
 
-(40) BroadcastExchange
-Input [5]: [s_store_sk#21, s_store_name#22, s_state#24, ca_state#26, ca_country#28]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, string, true])),false), [plan_id=8]
+(11) BroadcastExchange
+Input [5]: [s_store_sk#1, s_store_name#2, s_state#4, ca_state#6, ca_country#8]
+Arguments: HashedRelationBroadcastMode(List(upper(input[4, string, true])),false), [plan_id=2]
 
-(41) BroadcastHashJoin [codegen id : 12]
-Left keys [2]: [ss_store_sk#3, c_birth_country#17]
-Right keys [2]: [s_store_sk#21, upper(ca_country#28)]
+(12) Scan parquet spark_catalog.default.customer
+Output [4]: [c_customer_sk#9, c_first_name#10, c_last_name#11, c_birth_country#12]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_birth_country)]
+ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string,c_birth_country:string>
+
+(13) ColumnarToRow
+Input [4]: [c_customer_sk#9, c_first_name#10, c_last_name#11, c_birth_country#12]
+
+(14) Filter
+Input [4]: [c_customer_sk#9, c_first_name#10, c_last_name#11, c_birth_country#12]
+Condition : (isnotnull(c_customer_sk#9) AND isnotnull(c_birth_country#12))
+
+(15) BroadcastHashJoin [codegen id : 3]
+Left keys [1]: [upper(ca_country#8)]
+Right keys [1]: [c_birth_country#12]
+Join type: Inner
+Join condition: None
+
+(16) Project [codegen id : 3]
+Output [7]: [s_store_sk#1, s_store_name#2, s_state#4, ca_state#6, c_customer_sk#9, c_first_name#10, c_last_name#11]
+Input [9]: [s_store_sk#1, s_store_name#2, s_state#4, ca_state#6, ca_country#8, c_customer_sk#9, c_first_name#10, c_last_name#11, c_birth_country#12]
+
+(17) Exchange
+Input [7]: [s_store_sk#1, s_store_name#2, s_state#4, ca_state#6, c_customer_sk#9, c_first_name#10, c_last_name#11]
+Arguments: hashpartitioning(s_store_sk#1, c_customer_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(18) Sort [codegen id : 4]
+Input [7]: [s_store_sk#1, s_store_name#2, s_state#4, ca_state#6, c_customer_sk#9, c_first_name#10, c_last_name#11]
+Arguments: [s_store_sk#1 ASC NULLS FIRST, c_customer_sk#9 ASC NULLS FIRST], false, 0
+
+(19) Scan parquet spark_catalog.default.store_sales
+Output [6]: [ss_item_sk#13, ss_customer_sk#14, ss_store_sk#15, ss_ticket_number#16, ss_net_paid#17, ss_sold_date_sk#18]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store_sales]
+PushedFilters: [IsNotNull(ss_ticket_number), IsNotNull(ss_item_sk), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk)]
+ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_net_paid:decimal(7,2)>
+
+(20) ColumnarToRow [codegen id : 6]
+Input [6]: [ss_item_sk#13, ss_customer_sk#14, ss_store_sk#15, ss_ticket_number#16, ss_net_paid#17, ss_sold_date_sk#18]
+
+(21) Filter [codegen id : 6]
+Input [6]: [ss_item_sk#13, ss_customer_sk#14, ss_store_sk#15, ss_ticket_number#16, ss_net_paid#17, ss_sold_date_sk#18]
+Condition : ((((isnotnull(ss_ticket_number#16) AND isnotnull(ss_item_sk#13)) AND isnotnull(ss_store_sk#15)) AND isnotnull(ss_customer_sk#14)) AND might_contain(Subquery scalar-subquery#19, [id=#4], xxhash64(ss_store_sk#15, 42)))
+
+(22) Project [codegen id : 6]
+Output [5]: [ss_item_sk#13, ss_customer_sk#14, ss_store_sk#15, ss_ticket_number#16, ss_net_paid#17]
+Input [6]: [ss_item_sk#13, ss_customer_sk#14, ss_store_sk#15, ss_ticket_number#16, ss_net_paid#17, ss_sold_date_sk#18]
+
+(23) Scan parquet spark_catalog.default.item
+Output [6]: [i_item_sk#20, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_color), EqualTo(i_color,pale                ), IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
+
+(24) ColumnarToRow [codegen id : 5]
+Input [6]: [i_item_sk#20, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+
+(25) Filter [codegen id : 5]
+Input [6]: [i_item_sk#20, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+Condition : ((isnotnull(i_color#23) AND (i_color#23 = pale                )) AND isnotnull(i_item_sk#20))
+
+(26) BroadcastExchange
+Input [6]: [i_item_sk#20, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
+
+(27) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [ss_item_sk#13]
+Right keys [1]: [i_item_sk#20]
+Join type: Inner
+Join condition: None
+
+(28) Project [codegen id : 6]
+Output [10]: [ss_item_sk#13, ss_customer_sk#14, ss_store_sk#15, ss_ticket_number#16, ss_net_paid#17, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+Input [11]: [ss_item_sk#13, ss_customer_sk#14, ss_store_sk#15, ss_ticket_number#16, ss_net_paid#17, i_item_sk#20, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+
+(29) Exchange
+Input [10]: [ss_item_sk#13, ss_customer_sk#14, ss_store_sk#15, ss_ticket_number#16, ss_net_paid#17, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+Arguments: hashpartitioning(ss_store_sk#15, ss_customer_sk#14, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(30) Sort [codegen id : 7]
+Input [10]: [ss_item_sk#13, ss_customer_sk#14, ss_store_sk#15, ss_ticket_number#16, ss_net_paid#17, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+Arguments: [ss_store_sk#15 ASC NULLS FIRST, ss_customer_sk#14 ASC NULLS FIRST], false, 0
+
+(31) SortMergeJoin [codegen id : 8]
+Left keys [2]: [s_store_sk#1, c_customer_sk#9]
+Right keys [2]: [ss_store_sk#15, ss_customer_sk#14]
+Join type: Inner
+Join condition: None
+
+(32) Project [codegen id : 8]
+Output [13]: [s_store_name#2, s_state#4, ca_state#6, c_first_name#10, c_last_name#11, ss_item_sk#13, ss_ticket_number#16, ss_net_paid#17, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+Input [17]: [s_store_sk#1, s_store_name#2, s_state#4, ca_state#6, c_customer_sk#9, c_first_name#10, c_last_name#11, ss_item_sk#13, ss_customer_sk#14, ss_store_sk#15, ss_ticket_number#16, ss_net_paid#17, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+
+(33) Exchange
+Input [13]: [s_store_name#2, s_state#4, ca_state#6, c_first_name#10, c_last_name#11, ss_item_sk#13, ss_ticket_number#16, ss_net_paid#17, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+Arguments: hashpartitioning(ss_ticket_number#16, ss_item_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(34) Sort [codegen id : 9]
+Input [13]: [s_store_name#2, s_state#4, ca_state#6, c_first_name#10, c_last_name#11, ss_item_sk#13, ss_ticket_number#16, ss_net_paid#17, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+Arguments: [ss_ticket_number#16 ASC NULLS FIRST, ss_item_sk#13 ASC NULLS FIRST], false, 0
+
+(35) Scan parquet spark_catalog.default.store_returns
+Output [3]: [sr_item_sk#26, sr_ticket_number#27, sr_returned_date_sk#28]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store_returns]
+PushedFilters: [IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
+ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int>
+
+(36) ColumnarToRow [codegen id : 10]
+Input [3]: [sr_item_sk#26, sr_ticket_number#27, sr_returned_date_sk#28]
+
+(37) Filter [codegen id : 10]
+Input [3]: [sr_item_sk#26, sr_ticket_number#27, sr_returned_date_sk#28]
+Condition : (isnotnull(sr_ticket_number#27) AND isnotnull(sr_item_sk#26))
+
+(38) Project [codegen id : 10]
+Output [2]: [sr_item_sk#26, sr_ticket_number#27]
+Input [3]: [sr_item_sk#26, sr_ticket_number#27, sr_returned_date_sk#28]
+
+(39) Exchange
+Input [2]: [sr_item_sk#26, sr_ticket_number#27]
+Arguments: hashpartitioning(sr_ticket_number#27, sr_item_sk#26, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(40) Sort [codegen id : 11]
+Input [2]: [sr_item_sk#26, sr_ticket_number#27]
+Arguments: [sr_ticket_number#27 ASC NULLS FIRST, sr_item_sk#26 ASC NULLS FIRST], false, 0
+
+(41) SortMergeJoin [codegen id : 12]
+Left keys [2]: [ss_ticket_number#16, ss_item_sk#13]
+Right keys [2]: [sr_ticket_number#27, sr_item_sk#26]
 Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 12]
-Output [11]: [ss_net_paid#5, s_store_name#22, s_state#24, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, ca_state#26]
-Input [15]: [ss_store_sk#3, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17, s_store_sk#21, s_store_name#22, s_state#24, ca_state#26, ca_country#28]
+Output [11]: [ss_net_paid#17, s_store_name#2, s_state#4, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25, c_first_name#10, c_last_name#11, ca_state#6]
+Input [15]: [s_store_name#2, s_state#4, ca_state#6, c_first_name#10, c_last_name#11, ss_item_sk#13, ss_ticket_number#16, ss_net_paid#17, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25, sr_item_sk#26, sr_ticket_number#27]
 
 (43) HashAggregate [codegen id : 12]
-Input [11]: [ss_net_paid#5, s_store_name#22, s_state#24, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, ca_state#26]
-Keys [10]: [c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10]
-Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#5))]
+Input [11]: [ss_net_paid#17, s_store_name#2, s_state#4, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25, c_first_name#10, c_last_name#11, ca_state#6]
+Keys [10]: [c_last_name#11, c_first_name#10, s_store_name#2, ca_state#6, s_state#4, i_color#23, i_current_price#21, i_manager_id#25, i_units#24, i_size#22]
+Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#17))]
 Aggregate Attributes [1]: [sum#29]
-Results [11]: [c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10, sum#30]
+Results [11]: [c_last_name#11, c_first_name#10, s_store_name#2, ca_state#6, s_state#4, i_color#23, i_current_price#21, i_manager_id#25, i_units#24, i_size#22, sum#30]
 
 (44) Exchange
-Input [11]: [c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10, sum#30]
-Arguments: hashpartitioning(c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [11]: [c_last_name#11, c_first_name#10, s_store_name#2, ca_state#6, s_state#4, i_color#23, i_current_price#21, i_manager_id#25, i_units#24, i_size#22, sum#30]
+Arguments: hashpartitioning(c_last_name#11, c_first_name#10, s_store_name#2, ca_state#6, s_state#4, i_color#23, i_current_price#21, i_manager_id#25, i_units#24, i_size#22, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (45) HashAggregate [codegen id : 13]
-Input [11]: [c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10, sum#30]
-Keys [10]: [c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#31]
-Results [4]: [c_last_name#16, c_first_name#15, s_store_name#22, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#31,17,2) AS netpaid#32]
+Input [11]: [c_last_name#11, c_first_name#10, s_store_name#2, ca_state#6, s_state#4, i_color#23, i_current_price#21, i_manager_id#25, i_units#24, i_size#22, sum#30]
+Keys [10]: [c_last_name#11, c_first_name#10, s_store_name#2, ca_state#6, s_state#4, i_color#23, i_current_price#21, i_manager_id#25, i_units#24, i_size#22]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#17))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#17))#31]
+Results [4]: [c_last_name#11, c_first_name#10, s_store_name#2, MakeDecimal(sum(UnscaledValue(ss_net_paid#17))#31,17,2) AS netpaid#32]
 
 (46) HashAggregate [codegen id : 13]
-Input [4]: [c_last_name#16, c_first_name#15, s_store_name#22, netpaid#32]
-Keys [3]: [c_last_name#16, c_first_name#15, s_store_name#22]
+Input [4]: [c_last_name#11, c_first_name#10, s_store_name#2, netpaid#32]
+Keys [3]: [c_last_name#11, c_first_name#10, s_store_name#2]
 Functions [1]: [partial_sum(netpaid#32)]
 Aggregate Attributes [2]: [sum#33, isEmpty#34]
-Results [5]: [c_last_name#16, c_first_name#15, s_store_name#22, sum#35, isEmpty#36]
+Results [5]: [c_last_name#11, c_first_name#10, s_store_name#2, sum#35, isEmpty#36]
 
 (47) Exchange
-Input [5]: [c_last_name#16, c_first_name#15, s_store_name#22, sum#35, isEmpty#36]
-Arguments: hashpartitioning(c_last_name#16, c_first_name#15, s_store_name#22, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [5]: [c_last_name#11, c_first_name#10, s_store_name#2, sum#35, isEmpty#36]
+Arguments: hashpartitioning(c_last_name#11, c_first_name#10, s_store_name#2, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (48) HashAggregate [codegen id : 14]
-Input [5]: [c_last_name#16, c_first_name#15, s_store_name#22, sum#35, isEmpty#36]
-Keys [3]: [c_last_name#16, c_first_name#15, s_store_name#22]
+Input [5]: [c_last_name#11, c_first_name#10, s_store_name#2, sum#35, isEmpty#36]
+Keys [3]: [c_last_name#11, c_first_name#10, s_store_name#2]
 Functions [1]: [sum(netpaid#32)]
 Aggregate Attributes [1]: [sum(netpaid#32)#37]
-Results [4]: [c_last_name#16, c_first_name#15, s_store_name#22, sum(netpaid#32)#37 AS paid#38]
+Results [4]: [c_last_name#11, c_first_name#10, s_store_name#2, sum(netpaid#32)#37 AS paid#38]
 
 (49) Filter [codegen id : 14]
-Input [4]: [c_last_name#16, c_first_name#15, s_store_name#22, paid#38]
+Input [4]: [c_last_name#11, c_first_name#10, s_store_name#2, paid#38]
 Condition : (isnotnull(paid#38) AND (cast(paid#38 as decimal(33,8)) > cast(Subquery scalar-subquery#39, [id=#11] as decimal(33,8))))
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#39, [id=#11]
-* HashAggregate (96)
-+- Exchange (95)
-   +- * HashAggregate (94)
-      +- * HashAggregate (93)
-         +- Exchange (92)
-            +- * HashAggregate (91)
-               +- * Project (90)
-                  +- * SortMergeJoin Inner (89)
-                     :- * Sort (83)
-                     :  +- Exchange (82)
-                     :     +- * Project (81)
-                     :        +- * SortMergeJoin Inner (80)
-                     :           :- * Sort (77)
-                     :           :  +- Exchange (76)
-                     :           :     +- * Project (75)
-                     :           :        +- * SortMergeJoin Inner (74)
-                     :           :           :- * Sort (71)
-                     :           :           :  +- Exchange (70)
-                     :           :           :     +- * Project (69)
-                     :           :           :        +- * SortMergeJoin Inner (68)
-                     :           :           :           :- * Sort (62)
-                     :           :           :           :  +- Exchange (61)
-                     :           :           :           :     +- * Project (60)
-                     :           :           :           :        +- * BroadcastHashJoin Inner BuildRight (59)
-                     :           :           :           :           :- * Project (53)
-                     :           :           :           :           :  +- * Filter (52)
-                     :           :           :           :           :     +- * ColumnarToRow (51)
-                     :           :           :           :           :        +- Scan parquet spark_catalog.default.store_sales (50)
-                     :           :           :           :           +- BroadcastExchange (58)
-                     :           :           :           :              +- * Project (57)
-                     :           :           :           :                 +- * Filter (56)
-                     :           :           :           :                    +- * ColumnarToRow (55)
-                     :           :           :           :                       +- Scan parquet spark_catalog.default.store (54)
-                     :           :           :           +- * Sort (67)
-                     :           :           :              +- Exchange (66)
-                     :           :           :                 +- * Filter (65)
-                     :           :           :                    +- * ColumnarToRow (64)
-                     :           :           :                       +- Scan parquet spark_catalog.default.item (63)
-                     :           :           +- * Sort (73)
-                     :           :              +- ReusedExchange (72)
-                     :           +- * Sort (79)
-                     :              +- ReusedExchange (78)
-                     +- * Sort (88)
-                        +- Exchange (87)
-                           +- * Filter (86)
-                              +- * ColumnarToRow (85)
-                                 +- Scan parquet spark_catalog.default.customer_address (84)
+* HashAggregate (99)
++- Exchange (98)
+   +- * HashAggregate (97)
+      +- * HashAggregate (96)
+         +- Exchange (95)
+            +- * HashAggregate (94)
+               +- * Project (93)
+                  +- * SortMergeJoin Inner (92)
+                     :- * Sort (89)
+                     :  +- Exchange (88)
+                     :     +- * Project (87)
+                     :        +- * SortMergeJoin Inner (86)
+                     :           :- * Sort (71)
+                     :           :  +- Exchange (70)
+                     :           :     +- * Project (69)
+                     :           :        +- * SortMergeJoin Inner (68)
+                     :           :           :- * Sort (62)
+                     :           :           :  +- Exchange (61)
+                     :           :           :     +- * Project (60)
+                     :           :           :        +- * BroadcastHashJoin Inner BuildRight (59)
+                     :           :           :           :- * Project (53)
+                     :           :           :           :  +- * Filter (52)
+                     :           :           :           :     +- * ColumnarToRow (51)
+                     :           :           :           :        +- Scan parquet spark_catalog.default.store_sales (50)
+                     :           :           :           +- BroadcastExchange (58)
+                     :           :           :              +- * Project (57)
+                     :           :           :                 +- * Filter (56)
+                     :           :           :                    +- * ColumnarToRow (55)
+                     :           :           :                       +- Scan parquet spark_catalog.default.store (54)
+                     :           :           +- * Sort (67)
+                     :           :              +- Exchange (66)
+                     :           :                 +- * Filter (65)
+                     :           :                    +- * ColumnarToRow (64)
+                     :           :                       +- Scan parquet spark_catalog.default.item (63)
+                     :           +- * Sort (85)
+                     :              +- Exchange (84)
+                     :                 +- * Project (83)
+                     :                    +- * SortMergeJoin Inner (82)
+                     :                       :- * Sort (76)
+                     :                       :  +- Exchange (75)
+                     :                       :     +- * Filter (74)
+                     :                       :        +- * ColumnarToRow (73)
+                     :                       :           +- Scan parquet spark_catalog.default.customer (72)
+                     :                       +- * Sort (81)
+                     :                          +- Exchange (80)
+                     :                             +- * Filter (79)
+                     :                                +- * ColumnarToRow (78)
+                     :                                   +- Scan parquet spark_catalog.default.customer_address (77)
+                     +- * Sort (91)
+                        +- ReusedExchange (90)
 
 
 (50) Scan parquet spark_catalog.default.store_sales
@@ -424,174 +427,189 @@ Input [13]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#
 
 (70) Exchange
 Input [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Arguments: hashpartitioning(ss_customer_sk#41, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+Arguments: hashpartitioning(ss_customer_sk#41, s_zip#50, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
 (71) Sort [codegen id : 7]
 Input [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Arguments: [ss_customer_sk#41 ASC NULLS FIRST], false, 0
+Arguments: [ss_customer_sk#41 ASC NULLS FIRST, s_zip#50 ASC NULLS FIRST], false, 0
 
-(72) ReusedExchange [Reuses operator id: 16]
+(72) Scan parquet spark_catalog.default.customer
 Output [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_birth_country)]
+ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string,c_birth_country:string>
 
-(73) Sort [codegen id : 9]
+(73) ColumnarToRow [codegen id : 8]
 Input [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
-Arguments: [c_customer_sk#57 ASC NULLS FIRST], false, 0
 
-(74) SortMergeJoin [codegen id : 10]
-Left keys [1]: [ss_customer_sk#41]
-Right keys [1]: [c_customer_sk#57]
-Join type: Inner
-Join condition: None
+(74) Filter [codegen id : 8]
+Input [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+Condition : (isnotnull(c_customer_sk#57) AND isnotnull(c_birth_country#60))
 
-(75) Project [codegen id : 10]
-Output [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Input [16]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+(75) Exchange
+Input [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: hashpartitioning(c_birth_country#60, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
-(76) Exchange
-Input [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Arguments: hashpartitioning(ss_ticket_number#43, ss_item_sk#40, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+(76) Sort [codegen id : 9]
+Input [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: [c_birth_country#60 ASC NULLS FIRST], false, 0
 
-(77) Sort [codegen id : 11]
-Input [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Arguments: [ss_ticket_number#43 ASC NULLS FIRST, ss_item_sk#40 ASC NULLS FIRST], false, 0
-
-(78) ReusedExchange [Reuses operator id: 26]
-Output [2]: [sr_item_sk#61, sr_ticket_number#62]
-
-(79) Sort [codegen id : 13]
-Input [2]: [sr_item_sk#61, sr_ticket_number#62]
-Arguments: [sr_ticket_number#62 ASC NULLS FIRST, sr_item_sk#61 ASC NULLS FIRST], false, 0
-
-(80) SortMergeJoin [codegen id : 14]
-Left keys [2]: [ss_ticket_number#43, ss_item_sk#40]
-Right keys [2]: [sr_ticket_number#62, sr_item_sk#61]
-Join type: Inner
-Join condition: None
-
-(81) Project [codegen id : 14]
-Output [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Input [16]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60, sr_item_sk#61, sr_ticket_number#62]
-
-(82) Exchange
-Input [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Arguments: hashpartitioning(c_birth_country#60, s_zip#50, 5), ENSURE_REQUIREMENTS, [plan_id=17]
-
-(83) Sort [codegen id : 15]
-Input [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Arguments: [c_birth_country#60 ASC NULLS FIRST, s_zip#50 ASC NULLS FIRST], false, 0
-
-(84) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#63, ca_zip#64, ca_country#65]
+(77) Scan parquet spark_catalog.default.customer_address
+Output [3]: [ca_state#61, ca_zip#62, ca_country#63]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
-(85) ColumnarToRow [codegen id : 16]
-Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
+(78) ColumnarToRow [codegen id : 10]
+Input [3]: [ca_state#61, ca_zip#62, ca_country#63]
 
-(86) Filter [codegen id : 16]
-Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
-Condition : (isnotnull(ca_country#65) AND isnotnull(ca_zip#64))
+(79) Filter [codegen id : 10]
+Input [3]: [ca_state#61, ca_zip#62, ca_country#63]
+Condition : (isnotnull(ca_country#63) AND isnotnull(ca_zip#62))
 
-(87) Exchange
-Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
-Arguments: hashpartitioning(upper(ca_country#65), ca_zip#64, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+(80) Exchange
+Input [3]: [ca_state#61, ca_zip#62, ca_country#63]
+Arguments: hashpartitioning(upper(ca_country#63), 5), ENSURE_REQUIREMENTS, [plan_id=17]
 
-(88) Sort [codegen id : 17]
-Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
-Arguments: [upper(ca_country#65) ASC NULLS FIRST, ca_zip#64 ASC NULLS FIRST], false, 0
+(81) Sort [codegen id : 11]
+Input [3]: [ca_state#61, ca_zip#62, ca_country#63]
+Arguments: [upper(ca_country#63) ASC NULLS FIRST], false, 0
 
-(89) SortMergeJoin [codegen id : 18]
-Left keys [2]: [c_birth_country#60, s_zip#50]
-Right keys [2]: [upper(ca_country#65), ca_zip#64]
+(82) SortMergeJoin [codegen id : 12]
+Left keys [1]: [c_birth_country#60]
+Right keys [1]: [upper(ca_country#63)]
 Join type: Inner
 Join condition: None
 
-(90) Project [codegen id : 18]
-Output [11]: [ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#63]
-Input [15]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60, ca_state#63, ca_zip#64, ca_country#65]
+(83) Project [codegen id : 12]
+Output [5]: [c_customer_sk#57, c_first_name#58, c_last_name#59, ca_state#61, ca_zip#62]
+Input [7]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60, ca_state#61, ca_zip#62, ca_country#63]
 
-(91) HashAggregate [codegen id : 18]
-Input [11]: [ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#63]
-Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
+(84) Exchange
+Input [5]: [c_customer_sk#57, c_first_name#58, c_last_name#59, ca_state#61, ca_zip#62]
+Arguments: hashpartitioning(c_customer_sk#57, ca_zip#62, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+
+(85) Sort [codegen id : 13]
+Input [5]: [c_customer_sk#57, c_first_name#58, c_last_name#59, ca_state#61, ca_zip#62]
+Arguments: [c_customer_sk#57 ASC NULLS FIRST, ca_zip#62 ASC NULLS FIRST], false, 0
+
+(86) SortMergeJoin [codegen id : 14]
+Left keys [2]: [ss_customer_sk#41, s_zip#50]
+Right keys [2]: [c_customer_sk#57, ca_zip#62]
+Join type: Inner
+Join condition: None
+
+(87) Project [codegen id : 14]
+Output [13]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#61]
+Input [17]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_customer_sk#57, c_first_name#58, c_last_name#59, ca_state#61, ca_zip#62]
+
+(88) Exchange
+Input [13]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#61]
+Arguments: hashpartitioning(ss_ticket_number#43, ss_item_sk#40, 5), ENSURE_REQUIREMENTS, [plan_id=19]
+
+(89) Sort [codegen id : 15]
+Input [13]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#61]
+Arguments: [ss_ticket_number#43 ASC NULLS FIRST, ss_item_sk#40 ASC NULLS FIRST], false, 0
+
+(90) ReusedExchange [Reuses operator id: 39]
+Output [2]: [sr_item_sk#64, sr_ticket_number#65]
+
+(91) Sort [codegen id : 17]
+Input [2]: [sr_item_sk#64, sr_ticket_number#65]
+Arguments: [sr_ticket_number#65 ASC NULLS FIRST, sr_item_sk#64 ASC NULLS FIRST], false, 0
+
+(92) SortMergeJoin [codegen id : 18]
+Left keys [2]: [ss_ticket_number#43, ss_item_sk#40]
+Right keys [2]: [sr_ticket_number#65, sr_item_sk#64]
+Join type: Inner
+Join condition: None
+
+(93) Project [codegen id : 18]
+Output [11]: [ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#61]
+Input [15]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#61, sr_item_sk#64, sr_ticket_number#65]
+
+(94) HashAggregate [codegen id : 18]
+Input [11]: [ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#61]
+Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
 Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#44))]
 Aggregate Attributes [1]: [sum#66]
-Results [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
+Results [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
 
-(92) Exchange
-Input [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
-Arguments: hashpartitioning(c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, 5), ENSURE_REQUIREMENTS, [plan_id=19]
+(95) Exchange
+Input [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
+Arguments: hashpartitioning(c_last_name#59, c_first_name#58, s_store_name#47, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, 5), ENSURE_REQUIREMENTS, [plan_id=20]
 
-(93) HashAggregate [codegen id : 19]
-Input [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
-Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
+(96) HashAggregate [codegen id : 19]
+Input [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
+Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
 Functions [1]: [sum(UnscaledValue(ss_net_paid#44))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#44))#31]
 Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#44))#31,17,2) AS netpaid#68]
 
-(94) HashAggregate [codegen id : 19]
+(97) HashAggregate [codegen id : 19]
 Input [1]: [netpaid#68]
 Keys: []
 Functions [1]: [partial_avg(netpaid#68)]
 Aggregate Attributes [2]: [sum#69, count#70]
 Results [2]: [sum#71, count#72]
 
-(95) Exchange
+(98) Exchange
 Input [2]: [sum#71, count#72]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=20]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=21]
 
-(96) HashAggregate [codegen id : 20]
+(99) HashAggregate [codegen id : 20]
 Input [2]: [sum#71, count#72]
 Keys: []
 Functions [1]: [avg(netpaid#68)]
 Aggregate Attributes [1]: [avg(netpaid#68)#73]
 Results [1]: [(0.05 * avg(netpaid#68)#73) AS (0.05 * avg(netpaid))#74]
 
-Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#1]
-ObjectHashAggregate (103)
-+- Exchange (102)
-   +- ObjectHashAggregate (101)
-      +- * Project (100)
-         +- * Filter (99)
-            +- * ColumnarToRow (98)
-               +- Scan parquet spark_catalog.default.store (97)
+Subquery:2 Hosting operator id = 21 Hosting Expression = Subquery scalar-subquery#19, [id=#4]
+ObjectHashAggregate (106)
++- Exchange (105)
+   +- ObjectHashAggregate (104)
+      +- * Project (103)
+         +- * Filter (102)
+            +- * ColumnarToRow (101)
+               +- Scan parquet spark_catalog.default.store (100)
 
 
-(97) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#21, s_market_id#23, s_zip#25]
+(100) Scan parquet spark_catalog.default.store
+Output [3]: [s_store_sk#1, s_market_id#3, s_zip#5]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_market_id:int,s_zip:string>
 
-(98) ColumnarToRow [codegen id : 1]
-Input [3]: [s_store_sk#21, s_market_id#23, s_zip#25]
+(101) ColumnarToRow [codegen id : 1]
+Input [3]: [s_store_sk#1, s_market_id#3, s_zip#5]
 
-(99) Filter [codegen id : 1]
-Input [3]: [s_store_sk#21, s_market_id#23, s_zip#25]
-Condition : (((isnotnull(s_market_id#23) AND (s_market_id#23 = 8)) AND isnotnull(s_store_sk#21)) AND isnotnull(s_zip#25))
+(102) Filter [codegen id : 1]
+Input [3]: [s_store_sk#1, s_market_id#3, s_zip#5]
+Condition : (((isnotnull(s_market_id#3) AND (s_market_id#3 = 8)) AND isnotnull(s_store_sk#1)) AND isnotnull(s_zip#5))
 
-(100) Project [codegen id : 1]
-Output [1]: [s_store_sk#21]
-Input [3]: [s_store_sk#21, s_market_id#23, s_zip#25]
+(103) Project [codegen id : 1]
+Output [1]: [s_store_sk#1]
+Input [3]: [s_store_sk#1, s_market_id#3, s_zip#5]
 
-(101) ObjectHashAggregate
-Input [1]: [s_store_sk#21]
+(104) ObjectHashAggregate
+Input [1]: [s_store_sk#1]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(s_store_sk#21, 42), 40, 1250, 0, 0)]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(s_store_sk#1, 42), 40, 1250, 0, 0)]
 Aggregate Attributes [1]: [buf#75]
 Results [1]: [buf#76]
 
-(102) Exchange
+(105) Exchange
 Input [1]: [buf#76]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=21]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=22]
 
-(103) ObjectHashAggregate
+(106) ObjectHashAggregate
 Input [1]: [buf#76]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(s_store_sk#21, 42), 40, 1250, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(s_store_sk#21, 42), 40, 1250, 0, 0)#77]
-Results [1]: [bloom_filter_agg(xxhash64(s_store_sk#21, 42), 40, 1250, 0, 0)#77 AS bloomFilter#78]
+Functions [1]: [bloom_filter_agg(xxhash64(s_store_sk#1, 42), 40, 1250, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(s_store_sk#1, 42), 40, 1250, 0, 0)#77]
+Results [1]: [bloom_filter_agg(xxhash64(s_store_sk#1, 42), 40, 1250, 0, 0)#77 AS bloomFilter#78]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/simplified.txt
@@ -13,82 +13,87 @@ WholeStageCodegen (14)
                         WholeStageCodegen (18)
                           HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,ss_net_paid] [sum,sum]
                             Project [ss_net_paid,s_store_name,s_state,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,ca_state]
-                              SortMergeJoin [c_birth_country,s_zip,ca_country,ca_zip]
+                              SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
                                 InputAdapter
                                   WholeStageCodegen (15)
-                                    Sort [c_birth_country,s_zip]
+                                    Sort [ss_ticket_number,ss_item_sk]
                                       InputAdapter
-                                        Exchange [c_birth_country,s_zip] #13
+                                        Exchange [ss_ticket_number,ss_item_sk] #13
                                           WholeStageCodegen (14)
-                                            Project [ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
-                                              SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                                            Project [ss_item_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,ca_state]
+                                              SortMergeJoin [ss_customer_sk,s_zip,c_customer_sk,ca_zip]
                                                 InputAdapter
-                                                  WholeStageCodegen (11)
-                                                    Sort [ss_ticket_number,ss_item_sk]
+                                                  WholeStageCodegen (7)
+                                                    Sort [ss_customer_sk,s_zip]
                                                       InputAdapter
-                                                        Exchange [ss_ticket_number,ss_item_sk] #14
-                                                          WholeStageCodegen (10)
-                                                            Project [ss_item_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
-                                                              SortMergeJoin [ss_customer_sk,c_customer_sk]
+                                                        Exchange [ss_customer_sk,s_zip] #14
+                                                          WholeStageCodegen (6)
+                                                            Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                              SortMergeJoin [ss_item_sk,i_item_sk]
                                                                 InputAdapter
-                                                                  WholeStageCodegen (7)
-                                                                    Sort [ss_customer_sk]
+                                                                  WholeStageCodegen (3)
+                                                                    Sort [ss_item_sk]
                                                                       InputAdapter
-                                                                        Exchange [ss_customer_sk] #15
-                                                                          WholeStageCodegen (6)
-                                                                            Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id]
-                                                                              SortMergeJoin [ss_item_sk,i_item_sk]
-                                                                                InputAdapter
-                                                                                  WholeStageCodegen (3)
-                                                                                    Sort [ss_item_sk]
+                                                                        Exchange [ss_item_sk] #15
+                                                                          WholeStageCodegen (2)
+                                                                            Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip]
+                                                                              BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                                                Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
+                                                                                  Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
+                                                                                    ColumnarToRow
                                                                                       InputAdapter
-                                                                                        Exchange [ss_item_sk] #16
-                                                                                          WholeStageCodegen (2)
-                                                                                            Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip]
-                                                                                              BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                                                                Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
-                                                                                                  Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
-                                                                                                    ColumnarToRow
-                                                                                                      InputAdapter
-                                                                                                        Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
-                                                                                                InputAdapter
-                                                                                                  BroadcastExchange #17
-                                                                                                    WholeStageCodegen (1)
-                                                                                                      Project [s_store_sk,s_store_name,s_state,s_zip]
-                                                                                                        Filter [s_market_id,s_store_sk,s_zip]
-                                                                                                          ColumnarToRow
-                                                                                                            InputAdapter
-                                                                                                              Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_market_id,s_state,s_zip]
+                                                                                        Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
                                                                                 InputAdapter
-                                                                                  WholeStageCodegen (5)
-                                                                                    Sort [i_item_sk]
-                                                                                      InputAdapter
-                                                                                        Exchange [i_item_sk] #18
-                                                                                          WholeStageCodegen (4)
-                                                                                            Filter [i_item_sk]
-                                                                                              ColumnarToRow
-                                                                                                InputAdapter
-                                                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                                                  BroadcastExchange #16
+                                                                                    WholeStageCodegen (1)
+                                                                                      Project [s_store_sk,s_store_name,s_state,s_zip]
+                                                                                        Filter [s_market_id,s_store_sk,s_zip]
+                                                                                          ColumnarToRow
+                                                                                            InputAdapter
+                                                                                              Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_market_id,s_state,s_zip]
                                                                 InputAdapter
-                                                                  WholeStageCodegen (9)
-                                                                    Sort [c_customer_sk]
+                                                                  WholeStageCodegen (5)
+                                                                    Sort [i_item_sk]
                                                                       InputAdapter
-                                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name,c_birth_country] #7
+                                                                        Exchange [i_item_sk] #17
+                                                                          WholeStageCodegen (4)
+                                                                            Filter [i_item_sk]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
                                                 InputAdapter
                                                   WholeStageCodegen (13)
-                                                    Sort [sr_ticket_number,sr_item_sk]
+                                                    Sort [c_customer_sk,ca_zip]
                                                       InputAdapter
-                                                        ReusedExchange [sr_item_sk,sr_ticket_number] #8
+                                                        Exchange [c_customer_sk,ca_zip] #18
+                                                          WholeStageCodegen (12)
+                                                            Project [c_customer_sk,c_first_name,c_last_name,ca_state,ca_zip]
+                                                              SortMergeJoin [c_birth_country,ca_country]
+                                                                InputAdapter
+                                                                  WholeStageCodegen (9)
+                                                                    Sort [c_birth_country]
+                                                                      InputAdapter
+                                                                        Exchange [c_birth_country] #19
+                                                                          WholeStageCodegen (8)
+                                                                            Filter [c_customer_sk,c_birth_country]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name,c_birth_country]
+                                                                InputAdapter
+                                                                  WholeStageCodegen (11)
+                                                                    Sort [ca_country]
+                                                                      InputAdapter
+                                                                        Exchange [ca_country] #20
+                                                                          WholeStageCodegen (10)
+                                                                            Filter [ca_country,ca_zip]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet spark_catalog.default.customer_address [ca_state,ca_zip,ca_country]
                                 InputAdapter
                                   WholeStageCodegen (17)
-                                    Sort [ca_country,ca_zip]
+                                    Sort [sr_ticket_number,sr_item_sk]
                                       InputAdapter
-                                        Exchange [ca_country,ca_zip] #19
-                                          WholeStageCodegen (16)
-                                            Filter [ca_country,ca_zip]
-                                              ColumnarToRow
-                                                InputAdapter
-                                                  Scan parquet spark_catalog.default.customer_address [ca_state,ca_zip,ca_country]
+                                        ReusedExchange [sr_item_sk,sr_ticket_number] #10
     HashAggregate [c_last_name,c_first_name,s_store_name,sum,isEmpty] [sum(netpaid),paid,sum,isEmpty]
       InputAdapter
         Exchange [c_last_name,c_first_name,s_store_name] #1
@@ -100,82 +105,82 @@ WholeStageCodegen (14)
                     WholeStageCodegen (12)
                       HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,ss_net_paid] [sum,sum]
                         Project [ss_net_paid,s_store_name,s_state,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,ca_state]
-                          BroadcastHashJoin [ss_store_sk,c_birth_country,s_store_sk,ca_country]
-                            Project [ss_store_sk,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
-                              SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
-                                InputAdapter
-                                  WholeStageCodegen (7)
-                                    Sort [ss_ticket_number,ss_item_sk]
-                                      InputAdapter
-                                        Exchange [ss_ticket_number,ss_item_sk] #3
-                                          WholeStageCodegen (6)
-                                            Project [ss_item_sk,ss_store_sk,ss_ticket_number,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
-                                              SortMergeJoin [ss_customer_sk,c_customer_sk]
-                                                InputAdapter
-                                                  WholeStageCodegen (3)
-                                                    Sort [ss_customer_sk]
-                                                      InputAdapter
-                                                        Exchange [ss_customer_sk] #4
-                                                          WholeStageCodegen (2)
-                                                            Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id]
-                                                              BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
-                                                                  Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
-                                                                    Subquery #1
-                                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(s_store_sk, 42), 40, 1250, 0, 0),bloomFilter,buf]
-                                                                        Exchange #5
-                                                                          ObjectHashAggregate [s_store_sk] [buf,buf]
-                                                                            WholeStageCodegen (1)
-                                                                              Project [s_store_sk]
-                                                                                Filter [s_market_id,s_store_sk,s_zip]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet spark_catalog.default.store [s_store_sk,s_market_id,s_zip]
-                                                                    ColumnarToRow
+                          SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                            InputAdapter
+                              WholeStageCodegen (9)
+                                Sort [ss_ticket_number,ss_item_sk]
+                                  InputAdapter
+                                    Exchange [ss_ticket_number,ss_item_sk] #3
+                                      WholeStageCodegen (8)
+                                        Project [s_store_name,s_state,ca_state,c_first_name,c_last_name,ss_item_sk,ss_ticket_number,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                          SortMergeJoin [s_store_sk,c_customer_sk,ss_store_sk,ss_customer_sk]
+                                            InputAdapter
+                                              WholeStageCodegen (4)
+                                                Sort [s_store_sk,c_customer_sk]
+                                                  InputAdapter
+                                                    Exchange [s_store_sk,c_customer_sk] #4
+                                                      WholeStageCodegen (3)
+                                                        Project [s_store_sk,s_store_name,s_state,ca_state,c_customer_sk,c_first_name,c_last_name]
+                                                          BroadcastHashJoin [ca_country,c_birth_country]
+                                                            InputAdapter
+                                                              BroadcastExchange #5
+                                                                WholeStageCodegen (2)
+                                                                  Project [s_store_sk,s_store_name,s_state,ca_state,ca_country]
+                                                                    BroadcastHashJoin [s_zip,ca_zip]
                                                                       InputAdapter
-                                                                        Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
-                                                                InputAdapter
-                                                                  BroadcastExchange #6
-                                                                    WholeStageCodegen (1)
-                                                                      Filter [i_color,i_item_sk]
+                                                                        BroadcastExchange #6
+                                                                          WholeStageCodegen (1)
+                                                                            Project [s_store_sk,s_store_name,s_state,s_zip]
+                                                                              Filter [s_market_id,s_store_sk,s_zip]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_market_id,s_state,s_zip]
+                                                                      Filter [ca_country,ca_zip]
                                                                         ColumnarToRow
                                                                           InputAdapter
-                                                                            Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
-                                                InputAdapter
-                                                  WholeStageCodegen (5)
-                                                    Sort [c_customer_sk]
-                                                      InputAdapter
-                                                        Exchange [c_customer_sk] #7
-                                                          WholeStageCodegen (4)
+                                                                            Scan parquet spark_catalog.default.customer_address [ca_state,ca_zip,ca_country]
                                                             Filter [c_customer_sk,c_birth_country]
                                                               ColumnarToRow
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name,c_birth_country]
-                                InputAdapter
-                                  WholeStageCodegen (9)
-                                    Sort [sr_ticket_number,sr_item_sk]
-                                      InputAdapter
-                                        Exchange [sr_ticket_number,sr_item_sk] #8
-                                          WholeStageCodegen (8)
-                                            Project [sr_item_sk,sr_ticket_number]
-                                              Filter [sr_ticket_number,sr_item_sk]
-                                                ColumnarToRow
+                                            InputAdapter
+                                              WholeStageCodegen (7)
+                                                Sort [ss_store_sk,ss_customer_sk]
                                                   InputAdapter
-                                                    Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]
+                                                    Exchange [ss_store_sk,ss_customer_sk] #7
+                                                      WholeStageCodegen (6)
+                                                        Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                          BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                            Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
+                                                              Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
+                                                                Subquery #1
+                                                                  ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(s_store_sk, 42), 40, 1250, 0, 0),bloomFilter,buf]
+                                                                    Exchange #8
+                                                                      ObjectHashAggregate [s_store_sk] [buf,buf]
+                                                                        WholeStageCodegen (1)
+                                                                          Project [s_store_sk]
+                                                                            Filter [s_market_id,s_store_sk,s_zip]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet spark_catalog.default.store [s_store_sk,s_market_id,s_zip]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
+                                                            InputAdapter
+                                                              BroadcastExchange #9
+                                                                WholeStageCodegen (5)
+                                                                  Filter [i_color,i_item_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
                             InputAdapter
-                              BroadcastExchange #9
-                                WholeStageCodegen (11)
-                                  Project [s_store_sk,s_store_name,s_state,ca_state,ca_country]
-                                    BroadcastHashJoin [s_zip,ca_zip]
-                                      InputAdapter
-                                        BroadcastExchange #10
-                                          WholeStageCodegen (10)
-                                            Project [s_store_sk,s_store_name,s_state,s_zip]
-                                              Filter [s_market_id,s_store_sk,s_zip]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_market_id,s_state,s_zip]
-                                      Filter [ca_country,ca_zip]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.customer_address [ca_state,ca_zip,ca_country]
+                              WholeStageCodegen (11)
+                                Sort [sr_ticket_number,sr_item_sk]
+                                  InputAdapter
+                                    Exchange [sr_ticket_number,sr_item_sk] #10
+                                      WholeStageCodegen (10)
+                                        Project [sr_item_sk,sr_ticket_number]
+                                          Filter [sr_ticket_number,sr_item_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/explain.txt
@@ -7,329 +7,332 @@
             +- Exchange (44)
                +- * HashAggregate (43)
                   +- * Project (42)
-                     +- * BroadcastHashJoin Inner BuildRight (41)
-                        :- * Project (29)
-                        :  +- * SortMergeJoin Inner (28)
-                        :     :- * Sort (21)
-                        :     :  +- Exchange (20)
-                        :     :     +- * Project (19)
-                        :     :        +- * SortMergeJoin Inner (18)
-                        :     :           :- * Sort (12)
-                        :     :           :  +- Exchange (11)
-                        :     :           :     +- * Project (10)
-                        :     :           :        +- * BroadcastHashJoin Inner BuildRight (9)
-                        :     :           :           :- * Project (4)
-                        :     :           :           :  +- * Filter (3)
-                        :     :           :           :     +- * ColumnarToRow (2)
-                        :     :           :           :        +- Scan parquet spark_catalog.default.store_sales (1)
-                        :     :           :           +- BroadcastExchange (8)
-                        :     :           :              +- * Filter (7)
-                        :     :           :                 +- * ColumnarToRow (6)
-                        :     :           :                    +- Scan parquet spark_catalog.default.item (5)
-                        :     :           +- * Sort (17)
-                        :     :              +- Exchange (16)
-                        :     :                 +- * Filter (15)
-                        :     :                    +- * ColumnarToRow (14)
-                        :     :                       +- Scan parquet spark_catalog.default.customer (13)
-                        :     +- * Sort (27)
-                        :        +- Exchange (26)
-                        :           +- * Project (25)
-                        :              +- * Filter (24)
-                        :                 +- * ColumnarToRow (23)
-                        :                    +- Scan parquet spark_catalog.default.store_returns (22)
-                        +- BroadcastExchange (40)
-                           +- * Project (39)
-                              +- * BroadcastHashJoin Inner BuildLeft (38)
-                                 :- BroadcastExchange (34)
-                                 :  +- * Project (33)
-                                 :     +- * Filter (32)
-                                 :        +- * ColumnarToRow (31)
-                                 :           +- Scan parquet spark_catalog.default.store (30)
+                     +- * SortMergeJoin Inner (41)
+                        :- * Sort (34)
+                        :  +- Exchange (33)
+                        :     +- * Project (32)
+                        :        +- * SortMergeJoin Inner (31)
+                        :           :- * Sort (18)
+                        :           :  +- Exchange (17)
+                        :           :     +- * Project (16)
+                        :           :        +- * BroadcastHashJoin Inner BuildLeft (15)
+                        :           :           :- BroadcastExchange (11)
+                        :           :           :  +- * Project (10)
+                        :           :           :     +- * BroadcastHashJoin Inner BuildLeft (9)
+                        :           :           :        :- BroadcastExchange (5)
+                        :           :           :        :  +- * Project (4)
+                        :           :           :        :     +- * Filter (3)
+                        :           :           :        :        +- * ColumnarToRow (2)
+                        :           :           :        :           +- Scan parquet spark_catalog.default.store (1)
+                        :           :           :        +- * Filter (8)
+                        :           :           :           +- * ColumnarToRow (7)
+                        :           :           :              +- Scan parquet spark_catalog.default.customer_address (6)
+                        :           :           +- * Filter (14)
+                        :           :              +- * ColumnarToRow (13)
+                        :           :                 +- Scan parquet spark_catalog.default.customer (12)
+                        :           +- * Sort (30)
+                        :              +- Exchange (29)
+                        :                 +- * Project (28)
+                        :                    +- * BroadcastHashJoin Inner BuildRight (27)
+                        :                       :- * Project (22)
+                        :                       :  +- * Filter (21)
+                        :                       :     +- * ColumnarToRow (20)
+                        :                       :        +- Scan parquet spark_catalog.default.store_sales (19)
+                        :                       +- BroadcastExchange (26)
+                        :                          +- * Filter (25)
+                        :                             +- * ColumnarToRow (24)
+                        :                                +- Scan parquet spark_catalog.default.item (23)
+                        +- * Sort (40)
+                           +- Exchange (39)
+                              +- * Project (38)
                                  +- * Filter (37)
                                     +- * ColumnarToRow (36)
-                                       +- Scan parquet spark_catalog.default.customer_address (35)
+                                       +- Scan parquet spark_catalog.default.store_returns (35)
 
 
-(1) Scan parquet spark_catalog.default.store_sales
-Output [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store_sales]
-PushedFilters: [IsNotNull(ss_ticket_number), IsNotNull(ss_item_sk), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk)]
-ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_net_paid:decimal(7,2)>
-
-(2) ColumnarToRow [codegen id : 2]
-Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
-
-(3) Filter [codegen id : 2]
-Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
-Condition : ((((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#1], xxhash64(ss_store_sk#3, 42)))
-
-(4) Project [codegen id : 2]
-Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5]
-Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
-
-(5) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#8, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_color), EqualTo(i_color,chiffon             ), IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
-
-(6) ColumnarToRow [codegen id : 1]
-Input [6]: [i_item_sk#8, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
-
-(7) Filter [codegen id : 1]
-Input [6]: [i_item_sk#8, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
-Condition : ((isnotnull(i_color#11) AND (i_color#11 = chiffon             )) AND isnotnull(i_item_sk#8))
-
-(8) BroadcastExchange
-Input [6]: [i_item_sk#8, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
-
-(9) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#8]
-Join type: Inner
-Join condition: None
-
-(10) Project [codegen id : 2]
-Output [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
-Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_item_sk#8, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
-
-(11) Exchange
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
-Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(12) Sort [codegen id : 3]
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13]
-Arguments: [ss_customer_sk#2 ASC NULLS FIRST], false, 0
-
-(13) Scan parquet spark_catalog.default.customer
-Output [4]: [c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_birth_country)]
-ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string,c_birth_country:string>
-
-(14) ColumnarToRow [codegen id : 4]
-Input [4]: [c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
-
-(15) Filter [codegen id : 4]
-Input [4]: [c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
-Condition : (isnotnull(c_customer_sk#14) AND isnotnull(c_birth_country#17))
-
-(16) Exchange
-Input [4]: [c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
-Arguments: hashpartitioning(c_customer_sk#14, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(17) Sort [codegen id : 5]
-Input [4]: [c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
-Arguments: [c_customer_sk#14 ASC NULLS FIRST], false, 0
-
-(18) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_customer_sk#2]
-Right keys [1]: [c_customer_sk#14]
-Join type: Inner
-Join condition: None
-
-(19) Project [codegen id : 6]
-Output [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17]
-Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_customer_sk#14, c_first_name#15, c_last_name#16, c_birth_country#17]
-
-(20) Exchange
-Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17]
-Arguments: hashpartitioning(ss_ticket_number#4, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(21) Sort [codegen id : 7]
-Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17]
-Arguments: [ss_ticket_number#4 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST], false, 0
-
-(22) Scan parquet spark_catalog.default.store_returns
-Output [3]: [sr_item_sk#18, sr_ticket_number#19, sr_returned_date_sk#20]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store_returns]
-PushedFilters: [IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
-ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int>
-
-(23) ColumnarToRow [codegen id : 8]
-Input [3]: [sr_item_sk#18, sr_ticket_number#19, sr_returned_date_sk#20]
-
-(24) Filter [codegen id : 8]
-Input [3]: [sr_item_sk#18, sr_ticket_number#19, sr_returned_date_sk#20]
-Condition : (isnotnull(sr_ticket_number#19) AND isnotnull(sr_item_sk#18))
-
-(25) Project [codegen id : 8]
-Output [2]: [sr_item_sk#18, sr_ticket_number#19]
-Input [3]: [sr_item_sk#18, sr_ticket_number#19, sr_returned_date_sk#20]
-
-(26) Exchange
-Input [2]: [sr_item_sk#18, sr_ticket_number#19]
-Arguments: hashpartitioning(sr_ticket_number#19, sr_item_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(27) Sort [codegen id : 9]
-Input [2]: [sr_item_sk#18, sr_ticket_number#19]
-Arguments: [sr_ticket_number#19 ASC NULLS FIRST, sr_item_sk#18 ASC NULLS FIRST], false, 0
-
-(28) SortMergeJoin [codegen id : 12]
-Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
-Right keys [2]: [sr_ticket_number#19, sr_item_sk#18]
-Join type: Inner
-Join condition: None
-
-(29) Project [codegen id : 12]
-Output [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17]
-Input [14]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17, sr_item_sk#18, sr_ticket_number#19]
-
-(30) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#21, s_store_name#22, s_market_id#23, s_state#24, s_zip#25]
+(1) Scan parquet spark_catalog.default.store
+Output [5]: [s_store_sk#1, s_store_name#2, s_market_id#3, s_state#4, s_zip#5]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
 
-(31) ColumnarToRow [codegen id : 10]
-Input [5]: [s_store_sk#21, s_store_name#22, s_market_id#23, s_state#24, s_zip#25]
+(2) ColumnarToRow [codegen id : 1]
+Input [5]: [s_store_sk#1, s_store_name#2, s_market_id#3, s_state#4, s_zip#5]
 
-(32) Filter [codegen id : 10]
-Input [5]: [s_store_sk#21, s_store_name#22, s_market_id#23, s_state#24, s_zip#25]
-Condition : (((isnotnull(s_market_id#23) AND (s_market_id#23 = 8)) AND isnotnull(s_store_sk#21)) AND isnotnull(s_zip#25))
+(3) Filter [codegen id : 1]
+Input [5]: [s_store_sk#1, s_store_name#2, s_market_id#3, s_state#4, s_zip#5]
+Condition : (((isnotnull(s_market_id#3) AND (s_market_id#3 = 8)) AND isnotnull(s_store_sk#1)) AND isnotnull(s_zip#5))
 
-(33) Project [codegen id : 10]
-Output [4]: [s_store_sk#21, s_store_name#22, s_state#24, s_zip#25]
-Input [5]: [s_store_sk#21, s_store_name#22, s_market_id#23, s_state#24, s_zip#25]
+(4) Project [codegen id : 1]
+Output [4]: [s_store_sk#1, s_store_name#2, s_state#4, s_zip#5]
+Input [5]: [s_store_sk#1, s_store_name#2, s_market_id#3, s_state#4, s_zip#5]
 
-(34) BroadcastExchange
-Input [4]: [s_store_sk#21, s_store_name#22, s_state#24, s_zip#25]
-Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=7]
+(5) BroadcastExchange
+Input [4]: [s_store_sk#1, s_store_name#2, s_state#4, s_zip#5]
+Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=1]
 
-(35) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#26, ca_zip#27, ca_country#28]
+(6) Scan parquet spark_catalog.default.customer_address
+Output [3]: [ca_state#6, ca_zip#7, ca_country#8]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
-(36) ColumnarToRow
-Input [3]: [ca_state#26, ca_zip#27, ca_country#28]
+(7) ColumnarToRow
+Input [3]: [ca_state#6, ca_zip#7, ca_country#8]
 
-(37) Filter
-Input [3]: [ca_state#26, ca_zip#27, ca_country#28]
-Condition : (isnotnull(ca_country#28) AND isnotnull(ca_zip#27))
+(8) Filter
+Input [3]: [ca_state#6, ca_zip#7, ca_country#8]
+Condition : (isnotnull(ca_country#8) AND isnotnull(ca_zip#7))
 
-(38) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [s_zip#25]
-Right keys [1]: [ca_zip#27]
+(9) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [s_zip#5]
+Right keys [1]: [ca_zip#7]
 Join type: Inner
 Join condition: None
 
-(39) Project [codegen id : 11]
-Output [5]: [s_store_sk#21, s_store_name#22, s_state#24, ca_state#26, ca_country#28]
-Input [7]: [s_store_sk#21, s_store_name#22, s_state#24, s_zip#25, ca_state#26, ca_zip#27, ca_country#28]
+(10) Project [codegen id : 2]
+Output [5]: [s_store_sk#1, s_store_name#2, s_state#4, ca_state#6, ca_country#8]
+Input [7]: [s_store_sk#1, s_store_name#2, s_state#4, s_zip#5, ca_state#6, ca_zip#7, ca_country#8]
 
-(40) BroadcastExchange
-Input [5]: [s_store_sk#21, s_store_name#22, s_state#24, ca_state#26, ca_country#28]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, string, true])),false), [plan_id=8]
+(11) BroadcastExchange
+Input [5]: [s_store_sk#1, s_store_name#2, s_state#4, ca_state#6, ca_country#8]
+Arguments: HashedRelationBroadcastMode(List(upper(input[4, string, true])),false), [plan_id=2]
 
-(41) BroadcastHashJoin [codegen id : 12]
-Left keys [2]: [ss_store_sk#3, c_birth_country#17]
-Right keys [2]: [s_store_sk#21, upper(ca_country#28)]
+(12) Scan parquet spark_catalog.default.customer
+Output [4]: [c_customer_sk#9, c_first_name#10, c_last_name#11, c_birth_country#12]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_birth_country)]
+ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string,c_birth_country:string>
+
+(13) ColumnarToRow
+Input [4]: [c_customer_sk#9, c_first_name#10, c_last_name#11, c_birth_country#12]
+
+(14) Filter
+Input [4]: [c_customer_sk#9, c_first_name#10, c_last_name#11, c_birth_country#12]
+Condition : (isnotnull(c_customer_sk#9) AND isnotnull(c_birth_country#12))
+
+(15) BroadcastHashJoin [codegen id : 3]
+Left keys [1]: [upper(ca_country#8)]
+Right keys [1]: [c_birth_country#12]
+Join type: Inner
+Join condition: None
+
+(16) Project [codegen id : 3]
+Output [7]: [s_store_sk#1, s_store_name#2, s_state#4, ca_state#6, c_customer_sk#9, c_first_name#10, c_last_name#11]
+Input [9]: [s_store_sk#1, s_store_name#2, s_state#4, ca_state#6, ca_country#8, c_customer_sk#9, c_first_name#10, c_last_name#11, c_birth_country#12]
+
+(17) Exchange
+Input [7]: [s_store_sk#1, s_store_name#2, s_state#4, ca_state#6, c_customer_sk#9, c_first_name#10, c_last_name#11]
+Arguments: hashpartitioning(s_store_sk#1, c_customer_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(18) Sort [codegen id : 4]
+Input [7]: [s_store_sk#1, s_store_name#2, s_state#4, ca_state#6, c_customer_sk#9, c_first_name#10, c_last_name#11]
+Arguments: [s_store_sk#1 ASC NULLS FIRST, c_customer_sk#9 ASC NULLS FIRST], false, 0
+
+(19) Scan parquet spark_catalog.default.store_sales
+Output [6]: [ss_item_sk#13, ss_customer_sk#14, ss_store_sk#15, ss_ticket_number#16, ss_net_paid#17, ss_sold_date_sk#18]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store_sales]
+PushedFilters: [IsNotNull(ss_ticket_number), IsNotNull(ss_item_sk), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk)]
+ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_net_paid:decimal(7,2)>
+
+(20) ColumnarToRow [codegen id : 6]
+Input [6]: [ss_item_sk#13, ss_customer_sk#14, ss_store_sk#15, ss_ticket_number#16, ss_net_paid#17, ss_sold_date_sk#18]
+
+(21) Filter [codegen id : 6]
+Input [6]: [ss_item_sk#13, ss_customer_sk#14, ss_store_sk#15, ss_ticket_number#16, ss_net_paid#17, ss_sold_date_sk#18]
+Condition : ((((isnotnull(ss_ticket_number#16) AND isnotnull(ss_item_sk#13)) AND isnotnull(ss_store_sk#15)) AND isnotnull(ss_customer_sk#14)) AND might_contain(Subquery scalar-subquery#19, [id=#4], xxhash64(ss_store_sk#15, 42)))
+
+(22) Project [codegen id : 6]
+Output [5]: [ss_item_sk#13, ss_customer_sk#14, ss_store_sk#15, ss_ticket_number#16, ss_net_paid#17]
+Input [6]: [ss_item_sk#13, ss_customer_sk#14, ss_store_sk#15, ss_ticket_number#16, ss_net_paid#17, ss_sold_date_sk#18]
+
+(23) Scan parquet spark_catalog.default.item
+Output [6]: [i_item_sk#20, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_color), EqualTo(i_color,chiffon             ), IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
+
+(24) ColumnarToRow [codegen id : 5]
+Input [6]: [i_item_sk#20, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+
+(25) Filter [codegen id : 5]
+Input [6]: [i_item_sk#20, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+Condition : ((isnotnull(i_color#23) AND (i_color#23 = chiffon             )) AND isnotnull(i_item_sk#20))
+
+(26) BroadcastExchange
+Input [6]: [i_item_sk#20, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
+
+(27) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [ss_item_sk#13]
+Right keys [1]: [i_item_sk#20]
+Join type: Inner
+Join condition: None
+
+(28) Project [codegen id : 6]
+Output [10]: [ss_item_sk#13, ss_customer_sk#14, ss_store_sk#15, ss_ticket_number#16, ss_net_paid#17, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+Input [11]: [ss_item_sk#13, ss_customer_sk#14, ss_store_sk#15, ss_ticket_number#16, ss_net_paid#17, i_item_sk#20, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+
+(29) Exchange
+Input [10]: [ss_item_sk#13, ss_customer_sk#14, ss_store_sk#15, ss_ticket_number#16, ss_net_paid#17, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+Arguments: hashpartitioning(ss_store_sk#15, ss_customer_sk#14, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(30) Sort [codegen id : 7]
+Input [10]: [ss_item_sk#13, ss_customer_sk#14, ss_store_sk#15, ss_ticket_number#16, ss_net_paid#17, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+Arguments: [ss_store_sk#15 ASC NULLS FIRST, ss_customer_sk#14 ASC NULLS FIRST], false, 0
+
+(31) SortMergeJoin [codegen id : 8]
+Left keys [2]: [s_store_sk#1, c_customer_sk#9]
+Right keys [2]: [ss_store_sk#15, ss_customer_sk#14]
+Join type: Inner
+Join condition: None
+
+(32) Project [codegen id : 8]
+Output [13]: [s_store_name#2, s_state#4, ca_state#6, c_first_name#10, c_last_name#11, ss_item_sk#13, ss_ticket_number#16, ss_net_paid#17, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+Input [17]: [s_store_sk#1, s_store_name#2, s_state#4, ca_state#6, c_customer_sk#9, c_first_name#10, c_last_name#11, ss_item_sk#13, ss_customer_sk#14, ss_store_sk#15, ss_ticket_number#16, ss_net_paid#17, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+
+(33) Exchange
+Input [13]: [s_store_name#2, s_state#4, ca_state#6, c_first_name#10, c_last_name#11, ss_item_sk#13, ss_ticket_number#16, ss_net_paid#17, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+Arguments: hashpartitioning(ss_ticket_number#16, ss_item_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(34) Sort [codegen id : 9]
+Input [13]: [s_store_name#2, s_state#4, ca_state#6, c_first_name#10, c_last_name#11, ss_item_sk#13, ss_ticket_number#16, ss_net_paid#17, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25]
+Arguments: [ss_ticket_number#16 ASC NULLS FIRST, ss_item_sk#13 ASC NULLS FIRST], false, 0
+
+(35) Scan parquet spark_catalog.default.store_returns
+Output [3]: [sr_item_sk#26, sr_ticket_number#27, sr_returned_date_sk#28]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store_returns]
+PushedFilters: [IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
+ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int>
+
+(36) ColumnarToRow [codegen id : 10]
+Input [3]: [sr_item_sk#26, sr_ticket_number#27, sr_returned_date_sk#28]
+
+(37) Filter [codegen id : 10]
+Input [3]: [sr_item_sk#26, sr_ticket_number#27, sr_returned_date_sk#28]
+Condition : (isnotnull(sr_ticket_number#27) AND isnotnull(sr_item_sk#26))
+
+(38) Project [codegen id : 10]
+Output [2]: [sr_item_sk#26, sr_ticket_number#27]
+Input [3]: [sr_item_sk#26, sr_ticket_number#27, sr_returned_date_sk#28]
+
+(39) Exchange
+Input [2]: [sr_item_sk#26, sr_ticket_number#27]
+Arguments: hashpartitioning(sr_ticket_number#27, sr_item_sk#26, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(40) Sort [codegen id : 11]
+Input [2]: [sr_item_sk#26, sr_ticket_number#27]
+Arguments: [sr_ticket_number#27 ASC NULLS FIRST, sr_item_sk#26 ASC NULLS FIRST], false, 0
+
+(41) SortMergeJoin [codegen id : 12]
+Left keys [2]: [ss_ticket_number#16, ss_item_sk#13]
+Right keys [2]: [sr_ticket_number#27, sr_item_sk#26]
 Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 12]
-Output [11]: [ss_net_paid#5, s_store_name#22, s_state#24, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, ca_state#26]
-Input [15]: [ss_store_sk#3, ss_net_paid#5, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, c_birth_country#17, s_store_sk#21, s_store_name#22, s_state#24, ca_state#26, ca_country#28]
+Output [11]: [ss_net_paid#17, s_store_name#2, s_state#4, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25, c_first_name#10, c_last_name#11, ca_state#6]
+Input [15]: [s_store_name#2, s_state#4, ca_state#6, c_first_name#10, c_last_name#11, ss_item_sk#13, ss_ticket_number#16, ss_net_paid#17, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25, sr_item_sk#26, sr_ticket_number#27]
 
 (43) HashAggregate [codegen id : 12]
-Input [11]: [ss_net_paid#5, s_store_name#22, s_state#24, i_current_price#9, i_size#10, i_color#11, i_units#12, i_manager_id#13, c_first_name#15, c_last_name#16, ca_state#26]
-Keys [10]: [c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10]
-Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#5))]
+Input [11]: [ss_net_paid#17, s_store_name#2, s_state#4, i_current_price#21, i_size#22, i_color#23, i_units#24, i_manager_id#25, c_first_name#10, c_last_name#11, ca_state#6]
+Keys [10]: [c_last_name#11, c_first_name#10, s_store_name#2, ca_state#6, s_state#4, i_color#23, i_current_price#21, i_manager_id#25, i_units#24, i_size#22]
+Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#17))]
 Aggregate Attributes [1]: [sum#29]
-Results [11]: [c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10, sum#30]
+Results [11]: [c_last_name#11, c_first_name#10, s_store_name#2, ca_state#6, s_state#4, i_color#23, i_current_price#21, i_manager_id#25, i_units#24, i_size#22, sum#30]
 
 (44) Exchange
-Input [11]: [c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10, sum#30]
-Arguments: hashpartitioning(c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [11]: [c_last_name#11, c_first_name#10, s_store_name#2, ca_state#6, s_state#4, i_color#23, i_current_price#21, i_manager_id#25, i_units#24, i_size#22, sum#30]
+Arguments: hashpartitioning(c_last_name#11, c_first_name#10, s_store_name#2, ca_state#6, s_state#4, i_color#23, i_current_price#21, i_manager_id#25, i_units#24, i_size#22, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (45) HashAggregate [codegen id : 13]
-Input [11]: [c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10, sum#30]
-Keys [10]: [c_last_name#16, c_first_name#15, s_store_name#22, ca_state#26, s_state#24, i_color#11, i_current_price#9, i_manager_id#13, i_units#12, i_size#10]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#31]
-Results [4]: [c_last_name#16, c_first_name#15, s_store_name#22, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#31,17,2) AS netpaid#32]
+Input [11]: [c_last_name#11, c_first_name#10, s_store_name#2, ca_state#6, s_state#4, i_color#23, i_current_price#21, i_manager_id#25, i_units#24, i_size#22, sum#30]
+Keys [10]: [c_last_name#11, c_first_name#10, s_store_name#2, ca_state#6, s_state#4, i_color#23, i_current_price#21, i_manager_id#25, i_units#24, i_size#22]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#17))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#17))#31]
+Results [4]: [c_last_name#11, c_first_name#10, s_store_name#2, MakeDecimal(sum(UnscaledValue(ss_net_paid#17))#31,17,2) AS netpaid#32]
 
 (46) HashAggregate [codegen id : 13]
-Input [4]: [c_last_name#16, c_first_name#15, s_store_name#22, netpaid#32]
-Keys [3]: [c_last_name#16, c_first_name#15, s_store_name#22]
+Input [4]: [c_last_name#11, c_first_name#10, s_store_name#2, netpaid#32]
+Keys [3]: [c_last_name#11, c_first_name#10, s_store_name#2]
 Functions [1]: [partial_sum(netpaid#32)]
 Aggregate Attributes [2]: [sum#33, isEmpty#34]
-Results [5]: [c_last_name#16, c_first_name#15, s_store_name#22, sum#35, isEmpty#36]
+Results [5]: [c_last_name#11, c_first_name#10, s_store_name#2, sum#35, isEmpty#36]
 
 (47) Exchange
-Input [5]: [c_last_name#16, c_first_name#15, s_store_name#22, sum#35, isEmpty#36]
-Arguments: hashpartitioning(c_last_name#16, c_first_name#15, s_store_name#22, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [5]: [c_last_name#11, c_first_name#10, s_store_name#2, sum#35, isEmpty#36]
+Arguments: hashpartitioning(c_last_name#11, c_first_name#10, s_store_name#2, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (48) HashAggregate [codegen id : 14]
-Input [5]: [c_last_name#16, c_first_name#15, s_store_name#22, sum#35, isEmpty#36]
-Keys [3]: [c_last_name#16, c_first_name#15, s_store_name#22]
+Input [5]: [c_last_name#11, c_first_name#10, s_store_name#2, sum#35, isEmpty#36]
+Keys [3]: [c_last_name#11, c_first_name#10, s_store_name#2]
 Functions [1]: [sum(netpaid#32)]
 Aggregate Attributes [1]: [sum(netpaid#32)#37]
-Results [4]: [c_last_name#16, c_first_name#15, s_store_name#22, sum(netpaid#32)#37 AS paid#38]
+Results [4]: [c_last_name#11, c_first_name#10, s_store_name#2, sum(netpaid#32)#37 AS paid#38]
 
 (49) Filter [codegen id : 14]
-Input [4]: [c_last_name#16, c_first_name#15, s_store_name#22, paid#38]
+Input [4]: [c_last_name#11, c_first_name#10, s_store_name#2, paid#38]
 Condition : (isnotnull(paid#38) AND (cast(paid#38 as decimal(33,8)) > cast(Subquery scalar-subquery#39, [id=#11] as decimal(33,8))))
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#39, [id=#11]
-* HashAggregate (96)
-+- Exchange (95)
-   +- * HashAggregate (94)
-      +- * HashAggregate (93)
-         +- Exchange (92)
-            +- * HashAggregate (91)
-               +- * Project (90)
-                  +- * SortMergeJoin Inner (89)
-                     :- * Sort (83)
-                     :  +- Exchange (82)
-                     :     +- * Project (81)
-                     :        +- * SortMergeJoin Inner (80)
-                     :           :- * Sort (77)
-                     :           :  +- Exchange (76)
-                     :           :     +- * Project (75)
-                     :           :        +- * SortMergeJoin Inner (74)
-                     :           :           :- * Sort (71)
-                     :           :           :  +- Exchange (70)
-                     :           :           :     +- * Project (69)
-                     :           :           :        +- * SortMergeJoin Inner (68)
-                     :           :           :           :- * Sort (62)
-                     :           :           :           :  +- Exchange (61)
-                     :           :           :           :     +- * Project (60)
-                     :           :           :           :        +- * BroadcastHashJoin Inner BuildRight (59)
-                     :           :           :           :           :- * Project (53)
-                     :           :           :           :           :  +- * Filter (52)
-                     :           :           :           :           :     +- * ColumnarToRow (51)
-                     :           :           :           :           :        +- Scan parquet spark_catalog.default.store_sales (50)
-                     :           :           :           :           +- BroadcastExchange (58)
-                     :           :           :           :              +- * Project (57)
-                     :           :           :           :                 +- * Filter (56)
-                     :           :           :           :                    +- * ColumnarToRow (55)
-                     :           :           :           :                       +- Scan parquet spark_catalog.default.store (54)
-                     :           :           :           +- * Sort (67)
-                     :           :           :              +- Exchange (66)
-                     :           :           :                 +- * Filter (65)
-                     :           :           :                    +- * ColumnarToRow (64)
-                     :           :           :                       +- Scan parquet spark_catalog.default.item (63)
-                     :           :           +- * Sort (73)
-                     :           :              +- ReusedExchange (72)
-                     :           +- * Sort (79)
-                     :              +- ReusedExchange (78)
-                     +- * Sort (88)
-                        +- Exchange (87)
-                           +- * Filter (86)
-                              +- * ColumnarToRow (85)
-                                 +- Scan parquet spark_catalog.default.customer_address (84)
+* HashAggregate (99)
++- Exchange (98)
+   +- * HashAggregate (97)
+      +- * HashAggregate (96)
+         +- Exchange (95)
+            +- * HashAggregate (94)
+               +- * Project (93)
+                  +- * SortMergeJoin Inner (92)
+                     :- * Sort (89)
+                     :  +- Exchange (88)
+                     :     +- * Project (87)
+                     :        +- * SortMergeJoin Inner (86)
+                     :           :- * Sort (71)
+                     :           :  +- Exchange (70)
+                     :           :     +- * Project (69)
+                     :           :        +- * SortMergeJoin Inner (68)
+                     :           :           :- * Sort (62)
+                     :           :           :  +- Exchange (61)
+                     :           :           :     +- * Project (60)
+                     :           :           :        +- * BroadcastHashJoin Inner BuildRight (59)
+                     :           :           :           :- * Project (53)
+                     :           :           :           :  +- * Filter (52)
+                     :           :           :           :     +- * ColumnarToRow (51)
+                     :           :           :           :        +- Scan parquet spark_catalog.default.store_sales (50)
+                     :           :           :           +- BroadcastExchange (58)
+                     :           :           :              +- * Project (57)
+                     :           :           :                 +- * Filter (56)
+                     :           :           :                    +- * ColumnarToRow (55)
+                     :           :           :                       +- Scan parquet spark_catalog.default.store (54)
+                     :           :           +- * Sort (67)
+                     :           :              +- Exchange (66)
+                     :           :                 +- * Filter (65)
+                     :           :                    +- * ColumnarToRow (64)
+                     :           :                       +- Scan parquet spark_catalog.default.item (63)
+                     :           +- * Sort (85)
+                     :              +- Exchange (84)
+                     :                 +- * Project (83)
+                     :                    +- * SortMergeJoin Inner (82)
+                     :                       :- * Sort (76)
+                     :                       :  +- Exchange (75)
+                     :                       :     +- * Filter (74)
+                     :                       :        +- * ColumnarToRow (73)
+                     :                       :           +- Scan parquet spark_catalog.default.customer (72)
+                     :                       +- * Sort (81)
+                     :                          +- Exchange (80)
+                     :                             +- * Filter (79)
+                     :                                +- * ColumnarToRow (78)
+                     :                                   +- Scan parquet spark_catalog.default.customer_address (77)
+                     +- * Sort (91)
+                        +- ReusedExchange (90)
 
 
 (50) Scan parquet spark_catalog.default.store_sales
@@ -424,174 +427,189 @@ Input [13]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#
 
 (70) Exchange
 Input [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Arguments: hashpartitioning(ss_customer_sk#41, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+Arguments: hashpartitioning(ss_customer_sk#41, s_zip#50, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
 (71) Sort [codegen id : 7]
 Input [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Arguments: [ss_customer_sk#41 ASC NULLS FIRST], false, 0
+Arguments: [ss_customer_sk#41 ASC NULLS FIRST, s_zip#50 ASC NULLS FIRST], false, 0
 
-(72) ReusedExchange [Reuses operator id: 16]
+(72) Scan parquet spark_catalog.default.customer
 Output [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_birth_country)]
+ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string,c_birth_country:string>
 
-(73) Sort [codegen id : 9]
+(73) ColumnarToRow [codegen id : 8]
 Input [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
-Arguments: [c_customer_sk#57 ASC NULLS FIRST], false, 0
 
-(74) SortMergeJoin [codegen id : 10]
-Left keys [1]: [ss_customer_sk#41]
-Right keys [1]: [c_customer_sk#57]
-Join type: Inner
-Join condition: None
+(74) Filter [codegen id : 8]
+Input [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+Condition : (isnotnull(c_customer_sk#57) AND isnotnull(c_birth_country#60))
 
-(75) Project [codegen id : 10]
-Output [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Input [16]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+(75) Exchange
+Input [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: hashpartitioning(c_birth_country#60, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
-(76) Exchange
-Input [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Arguments: hashpartitioning(ss_ticket_number#43, ss_item_sk#40, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+(76) Sort [codegen id : 9]
+Input [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: [c_birth_country#60 ASC NULLS FIRST], false, 0
 
-(77) Sort [codegen id : 11]
-Input [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Arguments: [ss_ticket_number#43 ASC NULLS FIRST, ss_item_sk#40 ASC NULLS FIRST], false, 0
-
-(78) ReusedExchange [Reuses operator id: 26]
-Output [2]: [sr_item_sk#61, sr_ticket_number#62]
-
-(79) Sort [codegen id : 13]
-Input [2]: [sr_item_sk#61, sr_ticket_number#62]
-Arguments: [sr_ticket_number#62 ASC NULLS FIRST, sr_item_sk#61 ASC NULLS FIRST], false, 0
-
-(80) SortMergeJoin [codegen id : 14]
-Left keys [2]: [ss_ticket_number#43, ss_item_sk#40]
-Right keys [2]: [sr_ticket_number#62, sr_item_sk#61]
-Join type: Inner
-Join condition: None
-
-(81) Project [codegen id : 14]
-Output [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Input [16]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60, sr_item_sk#61, sr_ticket_number#62]
-
-(82) Exchange
-Input [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Arguments: hashpartitioning(c_birth_country#60, s_zip#50, 5), ENSURE_REQUIREMENTS, [plan_id=17]
-
-(83) Sort [codegen id : 15]
-Input [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Arguments: [c_birth_country#60 ASC NULLS FIRST, s_zip#50 ASC NULLS FIRST], false, 0
-
-(84) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#63, ca_zip#64, ca_country#65]
+(77) Scan parquet spark_catalog.default.customer_address
+Output [3]: [ca_state#61, ca_zip#62, ca_country#63]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
-(85) ColumnarToRow [codegen id : 16]
-Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
+(78) ColumnarToRow [codegen id : 10]
+Input [3]: [ca_state#61, ca_zip#62, ca_country#63]
 
-(86) Filter [codegen id : 16]
-Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
-Condition : (isnotnull(ca_country#65) AND isnotnull(ca_zip#64))
+(79) Filter [codegen id : 10]
+Input [3]: [ca_state#61, ca_zip#62, ca_country#63]
+Condition : (isnotnull(ca_country#63) AND isnotnull(ca_zip#62))
 
-(87) Exchange
-Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
-Arguments: hashpartitioning(upper(ca_country#65), ca_zip#64, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+(80) Exchange
+Input [3]: [ca_state#61, ca_zip#62, ca_country#63]
+Arguments: hashpartitioning(upper(ca_country#63), 5), ENSURE_REQUIREMENTS, [plan_id=17]
 
-(88) Sort [codegen id : 17]
-Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
-Arguments: [upper(ca_country#65) ASC NULLS FIRST, ca_zip#64 ASC NULLS FIRST], false, 0
+(81) Sort [codegen id : 11]
+Input [3]: [ca_state#61, ca_zip#62, ca_country#63]
+Arguments: [upper(ca_country#63) ASC NULLS FIRST], false, 0
 
-(89) SortMergeJoin [codegen id : 18]
-Left keys [2]: [c_birth_country#60, s_zip#50]
-Right keys [2]: [upper(ca_country#65), ca_zip#64]
+(82) SortMergeJoin [codegen id : 12]
+Left keys [1]: [c_birth_country#60]
+Right keys [1]: [upper(ca_country#63)]
 Join type: Inner
 Join condition: None
 
-(90) Project [codegen id : 18]
-Output [11]: [ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#63]
-Input [15]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60, ca_state#63, ca_zip#64, ca_country#65]
+(83) Project [codegen id : 12]
+Output [5]: [c_customer_sk#57, c_first_name#58, c_last_name#59, ca_state#61, ca_zip#62]
+Input [7]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60, ca_state#61, ca_zip#62, ca_country#63]
 
-(91) HashAggregate [codegen id : 18]
-Input [11]: [ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#63]
-Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
+(84) Exchange
+Input [5]: [c_customer_sk#57, c_first_name#58, c_last_name#59, ca_state#61, ca_zip#62]
+Arguments: hashpartitioning(c_customer_sk#57, ca_zip#62, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+
+(85) Sort [codegen id : 13]
+Input [5]: [c_customer_sk#57, c_first_name#58, c_last_name#59, ca_state#61, ca_zip#62]
+Arguments: [c_customer_sk#57 ASC NULLS FIRST, ca_zip#62 ASC NULLS FIRST], false, 0
+
+(86) SortMergeJoin [codegen id : 14]
+Left keys [2]: [ss_customer_sk#41, s_zip#50]
+Right keys [2]: [c_customer_sk#57, ca_zip#62]
+Join type: Inner
+Join condition: None
+
+(87) Project [codegen id : 14]
+Output [13]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#61]
+Input [17]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_customer_sk#57, c_first_name#58, c_last_name#59, ca_state#61, ca_zip#62]
+
+(88) Exchange
+Input [13]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#61]
+Arguments: hashpartitioning(ss_ticket_number#43, ss_item_sk#40, 5), ENSURE_REQUIREMENTS, [plan_id=19]
+
+(89) Sort [codegen id : 15]
+Input [13]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#61]
+Arguments: [ss_ticket_number#43 ASC NULLS FIRST, ss_item_sk#40 ASC NULLS FIRST], false, 0
+
+(90) ReusedExchange [Reuses operator id: 39]
+Output [2]: [sr_item_sk#64, sr_ticket_number#65]
+
+(91) Sort [codegen id : 17]
+Input [2]: [sr_item_sk#64, sr_ticket_number#65]
+Arguments: [sr_ticket_number#65 ASC NULLS FIRST, sr_item_sk#64 ASC NULLS FIRST], false, 0
+
+(92) SortMergeJoin [codegen id : 18]
+Left keys [2]: [ss_ticket_number#43, ss_item_sk#40]
+Right keys [2]: [sr_ticket_number#65, sr_item_sk#64]
+Join type: Inner
+Join condition: None
+
+(93) Project [codegen id : 18]
+Output [11]: [ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#61]
+Input [15]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#61, sr_item_sk#64, sr_ticket_number#65]
+
+(94) HashAggregate [codegen id : 18]
+Input [11]: [ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#61]
+Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
 Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#44))]
 Aggregate Attributes [1]: [sum#66]
-Results [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
+Results [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
 
-(92) Exchange
-Input [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
-Arguments: hashpartitioning(c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, 5), ENSURE_REQUIREMENTS, [plan_id=19]
+(95) Exchange
+Input [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
+Arguments: hashpartitioning(c_last_name#59, c_first_name#58, s_store_name#47, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, 5), ENSURE_REQUIREMENTS, [plan_id=20]
 
-(93) HashAggregate [codegen id : 19]
-Input [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
-Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
+(96) HashAggregate [codegen id : 19]
+Input [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
+Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#61, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
 Functions [1]: [sum(UnscaledValue(ss_net_paid#44))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#44))#31]
 Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#44))#31,17,2) AS netpaid#68]
 
-(94) HashAggregate [codegen id : 19]
+(97) HashAggregate [codegen id : 19]
 Input [1]: [netpaid#68]
 Keys: []
 Functions [1]: [partial_avg(netpaid#68)]
 Aggregate Attributes [2]: [sum#69, count#70]
 Results [2]: [sum#71, count#72]
 
-(95) Exchange
+(98) Exchange
 Input [2]: [sum#71, count#72]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=20]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=21]
 
-(96) HashAggregate [codegen id : 20]
+(99) HashAggregate [codegen id : 20]
 Input [2]: [sum#71, count#72]
 Keys: []
 Functions [1]: [avg(netpaid#68)]
 Aggregate Attributes [1]: [avg(netpaid#68)#73]
 Results [1]: [(0.05 * avg(netpaid#68)#73) AS (0.05 * avg(netpaid))#74]
 
-Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#1]
-ObjectHashAggregate (103)
-+- Exchange (102)
-   +- ObjectHashAggregate (101)
-      +- * Project (100)
-         +- * Filter (99)
-            +- * ColumnarToRow (98)
-               +- Scan parquet spark_catalog.default.store (97)
+Subquery:2 Hosting operator id = 21 Hosting Expression = Subquery scalar-subquery#19, [id=#4]
+ObjectHashAggregate (106)
++- Exchange (105)
+   +- ObjectHashAggregate (104)
+      +- * Project (103)
+         +- * Filter (102)
+            +- * ColumnarToRow (101)
+               +- Scan parquet spark_catalog.default.store (100)
 
 
-(97) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#21, s_market_id#23, s_zip#25]
+(100) Scan parquet spark_catalog.default.store
+Output [3]: [s_store_sk#1, s_market_id#3, s_zip#5]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_market_id:int,s_zip:string>
 
-(98) ColumnarToRow [codegen id : 1]
-Input [3]: [s_store_sk#21, s_market_id#23, s_zip#25]
+(101) ColumnarToRow [codegen id : 1]
+Input [3]: [s_store_sk#1, s_market_id#3, s_zip#5]
 
-(99) Filter [codegen id : 1]
-Input [3]: [s_store_sk#21, s_market_id#23, s_zip#25]
-Condition : (((isnotnull(s_market_id#23) AND (s_market_id#23 = 8)) AND isnotnull(s_store_sk#21)) AND isnotnull(s_zip#25))
+(102) Filter [codegen id : 1]
+Input [3]: [s_store_sk#1, s_market_id#3, s_zip#5]
+Condition : (((isnotnull(s_market_id#3) AND (s_market_id#3 = 8)) AND isnotnull(s_store_sk#1)) AND isnotnull(s_zip#5))
 
-(100) Project [codegen id : 1]
-Output [1]: [s_store_sk#21]
-Input [3]: [s_store_sk#21, s_market_id#23, s_zip#25]
+(103) Project [codegen id : 1]
+Output [1]: [s_store_sk#1]
+Input [3]: [s_store_sk#1, s_market_id#3, s_zip#5]
 
-(101) ObjectHashAggregate
-Input [1]: [s_store_sk#21]
+(104) ObjectHashAggregate
+Input [1]: [s_store_sk#1]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(s_store_sk#21, 42), 40, 1250, 0, 0)]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(s_store_sk#1, 42), 40, 1250, 0, 0)]
 Aggregate Attributes [1]: [buf#75]
 Results [1]: [buf#76]
 
-(102) Exchange
+(105) Exchange
 Input [1]: [buf#76]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=21]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=22]
 
-(103) ObjectHashAggregate
+(106) ObjectHashAggregate
 Input [1]: [buf#76]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(s_store_sk#21, 42), 40, 1250, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(s_store_sk#21, 42), 40, 1250, 0, 0)#77]
-Results [1]: [bloom_filter_agg(xxhash64(s_store_sk#21, 42), 40, 1250, 0, 0)#77 AS bloomFilter#78]
+Functions [1]: [bloom_filter_agg(xxhash64(s_store_sk#1, 42), 40, 1250, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(s_store_sk#1, 42), 40, 1250, 0, 0)#77]
+Results [1]: [bloom_filter_agg(xxhash64(s_store_sk#1, 42), 40, 1250, 0, 0)#77 AS bloomFilter#78]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/simplified.txt
@@ -13,82 +13,87 @@ WholeStageCodegen (14)
                         WholeStageCodegen (18)
                           HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,ss_net_paid] [sum,sum]
                             Project [ss_net_paid,s_store_name,s_state,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,ca_state]
-                              SortMergeJoin [c_birth_country,s_zip,ca_country,ca_zip]
+                              SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
                                 InputAdapter
                                   WholeStageCodegen (15)
-                                    Sort [c_birth_country,s_zip]
+                                    Sort [ss_ticket_number,ss_item_sk]
                                       InputAdapter
-                                        Exchange [c_birth_country,s_zip] #13
+                                        Exchange [ss_ticket_number,ss_item_sk] #13
                                           WholeStageCodegen (14)
-                                            Project [ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
-                                              SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                                            Project [ss_item_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,ca_state]
+                                              SortMergeJoin [ss_customer_sk,s_zip,c_customer_sk,ca_zip]
                                                 InputAdapter
-                                                  WholeStageCodegen (11)
-                                                    Sort [ss_ticket_number,ss_item_sk]
+                                                  WholeStageCodegen (7)
+                                                    Sort [ss_customer_sk,s_zip]
                                                       InputAdapter
-                                                        Exchange [ss_ticket_number,ss_item_sk] #14
-                                                          WholeStageCodegen (10)
-                                                            Project [ss_item_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
-                                                              SortMergeJoin [ss_customer_sk,c_customer_sk]
+                                                        Exchange [ss_customer_sk,s_zip] #14
+                                                          WholeStageCodegen (6)
+                                                            Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                              SortMergeJoin [ss_item_sk,i_item_sk]
                                                                 InputAdapter
-                                                                  WholeStageCodegen (7)
-                                                                    Sort [ss_customer_sk]
+                                                                  WholeStageCodegen (3)
+                                                                    Sort [ss_item_sk]
                                                                       InputAdapter
-                                                                        Exchange [ss_customer_sk] #15
-                                                                          WholeStageCodegen (6)
-                                                                            Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id]
-                                                                              SortMergeJoin [ss_item_sk,i_item_sk]
-                                                                                InputAdapter
-                                                                                  WholeStageCodegen (3)
-                                                                                    Sort [ss_item_sk]
+                                                                        Exchange [ss_item_sk] #15
+                                                                          WholeStageCodegen (2)
+                                                                            Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip]
+                                                                              BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                                                Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
+                                                                                  Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
+                                                                                    ColumnarToRow
                                                                                       InputAdapter
-                                                                                        Exchange [ss_item_sk] #16
-                                                                                          WholeStageCodegen (2)
-                                                                                            Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip]
-                                                                                              BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                                                                Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
-                                                                                                  Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
-                                                                                                    ColumnarToRow
-                                                                                                      InputAdapter
-                                                                                                        Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
-                                                                                                InputAdapter
-                                                                                                  BroadcastExchange #17
-                                                                                                    WholeStageCodegen (1)
-                                                                                                      Project [s_store_sk,s_store_name,s_state,s_zip]
-                                                                                                        Filter [s_market_id,s_store_sk,s_zip]
-                                                                                                          ColumnarToRow
-                                                                                                            InputAdapter
-                                                                                                              Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_market_id,s_state,s_zip]
+                                                                                        Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
                                                                                 InputAdapter
-                                                                                  WholeStageCodegen (5)
-                                                                                    Sort [i_item_sk]
-                                                                                      InputAdapter
-                                                                                        Exchange [i_item_sk] #18
-                                                                                          WholeStageCodegen (4)
-                                                                                            Filter [i_item_sk]
-                                                                                              ColumnarToRow
-                                                                                                InputAdapter
-                                                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                                                  BroadcastExchange #16
+                                                                                    WholeStageCodegen (1)
+                                                                                      Project [s_store_sk,s_store_name,s_state,s_zip]
+                                                                                        Filter [s_market_id,s_store_sk,s_zip]
+                                                                                          ColumnarToRow
+                                                                                            InputAdapter
+                                                                                              Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_market_id,s_state,s_zip]
                                                                 InputAdapter
-                                                                  WholeStageCodegen (9)
-                                                                    Sort [c_customer_sk]
+                                                                  WholeStageCodegen (5)
+                                                                    Sort [i_item_sk]
                                                                       InputAdapter
-                                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name,c_birth_country] #7
+                                                                        Exchange [i_item_sk] #17
+                                                                          WholeStageCodegen (4)
+                                                                            Filter [i_item_sk]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
                                                 InputAdapter
                                                   WholeStageCodegen (13)
-                                                    Sort [sr_ticket_number,sr_item_sk]
+                                                    Sort [c_customer_sk,ca_zip]
                                                       InputAdapter
-                                                        ReusedExchange [sr_item_sk,sr_ticket_number] #8
+                                                        Exchange [c_customer_sk,ca_zip] #18
+                                                          WholeStageCodegen (12)
+                                                            Project [c_customer_sk,c_first_name,c_last_name,ca_state,ca_zip]
+                                                              SortMergeJoin [c_birth_country,ca_country]
+                                                                InputAdapter
+                                                                  WholeStageCodegen (9)
+                                                                    Sort [c_birth_country]
+                                                                      InputAdapter
+                                                                        Exchange [c_birth_country] #19
+                                                                          WholeStageCodegen (8)
+                                                                            Filter [c_customer_sk,c_birth_country]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name,c_birth_country]
+                                                                InputAdapter
+                                                                  WholeStageCodegen (11)
+                                                                    Sort [ca_country]
+                                                                      InputAdapter
+                                                                        Exchange [ca_country] #20
+                                                                          WholeStageCodegen (10)
+                                                                            Filter [ca_country,ca_zip]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet spark_catalog.default.customer_address [ca_state,ca_zip,ca_country]
                                 InputAdapter
                                   WholeStageCodegen (17)
-                                    Sort [ca_country,ca_zip]
+                                    Sort [sr_ticket_number,sr_item_sk]
                                       InputAdapter
-                                        Exchange [ca_country,ca_zip] #19
-                                          WholeStageCodegen (16)
-                                            Filter [ca_country,ca_zip]
-                                              ColumnarToRow
-                                                InputAdapter
-                                                  Scan parquet spark_catalog.default.customer_address [ca_state,ca_zip,ca_country]
+                                        ReusedExchange [sr_item_sk,sr_ticket_number] #10
     HashAggregate [c_last_name,c_first_name,s_store_name,sum,isEmpty] [sum(netpaid),paid,sum,isEmpty]
       InputAdapter
         Exchange [c_last_name,c_first_name,s_store_name] #1
@@ -100,82 +105,82 @@ WholeStageCodegen (14)
                     WholeStageCodegen (12)
                       HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,ss_net_paid] [sum,sum]
                         Project [ss_net_paid,s_store_name,s_state,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,ca_state]
-                          BroadcastHashJoin [ss_store_sk,c_birth_country,s_store_sk,ca_country]
-                            Project [ss_store_sk,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
-                              SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
-                                InputAdapter
-                                  WholeStageCodegen (7)
-                                    Sort [ss_ticket_number,ss_item_sk]
-                                      InputAdapter
-                                        Exchange [ss_ticket_number,ss_item_sk] #3
-                                          WholeStageCodegen (6)
-                                            Project [ss_item_sk,ss_store_sk,ss_ticket_number,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
-                                              SortMergeJoin [ss_customer_sk,c_customer_sk]
-                                                InputAdapter
-                                                  WholeStageCodegen (3)
-                                                    Sort [ss_customer_sk]
-                                                      InputAdapter
-                                                        Exchange [ss_customer_sk] #4
-                                                          WholeStageCodegen (2)
-                                                            Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id]
-                                                              BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
-                                                                  Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
-                                                                    Subquery #1
-                                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(s_store_sk, 42), 40, 1250, 0, 0),bloomFilter,buf]
-                                                                        Exchange #5
-                                                                          ObjectHashAggregate [s_store_sk] [buf,buf]
-                                                                            WholeStageCodegen (1)
-                                                                              Project [s_store_sk]
-                                                                                Filter [s_market_id,s_store_sk,s_zip]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet spark_catalog.default.store [s_store_sk,s_market_id,s_zip]
-                                                                    ColumnarToRow
+                          SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                            InputAdapter
+                              WholeStageCodegen (9)
+                                Sort [ss_ticket_number,ss_item_sk]
+                                  InputAdapter
+                                    Exchange [ss_ticket_number,ss_item_sk] #3
+                                      WholeStageCodegen (8)
+                                        Project [s_store_name,s_state,ca_state,c_first_name,c_last_name,ss_item_sk,ss_ticket_number,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                          SortMergeJoin [s_store_sk,c_customer_sk,ss_store_sk,ss_customer_sk]
+                                            InputAdapter
+                                              WholeStageCodegen (4)
+                                                Sort [s_store_sk,c_customer_sk]
+                                                  InputAdapter
+                                                    Exchange [s_store_sk,c_customer_sk] #4
+                                                      WholeStageCodegen (3)
+                                                        Project [s_store_sk,s_store_name,s_state,ca_state,c_customer_sk,c_first_name,c_last_name]
+                                                          BroadcastHashJoin [ca_country,c_birth_country]
+                                                            InputAdapter
+                                                              BroadcastExchange #5
+                                                                WholeStageCodegen (2)
+                                                                  Project [s_store_sk,s_store_name,s_state,ca_state,ca_country]
+                                                                    BroadcastHashJoin [s_zip,ca_zip]
                                                                       InputAdapter
-                                                                        Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
-                                                                InputAdapter
-                                                                  BroadcastExchange #6
-                                                                    WholeStageCodegen (1)
-                                                                      Filter [i_color,i_item_sk]
+                                                                        BroadcastExchange #6
+                                                                          WholeStageCodegen (1)
+                                                                            Project [s_store_sk,s_store_name,s_state,s_zip]
+                                                                              Filter [s_market_id,s_store_sk,s_zip]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_market_id,s_state,s_zip]
+                                                                      Filter [ca_country,ca_zip]
                                                                         ColumnarToRow
                                                                           InputAdapter
-                                                                            Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
-                                                InputAdapter
-                                                  WholeStageCodegen (5)
-                                                    Sort [c_customer_sk]
-                                                      InputAdapter
-                                                        Exchange [c_customer_sk] #7
-                                                          WholeStageCodegen (4)
+                                                                            Scan parquet spark_catalog.default.customer_address [ca_state,ca_zip,ca_country]
                                                             Filter [c_customer_sk,c_birth_country]
                                                               ColumnarToRow
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name,c_birth_country]
-                                InputAdapter
-                                  WholeStageCodegen (9)
-                                    Sort [sr_ticket_number,sr_item_sk]
-                                      InputAdapter
-                                        Exchange [sr_ticket_number,sr_item_sk] #8
-                                          WholeStageCodegen (8)
-                                            Project [sr_item_sk,sr_ticket_number]
-                                              Filter [sr_ticket_number,sr_item_sk]
-                                                ColumnarToRow
+                                            InputAdapter
+                                              WholeStageCodegen (7)
+                                                Sort [ss_store_sk,ss_customer_sk]
                                                   InputAdapter
-                                                    Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]
+                                                    Exchange [ss_store_sk,ss_customer_sk] #7
+                                                      WholeStageCodegen (6)
+                                                        Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                          BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                            Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
+                                                              Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
+                                                                Subquery #1
+                                                                  ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(s_store_sk, 42), 40, 1250, 0, 0),bloomFilter,buf]
+                                                                    Exchange #8
+                                                                      ObjectHashAggregate [s_store_sk] [buf,buf]
+                                                                        WholeStageCodegen (1)
+                                                                          Project [s_store_sk]
+                                                                            Filter [s_market_id,s_store_sk,s_zip]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet spark_catalog.default.store [s_store_sk,s_market_id,s_zip]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
+                                                            InputAdapter
+                                                              BroadcastExchange #9
+                                                                WholeStageCodegen (5)
+                                                                  Filter [i_color,i_item_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
                             InputAdapter
-                              BroadcastExchange #9
-                                WholeStageCodegen (11)
-                                  Project [s_store_sk,s_store_name,s_state,ca_state,ca_country]
-                                    BroadcastHashJoin [s_zip,ca_zip]
-                                      InputAdapter
-                                        BroadcastExchange #10
-                                          WholeStageCodegen (10)
-                                            Project [s_store_sk,s_store_name,s_state,s_zip]
-                                              Filter [s_market_id,s_store_sk,s_zip]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_market_id,s_state,s_zip]
-                                      Filter [ca_country,ca_zip]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.customer_address [ca_state,ca_zip,ca_country]
+                              WholeStageCodegen (11)
+                                Sort [sr_ticket_number,sr_item_sk]
+                                  InputAdapter
+                                    Exchange [sr_ticket_number,sr_item_sk] #10
+                                      WholeStageCodegen (10)
+                                        Project [sr_item_sk,sr_ticket_number]
+                                          Filter [sr_ticket_number,sr_item_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve join estimation in case where equal-join's join key column stats are missing. Currently, the estimator could fall back to a Cartesian product `T(A) * T(B`), which often leads to severe overestimation.

We can instead use `max(T(A), T(B))` as a more accurate estimate.

### Why are the changes needed?
To improve the reliability of join estimation especially in AQE re-optimize.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Add unit test, and test on the prod Spark job.

TPC-DS benchmark shows no performance regression:
- Before
```bash
[info] TPCDS:                                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] q24a                                             237404         237715         440          1.3         775.7       1.0X
```
- After
```bash
[info] Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz
[info] TPCDS:                                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] q24a                                             236725         237440        1011          1.3         773.5       1.0X
```

### Was this patch authored or co-authored using generative AI tooling?
Cursor / Opus 4.6
