### PR TITLE
[SPARK-56373][PYSPARK] Add docstring annotations to classify PySpark APIs for Spark Connect compatibility

### DIFF
--- a/python/pyspark/__init__.py
+++ b/python/pyspark/__init__.py
@@ -45,20 +45,6 @@ Public classes:
   - :class:`InheritableThread`:
       A inheritable thread to use in Spark when the pinned thread mode is on.
 
-Spark Connect compatibility annotations
-=======================================
-
-The following RST directives annotate PySpark modules, classes, and methods with
-their Spark Connect compatibility status:
-
-- ``.. classic:: true`` -- the API is only available in Classic Spark (not Spark Connect).
-- ``.. connect:: true`` -- the API is available in Spark Connect.
-- ``.. connect_migration:: <message>`` -- migration guidance for users transitioning
-  from Classic Spark to Spark Connect.
-
-Annotations are resolved by inheriting from the nearest annotated ancestor. A child
-annotation overrides the parent's.
-
 .. classic:: true
 .. connect:: true
 """

--- a/python/pyspark/__init__.py
+++ b/python/pyspark/__init__.py
@@ -45,6 +45,20 @@ Public classes:
   - :class:`InheritableThread`:
       A inheritable thread to use in Spark when the pinned thread mode is on.
 
+Spark Connect compatibility annotations
+=======================================
+
+The following RST directives annotate PySpark modules, classes, and methods with
+their Spark Connect compatibility status:
+
+- ``.. classic:: true`` -- the API is only available in Classic Spark (not Spark Connect).
+- ``.. connect:: true`` -- the API is available in Spark Connect.
+- ``.. connect_migration:: <message>`` -- migration guidance for users transitioning
+  from Classic Spark to Spark Connect.
+
+Annotations are resolved by inheriting from the nearest annotated ancestor. A child
+annotation overrides the parent's.
+
 .. classic:: true
 .. connect:: true
 """

--- a/python/pyspark/__init__.py
+++ b/python/pyspark/__init__.py
@@ -44,6 +44,23 @@ Public classes:
       Information about a barrier task.
   - :class:`InheritableThread`:
       A inheritable thread to use in Spark when the pinned thread mode is on.
+
+Spark Connect compatibility annotations
+=======================================
+
+The following RST directives annotate PySpark modules, classes, and methods with
+their Spark Connect compatibility status:
+
+- ``.. classic:: true`` -- the API is only available in Classic Spark (not Spark Connect).
+- ``.. connect:: true`` -- the API is available in Spark Connect.
+- ``.. connect_migration:: <message>`` -- migration guidance for users transitioning
+  from Classic Spark to Spark Connect.
+
+Annotations are resolved by inheriting from the nearest annotated ancestor. A child
+annotation overrides the parent's.
+
+.. classic:: true
+.. connect:: true
 """
 
 import sys

--- a/python/pyspark/accumulators.py
+++ b/python/pyspark/accumulators.py
@@ -15,6 +15,13 @@
 # limitations under the License.
 #
 
+"""
+.. classic:: true
+
+.. connect_migration:: Use `df.observe(name, *exprs)` to collect named metrics during
+    query execution.
+"""
+
 import os
 import sys
 import select

--- a/python/pyspark/conf.py
+++ b/python/pyspark/conf.py
@@ -15,6 +15,13 @@
 # limitations under the License.
 #
 
+"""
+.. classic:: true
+
+.. connect_migration:: Read Spark SQL configuration values using `spark.conf.get(key)`
+    and write them using `spark.conf.set(key, value)`.
+"""
+
 __all__ = ["SparkConf"]
 
 import sys

--- a/python/pyspark/core/__init__.py
+++ b/python/pyspark/core/__init__.py
@@ -14,3 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""
+.. classic:: true
+"""

--- a/python/pyspark/core/context.py
+++ b/python/pyspark/core/context.py
@@ -559,7 +559,8 @@ class SparkContext:
         --------
         >>> sc.setLogLevel("WARN")  # doctest :+SKIP
 
-        .. connect_migration:: Replace sc.setLogLevel(level) with spark.log.level(level)
+        .. connect_migration:: Replace sc.setLogLevel(level) with
+            spark.conf.set("spark.log.level", level)
         """
         self._jsc.setLogLevel(logLevel)
 
@@ -681,7 +682,8 @@ class SparkContext:
         True
 
         .. connect_migration:: Replace spark.sparkContext.defaultParallelism with
-            int(spark.conf.get("spark.default.parallelism", "200"))
+            int(spark.conf.get("spark.default.parallelism")) if set, otherwise
+            the default depends on the cluster executor configuration.
         """
         return self._jsc.sc().defaultParallelism()
 
@@ -2227,8 +2229,9 @@ class SparkContext:
         Cancelled
 
         .. connect_migration:: Replace sc.setJobGroup(groupId, desc) with
-            spark.conf.set("spark.job.group.id", groupId) and
-            spark.conf.set("spark.job.description", desc)
+            spark.addTag(groupId) for grouping and cancellation via
+            spark.interruptTag(groupId). Job description and interruptOnCancel
+            are not directly supported in Spark Connect.
         """
         self._jsc.setJobGroup(groupId, description, interruptOnCancel)
 
@@ -2429,7 +2432,9 @@ class SparkContext:
         local inheritance.
 
         .. connect_migration:: Replace spark.sparkContext.setLocalProperty(key, value) with
-            spark.conf.set(key, value)
+            spark.conf.set(key, value) for SQL configuration keys. Note that
+            spark.conf.set is session-global; thread-local isolation is not
+            supported in Spark Connect.
         """
         self._jsc.setLocalProperty(key, value)
 

--- a/python/pyspark/core/context.py
+++ b/python/pyspark/core/context.py
@@ -558,6 +558,8 @@ class SparkContext:
         Examples
         --------
         >>> sc.setLogLevel("WARN")  # doctest :+SKIP
+
+        .. connect_migration:: Replace sc.setLogLevel(level) with spark.log.level(level)
         """
         self._jsc.setLogLevel(logLevel)
 
@@ -630,6 +632,8 @@ class SparkContext:
         --------
         >>> sc.applicationId  # doctest: +ELLIPSIS
         'local-...'
+
+        .. connect_migration:: Replace spark.sparkContext.applicationId with spark.conf.get("spark.app.id")
         """
         return self._jsc.sc().applicationId()
 
@@ -675,6 +679,9 @@ class SparkContext:
         --------
         >>> sc.defaultParallelism > 0
         True
+
+        .. connect_migration:: Replace spark.sparkContext.defaultParallelism with
+            int(spark.conf.get("spark.default.parallelism", "200"))
         """
         return self._jsc.sc().defaultParallelism()
 
@@ -734,6 +741,9 @@ class SparkContext:
         EmptyRDD...
         >>> sc.emptyRDD().count()
         0
+
+        .. connect_migration:: Replace sc.emptyRDD with an empty list. When used with
+            createDataFrame: spark.createDataFrame([], schema)
         """
         return RDD(self._jsc.emptyRDD(), self, NoOpSerializer())
 
@@ -828,6 +838,9 @@ class SparkContext:
         >>> strings = ["a", "b", "c"]
         >>> sc.parallelize(strings, 2).glom().collect()
         [['a'], ['b', 'c']]
+
+        .. connect_migration:: Replace sc.parallelize(data) with the Python collection directly.
+            When used with createDataFrame: spark.createDataFrame(data, schema)
         """
         numSlices = int(numSlices) if numSlices is not None else self.defaultParallelism
         if isinstance(c, range):
@@ -2212,6 +2225,10 @@ class SparkContext:
         >>> suppress = lock.acquire()
         >>> print(result)
         Cancelled
+
+        .. connect_migration:: Replace sc.setJobGroup(groupId, desc) with
+            spark.conf.set("spark.job.group.id", groupId) and
+            spark.conf.set("spark.job.description", desc)
         """
         self._jsc.setJobGroup(groupId, description, interruptOnCancel)
 
@@ -2410,6 +2427,9 @@ class SparkContext:
         -----
         If you run jobs in parallel, use :class:`pyspark.InheritableThread` for thread
         local inheritance.
+
+        .. connect_migration:: Replace spark.sparkContext.setLocalProperty(key, value) with
+            spark.conf.set(key, value)
         """
         self._jsc.setLocalProperty(key, value)
 
@@ -2441,6 +2461,9 @@ class SparkContext:
         -----
         If you run jobs in parallel, use :class:`pyspark.InheritableThread` for thread
         local inheritance.
+
+        .. connect_migration:: Replace sc.setJobDescription(desc) with
+            spark.conf.set("spark.job.description", desc)
         """
         self._jsc.setJobDescription(value)
 
@@ -2610,6 +2633,9 @@ class SparkContext:
         """Return a copy of this SparkContext's configuration :class:`SparkConf`.
 
         .. versionadded:: 2.1.0
+
+        .. connect_migration:: Replace sc.getConf() with spark.conf. For a specific key use
+            spark.conf.get(key)
         """
         conf = SparkConf()
         conf.setAll(self._conf.getAll())

--- a/python/pyspark/core/rdd.py
+++ b/python/pyspark/core/rdd.py
@@ -609,6 +609,9 @@ class RDD(Generic[T_co]):
         >>> rdd = sc.parallelize(["b", "a", "c"])
         >>> sorted(rdd.map(lambda x: (x, 1)).collect())
         [('a', 1), ('b', 1), ('c', 1)]
+
+        .. connect_migration:: Replace rdd.map() with DataFrame operations. Use
+            df.withColumn(), df.select() with a UDF, or a pandas UDF instead.
         """
 
         def func(_: int, iterator: Iterable[T]) -> Iterable[U]:
@@ -697,6 +700,9 @@ class RDD(Generic[T_co]):
         ...
         >>> rdd.mapPartitions(f).collect()
         [3, 7]
+
+        .. connect_migration:: Replace rdd.mapPartitions() with a pandas UDF using
+            applyInPandas.
         """
 
         def func(_: int, iterator: Iterable[T]) -> Iterable[U]:

--- a/python/pyspark/errors/exceptions/connect.py
+++ b/python/pyspark/errors/exceptions/connect.py
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""
+.. connect:: true
+"""
+
 import grpc
 import json
 from grpc import StatusCode

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -15,6 +15,10 @@
 # limitations under the License.
 #
 
+"""
+.. classic:: true
+"""
+
 import atexit
 import os
 import signal

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -1429,6 +1429,10 @@ class LDAModel(JavaModel, _LDAParams):
     including local and distributed data structures.
 
     .. versionadded:: 2.0.0
+
+    .. classic:: true
+
+    .. connect_migration:: LDA model family is not supported in Spark Connect.
     """
 
     @since("3.0.0")
@@ -1530,6 +1534,10 @@ class DistributedLDAModel(LDAModel, JavaMLReadable["DistributedLDAModel"], JavaM
     for each training document.
 
     .. versionadded:: 2.0.0
+
+    .. classic:: true
+
+    .. connect_migration:: LDA model family is not supported in Spark Connect.
     """
 
     @functools.cache
@@ -1608,6 +1616,10 @@ class LocalLDAModel(LDAModel, JavaMLReadable["LocalLDAModel"], JavaMLWritable):
     This model stores the inferred topics only; it does not store info about the training dataset.
 
     .. versionadded:: 2.0.0
+
+    .. classic:: true
+
+    .. connect_migration:: LDA model family is not supported in Spark Connect.
     """
 
     pass
@@ -1682,6 +1694,10 @@ class LDA(JavaEstimator[LDAModel], _LDAParams, JavaMLReadable["LDA"], JavaMLWrit
     >>> sameLocalModel = LocalLDAModel.load(local_model_path)
     >>> model.transform(df).take(1) == sameLocalModel.transform(df).take(1)
     True
+
+    .. classic:: true
+
+    .. connect_migration:: LDA model family is not supported in Spark Connect.
     """
 
     _input_kwargs: Dict[str, Any]

--- a/python/pyspark/ml/connect/__init__.py
+++ b/python/pyspark/ml/connect/__init__.py
@@ -15,7 +15,11 @@
 # limitations under the License.
 #
 
-"""Spark Connect Python Client - ML module"""
+"""
+Spark Connect Python Client - ML module
+
+.. connect:: true
+"""
 
 from pyspark.sql.connect.utils import check_dependencies
 

--- a/python/pyspark/ml/deepspeed/__init__.py
+++ b/python/pyspark/ml/deepspeed/__init__.py
@@ -14,3 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""
+.. classic:: true
+
+.. connect_migration:: Migrate to pyspark.ml.connect
+"""

--- a/python/pyspark/ml/torch/__init__.py
+++ b/python/pyspark/ml/torch/__init__.py
@@ -14,3 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""
+.. classic:: true
+
+.. connect_migration:: Migrate to pyspark.ml.connect
+"""

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -15,6 +15,10 @@
 # limitations under the License.
 #
 
+"""
+.. classic:: true
+"""
+
 from abc import ABCMeta, abstractmethod
 from typing import Any, Generic, Optional, List, Type, TypeVar, TYPE_CHECKING
 

--- a/python/pyspark/mllib/__init__.py
+++ b/python/pyspark/mllib/__init__.py
@@ -23,7 +23,10 @@ migration to the DataFrame-based APIs under the `pyspark.ml` package.
 
 .. classic:: true
 
-.. connect_migration:: Migrate to pyspark.ml.connect
+.. connect_migration:: Migrate to pyspark.ml.connect where supported (classification,
+    evaluation, feature, pipeline, summarizer, tuning). Modules without a Connect
+    equivalent (clustering, fpm, linalg, random, recommendation, regression, stat,
+    tree) have no direct replacement.
 """
 
 # MLlib currently needs NumPy 1.4+, so complain if lower

--- a/python/pyspark/mllib/__init__.py
+++ b/python/pyspark/mllib/__init__.py
@@ -20,6 +20,10 @@ RDD-based machine learning APIs for Python (in maintenance mode).
 
 The `pyspark.mllib` package is in maintenance mode as of the Spark 2.0.0 release to encourage
 migration to the DataFrame-based APIs under the `pyspark.ml` package.
+
+.. classic:: true
+
+.. connect_migration:: Migrate to pyspark.ml.connect
 """
 
 # MLlib currently needs NumPy 1.4+, so complain if lower

--- a/python/pyspark/profiler.py
+++ b/python/pyspark/profiler.py
@@ -15,6 +15,10 @@
 # limitations under the License.
 #
 
+"""
+.. classic:: true
+"""
+
 from typing import (
     Any,
     Callable,

--- a/python/pyspark/rddsampler.py
+++ b/python/pyspark/rddsampler.py
@@ -15,6 +15,10 @@
 # limitations under the License.
 #
 
+"""
+.. classic:: true
+"""
+
 import sys
 import random
 import math

--- a/python/pyspark/sql/classic/__init__.py
+++ b/python/pyspark/sql/classic/__init__.py
@@ -15,4 +15,8 @@
 # limitations under the License.
 #
 
-"""Spark Classic specific"""
+"""
+Spark Classic specific
+
+.. classic:: true
+"""

--- a/python/pyspark/sql/connect/__init__.py
+++ b/python/pyspark/sql/connect/__init__.py
@@ -15,7 +15,11 @@
 # limitations under the License.
 #
 
-"""Spark Connect client"""
+"""
+Spark Connect client
+
+.. connect:: true
+"""
 
 from pyspark.sql.connect.utils import check_dependencies
 

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+.. classic:: true
+
+.. connect_migration:: Use SparkSession instead.
+"""
+
 import sys
 import warnings
 from typing import (

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -187,6 +187,9 @@ class DataFrame:
             >>> df = spark.range(1)
             >>> type(df.rdd)
             <class 'pyspark.core.rdd.RDD'>
+
+            .. connect_migration:: Use DataFrame operations directly as RDD is not supported
+                in Spark Connect.
             """
             ...
 

--- a/python/pyspark/sql/metrics.py
+++ b/python/pyspark/sql/metrics.py
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""
+.. connect:: true
+"""
+
 import abc
 import dataclasses
 from typing import Optional, List, Tuple, Dict, Any, Union, TYPE_CHECKING, Sequence

--- a/python/pyspark/sql/profiler.py
+++ b/python/pyspark/sql/profiler.py
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""
+.. classic:: true
+"""
+
 from abc import ABC, abstractmethod
 from io import StringIO
 import cProfile

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -435,9 +435,11 @@ class DataFrameReader(OptionUtils):
         | Bob| 30|
         +----+---+
 
-        .. connect_migration:: Does not support RDD arguments in Spark Connect. Collect the
-            data first: rows = [Row(**json_dict) for json_dict in json_data] then
-            df = spark.createDataFrame(rows).
+        .. connect_migration:: Does not support RDD arguments in Spark Connect. For a list
+            of JSON strings, parse them first: import json;
+            spark.createDataFrame([json.loads(s) for s in json_strings]).
+            Alternatively, write the strings to a file path and use
+            spark.read.json(path).
         """
         self._set_opts(
             schema=schema,

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -434,6 +434,10 @@ class DataFrameReader(OptionUtils):
         +----+---+
         | Bob| 30|
         +----+---+
+
+        .. connect_migration:: Does not support RDD arguments in Spark Connect. Collect the
+            data first: rows = [Row(**json_dict) for json_dict in json_data] then
+            df = spark.createDataFrame(rows).
         """
         self._set_opts(
             schema=schema,

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -773,8 +773,10 @@ class UDFRegistration:
         >>> spark.sql("SELECT javaStringLength3('test')").collect()  # doctest: +SKIP
         [Row(javaStringLength3(test)=4)]
 
-        .. connect_migration:: Use spark.udf.register in a Scala notebook cell to register a
-            Scala UDF; it will be accessible from Python in the same session.
+        .. connect_migration:: Java UDF registration is not supported in Spark Connect.
+            In mixed-language notebooks, register the UDF from a Scala cell using
+            spark.udf.register; it will then be accessible from Python in the same
+            session. For standalone applications, rewrite the UDF in Python.
         """
 
         jdt = None

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -772,6 +772,9 @@ class UDFRegistration:
         ... # doctest: +SKIP
         >>> spark.sql("SELECT javaStringLength3('test')").collect()  # doctest: +SKIP
         [Row(javaStringLength3(test)=4)]
+
+        .. connect_migration:: Use spark.udf.register in a Scala notebook cell to register a
+            Scala UDF; it will be accessible from Python in the same session.
         """
 
         jdt = None

--- a/python/pyspark/statcounter.py
+++ b/python/pyspark/statcounter.py
@@ -15,6 +15,13 @@
 # limitations under the License.
 #
 
+"""
+.. classic:: true
+
+.. connect_migration:: Use `df.describe()` for summary statistics, or
+    `df.observe(name, *exprs)` for named metrics.
+"""
+
 # This file is ported from spark/util/StatCounter.scala
 
 import copy

--- a/python/pyspark/streaming/__init__.py
+++ b/python/pyspark/streaming/__init__.py
@@ -15,6 +15,10 @@
 # limitations under the License.
 #
 
+"""
+.. classic:: true
+"""
+
 from pyspark.streaming.context import StreamingContext
 from pyspark.streaming.dstream import DStream
 from pyspark.streaming.listener import StreamingListener

--- a/python/pyspark/testing/mllibutils.py
+++ b/python/pyspark/testing/mllibutils.py
@@ -15,6 +15,10 @@
 # limitations under the License.
 #
 
+"""
+.. classic:: true
+"""
+
 import unittest
 
 from pyspark import SparkContext


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds three RST docstring directives to PySpark modules, classes, and methods to annotate their Spark Connect compatibility:

- `.. classic:: true` — the API is only available in Classic Spark (not Spark Connect)
- `.. connect:: true` — the API is available in Spark Connect
- `.. connect_migration:: <message>` — migration guidance for users transitioning from Classic Spark to Spark Connect

The annotation spec is documented in `python/pyspark/__init__.py`. Annotations are resolved by inheriting from the nearest annotated ancestor; a child annotation overrides the parent's.

Annotated modules/classes in this PR:
- `pyspark.core` and its submodules (RDD, SparkContext, etc.) — Classic only, with per-method migration guidance
- `pyspark.mllib` — Classic only, migrate to `pyspark.ml.connect`
- `pyspark.ml.clustering` (LDA family) — Classic only
- `pyspark.ml.deepspeed`, `pyspark.ml.torch` — Classic only
- `pyspark.ml.wrapper` — Classic only
- `pyspark.ml.connect` — Connect
- `pyspark.sql.classic`, `pyspark.sql.connect` — Classic / Connect respectively
- `pyspark.sql.context` — Classic only (use SparkSession instead)
- `pyspark.sql.dataframe.DataFrame.rdd` — migration guidance
- `pyspark.sql.readwriter.DataFrameReader.json` — migration guidance for RDD arg
- `pyspark.sql.udf.UDFRegistration.registerJavaFunction` — migration guidance
- `pyspark.sql.metrics`, `pyspark.errors.exceptions.connect` — Connect
- Various internal/utility modules — Classic only

### Why are the changes needed?

These annotations enable tooling (IDEs, documentation generators, linters) to surface accurate Spark Connect compatibility information to users, helping them understand which APIs are available in Spark Connect and how to migrate.

### Does this PR introduce _any_ user-facing change?

No. Docstring-only changes; no functional code modifications.

### How was this patch tested?

No tests added — docstring-only changes. Existing test suites continue to pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude (Anthropic), claude-sonnet-4-6