### PR TITLE
[SPARK-56378] Add PR description guidelines to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,9 @@ Run a single test case:
 
 ## Pull Request Workflow
 
-PR title requires a JIRA ticket ID (e.g., `[SPARK-xxxx][SQL] Title`). Ask the user to create a new ticket or provide an existing one if not given. Follow the template in `.github/PULL_REQUEST_TEMPLATE` for the PR description.
+PR title requires a JIRA ticket ID (e.g., `[SPARK-xxxx][SQL] Title`). Ask the user to create a new ticket or provide an existing one if not given.
+
+PR descriptions MUST use the section headings from `.github/PULL_REQUEST_TEMPLATE` (omit the HTML comments).
 
 DO NOT push to the upstream repo. Always push to the personal fork. Open PRs against `master` on the upstream repo.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Require PR descriptions to use the section headings from `.github/PULL_REQUEST_TEMPLATE` in `AGENTS.md` (AI agent instructions).

### Why are the changes needed?

The previous instruction ("Follow the template") was too vague and resulted in AI-generated PRs that did not follow the template format.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No tests needed — documentation-only change.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude (Cursor agent mode)