### PR TITLE
[SPARK-56403] Refactor kafka test so it's skipped when dependency is not available

### DIFF
--- a/python/pyspark/sql/tests/streaming/kafka_utils.py
+++ b/python/pyspark/sql/tests/streaming/kafka_utils.py
@@ -80,16 +80,6 @@ class KafkaUtils:
         self._producer = None
         self.broker = None
 
-    @classmethod
-    def has_dependencies(cls) -> bool:
-        try:
-            import testcontainers  # noqa: F401
-            import kafka  # noqa: F401
-
-            return True
-        except ImportError:
-            return False
-
     def setup(self) -> None:
         """
         Start the Kafka container and initialize admin client and producer.

--- a/python/pyspark/sql/tests/streaming/kafka_utils.py
+++ b/python/pyspark/sql/tests/streaming/kafka_utils.py
@@ -80,6 +80,16 @@ class KafkaUtils:
         self._producer = None
         self.broker = None
 
+    @classmethod
+    def has_dependencies(cls) -> bool:
+        try:
+            import testcontainers  # noqa: F401
+            import kafka  # noqa: F401
+
+            return True
+        except ImportError:
+            return False
+
     def setup(self) -> None:
         """
         Start the Kafka container and initialize admin client and producer.

--- a/python/pyspark/sql/tests/streaming/test_streaming_kafka_rtm.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_kafka_rtm.py
@@ -32,6 +32,12 @@ import uuid
 
 from pyspark.sql.tests.streaming.kafka_utils import KafkaUtils
 from pyspark.testing.sqlutils import ReusedSQLTestCase, search_jar, read_classpath
+from pyspark.testing.utils import (
+    have_kafka,
+    have_testcontainers,
+    kafka_requirement_message,
+    testcontainers_requirement_message,
+)
 
 
 class StreamingKafkaTestsMixin:
@@ -118,7 +124,8 @@ def _is_docker_available():
         return False
 
 
-@unittest.skipIf(not KafkaUtils.has_dependencies(), "Kafka test dependencies are not installed")
+@unittest.skipIf(not have_kafka, kafka_requirement_message)
+@unittest.skipIf(not have_testcontainers, testcontainers_requirement_message)
 @unittest.skipIf(not _is_docker_available(), "Docker is not available")
 class StreamingKafkaTests(StreamingKafkaTestsMixin, ReusedSQLTestCase):
     """

--- a/python/pyspark/sql/tests/streaming/test_streaming_kafka_rtm.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_kafka_rtm.py
@@ -30,52 +30,8 @@ import tempfile
 import unittest
 import uuid
 
-from pyspark.testing.sqlutils import ReusedSQLTestCase, search_jar, read_classpath
-
-# Setup Kafka JAR on classpath before SparkSession is created
-# This follows the same pattern as streamingutils.py for Kinesis
-kafka_sql_jar = search_jar(
-    "connector/kafka-0-10-sql",
-    "spark-sql-kafka-0-10_",
-    "spark-sql-kafka-0-10_",
-    return_first=True,
-)
-
-if kafka_sql_jar is None:
-    raise RuntimeError(
-        "Kafka SQL connector JAR was not found. "
-        "To run these tests, you need to build Spark with "
-        "'build/mvn package' or 'build/sbt Test/package' "
-        "before running this test."
-    )
-
-# Read the full classpath including all dependencies
-# This works for both Maven builds (reads classpath.txt) and SBT builds (queries SBT)
-# Define the project name mapping for SBT builds
-kafka_project_name_map = {
-    "connector/kafka-0-10-sql": "sql-kafka-0-10",
-}
-kafka_classpath = read_classpath("connector/kafka-0-10-sql", kafka_project_name_map)
-all_jars = f"{kafka_sql_jar},{kafka_classpath}"
-
-# Add Kafka JAR to PYSPARK_SUBMIT_ARGS before SparkSession is created
-existing_args = os.environ.get("PYSPARK_SUBMIT_ARGS", "pyspark-shell")
-jars_args = "--jars %s" % all_jars
-
-os.environ["PYSPARK_SUBMIT_ARGS"] = " ".join([jars_args, existing_args])
-
 from pyspark.sql.tests.streaming.kafka_utils import KafkaUtils
-
-
-# Check if required Python dependencies are available
-try:
-    import testcontainers  # noqa: F401
-    import kafka  # noqa: F401
-except ImportError as e:
-    raise ImportError(
-        "Kafka test dependencies not available. "
-        "Install with: pip install testcontainers[kafka] kafka-python"
-    ) from e
+from pyspark.testing.sqlutils import ReusedSQLTestCase, search_jar, read_classpath
 
 
 class StreamingKafkaTestsMixin:
@@ -87,12 +43,52 @@ class StreamingKafkaTestsMixin:
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
+        # Setup Kafka JAR on classpath before SparkSession is created
+        # This follows the same pattern as streamingutils.py for Kinesis
+        kafka_sql_jar = search_jar(
+            "connector/kafka-0-10-sql",
+            "spark-sql-kafka-0-10_",
+            "spark-sql-kafka-0-10_",
+            return_first=True,
+        )
+
+        if kafka_sql_jar is None:
+            raise RuntimeError(
+                "Kafka SQL connector JAR was not found. "
+                "To run these tests, you need to build Spark with "
+                "'build/mvn package' or 'build/sbt Test/package' "
+                "before running this test."
+            )
+
+        # Read the full classpath including all dependencies
+        # This works for both Maven builds (reads classpath.txt) and SBT builds (queries SBT)
+        # Define the project name mapping for SBT builds
+        kafka_project_name_map = {
+            "connector/kafka-0-10-sql": "sql-kafka-0-10",
+        }
+        kafka_classpath = read_classpath("connector/kafka-0-10-sql", kafka_project_name_map)
+        all_jars = f"{kafka_sql_jar},{kafka_classpath}"
+
+        # Add Kafka JAR to PYSPARK_SUBMIT_ARGS before SparkSession is created
+        cls.original_pyspark_submit_args = os.environ.get("PYSPARK_SUBMIT_ARGS")
+
+        if cls.original_pyspark_submit_args is None:
+            pyspark_submit_args = "pyspark-shell"
+        else:
+            pyspark_submit_args = cls.original_pyspark_submit_args
+        jars_args = "--jars %s" % all_jars
+
+        os.environ["PYSPARK_SUBMIT_ARGS"] = " ".join([jars_args, pyspark_submit_args])
+
         # Start Kafka container - this may take 10-30 seconds on first run
         cls.kafka_utils = KafkaUtils()
         cls.kafka_utils.setup()
 
     @classmethod
     def tearDownClass(cls):
+        os.environ["PYSPARK_SUBMIT_ARGS"] = cls.original_pyspark_submit_args
+
         # Stop Kafka container and clean up resources
         if hasattr(cls, "kafka_utils"):
             cls.kafka_utils.teardown()
@@ -122,16 +118,12 @@ def _is_docker_available():
         return False
 
 
+@unittest.skipIf(not KafkaUtils.has_dependencies(), "Kafka test dependencies are not installed")
+@unittest.skipIf(not _is_docker_available(), "Docker is not available")
 class StreamingKafkaTests(StreamingKafkaTestsMixin, ReusedSQLTestCase):
     """
     Tests for Kafka streaming integration with PySpark.
     """
-
-    @classmethod
-    def setUpClass(cls):
-        if not _is_docker_available():
-            raise unittest.SkipTest("Docker is not available")
-        super().setUpClass()
 
     def test_streaming_stateless(self):
         """
@@ -177,10 +169,6 @@ class StreamingKafkaTests(StreamingKafkaTestsMixin, ReusedSQLTestCase):
 
 
 if __name__ == "__main__":
-    try:
-        import xmlrunner
+    from pyspark.testing import main
 
-        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
-    except ImportError:
-        testRunner = None
-    unittest.main(testRunner=testRunner, verbosity=2)
+    main()

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -103,6 +103,14 @@ grpc_status_requirement_message = "" if have_grpc_status else "No module named '
 have_zstandard = have_package("zstandard")
 zstandard_requirement_message = "" if have_zstandard else "No module named 'zstandard'"
 
+have_kafka = have_package("kafka")
+kafka_requirement_message = "" if have_kafka else "No module named 'kafka'"
+
+have_testcontainers = have_package("testcontainers")
+testcontainers_requirement_message = (
+    "" if have_testcontainers else "No module named 'testcontainers'"
+)
+
 
 googleapis_common_protos_requirement_message = ""
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

* Add a kafka and testcontainers to testing/utils package check
* Move all the module-level code of kafka test inside classs
* Skip the kafka test when dependency is not available, instead of raising an error
* Restore `os.environ` after the test
* Use the testing utility in `__main__` instead of old entry

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We don't want a test to fail if optional dependency is not available. It's breaking our CIs - https://github.com/apache/spark/actions/runs/24128422095 . The test itself should not have too much module-level code, and should have minimum side effect on the environment.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Confirmed it was correctly skipped when dependency was not available. CI should confirm whether test is still working properly.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.