### PR TITLE
Implement `SET` command in single-pass analyzer

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ResolutionValidator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ResolutionValidator.scala
@@ -118,6 +118,8 @@ class ResolutionValidator {
         validateRelation(multiInstanceRelation)
       case supervisingCommand: SupervisingCommand =>
         validateSupervisingCommand(supervisingCommand)
+      case setCommandBase: SetCommandBase =>
+        validateSetCommandBase(setCommandBase)
     }
 
     operator match {
@@ -350,6 +352,8 @@ class ResolutionValidator {
   }
 
   private def validateSupervisingCommand(supervisingCommand: SupervisingCommand): Unit = {}
+
+  private def validateSetCommandBase(setCommandBase: SetCommandBase): Unit = {}
 
   private def handleOperatorOutput(operator: LogicalPlan): Unit = {
     attributeScopeStack.overwriteCurrent(operator.output)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/Resolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/Resolver.scala
@@ -320,6 +320,8 @@ class Resolver(
             handleLeafOperator(hiveTableRelation)
           case supervisingCommand: SupervisingCommand =>
             resolveSupervisingCommand(supervisingCommand)
+          case setCommandBase: SetCommandBase =>
+            resolveSetCommand(setCommandBase)
           case repartition: Repartition =>
             resolveRepartition(repartition)
           case sample: Sample =>
@@ -729,6 +731,14 @@ class Resolver(
    */
   private def resolveSupervisingCommand(supervisingCommand: SupervisingCommand): LogicalPlan = {
     supervisingCommand
+  }
+
+  /**
+   * [[SetCommandBase]] is a leaf command that is fully formed by the parser and requires no
+   * resolution.
+   */
+  private def resolveSetCommand(setCommandBase: SetCommandBase): LogicalPlan = {
+    setCommandBase
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ResolverGuard.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ResolverGuard.scala
@@ -151,6 +151,11 @@ class ResolverGuard(
         checkSort(sort)
       case supervisingCommand: SupervisingCommand =>
         None
+      case _: SetCommandBase
+          if conf.getConf(
+            SQLConf.ANALYZER_SINGLE_PASS_RESOLVER_ENABLE_SET_COMMAND_RESOLUTION
+          ) =>
+        None
       case repartition: Repartition =>
         checkRepartition(repartition)
       case having: UnresolvedHaving =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Command.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Command.scala
@@ -74,3 +74,10 @@ trait SupervisingCommand extends LeafCommand {
    */
   def withTransformedSupervisedPlan(transformer: LogicalPlan => LogicalPlan): LogicalPlan
 }
+
+/**
+ * A base trait for the SET command that lives in `sql/core`. This trait is
+ * defined in `sql/catalyst` so that the single-pass analyzer can
+ * pattern-match on it without depending on `sql/core`.
+ */
+trait SetCommandBase extends Command

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -463,6 +463,17 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val ANALYZER_SINGLE_PASS_RESOLVER_ENABLE_SET_COMMAND_RESOLUTION =
+    buildConf("spark.sql.analyzer.singlePassResolver.enableSetCommandResolution")
+      .internal()
+      .doc(
+        "When true, enables SetCommand resolution in single-pass analyzer. Otherwise, " +
+        "resolution falls back to fixed-point analyzer."
+      )
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val ANALYZER_SINGLE_PASS_RESOLVER_RUN_HEAVY_EXTENDED_RESOLUTION_CHECKS =
     buildConf("spark.sql.analyzer.singlePassResolver.runHeavyExtendedResolutionChecks")
       .internal()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.VariableResolution
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.parser.ParseException
+import org.apache.spark.sql.catalyst.plans.logical.SetCommandBase
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.classic.ClassicConversions.castToImpl
 import org.apache.spark.sql.errors.QueryCompilationErrors.toSQLId
@@ -39,7 +40,7 @@ import org.apache.spark.sql.types.{StringType, StructField, StructType}
  * }}}
  */
 case class SetCommand(kv: Option[(String, Option[String])])
-  extends LeafRunnableCommand with Logging {
+  extends LeafRunnableCommand with Logging with SetCommandBase {
 
   private def keyValueOutput: Seq[Attribute] = {
     val schema = StructType(Array(

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/ResolverGuardSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/ResolverGuardSuite.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.catalyst.analysis.resolver.{
 }
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 class ResolverGuardSuite extends ResolverGuardSuiteBase {
@@ -257,6 +258,25 @@ class ResolverGuardSuite extends ResolverGuardSuiteBase {
 
   test("DESCRIBE") {
     checkResolverGuard("DESCRIBE QUERY SELECT * FROM VALUES (1)")
+  }
+
+  Seq(true, false).foreach { enabled =>
+    val expectedReason = if (enabled) {
+      None
+    } else {
+      Some("class org.apache.spark.sql.execution.command.SetCommand operator resolution")
+    }
+    test(s"SET command - enabled=$enabled") {
+      withSQLConf(
+        SQLConf.ANALYZER_SINGLE_PASS_RESOLVER_ENABLE_SET_COMMAND_RESOLUTION.key ->
+          enabled.toString
+      ) {
+        checkResolverGuard("SET", expectedReason)
+        checkResolverGuard("SET spark.sql.shuffle.partitions=10", expectedReason)
+        checkResolverGuard("SET spark.sql.shuffle.partitions", expectedReason)
+        checkResolverGuard("SET -v", expectedReason)
+      }
+    }
   }
 
   test("HAVING") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
