### PR TITLE
[SPARK-55306][PYTHON][TESTS][FOLLOW-UP] Skip Kafka streaming RTM tests when dependencies are not installed

### DIFF
--- a/python/pyspark/sql/tests/streaming/test_streaming_kafka_rtm.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_kafka_rtm.py
@@ -113,7 +113,7 @@ def _is_docker_available():
 
 
 @unittest.skipIf(
-    not (have_testcontainers and have_kafka),
+    not have_testcontainers or not have_kafka,
     "Kafka test dependencies not available (testcontainers, kafka-python)",
 )
 class StreamingKafkaTests(StreamingKafkaTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/streaming/test_streaming_kafka_rtm.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_kafka_rtm.py
@@ -65,16 +65,7 @@ jars_args = "--jars %s" % all_jars
 os.environ["PYSPARK_SUBMIT_ARGS"] = " ".join([jars_args, existing_args])
 
 from pyspark.sql.tests.streaming.kafka_utils import KafkaUtils
-
-
-# Check if required Python dependencies are available
-try:
-    import testcontainers  # noqa: F401
-    import kafka  # noqa: F401
-
-    have_kafka_deps = True
-except ImportError:
-    have_kafka_deps = False
+from pyspark.testing.utils import have_testcontainers, have_kafka
 
 
 class StreamingKafkaTestsMixin:
@@ -122,7 +113,7 @@ def _is_docker_available():
 
 
 @unittest.skipIf(
-    not have_kafka_deps,
+    not (have_testcontainers and have_kafka),
     "Kafka test dependencies not available (testcontainers, kafka-python)",
 )
 class StreamingKafkaTests(StreamingKafkaTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/streaming/test_streaming_kafka_rtm.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_kafka_rtm.py
@@ -65,7 +65,12 @@ jars_args = "--jars %s" % all_jars
 os.environ["PYSPARK_SUBMIT_ARGS"] = " ".join([jars_args, existing_args])
 
 from pyspark.sql.tests.streaming.kafka_utils import KafkaUtils
-from pyspark.testing.utils import have_testcontainers, have_kafka
+from pyspark.testing.utils import (
+    have_testcontainers,
+    testcontainers_requirement_message,
+    have_kafka,
+    kafka_requirement_message,
+)
 
 
 class StreamingKafkaTestsMixin:
@@ -114,7 +119,7 @@ def _is_docker_available():
 
 @unittest.skipIf(
     not have_testcontainers or not have_kafka,
-    "Kafka test dependencies not available (testcontainers, kafka-python)",
+    testcontainers_requirement_message or kafka_requirement_message,
 )
 class StreamingKafkaTests(StreamingKafkaTestsMixin, ReusedSQLTestCase):
     """

--- a/python/pyspark/sql/tests/streaming/test_streaming_kafka_rtm.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_kafka_rtm.py
@@ -71,11 +71,10 @@ from pyspark.sql.tests.streaming.kafka_utils import KafkaUtils
 try:
     import testcontainers  # noqa: F401
     import kafka  # noqa: F401
-except ImportError as e:
-    raise ImportError(
-        "Kafka test dependencies not available. "
-        "Install with: pip install testcontainers[kafka] kafka-python"
-    ) from e
+
+    have_kafka_deps = True
+except ImportError:
+    have_kafka_deps = False
 
 
 class StreamingKafkaTestsMixin:
@@ -122,6 +121,10 @@ def _is_docker_available():
         return False
 
 
+@unittest.skipIf(
+    not have_kafka_deps,
+    "Kafka test dependencies not available (testcontainers, kafka-python)",
+)
 class StreamingKafkaTests(StreamingKafkaTestsMixin, ReusedSQLTestCase):
     """
     Tests for Kafka streaming integration with PySpark.

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -103,6 +103,14 @@ grpc_status_requirement_message = "" if have_grpc_status else "No module named '
 have_zstandard = have_package("zstandard")
 zstandard_requirement_message = "" if have_zstandard else "No module named 'zstandard'"
 
+have_testcontainers = have_package("testcontainers")
+testcontainers_requirement_message = (
+    "" if have_testcontainers else "No module named 'testcontainers'"
+)
+
+have_kafka = have_package("kafka")
+kafka_requirement_message = "" if have_kafka else "No module named 'kafka'"
+
 
 googleapis_common_protos_requirement_message = ""
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Skip `StreamingKafkaTests` in `test_streaming_kafka_rtm.py` when `testcontainers` or `kafka-python` is not installed, instead of raising an `ImportError` that crashes the entire test module.

### Why are the changes needed?

The CI job `pyspark-structured-streaming` fails because `test_streaming_kafka_rtm.py` raises `ImportError` at module level when `testcontainers` is not installed. This causes the entire test runner to exit with a non-zero code, failing the CI build. See: https://github.com/apache/spark/actions/runs/24128422095/job/70399041605

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The test class is now decorated with `@unittest.skipIf(not have_kafka_deps, ...)`, which gracefully skips when the dependencies are missing — the same pattern used for Docker availability in the same file.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code