### PR TITLE
[SPARK-56362][INFRA] Add cmake to release Docker base image

### DIFF
--- a/dev/create-release/spark-rm/Dockerfile.base
+++ b/dev/create-release/spark-rm/Dockerfile.base
@@ -43,6 +43,7 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \
+    cmake \
     curl \
     gfortran \
     git \


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add cmake to the apt-get install list in `dev/create-release/spark-rm/Dockerfile.base`.


### Why are the changes needed?

Some R packages (e.g. `fs`) build native code with CMake; without cmake, the base image’s R `install.packages` step can fail when those builds run from source.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

I am testing this in my fork.

### Was this patch authored or co-authored using generative AI tooling?

No.