### PR TITLE
[SPARK-56390][SQL] Avoid throwing away resolved child when constructing V1 command variants of ShowColumns and DescribeRelation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -196,8 +196,11 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
 
     // Use v1 command to describe (temp) view, as v2 catalog doesn't support view yet.
     case DescribeRelation(
-        ResolvedV1TableOrViewIdentifier(ident), partitionSpec, isExtended, output) =>
-      DescribeTableCommand(ident, partitionSpec, isExtended, output)
+        resolvedChild @ ResolvedV1TableOrViewIdentifier(ident),
+        partitionSpec,
+        isExtended,
+        output) =>
+      DescribeTableCommand(resolvedChild, ident, partitionSpec, isExtended, output)
 
     case DescribeColumn(
         ResolvedViewIdentifier(ident), column: UnresolvedAttribute, isExtended, output) =>
@@ -431,7 +434,7 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
         output,
         pattern.map(_.asInstanceOf[UnresolvedPartitionSpec].spec))
 
-    case ShowColumns(ResolvedViewIdentifier(ident), ns, output) =>
+    case ShowColumns(resolvedChild @ ResolvedViewIdentifier(ident), ns, output) =>
       val resolver = conf.resolver
       val db = ns match {
         case Some(nsSeq) if ident.database.exists(!resolver(_, nsSeq.head)) =>
@@ -443,9 +446,10 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
       // matches expected format (e.g. "SHOW COLUMNS IN showcolumn4 FROM global_temp").
       val tableNameForCommand =
         if (db.isDefined && ident.database == db) TableIdentifier(ident.table, None) else ident
-      ShowColumnsCommand(db, tableNameForCommand, output)
+      ShowColumnsCommand(resolvedChild, db, tableNameForCommand, output)
 
-    case ShowColumns(ResolvedV1TableIdentifier(ident), ns, output) =>
+    case ShowColumns(
+        resolvedChild @ ResolvedV1TableIdentifier(ident), ns, output) =>
       val v1TableName = ident
       val resolver = conf.resolver
       val db = ns match {
@@ -454,7 +458,7 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
             Seq(db.head), Seq(v1TableName.database.get))
         case _ => ns.map(_.head)
       }
-      ShowColumnsCommand(db, v1TableName, output)
+      ShowColumnsCommand(resolvedChild, db, v1TableName, output)
 
     // V2 catalog doesn't support RECOVER PARTITIONS yet, we must use v1 command here.
     case RecoverPartitions(ResolvedV1TableIdentifierInSessionCatalog(ident)) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -586,17 +586,16 @@ object ResolvedChildHelper {
   def getTableMetadata(
       child: LogicalPlan,
       sparkSession: SparkSession,
-      table: TableIdentifier): CatalogTable = child match {
-    case ResolvedTempView(_, metadata) => metadata
-    case ResolvedPersistentView(_, _, metadata) => metadata
-    case ResolvedTable(_, _, t: V1Table, _) => t.v1Table
-    case _ =>
-      val catalog = sparkSession.sessionState.catalog
-      if (catalog.isTempView(table)) {
-        catalog.getTempViewOrPermanentTableMetadata(table)
-      } else {
-        catalog.getTableRawMetadata(table)
-      }
+      table: TableIdentifier): CatalogTable = {
+    val catalog = sparkSession.sessionState.catalog
+    child match {
+      case ResolvedTempView(_, metadata) => metadata
+      case ResolvedPersistentView(_, _, metadata) => metadata
+      case ResolvedTable(_, _, t: V1Table, _) => t.v1Table
+      case _ if (catalog.isTempView(table)) =>
+          catalog.getTempViewOrPermanentTableMetadata(table)
+      case _ => catalog.getTableRawMetadata(table)
+    }
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -639,7 +639,12 @@ case class DescribeTableCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val result = new ArrayBuffer[Row]
     val catalog = sparkSession.sessionState.catalog
-    val metadata = ResolvedChildHelper.getTableMetadata(child, sparkSession, table)
+    // V2SessionCatalog.loadTable uses getTableMetadata which replaces char/varchar with string
+    // in the CatalogTable schema. Restore the original types from field metadata so that
+    // DESCRIBE TABLE reports char(n)/varchar(n) instead of string.
+    val rawMetadata = ResolvedChildHelper.getTableMetadata(child, sparkSession, table)
+    val metadata = rawMetadata.copy(
+      schema = CharVarcharUtils.getRawSchema(rawMetadata.schema))
 
     if (catalog.isTempView(table)) {
       if (partitionSpec.nonEmpty) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -28,7 +28,7 @@ import org.apache.hadoop.fs.permission.{AclEntry, AclEntryScope, AclEntryType, F
 
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.{SQLConfHelper, TableIdentifier}
-import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.analysis.{ResolvedPersistentView, ResolvedTable, ResolvedTempView, UnresolvedAttribute}
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.catalog.CatalogTableType._
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
@@ -39,8 +39,8 @@ import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.{escapeSingleQuotedString, quoteIfNeeded, CaseInsensitiveMap, CharVarcharUtils, DateTimeUtils, ResolveDefaultColumns}
 import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns.CURRENT_DEFAULT_COLUMN_METADATA_KEY
 import org.apache.spark.sql.classic.ClassicConversions.castToImpl
+import org.apache.spark.sql.connector.catalog.{TableCatalog, V1Table}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.TableIdentifierHelper
-import org.apache.spark.sql.connector.catalog.TableCatalog
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.CommandExecutionMode
 import org.apache.spark.sql.execution.datasources.DataSource
@@ -577,6 +577,29 @@ case class TruncateTableCommand(
   }
 }
 
+object ResolvedChildHelper {
+  /**
+   * Used by ShowColumnsCommand and DescribeTableCommand to
+   * extract CatalogTable from the plan representing the entity
+   * being described.
+   */
+  def getTableMetadata(
+      child: LogicalPlan,
+      sparkSession: SparkSession,
+      table: TableIdentifier): CatalogTable = child match {
+    case ResolvedTempView(_, metadata) => metadata
+    case ResolvedPersistentView(_, _, metadata) => metadata
+    case ResolvedTable(_, _, t: V1Table, _) => t.v1Table
+    case _ =>
+      val catalog = sparkSession.sessionState.catalog
+      if (catalog.isTempView(table)) {
+        catalog.getTempViewOrPermanentTableMetadata(table)
+      } else {
+        catalog.getTableRawMetadata(table)
+      }
+  }
+}
+
 trait DescribeCommandBase {
   def output: Seq[Attribute]
 
@@ -617,15 +640,14 @@ case class DescribeTableCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val result = new ArrayBuffer[Row]
     val catalog = sparkSession.sessionState.catalog
+    val metadata = ResolvedChildHelper.getTableMetadata(child, sparkSession, table)
 
     if (catalog.isTempView(table)) {
       if (partitionSpec.nonEmpty) {
         throw QueryCompilationErrors.descPartitionNotAllowedOnTempView(table.identifier)
       }
-      val schema = catalog.getTempViewOrPermanentTableMetadata(table).schema
-      describeSchema(schema, result, header = false)
+      describeSchema(metadata.schema, result, header = false)
     } else {
-      val metadata = catalog.getTableRawMetadata(table)
       if (metadata.schema.isEmpty) {
         // In older version(prior to 2.1) of Spark, the table schema can be empty and should be
         // inferred at runtime. We should still support it.
@@ -1004,13 +1026,12 @@ case class ShowColumnsCommand(
     copy(child = newChild)
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val catalog = sparkSession.sessionState.catalog
     val lookupTable = databaseName match {
       case None => tableName
       case Some(db) => TableIdentifier(tableName.identifier, Some(db))
     }
-    val table = catalog.getTempViewOrPermanentTableMetadata(lookupTable)
-    table.schema.map { c =>
+    val metadata = ResolvedChildHelper.getTableMetadata(child, sparkSession, lookupTable)
+    metadata.schema.map { c =>
       Row(c.name)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -577,7 +577,9 @@ case class TruncateTableCommand(
   }
 }
 
-abstract class DescribeCommandBase extends LeafRunnableCommand {
+trait DescribeCommandBase {
+  def output: Seq[Attribute]
+
   protected def describeSchema(
       schema: StructType,
       buffer: ArrayBuffer[Row],
@@ -602,11 +604,15 @@ abstract class DescribeCommandBase extends LeafRunnableCommand {
  * }}}
  */
 case class DescribeTableCommand(
+    override val child: LogicalPlan,
     table: TableIdentifier,
     partitionSpec: TablePartitionSpec,
     isExtended: Boolean,
     override val output: Seq[Attribute])
-  extends DescribeCommandBase {
+  extends UnaryRunnableCommand with DescribeCommandBase {
+
+  override def withNewChildInternal(newChild: LogicalPlan): LogicalPlan =
+    copy(child = newChild)
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val result = new ArrayBuffer[Row]
@@ -747,7 +753,7 @@ case class DescribeTableCommand(
  * 7. Common table expressions (CTEs)
  */
 case class DescribeQueryCommand(queryText: String, plan: LogicalPlan)
-  extends DescribeCommandBase with SupervisingCommand with CTEInChildren {
+  extends LeafRunnableCommand with DescribeCommandBase with SupervisingCommand with CTEInChildren {
 
   override val output = DescribeCommandSchema.describeTableAttributes()
 
@@ -988,9 +994,14 @@ case class ShowTablePropertiesCommand(
  * }}}
  */
 case class ShowColumnsCommand(
+    override val child: LogicalPlan,
     databaseName: Option[String],
     tableName: TableIdentifier,
-    override val output: Seq[Attribute]) extends LeafRunnableCommand {
+    override val output: Seq[Attribute])
+  extends UnaryRunnableCommand {
+
+  override def withNewChildInternal(newChild: LogicalPlan): LogicalPlan =
+    copy(child = newChild)
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/change-column.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/change-column.sql.out
@@ -9,6 +9,7 @@ CreateDataSourceTableCommand `spark_catalog`.`default`.`test_change`, false
 DESC test_change
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`test_change`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.test_change, V1Table(default.test_change), [a#x, b#x, c#x]
 
 
 -- !query
@@ -34,6 +35,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 DESC test_change
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`test_change`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.test_change, V1Table(default.test_change), [a#x, b#x, c#x]
 
 
 -- !query
@@ -54,6 +56,7 @@ org.apache.spark.sql.AnalysisException
 DESC test_change
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`test_change`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.test_change, V1Table(default.test_change), [a#x, b#x, c#x]
 
 
 -- !query
@@ -84,6 +87,7 @@ org.apache.spark.sql.AnalysisException
 DESC test_change
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`test_change`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.test_change, V1Table(default.test_change), [a#x, b#x, c#x]
 
 
 -- !query
@@ -118,6 +122,7 @@ org.apache.spark.sql.AnalysisException
 DESC test_change
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`test_change`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.test_change, V1Table(default.test_change), [a#x, b#x, c#x]
 
 
 -- !query
@@ -142,6 +147,7 @@ AlterTableChangeColumnCommand `spark_catalog`.`default`.`test_change`, c, Struct
 DESC test_change
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`test_change`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.test_change, V1Table(default.test_change), [a#x, b#x, c#x]
 
 
 -- !query
@@ -160,6 +166,7 @@ AlterTableChangeColumnCommand `spark_catalog`.`default`.`test_change`, a, Struct
 DESC test_change
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`test_change`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.test_change, V1Table(default.test_change), [a#x, b#x, c#x]
 
 
 -- !query
@@ -187,6 +194,7 @@ org.apache.spark.sql.AnalysisException
 DESC test_change
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`test_change`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.test_change, V1Table(default.test_change), [a#x, b#x, c#x]
 
 
 -- !query
@@ -199,6 +207,7 @@ AlterTableChangeColumnCommand `spark_catalog`.`default`.`test_change`, a, Struct
 DESC test_change
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`test_change`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.test_change, V1Table(default.test_change), [a#x, b#x, c#x]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/charvarchar.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/charvarchar.sql.out
@@ -9,6 +9,7 @@ CreateDataSourceTableCommand `spark_catalog`.`default`.`char_tbl`, false
 desc formatted char_tbl
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`char_tbl`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.char_tbl, V1Table(default.char_tbl), [c#x, v#x]
 
 
 -- !query
@@ -44,6 +45,7 @@ ShowCreateTable false, [createtab_stmt#x]
 desc formatted char_tbl2
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`char_tbl2`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.char_tbl2, V1Table(default.char_tbl2), [c#x, v#x]
 
 
 -- !query
@@ -62,6 +64,7 @@ CreateTableLikeCommand `spark_catalog`.`default`.`char_tbl3`, `spark_catalog`.`d
 desc formatted char_tbl3
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`char_tbl3`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.char_tbl3, V1Table(default.char_tbl3), [c#x, v#x]
 
 
 -- !query
@@ -94,6 +97,7 @@ org.apache.spark.sql.AnalysisException
 desc formatted char_view
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`char_view`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.char_view, `spark_catalog`.`default`.`char_view`
 
 
 -- !query
@@ -118,6 +122,7 @@ AlterTableRenameCommand `spark_catalog`.`default`.`char_tbl`, `char_tbl1`, false
 desc formatted char_tbl1
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`char_tbl1`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.char_tbl1, V1Table(default.char_tbl1), [c#x, v#x]
 
 
 -- !query
@@ -154,6 +159,7 @@ AlterTableChangeColumnCommand `spark_catalog`.`default`.`char_tbl1`, c, StructFi
 desc formatted char_tbl1
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`char_tbl1`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.char_tbl1, V1Table(default.char_tbl1), [c#x, v#x]
 
 
 -- !query
@@ -166,6 +172,7 @@ AlterTableAddColumnsCommand `spark_catalog`.`default`.`char_tbl1`, [StructField(
 desc formatted char_tbl1
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`char_tbl1`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.char_tbl1, V1Table(default.char_tbl1), [c#x, v#x, d#x]
 
 
 -- !query
@@ -182,6 +189,7 @@ AlterViewAsCommand `spark_catalog`.`default`.`char_view`, select * from char_tbl
 desc formatted char_view
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`char_view`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.char_view, `spark_catalog`.`default`.`char_view`
 
 
 -- !query
@@ -194,6 +202,7 @@ AlterTableSetPropertiesCommand `spark_catalog`.`default`.`char_tbl1`, [yes=no], 
 desc formatted char_tbl1
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`char_tbl1`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.char_tbl1, V1Table(default.char_tbl1), [c#x, v#x, d#x]
 
 
 -- !query
@@ -206,6 +215,7 @@ AlterTableSetPropertiesCommand `spark_catalog`.`default`.`char_view`, [yes=no], 
 desc formatted char_view
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`char_view`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.char_view, `spark_catalog`.`default`.`char_view`
 
 
 -- !query
@@ -218,6 +228,7 @@ AlterTableUnsetPropertiesCommand `spark_catalog`.`default`.`char_tbl1`, [yes], f
 desc formatted char_tbl1
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`char_tbl1`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.char_tbl1, V1Table(default.char_tbl1), [c#x, v#x, d#x]
 
 
 -- !query
@@ -230,6 +241,7 @@ AlterTableUnsetPropertiesCommand `spark_catalog`.`default`.`char_view`, [yes], f
 desc formatted char_view
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`char_view`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.char_view, `spark_catalog`.`default`.`char_view`
 
 
 -- !query
@@ -242,6 +254,7 @@ AlterTableSerDePropertiesCommand `spark_catalog`.`default`.`char_tbl1`, Map(yes 
 desc formatted char_tbl1
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`char_tbl1`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.char_tbl1, V1Table(default.char_tbl1), [c#x, v#x, d#x]
 
 
 -- !query
@@ -261,6 +274,7 @@ org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
 desc formatted char_part
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`char_part`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.char_part, V1Table(default.char_part), [c1#x, v1#x, v2#x, c2#x]
 
 
 -- !query
@@ -293,6 +307,7 @@ org.apache.spark.sql.catalyst.analysis.PartitionsAlreadyExistException
 desc formatted char_part
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`char_part`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.char_part, V1Table(default.char_part), [c1#x, v1#x, v2#x, c2#x]
 
 
 -- !query
@@ -313,6 +328,7 @@ org.apache.spark.sql.AnalysisException
 desc formatted char_part
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`char_part`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.char_part, V1Table(default.char_part), [c1#x, v1#x, v2#x, c2#x]
 
 
 -- !query
@@ -325,6 +341,7 @@ AlterTableSetLocationCommand `spark_catalog`.`default`.`char_part`, Map(v2 -> ke
 desc formatted char_part
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`char_part`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.char_part, V1Table(default.char_part), [c1#x, v1#x, v2#x, c2#x]
 
 
 -- !query
@@ -337,6 +354,7 @@ RepairTableCommand `spark_catalog`.`default`.`char_part`, true, false, MSCK REPA
 desc formatted char_part
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`char_part`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.char_part, V1Table(default.char_part), [c1#x, v1#x, v2#x, c2#x]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/collations-basic.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/collations-basic.sql.out
@@ -55,6 +55,7 @@ InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_d
 describe table t1
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`t1`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t1, V1Table(default.t1), [utf8_binary#x, utf8_lcase#x]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/describe-part-after-analyze.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/describe-part-after-analyze.sql.out
@@ -40,6 +40,7 @@ InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_d
 DESC EXTENDED t PARTITION (ds='2017-08-01', hr=10)
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`t`, [ds=2017-08-01, hr=10], true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [key#x, value#x, ds#x, hr#x]
 
 
 -- !query
@@ -52,6 +53,7 @@ AnalyzePartitionCommand `spark_catalog`.`default`.`t`, [ds=Some(2017-08-01), hr=
 DESC EXTENDED t PARTITION (ds='2017-08-01', hr=10)
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`t`, [ds=2017-08-01, hr=10], true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [key#x, value#x, ds#x, hr#x]
 
 
 -- !query
@@ -64,12 +66,14 @@ AnalyzePartitionCommand `spark_catalog`.`default`.`t`, [ds=Some(2017-08-01)], fa
 DESC EXTENDED t PARTITION (ds='2017-08-01', hr=10)
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`t`, [ds=2017-08-01, hr=10], true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [key#x, value#x, ds#x, hr#x]
 
 
 -- !query
 DESC EXTENDED t PARTITION (ds='2017-08-01', hr=11)
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`t`, [ds=2017-08-01, hr=11], true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [key#x, value#x, ds#x, hr#x]
 
 
 -- !query
@@ -82,18 +86,21 @@ AnalyzePartitionCommand `spark_catalog`.`default`.`t`, [ds=None, hr=None], false
 DESC EXTENDED t PARTITION (ds='2017-08-01', hr=10)
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`t`, [ds=2017-08-01, hr=10], true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [key#x, value#x, ds#x, hr#x]
 
 
 -- !query
 DESC EXTENDED t PARTITION (ds='2017-08-01', hr=11)
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`t`, [ds=2017-08-01, hr=11], true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [key#x, value#x, ds#x, hr#x]
 
 
 -- !query
 DESC EXTENDED t PARTITION (ds='2017-09-01', hr=5)
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`t`, [ds=2017-09-01, hr=5], true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [key#x, value#x, ds#x, hr#x]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/describe-table-after-alter-table.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/describe-table-after-alter-table.sql.out
@@ -9,6 +9,7 @@ CreateDataSourceTableCommand `spark_catalog`.`default`.`table_with_comment`, fal
 DESC FORMATTED table_with_comment
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`table_with_comment`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.table_with_comment, V1Table(default.table_with_comment), [a#x, b#x, c#x, d#x]
 
 
 -- !query
@@ -21,6 +22,7 @@ AlterTableSetPropertiesCommand `spark_catalog`.`default`.`table_with_comment`, [
 DESC FORMATTED table_with_comment
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`table_with_comment`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.table_with_comment, V1Table(default.table_with_comment), [a#x, b#x, c#x, d#x]
 
 
 -- !query
@@ -40,6 +42,7 @@ CreateDataSourceTableCommand `spark_catalog`.`default`.`table_comment`, false
 DESC FORMATTED table_comment
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`table_comment`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.table_comment, V1Table(default.table_comment), [a#x, b#x]
 
 
 -- !query
@@ -52,6 +55,7 @@ AlterTableSetPropertiesCommand `spark_catalog`.`default`.`table_comment`, [comme
 DESC formatted table_comment
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`table_comment`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.table_comment, V1Table(default.table_comment), [a#x, b#x]
 
 
 -- !query
@@ -64,6 +68,7 @@ AlterTableUnsetPropertiesCommand `spark_catalog`.`default`.`table_comment`, [com
 DESC FORMATTED table_comment
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`table_comment`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.table_comment, V1Table(default.table_comment), [a#x, b#x]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/describe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/describe.sql.out
@@ -54,6 +54,7 @@ AlterTableAddPartitionCommand `spark_catalog`.`default`.`t`, [(Map(c -> Us, d ->
 DESCRIBE t
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`t`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [a#x, b#x, c#x, d#x]
 
 
 -- !query
@@ -90,24 +91,28 @@ org.apache.spark.sql.catalyst.parser.ParseException
 DESC default.t
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`t`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [a#x, b#x, c#x, d#x]
 
 
 -- !query
 DESC TABLE t
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`t`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [a#x, b#x, c#x, d#x]
 
 
 -- !query
 DESC FORMATTED t
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`t`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [a#x, b#x, c#x, d#x]
 
 
 -- !query
 DESC EXTENDED t
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`t`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [a#x, b#x, c#x, d#x]
 
 
 -- !query
@@ -120,6 +125,7 @@ AlterTableUnsetPropertiesCommand `spark_catalog`.`default`.`t`, [e], false, fals
 DESC EXTENDED t
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`t`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [a#x, b#x, c#x, d#x]
 
 
 -- !query
@@ -132,12 +138,14 @@ AlterTableUnsetPropertiesCommand `spark_catalog`.`default`.`t`, [comment], false
 DESC EXTENDED t
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`t`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [a#x, b#x, c#x, d#x]
 
 
 -- !query
 DESC t PARTITION (c='Us', d=1)
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`t`, [c=Us, d=1], false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [a#x, b#x, c#x, d#x]
 
 
 -- !query
@@ -151,18 +159,21 @@ DescribeRelationJsonCommand [c=Us, d=1], true, [json_metadata#x]
 DESC EXTENDED t PARTITION (c='Us', d=1)
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`t`, [c=Us, d=1], true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [a#x, b#x, c#x, d#x]
 
 
 -- !query
 DESC FORMATTED t PARTITION (c='Us', d=1)
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`t`, [c=Us, d=1], true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [a#x, b#x, c#x, d#x]
 
 
 -- !query
 DESC EXTENDED t PARTITION (C='Us', D=1)
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`t`, [C=Us, D=1], true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [a#x, b#x, c#x, d#x]
 
 
 -- !query
@@ -252,30 +263,35 @@ DescribeNamespace true, [info_name#x, info_value#x]
 DESC temp_v
 -- !query analysis
 DescribeTableCommand `temp_v`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTempView temp_v, `temp_v`
 
 
 -- !query
 DESC TABLE temp_v
 -- !query analysis
 DescribeTableCommand `temp_v`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTempView temp_v, `temp_v`
 
 
 -- !query
 DESC FORMATTED temp_v
 -- !query analysis
 DescribeTableCommand `temp_v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTempView temp_v, `temp_v`
 
 
 -- !query
 DESC EXTENDED temp_v
 -- !query analysis
 DescribeTableCommand `temp_v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTempView temp_v, `temp_v`
 
 
 -- !query
 DESC temp_Data_Source_View
 -- !query analysis
 DescribeTableCommand `temp_Data_Source_View`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTempView temp_Data_Source_View, `temp_Data_Source_View`
 
 
 -- !query
@@ -297,24 +313,28 @@ org.apache.spark.sql.AnalysisException
 DESC v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
 DESC TABLE v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
 DESC FORMATTED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
 DESC EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -378,24 +398,28 @@ CreateDataSourceTableCommand `spark_catalog`.`default`.`d`, false
 DESC d
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`d`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.d, V1Table(default.d), [a#x, b#x]
 
 
 -- !query
 DESC EXTENDED d
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`d`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.d, V1Table(default.d), [a#x, b#x]
 
 
 -- !query
 DESC TABLE EXTENDED d
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`d`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.d, V1Table(default.d), [a#x, b#x]
 
 
 -- !query
 DESC FORMATTED d
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`d`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.d, V1Table(default.d), [a#x, b#x]
 
 
 -- !query
@@ -408,24 +432,28 @@ CreateDataSourceTableCommand `spark_catalog`.`default`.`e`, false
 DESC e
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`e`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.e, V1Table(default.e), [a#x, b#x]
 
 
 -- !query
 DESC EXTENDED e
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`e`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.e, V1Table(default.e), [a#x, b#x]
 
 
 -- !query
 DESC TABLE EXTENDED e
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`e`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.e, V1Table(default.e), [a#x, b#x]
 
 
 -- !query
 DESC FORMATTED e
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`e`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.e, V1Table(default.e), [a#x, b#x]
 
 
 -- !query
@@ -440,6 +468,7 @@ CreateDataSourceTableAsSelectCommand `spark_catalog`.`default`.`f`, ErrorIfExist
 DESC FORMATTED f PARTITION (B='SPARK', C=TIMESTAMP'2018-11-17 13:33:33')
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`f`, [B=SPARK, C=2018-11-17 13:33:33], true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.f, V1Table(default.f), [A#x, B#x, C#x]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/identifier-clause-legacy.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/identifier-clause-legacy.sql.out
@@ -328,6 +328,7 @@ Project [c1#x]
 DESCRIBE IDENTIFIER('ta' || 'b')
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`tab`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.tab, V1Table(default.tab), [c1#x]
 
 
 -- !query
@@ -353,6 +354,7 @@ ShowTableProperties [key#x, value#x]
 SHOW COLUMNS FROM IDENTIFIER('ta' || 'b')
 -- !query analysis
 ShowColumnsCommand `spark_catalog`.`default`.`tab`, [col_name#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.tab, V1Table(default.tab), [c1#x, c2#x]
 
 
 -- !query
@@ -1711,24 +1713,28 @@ CreateDataSourceTableCommand `spark_catalog`.`identifier_clause_test_schema`.`te
 DESCRIBE TABLE IDENTIFIER('test_desc')
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`identifier_clause_test_schema`.`test_desc`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), identifier_clause_test_schema.test_desc, V1Table(identifier_clause_test_schema.test_desc), [c1#x]
 
 
 -- !query
 DESCRIBE FORMATTED IDENTIFIER('test_desc')
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`identifier_clause_test_schema`.`test_desc`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), identifier_clause_test_schema.test_desc, V1Table(identifier_clause_test_schema.test_desc), [c1#x]
 
 
 -- !query
 DESCRIBE EXTENDED IDENTIFIER('test_desc')
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`identifier_clause_test_schema`.`test_desc`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), identifier_clause_test_schema.test_desc, V1Table(identifier_clause_test_schema.test_desc), [c1#x]
 
 
 -- !query
 DESC IDENTIFIER('test_desc')
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`identifier_clause_test_schema`.`test_desc`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), identifier_clause_test_schema.test_desc, V1Table(identifier_clause_test_schema.test_desc), [c1#x]
 
 
 -- !query
@@ -1794,12 +1800,14 @@ RefreshTableCommand `spark_catalog`.`identifier_clause_test_schema`.`test_table`
 DESCRIBE IDENTIFIER('identifier_clause_test_schema.test_table')
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`identifier_clause_test_schema`.`test_table`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), identifier_clause_test_schema.test_table, V1Table(identifier_clause_test_schema.test_table), [c1#x]
 
 
 -- !query
 SHOW COLUMNS FROM IDENTIFIER('identifier_clause_test_schema.test_table')
 -- !query analysis
 ShowColumnsCommand `spark_catalog`.`identifier_clause_test_schema`.`test_table`, [col_name#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), identifier_clause_test_schema.test_table, V1Table(identifier_clause_test_schema.test_table), [c1#x]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/identifier-clause.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/identifier-clause.sql.out
@@ -328,6 +328,7 @@ Project [c1#x]
 DESCRIBE IDENTIFIER('ta' || 'b')
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`tab`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.tab, V1Table(default.tab), [c1#x]
 
 
 -- !query
@@ -353,6 +354,7 @@ ShowTableProperties [key#x, value#x]
 SHOW COLUMNS FROM IDENTIFIER('ta' || 'b')
 -- !query analysis
 ShowColumnsCommand `spark_catalog`.`default`.`tab`, [col_name#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.tab, V1Table(default.tab), [c1#x, c2#x]
 
 
 -- !query
@@ -1625,24 +1627,28 @@ CreateDataSourceTableCommand `spark_catalog`.`identifier_clause_test_schema`.`te
 DESCRIBE TABLE IDENTIFIER('test_desc')
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`identifier_clause_test_schema`.`test_desc`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), identifier_clause_test_schema.test_desc, V1Table(identifier_clause_test_schema.test_desc), [c1#x]
 
 
 -- !query
 DESCRIBE FORMATTED IDENTIFIER('test_desc')
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`identifier_clause_test_schema`.`test_desc`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), identifier_clause_test_schema.test_desc, V1Table(identifier_clause_test_schema.test_desc), [c1#x]
 
 
 -- !query
 DESCRIBE EXTENDED IDENTIFIER('test_desc')
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`identifier_clause_test_schema`.`test_desc`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), identifier_clause_test_schema.test_desc, V1Table(identifier_clause_test_schema.test_desc), [c1#x]
 
 
 -- !query
 DESC IDENTIFIER('test_desc')
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`identifier_clause_test_schema`.`test_desc`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), identifier_clause_test_schema.test_desc, V1Table(identifier_clause_test_schema.test_desc), [c1#x]
 
 
 -- !query
@@ -1700,12 +1706,14 @@ RefreshTableCommand `spark_catalog`.`identifier_clause_test_schema`.`test_table`
 DESCRIBE IDENTIFIER('identifier_clause_test_schema.test_table')
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`identifier_clause_test_schema`.`test_table`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), identifier_clause_test_schema.test_table, V1Table(identifier_clause_test_schema.test_table), [c1#x]
 
 
 -- !query
 SHOW COLUMNS FROM IDENTIFIER('identifier_clause_test_schema.test_table')
 -- !query analysis
 ShowColumnsCommand `spark_catalog`.`identifier_clause_test_schema`.`test_table`, [col_name#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), identifier_clause_test_schema.test_table, V1Table(identifier_clause_test_schema.test_table), [c1#x]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/create_view.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/create_view.sql.out
@@ -262,6 +262,7 @@ CreateViewCommand `spark_catalog`.`temp_view_test`.`v1`, SELECT * FROM base_tabl
 DESC TABLE EXTENDED v1
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`temp_view_test`.`v1`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), temp_view_test.v1, `spark_catalog`.`temp_view_test`.`v1`
 
 
 -- !query
@@ -293,6 +294,7 @@ CreateViewCommand `v2_temp`, SELECT * FROM base_table, false, false, LocalTempVi
 DESC TABLE EXTENDED v2_temp
 -- !query analysis
 DescribeTableCommand `v2_temp`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTempView v2_temp, `v2_temp`
 
 
 -- !query
@@ -308,6 +310,7 @@ CreateViewCommand `spark_catalog`.`temp_view_test`.`v2`, SELECT * FROM base_tabl
 DESC TABLE EXTENDED temp_view_test.v2
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`temp_view_test`.`v2`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), temp_view_test.v2, `spark_catalog`.`temp_view_test`.`v2`
 
 
 -- !query
@@ -350,6 +353,7 @@ CreateViewCommand `spark_catalog`.`temp_view_test`.`v3`, SELECT t1.a AS t1_a, t2
 DESC TABLE EXTENDED v3
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`temp_view_test`.`v3`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), temp_view_test.v3, `spark_catalog`.`temp_view_test`.`v3`
 
 
 -- !query
@@ -407,6 +411,7 @@ CreateViewCommand `spark_catalog`.`temp_view_test`.`v4`, SELECT * FROM base_tabl
 DESC TABLE EXTENDED v4
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`temp_view_test`.`v4`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), temp_view_test.v4, `spark_catalog`.`temp_view_test`.`v4`
 
 
 -- !query
@@ -428,6 +433,7 @@ CreateViewCommand `spark_catalog`.`temp_view_test`.`v5`, SELECT t1.id, t2.a FROM
 DESC TABLE EXTENDED v5
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`temp_view_test`.`v5`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), temp_view_test.v5, `spark_catalog`.`temp_view_test`.`v5`
 
 
 -- !query
@@ -447,6 +453,7 @@ CreateViewCommand `spark_catalog`.`temp_view_test`.`v6`, SELECT * FROM base_tabl
 DESC TABLE EXTENDED v6
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`temp_view_test`.`v6`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), temp_view_test.v6, `spark_catalog`.`temp_view_test`.`v6`
 
 
 -- !query
@@ -466,6 +473,7 @@ CreateViewCommand `spark_catalog`.`temp_view_test`.`v7`, SELECT * FROM base_tabl
 DESC TABLE EXTENDED v7
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`temp_view_test`.`v7`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), temp_view_test.v7, `spark_catalog`.`temp_view_test`.`v7`
 
 
 -- !query
@@ -484,6 +492,7 @@ CreateViewCommand `spark_catalog`.`temp_view_test`.`v8`, SELECT * FROM base_tabl
 DESC TABLE EXTENDED v8
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`temp_view_test`.`v8`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), temp_view_test.v8, `spark_catalog`.`temp_view_test`.`v8`
 
 
 -- !query
@@ -666,6 +675,7 @@ CreateViewCommand `spark_catalog`.`testviewschm2`.`nontemp1`, SELECT * FROM t1 C
 DESC TABLE EXTENDED nontemp1
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`nontemp1`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.nontemp1, `spark_catalog`.`testviewschm2`.`nontemp1`
 
 
 -- !query
@@ -700,6 +710,7 @@ CreateViewCommand `spark_catalog`.`testviewschm2`.`nontemp2`, SELECT * FROM t1 I
 DESC TABLE EXTENDED nontemp2
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`nontemp2`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.nontemp2, `spark_catalog`.`testviewschm2`.`nontemp2`
 
 
 -- !query
@@ -734,6 +745,7 @@ CreateViewCommand `spark_catalog`.`testviewschm2`.`nontemp3`, SELECT * FROM t1 L
 DESC TABLE EXTENDED nontemp3
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`nontemp3`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.nontemp3, `spark_catalog`.`testviewschm2`.`nontemp3`
 
 
 -- !query
@@ -768,6 +780,7 @@ CreateViewCommand `spark_catalog`.`testviewschm2`.`nontemp4`, SELECT * FROM t1 L
 DESC TABLE EXTENDED nontemp4
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`nontemp4`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.nontemp4, `spark_catalog`.`testviewschm2`.`nontemp4`
 
 
 -- !query
@@ -872,6 +885,7 @@ AND EXISTS (SELECT g FROM tbl4 LEFT JOIN tbl3 ON tbl4.h = tbl3.f), false, false,
 DESC TABLE EXTENDED pubview
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`pubview`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.pubview, `spark_catalog`.`testviewschm2`.`pubview`
 
 
 -- !query
@@ -914,6 +928,7 @@ AND NOT EXISTS (SELECT g FROM tbl4 LEFT JOIN tmptbl ON tbl4.h = tmptbl.j), false
 DESC TABLE EXTENDED mytempview
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`mytempview`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.mytempview, `spark_catalog`.`testviewschm2`.`mytempview`
 
 
 -- !query
@@ -1059,24 +1074,28 @@ CreateViewCommand `spark_catalog`.`testviewschm2`.`aliased_view_4`, select * fro
 DESC TABLE aliased_view_1
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`aliased_view_1`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.aliased_view_1, `spark_catalog`.`testviewschm2`.`aliased_view_1`
 
 
 -- !query
 DESC TABLE aliased_view_2
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`aliased_view_2`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.aliased_view_2, `spark_catalog`.`testviewschm2`.`aliased_view_2`
 
 
 -- !query
 DESC TABLE aliased_view_3
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`aliased_view_3`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.aliased_view_3, `spark_catalog`.`testviewschm2`.`aliased_view_3`
 
 
 -- !query
 DESC TABLE aliased_view_4
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`aliased_view_4`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.aliased_view_4, `spark_catalog`.`testviewschm2`.`aliased_view_4`
 
 
 -- !query
@@ -1089,24 +1108,28 @@ AlterTableRenameCommand `spark_catalog`.`testviewschm2`.`tx1`, `a1`, false
 DESC TABLE aliased_view_1
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`aliased_view_1`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.aliased_view_1, `spark_catalog`.`testviewschm2`.`aliased_view_1`
 
 
 -- !query
 DESC TABLE aliased_view_2
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`aliased_view_2`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.aliased_view_2, `spark_catalog`.`testviewschm2`.`aliased_view_2`
 
 
 -- !query
 DESC TABLE aliased_view_3
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`aliased_view_3`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.aliased_view_3, `spark_catalog`.`testviewschm2`.`aliased_view_3`
 
 
 -- !query
 DESC TABLE aliased_view_4
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`aliased_view_4`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.aliased_view_4, `spark_catalog`.`testviewschm2`.`aliased_view_4`
 
 
 -- !query
@@ -1119,24 +1142,28 @@ AlterTableRenameCommand `spark_catalog`.`testviewschm2`.`tt1`, `a2`, false
 DESC TABLE aliased_view_1
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`aliased_view_1`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.aliased_view_1, `spark_catalog`.`testviewschm2`.`aliased_view_1`
 
 
 -- !query
 DESC TABLE aliased_view_2
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`aliased_view_2`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.aliased_view_2, `spark_catalog`.`testviewschm2`.`aliased_view_2`
 
 
 -- !query
 DESC TABLE aliased_view_3
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`aliased_view_3`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.aliased_view_3, `spark_catalog`.`testviewschm2`.`aliased_view_3`
 
 
 -- !query
 DESC TABLE aliased_view_4
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`aliased_view_4`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.aliased_view_4, `spark_catalog`.`testviewschm2`.`aliased_view_4`
 
 
 -- !query
@@ -1149,24 +1176,28 @@ AlterTableRenameCommand `spark_catalog`.`testviewschm2`.`a1`, `tt1`, false
 DESC TABLE aliased_view_1
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`aliased_view_1`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.aliased_view_1, `spark_catalog`.`testviewschm2`.`aliased_view_1`
 
 
 -- !query
 DESC TABLE aliased_view_2
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`aliased_view_2`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.aliased_view_2, `spark_catalog`.`testviewschm2`.`aliased_view_2`
 
 
 -- !query
 DESC TABLE aliased_view_3
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`aliased_view_3`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.aliased_view_3, `spark_catalog`.`testviewschm2`.`aliased_view_3`
 
 
 -- !query
 DESC TABLE aliased_view_4
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`aliased_view_4`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.aliased_view_4, `spark_catalog`.`testviewschm2`.`aliased_view_4`
 
 
 -- !query
@@ -1303,30 +1334,35 @@ CreateViewCommand `spark_catalog`.`testviewschm2`.`v3`, select * from tt2 join t
 DESC TABLE v1
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`v1`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.v1, `spark_catalog`.`testviewschm2`.`v1`
 
 
 -- !query
 DESC TABLE v1a
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`v1a`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.v1a, `spark_catalog`.`testviewschm2`.`v1a`
 
 
 -- !query
 DESC TABLE v2
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`v2`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.v2, `spark_catalog`.`testviewschm2`.`v2`
 
 
 -- !query
 DESC TABLE v2a
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`v2a`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.v2a, `spark_catalog`.`testviewschm2`.`v2a`
 
 
 -- !query
 DESC TABLE v3
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`v3`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.v3, `spark_catalog`.`testviewschm2`.`v3`
 
 
 -- !query
@@ -1345,30 +1381,35 @@ AlterTableAddColumnsCommand `spark_catalog`.`testviewschm2`.`tt2`, [StructField(
 DESC TABLE v1
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`v1`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.v1, `spark_catalog`.`testviewschm2`.`v1`
 
 
 -- !query
 DESC TABLE v1a
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`v1a`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.v1a, `spark_catalog`.`testviewschm2`.`v1a`
 
 
 -- !query
 DESC TABLE v2
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`v2`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.v2, `spark_catalog`.`testviewschm2`.`v2`
 
 
 -- !query
 DESC TABLE v2a
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`v2a`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.v2a, `spark_catalog`.`testviewschm2`.`v2a`
 
 
 -- !query
 DESC TABLE v3
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`v3`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.v3, `spark_catalog`.`testviewschm2`.`v3`
 
 
 -- !query
@@ -1400,30 +1441,35 @@ AlterTableAddColumnsCommand `spark_catalog`.`testviewschm2`.`tt3`, [StructField(
 DESC TABLE v1
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`v1`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.v1, `spark_catalog`.`testviewschm2`.`v1`
 
 
 -- !query
 DESC TABLE v1a
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`v1a`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.v1a, `spark_catalog`.`testviewschm2`.`v1a`
 
 
 -- !query
 DESC TABLE v2
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`v2`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.v2, `spark_catalog`.`testviewschm2`.`v2`
 
 
 -- !query
 DESC TABLE v2a
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`v2a`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.v2a, `spark_catalog`.`testviewschm2`.`v2a`
 
 
 -- !query
 DESC TABLE v3
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`v3`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.v3, `spark_catalog`.`testviewschm2`.`v3`
 
 
 -- !query
@@ -1456,6 +1502,7 @@ CreateViewCommand `spark_catalog`.`testviewschm2`.`vv1`, select * from (tt5 cros
 DESC TABLE vv1
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`vv1`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.vv1, `spark_catalog`.`testviewschm2`.`vv1`
 
 
 -- !query
@@ -1468,6 +1515,7 @@ AlterTableAddColumnsCommand `spark_catalog`.`testviewschm2`.`tt5`, [StructField(
 DESC TABLE vv1
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`vv1`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.vv1, `spark_catalog`.`testviewschm2`.`vv1`
 
 
 -- !query
@@ -1480,6 +1528,7 @@ AlterTableAddColumnsCommand `spark_catalog`.`testviewschm2`.`tt5`, [StructField(
 DESC TABLE vv1
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`vv1`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.vv1, `spark_catalog`.`testviewschm2`.`vv1`
 
 
 -- !query
@@ -1525,6 +1574,7 @@ select * from tt7 full join tt8 using (x), tt8 tt8x, false, false, PersistedView
 DESC TABLE vv2
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`vv2`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.vv2, `spark_catalog`.`testviewschm2`.`vv2`
 
 
 -- !query
@@ -1567,6 +1617,7 @@ select * from
 DESC TABLE vv3
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`vv3`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.vv3, `spark_catalog`.`testviewschm2`.`vv3`
 
 
 -- !query
@@ -1614,6 +1665,7 @@ select * from
 DESC TABLE vv4
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`vv4`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.vv4, `spark_catalog`.`testviewschm2`.`vv4`
 
 
 -- !query
@@ -1638,18 +1690,21 @@ AlterTableAddColumnsCommand `spark_catalog`.`testviewschm2`.`tt8`, [StructField(
 DESC TABLE vv2
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`vv2`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.vv2, `spark_catalog`.`testviewschm2`.`vv2`
 
 
 -- !query
 DESC TABLE vv3
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`vv3`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.vv3, `spark_catalog`.`testviewschm2`.`vv3`
 
 
 -- !query
 DESC TABLE vv4
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`vv4`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.vv4, `spark_catalog`.`testviewschm2`.`vv4`
 
 
 -- !query
@@ -1696,12 +1751,14 @@ select * from tt7a left join tt8a using (x), tt8a tt8ax, false, false, Persisted
 DESC TABLE vv4
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`vv4`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.vv4, `spark_catalog`.`testviewschm2`.`vv4`
 
 
 -- !query
 DESC TABLE vv2a
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`vv2a`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.vv2a, `spark_catalog`.`testviewschm2`.`vv2a`
 
 
 -- !query
@@ -1733,12 +1790,14 @@ CreateViewCommand `spark_catalog`.`testviewschm2`.`vv5`, select x,y,z from tt9 j
 DESC TABLE vv5
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`vv5`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.vv5, `spark_catalog`.`testviewschm2`.`vv5`
 
 
 -- !query
 DESC TABLE vv5
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`vv5`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.vv5, `spark_catalog`.`testviewschm2`.`vv5`
 
 
 -- !query
@@ -1782,6 +1841,7 @@ CreateViewCommand `spark_catalog`.`testviewschm2`.`vv6`, select x,y,z,q from
 DESC TABLE vv6
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`vv6`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.vv6, `spark_catalog`.`testviewschm2`.`vv6`
 
 
 -- !query
@@ -1794,6 +1854,7 @@ AlterTableAddColumnsCommand `spark_catalog`.`testviewschm2`.`tt11`, [StructField
 DESC TABLE vv6
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`vv6`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.vv6, `spark_catalog`.`testviewschm2`.`vv6`
 
 
 -- !query
@@ -1826,6 +1887,7 @@ CreateViewCommand `spark_catalog`.`testviewschm2`.`tt18v`, select * from int8_tb
 DESC TABLE tt18v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`tt18v`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.tt18v, `spark_catalog`.`testviewschm2`.`tt18v`
 
 
 -- !query
@@ -1846,6 +1908,7 @@ CreateViewCommand `spark_catalog`.`testviewschm2`.`tt21v`, select * from tt5 nat
 DESC TABLE tt21v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`tt21v`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.tt21v, `spark_catalog`.`testviewschm2`.`tt21v`
 
 
 -- !query
@@ -1866,6 +1929,7 @@ CreateViewCommand `spark_catalog`.`testviewschm2`.`tt22v`, select * from tt5 nat
 DESC TABLE tt22v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`tt22v`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.tt22v, `spark_catalog`.`testviewschm2`.`tt22v`
 
 
 -- !query
@@ -1890,6 +1954,7 @@ select 42, 43, false, false, PersistedView, COMPENSATION, true
 DESC TABLE tt23v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`testviewschm2`.`tt23v`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), testviewschm2.tt23v, `spark_catalog`.`testviewschm2`.`tt23v`
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/show_columns.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/show_columns.sql.out
@@ -43,24 +43,28 @@ CreateViewCommand `showColumn4`, SELECT 1 as col1, 'abc' as `col 5`, false, fals
 SHOW COLUMNS IN showcolumn1
 -- !query analysis
 ShowColumnsCommand `spark_catalog`.`showdb`.`showcolumn1`, [col_name#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), showdb.showcolumn1, V1Table(showdb.showcolumn1), [col1#x, col 2#x]
 
 
 -- !query
 SHOW COLUMNS IN showdb.showcolumn1
 -- !query analysis
 ShowColumnsCommand `spark_catalog`.`showdb`.`showcolumn1`, [col_name#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), showdb.showcolumn1, V1Table(showdb.showcolumn1), [col1#x, col 2#x]
 
 
 -- !query
 SHOW COLUMNS IN showcolumn1 FROM showdb
 -- !query analysis
 ShowColumnsCommand showdb, `spark_catalog`.`showdb`.`showcolumn1`, [col_name#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), showdb.showcolumn1, V1Table(showdb.showcolumn1), [col1#x, col 2#x]
 
 
 -- !query
 SHOW COLUMNS IN showcolumn2 IN showdb
 -- !query analysis
 ShowColumnsCommand showdb, `spark_catalog`.`showdb`.`showcolumn2`, [col_name#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), showdb.showcolumn2, V1Table(showdb.showcolumn2), [price#x, qty#x, year#x, month#x]
 
 
 -- !query
@@ -88,6 +92,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 SHOW COLUMNS IN showdb.showcolumn1 from SHOWDB
 -- !query analysis
 ShowColumnsCommand SHOWDB, `spark_catalog`.`showdb`.`showcolumn1`, [col_name#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), showdb.showcolumn1, V1Table(showdb.showcolumn1), [col1#x, col 2#x]
 
 
 -- !query
@@ -108,6 +113,7 @@ org.apache.spark.sql.AnalysisException
 SHOW COLUMNS IN showcolumn3
 -- !query analysis
 ShowColumnsCommand `showcolumn3`, [col_name#x]
++- ResolvedTempView showcolumn3, `showColumn3`
 
 
 -- !query
@@ -177,12 +183,14 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 SHOW COLUMNS IN global_temp.showcolumn4
 -- !query analysis
 ShowColumnsCommand `global_temp`.`showcolumn4`, [col_name#x]
++- ResolvedTempView global_temp.showcolumn4, `global_temp`.`showColumn4`
 
 
 -- !query
 SHOW COLUMNS IN showcolumn4 FROM global_temp
 -- !query analysis
 ShowColumnsCommand global_temp, `showcolumn4`, [col_name#x]
++- ResolvedTempView global_temp.showcolumn4, `global_temp`.`showColumn4`
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz.sql.out
@@ -292,6 +292,7 @@ InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_d
 DESC FORMATTED a
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`a`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.a, V1Table(default.a), [b#x, a#x]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/view-schema-binding-config.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/view-schema-binding-config.sql.out
@@ -111,6 +111,7 @@ CreateViewCommand `spark_catalog`.`default`.`v`, SELECT 1, false, true, Persiste
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -143,6 +144,7 @@ CreateViewCommand `v`, SELECT 1, false, true, LocalTempView, UNSUPPORTED, true
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTempView v, `v`
 
 
 -- !query
@@ -195,6 +197,7 @@ Project [c1#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -232,6 +235,7 @@ Project [c1#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -290,6 +294,7 @@ Project [c1#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -339,6 +344,7 @@ org.apache.spark.sql.AnalysisException
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -391,6 +397,7 @@ Project [c1#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -436,6 +443,7 @@ Project [c1#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -481,6 +489,7 @@ Project [c1#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -542,6 +551,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -590,6 +600,7 @@ Project [c1#x, c2#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -626,6 +637,7 @@ org.apache.spark.sql.AnalysisException
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -662,6 +674,7 @@ org.apache.spark.sql.AnalysisException
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -694,6 +707,7 @@ SetCommand (spark.sql.legacy.viewSchemaBindingMode,Some(true))
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -718,6 +732,7 @@ SetCommand (spark.sql.legacy.viewSchemaCompensation,Some(true))
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -768,6 +783,7 @@ SetCommand (spark.sql.legacy.viewSchemaBindingMode,Some(true))
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTempView v, `v`
 
 
 -- !query
@@ -786,6 +802,7 @@ SetCommand (spark.sql.legacy.viewSchemaCompensation,Some(true))
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedTempView v, `v`
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/view-schema-binding.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/view-schema-binding.sql.out
@@ -37,6 +37,7 @@ Project [c1#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -72,6 +73,7 @@ org.apache.spark.sql.AnalysisException
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -112,6 +114,7 @@ Project [c1#x, c2#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -148,6 +151,7 @@ org.apache.spark.sql.AnalysisException
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -194,6 +198,7 @@ Project [c1#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -206,6 +211,7 @@ AlterViewSchemaBindingCommand `spark_catalog`.`default`.`v`, BINDING
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -241,6 +247,7 @@ org.apache.spark.sql.AnalysisException
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/view-schema-compensation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/view-schema-compensation.sql.out
@@ -43,6 +43,7 @@ Project [c1#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -82,6 +83,7 @@ Project [c1#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -121,6 +123,7 @@ Project [c1#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -182,6 +185,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -230,6 +234,7 @@ Project [c1#x, c2#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -266,6 +271,7 @@ org.apache.spark.sql.AnalysisException
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -302,6 +308,7 @@ org.apache.spark.sql.AnalysisException
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -338,6 +345,7 @@ CreateViewCommand `spark_catalog`.`default`.`v`, SELECT * FROM t, false, true, P
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -387,6 +395,7 @@ AlterViewSchemaBindingCommand `spark_catalog`.`default`.`v`, COMPENSATION
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/view-schema-evolution.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/view-schema-evolution.sql.out
@@ -44,6 +44,7 @@ Project [c1#x, c2#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -82,6 +83,7 @@ Project [c4#x, c5#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -120,6 +122,7 @@ Project [c4#x, c5#x, c6#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -167,6 +170,7 @@ Project [c1#x, c2#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -197,6 +201,7 @@ Project [c1#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -245,6 +250,7 @@ Project [a1#x, a2#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -284,6 +290,7 @@ Project [a1#x, a2#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -323,6 +330,7 @@ Project [a1#x, a2#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -371,6 +379,7 @@ Project [a1#x, a2#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -407,6 +416,7 @@ org.apache.spark.sql.AnalysisException
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -443,6 +453,7 @@ org.apache.spark.sql.AnalysisException
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -471,6 +482,7 @@ CreateViewCommand `spark_catalog`.`default`.`v`, [(a1,None), (a2,None)], SELECT 
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -486,6 +498,7 @@ CreateViewCommand `spark_catalog`.`default`.`v`, [(a1,None), (a2,None)], SELECT 
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -517,6 +530,7 @@ Project [a1#xL, a2#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -532,6 +546,7 @@ CreateViewCommand `spark_catalog`.`default`.`v`, [(a1,Some(a1)), (a2,Some(a2))],
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -563,6 +578,7 @@ Project [a1#xL, a2#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -578,6 +594,7 @@ CreateViewCommand `spark_catalog`.`default`.`v`, SELECT * FROM t, false, true, P
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -608,6 +625,7 @@ Project [c1#xL, c2#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -766,6 +784,7 @@ Project [c1#x, c2#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/view-schema-type-evolution.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/view-schema-type-evolution.sql.out
@@ -45,6 +45,7 @@ Project [c1#x, c2#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -84,6 +85,7 @@ Project [c1#x, c2#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -123,6 +125,7 @@ Project [c1#x, c2#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -171,6 +174,7 @@ Project [c1#x, c2#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -207,6 +211,7 @@ org.apache.spark.sql.AnalysisException
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -243,6 +248,7 @@ org.apache.spark.sql.AnalysisException
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -271,6 +277,7 @@ CreateViewCommand `spark_catalog`.`default`.`v`, [(a1,None), (a2,None)], SELECT 
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -302,6 +309,7 @@ Project [a1#xL, a2#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -317,6 +325,7 @@ CreateViewCommand `spark_catalog`.`default`.`v`, [(a1,Some(a1)), (a2,Some(a2))],
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -348,6 +357,7 @@ Project [a1#xL, a2#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -417,6 +427,7 @@ Project [c1#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query
@@ -441,6 +452,7 @@ Project [c1#x]
 DESCRIBE EXTENDED v
 -- !query analysis
 DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
++- ResolvedPersistentView V2SessionCatalog(spark_catalog), default.v, `spark_catalog`.`default`.`v`
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/describe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/describe.sql.out
@@ -686,6 +686,7 @@ struct<plan:string>
 == Physical Plan ==
 Execute DescribeTableCommand
    +- DescribeTableCommand `spark_catalog`.`default`.`t`, false, [col_name#x, data_type#x, comment#x]
+      +- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [a#x, b#x, c#x, d#x]
 
 
 -- !query
@@ -696,6 +697,7 @@ struct<plan:string>
 == Physical Plan ==
 Execute DescribeTableCommand
    +- DescribeTableCommand `spark_catalog`.`default`.`t`, true, [col_name#x, data_type#x, comment#x]
+      +- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [a#x, b#x, c#x, d#x]
 
 
 -- !query
@@ -710,13 +712,16 @@ struct<plan:string>
 == Analyzed Logical Plan ==
 col_name: string, data_type: string, comment: string
 DescribeTableCommand `spark_catalog`.`default`.`t`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [a#x, b#x, c#x, d#x]
 
 == Optimized Logical Plan ==
 DescribeTableCommand `spark_catalog`.`default`.`t`, false, [col_name#x, data_type#x, comment#x]
++- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [a#x, b#x, c#x, d#x]
 
 == Physical Plan ==
 Execute DescribeTableCommand
    +- DescribeTableCommand `spark_catalog`.`default`.`t`, false, [col_name#x, data_type#x, comment#x]
+      +- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [a#x, b#x, c#x, d#x]
 
 
 -- !query
@@ -737,6 +742,7 @@ struct<plan:string>
 == Physical Plan ==
 Execute DescribeTableCommand
    +- DescribeTableCommand `spark_catalog`.`default`.`t`, [c=Us, d=2], false, [col_name#x, data_type#x, comment#x]
+      +- ResolvedTable V2SessionCatalog(spark_catalog), default.t, V1Table(default.t), [a#x, b#x, c#x, d#x]
 
 
 -- !query

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -931,9 +931,11 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
         val parsed2 = parseAndResolve(sql2)
         if (useV1Command) {
           val expected1 = DescribeTableCommand(
+            parsed1.asInstanceOf[DescribeTableCommand].child,
             TableIdentifier(tblName, Some("default"), Some(SESSION_CATALOG_NAME)),
             Map.empty, false, parsed1.output)
           val expected2 = DescribeTableCommand(
+            parsed2.asInstanceOf[DescribeTableCommand].child,
             TableIdentifier(tblName, Some("default"), Some(SESSION_CATALOG_NAME)),
             Map.empty, true, parsed2.output)
 
@@ -957,6 +959,7 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
         val parsed3 = parseAndResolve(sql3)
         if (useV1Command) {
           val expected3 = DescribeTableCommand(
+            parsed3.asInstanceOf[DescribeTableCommand].child,
             TableIdentifier(tblName, Some("default"), Some(SESSION_CATALOG_NAME)),
             Map("a" -> "1"), false, parsed3.output)
           comparePlans(parsed3, expected3)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveComparisonTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveComparisonTest.scala
@@ -171,7 +171,7 @@ abstract class HiveComparisonTest extends SparkFunSuite {
       // and does not return it as a query answer.
       case _: SetCommand => Seq("0")
       case _: ExplainCommand => answer
-      case _: DescribeCommandBase | ShowColumnsCommand(_, _, _) =>
+      case _: DescribeCommandBase | _: ShowColumnsCommand =>
         // Filter out non-deterministic lines and lines which do not have actual results but
         // can introduce problems because of the way Hive formats these lines.
         // Then, remove empty lines. Do not sort the results.

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/DescribeTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/DescribeTableSuite.scala
@@ -34,7 +34,7 @@ class DescribeTableSuite extends v1.DescribeTableSuiteBase with CommandSuiteBase
   test("Table Ownership") {
     withNamespaceAndTable("ns", "tbl") { t =>
       sql(s"CREATE TABLE $t (c int) $defaultUsing")
-      checkHiveClientCalls(expected = 2) {
+      checkHiveClientCalls(expected = 1) {
         checkAnswer(
           sql(s"DESCRIBE TABLE EXTENDED $t")
             .where("col_name='Owner'")


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
ResolveSessionCatalog transforms `DescribeRelation` (DESCRIBE TABLE) to `DescribeTableCommand` and `ShowColumns` to `ShowColumnsCommand` in some scenarios. While doing so, it throws away the resolved entity information. This PR, adds a child `LogicalPlan` to `ShowColumnsCommand` and `DescribeTableCommand` to store this resolved entity just like their V2 counterparts `ShowColumns` and `DescribeRelation`.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
By storing the resolved entity in the V1 command variants, we can avoid throwing away useful info that can help us avoid extra catalog lookups.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Ran PlanResolutionSuite and SQLQueryTestSuite

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No