### PR TITLE
[SPARK-56370] Optimize Platform.copyMemory with a fast path for small copies

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -240,6 +240,10 @@ public final class Platform {
 
   public static void copyMemory(
     Object src, long srcOffset, Object dst, long dstOffset, long length) {
+    if (length <= UNSAFE_COPY_THRESHOLD) {
+      _UNSAFE.copyMemory(src, srcOffset, dst, dstOffset, length);
+      return;
+    }
     // Check if dstOffset is before or after srcOffset to determine if we should copy
     // forward or backwards. This is necessary in case src and dst overlap.
     if (dstOffset < srcOffset) {

--- a/core/benchmarks/PlatformBenchmark-results.txt
+++ b/core/benchmarks/PlatformBenchmark-results.txt
@@ -2,277 +2,277 @@
 Platform Byte Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+0 on Mac OS X 26.2
+Apple M4 Pro
 Byte Access:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putByte: On-heap                                     63             63           0       1590.5           0.6       1.0X
-putByte: Off-heap                                    80             80           0       1245.7           0.8       0.8X
-getByte: On-heap                                     59             59           0       1685.7           0.6       1.1X
-getByte: Off-heap                                    47             48           1       2112.6           0.5       1.3X
+putByte: On-heap                                     13             13           0       7745.2           0.1       1.0X
+putByte: Off-heap                                    14             18           4       7026.1           0.1       0.9X
+getByte: On-heap                                     25             26           0       3922.1           0.3       0.5X
+getByte: Off-heap                                    25             27           3       3953.4           0.3       0.5X
 
 
 ================================================================================================
 Platform Short Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+0 on Mac OS X 26.2
+Apple M4 Pro
 Short Access:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putShort: On-heap                                    63             63           1       1586.2           0.6       1.0X
-putShort: Off-heap                                  119            119           0        839.2           1.2       0.5X
-getShort: On-heap                                    44             44           0       2256.6           0.4       1.4X
-getShort: Off-heap                                   57             57           0       1761.1           0.6       1.1X
+putShort: On-heap                                    13             14           0       7505.4           0.1       1.0X
+putShort: Off-heap                                   17             18           0       5757.3           0.2       0.8X
+getShort: On-heap                                    25             26           0       3987.2           0.3       0.5X
+getShort: Off-heap                                   25             26           2       3977.0           0.3       0.5X
 
 
 ================================================================================================
 Platform Int Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+0 on Mac OS X 26.2
+Apple M4 Pro
 Int Access:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putInt: On-heap                                      42             42           0       2369.5           0.4       1.0X
-putInt: Off-heap                                     50             50           0       2000.7           0.5       0.8X
-getInt: On-heap                                      34             34           0       2941.2           0.3       1.2X
-getInt: Off-heap                                     49             49           0       2034.2           0.5       0.9X
+putInt: On-heap                                      14             15           1       7017.4           0.1       1.0X
+putInt: Off-heap                                     17             23          10       5727.9           0.2       0.8X
+getInt: On-heap                                      25             27           3       3936.3           0.3       0.6X
+getInt: Off-heap                                     26             27           1       3906.0           0.3       0.6X
 
 
 ================================================================================================
 Platform Long Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+0 on Mac OS X 26.2
+Apple M4 Pro
 Long Access:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putLong: On-heap                                     65             65           0       1546.6           0.6       1.0X
-putLong: Off-heap                                    48             48           0       2084.7           0.5       1.3X
-getLong: On-heap                                     40             42           1       2493.5           0.4       1.6X
-getLong: Off-heap                                    52             52           0       1941.1           0.5       1.3X
+putLong: On-heap                                     16             17           1       6254.9           0.2       1.0X
+putLong: Off-heap                                    18             20           2       5549.6           0.2       0.9X
+getLong: On-heap                                     26             26           1       3893.8           0.3       0.6X
+getLong: Off-heap                                    26             27           1       3884.1           0.3       0.6X
 
 
 ================================================================================================
 Platform Float Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+0 on Mac OS X 26.2
+Apple M4 Pro
 Float Access:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putFloat: On-heap                                    47             47           0       2115.7           0.5       1.0X
-putFloat: Off-heap                                   63             63           0       1596.2           0.6       0.8X
-getFloat: On-heap                                    94             94           0       1068.3           0.9       0.5X
-getFloat: Off-heap                                   94             94           0       1067.6           0.9       0.5X
+putFloat: On-heap                                    16             16           0       6234.2           0.2       1.0X
+putFloat: Off-heap                                   19             20           0       5231.7           0.2       0.8X
+getFloat: On-heap                                    54             54           0       1859.0           0.5       0.3X
+getFloat: Off-heap                                   55             55           1       1828.0           0.5       0.3X
 
 
 ================================================================================================
 Platform Double Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+0 on Mac OS X 26.2
+Apple M4 Pro
 Double Access:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putDouble: On-heap                                   49             49           0       2043.5           0.5       1.0X
-putDouble: Off-heap                                  64             64           0       1562.3           0.6       0.8X
-getDouble: On-heap                                   94             94           0       1061.5           0.9       0.5X
-getDouble: Off-heap                                  95             95           0       1057.1           0.9       0.5X
+putDouble: On-heap                                   17             18           3       5933.6           0.2       1.0X
+putDouble: Off-heap                                  20             22           6       5112.3           0.2       0.9X
+getDouble: On-heap                                   54             56           1       1837.6           0.5       0.3X
+getDouble: Off-heap                                  56             56           0       1799.8           0.6       0.3X
 
 
 ================================================================================================
 Platform Boolean Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+0 on Mac OS X 26.2
+Apple M4 Pro
 Boolean Access:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putBoolean: On-heap                                  78             78           0       1279.0           0.8       1.0X
-putBoolean: Off-heap                                 76             76           1       1314.5           0.8       1.0X
-getBoolean: On-heap                                  62             62           0       1604.5           0.6       1.3X
-getBoolean: Off-heap                                 62             63           0       1601.0           0.6       1.3X
+putBoolean: On-heap                                  17             18           2       5724.4           0.2       1.0X
+putBoolean: Off-heap                                 21             21           0       4778.2           0.2       0.8X
+getBoolean: On-heap                                  50             51           1       1981.1           0.5       0.3X
+getBoolean: Off-heap                                 51             52           3       1977.1           0.5       0.3X
 
 
 ================================================================================================
 Platform Bulk Operations 4k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+0 on Mac OS X 26.2
+Apple M4 Pro
 Bulk Operations 4k Ints:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      0              0           0          5.4         184.3       1.0X
-copyMemory: Heap -> Off-heap                          0              0           0          1.6         608.2       0.3X
-copyMemory: Off-heap -> Heap                          0              0           0          4.9         202.3       0.9X
-copyMemory: Heap -> Heap                              0              0           0          4.7         211.3       0.9X
-manual: Heap -> Heap                                  0              0           0          0.9        1063.0       0.2X
-manual: Off-heap -> Heap                              0              0           0          1.0         960.7       0.2X
-setMemory: Off-heap                                   0              0           0          1.5         649.2       0.3X
+copyMemory: Off-heap -> Off-heap                      0              0           0          6.5         154.1       1.0X
+copyMemory: Heap -> Off-heap                          0              0           0          7.7         129.1       1.2X
+copyMemory: Off-heap -> Heap                          0              0           0          8.0         125.0       1.2X
+copyMemory: Heap -> Heap                              0              0           0          8.0         125.0       1.2X
+manual: Heap -> Heap                                  0              0           0          2.1         470.8       0.3X
+manual: Off-heap -> Heap                              0              0           0          2.5         395.8       0.4X
+setMemory: Off-heap                                   0              0           0          2.6         379.2       0.4X
 
 
 ================================================================================================
 Platform Bulk Operations 16k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+0 on Mac OS X 26.2
+Apple M4 Pro
 Bulk Operations 16k Ints:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      0              0           0          0.8        1294.4       1.0X
-copyMemory: Heap -> Off-heap                          0              0           0          0.7        1414.7       0.9X
-copyMemory: Off-heap -> Heap                          0              0           0          0.8        1287.4       1.0X
-copyMemory: Heap -> Heap                              0              0           0          0.8        1286.4       1.0X
-manual: Heap -> Heap                                  0              0           0          0.2        5439.1       0.2X
-manual: Off-heap -> Heap                              0              0           0          0.3        3849.2       0.3X
-setMemory: Off-heap                                   0              0           0          0.4        2552.7       0.5X
+copyMemory: Off-heap -> Off-heap                      0              0           0          1.4         700.0       1.0X
+copyMemory: Heap -> Off-heap                          0              0           0          2.0         508.3       1.4X
+copyMemory: Off-heap -> Heap                          0              0           0          2.0         508.3       1.4X
+copyMemory: Heap -> Heap                              0              0           0          2.0         512.5       1.4X
+manual: Heap -> Heap                                  0              0           0          0.5        1908.3       0.4X
+manual: Off-heap -> Heap                              0              0           0          0.6        1620.8       0.4X
+setMemory: Off-heap                                   0              0           0          0.7        1433.3       0.5X
 
 
 ================================================================================================
 Platform Bulk Operations 256k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+0 on Mac OS X 26.2
+Apple M4 Pro
 Bulk Operations 256k Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      0              0           0          0.0       27951.4       1.0X
-copyMemory: Heap -> Off-heap                          0              0           0          0.0       27292.1       1.0X
-copyMemory: Off-heap -> Heap                          0              0           0          0.0       25880.5       1.1X
-copyMemory: Heap -> Heap                              0              0           0          0.0       25672.1       1.1X
-manual: Heap -> Heap                                  1              1           0          0.0       88010.9       0.3X
-manual: Off-heap -> Heap                              1              1           0          0.0       62301.7       0.4X
-setMemory: Off-heap                                   0              0           0          0.0       40585.0       0.7X
+copyMemory: Off-heap -> Off-heap                      0              0           0          0.1       11270.9       1.0X
+copyMemory: Heap -> Off-heap                          0              0           0          0.1       11862.5       1.0X
+copyMemory: Off-heap -> Heap                          0              0           0          0.1       11604.2       1.0X
+copyMemory: Heap -> Heap                              0              0           0          0.1       11804.1       1.0X
+manual: Heap -> Heap                                  0              0           0          0.0       33795.8       0.3X
+manual: Off-heap -> Heap                              0              0           0          0.0       32729.1       0.3X
+setMemory: Off-heap                                   0              0           0          0.0       24058.4       0.5X
 
 
 ================================================================================================
 Platform Bulk Operations 1m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+0 on Mac OS X 26.2
+Apple M4 Pro
 Bulk Operations 1m Ints:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      1              2           0          0.0      138711.9       1.0X
-copyMemory: Heap -> Off-heap                          1              1           0          0.0      104891.6       1.3X
-copyMemory: Off-heap -> Heap                          1              1           0          0.0      104430.8       1.3X
-copyMemory: Heap -> Heap                              1              1           0          0.0      103958.9       1.3X
-manual: Heap -> Heap                                  3              3           0          0.0      274934.2       0.5X
-manual: Off-heap -> Heap                              3              3           1          0.0      252551.2       0.5X
-setMemory: Off-heap                                   2              2           0          0.0      162971.4       0.9X
+copyMemory: Off-heap -> Off-heap                      0              1           0          0.0       49304.1       1.0X
+copyMemory: Heap -> Off-heap                          0              1           0          0.0       49291.6       1.0X
+copyMemory: Off-heap -> Heap                          0              1           0          0.0       49237.5       1.0X
+copyMemory: Heap -> Heap                              0              1           0          0.0       49070.9       1.0X
+manual: Heap -> Heap                                  1              2           0          0.0      148687.5       0.3X
+manual: Off-heap -> Heap                              1              2           0          0.0      146025.0       0.3X
+setMemory: Off-heap                                   1              1           0          0.0       97887.5       0.5X
 
 
 ================================================================================================
 Platform Bulk Operations 8m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+0 on Mac OS X 26.2
+Apple M4 Pro
 Bulk Operations 8m Ints:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                     15             16           0          0.0     1494501.6       1.0X
-copyMemory: Heap -> Off-heap                         17             18           0          0.0     1696782.5       0.9X
-copyMemory: Off-heap -> Heap                         17             17           0          0.0     1674377.6       0.9X
-copyMemory: Heap -> Heap                             17             17           0          0.0     1665476.9       0.9X
-manual: Heap -> Heap                                 25             25           0          0.0     2459913.6       0.6X
-manual: Off-heap -> Heap                             25             25           0          0.0     2455565.3       0.6X
-setMemory: Off-heap                                  14             15           0          0.0     1409985.1       1.1X
+copyMemory: Off-heap -> Off-heap                      5              6           1          0.0      534075.0       1.0X
+copyMemory: Heap -> Off-heap                          5              6           1          0.0      537095.8       1.0X
+copyMemory: Off-heap -> Heap                          5              6           1          0.0      506095.9       1.1X
+copyMemory: Heap -> Heap                              5              6           1          0.0      505229.1       1.1X
+manual: Heap -> Heap                                 12             12           0          0.0     1188187.5       0.4X
+manual: Off-heap -> Heap                             12             13           3          0.0     1180400.0       0.5X
+setMemory: Off-heap                                   8              8           0          0.0      780979.2       0.7X
 
 
 ================================================================================================
 Platform Bulk Operations 32m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+0 on Mac OS X 26.2
+Apple M4 Pro
 Bulk Operations 32m Ints:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                     77             77           1          0.0     7664570.1       1.0X
-copyMemory: Heap -> Off-heap                         84             86           1          0.0     8400167.3       0.9X
-copyMemory: Off-heap -> Heap                         81             85           1          0.0     8115112.6       0.9X
-copyMemory: Heap -> Heap                             82             84           1          0.0     8232211.9       0.9X
-manual: Heap -> Heap                                 99            100           1          0.0     9924878.4       0.8X
-manual: Off-heap -> Heap                            101            103           1          0.0    10107944.3       0.8X
-setMemory: Off-heap                                  59             60           1          0.0     5916000.3       1.3X
+copyMemory: Off-heap -> Off-heap                     24             27           4          0.0     2373125.0       1.0X
+copyMemory: Heap -> Off-heap                         23             24           0          0.0     2344312.5       1.0X
+copyMemory: Off-heap -> Heap                         23             24           0          0.0     2310845.8       1.0X
+copyMemory: Heap -> Heap                             23             24           1          0.0     2340620.8       1.0X
+manual: Heap -> Heap                                 48             49           1          0.0     4773675.0       0.5X
+manual: Off-heap -> Heap                             56             57           2          0.0     5592891.7       0.4X
+setMemory: Off-heap                                  31             32           1          0.0     3139204.2       0.8X
 
 
 ================================================================================================
 Platform Memory Allocation 4k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+0 on Mac OS X 26.2
+Apple M4 Pro
 Memory Allocation 4k Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      40816.3           0.0       1.0X
-freeMemory                                            0              0           0      50000.0           0.0       1.2X
-reallocateMemory: double in size                      0              0           0       5882.4           0.2       0.1X
+allocateMemory                                        0              0           0     Infinity           0.0       NaNX
+freeMemory                                            0              0           0     Infinity           0.0       NaNX
+reallocateMemory: double in size                      0              0           0      16000.0           0.1       0.0X
 
 
 ================================================================================================
 Platform Memory Allocation 16k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+0 on Mac OS X 26.2
+Apple M4 Pro
 Memory Allocation 16k Ints:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      40816.3           0.0       1.0X
-freeMemory                                            0              0           0      50000.0           0.0       1.2X
-reallocateMemory: double in size                      0              0           0       1296.2           0.8       0.0X
+allocateMemory                                        0              0           0      24096.4           0.0       1.0X
+freeMemory                                            0              0           0       9615.4           0.1       0.4X
+reallocateMemory: double in size                      0              0           0       2401.0           0.4       0.1X
 
 
 ================================================================================================
 Platform Memory Allocation 256k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+0 on Mac OS X 26.2
+Apple M4 Pro
 Memory Allocation 256k Ints:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      50000.0           0.0       1.0X
-freeMemory                                            0              0           0      50000.0           0.0       1.0X
-reallocateMemory: double in size                      0              0           0         45.6          21.9       0.0X
+allocateMemory                                        0              0           0      24096.4           0.0       1.0X
+freeMemory                                            0              0           0       9615.4           0.1       0.4X
+reallocateMemory: double in size                      0              0           0        175.8           5.7       0.0X
 
 
 ================================================================================================
 Platform Memory Allocation 1m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+0 on Mac OS X 26.2
+Apple M4 Pro
 Memory Allocation 1m Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      50000.0           0.0       1.0X
-freeMemory                                            0              0           0      50000.0           0.0       1.0X
-reallocateMemory: double in size                      0              0           0         13.5          73.9       0.0X
+allocateMemory                                        0              0           0      24096.4           0.0       1.0X
+freeMemory                                            0              0           0      47619.0           0.0       2.0X
+reallocateMemory: double in size                      0              0           0         44.9          22.3       0.0X
 
 
 ================================================================================================
 Platform Memory Allocation 8m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+0 on Mac OS X 26.2
+Apple M4 Pro
 Memory Allocation 8m Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0        400.9           2.5       1.0X
-freeMemory                                            0              0           0        386.8           2.6       1.0X
-reallocateMemory: double in size                      3              3           0          0.7        1384.4       0.0X
+allocateMemory                                        0              0           0      16000.0           0.1       1.0X
+freeMemory                                            0              0           0      48780.5           0.0       3.0X
+reallocateMemory: double in size                      0              1           0          4.3         232.8       0.0X
 
 
 ================================================================================================
 Platform Memory Allocation 32m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+0 on Mac OS X 26.2
+Apple M4 Pro
 Memory Allocation 32m Ints:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0        476.5           2.1       1.0X
-freeMemory                                            0              0           0        294.9           3.4       0.6X
-reallocateMemory: double in size                     11             11           0          0.2        5518.7       0.0X
+allocateMemory                                        0              0           0      47619.0           0.0       1.0X
+freeMemory                                            0              0           0      24096.4           0.0       0.5X
+reallocateMemory: double in size                      2              2           0          0.9        1123.3       0.0X
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a fast path in `Platform.copyMemory()` for copies where `length <= UNSAFE_COPY_THRESHOLD` (1MB). When the copy fits within a single threshold-sized chunk, we directly call `_UNSAFE.copyMemory()` and return immediately, bypassing the direction check and while loop.

This is functionally equivalent to the original code because when `length <= UNSAFE_COPY_THRESHOLD`, both the forward and backward copy paths produce the exact same single call to `_UNSAFE.copyMemory()` — the loop executes exactly once regardless of direction. The fast path simply avoids the unnecessary branch, loop setup, and `Math.min` computation.

### Why are the changes needed?

The vast majority of `Platform.copyMemory` calls in Spark (shuffle, sort, serialization, etc.) copy far less than 1MB. For these small copies, the current code still pays the overhead of:
- A conditional branch to determine copy direction (`dstOffset < srcOffset`)
- While loop initialization and condition check
- `Math.min(length, UNSAFE_COPY_THRESHOLD)` computation

While each individual overhead is small, `Platform.copyMemory` is on an extremely hot path — it is called millions of times per task during shuffle and sort operations. In our production testing, this optimization resulted in a measurable reduction in CPU time.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing unit tests.

### Was this patch authored or co-authored using generative AI tooling?

No.