### PR TITLE
[SPARK-56328][SQL][FOLLOWUP] Handle SubqueryAlias-wrapped inline tables in INSERT VALUES collation fix

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveInlineTables.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveInlineTables.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.catalyst.expressions.EvalHelper
-import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoStatement, LogicalPlan, OverwriteByExpression}
+import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoStatement, LogicalPlan, OverwriteByExpression, SubqueryAlias}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.CurrentOrigin
 import org.apache.spark.sql.catalyst.trees.TreePattern.INLINE_TABLE_EVAL
@@ -40,11 +40,25 @@ object ResolveInlineTables extends Rule[LogicalPlan] with EvalHelper {
           i.copy(query = EvaluateUnresolvedInlineTable
             .evaluateUnresolvedInlineTable(table, ignoreCollation = true))
         }
+      case i @ InsertIntoStatement(
+          _, _, _, sa @ SubqueryAlias(_, table: UnresolvedInlineTable), _, _, _, _, _)
+          if table.expressionsResolved =>
+        CurrentOrigin.withOrigin(table.origin) {
+          i.copy(query = sa.copy(child = EvaluateUnresolvedInlineTable
+            .evaluateUnresolvedInlineTable(table, ignoreCollation = true)))
+        }
       case w @ OverwriteByExpression(_, _, table: UnresolvedInlineTable, _, _, _, _, _)
           if table.expressionsResolved =>
         CurrentOrigin.withOrigin(table.origin) {
           w.copy(query = EvaluateUnresolvedInlineTable
             .evaluateUnresolvedInlineTable(table, ignoreCollation = true))
+        }
+      case w @ OverwriteByExpression(
+          _, _, sa @ SubqueryAlias(_, table: UnresolvedInlineTable), _, _, _, _, _)
+          if table.expressionsResolved =>
+        CurrentOrigin.withOrigin(table.origin) {
+          w.copy(query = sa.copy(child = EvaluateUnresolvedInlineTable
+            .evaluateUnresolvedInlineTable(table, ignoreCollation = true)))
         }
       case table: UnresolvedInlineTable if table.expressionsResolved =>
         EvaluateUnresolvedInlineTable.evaluateUnresolvedInlineTable(table)

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
@@ -2519,9 +2519,13 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
         withTable("t") {
           sql("CREATE TABLE t (c1 STRING COLLATE UTF8_LCASE)")
           sql("INSERT INTO t VALUES ('a' COLLATE UTF8_LCASE), ('b' COLLATE UNICODE)")
+          sql(
+            """INSERT INTO t
+              |VALUES ('c' COLLATE UTF8_LCASE), ('d' COLLATE UNICODE)
+              |AS vals(c1)""".stripMargin)
           checkAnswer(
             sql("SELECT * FROM t"),
-            Seq(Row("a"), Row("b"))
+            Seq(Row("a"), Row("b"), Row("c"), Row("d"))
           )
         }
       }
@@ -2597,6 +2601,14 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
           checkAnswer(
             sql("SELECT * FROM testcat.t"),
             Seq(Row("a"), Row("b"))
+          )
+          sql(
+            """INSERT INTO testcat.t REPLACE WHERE TRUE
+              |  VALUES ('c' COLLATE UTF8_LCASE), ('d' COLLATE UNICODE)
+              |  AS vals(c1)""".stripMargin)
+          checkAnswer(
+            sql("SELECT * FROM testcat.t"),
+            Seq(Row("c"), Row("d"))
           )
         }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a followup to #55160. It fixes a case missed in the original PR where the `VALUES` clause has a table alias (e.g., `INSERT INTO t VALUES (...) AS T(c1)`), which wraps the `UnresolvedInlineTable` in a `SubqueryAlias`.

The original fix in `ResolveInlineTables` only pattern-matched `InsertIntoStatement` and `OverwriteByExpression` with a direct `UnresolvedInlineTable` child. When a table alias is present, the query child is a `SubqueryAlias` wrapping the `UnresolvedInlineTable`, so the pattern didn't match and fell through to the generic case without `ignoreCollation`, failing with `INCOMPATIBLE_TYPES_IN_INLINE_TABLE`.

This PR adds `SubqueryAlias`-wrapped cases for both `InsertIntoStatement` and `OverwriteByExpression`.

Note: the eager evaluation path (parser) was not affected because `isInlineTableInsideInsertValuesClause` runs before `optionalMap` wraps the table in a `SubqueryAlias`.

### Why are the changes needed?

Without this fix, the following fails when eager evaluation is disabled:

```sql
CREATE TABLE t (c1 STRING COLLATE UTF8_LCASE);
INSERT INTO t VALUES ('a' COLLATE UTF8_LCASE), ('b' COLLATE UNICODE) AS vals(c1);
-- AnalysisException: INCOMPATIBLE_TYPES_IN_INLINE_TABLE
```

### Does this PR introduce _any_ user-facing change?

Yes. `INSERT INTO ... VALUES (...) AS T(c1)` with conflicting collations now succeeds when the target column has a collation, matching the behavior of the non-aliased form.

### How was this patch tested?

Extended the existing "INSERT VALUES with explicit conflicting collations" test in `CollationSuite` to include a second INSERT with a table alias (`AS vals(c1)`), covering both eager and non-eager evaluation paths.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code