### PR TITLE
[SPARK-56338][INFRA][FOLLOWUP] Support MAVEN_MIRROR_URL in SBT launcher bootstrap

### DIFF
--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -39,11 +39,12 @@ dlog () {
 
 acquire_sbt_jar () {
   SBT_VERSION=`awk -F "=" '/sbt\.version/ {print $2}' ./project/build.properties`
-  # DEFAULT_ARTIFACT_REPOSITORY env variable can be used to only fetch
-  # artifacts from internal repos only.
+  # Artifacts are fetched from DEFAULT_ARTIFACT_REPOSITORY if set, then
+  # MAVEN_MIRROR_URL, and finally the default Google mirror of Maven Central.
   # Ex:
   #   DEFAULT_ARTIFACT_REPOSITORY=https://artifacts.internal.com/libs-release/
-  DEFAULT_ARTIFACT_REPOSITORY=${DEFAULT_ARTIFACT_REPOSITORY:-https://maven-central.storage-download.googleapis.com/maven2/}
+  local default_repo=${MAVEN_MIRROR_URL:-https://maven-central.storage-download.googleapis.com/maven2/}
+  DEFAULT_ARTIFACT_REPOSITORY=${DEFAULT_ARTIFACT_REPOSITORY:-$default_repo}
   URL1=${DEFAULT_ARTIFACT_REPOSITORY%/}/org/scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch-${SBT_VERSION}.jar
   JAR=build/sbt-launch-${SBT_VERSION}.jar
 
@@ -181,6 +182,18 @@ run() {
   process_args "$@"
   set -- "${residual_args[@]}"
   argumentCount=$#
+
+  # If MAVEN_MIRROR_URL is set, generate a repositories config so the SBT launcher
+  # resolves SBT and Scala through the mirror during the boot phase.
+  if [[ -n "$MAVEN_MIRROR_URL" ]]; then
+    local sbt_repo_config="$(mktemp /tmp/sbt-repositories.XXXXXX)"
+    cat > "$sbt_repo_config" <<EOF
+[repositories]
+  local
+  maven-mirror: ${MAVEN_MIRROR_URL}
+EOF
+    addJava "-Dsbt.repository.config=$sbt_repo_config"
+  fi
 
   # run sbt
   execRunner "$java_cmd" \

--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -185,8 +185,10 @@ run() {
 
   # If MAVEN_MIRROR_URL is set, generate a repositories config so the SBT launcher
   # resolves SBT and Scala through the mirror during the boot phase.
-  if [[ -n "$MAVEN_MIRROR_URL" ]]; then
+  # Skip if the user already configured -Dsbt.repository.config.
+  if [[ -n "$MAVEN_MIRROR_URL" && ! "$SBT_OPTS" =~ sbt\.repository\.config ]]; then
     local sbt_repo_config="$(mktemp /tmp/sbt-repositories.XXXXXX)"
+    trap "rm -f '$sbt_repo_config'" EXIT
     cat > "$sbt_repo_config" <<EOF
 [repositories]
   local


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to #55168. The SBT launcher script (`build/sbt-launch-lib.bash`) did not respect `MAVEN_MIRROR_URL`. This patch adds support for it in two places:

1. **Launcher JAR download**: `MAVEN_MIRROR_URL` is used as the default for `DEFAULT_ARTIFACT_REPOSITORY` when neither is explicitly set.
2. **SBT boot phase**: When `MAVEN_MIRROR_URL` is set, a temporary SBT repositories config is generated and passed via `-Dsbt.repository.config` so SBT resolves itself and Scala through the mirror.

### Why are the changes needed?

SPARK-56338 added `MAVEN_MIRROR_URL` support for Maven (`pom.xml`) and SBT project builds (`SparkBuild.scala`), but the SBT launcher script was not covered. In environments where default Maven repositories are unreachable, the SBT launcher JAR download and boot phase still fail without manual configuration (e.g. `~/.sbt/repositories`).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually tested by setting `MAVEN_MIRROR_URL` and building Spark with SBT from scratch (launcher JAR removed, no `~/.sbt/repositories`).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code