### PR TITLE
[SPARK-56360][INFRA] Wait for base and RM Docker logs in release workflow; avoid hang on early failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,27 +220,41 @@ jobs:
           bash -c "$CMD" &
           RELEASE_PID=$!
 
-          # Tail logs during dry run
-          # do-release-docker.sh creates docker-build-base.log before docker-build.log.
+          # Stream Docker build logs to the job console. Wait until each file exists (they appear when each
+          # run_silent starts). If the release script exits early, stop waiting so we do not hang forever on
+          # docker-build.log when the base image build fails.
+          TAIL_PID_BASE=
+          TAIL_PID1=
+
           BASE_LOG_FILE="$RELEASE_DIR/docker-build-base.log"
           echo "Waiting for log file: $BASE_LOG_FILE"
           while [ ! -f "$BASE_LOG_FILE" ]; do
+            if ! kill -0 "$RELEASE_PID" 2>/dev/null; then
+              echo "Release process exited before $BASE_LOG_FILE was created."
+              break
+            fi
             sleep 3
           done
-
-          echo "Base log file found. Starting tail."
-          tail -F "$BASE_LOG_FILE" &
-          TAIL_PID_BASE=$!
+          if [ -f "$BASE_LOG_FILE" ]; then
+            echo "Base log file found. Starting tail."
+            tail -F "$BASE_LOG_FILE" &
+            TAIL_PID_BASE=$!
+          fi
 
           LOG_FILE="$RELEASE_DIR/docker-build.log"
           echo "Waiting for log file: $LOG_FILE"
           while [ ! -f "$LOG_FILE" ]; do
+            if ! kill -0 "$RELEASE_PID" 2>/dev/null; then
+              echo "Release process exited before $LOG_FILE was created."
+              break
+            fi
             sleep 3
           done
-
-          echo "Docker image log file found. Starting tail."
-          tail -F "$LOG_FILE" &
-          TAIL_PID1=$!
+          if [ -f "$LOG_FILE" ]; then
+            echo "Docker image log file found. Starting tail."
+            tail -F "$LOG_FILE" &
+            TAIL_PID1=$!
+          fi
 
           (
             LOGGED_FILES=()
@@ -259,7 +273,9 @@ jobs:
           TAIL_PID2=$!
 
           wait $RELEASE_PID
-          kill $TAIL_PID_BASE $TAIL_PID1 $TAIL_PID2 || true
+          [ -n "${TAIL_PID_BASE:-}" ] && kill "$TAIL_PID_BASE" 2>/dev/null || true
+          [ -n "${TAIL_PID1:-}" ] && kill "$TAIL_PID1" 2>/dev/null || true
+          kill "$TAIL_PID2" 2>/dev/null || true
 
           # Redact sensitive information in log files
           shopt -s globstar nullglob


### PR DESCRIPTION
### What changes were proposed in this pull request?

Release workflow: wait for docker-build-base.log and docker-build.log before tail; stop waiting if the release process exits; include base log in redact/zip; kill tails safely.

### Why are the changes needed?

Base build only writes docker-build-base.log first; waiting only on docker-build.log hid progress and could hang if the script exited before that file existed.

### Does this PR introduce _any_ user-facing change?

No, dev-only

### How was this patch tested?

I will test it in my fork.

### Was this patch authored or co-authored using generative AI tooling?

No.
