### PR TITLE
[SPARK-56399][PYTHON][TESTS] Add SimpleWorkerTests for non-daemon worker path

### DIFF
--- a/python/pyspark/tests/test_worker.py
+++ b/python/pyspark/tests/test_worker.py
@@ -272,6 +272,20 @@ class WorkerPoolCrashTest(PySparkTestCase):
         rdd.map(lambda x: os.getpid()).collect()
 
 
+class SimpleWorkerTests(WorkerTests):
+    """Run worker tests through the non-daemon (simple-worker) path.
+
+    Windows always uses this path; Linux/macOS use it when
+    spark.python.use.daemon=false.
+    """
+
+    @classmethod
+    def conf(cls):
+        conf = super().conf()
+        conf.set("spark.python.use.daemon", "false")
+        return conf
+
+
 if __name__ == "__main__":
     from pyspark.testing import main
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds `SimpleWorkerTests` class in `python/pyspark/tests/test_worker.py` that runs the full `WorkerTests` suite through the non-daemon (simple-worker) path by setting `spark.python.use.daemon=false`.

This PR was split from #55201 per [gaogaotiantian's suggestion](https://github.com/apache/spark/pull/55201#issuecomment-4194911340) (confirmed by HyukjinKwon) to keep the fix-only backports separate from the regression test coverage on master.

Explicit DataFrame, UDF, and DataSource tests were intentionally omitted: the worker socket lifecycle is shared across all eval types (`worker_util.py:get_sock_file_to_executor`), so RDD-level coverage via the inherited `WorkerTests` is sufficient for the simple-worker path. Higher-level APIs are covered by their own test suites, and per [gaogaotiantian's comment](https://github.com/apache/spark/pull/55201#issuecomment-4194911340), Python Data Source is already tested against the simple worker.

#### Related PRs
- #55201 — Fix for branch-4.1 (parent PR where the split was discussed)
- #55224 — Backport fix for branch-4.0
- #55225 — Backport fix for branch-3.5

### Why are the changes needed?

The simple-worker path (used always on Windows, and on Linux/macOS when `spark.python.use.daemon=false`) had no dedicated test coverage. SPARK-53759 exposed a bug in this path where the socket was not explicitly closed before process exit, causing `EOFException` — these tests would catch such regressions.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This is a tests-only PR.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.6)