### PR TITLE
[SPARK-55115][INFRA][FOLLOW-UP] Fix release workflow log tailing for base Docker image build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,13 +221,24 @@ jobs:
           RELEASE_PID=$!
 
           # Tail logs during dry run
+          # do-release-docker.sh creates docker-build-base.log before docker-build.log.
+          BASE_LOG_FILE="$RELEASE_DIR/docker-build-base.log"
+          echo "Waiting for log file: $BASE_LOG_FILE"
+          while [ ! -f "$BASE_LOG_FILE" ]; do
+            sleep 3
+          done
+
+          echo "Base log file found. Starting tail."
+          tail -F "$BASE_LOG_FILE" &
+          TAIL_PID_BASE=$!
+
           LOG_FILE="$RELEASE_DIR/docker-build.log"
           echo "Waiting for log file: $LOG_FILE"
           while [ ! -f "$LOG_FILE" ]; do
             sleep 3
           done
-            
-          echo "Log file found. Starting tail."
+
+          echo "Docker image log file found. Starting tail."
           tail -F "$LOG_FILE" &
           TAIL_PID1=$!
 
@@ -248,11 +259,11 @@ jobs:
           TAIL_PID2=$!
 
           wait $RELEASE_PID
-          kill $TAIL_PID1 $TAIL_PID2 || true
+          kill $TAIL_PID_BASE $TAIL_PID1 $TAIL_PID2 || true
 
           # Redact sensitive information in log files
           shopt -s globstar nullglob
-          FILES=("$RELEASE_DIR/docker-build.log" "$OUTPUT_DIR/"*.log)
+          FILES=("$RELEASE_DIR/docker-build-base.log" "$RELEASE_DIR/docker-build.log" "$OUTPUT_DIR/"*.log)
           PATTERNS=("$ASF_USERNAME" "$ASF_PASSWORD" "$GPG_PRIVATE_KEY" "$GPG_PASSPHRASE" "$PYPI_API_TOKEN" "$ASF_NEXUS_TOKEN")
           for file in "${FILES[@]}"; do
             [ -f "$file" ] || continue
@@ -275,10 +286,10 @@ jobs:
 
           # Zip logs/output
           if [ "$DRYRUN_MODE" = "1" ]; then
-            zip logs.zip "$RELEASE_DIR/docker-build.log" "$OUTPUT_DIR/"*.log
+            zip logs.zip "$RELEASE_DIR/docker-build-base.log" "$RELEASE_DIR/docker-build.log" "$OUTPUT_DIR/"*.log
             zip -9 output.zip -r "$OUTPUT_DIR"
           else
-            zip -P "$ASF_PASSWORD" logs.zip "$RELEASE_DIR/docker-build.log" "$OUTPUT_DIR/"*.log
+            zip -P "$ASF_PASSWORD" logs.zip "$RELEASE_DIR/docker-build-base.log" "$RELEASE_DIR/docker-build.log" "$OUTPUT_DIR/"*.log
             zip -9 -P "$ASF_PASSWORD" output.zip -r "$OUTPUT_DIR"
           fi
       - name: Upload logs


### PR DESCRIPTION
### What changes were proposed in this pull request?

Tail and wait on `docker-build-base.log` before `docker-build.log`; kill that tail; add the base log to redact/zip.

### Why are the changes needed?

The base image build logs only to `docker-build-base.log` first, so the old workflow showed no tail until `docker-build.log` existed.

### Does this PR introduce _any_ user-facing change?

Dev-only.

### How was this patch tested?

Not run in CI from here; verify with a fork workflow run.

### Was this patch authored or co-authored using generative AI tooling?

No.