### PR TITLE
[SPARK-56393][K8S][DOCS] Drop K8s v1.33 Support

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -44,7 +44,7 @@ Cluster administrators should use the [Pod Security Admission Controller](https:
 
 # Prerequisites
 
-* A running Kubernetes cluster at version >= 1.33 with access configured to it using
+* A running Kubernetes cluster at version >= 1.34 with access configured to it using
 [kubectl](https://kubernetes.io/docs/reference/kubectl/).  If you do not already have a working Kubernetes cluster,
 you may set up a test cluster on your local machine using
 [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/).


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update K8s docs to recommend K8s v1.34+ at Apache Spark 4.2.0 to utilize more stable features like the following example features at K8s v1.34.

- [Dynamic Resource Allocation (GA)](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/)

### Why are the changes needed?

**1. K8s v1.33 will enter the maintenance mode soon (2026-04-28) and will reach the end of support on 2026-06-28**
- https://kubernetes.io/releases/patch-releases/#1-33

**2. Default K8s Versions in Public Cloud environments**

The default K8s versions of public cloud providers are already moving to K8s 1.35+ like the following.

- EKS: v1.35 (Default)
- AKS: v1.35 (Default)
- GKE: v1.35 (Stable)

**3. End Of Support in Public Cloud environments**

In addition, K8s 1.33 will reach the end of standard support.

| K8s  |   AKE  |  EKS  |  GKE  |
| ---- | ------- | ------- | ------- |
| 1.33 | 2026-06 | 2026-07 | 2026-08 |

- [AKS EOL Schedule](https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar)
- [EKS EOL Schedule](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar)
- [GKE EOL Schedule](https://cloud.google.com/kubernetes-engine/docs/release-schedule)

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only change about K8s versions.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.