### PR TITLE
[SPARK-56387][PYTHON] Refactor ProfileResults to a dict of dict

### DIFF
--- a/python/pyspark/sql/_typing.pyi
+++ b/python/pyspark/sql/_typing.pyi
@@ -23,6 +23,7 @@ from typing import (
     List,
     Optional,
     Tuple,
+    TypedDict,
     TypeVar,
     Union,
 )
@@ -85,4 +86,8 @@ class UserDefinedFunctionLike(Protocol):
     def __call__(self, *args: ColumnOrName) -> Column: ...
     def asNondeterministic(self) -> UserDefinedFunctionLike: ...
 
-ProfileResults = Dict[Union[int, str], Tuple[Optional[pstats.Stats], Optional[CodeMapDict]]]
+class ProfileResult(TypedDict, total=False):
+    perf: pstats.Stats
+    memory: CodeMapDict
+
+ProfileResults = Dict[Union[int, str], ProfileResult]

--- a/python/pyspark/sql/connect/profiler.py
+++ b/python/pyspark/sql/connect/profiler.py
@@ -29,7 +29,7 @@ class ConnectProfilerCollector(ProfilerCollector):
 
     def __init__(self) -> None:
         super().__init__()
-        self._value = ProfileResultsParam.zero(None)
+        self._value = ProfileResultsParam.zero({})
 
     @property
     def _profile_results(self) -> "ProfileResults":

--- a/python/pyspark/sql/profiler.py
+++ b/python/pyspark/sql/profiler.py
@@ -54,35 +54,32 @@ if TYPE_CHECKING:
     from pyspark.sql._typing import ProfileResults
 
 
-class _ProfileResultsParam(AccumulatorParam[Optional["ProfileResults"]]):
+class _ProfileResultsParam(AccumulatorParam["ProfileResults"]):
     """
     AccumulatorParam for profilers.
     """
 
     @staticmethod
-    def zero(value: Optional["ProfileResults"]) -> Optional["ProfileResults"]:
-        return value
+    def zero(value: "ProfileResults") -> "ProfileResults":
+        return {}
 
     @staticmethod
-    def addInPlace(
-        value1: Optional["ProfileResults"], value2: Optional["ProfileResults"]
-    ) -> Optional["ProfileResults"]:
-        if value1 is None or len(value1) == 0:
-            value1 = {}
-        if value2 is None or len(value2) == 0:
-            value2 = {}
-
-        value = value1.copy()
-        for key, (perf, mem, *_) in value2.items():
-            if key in value1:
-                orig_perf, orig_mem, *_ = value1[key]
+    def addInPlace(value1: "ProfileResults", value2: "ProfileResults") -> "ProfileResults":
+        for key, result in value2.items():
+            if key not in value1:
+                value1[key] = result
             else:
-                orig_perf, orig_mem = (PStatsParam.zero(None), MemUsageParam.zero(None))
-            value[key] = (
-                PStatsParam.addInPlace(orig_perf, perf),
-                MemUsageParam.addInPlace(orig_mem, mem),
-            )
-        return value
+                perf = PStatsParam.addInPlace(
+                    value1[key].get("perf", None), result.get("perf", None)
+                )
+                if perf is not None:
+                    value1[key]["perf"] = perf
+                memory = MemUsageParam.addInPlace(
+                    value1[key].get("memory", None), result.get("memory", None)
+                )
+                if memory is not None:
+                    value1[key]["memory"] = memory
+        return value1
 
 
 ProfileResultsParam = _ProfileResultsParam()
@@ -94,7 +91,7 @@ class WorkerPerfProfiler:
     """
 
     def __init__(
-        self, accumulator: Accumulator[Optional["ProfileResults"]], result_key: Union[int, str]
+        self, accumulator: Accumulator["ProfileResults"], result_key: Union[int, str]
     ) -> None:
         self._accumulator = accumulator
         self._profiler = cProfile.Profile()
@@ -111,7 +108,7 @@ class WorkerPerfProfiler:
         # make it picklable
         st.stream = None  # type: ignore[attr-defined]
         st.strip_dirs()
-        self._accumulator.add({self._result_key: (st, None)})
+        self._accumulator.add({self._result_key: {"perf": st}})
 
     def __enter__(self) -> "WorkerPerfProfiler":
         self.start()
@@ -134,7 +131,7 @@ class WorkerMemoryProfiler:
 
     def __init__(
         self,
-        accumulator: Accumulator[Optional["ProfileResults"]],
+        accumulator: Accumulator["ProfileResults"],
         result_key: Union[int, str],
         func_or_code: Union[Callable, CodeType],
     ) -> None:
@@ -159,7 +156,7 @@ class WorkerMemoryProfiler:
             filename: list(line_iterator)
             for filename, line_iterator in self._profiler.code_map.items()
         }
-        self._accumulator.add({self._result_key: (None, codemap_dict)})
+        self._accumulator.add({self._result_key: {"memory": codemap_dict}})
 
     def __enter__(self) -> "WorkerMemoryProfiler":
         self.start()
@@ -226,9 +223,9 @@ class ProfilerCollector(ABC):
     def _perf_profile_results(self) -> Dict[Union[int, str], pstats.Stats]:
         with self._lock:
             return {
-                result_id: perf
-                for result_id, (perf, _, *_) in self._profile_results.items()
-                if perf is not None
+                result_id: result["perf"]
+                for result_id, result in self._profile_results.items()
+                if result.get("perf", None) is not None
             }
 
     def show_memory_profiles(self, id: Optional[Union[int, str]] = None) -> None:
@@ -272,9 +269,9 @@ class ProfilerCollector(ABC):
     def _memory_profile_results(self) -> Dict[Union[int, str], CodeMapDict]:
         with self._lock:
             return {
-                result_id: mem
-                for result_id, (_, mem, *_) in self._profile_results.items()
-                if mem is not None
+                result_id: result["memory"]
+                for result_id, result in self._profile_results.items()
+                if result.get("memory", None) is not None
             }
 
     @property
@@ -368,15 +365,14 @@ class ProfilerCollector(ABC):
         with self._lock:
             if id is not None:
                 if id in self._profile_results:
-                    perf, mem, *_ = self._profile_results[id]
-                    self._profile_results[id] = (None, mem, *_)
-                    if mem is None:
-                        self._profile_results.pop(id, None)
+                    self._profile_results[id].pop("perf", None)
+                    if not self._profile_results[id]:
+                        self._profile_results.pop(id)
             else:
-                for id, (perf, mem, *_) in list(self._profile_results.items()):
-                    self._profile_results[id] = (None, mem, *_)
-                    if mem is None:
-                        self._profile_results.pop(id, None)
+                for id in list(self._profile_results.keys()):
+                    self._profile_results[id].pop("perf", None)
+                    if not self._profile_results[id]:
+                        self._profile_results.pop(id)
 
     def clear_memory_profiles(self, id: Optional[Union[int, str]] = None) -> None:
         """
@@ -393,15 +389,14 @@ class ProfilerCollector(ABC):
         with self._lock:
             if id is not None:
                 if id in self._profile_results:
-                    perf, mem, *_ = self._profile_results[id]
-                    self._profile_results[id] = (perf, None, *_)
-                    if perf is None:
-                        self._profile_results.pop(id, None)
+                    self._profile_results[id].pop("memory", None)
+                    if not self._profile_results[id]:
+                        self._profile_results.pop(id)
             else:
-                for id, (perf, mem, *_) in list(self._profile_results.items()):
-                    self._profile_results[id] = (perf, None, *_)
-                    if perf is None:
-                        self._profile_results.pop(id, None)
+                for id in list(self._profile_results.keys()):
+                    self._profile_results[id].pop("memory", None)
+                    if not self._profile_results[id]:
+                        self._profile_results.pop(id)
 
 
 class AccumulatorProfilerCollector(ProfilerCollector):
@@ -411,7 +406,7 @@ class AccumulatorProfilerCollector(ProfilerCollector):
             self._accumulator = _accumulatorRegistry[SpecialAccumulatorIds.SQL_UDF_PROFIER]
         else:
             self._accumulator = Accumulator(
-                SpecialAccumulatorIds.SQL_UDF_PROFIER, None, ProfileResultsParam
+                SpecialAccumulatorIds.SQL_UDF_PROFIER, {}, ProfileResultsParam
             )
 
     @property

--- a/python/pyspark/sql/tests/test_udf_profiler.py
+++ b/python/pyspark/sql/tests/test_udf_profiler.py
@@ -752,7 +752,7 @@ class UDFProfiler2TestsMixin:
 class UDFProfiler2Tests(UDFProfiler2TestsMixin, ReusedSQLTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.spark._profiler_collector._accumulator._value = None
+        self.spark._profiler_collector._accumulator._value = {}
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/worker/utils.py
+++ b/python/pyspark/sql/worker/utils.py
@@ -67,7 +67,7 @@ def worker_run(main: Callable, infile: IO, outfile: IO) -> None:
 
         _accumulatorRegistry.clear()
         accumulator = _deserialize_accumulator(
-            SpecialAccumulatorIds.SQL_UDF_PROFIER, None, ProfileResultsParam
+            SpecialAccumulatorIds.SQL_UDF_PROFIER, {}, ProfileResultsParam
         )
 
         if main.__module__ == "__main__":

--- a/python/pyspark/tests/test_memory_profiler.py
+++ b/python/pyspark/tests/test_memory_profiler.py
@@ -612,7 +612,7 @@ class MemoryProfiler2TestsMixin:
 class MemoryProfiler2Tests(MemoryProfiler2TestsMixin, ReusedSQLTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.spark._profiler_collector._accumulator._value = None
+        self.spark._profiler_collector._accumulator._value = {}
 
 
 if __name__ == "__main__":

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -1069,7 +1069,7 @@ def wrap_perf_profiler(f, eval_type, result_id):
     from pyspark.sql.profiler import ProfileResultsParam, WorkerPerfProfiler
 
     accumulator = _deserialize_accumulator(
-        SpecialAccumulatorIds.SQL_UDF_PROFIER, None, ProfileResultsParam
+        SpecialAccumulatorIds.SQL_UDF_PROFIER, {}, ProfileResultsParam
     )
 
     if _is_iter_based(eval_type):
@@ -1103,7 +1103,7 @@ def wrap_memory_profiler(f, eval_type, result_id):
         return f
 
     accumulator = _deserialize_accumulator(
-        SpecialAccumulatorIds.SQL_UDF_PROFIER, None, ProfileResultsParam
+        SpecialAccumulatorIds.SQL_UDF_PROFIER, {}, ProfileResultsParam
     )
 
     if _is_iter_based(eval_type):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Refactor `ProfileResults` to a real dict of dict with proper types.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently `ProfileResults` has a zero value `None`, which makes the code unnecessarily complicated - we need to take care of `None` all the time. `{}` is a perfect zero value for dict already. The values in `ProfileResults` is a tuple of perf and memory results, even if they don't exist. They are accessed with index and could be `None` too. We could just not add it to the dict if it does not exist so we don't need to deal with `None` anymore. We just need to make it a dict.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No. This should be private API.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

`test_udf_profiler` passed locally.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.