### PR TITLE
[SPARK-56369][SS] Introduce a new API "rangeScan/rangeScanWithMultiValues" in StateStore

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/SymmetricHashJoinStateManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/SymmetricHashJoinStateManager.scala
@@ -27,7 +27,7 @@ import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{END_INDEX, INDEX, JOIN_SIDE, KEY, NUM_VALUES, PARTITION_ID, START_INDEX, STATE_STORE_ID, STATE_STORE_VERSION}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, GenericInternalRow, JoinedRow, Literal, SafeProjection, SpecificInternalRow, UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, JoinedRow, Literal, SafeProjection, SpecificInternalRow, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.streaming.operators.stateful.{StatefulOperatorStateInfo, StatefulOpStateStoreCheckpointInfo, WatermarkSupport}
@@ -647,25 +647,17 @@ class SymmetricHashJoinStateManagerV4(
 
     /**
      * Returns entries where minTs <= timestamp <= maxTs (both inclusive), grouped by timestamp.
-     *
-     * When a bounded range is provided, leverages RocksDB's native seek and upper bound via
-     * [[StateStore.scanWithMultiValues]] to avoid reading entries outside the range.
-     * Falls back to [[StateStore.prefixScanWithMultiValues]] when the full range is requested.
+     * Skips entries before minTs and stops iterating past maxTs (timestamps are sorted).
      */
     def getValuesInRange(
         key: UnsafeRow, minTs: Long, maxTs: Long): Iterator[GetValuesResult] = {
       val reusableGetValuesResult = new GetValuesResult()
 
       new NextIterator[GetValuesResult] {
-        private val iter = if (minTs == Long.MinValue && maxTs == Long.MaxValue) {
-          stateStore.prefixScanWithMultiValues(key, colFamilyName)
-        } else {
-          val startKeyRow = createKeyRow(key, minTs).copy()
-          val endKeyRow = createKeyRow(key, maxTs + 1)
-          stateStore.scanWithMultiValues(Some(startKeyRow), Some(endKeyRow), colFamilyName)
-        }
+        private val iter = stateStore.prefixScanWithMultiValues(key, colFamilyName)
 
         private var currentTs = -1L
+        private var pastUpperBound = false
         private val valueAndMatchPairs = scala.collection.mutable.ArrayBuffer[ValueAndMatchPair]()
 
         private def flushAccumulated(): GetValuesResult = {
@@ -683,13 +675,18 @@ class SymmetricHashJoinStateManagerV4(
 
         @tailrec
         override protected def getNext(): GetValuesResult = {
-          if (!iter.hasNext) {
+          if (pastUpperBound || !iter.hasNext) {
             flushAccumulated()
           } else {
             val unsafeRowPair = iter.next()
             val ts = TimestampKeyStateEncoder.extractTimestamp(unsafeRowPair.key)
 
-            if (currentTs == -1L || currentTs == ts) {
+            if (ts > maxTs) {
+              pastUpperBound = true
+              getNext()
+            } else if (ts < minTs) {
+              getNext()
+            } else if (currentTs == -1L || currentTs == ts) {
               currentTs = ts
               valueAndMatchPairs += valueRowConverter.convertValue(unsafeRowPair.value)
               getNext()
@@ -773,18 +770,11 @@ class SymmetricHashJoinStateManagerV4(
       stateStore.remove(createKeyRow(key, timestamp), colFamilyName)
     }
 
-    private lazy val dummyKeyRow: UnsafeRow = {
-      val defaultValues = keySchema.fields.map(f => Literal.default(f.dataType).eval())
-      val projection = UnsafeProjection.create(keySchema)
-      projection(new GenericInternalRow(defaultValues)).copy()
-    }
-
     case class EvictedKeysResult(key: UnsafeRow, timestamp: Long, numValues: Int)
 
     // NOTE: This assumes we consume the whole iterator to trigger completion.
     def scanEvictedKeys(endTimestamp: Long): Iterator[EvictedKeysResult] = {
-      val endKeyRow = createKeyRow(dummyKeyRow, endTimestamp + 1)
-      val evictIterator = stateStore.scanWithMultiValues(None, Some(endKeyRow), colFamilyName)
+      val evictIterator = stateStore.iteratorWithMultiValues(colFamilyName)
       new NextIterator[EvictedKeysResult]() {
         var currentKeyRow: UnsafeRow = null
         var currentEventTime: Long = -1L
@@ -799,19 +789,25 @@ class SymmetricHashJoinStateManagerV4(
             val ts = TimestampKeyStateEncoder.extractTimestamp(kv.key)
 
             if (keyRow == currentKeyRow && ts == currentEventTime) {
+              // new value with same (key, ts)
               count += 1
             } else if (ts > endTimestamp) {
-              // Safety check for boundary edge case: a small number of entries at exactly
-              // endTimestamp + 1 may leak through the upper bound because the encoded end key
-              // includes a join key suffix.
+              // we found the timestamp beyond the range - we shouldn't continue further
               isBeyondUpperBound = true
+
+              // We don't need to construct the last (key, ts) into EvictedKeysResult - the code
+              // after loop will handle that if there is leftover. That said, we do not reset the
+              // current (key, ts) info here.
             } else if (currentKeyRow == null && currentEventTime == -1L) {
+              // first value to process
               currentKeyRow = keyRow.copy()
               currentEventTime = ts
               count = 1
             } else {
+              // construct the last (key, ts) into EvictedKeysResult
               ret = EvictedKeysResult(currentKeyRow, currentEventTime, count)
 
+              // register the next (key, ts) to process
               currentKeyRow = keyRow.copy()
               currentEventTime = ts
               count = 1
@@ -821,8 +817,10 @@ class SymmetricHashJoinStateManagerV4(
           if (ret != null) {
             ret
           } else if (count > 0) {
+            // there is a final leftover (key, ts) to return
             ret = EvictedKeysResult(currentKeyRow, currentEventTime, count)
 
+            // we shouldn't continue further
             currentKeyRow = null
             currentEventTime = -1L
             count = 0

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/SymmetricHashJoinStateManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/SymmetricHashJoinStateManager.scala
@@ -660,7 +660,7 @@ class SymmetricHashJoinStateManagerV4(
         private val iter = if (minTs == Long.MinValue && maxTs == Long.MaxValue) {
           stateStore.prefixScanWithMultiValues(key, colFamilyName)
         } else {
-          val startKeyRow = createKeyRow(key, minTs)
+          val startKeyRow = createKeyRow(key, minTs).copy()
           val endKeyRow = createKeyRow(key, maxTs + 1)
           stateStore.scanWithMultiValues(Some(startKeyRow), endKeyRow, colFamilyName)
         }
@@ -774,8 +774,9 @@ class SymmetricHashJoinStateManagerV4(
     }
 
     private lazy val dummyKeyRow: UnsafeRow = {
+      val defaultValues = keySchema.fields.map(f => Literal.default(f.dataType).eval())
       val projection = UnsafeProjection.create(keySchema)
-      projection(new GenericInternalRow(keySchema.length)).copy()
+      projection(new GenericInternalRow(defaultValues)).copy()
     }
 
     case class EvictedKeysResult(key: UnsafeRow, timestamp: Long, numValues: Int)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/SymmetricHashJoinStateManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/SymmetricHashJoinStateManager.scala
@@ -27,7 +27,7 @@ import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{END_INDEX, INDEX, JOIN_SIDE, KEY, NUM_VALUES, PARTITION_ID, START_INDEX, STATE_STORE_ID, STATE_STORE_VERSION}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, JoinedRow, Literal, SafeProjection, SpecificInternalRow, UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, GenericInternalRow, JoinedRow, Literal, SafeProjection, SpecificInternalRow, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.streaming.operators.stateful.{StatefulOperatorStateInfo, StatefulOpStateStoreCheckpointInfo, WatermarkSupport}
@@ -647,17 +647,25 @@ class SymmetricHashJoinStateManagerV4(
 
     /**
      * Returns entries where minTs <= timestamp <= maxTs (both inclusive), grouped by timestamp.
-     * Skips entries before minTs and stops iterating past maxTs (timestamps are sorted).
+     *
+     * When a bounded range is provided, leverages RocksDB's native seek and upper bound via
+     * [[StateStore.scanWithMultiValues]] to avoid reading entries outside the range.
+     * Falls back to [[StateStore.prefixScanWithMultiValues]] when the full range is requested.
      */
     def getValuesInRange(
         key: UnsafeRow, minTs: Long, maxTs: Long): Iterator[GetValuesResult] = {
       val reusableGetValuesResult = new GetValuesResult()
 
       new NextIterator[GetValuesResult] {
-        private val iter = stateStore.prefixScanWithMultiValues(key, colFamilyName)
+        private val iter = if (minTs == Long.MinValue && maxTs == Long.MaxValue) {
+          stateStore.prefixScanWithMultiValues(key, colFamilyName)
+        } else {
+          val startKeyRow = createKeyRow(key, minTs)
+          val endKeyRow = createKeyRow(key, maxTs + 1)
+          stateStore.scanWithMultiValues(Some(startKeyRow), endKeyRow, colFamilyName)
+        }
 
         private var currentTs = -1L
-        private var pastUpperBound = false
         private val valueAndMatchPairs = scala.collection.mutable.ArrayBuffer[ValueAndMatchPair]()
 
         private def flushAccumulated(): GetValuesResult = {
@@ -675,18 +683,13 @@ class SymmetricHashJoinStateManagerV4(
 
         @tailrec
         override protected def getNext(): GetValuesResult = {
-          if (pastUpperBound || !iter.hasNext) {
+          if (!iter.hasNext) {
             flushAccumulated()
           } else {
             val unsafeRowPair = iter.next()
             val ts = TimestampKeyStateEncoder.extractTimestamp(unsafeRowPair.key)
 
-            if (ts > maxTs) {
-              pastUpperBound = true
-              getNext()
-            } else if (ts < minTs) {
-              getNext()
-            } else if (currentTs == -1L || currentTs == ts) {
+            if (currentTs == -1L || currentTs == ts) {
               currentTs = ts
               valueAndMatchPairs += valueRowConverter.convertValue(unsafeRowPair.value)
               getNext()
@@ -770,11 +773,17 @@ class SymmetricHashJoinStateManagerV4(
       stateStore.remove(createKeyRow(key, timestamp), colFamilyName)
     }
 
+    private lazy val dummyKeyRow: UnsafeRow = {
+      val projection = UnsafeProjection.create(keySchema)
+      projection(new GenericInternalRow(keySchema.length)).copy()
+    }
+
     case class EvictedKeysResult(key: UnsafeRow, timestamp: Long, numValues: Int)
 
     // NOTE: This assumes we consume the whole iterator to trigger completion.
     def scanEvictedKeys(endTimestamp: Long): Iterator[EvictedKeysResult] = {
-      val evictIterator = stateStore.iteratorWithMultiValues(colFamilyName)
+      val endKeyRow = createKeyRow(dummyKeyRow, endTimestamp + 1)
+      val evictIterator = stateStore.scanWithMultiValues(None, endKeyRow, colFamilyName)
       new NextIterator[EvictedKeysResult]() {
         var currentKeyRow: UnsafeRow = null
         var currentEventTime: Long = -1L
@@ -789,25 +798,19 @@ class SymmetricHashJoinStateManagerV4(
             val ts = TimestampKeyStateEncoder.extractTimestamp(kv.key)
 
             if (keyRow == currentKeyRow && ts == currentEventTime) {
-              // new value with same (key, ts)
               count += 1
             } else if (ts > endTimestamp) {
-              // we found the timestamp beyond the range - we shouldn't continue further
+              // Safety check for boundary edge case: a small number of entries at exactly
+              // endTimestamp + 1 may leak through the upper bound because the encoded end key
+              // includes a join key suffix.
               isBeyondUpperBound = true
-
-              // We don't need to construct the last (key, ts) into EvictedKeysResult - the code
-              // after loop will handle that if there is leftover. That said, we do not reset the
-              // current (key, ts) info here.
             } else if (currentKeyRow == null && currentEventTime == -1L) {
-              // first value to process
               currentKeyRow = keyRow.copy()
               currentEventTime = ts
               count = 1
             } else {
-              // construct the last (key, ts) into EvictedKeysResult
               ret = EvictedKeysResult(currentKeyRow, currentEventTime, count)
 
-              // register the next (key, ts) to process
               currentKeyRow = keyRow.copy()
               currentEventTime = ts
               count = 1
@@ -817,10 +820,8 @@ class SymmetricHashJoinStateManagerV4(
           if (ret != null) {
             ret
           } else if (count > 0) {
-            // there is a final leftover (key, ts) to return
             ret = EvictedKeysResult(currentKeyRow, currentEventTime, count)
 
-            // we shouldn't continue further
             currentKeyRow = null
             currentEventTime = -1L
             count = 0

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/SymmetricHashJoinStateManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/SymmetricHashJoinStateManager.scala
@@ -662,7 +662,7 @@ class SymmetricHashJoinStateManagerV4(
         } else {
           val startKeyRow = createKeyRow(key, minTs).copy()
           val endKeyRow = createKeyRow(key, maxTs + 1)
-          stateStore.scanWithMultiValues(Some(startKeyRow), endKeyRow, colFamilyName)
+          stateStore.scanWithMultiValues(Some(startKeyRow), Some(endKeyRow), colFamilyName)
         }
 
         private var currentTs = -1L
@@ -784,7 +784,7 @@ class SymmetricHashJoinStateManagerV4(
     // NOTE: This assumes we consume the whole iterator to trigger completion.
     def scanEvictedKeys(endTimestamp: Long): Iterator[EvictedKeysResult] = {
       val endKeyRow = createKeyRow(dummyKeyRow, endTimestamp + 1)
-      val evictIterator = stateStore.scanWithMultiValues(None, endKeyRow, colFamilyName)
+      val evictIterator = stateStore.scanWithMultiValues(None, Some(endKeyRow), colFamilyName)
       new NextIterator[EvictedKeysResult]() {
         var currentKeyRow: UnsafeRow = null
         var currentEventTime: Long = -1L

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -1759,7 +1759,7 @@ class RocksDB(
    * @param cfName   The column family name.
    * @return An iterator of ByteArrayPairs in the given range.
    */
-  def scan(
+  def rangeScan(
       startKey: Option[Array[Byte]],
       endKey: Option[Array[Byte]],
       cfName: String = StateStore.DEFAULT_COL_FAMILY_NAME): NextIterator[ByteArrayPair] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -1749,6 +1749,86 @@ class RocksDB(
     }
   }
 
+  /**
+   * Scan key-value pairs in the range [startKey, endKey).
+   *
+   * @param startKey None to seek to the beginning of the column family,
+   *                 or Some(key) to seek to the given start position (inclusive).
+   * @param endKey   The exclusive upper bound for the scan (encoded key bytes).
+   * @param cfName   The column family name.
+   * @return An iterator of ByteArrayPairs in the given range.
+   */
+  def scan(
+      startKey: Option[Array[Byte]],
+      endKey: Array[Byte],
+      cfName: String = StateStore.DEFAULT_COL_FAMILY_NAME): NextIterator[ByteArrayPair] = {
+    updateMemoryUsageIfNeeded()
+
+    val updatedEndKey = if (useColumnFamilies) {
+      encodeStateRowWithPrefix(endKey, cfName)
+    } else {
+      endKey
+    }
+
+    val seekTarget = startKey match {
+      case Some(key) =>
+        if (useColumnFamilies) encodeStateRowWithPrefix(key, cfName) else key
+      case None =>
+        if (useColumnFamilies) encodeStateRowWithPrefix(Array.emptyByteArray, cfName)
+        else null
+    }
+
+    val upperBoundSlice = new Slice(updatedEndKey)
+    val scanReadOptions = new ReadOptions()
+    scanReadOptions.setIterateUpperBound(upperBoundSlice)
+
+    val iter = db.newIterator(scanReadOptions)
+    if (seekTarget != null) {
+      iter.seek(seekTarget)
+    } else {
+      iter.seekToFirst()
+    }
+
+    def closeResources(): Unit = {
+      iter.close()
+      scanReadOptions.close()
+      upperBoundSlice.close()
+    }
+
+    Option(TaskContext.get()).foreach { tc =>
+      tc.addTaskCompletionListener[Unit] { _ => closeResources() }
+    }
+
+    new NextIterator[ByteArrayPair] {
+      override protected def getNext(): ByteArrayPair = {
+        if (iter.isValid) {
+          val key = if (useColumnFamilies) {
+            decodeStateRowWithPrefix(iter.key)._1
+          } else {
+            iter.key
+          }
+
+          val value = if (conf.rowChecksumEnabled) {
+            KeyValueChecksumEncoder.decodeAndVerifyValueRowWithChecksum(
+              readVerifier, iter.key, iter.value, delimiterSize)
+          } else {
+            iter.value
+          }
+
+          byteArrayPair.set(key, value)
+          iter.next()
+          byteArrayPair
+        } else {
+          finished = true
+          closeResources()
+          null
+        }
+      }
+
+      override protected def close(): Unit = closeResources()
+    }
+  }
+
   def release(): Unit = {}
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -1754,20 +1754,27 @@ class RocksDB(
    *
    * @param startKey None to seek to the beginning of the column family,
    *                 or Some(key) to seek to the given start position (inclusive).
-   * @param endKey   The exclusive upper bound for the scan (encoded key bytes).
+   * @param endKey   None to scan to the end of the column family,
+   *                 or Some(key) as the exclusive upper bound for the scan (encoded key bytes).
    * @param cfName   The column family name.
    * @return An iterator of ByteArrayPairs in the given range.
    */
   def scan(
       startKey: Option[Array[Byte]],
-      endKey: Array[Byte],
+      endKey: Option[Array[Byte]],
       cfName: String = StateStore.DEFAULT_COL_FAMILY_NAME): NextIterator[ByteArrayPair] = {
     updateMemoryUsageIfNeeded()
 
-    val updatedEndKey = if (useColumnFamilies) {
-      encodeStateRowWithPrefix(endKey, cfName)
-    } else {
-      endKey
+    val upperBoundBytes: Option[Array[Byte]] = endKey match {
+      case Some(key) =>
+        Some(if (useColumnFamilies) encodeStateRowWithPrefix(key, cfName) else key)
+      case None =>
+        if (useColumnFamilies) {
+          val cfPrefix = encodeStateRowWithPrefix(Array.emptyByteArray, cfName)
+          RocksDB.prefixUpperBound(cfPrefix)
+        } else {
+          None
+        }
     }
 
     val seekTarget = startKey match {
@@ -1778,9 +1785,9 @@ class RocksDB(
         else null
     }
 
-    val upperBoundSlice = new Slice(updatedEndKey)
+    val upperBoundSlice = upperBoundBytes.map(new Slice(_))
     val scanReadOptions = new ReadOptions()
-    scanReadOptions.setIterateUpperBound(upperBoundSlice)
+    upperBoundSlice.foreach(scanReadOptions.setIterateUpperBound)
 
     val iter = db.newIterator(scanReadOptions)
     if (seekTarget != null) {
@@ -1792,7 +1799,7 @@ class RocksDB(
     def closeResources(): Unit = {
       iter.close()
       scanReadOptions.close()
-      upperBoundSlice.close()
+      upperBoundSlice.foreach(_.close())
     }
 
     Option(TaskContext.get()).foreach { tc =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
@@ -46,6 +46,7 @@ import org.apache.spark.unsafe.Platform
 sealed trait RocksDBKeyStateEncoder {
   def supportPrefixKeyScan: Boolean
   def supportsDeleteRange: Boolean
+  def supportsRangeScan: Boolean
   def encodePrefixKey(prefixKey: UnsafeRow): Array[Byte]
   def encodeKey(row: UnsafeRow): Array[Byte]
   def decodeKey(keyBytes: Array[Byte]): UnsafeRow
@@ -1500,6 +1501,8 @@ class PrefixKeyScanStateEncoder(
   override def supportPrefixKeyScan: Boolean = true
 
   override def supportsDeleteRange: Boolean = false
+
+  override def supportsRangeScan: Boolean = false
 }
 
 /**
@@ -1699,6 +1702,8 @@ class RangeKeyScanStateEncoder(
   override def supportPrefixKeyScan: Boolean = true
 
   override def supportsDeleteRange: Boolean = true
+
+  override def supportsRangeScan: Boolean = true
 }
 
 /**
@@ -1730,6 +1735,8 @@ class NoPrefixKeyStateEncoder(
   override def supportPrefixKeyScan: Boolean = false
 
   override def supportsDeleteRange: Boolean = false
+
+  override def supportsRangeScan: Boolean = false
 
   override def encodePrefixKey(prefixKey: UnsafeRow): Array[Byte] = {
     throw new IllegalStateException("This encoder doesn't support prefix key!")
@@ -1884,6 +1891,8 @@ class TimestampAsPrefixKeyStateEncoder(
 
   // TODO: [SPARK-55491] Revisit this to support delete range if needed.
   override def supportsDeleteRange: Boolean = false
+
+  override def supportsRangeScan: Boolean = true
 }
 
 /**
@@ -1932,6 +1941,8 @@ class TimestampAsPostfixKeyStateEncoder(
   }
 
   override def supportsDeleteRange: Boolean = false
+
+  override def supportsRangeScan: Boolean = true
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -556,14 +556,17 @@ private[sql] class RocksDBStateStoreProvider
       new StateStoreIterator(iter, rocksDbIter.closeIfNeeded)
     }
 
-    override def scan(
+    override def rangeScan(
         startKey: Option[UnsafeRow],
         endKey: Option[UnsafeRow],
         colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
       validateAndTransitionState(UPDATE)
-      verifyColFamilyOperations("scan", colFamilyName)
+      verifyColFamilyOperations("rangeScan", colFamilyName)
 
       val kvEncoder = keyValueEncoderMap.get(colFamilyName)
+      require(kvEncoder._1.supportsRangeScan,
+        "Range scan requires an encoder that supports range scanning!")
+
       val encodedStartKey = startKey.map(kvEncoder._1.encodeKey)
       val encodedEndKey = endKey.map(kvEncoder._1.encodeKey)
 
@@ -578,14 +581,16 @@ private[sql] class RocksDBStateStoreProvider
       new StateStoreIterator(iter, rocksDbIter.closeIfNeeded)
     }
 
-    override def scanWithMultiValues(
+    override def rangeScanWithMultiValues(
         startKey: Option[UnsafeRow],
         endKey: Option[UnsafeRow],
         colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
       validateAndTransitionState(UPDATE)
-      verifyColFamilyOperations("scanWithMultiValues", colFamilyName)
+      verifyColFamilyOperations("rangeScanWithMultiValues", colFamilyName)
 
       val kvEncoder = keyValueEncoderMap.get(colFamilyName)
+      require(kvEncoder._1.supportsRangeScan,
+        "Range scan requires an encoder that supports range scanning!")
       verify(
         kvEncoder._2.supportsMultipleValuesPerKey,
         "Multi-value iterator operation requires an encoder" +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -556,6 +556,63 @@ private[sql] class RocksDBStateStoreProvider
       new StateStoreIterator(iter, rocksDbIter.closeIfNeeded)
     }
 
+    override def scan(
+        startKey: Option[UnsafeRow],
+        endKey: UnsafeRow,
+        colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
+      validateAndTransitionState(UPDATE)
+      verifyColFamilyOperations("scan", colFamilyName)
+
+      val kvEncoder = keyValueEncoderMap.get(colFamilyName)
+      val encodedStartKey = startKey.map(kvEncoder._1.encodeKey)
+      val encodedEndKey = kvEncoder._1.encodeKey(endKey)
+
+      val rowPair = new UnsafeRowPair()
+      val rocksDbIter = rocksDB.scan(encodedStartKey, encodedEndKey, colFamilyName)
+      val iter = rocksDbIter.map { kv =>
+        rowPair.withRows(kvEncoder._1.decodeKey(kv.key),
+          kvEncoder._2.decodeValue(kv.value))
+        rowPair
+      }
+
+      new StateStoreIterator(iter, rocksDbIter.closeIfNeeded)
+    }
+
+    override def scanWithMultiValues(
+        startKey: Option[UnsafeRow],
+        endKey: UnsafeRow,
+        colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
+      validateAndTransitionState(UPDATE)
+      verifyColFamilyOperations("scanWithMultiValues", colFamilyName)
+
+      val kvEncoder = keyValueEncoderMap.get(colFamilyName)
+      verify(
+        kvEncoder._2.supportsMultipleValuesPerKey,
+        "Multi-value iterator operation requires an encoder" +
+          " which supports multiple values for a single key")
+
+      val encodedStartKey = startKey.map(kvEncoder._1.encodeKey)
+      val encodedEndKey = kvEncoder._1.encodeKey(endKey)
+      val rocksDbIter = rocksDB.scan(encodedStartKey, encodedEndKey, colFamilyName)
+
+      val rowPair = new UnsafeRowPair()
+      val iter = rocksDbIter.flatMap { kv =>
+        val keyRow = kvEncoder._1.decodeKey(kv.key)
+        val valueRows = kvEncoder._2.decodeValues(kv.value)
+        valueRows.iterator.map { valueRow =>
+          rowPair.withRows(keyRow, valueRow)
+          if (!isValidated && rowPair.value != null && !useColumnFamilies) {
+            StateStoreProvider.validateStateRowFormat(
+              rowPair.key, keySchema, rowPair.value, valueSchema, stateStoreId, storeConf)
+            isValidated = true
+          }
+          rowPair
+        }
+      }
+
+      new StateStoreIterator(iter, rocksDbIter.closeIfNeeded)
+    }
+
     var checkpointInfo: Option[StateStoreCheckpointInfo] = None
     private var storedMetrics: Option[RocksDBMetrics] = None
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -571,7 +571,7 @@ private[sql] class RocksDBStateStoreProvider
       val encodedEndKey = endKey.map(kvEncoder._1.encodeKey)
 
       val rowPair = new UnsafeRowPair()
-      val rocksDbIter = rocksDB.scan(encodedStartKey, encodedEndKey, colFamilyName)
+      val rocksDbIter = rocksDB.rangeScan(encodedStartKey, encodedEndKey, colFamilyName)
       val iter = rocksDbIter.map { kv =>
         rowPair.withRows(kvEncoder._1.decodeKey(kv.key),
           kvEncoder._2.decodeValue(kv.value))
@@ -598,7 +598,7 @@ private[sql] class RocksDBStateStoreProvider
 
       val encodedStartKey = startKey.map(kvEncoder._1.encodeKey)
       val encodedEndKey = endKey.map(kvEncoder._1.encodeKey)
-      val rocksDbIter = rocksDB.scan(encodedStartKey, encodedEndKey, colFamilyName)
+      val rocksDbIter = rocksDB.rangeScan(encodedStartKey, encodedEndKey, colFamilyName)
 
       val rowPair = new UnsafeRowPair()
       val iter = rocksDbIter.flatMap { kv =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -558,14 +558,14 @@ private[sql] class RocksDBStateStoreProvider
 
     override def scan(
         startKey: Option[UnsafeRow],
-        endKey: UnsafeRow,
+        endKey: Option[UnsafeRow],
         colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
       validateAndTransitionState(UPDATE)
       verifyColFamilyOperations("scan", colFamilyName)
 
       val kvEncoder = keyValueEncoderMap.get(colFamilyName)
       val encodedStartKey = startKey.map(kvEncoder._1.encodeKey)
-      val encodedEndKey = kvEncoder._1.encodeKey(endKey)
+      val encodedEndKey = endKey.map(kvEncoder._1.encodeKey)
 
       val rowPair = new UnsafeRowPair()
       val rocksDbIter = rocksDB.scan(encodedStartKey, encodedEndKey, colFamilyName)
@@ -580,7 +580,7 @@ private[sql] class RocksDBStateStoreProvider
 
     override def scanWithMultiValues(
         startKey: Option[UnsafeRow],
-        endKey: UnsafeRow,
+        endKey: Option[UnsafeRow],
         colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
       validateAndTransitionState(UPDATE)
       verifyColFamilyOperations("scanWithMultiValues", colFamilyName)
@@ -592,7 +592,7 @@ private[sql] class RocksDBStateStoreProvider
           " which supports multiple values for a single key")
 
       val encodedStartKey = startKey.map(kvEncoder._1.encodeKey)
-      val encodedEndKey = kvEncoder._1.encodeKey(endKey)
+      val encodedEndKey = endKey.map(kvEncoder._1.encodeKey)
       val rocksDbIter = rocksDB.scan(encodedStartKey, encodedEndKey, colFamilyName)
 
       val rowPair = new UnsafeRowPair()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -590,7 +590,7 @@ private[sql] class RocksDBStateStoreProvider
 
       val kvEncoder = keyValueEncoderMap.get(colFamilyName)
       require(kvEncoder._1.supportsRangeScan,
-        "Range scan requires an encoder that supports range scanning!")
+        "Range scan with multiple values requires an encoder that supports range scanning!")
       verify(
         kvEncoder._2.supportsMultipleValuesPerKey,
         "Multi-value iterator operation requires an encoder" +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -188,7 +188,8 @@ trait ReadStateStore {
    *
    * @param startKey None to scan from the beginning of the column family,
    *                 or Some(key) to seek to the given start position (inclusive).
-   * @param endKey   The exclusive upper bound for the scan.
+   * @param endKey   None to scan to the end of the column family,
+   *                 or Some(key) as the exclusive upper bound for the scan.
    * @param colFamilyName The column family name.
    *
    * Callers must ensure the column family's key encoder produces lexicographically ordered
@@ -197,7 +198,7 @@ trait ReadStateStore {
    */
   def scan(
       startKey: Option[UnsafeRow],
-      endKey: UnsafeRow,
+      endKey: Option[UnsafeRow],
       colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME)
     : StateStoreIterator[UnsafeRowPair] = {
     throw StateStoreErrors.unsupportedOperationException("scan", "")
@@ -208,7 +209,8 @@ trait ReadStateStore {
    *
    * @param startKey None to scan from the beginning of the column family,
    *                 or Some(key) to seek to the given start position (inclusive).
-   * @param endKey   The exclusive upper bound for the scan.
+   * @param endKey   None to scan to the end of the column family,
+   *                 or Some(key) as the exclusive upper bound for the scan.
    * @param colFamilyName The column family name.
    *
    * Callers must ensure the column family's key encoder produces lexicographically ordered
@@ -220,7 +222,7 @@ trait ReadStateStore {
    */
   def scanWithMultiValues(
       startKey: Option[UnsafeRow],
-      endKey: UnsafeRow,
+      endKey: Option[UnsafeRow],
       colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME)
     : StateStoreIterator[UnsafeRowPair] = {
     throw StateStoreErrors.unsupportedOperationException("scanWithMultiValues", "")
@@ -456,14 +458,14 @@ class WrappedReadStateStore(store: StateStore) extends ReadStateStore {
 
   override def scan(
       startKey: Option[UnsafeRow],
-      endKey: UnsafeRow,
+      endKey: Option[UnsafeRow],
       colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
     store.scan(startKey, endKey, colFamilyName)
   }
 
   override def scanWithMultiValues(
       startKey: Option[UnsafeRow],
-      endKey: UnsafeRow,
+      endKey: Option[UnsafeRow],
       colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
     store.scanWithMultiValues(startKey, endKey, colFamilyName)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -196,12 +196,12 @@ trait ReadStateStore {
    * bytes for the scan range to be meaningful (e.g., timestamp-based encoders or
    * RangeKeyScanStateEncoder).
    */
-  def scan(
+  def rangeScan(
       startKey: Option[UnsafeRow],
       endKey: Option[UnsafeRow],
       colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME)
     : StateStoreIterator[UnsafeRowPair] = {
-    throw StateStoreErrors.unsupportedOperationException("scan", "")
+    throw StateStoreErrors.unsupportedOperationException("rangeScan", "")
   }
 
   /**
@@ -220,12 +220,12 @@ trait ReadStateStore {
    * It is expected to throw exception if Spark calls this method without setting
    * multipleValuesPerKey as true for the column family.
    */
-  def scanWithMultiValues(
+  def rangeScanWithMultiValues(
       startKey: Option[UnsafeRow],
       endKey: Option[UnsafeRow],
       colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME)
     : StateStoreIterator[UnsafeRowPair] = {
-    throw StateStoreErrors.unsupportedOperationException("scanWithMultiValues", "")
+    throw StateStoreErrors.unsupportedOperationException("rangeScanWithMultiValues", "")
   }
 
   /** Return an iterator containing all the key-value pairs in the StateStore. */
@@ -456,18 +456,18 @@ class WrappedReadStateStore(store: StateStore) extends ReadStateStore {
     store.prefixScanWithMultiValues(prefixKey, colFamilyName)
   }
 
-  override def scan(
+  override def rangeScan(
       startKey: Option[UnsafeRow],
       endKey: Option[UnsafeRow],
       colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
-    store.scan(startKey, endKey, colFamilyName)
+    store.rangeScan(startKey, endKey, colFamilyName)
   }
 
-  override def scanWithMultiValues(
+  override def rangeScanWithMultiValues(
       startKey: Option[UnsafeRow],
       endKey: Option[UnsafeRow],
       colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
-    store.scanWithMultiValues(startKey, endKey, colFamilyName)
+    store.rangeScanWithMultiValues(startKey, endKey, colFamilyName)
   }
 
   override def iteratorWithMultiValues(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -183,6 +183,49 @@ trait ReadStateStore {
       prefixKey: UnsafeRow,
       colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): StateStoreIterator[UnsafeRowPair]
 
+  /**
+   * Scan key-value pairs in the range [startKey, endKey).
+   *
+   * @param startKey None to scan from the beginning of the column family,
+   *                 or Some(key) to seek to the given start position (inclusive).
+   * @param endKey   The exclusive upper bound for the scan.
+   * @param colFamilyName The column family name.
+   *
+   * Callers must ensure the column family's key encoder produces lexicographically ordered
+   * bytes for the scan range to be meaningful (e.g., timestamp-based encoders or
+   * RangeKeyScanStateEncoder).
+   */
+  def scan(
+      startKey: Option[UnsafeRow],
+      endKey: UnsafeRow,
+      colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME)
+    : StateStoreIterator[UnsafeRowPair] = {
+    throw StateStoreErrors.unsupportedOperationException("scan", "")
+  }
+
+  /**
+   * Scan key-value pairs in the range [startKey, endKey), expanding multi-valued entries.
+   *
+   * @param startKey None to scan from the beginning of the column family,
+   *                 or Some(key) to seek to the given start position (inclusive).
+   * @param endKey   The exclusive upper bound for the scan.
+   * @param colFamilyName The column family name.
+   *
+   * Callers must ensure the column family's key encoder produces lexicographically ordered
+   * bytes for the scan range to be meaningful (e.g., timestamp-based encoders or
+   * RangeKeyScanStateEncoder).
+   *
+   * It is expected to throw exception if Spark calls this method without setting
+   * multipleValuesPerKey as true for the column family.
+   */
+  def scanWithMultiValues(
+      startKey: Option[UnsafeRow],
+      endKey: UnsafeRow,
+      colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME)
+    : StateStoreIterator[UnsafeRowPair] = {
+    throw StateStoreErrors.unsupportedOperationException("scanWithMultiValues", "")
+  }
+
   /** Return an iterator containing all the key-value pairs in the StateStore. */
   def iterator(
       colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): StateStoreIterator[UnsafeRowPair]
@@ -409,6 +452,20 @@ class WrappedReadStateStore(store: StateStore) extends ReadStateStore {
       prefixKey: UnsafeRow,
       colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
     store.prefixScanWithMultiValues(prefixKey, colFamilyName)
+  }
+
+  override def scan(
+      startKey: Option[UnsafeRow],
+      endKey: UnsafeRow,
+      colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
+    store.scan(startKey, endKey, colFamilyName)
+  }
+
+  override def scanWithMultiValues(
+      startKey: Option[UnsafeRow],
+      endKey: UnsafeRow,
+      colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
+    store.scanWithMultiValues(startKey, endKey, colFamilyName)
   }
 
   override def iteratorWithMultiValues(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreCheckpointFormatV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreCheckpointFormatV2Suite.scala
@@ -172,6 +172,20 @@ case class CkptIdCollectingStateStoreWrapper(innerStore: StateStore) extends Sta
     innerStore.prefixScanWithMultiValues(prefixKey, colFamilyName)
   }
 
+  override def scan(
+      startKey: Option[UnsafeRow],
+      endKey: UnsafeRow,
+      colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
+    innerStore.scan(startKey, endKey, colFamilyName)
+  }
+
+  override def scanWithMultiValues(
+      startKey: Option[UnsafeRow],
+      endKey: UnsafeRow,
+      colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
+    innerStore.scanWithMultiValues(startKey, endKey, colFamilyName)
+  }
+
   override def iteratorWithMultiValues(
       colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
     innerStore.iteratorWithMultiValues(colFamilyName)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreCheckpointFormatV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreCheckpointFormatV2Suite.scala
@@ -174,14 +174,14 @@ case class CkptIdCollectingStateStoreWrapper(innerStore: StateStore) extends Sta
 
   override def scan(
       startKey: Option[UnsafeRow],
-      endKey: UnsafeRow,
+      endKey: Option[UnsafeRow],
       colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
     innerStore.scan(startKey, endKey, colFamilyName)
   }
 
   override def scanWithMultiValues(
       startKey: Option[UnsafeRow],
-      endKey: UnsafeRow,
+      endKey: Option[UnsafeRow],
       colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
     innerStore.scanWithMultiValues(startKey, endKey, colFamilyName)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreCheckpointFormatV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreCheckpointFormatV2Suite.scala
@@ -172,18 +172,18 @@ case class CkptIdCollectingStateStoreWrapper(innerStore: StateStore) extends Sta
     innerStore.prefixScanWithMultiValues(prefixKey, colFamilyName)
   }
 
-  override def scan(
+  override def rangeScan(
       startKey: Option[UnsafeRow],
       endKey: Option[UnsafeRow],
       colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
-    innerStore.scan(startKey, endKey, colFamilyName)
+    innerStore.rangeScan(startKey, endKey, colFamilyName)
   }
 
-  override def scanWithMultiValues(
+  override def rangeScanWithMultiValues(
       startKey: Option[UnsafeRow],
       endKey: Option[UnsafeRow],
       colFamilyName: String): StateStoreIterator[UnsafeRowPair] = {
-    innerStore.scanWithMultiValues(startKey, endKey, colFamilyName)
+    innerStore.rangeScanWithMultiValues(startKey, endKey, colFamilyName)
   }
 
   override def iteratorWithMultiValues(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -1638,7 +1638,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
     -32L, -64L, -256L, 64L, 32L, 1024L, 4096L, 0L)
 
   testWithColumnFamiliesAndEncodingTypes("rocksdb range scan - rangeScan",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+    TestWithChangelogCheckpointingDisabled) { colFamiliesEnabled =>
 
     tryWithProviderResource(newStoreProvider(keySchemaWithRangeScan,
       RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
@@ -1708,6 +1708,12 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
         val negResults = negIter.map(_.key.getLong(0)).toList
         negIter.close()
         assert(negResults === diverseTimestamps.filter(ts => ts >= -300 && ts < 0).sorted)
+
+        // Both None: scan entire column family
+        val allIter = store.rangeScan(None, None, cfName)
+        val allResults = allIter.map(_.key.getLong(0)).toList
+        allIter.close()
+        assert(allResults === diverseTimestamps.sorted)
       } finally {
         if (!store.hasCommitted) store.abort()
       }
@@ -1716,7 +1722,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
 
   testWithColumnFamiliesAndEncodingTypes(
     "rocksdb range scan - scan with multiple key2 values within same key1 range",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+    TestWithChangelogCheckpointingDisabled) { colFamiliesEnabled =>
 
     tryWithProviderResource(newStoreProvider(keySchemaWithRangeScan,
       RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
@@ -1756,7 +1762,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
 
   testWithColumnFamiliesAndEncodingTypes(
     "rocksdb range scan - rangeScanWithMultiValues",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+    TestWithChangelogCheckpointingDisabled) { colFamiliesEnabled =>
 
     if (colFamiliesEnabled) {
       tryWithProviderResource(newStoreProvider(
@@ -1837,6 +1843,12 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
           negIter.close()
           assert(negResults.distinct === diverseTimestamps
             .filter(ts => ts >= -300 && ts < 0).sorted)
+
+          // Both None: scan entire column family
+          val allIter = store.rangeScanWithMultiValues(None, None, cfName)
+          val allResults = allIter.map(_.key.getLong(0)).toList
+          allIter.close()
+          assert(allResults.distinct === diverseTimestamps.sorted)
         } finally {
           if (!store.hasCommitted) store.abort()
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -1637,7 +1637,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
     -230L, -14569L, -92L, -7434253L, 35L, 6L, 9L, -323L, 5L,
     -32L, -64L, -256L, 64L, 32L, 1024L, 4096L, 0L)
 
-  testWithColumnFamiliesAndEncodingTypes("rocksdb range scan",
+  testWithColumnFamiliesAndEncodingTypes("rocksdb range scan - scan",
     TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
 
     tryWithProviderResource(newStoreProvider(keySchemaWithRangeScan,
@@ -1667,6 +1667,18 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
         val expectedBoundedTs = diverseTimestamps.filter(ts => ts >= 0 && ts < 100).sorted
         assert(boundedResults.map(_._1) === expectedBoundedTs)
         assert(boundedResults.map(_._2) === expectedBoundedTs.map(_.toInt))
+
+        // Exact bound: startKey is inclusive, endKey is exclusive.
+        // 9 exists in diverseTimestamps, 90 exists in diverseTimestamps.
+        // Scan [9, 90) should include 9 but exclude 90.
+        val exactIter = store.scan(
+          Some(dataToKeyRowWithRangeScan(9L, "a")),
+          Some(dataToKeyRowWithRangeScan(90L, "a")), cfName)
+        val exactResults = exactIter.map(_.key.getLong(0)).toList
+        exactIter.close()
+        assert(exactResults === diverseTimestamps.filter(ts => ts >= 9 && ts < 90).sorted)
+        assert(exactResults.contains(9L))
+        assert(!exactResults.contains(90L))
 
         // None startKey scans from beginning to 0
         val noneStartIter = store.scan(
@@ -1732,8 +1744,10 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
         }.toList
         iter.close()
 
-        assert(results.map(_._1).distinct.sorted === Seq(100L, 200L))
-        assert(results.length === 6) // 3 key2 values x 2 key1 values
+        val expectedResults = Seq(
+          (100L, "a"), (100L, "b"), (100L, "c"),
+          (200L, "a"), (200L, "b"), (200L, "c"))
+        assert(results === expectedResults)
       } finally {
         if (!store.hasCommitted) store.abort()
       }
@@ -1781,13 +1795,48 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
             .flatMap { case (_, idx) => Seq(idx * 10, idx * 10 + 1) }
           assert(boundedResults.map(_._2) === expectedValues)
 
+          // Exact bound: startKey is inclusive, endKey is exclusive.
+          // 9 exists in diverseTimestamps, 90 exists in diverseTimestamps.
+          val exactIter = store.scanWithMultiValues(
+            Some(dataToKeyRowWithRangeScan(9L, "a")),
+            Some(dataToKeyRowWithRangeScan(90L, "a")), cfName)
+          val exactResults = exactIter.map(_.key.getLong(0)).toList
+          exactIter.close()
+          val exactResultsDistinct = exactResults.distinct
+          assert(exactResultsDistinct === diverseTimestamps
+            .filter(ts => ts >= 9 && ts < 90).sorted)
+          assert(exactResultsDistinct.contains(9L))
+          assert(!exactResultsDistinct.contains(90L))
+
           // None startKey scans from beginning to 0
           val noneStartIter = store.scanWithMultiValues(
             None, Some(dataToKeyRowWithRangeScan(0L, "a")), cfName)
           val noneStartResults = noneStartIter.map(_.key.getLong(0)).toList
           noneStartIter.close()
-
           assert(noneStartResults.distinct === diverseTimestamps.filter(_ < 0).sorted)
+
+          // None endKey scans from 1000 to end
+          val noneEndIter = store.scanWithMultiValues(
+            Some(dataToKeyRowWithRangeScan(1000L, "a")), None, cfName)
+          val noneEndResults = noneEndIter.map(_.key.getLong(0)).toList
+          noneEndIter.close()
+          assert(noneEndResults.distinct === diverseTimestamps.filter(_ >= 1000).sorted)
+
+          // Empty range [10, 31) - no entries between 9 and 32
+          val emptyIter = store.scanWithMultiValues(
+            Some(dataToKeyRowWithRangeScan(10L, "a")),
+            Some(dataToKeyRowWithRangeScan(31L, "a")), cfName)
+          assert(!emptyIter.hasNext)
+          emptyIter.close()
+
+          // Bounded negative range [-300, 0)
+          val negIter = store.scanWithMultiValues(
+            Some(dataToKeyRowWithRangeScan(-300L, "a")),
+            Some(dataToKeyRowWithRangeScan(0L, "a")), cfName)
+          val negResults = negIter.map(_.key.getLong(0)).toList
+          negIter.close()
+          assert(negResults.distinct === diverseTimestamps
+            .filter(ts => ts >= -300 && ts < 0).sorted)
         } finally {
           if (!store.hasCommitted) store.abort()
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -1637,7 +1637,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
     -230L, -14569L, -92L, -7434253L, 35L, 6L, 9L, -323L, 5L,
     -32L, -64L, -256L, 64L, 32L, 1024L, 4096L, 0L)
 
-  testWithColumnFamiliesAndEncodingTypes("rocksdb range scan - scan",
+  testWithColumnFamiliesAndEncodingTypes("rocksdb range scan - rangeScan",
     TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
 
     tryWithProviderResource(newStoreProvider(keySchemaWithRangeScan,
@@ -1657,7 +1657,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
         }
 
         // Bounded positive range [0, 100)
-        val boundedIter = store.scan(
+        val boundedIter = store.rangeScan(
           Some(dataToKeyRowWithRangeScan(0L, "a")),
           Some(dataToKeyRowWithRangeScan(100L, "a")), cfName)
         val boundedResults = boundedIter.map { pair =>
@@ -1671,7 +1671,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
         // Exact bound: startKey is inclusive, endKey is exclusive.
         // 9 exists in diverseTimestamps, 90 exists in diverseTimestamps.
         // Scan [9, 90) should include 9 but exclude 90.
-        val exactIter = store.scan(
+        val exactIter = store.rangeScan(
           Some(dataToKeyRowWithRangeScan(9L, "a")),
           Some(dataToKeyRowWithRangeScan(90L, "a")), cfName)
         val exactResults = exactIter.map(_.key.getLong(0)).toList
@@ -1681,28 +1681,28 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
         assert(!exactResults.contains(90L))
 
         // None startKey scans from beginning to 0
-        val noneStartIter = store.scan(
+        val noneStartIter = store.rangeScan(
           None, Some(dataToKeyRowWithRangeScan(0L, "a")), cfName)
         val noneStartResults = noneStartIter.map(_.key.getLong(0)).toList
         noneStartIter.close()
         assert(noneStartResults === diverseTimestamps.filter(_ < 0).sorted)
 
         // None endKey scans from 1000 to end
-        val noneEndIter = store.scan(
+        val noneEndIter = store.rangeScan(
           Some(dataToKeyRowWithRangeScan(1000L, "a")), None, cfName)
         val noneEndResults = noneEndIter.map(_.key.getLong(0)).toList
         noneEndIter.close()
         assert(noneEndResults === diverseTimestamps.filter(_ >= 1000).sorted)
 
         // Empty range [10, 31) - no entries between 9 and 32
-        val emptyIter = store.scan(
+        val emptyIter = store.rangeScan(
           Some(dataToKeyRowWithRangeScan(10L, "a")),
           Some(dataToKeyRowWithRangeScan(31L, "a")), cfName)
         assert(!emptyIter.hasNext)
         emptyIter.close()
 
         // Bounded negative range [-300, 0)
-        val negIter = store.scan(
+        val negIter = store.rangeScan(
           Some(dataToKeyRowWithRangeScan(-300L, "a")),
           Some(dataToKeyRowWithRangeScan(0L, "a")), cfName)
         val negResults = negIter.map(_.key.getLong(0)).toList
@@ -1738,7 +1738,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
 
         val startKey = dataToKeyRowWithRangeScan(100L, "a")
         val endKey = dataToKeyRowWithRangeScan(201L, "a")
-        val iter = store.scan(Some(startKey), Some(endKey), cfName)
+        val iter = store.rangeScan(Some(startKey), Some(endKey), cfName)
         val results = iter.map { pair =>
           (pair.key.getLong(0), pair.key.getUTF8String(1).toString)
         }.toList
@@ -1755,7 +1755,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
   }
 
   testWithColumnFamiliesAndEncodingTypes(
-    "rocksdb range scan - scanWithMultiValues",
+    "rocksdb range scan - rangeScanWithMultiValues",
     TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
 
     if (colFamiliesEnabled) {
@@ -1779,7 +1779,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
           }
 
           // Bounded range [0, 1001)
-          val boundedIter = store.scanWithMultiValues(
+          val boundedIter = store.rangeScanWithMultiValues(
             Some(dataToKeyRowWithRangeScan(0L, "a")),
             Some(dataToKeyRowWithRangeScan(1001L, "a")), cfName)
           val boundedResults = boundedIter.map { pair =>
@@ -1797,7 +1797,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
 
           // Exact bound: startKey is inclusive, endKey is exclusive.
           // 9 exists in diverseTimestamps, 90 exists in diverseTimestamps.
-          val exactIter = store.scanWithMultiValues(
+          val exactIter = store.rangeScanWithMultiValues(
             Some(dataToKeyRowWithRangeScan(9L, "a")),
             Some(dataToKeyRowWithRangeScan(90L, "a")), cfName)
           val exactResults = exactIter.map(_.key.getLong(0)).toList
@@ -1809,28 +1809,28 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
           assert(!exactResultsDistinct.contains(90L))
 
           // None startKey scans from beginning to 0
-          val noneStartIter = store.scanWithMultiValues(
+          val noneStartIter = store.rangeScanWithMultiValues(
             None, Some(dataToKeyRowWithRangeScan(0L, "a")), cfName)
           val noneStartResults = noneStartIter.map(_.key.getLong(0)).toList
           noneStartIter.close()
           assert(noneStartResults.distinct === diverseTimestamps.filter(_ < 0).sorted)
 
           // None endKey scans from 1000 to end
-          val noneEndIter = store.scanWithMultiValues(
+          val noneEndIter = store.rangeScanWithMultiValues(
             Some(dataToKeyRowWithRangeScan(1000L, "a")), None, cfName)
           val noneEndResults = noneEndIter.map(_.key.getLong(0)).toList
           noneEndIter.close()
           assert(noneEndResults.distinct === diverseTimestamps.filter(_ >= 1000).sorted)
 
           // Empty range [10, 31) - no entries between 9 and 32
-          val emptyIter = store.scanWithMultiValues(
+          val emptyIter = store.rangeScanWithMultiValues(
             Some(dataToKeyRowWithRangeScan(10L, "a")),
             Some(dataToKeyRowWithRangeScan(31L, "a")), cfName)
           assert(!emptyIter.hasNext)
           emptyIter.close()
 
           // Bounded negative range [-300, 0)
-          val negIter = store.scanWithMultiValues(
+          val negIter = store.rangeScanWithMultiValues(
             Some(dataToKeyRowWithRangeScan(-300L, "a")),
             Some(dataToKeyRowWithRangeScan(0L, "a")), cfName)
           val negResults = negIter.map(_.key.getLong(0)).toList

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -1633,6 +1633,339 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
     }
   }
 
+  private val diverseTimestamps = Seq(931L, 8000L, 452300L, 4200L, -1L, 90L, 1L, 2L, 8L,
+    -230L, -14569L, -92L, -7434253L, 35L, 6L, 9L, -323L, 5L,
+    -32L, -64L, -256L, 64L, 32L, 1024L, 4096L, 0L)
+
+  testWithColumnFamiliesAndEncodingTypes("rocksdb range scan - scan bounded range",
+    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+
+    tryWithProviderResource(newStoreProvider(keySchemaWithRangeScan,
+      RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
+      colFamiliesEnabled)) { provider =>
+      val store = provider.getStore(0)
+      try {
+        val cfName = if (colFamiliesEnabled) "testColFamily" else "default"
+        if (colFamiliesEnabled) {
+          store.createColFamilyIfAbsent(cfName,
+            keySchemaWithRangeScan, valueSchema,
+            RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)))
+        }
+
+        val timestamps = Seq(100L, 200L, 300L, 400L, 500L)
+        timestamps.foreach { ts =>
+          store.put(dataToKeyRowWithRangeScan(ts, "a"), dataToValueRow(ts.toInt), cfName)
+        }
+
+        val startKey = dataToKeyRowWithRangeScan(200L, "a")
+        val endKey = dataToKeyRowWithRangeScan(401L, "a")
+        val iter = store.scan(Some(startKey), Some(endKey), cfName)
+        val results = iter.map { pair =>
+          (pair.key.getLong(0), pair.value.getInt(0))
+        }.toList
+        iter.close()
+
+        assert(results.map(_._1) === Seq(200L, 300L, 400L))
+        assert(results.map(_._2) === Seq(200, 300, 400))
+      } finally {
+        if (!store.hasCommitted) store.abort()
+      }
+    }
+  }
+
+  testWithColumnFamiliesAndEncodingTypes(
+    "rocksdb range scan - scan with None startKey scans from beginning",
+    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+
+    tryWithProviderResource(newStoreProvider(keySchemaWithRangeScan,
+      RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
+      colFamiliesEnabled)) { provider =>
+      val store = provider.getStore(0)
+      try {
+        val cfName = if (colFamiliesEnabled) "testColFamily" else "default"
+        if (colFamiliesEnabled) {
+          store.createColFamilyIfAbsent(cfName,
+            keySchemaWithRangeScan, valueSchema,
+            RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)))
+        }
+
+        val timestamps = Seq(100L, 200L, 300L, 400L, 500L)
+        timestamps.foreach { ts =>
+          store.put(dataToKeyRowWithRangeScan(ts, "a"), dataToValueRow(ts.toInt), cfName)
+        }
+
+        val endKey = dataToKeyRowWithRangeScan(301L, "a")
+        val iter = store.scan(None, Some(endKey), cfName)
+        val results = iter.map(_.key.getLong(0)).toList
+        iter.close()
+
+        assert(results === Seq(100L, 200L, 300L))
+      } finally {
+        if (!store.hasCommitted) store.abort()
+      }
+    }
+  }
+
+  testWithColumnFamiliesAndEncodingTypes(
+    "rocksdb range scan - scan with None endKey scans to end",
+    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+
+    tryWithProviderResource(newStoreProvider(keySchemaWithRangeScan,
+      RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
+      colFamiliesEnabled)) { provider =>
+      val store = provider.getStore(0)
+      try {
+        val cfName = if (colFamiliesEnabled) "testColFamily" else "default"
+        if (colFamiliesEnabled) {
+          store.createColFamilyIfAbsent(cfName,
+            keySchemaWithRangeScan, valueSchema,
+            RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)))
+        }
+
+        val timestamps = Seq(100L, 200L, 300L, 400L, 500L)
+        timestamps.foreach { ts =>
+          store.put(dataToKeyRowWithRangeScan(ts, "a"), dataToValueRow(ts.toInt), cfName)
+        }
+
+        val startKey = dataToKeyRowWithRangeScan(300L, "a")
+        val iter = store.scan(Some(startKey), None, cfName)
+        val results = iter.map(_.key.getLong(0)).toList
+        iter.close()
+
+        assert(results === Seq(300L, 400L, 500L))
+      } finally {
+        if (!store.hasCommitted) store.abort()
+      }
+    }
+  }
+
+  testWithColumnFamiliesAndEncodingTypes("rocksdb range scan - scan empty range",
+    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+
+    tryWithProviderResource(newStoreProvider(keySchemaWithRangeScan,
+      RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
+      colFamiliesEnabled)) { provider =>
+      val store = provider.getStore(0)
+      try {
+        val cfName = if (colFamiliesEnabled) "testColFamily" else "default"
+        if (colFamiliesEnabled) {
+          store.createColFamilyIfAbsent(cfName,
+            keySchemaWithRangeScan, valueSchema,
+            RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)))
+        }
+
+        store.put(dataToKeyRowWithRangeScan(100L, "a"), dataToValueRow(100), cfName)
+        store.put(dataToKeyRowWithRangeScan(500L, "a"), dataToValueRow(500), cfName)
+
+        val startKey = dataToKeyRowWithRangeScan(200L, "a")
+        val endKey = dataToKeyRowWithRangeScan(300L, "a")
+        val iter = store.scan(Some(startKey), Some(endKey), cfName)
+        assert(!iter.hasNext)
+        iter.close()
+      } finally {
+        if (!store.hasCommitted) store.abort()
+      }
+    }
+  }
+
+  testWithColumnFamiliesAndEncodingTypes(
+    "rocksdb range scan - scan with diverse timestamps bounded range",
+    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+
+    tryWithProviderResource(newStoreProvider(keySchemaWithRangeScan,
+      RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
+      colFamiliesEnabled)) { provider =>
+      val store = provider.getStore(0)
+      try {
+        val cfName = if (colFamiliesEnabled) "testColFamily" else "default"
+        if (colFamiliesEnabled) {
+          store.createColFamilyIfAbsent(cfName,
+            keySchemaWithRangeScan, valueSchema,
+            RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)))
+        }
+
+        diverseTimestamps.zipWithIndex.foreach { case (ts, idx) =>
+          store.put(dataToKeyRowWithRangeScan(ts, "a"), dataToValueRow(idx), cfName)
+        }
+
+        // Scan negative range: [-300, 0)
+        val startKey = dataToKeyRowWithRangeScan(-300L, "a")
+        val endKey = dataToKeyRowWithRangeScan(0L, "a")
+        val iter = store.scan(Some(startKey), Some(endKey), cfName)
+        val results = iter.map(_.key.getLong(0)).toList
+        iter.close()
+
+        val expected = diverseTimestamps.filter(ts => ts >= -300 && ts < 0).sorted
+        assert(results === expected)
+      } finally {
+        if (!store.hasCommitted) store.abort()
+      }
+    }
+  }
+
+  testWithColumnFamiliesAndEncodingTypes(
+    "rocksdb range scan - scan with multiple key2 values within same key1 range",
+    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+
+    tryWithProviderResource(newStoreProvider(keySchemaWithRangeScan,
+      RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
+      colFamiliesEnabled)) { provider =>
+      val store = provider.getStore(0)
+      try {
+        val cfName = if (colFamiliesEnabled) "testColFamily" else "default"
+        if (colFamiliesEnabled) {
+          store.createColFamilyIfAbsent(cfName,
+            keySchemaWithRangeScan, valueSchema,
+            RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)))
+        }
+
+        Seq("a", "b", "c").foreach { key2 =>
+          Seq(100L, 200L, 300L).foreach { ts =>
+            store.put(dataToKeyRowWithRangeScan(ts, key2), dataToValueRow(ts.toInt), cfName)
+          }
+        }
+
+        val startKey = dataToKeyRowWithRangeScan(100L, "a")
+        val endKey = dataToKeyRowWithRangeScan(201L, "a")
+        val iter = store.scan(Some(startKey), Some(endKey), cfName)
+        val results = iter.map { pair =>
+          (pair.key.getLong(0), pair.key.getUTF8String(1).toString)
+        }.toList
+        iter.close()
+
+        assert(results.map(_._1).distinct.sorted === Seq(100L, 200L))
+        assert(results.length === 6) // 3 key2 values x 2 key1 values
+      } finally {
+        if (!store.hasCommitted) store.abort()
+      }
+    }
+  }
+
+  testWithColumnFamiliesAndEncodingTypes(
+    "rocksdb range scan - scanWithMultiValues bounded range",
+    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+
+    // Multiple values per key requires column families
+    if (colFamiliesEnabled) {
+      tryWithProviderResource(newStoreProvider(
+        StateStoreId(newDir(), Random.nextInt(), 0),
+        RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
+        keySchema = keySchemaWithRangeScan,
+        useColumnFamilies = colFamiliesEnabled,
+        useMultipleValuesPerKey = true)) { provider =>
+        val store = provider.getStore(0)
+        try {
+          val cfName = "testColFamily"
+          store.createColFamilyIfAbsent(cfName,
+            keySchemaWithRangeScan, valueSchema,
+            RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
+            useMultipleValuesPerKey = true)
+
+          val timestamps = Seq(100L, 200L, 300L, 400L, 500L)
+          timestamps.foreach { ts =>
+            store.putList(dataToKeyRowWithRangeScan(ts, "a"),
+              Array(dataToValueRow(ts.toInt), dataToValueRow(ts.toInt + 1)), cfName)
+          }
+
+          val startKey = dataToKeyRowWithRangeScan(200L, "a")
+          val endKey = dataToKeyRowWithRangeScan(401L, "a")
+          val iter = store.scanWithMultiValues(Some(startKey), Some(endKey), cfName)
+          val results = iter.map { pair =>
+            (pair.key.getLong(0), pair.value.getInt(0))
+          }.toList
+          iter.close()
+
+          val resultTimestamps = results.map(_._1).distinct
+          assert(resultTimestamps === Seq(200L, 300L, 400L))
+          assert(results.length === 6) // 3 timestamps x 2 values each
+        } finally {
+          if (!store.hasCommitted) store.abort()
+        }
+      }
+    }
+  }
+
+  testWithColumnFamiliesAndEncodingTypes(
+    "rocksdb range scan - scanWithMultiValues with None startKey",
+    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+
+    if (colFamiliesEnabled) {
+      tryWithProviderResource(newStoreProvider(
+        StateStoreId(newDir(), Random.nextInt(), 0),
+        RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
+        keySchema = keySchemaWithRangeScan,
+        useColumnFamilies = colFamiliesEnabled,
+        useMultipleValuesPerKey = true)) { provider =>
+        val store = provider.getStore(0)
+        try {
+          val cfName = "testColFamily"
+          store.createColFamilyIfAbsent(cfName,
+            keySchemaWithRangeScan, valueSchema,
+            RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
+            useMultipleValuesPerKey = true)
+
+          val timestamps = Seq(100L, 200L, 300L, 400L, 500L)
+          timestamps.foreach { ts =>
+            store.merge(dataToKeyRowWithRangeScan(ts, "a"), dataToValueRow(ts.toInt), cfName)
+          }
+
+          val endKey = dataToKeyRowWithRangeScan(301L, "a")
+          val iter = store.scanWithMultiValues(None, Some(endKey), cfName)
+          val results = iter.map(_.key.getLong(0)).toList
+          iter.close()
+
+          assert(results === Seq(100L, 200L, 300L))
+        } finally {
+          if (!store.hasCommitted) store.abort()
+        }
+      }
+    }
+  }
+
+  testWithColumnFamiliesAndEncodingTypes(
+    "rocksdb range scan - scanWithMultiValues with diverse timestamps",
+    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+
+    if (colFamiliesEnabled) {
+      tryWithProviderResource(newStoreProvider(
+        StateStoreId(newDir(), Random.nextInt(), 0),
+        RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
+        keySchema = keySchemaWithRangeScan,
+        useColumnFamilies = colFamiliesEnabled,
+        useMultipleValuesPerKey = true)) { provider =>
+        val store = provider.getStore(0)
+        try {
+          val cfName = "testColFamily"
+          store.createColFamilyIfAbsent(cfName,
+            keySchemaWithRangeScan, valueSchema,
+            RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
+            useMultipleValuesPerKey = true)
+
+          diverseTimestamps.zipWithIndex.foreach { case (ts, idx) =>
+            store.putList(dataToKeyRowWithRangeScan(ts, "a"),
+              Array(dataToValueRow(idx * 10), dataToValueRow(idx * 10 + 1)), cfName)
+          }
+
+          // Scan [0, 1000] (inclusive via endKey = 1001)
+          val startKey = dataToKeyRowWithRangeScan(0L, "a")
+          val endKey = dataToKeyRowWithRangeScan(1001L, "a")
+          val iter = store.scanWithMultiValues(Some(startKey), Some(endKey), cfName)
+          val results = iter.map { pair =>
+            (pair.key.getLong(0), pair.value.getInt(0))
+          }.toList
+          iter.close()
+
+          val expectedTimestamps = diverseTimestamps.filter(ts => ts >= 0 && ts <= 1000).sorted
+          val resultTimestamps = results.map(_._1).distinct
+          assert(resultTimestamps === expectedTimestamps)
+          assert(results.length === expectedTimestamps.length * 2)
+        } finally {
+          if (!store.hasCommitted) store.abort()
+        }
+      }
+    }
+  }
+
   testWithColumnFamiliesAndEncodingTypes(
     "rocksdb key and value schema encoders for column families",
     TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -1637,7 +1637,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
     -230L, -14569L, -92L, -7434253L, 35L, 6L, 9L, -323L, 5L,
     -32L, -64L, -256L, 64L, 32L, 1024L, 4096L, 0L)
 
-  testWithColumnFamiliesAndEncodingTypes("rocksdb range scan - scan bounded range",
+  testWithColumnFamiliesAndEncodingTypes("rocksdb range scan",
     TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
 
     tryWithProviderResource(newStoreProvider(keySchemaWithRangeScan,
@@ -1652,151 +1652,50 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
             RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)))
         }
 
-        val timestamps = Seq(100L, 200L, 300L, 400L, 500L)
-        timestamps.foreach { ts =>
+        diverseTimestamps.foreach { ts =>
           store.put(dataToKeyRowWithRangeScan(ts, "a"), dataToValueRow(ts.toInt), cfName)
         }
 
-        val startKey = dataToKeyRowWithRangeScan(200L, "a")
-        val endKey = dataToKeyRowWithRangeScan(401L, "a")
-        val iter = store.scan(Some(startKey), Some(endKey), cfName)
-        val results = iter.map { pair =>
+        // Bounded positive range [0, 100)
+        val boundedIter = store.scan(
+          Some(dataToKeyRowWithRangeScan(0L, "a")),
+          Some(dataToKeyRowWithRangeScan(100L, "a")), cfName)
+        val boundedResults = boundedIter.map { pair =>
           (pair.key.getLong(0), pair.value.getInt(0))
         }.toList
-        iter.close()
+        boundedIter.close()
+        val expectedBoundedTs = diverseTimestamps.filter(ts => ts >= 0 && ts < 100).sorted
+        assert(boundedResults.map(_._1) === expectedBoundedTs)
+        assert(boundedResults.map(_._2) === expectedBoundedTs.map(_.toInt))
 
-        assert(results.map(_._1) === Seq(200L, 300L, 400L))
-        assert(results.map(_._2) === Seq(200, 300, 400))
-      } finally {
-        if (!store.hasCommitted) store.abort()
-      }
-    }
-  }
+        // None startKey scans from beginning to 0
+        val noneStartIter = store.scan(
+          None, Some(dataToKeyRowWithRangeScan(0L, "a")), cfName)
+        val noneStartResults = noneStartIter.map(_.key.getLong(0)).toList
+        noneStartIter.close()
+        assert(noneStartResults === diverseTimestamps.filter(_ < 0).sorted)
 
-  testWithColumnFamiliesAndEncodingTypes(
-    "rocksdb range scan - scan with None startKey scans from beginning",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+        // None endKey scans from 1000 to end
+        val noneEndIter = store.scan(
+          Some(dataToKeyRowWithRangeScan(1000L, "a")), None, cfName)
+        val noneEndResults = noneEndIter.map(_.key.getLong(0)).toList
+        noneEndIter.close()
+        assert(noneEndResults === diverseTimestamps.filter(_ >= 1000).sorted)
 
-    tryWithProviderResource(newStoreProvider(keySchemaWithRangeScan,
-      RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
-      colFamiliesEnabled)) { provider =>
-      val store = provider.getStore(0)
-      try {
-        val cfName = if (colFamiliesEnabled) "testColFamily" else "default"
-        if (colFamiliesEnabled) {
-          store.createColFamilyIfAbsent(cfName,
-            keySchemaWithRangeScan, valueSchema,
-            RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)))
-        }
+        // Empty range [10, 31) - no entries between 9 and 32
+        val emptyIter = store.scan(
+          Some(dataToKeyRowWithRangeScan(10L, "a")),
+          Some(dataToKeyRowWithRangeScan(31L, "a")), cfName)
+        assert(!emptyIter.hasNext)
+        emptyIter.close()
 
-        val timestamps = Seq(100L, 200L, 300L, 400L, 500L)
-        timestamps.foreach { ts =>
-          store.put(dataToKeyRowWithRangeScan(ts, "a"), dataToValueRow(ts.toInt), cfName)
-        }
-
-        val endKey = dataToKeyRowWithRangeScan(301L, "a")
-        val iter = store.scan(None, Some(endKey), cfName)
-        val results = iter.map(_.key.getLong(0)).toList
-        iter.close()
-
-        assert(results === Seq(100L, 200L, 300L))
-      } finally {
-        if (!store.hasCommitted) store.abort()
-      }
-    }
-  }
-
-  testWithColumnFamiliesAndEncodingTypes(
-    "rocksdb range scan - scan with None endKey scans to end",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
-
-    tryWithProviderResource(newStoreProvider(keySchemaWithRangeScan,
-      RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
-      colFamiliesEnabled)) { provider =>
-      val store = provider.getStore(0)
-      try {
-        val cfName = if (colFamiliesEnabled) "testColFamily" else "default"
-        if (colFamiliesEnabled) {
-          store.createColFamilyIfAbsent(cfName,
-            keySchemaWithRangeScan, valueSchema,
-            RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)))
-        }
-
-        val timestamps = Seq(100L, 200L, 300L, 400L, 500L)
-        timestamps.foreach { ts =>
-          store.put(dataToKeyRowWithRangeScan(ts, "a"), dataToValueRow(ts.toInt), cfName)
-        }
-
-        val startKey = dataToKeyRowWithRangeScan(300L, "a")
-        val iter = store.scan(Some(startKey), None, cfName)
-        val results = iter.map(_.key.getLong(0)).toList
-        iter.close()
-
-        assert(results === Seq(300L, 400L, 500L))
-      } finally {
-        if (!store.hasCommitted) store.abort()
-      }
-    }
-  }
-
-  testWithColumnFamiliesAndEncodingTypes("rocksdb range scan - scan empty range",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
-
-    tryWithProviderResource(newStoreProvider(keySchemaWithRangeScan,
-      RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
-      colFamiliesEnabled)) { provider =>
-      val store = provider.getStore(0)
-      try {
-        val cfName = if (colFamiliesEnabled) "testColFamily" else "default"
-        if (colFamiliesEnabled) {
-          store.createColFamilyIfAbsent(cfName,
-            keySchemaWithRangeScan, valueSchema,
-            RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)))
-        }
-
-        store.put(dataToKeyRowWithRangeScan(100L, "a"), dataToValueRow(100), cfName)
-        store.put(dataToKeyRowWithRangeScan(500L, "a"), dataToValueRow(500), cfName)
-
-        val startKey = dataToKeyRowWithRangeScan(200L, "a")
-        val endKey = dataToKeyRowWithRangeScan(300L, "a")
-        val iter = store.scan(Some(startKey), Some(endKey), cfName)
-        assert(!iter.hasNext)
-        iter.close()
-      } finally {
-        if (!store.hasCommitted) store.abort()
-      }
-    }
-  }
-
-  testWithColumnFamiliesAndEncodingTypes(
-    "rocksdb range scan - scan with diverse timestamps bounded range",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
-
-    tryWithProviderResource(newStoreProvider(keySchemaWithRangeScan,
-      RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
-      colFamiliesEnabled)) { provider =>
-      val store = provider.getStore(0)
-      try {
-        val cfName = if (colFamiliesEnabled) "testColFamily" else "default"
-        if (colFamiliesEnabled) {
-          store.createColFamilyIfAbsent(cfName,
-            keySchemaWithRangeScan, valueSchema,
-            RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)))
-        }
-
-        diverseTimestamps.zipWithIndex.foreach { case (ts, idx) =>
-          store.put(dataToKeyRowWithRangeScan(ts, "a"), dataToValueRow(idx), cfName)
-        }
-
-        // Scan negative range: [-300, 0)
-        val startKey = dataToKeyRowWithRangeScan(-300L, "a")
-        val endKey = dataToKeyRowWithRangeScan(0L, "a")
-        val iter = store.scan(Some(startKey), Some(endKey), cfName)
-        val results = iter.map(_.key.getLong(0)).toList
-        iter.close()
-
-        val expected = diverseTimestamps.filter(ts => ts >= -300 && ts < 0).sorted
-        assert(results === expected)
+        // Bounded negative range [-300, 0)
+        val negIter = store.scan(
+          Some(dataToKeyRowWithRangeScan(-300L, "a")),
+          Some(dataToKeyRowWithRangeScan(0L, "a")), cfName)
+        val negResults = negIter.map(_.key.getLong(0)).toList
+        negIter.close()
+        assert(negResults === diverseTimestamps.filter(ts => ts >= -300 && ts < 0).sorted)
       } finally {
         if (!store.hasCommitted) store.abort()
       }
@@ -1842,88 +1741,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
   }
 
   testWithColumnFamiliesAndEncodingTypes(
-    "rocksdb range scan - scanWithMultiValues bounded range",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
-
-    // Multiple values per key requires column families
-    if (colFamiliesEnabled) {
-      tryWithProviderResource(newStoreProvider(
-        StateStoreId(newDir(), Random.nextInt(), 0),
-        RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
-        keySchema = keySchemaWithRangeScan,
-        useColumnFamilies = colFamiliesEnabled,
-        useMultipleValuesPerKey = true)) { provider =>
-        val store = provider.getStore(0)
-        try {
-          val cfName = "testColFamily"
-          store.createColFamilyIfAbsent(cfName,
-            keySchemaWithRangeScan, valueSchema,
-            RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
-            useMultipleValuesPerKey = true)
-
-          val timestamps = Seq(100L, 200L, 300L, 400L, 500L)
-          timestamps.foreach { ts =>
-            store.putList(dataToKeyRowWithRangeScan(ts, "a"),
-              Array(dataToValueRow(ts.toInt), dataToValueRow(ts.toInt + 1)), cfName)
-          }
-
-          val startKey = dataToKeyRowWithRangeScan(200L, "a")
-          val endKey = dataToKeyRowWithRangeScan(401L, "a")
-          val iter = store.scanWithMultiValues(Some(startKey), Some(endKey), cfName)
-          val results = iter.map { pair =>
-            (pair.key.getLong(0), pair.value.getInt(0))
-          }.toList
-          iter.close()
-
-          val resultTimestamps = results.map(_._1).distinct
-          assert(resultTimestamps === Seq(200L, 300L, 400L))
-          assert(results.length === 6) // 3 timestamps x 2 values each
-        } finally {
-          if (!store.hasCommitted) store.abort()
-        }
-      }
-    }
-  }
-
-  testWithColumnFamiliesAndEncodingTypes(
-    "rocksdb range scan - scanWithMultiValues with None startKey",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
-
-    if (colFamiliesEnabled) {
-      tryWithProviderResource(newStoreProvider(
-        StateStoreId(newDir(), Random.nextInt(), 0),
-        RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
-        keySchema = keySchemaWithRangeScan,
-        useColumnFamilies = colFamiliesEnabled,
-        useMultipleValuesPerKey = true)) { provider =>
-        val store = provider.getStore(0)
-        try {
-          val cfName = "testColFamily"
-          store.createColFamilyIfAbsent(cfName,
-            keySchemaWithRangeScan, valueSchema,
-            RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
-            useMultipleValuesPerKey = true)
-
-          val timestamps = Seq(100L, 200L, 300L, 400L, 500L)
-          timestamps.foreach { ts =>
-            store.merge(dataToKeyRowWithRangeScan(ts, "a"), dataToValueRow(ts.toInt), cfName)
-          }
-
-          val endKey = dataToKeyRowWithRangeScan(301L, "a")
-          val iter = store.scanWithMultiValues(None, Some(endKey), cfName)
-          val results = iter.map(_.key.getLong(0)).toList
-          iter.close()
-
-          assert(results === Seq(100L, 200L, 300L))
-        } finally {
-          if (!store.hasCommitted) store.abort()
-        }
-      }
-    }
-  }
-
-  testWithColumnFamiliesAndEncodingTypes(
-    "rocksdb range scan - scanWithMultiValues with diverse timestamps",
+    "rocksdb range scan - scanWithMultiValues",
     TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
 
     if (colFamiliesEnabled) {
@@ -1946,19 +1764,30 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
               Array(dataToValueRow(idx * 10), dataToValueRow(idx * 10 + 1)), cfName)
           }
 
-          // Scan [0, 1000] (inclusive via endKey = 1001)
-          val startKey = dataToKeyRowWithRangeScan(0L, "a")
-          val endKey = dataToKeyRowWithRangeScan(1001L, "a")
-          val iter = store.scanWithMultiValues(Some(startKey), Some(endKey), cfName)
-          val results = iter.map { pair =>
+          // Bounded range [0, 1001)
+          val boundedIter = store.scanWithMultiValues(
+            Some(dataToKeyRowWithRangeScan(0L, "a")),
+            Some(dataToKeyRowWithRangeScan(1001L, "a")), cfName)
+          val boundedResults = boundedIter.map { pair =>
             (pair.key.getLong(0), pair.value.getInt(0))
           }.toList
-          iter.close()
+          boundedIter.close()
 
           val expectedTimestamps = diverseTimestamps.filter(ts => ts >= 0 && ts <= 1000).sorted
-          val resultTimestamps = results.map(_._1).distinct
-          assert(resultTimestamps === expectedTimestamps)
-          assert(results.length === expectedTimestamps.length * 2)
+          assert(boundedResults.map(_._1).distinct === expectedTimestamps)
+          val expectedValues = diverseTimestamps.zipWithIndex
+            .filter { case (ts, _) => ts >= 0 && ts <= 1000 }
+            .sortBy(_._1)
+            .flatMap { case (_, idx) => Seq(idx * 10, idx * 10 + 1) }
+          assert(boundedResults.map(_._2) === expectedValues)
+
+          // None startKey scans from beginning to 0
+          val noneStartIter = store.scanWithMultiValues(
+            None, Some(dataToKeyRowWithRangeScan(0L, "a")), cfName)
+          val noneStartResults = noneStartIter.map(_.key.getLong(0)).toList
+          noneStartIter.close()
+
+          assert(noneStartResults.distinct === diverseTimestamps.filter(_ < 0).sorted)
         } finally {
           if (!store.hasCommitted) store.abort()
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBTimestampEncoderOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBTimestampEncoderOperationsSuite.scala
@@ -591,7 +591,7 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
           val prefixKey = keyToRow("key1", 1)
           val startKey = keyAndTimestampToRow("key1", 1, 0L)
           val endKey = keyAndTimestampToRow("key1", 1, 1001L)
-          val iter = store.scanWithMultiValues(Some(startKey), endKey)
+          val iter = store.scanWithMultiValues(Some(startKey), Some(endKey))
 
           val results = iter.map { pair =>
             (pair.key.getLong(2), pair.value.getInt(0))
@@ -628,7 +628,7 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
           // Scan with Some(startKey) covering full range
           val startKey = keyAndTimestampToRow("key1", 1, Long.MinValue)
           val endKey = keyAndTimestampToRow("key1", 1, Long.MaxValue)
-          val iter = store.scanWithMultiValues(Some(startKey), endKey)
+          val iter = store.scanWithMultiValues(Some(startKey), Some(endKey))
           val results = iter.map(_.key.getLong(2)).toList
           iter.close()
 
@@ -657,7 +657,7 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
           // Scan range that contains no entries
           val startKey = keyAndTimestampToRow("key1", 1, 1500L)
           val endKey = keyAndTimestampToRow("key1", 1, 1600L)
-          val iter = store.scanWithMultiValues(Some(startKey), endKey)
+          val iter = store.scanWithMultiValues(Some(startKey), Some(endKey))
           assert(!iter.hasNext)
           iter.close()
         } finally {
@@ -685,7 +685,7 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
 
           // Scan from beginning (None) up to 301 (exclusive), covering [..300]
           val endKey = keyAndTimestampToRow("key1", 1, 301L)
-          val iter = store.scanWithMultiValues(None, endKey)
+          val iter = store.scanWithMultiValues(None, Some(endKey))
           val results = iter.map(_.key.getLong(2)).toList
           iter.close()
 
@@ -715,7 +715,7 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
           // Scan with endKey at timestamp 201 with dummyKey - should include
           // everything up to timestamp 200 regardless of join key
           val endKey = keyAndTimestampToRow("key1", 1, 201L)
-          val iter = store.scanWithMultiValues(None, endKey)
+          val iter = store.scanWithMultiValues(None, Some(endKey))
           val results = iter.map { pair =>
             (pair.key.getString(0), pair.key.getLong(2))
           }.toList
@@ -747,7 +747,7 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
 
           val startKey = keyAndTimestampToRow("key1", 1, 200L)
           val endKey = keyAndTimestampToRow("key1", 1, 401L)
-          val iter = store.scan(Some(startKey), endKey)
+          val iter = store.scan(Some(startKey), Some(endKey))
           val results = iter.map { pair =>
             (pair.key.getLong(2), pair.value.getInt(0))
           }.toList
@@ -778,7 +778,7 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
           // Scan negative range only: [-300, 0)
           val startKey = keyAndTimestampToRow("key1", 1, -300L)
           val endKey = keyAndTimestampToRow("key1", 1, 0L)
-          val iter = store.scan(Some(startKey), endKey)
+          val iter = store.scan(Some(startKey), Some(endKey))
           val results = iter.map(_.key.getLong(2)).toList
           iter.close()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBTimestampEncoderOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBTimestampEncoderOperationsSuite.scala
@@ -567,7 +567,7 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
   }
 
   Seq("unsaferow", "avro").foreach { encoding =>
-    test(s"scan with postfix encoder: bounded range (encoding = $encoding)") {
+    test(s"scan with postfix encoder (encoding = $encoding)") {
       tryWithProviderResource(
         newStoreProviderWithTimestampEncoder(
           encoderType = "postfix",
@@ -577,97 +577,54 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
         val store = provider.getStore(0)
 
         try {
-          // Insert entries for key1 at various timestamps
           diverseTimestamps.zipWithIndex.foreach { case (ts, idx) =>
             val keyRow = keyAndTimestampToRow("key1", 1, ts)
             store.putList(keyRow, Array(valueToRow(idx * 10), valueToRow(idx * 10 + 1)))
           }
 
-          // Insert entries for key2 to verify isolation
+          // key2 entry to verify prefix isolation
           store.putList(keyAndTimestampToRow("key2", 1, 500L),
             Array(valueToRow(999)))
 
-          // Scan key1 in range [0, 1000] (inclusive via endKey = 1001)
-          val prefixKey = keyToRow("key1", 1)
-          val startKey = keyAndTimestampToRow("key1", 1, 0L)
-          val endKey = keyAndTimestampToRow("key1", 1, 1001L)
-          val iter = store.scanWithMultiValues(Some(startKey), Some(endKey))
-
-          val results = iter.map { pair =>
+          // Bounded range [0, 1001)
+          val boundedIter = store.scanWithMultiValues(
+            Some(keyAndTimestampToRow("key1", 1, 0L)),
+            Some(keyAndTimestampToRow("key1", 1, 1001L)))
+          val boundedResults = boundedIter.map { pair =>
             (pair.key.getLong(2), pair.value.getInt(0))
           }.toList
-          iter.close()
+          boundedIter.close()
 
-          // Timestamps in [0, 1000]: 0, 1, 2, 5, 6, 8, 9, 32, 35, 64, 90, 931
           val expectedTimestamps = diverseTimestamps.filter(ts => ts >= 0 && ts <= 1000).sorted
-          val resultTimestamps = results.map(_._1).distinct
-          assert(resultTimestamps === expectedTimestamps)
-          assert(results.length === expectedTimestamps.length * 2) // 2 values per timestamp
+          assert(boundedResults.map(_._1).distinct === expectedTimestamps)
+          val expectedValues = diverseTimestamps.zipWithIndex
+            .filter { case (ts, _) => ts >= 0 && ts <= 1000 }
+            .sortBy(_._1)
+            .flatMap { case (_, idx) => Seq(idx * 10, idx * 10 + 1) }
+          assert(boundedResults.map(_._2) === expectedValues)
+
+          // Full range [MinValue, MaxValue)
+          val fullIter = store.scanWithMultiValues(
+            Some(keyAndTimestampToRow("key1", 1, Long.MinValue)),
+            Some(keyAndTimestampToRow("key1", 1, Long.MaxValue)))
+          val fullResults = fullIter.map(_.key.getLong(2)).toList
+          fullIter.close()
+
+          assert(fullResults.distinct === diverseTimestamps.sorted)
+
+          // Empty range [10, 31) - no diverseTimestamps entries between 9 and 32
+          val emptyIter = store.scanWithMultiValues(
+            Some(keyAndTimestampToRow("key1", 1, 10L)),
+            Some(keyAndTimestampToRow("key1", 1, 31L)))
+          assert(!emptyIter.hasNext)
+          emptyIter.close()
         } finally {
           store.abort()
         }
       }
     }
 
-    test(s"scan with postfix encoder: full range falls back correctly (encoding = $encoding)") {
-      tryWithProviderResource(
-        newStoreProviderWithTimestampEncoder(
-          encoderType = "postfix",
-          useMultipleValuesPerKey = true,
-          dataEncoding = encoding)
-      ) { provider =>
-        val store = provider.getStore(0)
-
-        try {
-          val timestamps = Seq(100L, 200L, 300L)
-          timestamps.foreach { ts =>
-            store.putList(keyAndTimestampToRow("key1", 1, ts),
-              Array(valueToRow(ts.toInt)))
-          }
-
-          // Scan with Some(startKey) covering full range
-          val startKey = keyAndTimestampToRow("key1", 1, Long.MinValue)
-          val endKey = keyAndTimestampToRow("key1", 1, Long.MaxValue)
-          val iter = store.scanWithMultiValues(Some(startKey), Some(endKey))
-          val results = iter.map(_.key.getLong(2)).toList
-          iter.close()
-
-          assert(results === timestamps)
-        } finally {
-          store.abort()
-        }
-      }
-    }
-
-    test(s"scan with postfix encoder: empty range (encoding = $encoding)") {
-      tryWithProviderResource(
-        newStoreProviderWithTimestampEncoder(
-          encoderType = "postfix",
-          useMultipleValuesPerKey = true,
-          dataEncoding = encoding)
-      ) { provider =>
-        val store = provider.getStore(0)
-
-        try {
-          store.putList(keyAndTimestampToRow("key1", 1, 1000L),
-            Array(valueToRow(100)))
-          store.putList(keyAndTimestampToRow("key1", 1, 2000L),
-            Array(valueToRow(200)))
-
-          // Scan range that contains no entries
-          val startKey = keyAndTimestampToRow("key1", 1, 1500L)
-          val endKey = keyAndTimestampToRow("key1", 1, 1600L)
-          val iter = store.scanWithMultiValues(Some(startKey), Some(endKey))
-          assert(!iter.hasNext)
-          iter.close()
-        } finally {
-          store.abort()
-        }
-      }
-    }
-
-    test(s"scan with prefix encoder: None startKey scans from beginning " +
-      s"(encoding = $encoding)") {
+    test(s"scan with prefix encoder (encoding = $encoding)") {
       tryWithProviderResource(
         newStoreProviderWithTimestampEncoder(
           encoderType = "prefix",
@@ -677,53 +634,30 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
         val store = provider.getStore(0)
 
         try {
-          // Insert entries at various timestamps
           val timestamps = Seq(100L, 200L, 300L, 400L, 500L)
-          timestamps.foreach { ts =>
-            store.merge(keyAndTimestampToRow("key1", 1, ts), valueToRow(ts.toInt))
-          }
-
-          // Scan from beginning (None) up to 301 (exclusive), covering [..300]
-          val endKey = keyAndTimestampToRow("key1", 1, 301L)
-          val iter = store.scanWithMultiValues(None, Some(endKey))
-          val results = iter.map(_.key.getLong(2)).toList
-          iter.close()
-
-          assert(results === Seq(100L, 200L, 300L))
-        } finally {
-          store.abort()
-        }
-      }
-    }
-
-    test(s"scan with prefix encoder: boundary safety check (encoding = $encoding)") {
-      tryWithProviderResource(
-        newStoreProviderWithTimestampEncoder(
-          encoderType = "prefix",
-          useMultipleValuesPerKey = true,
-          dataEncoding = encoding)
-      ) { provider =>
-        val store = provider.getStore(0)
-
-        try {
-          val timestamps = Seq(100L, 200L, 300L)
           timestamps.foreach { ts =>
             store.merge(keyAndTimestampToRow("key1", 1, ts), valueToRow(ts.toInt))
           }
           store.merge(keyAndTimestampToRow("key2", 2, 150L), valueToRow(150))
 
-          // Scan with endKey at timestamp 201 with dummyKey - should include
-          // everything up to timestamp 200 regardless of join key
-          val endKey = keyAndTimestampToRow("key1", 1, 201L)
-          val iter = store.scanWithMultiValues(None, Some(endKey))
-          val results = iter.map { pair =>
+          // None startKey scans from beginning up to 301 (exclusive)
+          val iter1 = store.scanWithMultiValues(None,
+            Some(keyAndTimestampToRow("key1", 1, 301L)))
+          val results1 = iter1.map(_.key.getLong(2)).toList
+          iter1.close()
+
+          assert(results1 === Seq(100L, 150L, 200L, 300L))
+
+          // Boundary safety: endKey at 201, includes everything up to 200
+          // regardless of join key
+          val iter2 = store.scanWithMultiValues(None,
+            Some(keyAndTimestampToRow("key1", 1, 201L)))
+          val results2 = iter2.map { pair =>
             (pair.key.getString(0), pair.key.getLong(2))
           }.toList
-          iter.close()
+          iter2.close()
 
-          // Should include key1@100, key2@150, key1@200
-          assert(results.length === 3)
-          assert(results.map(_._2) === Seq(100L, 150L, 200L))
+          assert(results2.map(_._2) === Seq(100L, 150L, 200L))
         } finally {
           store.abort()
         }
@@ -740,50 +674,32 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
         val store = provider.getStore(0)
 
         try {
-          val timestamps = Seq(100L, 200L, 300L, 400L, 500L)
-          timestamps.foreach { ts =>
+          diverseTimestamps.foreach { ts =>
             store.put(keyAndTimestampToRow("key1", 1, ts), valueToRow(ts.toInt))
           }
 
-          val startKey = keyAndTimestampToRow("key1", 1, 200L)
-          val endKey = keyAndTimestampToRow("key1", 1, 401L)
-          val iter = store.scan(Some(startKey), Some(endKey))
-          val results = iter.map { pair =>
+          // Bounded positive range [0, 100)
+          val posIter = store.scan(
+            Some(keyAndTimestampToRow("key1", 1, 0L)),
+            Some(keyAndTimestampToRow("key1", 1, 100L)))
+          val posResults = posIter.map { pair =>
             (pair.key.getLong(2), pair.value.getInt(0))
           }.toList
-          iter.close()
+          posIter.close()
 
-          assert(results.map(_._1) === Seq(200L, 300L, 400L))
-          assert(results.map(_._2) === Seq(200, 300, 400))
-        } finally {
-          store.abort()
-        }
-      }
-    }
+          val expectedPosTs = diverseTimestamps.filter(ts => ts >= 0 && ts < 100).sorted
+          assert(posResults.map(_._1) === expectedPosTs)
+          assert(posResults.map(_._2) === expectedPosTs.map(_.toInt))
 
-    test(s"scan with diverse timestamps and bounded range (encoding = $encoding)") {
-      tryWithProviderResource(
-        newStoreProviderWithTimestampEncoder(
-          encoderType = "postfix",
-          useMultipleValuesPerKey = false,
-          dataEncoding = encoding)
-      ) { provider =>
-        val store = provider.getStore(0)
+          // Bounded negative range [-300, 0)
+          val negIter = store.scan(
+            Some(keyAndTimestampToRow("key1", 1, -300L)),
+            Some(keyAndTimestampToRow("key1", 1, 0L)))
+          val negResults = negIter.map(_.key.getLong(2)).toList
+          negIter.close()
 
-        try {
-          diverseTimestamps.zipWithIndex.foreach { case (ts, idx) =>
-            store.put(keyAndTimestampToRow("key1", 1, ts), valueToRow(idx))
-          }
-
-          // Scan negative range only: [-300, 0)
-          val startKey = keyAndTimestampToRow("key1", 1, -300L)
-          val endKey = keyAndTimestampToRow("key1", 1, 0L)
-          val iter = store.scan(Some(startKey), Some(endKey))
-          val results = iter.map(_.key.getLong(2)).toList
-          iter.close()
-
-          val expected = diverseTimestamps.filter(ts => ts >= -300 && ts < 0).sorted
-          assert(results === expected)
+          val expectedNegTs = diverseTimestamps.filter(ts => ts >= -300 && ts < 0).sorted
+          assert(negResults === expectedNegTs)
         } finally {
           store.abort()
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBTimestampEncoderOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBTimestampEncoderOperationsSuite.scala
@@ -567,7 +567,7 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
   }
 
   Seq("unsaferow", "avro").foreach { encoding =>
-    test(s"scan with postfix encoder (encoding = $encoding)") {
+    test(s"rangeScan with postfix encoder (encoding = $encoding)") {
       tryWithProviderResource(
         newStoreProviderWithTimestampEncoder(
           encoderType = "postfix",
@@ -587,7 +587,7 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
             Array(valueToRow(999)))
 
           // Bounded range [0, 1001)
-          val boundedIter = store.scanWithMultiValues(
+          val boundedIter = store.rangeScanWithMultiValues(
             Some(keyAndTimestampToRow("key1", 1, 0L)),
             Some(keyAndTimestampToRow("key1", 1, 1001L)))
           val boundedResults = boundedIter.map { pair =>
@@ -606,7 +606,7 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
 
           // Exact bound: startKey is inclusive, endKey is exclusive.
           // 9 exists in diverseTimestamps, 90 exists in diverseTimestamps.
-          val exactIter = store.scanWithMultiValues(
+          val exactIter = store.rangeScanWithMultiValues(
             Some(keyAndTimestampToRow("key1", 1, 9L)),
             Some(keyAndTimestampToRow("key1", 1, 90L)))
           val exactResults = exactIter.map(_.key.getLong(2)).toList
@@ -623,7 +623,7 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
           // test bounded ranges with explicit keys here.
 
           // Full range [MinValue, MaxValue)
-          val fullIter = store.scanWithMultiValues(
+          val fullIter = store.rangeScanWithMultiValues(
             Some(keyAndTimestampToRow("key1", 1, Long.MinValue)),
             Some(keyAndTimestampToRow("key1", 1, Long.MaxValue)))
           val fullResults = fullIter.map(_.key.getLong(2)).toList
@@ -632,7 +632,7 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
           assert(fullResults.distinct === diverseTimestamps.sorted)
 
           // Bounded negative range [-300, 0)
-          val negIter = store.scanWithMultiValues(
+          val negIter = store.rangeScanWithMultiValues(
             Some(keyAndTimestampToRow("key1", 1, -300L)),
             Some(keyAndTimestampToRow("key1", 1, 0L)))
           val negResults = negIter.map(_.key.getLong(2)).toList
@@ -641,7 +641,7 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
             .filter(ts => ts >= -300 && ts < 0).sorted)
 
           // Empty range [10, 31) - no diverseTimestamps entries between 9 and 32
-          val emptyIter = store.scanWithMultiValues(
+          val emptyIter = store.rangeScanWithMultiValues(
             Some(keyAndTimestampToRow("key1", 1, 10L)),
             Some(keyAndTimestampToRow("key1", 1, 31L)))
           assert(!emptyIter.hasNext)
@@ -653,9 +653,9 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
     }
 
     // Sanity test for prefix encoder scan. Full scan coverage is in RocksDBStateStoreSuite's
-    // "rocksdb range scan - scan" and "rocksdb range scan - scanWithMultiValues" tests.
+    // "rocksdb range scan - rangeScan" and "rocksdb range scan - rangeScanWithMultiValues" tests.
     // This test verifies the timestamp prefix encoder integration works correctly.
-    test(s"scan with prefix encoder (encoding = $encoding)") {
+    test(s"rangeScan with prefix encoder (encoding = $encoding)") {
       tryWithProviderResource(
         newStoreProviderWithTimestampEncoder(
           encoderType = "prefix",
@@ -672,7 +672,7 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
           store.merge(keyAndTimestampToRow("key2", 2, 150L), valueToRow(150))
 
           // None startKey scans from beginning up to 301 (exclusive)
-          val iter1 = store.scanWithMultiValues(None,
+          val iter1 = store.rangeScanWithMultiValues(None,
             Some(keyAndTimestampToRow("key1", 1, 301L)))
           val results1 = iter1.map { pair =>
             (pair.key.getString(0), pair.key.getLong(2))
@@ -684,7 +684,7 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
 
           // Boundary safety: endKey at 201, includes everything up to 200
           // regardless of join key
-          val iter2 = store.scanWithMultiValues(None,
+          val iter2 = store.rangeScanWithMultiValues(None,
             Some(keyAndTimestampToRow("key1", 1, 201L)))
           val results2 = iter2.map { pair =>
             (pair.key.getString(0), pair.key.getLong(2))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBTimestampEncoderOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBTimestampEncoderOperationsSuite.scala
@@ -591,17 +591,36 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
             Some(keyAndTimestampToRow("key1", 1, 0L)),
             Some(keyAndTimestampToRow("key1", 1, 1001L)))
           val boundedResults = boundedIter.map { pair =>
-            (pair.key.getLong(2), pair.value.getInt(0))
+            (pair.key.getString(0), pair.key.getLong(2), pair.value.getInt(0))
           }.toList
           boundedIter.close()
 
           val expectedTimestamps = diverseTimestamps.filter(ts => ts >= 0 && ts <= 1000).sorted
-          assert(boundedResults.map(_._1).distinct === expectedTimestamps)
+          assert(boundedResults.map(_._2).distinct === expectedTimestamps)
           val expectedValues = diverseTimestamps.zipWithIndex
             .filter { case (ts, _) => ts >= 0 && ts <= 1000 }
             .sortBy(_._1)
             .flatMap { case (_, idx) => Seq(idx * 10, idx * 10 + 1) }
-          assert(boundedResults.map(_._2) === expectedValues)
+          assert(boundedResults.map(_._3) === expectedValues)
+          assert(boundedResults.forall(_._1 == "key1"))
+
+          // Exact bound: startKey is inclusive, endKey is exclusive.
+          // 9 exists in diverseTimestamps, 90 exists in diverseTimestamps.
+          val exactIter = store.scanWithMultiValues(
+            Some(keyAndTimestampToRow("key1", 1, 9L)),
+            Some(keyAndTimestampToRow("key1", 1, 90L)))
+          val exactResults = exactIter.map(_.key.getLong(2)).toList
+          exactIter.close()
+          val exactResultsDistinct = exactResults.distinct
+          assert(exactResultsDistinct === diverseTimestamps
+            .filter(ts => ts >= 9 && ts < 90).sorted)
+          assert(exactResultsDistinct.contains(9L))
+          assert(!exactResultsDistinct.contains(90L))
+
+          // Postfix timestamp encoder places the timestamp after the key prefix.
+          // With different key prefixes, None in startKey or endKey would scan across
+          // key boundaries, which is not meaningful for postfix encoding. Hence we only
+          // test bounded ranges with explicit keys here.
 
           // Full range [MinValue, MaxValue)
           val fullIter = store.scanWithMultiValues(
@@ -611,6 +630,15 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
           fullIter.close()
 
           assert(fullResults.distinct === diverseTimestamps.sorted)
+
+          // Bounded negative range [-300, 0)
+          val negIter = store.scanWithMultiValues(
+            Some(keyAndTimestampToRow("key1", 1, -300L)),
+            Some(keyAndTimestampToRow("key1", 1, 0L)))
+          val negResults = negIter.map(_.key.getLong(2)).toList
+          negIter.close()
+          assert(negResults.distinct === diverseTimestamps
+            .filter(ts => ts >= -300 && ts < 0).sorted)
 
           // Empty range [10, 31) - no diverseTimestamps entries between 9 and 32
           val emptyIter = store.scanWithMultiValues(
@@ -624,6 +652,9 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
       }
     }
 
+    // Sanity test for prefix encoder scan. Full scan coverage is in RocksDBStateStoreSuite's
+    // "rocksdb range scan - scan" and "rocksdb range scan - scanWithMultiValues" tests.
+    // This test verifies the timestamp prefix encoder integration works correctly.
     test(s"scan with prefix encoder (encoding = $encoding)") {
       tryWithProviderResource(
         newStoreProviderWithTimestampEncoder(
@@ -643,10 +674,13 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
           // None startKey scans from beginning up to 301 (exclusive)
           val iter1 = store.scanWithMultiValues(None,
             Some(keyAndTimestampToRow("key1", 1, 301L)))
-          val results1 = iter1.map(_.key.getLong(2)).toList
+          val results1 = iter1.map { pair =>
+            (pair.key.getString(0), pair.key.getLong(2))
+          }.toList
           iter1.close()
 
-          assert(results1 === Seq(100L, 150L, 200L, 300L))
+          assert(results1 === Seq(
+            ("key1", 100L), ("key2", 150L), ("key1", 200L), ("key1", 300L)))
 
           // Boundary safety: endKey at 201, includes everything up to 200
           // regardless of join key
@@ -657,54 +691,14 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
           }.toList
           iter2.close()
 
-          assert(results2.map(_._2) === Seq(100L, 150L, 200L))
+          assert(results2 === Seq(
+            ("key1", 100L), ("key2", 150L), ("key1", 200L)))
         } finally {
           store.abort()
         }
       }
     }
 
-    test(s"scan single-value variant (encoding = $encoding)") {
-      tryWithProviderResource(
-        newStoreProviderWithTimestampEncoder(
-          encoderType = "postfix",
-          useMultipleValuesPerKey = false,
-          dataEncoding = encoding)
-      ) { provider =>
-        val store = provider.getStore(0)
-
-        try {
-          diverseTimestamps.foreach { ts =>
-            store.put(keyAndTimestampToRow("key1", 1, ts), valueToRow(ts.toInt))
-          }
-
-          // Bounded positive range [0, 100)
-          val posIter = store.scan(
-            Some(keyAndTimestampToRow("key1", 1, 0L)),
-            Some(keyAndTimestampToRow("key1", 1, 100L)))
-          val posResults = posIter.map { pair =>
-            (pair.key.getLong(2), pair.value.getInt(0))
-          }.toList
-          posIter.close()
-
-          val expectedPosTs = diverseTimestamps.filter(ts => ts >= 0 && ts < 100).sorted
-          assert(posResults.map(_._1) === expectedPosTs)
-          assert(posResults.map(_._2) === expectedPosTs.map(_.toInt))
-
-          // Bounded negative range [-300, 0)
-          val negIter = store.scan(
-            Some(keyAndTimestampToRow("key1", 1, -300L)),
-            Some(keyAndTimestampToRow("key1", 1, 0L)))
-          val negResults = negIter.map(_.key.getLong(2)).toList
-          negIter.close()
-
-          val expectedNegTs = diverseTimestamps.filter(ts => ts >= -300 && ts < 0).sorted
-          assert(negResults === expectedNegTs)
-        } finally {
-          store.abort()
-        }
-      }
-    }
   }
 
   // Helper methods to create test data

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBTimestampEncoderOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBTimestampEncoderOperationsSuite.scala
@@ -698,7 +698,6 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
         }
       }
     }
-
   }
 
   // Helper methods to create test data

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBTimestampEncoderOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBTimestampEncoderOperationsSuite.scala
@@ -566,6 +566,231 @@ class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession
     }
   }
 
+  Seq("unsaferow", "avro").foreach { encoding =>
+    test(s"scan with postfix encoder: bounded range (encoding = $encoding)") {
+      tryWithProviderResource(
+        newStoreProviderWithTimestampEncoder(
+          encoderType = "postfix",
+          useMultipleValuesPerKey = true,
+          dataEncoding = encoding)
+      ) { provider =>
+        val store = provider.getStore(0)
+
+        try {
+          // Insert entries for key1 at various timestamps
+          diverseTimestamps.zipWithIndex.foreach { case (ts, idx) =>
+            val keyRow = keyAndTimestampToRow("key1", 1, ts)
+            store.putList(keyRow, Array(valueToRow(idx * 10), valueToRow(idx * 10 + 1)))
+          }
+
+          // Insert entries for key2 to verify isolation
+          store.putList(keyAndTimestampToRow("key2", 1, 500L),
+            Array(valueToRow(999)))
+
+          // Scan key1 in range [0, 1000] (inclusive via endKey = 1001)
+          val prefixKey = keyToRow("key1", 1)
+          val startKey = keyAndTimestampToRow("key1", 1, 0L)
+          val endKey = keyAndTimestampToRow("key1", 1, 1001L)
+          val iter = store.scanWithMultiValues(Some(startKey), endKey)
+
+          val results = iter.map { pair =>
+            (pair.key.getLong(2), pair.value.getInt(0))
+          }.toList
+          iter.close()
+
+          // Timestamps in [0, 1000]: 0, 1, 2, 5, 6, 8, 9, 32, 35, 64, 90, 931
+          val expectedTimestamps = diverseTimestamps.filter(ts => ts >= 0 && ts <= 1000).sorted
+          val resultTimestamps = results.map(_._1).distinct
+          assert(resultTimestamps === expectedTimestamps)
+          assert(results.length === expectedTimestamps.length * 2) // 2 values per timestamp
+        } finally {
+          store.abort()
+        }
+      }
+    }
+
+    test(s"scan with postfix encoder: full range falls back correctly (encoding = $encoding)") {
+      tryWithProviderResource(
+        newStoreProviderWithTimestampEncoder(
+          encoderType = "postfix",
+          useMultipleValuesPerKey = true,
+          dataEncoding = encoding)
+      ) { provider =>
+        val store = provider.getStore(0)
+
+        try {
+          val timestamps = Seq(100L, 200L, 300L)
+          timestamps.foreach { ts =>
+            store.putList(keyAndTimestampToRow("key1", 1, ts),
+              Array(valueToRow(ts.toInt)))
+          }
+
+          // Scan with Some(startKey) covering full range
+          val startKey = keyAndTimestampToRow("key1", 1, Long.MinValue)
+          val endKey = keyAndTimestampToRow("key1", 1, Long.MaxValue)
+          val iter = store.scanWithMultiValues(Some(startKey), endKey)
+          val results = iter.map(_.key.getLong(2)).toList
+          iter.close()
+
+          assert(results === timestamps)
+        } finally {
+          store.abort()
+        }
+      }
+    }
+
+    test(s"scan with postfix encoder: empty range (encoding = $encoding)") {
+      tryWithProviderResource(
+        newStoreProviderWithTimestampEncoder(
+          encoderType = "postfix",
+          useMultipleValuesPerKey = true,
+          dataEncoding = encoding)
+      ) { provider =>
+        val store = provider.getStore(0)
+
+        try {
+          store.putList(keyAndTimestampToRow("key1", 1, 1000L),
+            Array(valueToRow(100)))
+          store.putList(keyAndTimestampToRow("key1", 1, 2000L),
+            Array(valueToRow(200)))
+
+          // Scan range that contains no entries
+          val startKey = keyAndTimestampToRow("key1", 1, 1500L)
+          val endKey = keyAndTimestampToRow("key1", 1, 1600L)
+          val iter = store.scanWithMultiValues(Some(startKey), endKey)
+          assert(!iter.hasNext)
+          iter.close()
+        } finally {
+          store.abort()
+        }
+      }
+    }
+
+    test(s"scan with prefix encoder: None startKey scans from beginning " +
+      s"(encoding = $encoding)") {
+      tryWithProviderResource(
+        newStoreProviderWithTimestampEncoder(
+          encoderType = "prefix",
+          useMultipleValuesPerKey = true,
+          dataEncoding = encoding)
+      ) { provider =>
+        val store = provider.getStore(0)
+
+        try {
+          // Insert entries at various timestamps
+          val timestamps = Seq(100L, 200L, 300L, 400L, 500L)
+          timestamps.foreach { ts =>
+            store.merge(keyAndTimestampToRow("key1", 1, ts), valueToRow(ts.toInt))
+          }
+
+          // Scan from beginning (None) up to 301 (exclusive), covering [..300]
+          val endKey = keyAndTimestampToRow("key1", 1, 301L)
+          val iter = store.scanWithMultiValues(None, endKey)
+          val results = iter.map(_.key.getLong(2)).toList
+          iter.close()
+
+          assert(results === Seq(100L, 200L, 300L))
+        } finally {
+          store.abort()
+        }
+      }
+    }
+
+    test(s"scan with prefix encoder: boundary safety check (encoding = $encoding)") {
+      tryWithProviderResource(
+        newStoreProviderWithTimestampEncoder(
+          encoderType = "prefix",
+          useMultipleValuesPerKey = true,
+          dataEncoding = encoding)
+      ) { provider =>
+        val store = provider.getStore(0)
+
+        try {
+          val timestamps = Seq(100L, 200L, 300L)
+          timestamps.foreach { ts =>
+            store.merge(keyAndTimestampToRow("key1", 1, ts), valueToRow(ts.toInt))
+          }
+          store.merge(keyAndTimestampToRow("key2", 2, 150L), valueToRow(150))
+
+          // Scan with endKey at timestamp 201 with dummyKey - should include
+          // everything up to timestamp 200 regardless of join key
+          val endKey = keyAndTimestampToRow("key1", 1, 201L)
+          val iter = store.scanWithMultiValues(None, endKey)
+          val results = iter.map { pair =>
+            (pair.key.getString(0), pair.key.getLong(2))
+          }.toList
+          iter.close()
+
+          // Should include key1@100, key2@150, key1@200
+          assert(results.length === 3)
+          assert(results.map(_._2) === Seq(100L, 150L, 200L))
+        } finally {
+          store.abort()
+        }
+      }
+    }
+
+    test(s"scan single-value variant (encoding = $encoding)") {
+      tryWithProviderResource(
+        newStoreProviderWithTimestampEncoder(
+          encoderType = "postfix",
+          useMultipleValuesPerKey = false,
+          dataEncoding = encoding)
+      ) { provider =>
+        val store = provider.getStore(0)
+
+        try {
+          val timestamps = Seq(100L, 200L, 300L, 400L, 500L)
+          timestamps.foreach { ts =>
+            store.put(keyAndTimestampToRow("key1", 1, ts), valueToRow(ts.toInt))
+          }
+
+          val startKey = keyAndTimestampToRow("key1", 1, 200L)
+          val endKey = keyAndTimestampToRow("key1", 1, 401L)
+          val iter = store.scan(Some(startKey), endKey)
+          val results = iter.map { pair =>
+            (pair.key.getLong(2), pair.value.getInt(0))
+          }.toList
+          iter.close()
+
+          assert(results.map(_._1) === Seq(200L, 300L, 400L))
+          assert(results.map(_._2) === Seq(200, 300, 400))
+        } finally {
+          store.abort()
+        }
+      }
+    }
+
+    test(s"scan with diverse timestamps and bounded range (encoding = $encoding)") {
+      tryWithProviderResource(
+        newStoreProviderWithTimestampEncoder(
+          encoderType = "postfix",
+          useMultipleValuesPerKey = false,
+          dataEncoding = encoding)
+      ) { provider =>
+        val store = provider.getStore(0)
+
+        try {
+          diverseTimestamps.zipWithIndex.foreach { case (ts, idx) =>
+            store.put(keyAndTimestampToRow("key1", 1, ts), valueToRow(idx))
+          }
+
+          // Scan negative range only: [-300, 0)
+          val startKey = keyAndTimestampToRow("key1", 1, -300L)
+          val endKey = keyAndTimestampToRow("key1", 1, 0L)
+          val iter = store.scan(Some(startKey), endKey)
+          val results = iter.map(_.key.getLong(2)).toList
+          iter.close()
+
+          val expected = diverseTimestamps.filter(ts => ts >= -300 && ts < 0).sorted
+          assert(results === expected)
+        } finally {
+          store.abort()
+        }
+      }
+    }
+  }
+
   // Helper methods to create test data
   private val keyProjection = UnsafeProjection.create(keySchema)
   private val keyAndTimestampProjection = UnsafeProjection.create(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to introduce a new API "rangeScan/rangeScanWithMultiValues" in StateStore. This new API is mostly an optimization focused on RocksDB state store provider.

The new API receives startKey (inclusive) and endKey (exclusive), and provides valid entries in the range. The new API requires the column family to use the state key encoder which can support range scan. This PR adds a new flag on state key encoder to represent the case. At this point, the new API supports three state key encoders - range scan encoder, timestamp prefix/postfix encoder.

Worth noting that the new API supports the combination of "prefix + range (+ remaining)" along with "range + remaining", hence the callers should reason about the ordering for the keys based on the state key encoder they are using for the CF before calling the API. The API implementation may not prevent the incorrect orderliness of the given startKey and endKey (e.g. startKey being later than endKey, some unexpected keys in binary ordering of the keys between startKey and endKey), so the callers should be very careful of composing startKeys and endKeys.

### Why are the changes needed?

This will enable the pattern of range scan to optimize further, effectively skipping tombstones and valid keys in both sides (before the lower bound, after the upper bound) within CF.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New UTs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude 4.6 Opus