### PR TITLE
[SPARK-56367][SS][PYTHON][DOCS] Fix latestOffset docstring and tutorial to use correct field name and signature

### DIFF
--- a/python/docs/source/tutorial/sql/python_data_source.rst
+++ b/python/docs/source/tutorial/sql/python_data_source.rst
@@ -238,7 +238,7 @@ This is a dummy streaming data reader that generates 2 rows in every microbatch.
             """
             return {"offset": 0}
 
-        def latestOffset(self) -> dict:
+        def latestOffset(self, start: dict, limit) -> dict:
             """
             Return the current latest offset that the next microbatch will read to.
             """

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -756,7 +756,7 @@ class DataSourceStreamReader(ABC):
         ...     if isinstance(limit, ReadAllAvailable):
         ...        return {"index": start["index"] + 10}
         ...     else:  # e.g., limit is ReadMaxRows(5)
-        ...        return {"index": start["index"] + min(10, limit.maxRows)}
+        ...        return {"index": start["index"] + min(10, limit.max_rows)}
         """
         # NOTE: Previous Spark versions didn't have start offset and read limit parameters for this
         # method. While Spark will ensure the backward compatibility for existing data sources, the


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes two documentation bugs in PySpark's streaming data source API:

1. **Docstring attribute error** (`datasource.py`): The `DataSourceStreamReader.latestOffset()` docstring example incorrectly referenced `limit.maxRows` when it should be `limit.max_rows`. The `ReadMaxRows` dataclass uses Python snake_case convention.

2. **Outdated method signature** (`python_data_source.rst`): The tutorial's `FakeStreamReader` example showed the deprecated parameterless signature `def latestOffset(self)` instead of the recommended signature with admission control support: `def latestOffset(self, start: dict, limit)`.

### Why are the changes needed?

- Users copying the docstring example would encounter an `AttributeError` at runtime due to the incorrect attribute name.
- Tutorial users wouldn't learn about the `start` offset parameter or admission control capabilities introduced in SPARK-55304.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only fix.

### How was this patch tested?

Documentation changes only - no tests required.

### Was this patch authored or co-authored using generative AI tooling?

Yes, GitHub Copilot and Claude Code were used to assist with this patch.