### PR TITLE
[SPARK-56368] Make the number of rows per custom metrics update configurable

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2664,6 +2664,17 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val CUSTOM_METRICS_NUM_ROWS_PER_UPDATE =
+    buildConf("spark.sql.execution.customMetrics.numRowsPerUpdate")
+      .doc("The number of rows between custom metrics updates during data source read/write " +
+        "operations. Increasing this value reduces the frequency of metrics updates and can " +
+        "lower CPU overhead for high-throughput workloads.")
+      .version("4.1.0")
+      .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .intConf
+      .checkValue(_ > 0, "The value must be positive.")
+      .createWithDefault(100)
+
   val STATE_STORE_PROVIDER_CLASS =
     buildConf("spark.sql.streaming.stateStore.providerClass")
       .internal()
@@ -8272,6 +8283,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
     getConf(SQLConf.ALLOW_TEMP_VIEW_CREATION_WITH_MULTIPLE_NAME_PARTS)
 
   def usePartitionEvaluator: Boolean = getConf(SQLConf.USE_PARTITION_EVALUATOR)
+
+  def customMetricsNumRowsPerUpdate: Int = getConf(SQLConf.CUSTOM_METRICS_NUM_ROWS_PER_UPDATE)
 
   def legacyNegativeIndexInArrayInsert: Boolean = {
     getConf(SQLConf.LEGACY_NEGATIVE_INDEX_IN_ARRAY_INSERT)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatDataWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatDataWriter.scala
@@ -57,6 +57,7 @@ abstract class FileFormatDataWriter(
   protected val MAX_FILE_COUNTER: Int = 1000 * 1000
   protected val updatedPartitions: mutable.Set[String] = mutable.Set[String]()
   protected var currentWriter: OutputWriter = _
+  private val numRowsPerUpdate = CustomMetrics.numRowsPerUpdate
 
   /** Trackers for computing various statistics on the data as it's being written out. */
   protected val statsTrackers: Seq[WriteTaskStatsTracker] =
@@ -96,7 +97,7 @@ abstract class FileFormatDataWriter(
   def write(record: InternalRow): Unit
 
   final def writeWithMetrics(record: InternalRow, count: Long): Unit = {
-    if (count % CustomMetrics.NUM_ROWS_PER_UPDATE == 0) {
+    if (count % numRowsPerUpdate == 0) {
       CustomMetrics.updateMetrics(currentMetricsValues.toImmutableArraySeq, customMetrics)
     }
     enrichWriteError(Option(currentWriter).map(_.path()).getOrElse(description.path)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceRDD.scala
@@ -152,6 +152,7 @@ private class PartitionIterator[T](
     customMetrics: Map[String, SQLMetric]) extends Iterator[T] {
   private[this] var valuePrepared = false
   private[this] var hasMoreInput = true
+  private[this] val numRowsPerUpdate = CustomMetrics.numRowsPerUpdate
 
   private var numRow = 0L
 
@@ -167,7 +168,7 @@ private class PartitionIterator[T](
     if (!hasNext) {
       throw QueryExecutionErrors.endOfStreamError()
     }
-    if (numRow % CustomMetrics.NUM_ROWS_PER_UPDATE == 0) {
+    if (numRow % numRowsPerUpdate == 0) {
       CustomMetrics.updateMetrics(reader.currentMetricsValues.toImmutableArraySeq, customMetrics)
     }
     numRow += 1

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
@@ -595,11 +595,12 @@ trait WritingSparkTask[W <: DataWriter[InternalRow]] extends Logging with Serial
       dataWriter: W,
       customMetrics: Map[String, SQLMetric]) extends java.util.Iterator[InternalRow] {
     var count = 0L
+    private val numRowsPerUpdate = CustomMetrics.numRowsPerUpdate
 
     override def hasNext: Boolean = iter.hasNext
 
     override def next(): InternalRow = {
-      if (count % CustomMetrics.NUM_ROWS_PER_UPDATE == 0) {
+      if (count % numRowsPerUpdate == 0) {
         CustomMetrics.updateMetrics(
           dataWriter.currentMetricsValues.toImmutableArraySeq, customMetrics)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/CustomMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/CustomMetrics.scala
@@ -19,11 +19,12 @@ package org.apache.spark.sql.execution.metric
 
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.connector.metric.{CustomMetric, CustomTaskMetric}
+import org.apache.spark.sql.internal.SQLConf
 
 object CustomMetrics {
   private[spark] val V2_CUSTOM = "v2Custom"
 
-  private[spark] val NUM_ROWS_PER_UPDATE = 100
+  private[spark] def numRowsPerUpdate: Int = SQLConf.get.customMetricsNumRowsPerUpdate
 
   private[spark] val BUILTIN_OUTPUT_METRICS = Set("bytesWritten", "recordsWritten")
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousDataSourceRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousDataSourceRDD.scala
@@ -94,9 +94,10 @@ class ContinuousDataSourceRDD(
     val partitionReader = readerForPartition.getPartitionReader()
     new NextIterator[InternalRow] {
       private var numRow = 0L
+      private val numRowsPerUpdate = CustomMetrics.numRowsPerUpdate
 
       override def getNext(): InternalRow = {
-        if (numRow % CustomMetrics.NUM_ROWS_PER_UPDATE == 0) {
+        if (numRow % numRowsPerUpdate == 0) {
           CustomMetrics.updateMetrics(
             partitionReader.currentMetricsValues.toImmutableArraySeq, customMetrics)
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousWriteRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousWriteRDD.scala
@@ -59,9 +59,10 @@ class ContinuousWriteRDD(var prev: RDD[InternalRow], writerFactory: StreamingDat
             context.partitionId(),
             context.taskAttemptId(),
             EpochTracker.getCurrentEpoch.get)
+          val numRowsPerUpdate = CustomMetrics.numRowsPerUpdate
           var count = 0L
           while (dataIterator.hasNext) {
-            if (count % CustomMetrics.NUM_ROWS_PER_UPDATE == 0) {
+            if (count % numRowsPerUpdate == 0) {
               CustomMetrics.updateMetrics(
                 dataWriter.currentMetricsValues.toImmutableArraySeq, customMetrics)
             }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes the custom metrics update interval configurable by introducing a new SQL configuration `spark.sql.execution.customMetrics.numRowsPerUpdate`.

Previously, `CustomMetrics.NUM_ROWS_PER_UPDATE` was hardcoded to `100`, meaning custom metrics were updated every 100 rows during data source read/write operations. This PR replaces the hardcoded constant with a configurable value, with the default remaining at `100` for backward compatibility.


### Why are the changes needed?

Updating custom metrics every 100 rows introduces non-trivial CPU overhead for high-throughput workloads. In our production testing, increasing this value to `1000` resulted in a noticeable reduction in CPU time with no observable loss in metric accuracy.

Different workloads have different trade-offs between metric freshness and CPU overhead. Making this configurable allows users to tune the update frequency based on their specific requirements.

### Does this PR introduce _any_ user-facing change?

Yes. A new SQL configuration is added:

- **`spark.sql.execution.customMetrics.numRowsPerUpdate`** (default: `100`): Controls the number of rows between custom metrics updates during data source read/write operations. Increasing this value reduces the frequency of metrics updates and can lower CPU overhead for high-throughput workloads.

The default behavior is unchanged.

### How was this patch tested?

Existing unit tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor with Claude