### PR TITLE
[SPARK-56397][BUILD] Upgrade `ICU4J` to 78.3

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -99,7 +99,7 @@ hk2-locator/3.0.6//hk2-locator-3.0.6.jar
 hk2-utils/3.0.6//hk2-utils-3.0.6.jar
 httpclient/4.5.14//httpclient-4.5.14.jar
 httpcore/4.4.16//httpcore-4.4.16.jar
-icu4j/78.2//icu4j-78.2.jar
+icu4j/78.3//icu4j-78.3.jar
 ini4j/0.5.4//ini4j-0.5.4.jar
 istack-commons-runtime/4.1.2//istack-commons-runtime-4.1.2.jar
 ivy/2.5.3//ivy-2.5.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
     <datasketches.version>6.2.0</datasketches.version>
     <netty.version>4.2.12.Final</netty.version>
     <netty-tcnative.version>2.0.75.Final</netty-tcnative.version>
-    <icu4j.version>78.2</icu4j.version>
+    <icu4j.version>78.3</icu4j.version>
     <junit.version>6.0.3</junit.version>
     <jline.version>2.14.6</jline.version>
     <!--

--- a/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
@@ -1,88 +1,88 @@
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                          1700           1701           2          0.1       16999.2       1.0X
-UTF8_LCASE                                           2677           2680           4          0.0       26769.8       1.6X
-UNICODE                                             16807          16815          12          0.0      168065.3       9.9X
-UNICODE_CI                                          16675          16680           7          0.0      166754.2       9.8X
+UTF8_BINARY                                          1419           1420           1          0.1       14186.9       1.0X
+UTF8_LCASE                                           2787           2787           0          0.0       27869.7       2.0X
+UNICODE                                             16535          16536           2          0.0      165345.4      11.7X
+UNICODE_CI                                          16027          16027           1          0.0      160269.1      11.3X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                           1772           1772           0          0.1       17715.4       1.0X
-UTF8_LCASE                                            3826           3827           1          0.0       38260.0       2.2X
-UNICODE                                              17744          17749           8          0.0      177438.9      10.0X
-UNICODE_CI                                           17466          17468           4          0.0      174655.7       9.9X
+UTF8_BINARY                                           1656           1657           0          0.1       16562.2       1.0X
+UTF8_LCASE                                            2675           2676           0          0.0       26751.6       1.6X
+UNICODE                                              16196          16198           3          0.0      161955.9       9.8X
+UNICODE_CI                                           15868          15869           1          0.0      158679.6       9.6X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                       10829          10832           4          0.0      108287.4       1.0X
-UTF8_LCASE                                        17980          17991          14          0.0      179803.1       1.7X
-UNICODE                                          106747         106768          30          0.0     1067468.1       9.9X
-UNICODE_CI                                       153429         153454          35          0.0     1534292.9      14.2X
+UTF8_BINARY                                       10903          10903           1          0.0      109025.6       1.0X
+UTF8_LCASE                                        17399          17400           1          0.0      173994.0       1.6X
+UNICODE                                          117085         117090           8          0.0     1170847.9      10.7X
+UNICODE_CI                                       163656         163688          46          0.0     1636555.3      15.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        3025           3027           2          0.0       30253.4       1.0X
-UTF8_LCASE                                        14653          14660          10          0.0      146527.7       4.8X
-UNICODE                                          312274         312531         363          0.0     3122742.5     103.2X
-UNICODE_CI                                       321692         321807         162          0.0     3216921.4     106.3X
+UTF8_BINARY                                        2251           2253           2          0.0       22513.9       1.0X
+UTF8_LCASE                                        26923          26924           2          0.0      269231.8      12.0X
+UNICODE                                          482209         482784         813          0.0     4822094.5     214.2X
+UNICODE_CI                                       489363         490452        1540          0.0     4893633.2     217.4X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        2062           2064           2          0.0       20624.7       1.0X
-UTF8_LCASE                                         9960           9964           6          0.0       99597.4       4.8X
-UNICODE                                          321472         321769         419          0.0     3214722.6     155.9X
-UNICODE_CI                                       324168         324481         443          0.0     3241677.3     157.2X
+UTF8_BINARY                                        1811           1812           1          0.1       18112.7       1.0X
+UTF8_LCASE                                        13875          13878           3          0.0      138753.0       7.7X
+UNICODE                                          498193         499255        1502          0.0     4981931.4     275.1X
+UNICODE_CI                                       509087         509800        1009          0.0     5090869.3     281.1X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        2060           2061           2          0.0       20595.7       1.0X
-UTF8_LCASE                                         9931           9939          12          0.0       99312.2       4.8X
-UNICODE                                          326090         326389         422          0.0     3260901.9     158.3X
-UNICODE_CI                                       329588         329985         561          0.0     3295881.2     160.0X
+UTF8_BINARY                                        1841           1842           2          0.1       18411.3       1.0X
+UTF8_LCASE                                        13807          13808           2          0.0      138071.5       7.5X
+UNICODE                                          512425         512425           1          0.0     5124248.6     278.3X
+UNICODE_CI                                       512728         513123         559          0.0     5127280.4     278.5X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 collation unit benchmarks - initCap using impl execICU:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------------------
-UNICODE                                                           336            337           1          0.3        3363.9       1.0X
-UNICODE_CI                                                        344            344           1          0.3        3436.0       1.0X
+UNICODE                                                           351            352           1          0.3        3506.4       1.0X
+UNICODE_CI                                                        350            351           1          0.3        3503.6       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 collation unit benchmarks - initCap using impl execBinaryICU:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                                             580            581           1          0.2        5795.2       1.0X
-UTF8_LCASE                                                              580            582           1          0.2        5803.5       1.0X
-UNICODE                                                                 580            581           1          0.2        5796.4       1.0X
-UNICODE_CI                                                              580            581           1          0.2        5802.4       1.0X
+UTF8_BINARY                                                             575            577           1          0.2        5749.9       1.0X
+UTF8_LCASE                                                              576            577           1          0.2        5756.6       1.0X
+UNICODE                                                                 576            578           1          0.2        5762.7       1.0X
+UNICODE_CI                                                              575            579           6          0.2        5752.4       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 collation unit benchmarks - initCap using impl execBinary:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 -----------------------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                                          137            140           1          0.7        1370.0       1.0X
-UTF8_LCASE                                                           134            139           3          0.7        1335.7       1.0X
-UNICODE                                                              134            139           2          0.7        1340.8       1.0X
-UNICODE_CI                                                           134            140           2          0.7        1344.8       1.0X
+UTF8_BINARY                                                          149            150           1          0.7        1485.2       1.0X
+UTF8_LCASE                                                           148            150           1          0.7        1477.1       1.0X
+UNICODE                                                              148            151           1          0.7        1482.8       1.0X
+UNICODE_CI                                                           148            151           1          0.7        1476.7       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 collation unit benchmarks - initCap using impl execLowercase:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                                             329            334           3          0.3        3288.6       1.0X
-UTF8_LCASE                                                              332            336           2          0.3        3319.9       1.0X
-UNICODE                                                                 336            341           8          0.3        3364.7       1.0X
-UNICODE_CI                                                              337            337           1          0.3        3366.3       1.0X
+UTF8_BINARY                                                             348            350           1          0.3        3484.1       1.0X
+UTF8_LCASE                                                              349            350           1          0.3        3487.0       1.0X
+UNICODE                                                                 349            350           1          0.3        3488.5       1.0X
+UNICODE_CI                                                              349            350           1          0.3        3488.9       1.0X
 

--- a/sql/core/benchmarks/CollationBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-jdk25-results.txt
@@ -1,88 +1,88 @@
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                          2672           2673           2          0.0       26717.0       1.0X
-UTF8_LCASE                                           3902           3902           0          0.0       39024.8       1.5X
-UNICODE                                             17900          17918          26          0.0      178997.1       6.7X
-UNICODE_CI                                          17617          17632          21          0.0      176167.4       6.6X
+UTF8_BINARY                                          1692           1693           2          0.1       16918.6       1.0X
+UTF8_LCASE                                           3100           3103           4          0.0       31000.5       1.8X
+UNICODE                                             17654          17671          24          0.0      176538.5      10.4X
+UNICODE_CI                                          17338          17349          16          0.0      173375.2      10.2X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                           1806           1808           2          0.1       18064.4       1.0X
-UTF8_LCASE                                            3891           3891           0          0.0       38910.2       2.2X
-UNICODE                                              17894          17922          39          0.0      178937.5       9.9X
-UNICODE_CI                                           17650          17689          55          0.0      176502.1       9.8X
+UTF8_BINARY                                           1772           1772           0          0.1       17720.8       1.0X
+UTF8_LCASE                                            2485           2486           2          0.0       24849.7       1.4X
+UNICODE                                              17223          17230          11          0.0      172226.9       9.7X
+UNICODE_CI                                           16955          16962          10          0.0      169552.3       9.6X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                       12122          12124           2          0.0      121222.5       1.0X
-UTF8_LCASE                                        18710          18714           6          0.0      187103.9       1.5X
-UNICODE                                          104253         104256           4          0.0     1042531.5       8.6X
-UNICODE_CI                                       142640         142664          33          0.0     1426401.4      11.8X
+UTF8_BINARY                                       10161          10162           1          0.0      101613.4       1.0X
+UTF8_LCASE                                        16759          16761           2          0.0      167590.3       1.6X
+UNICODE                                          106102         106127          35          0.0     1061022.9      10.4X
+UNICODE_CI                                       158231         158254          33          0.0     1582309.6      15.6X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        2455           2456           2          0.0       24547.2       1.0X
-UTF8_LCASE                                        16158          16160           2          0.0      161582.7       6.6X
-UNICODE                                          310700         310973         386          0.0     3107002.0     126.6X
-UNICODE_CI                                       318729         319323         839          0.0     3187290.7     129.8X
+UTF8_BINARY                                        2896           2899           4          0.0       28961.7       1.0X
+UTF8_LCASE                                        13202          13259          81          0.0      132018.5       4.6X
+UNICODE                                          308694         309036         484          0.0     3086936.4     106.6X
+UNICODE_CI                                       314108         314129          30          0.0     3141078.5     108.5X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        2110           2111           1          0.0       21101.9       1.0X
-UTF8_LCASE                                        13327          13332           7          0.0      133272.1       6.3X
-UNICODE                                          315226         315289          88          0.0     3152262.8     149.4X
-UNICODE_CI                                       322243         322538         417          0.0     3222425.8     152.7X
+UTF8_BINARY                                        2119           2120           1          0.0       21187.7       1.0X
+UTF8_LCASE                                        10079          10137          82          0.0      100785.7       4.8X
+UNICODE                                          313596         313718         172          0.0     3135960.9     148.0X
+UNICODE_CI                                       313222         313825         854          0.0     3132215.4     147.8X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        2116           2138          31          0.0       21164.8       1.0X
-UTF8_LCASE                                        13535          13540           6          0.0      135349.5       6.4X
-UNICODE                                          332132         332492         509          0.0     3321319.3     156.9X
-UNICODE_CI                                       333198         333653         643          0.0     3331981.5     157.4X
+UTF8_BINARY                                        2153           2153           1          0.0       21526.0       1.0X
+UTF8_LCASE                                        10130          10140          15          0.0      101297.3       4.7X
+UNICODE                                          312571         312690         168          0.0     3125713.3     145.2X
+UNICODE_CI                                       316818         316961         202          0.0     3168179.8     147.2X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - initCap using impl execICU:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------------------
-UNICODE                                                           351            352           1          0.3        3514.1       1.0X
-UNICODE_CI                                                        351            353           2          0.3        3511.5       1.0X
+UNICODE                                                           366            366           0          0.3        3655.1       1.0X
+UNICODE_CI                                                        365            366           0          0.3        3647.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - initCap using impl execBinaryICU:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                                             593            594           1          0.2        5926.9       1.0X
-UTF8_LCASE                                                              593            594           1          0.2        5930.5       1.0X
-UNICODE                                                                 592            593           1          0.2        5922.6       1.0X
-UNICODE_CI                                                              593            593           1          0.2        5926.6       1.0X
+UTF8_BINARY                                                             594            595           1          0.2        5937.2       1.0X
+UTF8_LCASE                                                              594            595           1          0.2        5942.0       1.0X
+UNICODE                                                                 594            595           1          0.2        5939.3       1.0X
+UNICODE_CI                                                              594            595           1          0.2        5940.8       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - initCap using impl execBinary:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 -----------------------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                                          169            170           0          0.6        1690.4       1.0X
-UTF8_LCASE                                                           169            169           0          0.6        1685.8       1.0X
-UNICODE                                                              168            169           1          0.6        1683.5       1.0X
-UNICODE_CI                                                           168            169           1          0.6        1684.3       1.0X
+UTF8_BINARY                                                          170            171           2          0.6        1701.3       1.0X
+UTF8_LCASE                                                           170            171           0          0.6        1701.9       1.0X
+UNICODE                                                              170            171           0          0.6        1701.7       1.0X
+UNICODE_CI                                                           170            170           0          0.6        1699.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - initCap using impl execLowercase:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                                             351            351           1          0.3        3506.7       1.0X
-UTF8_LCASE                                                              351            352           2          0.3        3509.4       1.0X
-UNICODE                                                                 351            351           0          0.3        3506.9       1.0X
-UNICODE_CI                                                              351            352           1          0.3        3510.4       1.0X
+UTF8_BINARY                                                             368            369           0          0.3        3680.9       1.0X
+UTF8_LCASE                                                              368            369           1          0.3        3681.6       1.0X
+UNICODE                                                                 369            369           0          0.3        3685.5       1.0X
+UNICODE_CI                                                              369            369           0          0.3        3688.1       1.0X
 

--- a/sql/core/benchmarks/CollationBenchmark-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-results.txt
@@ -1,88 +1,88 @@
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                          1766           1768           2          0.1       17663.3       1.0X
-UTF8_LCASE                                           4133           4134           1          0.0       41334.1       2.3X
-UNICODE                                             20049          20050           2          0.0      200486.7      11.4X
-UNICODE_CI                                          19948          19949           3          0.0      199475.3      11.3X
+UTF8_BINARY                                          1750           1759          13          0.1       17495.5       1.0X
+UTF8_LCASE                                           3308           3308           0          0.0       33081.0       1.9X
+UNICODE                                             19078          19080           2          0.0      190783.4      10.9X
+UNICODE_CI                                          19128          19149          29          0.0      191281.0      10.9X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                           2811           2811           0          0.0       28112.4       1.0X
-UTF8_LCASE                                            4832           4841          12          0.0       48324.2       1.7X
-UNICODE                                              20250          20255           8          0.0      202496.4       7.2X
-UNICODE_CI                                           20121          20124           4          0.0      201214.1       7.2X
+UTF8_BINARY                                           1718           1721           5          0.1       17181.1       1.0X
+UTF8_LCASE                                            3995           4014          28          0.0       39946.5       2.3X
+UNICODE                                              18935          18950          20          0.0      189350.5      11.0X
+UNICODE_CI                                           18769          18817          69          0.0      187686.8      10.9X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                       14488          14496          12          0.0      144876.5       1.0X
-UTF8_LCASE                                        27216          27217           2          0.0      272158.9       1.9X
-UNICODE                                          115106         115133          37          0.0     1151063.9       7.9X
-UNICODE_CI                                       157558         157583          36          0.0     1575580.2      10.9X
+UTF8_BINARY                                       12855          12860           7          0.0      128552.0       1.0X
+UTF8_LCASE                                        24125          24132          10          0.0      241245.2       1.9X
+UNICODE                                          111122         111147          35          0.0     1111220.6       8.6X
+UNICODE_CI                                       153222         153265          61          0.0     1532219.5      11.9X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        3112           3112           0          0.0       31119.9       1.0X
-UTF8_LCASE                                        17761          17776          21          0.0      177611.1       5.7X
-UNICODE                                          307108         307289         257          0.0     3071076.6      98.7X
-UNICODE_CI                                       307434         307789         503          0.0     3074336.0      98.8X
+UTF8_BINARY                                        2492           2494           2          0.0       24924.2       1.0X
+UTF8_LCASE                                        17086          17097          16          0.0      170857.9       6.9X
+UNICODE                                          315941         316116         247          0.0     3159407.6     126.8X
+UNICODE_CI                                       316143         316692         777          0.0     3161431.5     126.8X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        2887           2889           2          0.0       28874.2       1.0X
-UTF8_LCASE                                        17453          17462          12          0.0      174533.3       6.0X
-UNICODE                                          304976         305021          63          0.0     3049760.8     105.6X
-UNICODE_CI                                       309352         309811         648          0.0     3093524.8     107.1X
+UTF8_BINARY                                        2490           2492           2          0.0       24900.7       1.0X
+UTF8_LCASE                                        17011          17024          18          0.0      170110.4       6.8X
+UNICODE                                          314401         315252        1203          0.0     3144011.9     126.3X
+UNICODE_CI                                       316226         316357         186          0.0     3162262.0     127.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        2878           2879           1          0.0       28778.5       1.0X
-UTF8_LCASE                                        17662          17668           8          0.0      176624.2       6.1X
-UNICODE                                          322660         322834         247          0.0     3226596.5     112.1X
-UNICODE_CI                                       325840         326152         441          0.0     3258403.0     113.2X
+UTF8_BINARY                                        2493           2493           0          0.0       24926.3       1.0X
+UTF8_LCASE                                        17066          17079          18          0.0      170656.7       6.8X
+UNICODE                                          329451         330395        1335          0.0     3294510.7     132.2X
+UNICODE_CI                                       331058         331863        1139          0.0     3310577.1     132.8X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - initCap using impl execICU:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------------------
-UNICODE                                                           423            424           1          0.2        4230.9       1.0X
-UNICODE_CI                                                        422            423           0          0.2        4224.7       1.0X
+UNICODE                                                           381            381           0          0.3        3810.0       1.0X
+UNICODE_CI                                                        380            381           1          0.3        3803.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - initCap using impl execBinaryICU:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                                             606            606           1          0.2        6057.1       1.0X
-UTF8_LCASE                                                              606            609           5          0.2        6061.2       1.0X
-UNICODE                                                                 607            614          13          0.2        6069.7       1.0X
-UNICODE_CI                                                              605            606           1          0.2        6054.0       1.0X
+UTF8_BINARY                                                             574            576           1          0.2        5742.3       1.0X
+UTF8_LCASE                                                              576            576           0          0.2        5759.5       1.0X
+UNICODE                                                                 575            576           1          0.2        5750.9       1.0X
+UNICODE_CI                                                              576            576           1          0.2        5755.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - initCap using impl execBinary:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 -----------------------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                                          180            181           1          0.6        1804.4       1.0X
-UTF8_LCASE                                                           180            181           0          0.6        1804.7       1.0X
-UNICODE                                                              180            181           1          0.6        1803.4       1.0X
-UNICODE_CI                                                           180            181           0          0.6        1802.2       1.0X
+UTF8_BINARY                                                          184            185           1          0.5        1843.4       1.0X
+UTF8_LCASE                                                           184            185           1          0.5        1844.3       1.0X
+UNICODE                                                              184            186           4          0.5        1844.1       1.0X
+UNICODE_CI                                                           184            185           0          0.5        1844.1       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - initCap using impl execLowercase:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                                             423            424           0          0.2        4229.7       1.0X
-UTF8_LCASE                                                              422            423           0          0.2        4224.8       1.0X
-UNICODE                                                                 423            424           1          0.2        4229.1       1.0X
-UNICODE_CI                                                              423            423           1          0.2        4226.4       1.0X
+UTF8_BINARY                                                             390            391           0          0.3        3904.1       1.0X
+UTF8_LCASE                                                              390            390           1          0.3        3895.9       1.0X
+UNICODE                                                                 390            391           1          0.3        3897.8       1.0X
+UNICODE_CI                                                              390            391           1          0.3        3895.7       1.0X
 

--- a/sql/core/benchmarks/CollationNonASCIIBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/CollationNonASCIIBenchmark-jdk21-results.txt
@@ -1,88 +1,88 @@
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                           194            194           0          0.2        4837.6       1.0X
-UTF8_LCASE                                           7765           7773          11          0.0      194137.4      40.1X
-UNICODE                                              5457           5461           6          0.0      136425.5      28.2X
-UNICODE_CI                                           5512           5513           2          0.0      137792.9      28.5X
+UTF8_BINARY                                           265            265           0          0.2        6628.1       1.0X
+UTF8_LCASE                                           8759           8761           2          0.0      218974.3      33.0X
+UNICODE                                              6509           6510           1          0.0      162736.8      24.6X
+UNICODE_CI                                           6452           6463          16          0.0      161299.1      24.3X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                            310            310           0          0.1        7753.3       1.0X
-UTF8_LCASE                                            7330           7332           3          0.0      183242.6      23.6X
-UNICODE                                               5351           5354           3          0.0      133782.8      17.3X
-UNICODE_CI                                            5298           5300           2          0.0      132459.8      17.1X
+UTF8_BINARY                                            411            411           1          0.1       10262.5       1.0X
+UTF8_LCASE                                            9779           9780           1          0.0      244484.6      23.8X
+UNICODE                                               6575           6575           0          0.0      164376.3      16.0X
+UNICODE_CI                                            6512           6514           2          0.0      162799.7      15.9X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        1679           1679           0          0.0       41970.7       1.0X
-UTF8_LCASE                                         5966           5969           4          0.0      149155.4       3.6X
-UNICODE                                           20645          20658          19          0.0      516121.0      12.3X
-UNICODE_CI                                        27031          27040          13          0.0      675767.7      16.1X
+UTF8_BINARY                                        1826           1826           0          0.0       45656.9       1.0X
+UTF8_LCASE                                         7528           7531           4          0.0      188202.1       4.1X
+UNICODE                                           24344          24370          37          0.0      608606.5      13.3X
+UNICODE_CI                                        31241          31243           2          0.0      781023.7      17.1X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                         534            535           1          0.1       13339.7       1.0X
-UTF8_LCASE                                         8141           8147           7          0.0      203536.5      15.3X
-UNICODE                                           61395          61430          50          0.0     1534863.9     115.1X
-UNICODE_CI                                        62334          62470         191          0.0     1558362.4     116.8X
+UTF8_BINARY                                         492            493           1          0.1       12306.3       1.0X
+UTF8_LCASE                                         9223           9226           5          0.0      230573.9      18.7X
+UNICODE                                           83767          83859         130          0.0     2094180.6     170.2X
+UNICODE_CI                                        84727          84880         216          0.0     2118169.1     172.1X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                         295            295           1          0.1        7368.5       1.0X
-UTF8_LCASE                                         5277           5278           1          0.0      131933.9      17.9X
-UNICODE                                           61115          61115           0          0.0     1527873.0     207.4X
-UNICODE_CI                                        61590          61593           4          0.0     1539747.4     209.0X
+UTF8_BINARY                                         374            375           0          0.1        9346.5       1.0X
+UTF8_LCASE                                         6389           6402          18          0.0      159735.3      17.1X
+UNICODE                                           83814          83856          60          0.0     2095344.5     224.2X
+UNICODE_CI                                        84627          84730         146          0.0     2115671.4     226.4X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                         294            295           1          0.1        7354.9       1.0X
-UTF8_LCASE                                         5391           5399          11          0.0      134784.4      18.3X
-UNICODE                                           68456          68479          32          0.0     1711406.7     232.7X
-UNICODE_CI                                        67460          67547         123          0.0     1686510.4     229.3X
+UTF8_BINARY                                         375            383          17          0.1        9363.9       1.0X
+UTF8_LCASE                                         6280           6296          22          0.0      157001.9      16.8X
+UNICODE                                           95829          95926         137          0.0     2395737.0     255.8X
+UNICODE_CI                                        95586          95610          35          0.0     2389646.2     255.2X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 collation unit benchmarks - initCap using impl execICU:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------------------
-UNICODE                                                           220            221           1          0.2        5508.0       1.0X
-UNICODE_CI                                                        220            221           1          0.2        5504.7       1.0X
+UNICODE                                                           238            239           1          0.2        5956.9       1.0X
+UNICODE_CI                                                        239            240           0          0.2        5969.5       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 collation unit benchmarks - initCap using impl execBinaryICU:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                                             328            329           1          0.1        8205.5       1.0X
-UTF8_LCASE                                                              328            329           0          0.1        8203.2       1.0X
-UNICODE                                                                 329            330           2          0.1        8212.8       1.0X
-UNICODE_CI                                                              328            329           1          0.1        8209.5       1.0X
+UTF8_BINARY                                                             304            304           1          0.1        7595.7       1.0X
+UTF8_LCASE                                                              303            304           1          0.1        7573.7       1.0X
+UNICODE                                                                 304            304           0          0.1        7596.1       1.0X
+UNICODE_CI                                                              304            305           1          0.1        7601.6       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 collation unit benchmarks - initCap using impl execBinary:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 -----------------------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                                           85             86           0          0.5        2120.4       1.0X
-UTF8_LCASE                                                            85             86           0          0.5        2122.9       1.0X
-UNICODE                                                               85             86           1          0.5        2118.9       1.0X
-UNICODE_CI                                                            85             86           0          0.5        2123.0       1.0X
+UTF8_BINARY                                                          148            149           1          0.3        3699.6       1.0X
+UTF8_LCASE                                                           148            151           5          0.3        3704.1       1.0X
+UNICODE                                                              148            149           1          0.3        3707.1       1.0X
+UNICODE_CI                                                           148            149           0          0.3        3708.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1008-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 collation unit benchmarks - initCap using impl execLowercase:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                                             220            221           1          0.2        5503.4       1.0X
-UTF8_LCASE                                                              220            221           1          0.2        5507.3       1.0X
-UNICODE                                                                 220            221           1          0.2        5504.7       1.0X
-UNICODE_CI                                                              220            221           0          0.2        5509.0       1.0X
+UTF8_BINARY                                                             225            225           1          0.2        5617.1       1.0X
+UTF8_LCASE                                                              224            225           0          0.2        5608.9       1.0X
+UNICODE                                                                 224            225           1          0.2        5607.4       1.0X
+UNICODE_CI                                                              224            225           0          0.2        5612.0       1.0X
 

--- a/sql/core/benchmarks/CollationNonASCIIBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/CollationNonASCIIBenchmark-jdk25-results.txt
@@ -1,88 +1,88 @@
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                           158            158           0          0.3        3943.1       1.0X
-UTF8_LCASE                                           7179           7186          10          0.0      179487.5      45.5X
-UNICODE                                              5040           5041           2          0.0      126001.2      32.0X
-UNICODE_CI                                           5124           5127           4          0.0      128108.7      32.5X
+UTF8_BINARY                                           271            271           1          0.1        6768.9       1.0X
+UTF8_LCASE                                           8171           8218          66          0.0      204284.2      30.2X
+UNICODE                                              6424           6425           2          0.0      160588.1      23.7X
+UNICODE_CI                                           6364           6373          14          0.0      159090.1      23.5X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                            528            529           2          0.1       13194.5       1.0X
-UTF8_LCASE                                            7432           7433           2          0.0      185789.3      14.1X
-UNICODE                                               5450           5459          13          0.0      136237.7      10.3X
-UNICODE_CI                                            5390           5392           2          0.0      134754.7      10.2X
+UTF8_BINARY                                            318            318           0          0.1        7948.1       1.0X
+UTF8_LCASE                                            7959           7973          21          0.0      198966.2      25.0X
+UNICODE                                               6500           6504           5          0.0      162500.1      20.4X
+UNICODE_CI                                            6439           6440           1          0.0      160976.9      20.3X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        1603           1605           2          0.0       40085.0       1.0X
-UTF8_LCASE                                         5857           5858           0          0.0      146436.7       3.7X
-UNICODE                                           19992          19993           1          0.0      499803.9      12.5X
-UNICODE_CI                                        26339          26352          19          0.0      658477.2      16.4X
+UTF8_BINARY                                        1989           1990           1          0.0       49719.9       1.0X
+UTF8_LCASE                                         6488           6491           5          0.0      162192.2       3.3X
+UNICODE                                           21233          21239           8          0.0      530835.1      10.7X
+UNICODE_CI                                        28152          28164          16          0.0      703805.3      14.2X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                         613            614           1          0.1       15332.3       1.0X
-UTF8_LCASE                                        10629          10630           2          0.0      265724.6      17.3X
-UNICODE                                           58338          58353          20          0.0     1458460.0      95.1X
-UNICODE_CI                                        58619          58622           5          0.0     1465466.5      95.6X
+UTF8_BINARY                                         541            542           1          0.1       13515.3       1.0X
+UTF8_LCASE                                         9070           9084          20          0.0      226757.4      16.8X
+UNICODE                                           58733          58796          88          0.0     1468326.5     108.6X
+UNICODE_CI                                        59845          59852          10          0.0     1496128.5     110.7X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                         297            298           0          0.1        7434.8       1.0X
-UTF8_LCASE                                         5542           5543           1          0.0      138545.3      18.6X
-UNICODE                                           57950          58089         197          0.0     1448737.8     194.9X
-UNICODE_CI                                        58980          59129         211          0.0     1474493.1     198.3X
+UTF8_BINARY                                         393            393           0          0.1        9818.8       1.0X
+UTF8_LCASE                                         5574           5580           8          0.0      139346.8      14.2X
+UNICODE                                           58010          58079          97          0.0     1450256.4     147.7X
+UNICODE_CI                                        59592          59599           9          0.0     1489802.8     151.7X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                         281            282           0          0.1        7034.1       1.0X
-UTF8_LCASE                                         6623           6625           3          0.0      165576.2      23.5X
-UNICODE                                           65126          65216         128          0.0     1628147.7     231.5X
-UNICODE_CI                                        64223          64248          36          0.0     1605563.0     228.3X
+UTF8_BINARY                                         373            374           1          0.1        9321.5       1.0X
+UTF8_LCASE                                         5633           5634           2          0.0      140818.0      15.1X
+UNICODE                                           67011          67034          32          0.0     1675271.7     179.7X
+UNICODE_CI                                        66844          66858          19          0.0     1671103.6     179.3X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - initCap using impl execICU:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------------------
-UNICODE                                                           202            202           0          0.2        5042.2       1.0X
-UNICODE_CI                                                        204            205           1          0.2        5105.3       1.0X
+UNICODE                                                           241            242           1          0.2        6031.4       1.0X
+UNICODE_CI                                                        241            242           1          0.2        6028.4       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - initCap using impl execBinaryICU:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                                             317            318           0          0.1        7934.8       1.0X
-UTF8_LCASE                                                              317            318           0          0.1        7935.0       1.0X
-UNICODE                                                                 317            318           1          0.1        7931.5       1.0X
-UNICODE_CI                                                              317            318           0          0.1        7937.0       1.0X
+UTF8_BINARY                                                             322            323           1          0.1        8048.8       1.0X
+UTF8_LCASE                                                              324            325           1          0.1        8099.6       1.0X
+UNICODE                                                                 323            324           1          0.1        8072.5       1.0X
+UNICODE_CI                                                              322            323           2          0.1        8051.4       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - initCap using impl execBinary:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 -----------------------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                                           86             87           0          0.5        2155.3       1.0X
-UTF8_LCASE                                                            87             88           4          0.5        2170.7       1.0X
-UNICODE                                                               87             87           0          0.5        2164.6       1.0X
-UNICODE_CI                                                            86             87           0          0.5        2155.0       1.0X
+UTF8_BINARY                                                          140            140           0          0.3        3488.8       1.0X
+UTF8_LCASE                                                           140            140           0          0.3        3495.6       1.0X
+UNICODE                                                              140            141           0          0.3        3498.5       1.0X
+UNICODE_CI                                                           140            141           1          0.3        3496.5       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1008-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - initCap using impl execLowercase:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                                             202            203           1          0.2        5057.3       1.0X
-UTF8_LCASE                                                              203            204           0          0.2        5079.1       1.0X
-UNICODE                                                                 202            203           1          0.2        5057.1       1.0X
-UNICODE_CI                                                              202            203           1          0.2        5061.9       1.0X
+UTF8_BINARY                                                             241            241           0          0.2        6019.4       1.0X
+UTF8_LCASE                                                              241            241           0          0.2        6016.7       1.0X
+UNICODE                                                                 241            241           0          0.2        6019.5       1.0X
+UNICODE_CI                                                              241            242           1          0.2        6027.6       1.0X
 

--- a/sql/core/benchmarks/CollationNonASCIIBenchmark-results.txt
+++ b/sql/core/benchmarks/CollationNonASCIIBenchmark-results.txt
@@ -1,88 +1,88 @@
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                           171            171           1          0.2        4265.1       1.0X
-UTF8_LCASE                                          10710          10718          11          0.0      267740.9      62.8X
-UNICODE                                              5648           5652           5          0.0      141197.1      33.1X
-UNICODE_CI                                           5717           5717           0          0.0      142930.8      33.5X
+UTF8_BINARY                                           275            275           0          0.1        6871.3       1.0X
+UTF8_LCASE                                           7381           7381           1          0.0      184513.0      26.9X
+UNICODE                                              6926           6936          13          0.0      173151.5      25.2X
+UNICODE_CI                                           6910           6912           3          0.0      172742.7      25.1X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                            461            462           1          0.1       11515.5       1.0X
-UTF8_LCASE                                            7483           7483           1          0.0      187063.3      16.2X
-UNICODE                                               5957           5958           1          0.0      148937.0      12.9X
-UNICODE_CI                                            5932           5935           4          0.0      148310.3      12.9X
+UTF8_BINARY                                            450            450           1          0.1       11240.8       1.0X
+UTF8_LCASE                                            7347           7350           4          0.0      183686.7      16.3X
+UNICODE                                               6936           6939           4          0.0      173406.7      15.4X
+UNICODE_CI                                            6910           6915           6          0.0      172759.5      15.4X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        2032           2033           2          0.0       50793.0       1.0X
-UTF8_LCASE                                         6182           6182           0          0.0      154539.6       3.0X
-UNICODE                                           21627          21630           5          0.0      540672.9      10.6X
-UNICODE_CI                                        28459          28475          24          0.0      711467.8      14.0X
+UTF8_BINARY                                        2279           2280           1          0.0       56985.7       1.0X
+UTF8_LCASE                                         6409           6438          40          0.0      160228.3       2.8X
+UNICODE                                           22185          22209          34          0.0      554620.6       9.7X
+UNICODE_CI                                        27988          27995          10          0.0      699696.3      12.3X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                         568            569           1          0.1       14210.1       1.0X
-UTF8_LCASE                                         9168           9173           7          0.0      229209.8      16.1X
-UNICODE                                           57010          57099         127          0.0     1425240.1     100.3X
-UNICODE_CI                                        57361          57465         147          0.0     1434028.9     100.9X
+UTF8_BINARY                                         600            600           0          0.1       15000.5       1.0X
+UTF8_LCASE                                         8942           8943           2          0.0      223537.8      14.9X
+UNICODE                                           59407          59441          48          0.0     1485174.9      99.0X
+UNICODE_CI                                        59828          60073         347          0.0     1495698.8      99.7X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                         365            366           0          0.1        9122.7       1.0X
-UTF8_LCASE                                         5459           5465           8          0.0      136481.7      15.0X
-UNICODE                                           57503          57647         203          0.0     1437582.7     157.6X
-UNICODE_CI                                        57736          57946         297          0.0     1443399.0     158.2X
+UTF8_BINARY                                         412            412           1          0.1       10291.0       1.0X
+UTF8_LCASE                                         5577           5578           1          0.0      139431.9      13.5X
+UNICODE                                           59947          59948           1          0.0     1498674.8     145.6X
+UNICODE_CI                                        60407          60611         289          0.0     1510169.7     146.7X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                         369            371           2          0.1        9218.6       1.0X
-UTF8_LCASE                                         5412           5419           9          0.0      135303.3      14.7X
-UNICODE                                           63726          63732           7          0.0     1593159.1     172.8X
-UNICODE_CI                                        63751          63859         152          0.0     1593784.2     172.9X
+UTF8_BINARY                                         398            399           1          0.1        9953.4       1.0X
+UTF8_LCASE                                         5365           5371           9          0.0      134132.4      13.5X
+UNICODE                                           66999          67018          27          0.0     1674971.1     168.3X
+UNICODE_CI                                        66289          66317          39          0.0     1657216.8     166.5X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - initCap using impl execICU:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------------------
-UNICODE                                                           219            220           0          0.2        5487.0       1.0X
-UNICODE_CI                                                        219            220           0          0.2        5482.7       1.0X
+UNICODE                                                           270            270           0          0.1        6741.3       1.0X
+UNICODE_CI                                                        270            271           1          0.1        6750.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - initCap using impl execBinaryICU:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                                             325            325           1          0.1        8112.8       1.0X
-UTF8_LCASE                                                              324            325           1          0.1        8106.5       1.0X
-UNICODE                                                                 324            325           1          0.1        8101.6       1.0X
-UNICODE_CI                                                              321            322           1          0.1        8032.0       1.0X
+UTF8_BINARY                                                             327            328           1          0.1        8178.4       1.0X
+UTF8_LCASE                                                              327            327           1          0.1        8168.1       1.0X
+UNICODE                                                                 327            327           0          0.1        8166.2       1.0X
+UNICODE_CI                                                              327            327           1          0.1        8167.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - initCap using impl execBinary:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 -----------------------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                                          111            112           0          0.4        2782.6       1.0X
-UTF8_LCASE                                                           111            112           0          0.4        2770.9       1.0X
-UNICODE                                                              111            112           1          0.4        2772.4       1.0X
-UNICODE_CI                                                           111            112           1          0.4        2777.0       1.0X
+UTF8_BINARY                                                          176            177           1          0.2        4405.0       1.0X
+UTF8_LCASE                                                           176            177           1          0.2        4403.7       1.0X
+UNICODE                                                              176            177           1          0.2        4404.9       1.0X
+UNICODE_CI                                                           176            177           0          0.2        4402.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - initCap using impl execLowercase:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                                             220            221           1          0.2        5501.4       1.0X
-UTF8_LCASE                                                              220            221           1          0.2        5493.7       1.0X
-UNICODE                                                                 220            221           1          0.2        5497.9       1.0X
-UNICODE_CI                                                              220            221           1          0.2        5503.0       1.0X
+UTF8_BINARY                                                             271            272           1          0.1        6781.9       1.0X
+UTF8_LCASE                                                              271            272           1          0.1        6779.5       1.0X
+UNICODE                                                                 271            272           2          0.1        6775.2       1.0X
+UNICODE_CI                                                              271            274           7          0.1        6778.1       1.0X
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the ICU4J dependency to 78.3.

### Why are the changes needed?

To keep the dependency up to date with the latest release.
- https://github.com/unicode-org/icu/releases/tag/release-78.3
  - https://github.com/unicode-org/icu/pull/3896
  - https://cldr.unicode.org/downloads/cldr-48#482-changes

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.6)