### PR TITLE
[SPARK-56372][INFRA] Add cmake to CI Docker images for R fs package compilation

### DIFF
--- a/dev/spark-test-image/docs/Dockerfile
+++ b/dev/spark-test-image/docs/Dockerfile
@@ -32,6 +32,7 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \
+    cmake \
     curl \
     gfortran \
     git \

--- a/dev/spark-test-image/lint/Dockerfile
+++ b/dev/spark-test-image/lint/Dockerfile
@@ -32,6 +32,7 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \
+    cmake \
     curl \
     gfortran \
     git \

--- a/dev/spark-test-image/lint/Dockerfile
+++ b/dev/spark-test-image/lint/Dockerfile
@@ -100,6 +100,7 @@ RUN python3.12 -m pip install \
     'pytest==7.1.3' \
     'scipy>=1.8.0' \
     'scipy-stubs' \
+    'types-protobuf==6.32.1.20260221' \
     && python3.12 -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu \
     && python3.12 -m pip install torcheval \
     && python3.12 -m pip cache purge

--- a/dev/spark-test-image/sparkr/Dockerfile
+++ b/dev/spark-test-image/sparkr/Dockerfile
@@ -32,6 +32,7 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \
+    cmake \
     curl \
     gfortran \
     git \


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `cmake` to the `apt-get install` list in CI Docker images (`docs`, `lint`, `sparkr`).

### Why are the changes needed?

The R `fs` package (a transitive dependency of `devtools`, `testthat`, `rmarkdown`) now bundles `libuv v1.52.0`, which requires `cmake` to build. This causes the "Base image build" job to fail with:

```
/bin/bash: line 2: cmake: command not found
make: *** [Makevars:44: libuv] Error 127
ERROR: compilation failed for package 'fs'
```

The `fs` compilation failure cascades into: `sass` → `bslib` → `shiny` → `rmarkdown` → `devtools` → `testthat`, breaking the entire R package installation.

See https://github.com/apache/spark/actions/runs/24067715329/job/70197367201

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI should pass with the updated Docker images.

### Was this patch authored or co-authored using generative AI tooling?

Co-authored-by: Claude code (Opus 4.6)
