### PR TITLE
[SPARK-56358][BUILD] Add gson version override to SBT build to align with Maven

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1194,6 +1194,8 @@ object DependencyOverrides {
     dependencyOverrides ++= {
       val guavaVersion = sys.props.get("guava.version").getOrElse(
         SbtPomKeys.effectivePom.value.getProperties.get("guava.version").asInstanceOf[String])
+      val gsonVersion =
+        SbtPomKeys.effectivePom.value.getProperties.get("gson.version").asInstanceOf[String]
       val jlineVersion =
         SbtPomKeys.effectivePom.value.getProperties.get("jline.version").asInstanceOf[String]
       val avroVersion =
@@ -1202,8 +1204,6 @@ object DependencyOverrides {
         SbtPomKeys.effectivePom.value.getProperties.get("slf4j.version").asInstanceOf[String]
       val xzVersion =
         SbtPomKeys.effectivePom.value.getProperties.get("xz.version").asInstanceOf[String]
-      val gsonVersion =
-        SbtPomKeys.effectivePom.value.getProperties.get("gson.version").asInstanceOf[String]
       Seq(
         "com.google.guava" % "guava" % guavaVersion,
         "com.google.code.gson" % "gson" % gsonVersion,

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1202,8 +1202,11 @@ object DependencyOverrides {
         SbtPomKeys.effectivePom.value.getProperties.get("slf4j.version").asInstanceOf[String]
       val xzVersion =
         SbtPomKeys.effectivePom.value.getProperties.get("xz.version").asInstanceOf[String]
+      val gsonVersion =
+        SbtPomKeys.effectivePom.value.getProperties.get("gson.version").asInstanceOf[String]
       Seq(
         "com.google.guava" % "guava" % guavaVersion,
+        "com.google.code.gson" % "gson" % gsonVersion,
         "jline" % "jline" % jlineVersion,
         "org.apache.avro" % "avro" % avroVersion,
         "org.slf4j" % "slf4j-api" % slf4jVersion,


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr add `com.google.code.gson:gson` to `DependencyOverrides` in `project/SparkBuild.scala`, reading the version from `gson.version` property in the effective pom.



### Why are the changes needed?
Maven's root `pom.xml` declares `gson.version=2.13.2` in `<dependencyManagement>`, forcing all modules to resolve that version. The SBT build's `DependencyOverrides` object already overrides guava, jackson, avro, slf4j, xz, and jline to match Maven, but **gson was missing**.

Without this override, Coursier resolves gson `2.11.0` from transitive dependencies (`grpc-core:1.76.0` → `gson:2.11.0`, `protobuf-java-util:4.33.5` → `gson:2.11.0`), while Maven resolves `2.13.2`.

This causes differences in assembled jars for modules that shade gson (e.g., `connect-client-jvm`): gson 2.11.0 → 2.13.2 underwent internal class restructuring (e.g., `$Gson$Types` → `GsonTypes`, `TypeAdapters$EnumTypeAdapter` → standalone `EnumTypeAdapter`), resulting in ~20 class differences.



### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Pass Github Actions


### Was this patch authored or co-authored using generative AI tooling?
No
