### PR TITLE
[SPARK-56414][SQL] Per-write options should take precedence over session config in file source writes

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.avro.AvroCompressionCodec._
 import org.apache.spark.sql.avro.AvroOptions.IGNORE_EXTENSION
 import org.apache.spark.sql.catalyst.{FileSourceOptions, InternalRow}
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
-import org.apache.spark.sql.execution.datasources.OutputWriterFactory
+import org.apache.spark.sql.execution.datasources.{DataSourceUtils, OutputWriterFactory}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
@@ -151,15 +151,17 @@ private[sql] object AvroUtils extends Logging {
                 case DEFLATE => Some(sqlConf.getConf(SQLConf.AVRO_DEFLATE_LEVEL), codecName)
                 case XZ => Some(sqlConf.getConf(SQLConf.AVRO_XZ_LEVEL), codecName)
                 case ZSTANDARD =>
-                  jobConf.setBoolean(AvroOutputFormat.ZSTD_BUFFERPOOL_KEY,
-                    sqlConf.getConf(SQLConf.AVRO_ZSTANDARD_BUFFER_POOL_ENABLED))
+                  DataSourceUtils.setConfIfAbsent(jobConf,
+                    AvroOutputFormat.ZSTD_BUFFERPOOL_KEY,
+                    sqlConf.getConf(SQLConf.AVRO_ZSTANDARD_BUFFER_POOL_ENABLED).toString)
                   Some(sqlConf.getConf(SQLConf.AVRO_ZSTANDARD_LEVEL), "zstd")
                 case _ => None
               }
               levelAndCodecName.foreach { case (level, mapredCodecName) =>
+                val levelKey = s"avro.mapred.$mapredCodecName.level"
+                DataSourceUtils.setConfIfAbsent(jobConf, levelKey, level.toString)
                 logInfo(log"Compressing Avro output using the ${MDC(CODEC_NAME, codecName)} " +
-                  log"codec at level ${MDC(CODEC_LEVEL, level)}")
-                jobConf.setInt(s"avro.mapred.$mapredCodecName.level", level.toInt)
+                  log"codec at level ${MDC(CODEC_LEVEL, jobConf.get(levelKey))}")
               }
             } else {
               logInfo(log"Compressing Avro output using the ${MDC(CODEC_NAME, codecName)} codec")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -31,7 +31,7 @@ import org.apache.spark.{SparkException, SparkUpgradeException}
 import org.apache.spark.sql.{sources, SPARK_LEGACY_DATETIME_METADATA_KEY, SPARK_LEGACY_INT96_METADATA_KEY, SPARK_TIMEZONE_METADATA_KEY, SPARK_VERSION_METADATA_KEY}
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogUtils}
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSet, Expression, ExpressionSet, PredicateHelper}
-import org.apache.spark.sql.catalyst.util.{RebaseDateTime, TypeUtils}
+import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, RebaseDateTime, TypeUtils}
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetOptions
@@ -45,10 +45,30 @@ import org.apache.spark.util.Utils
 object DataSourceUtils extends PredicateHelper {
 
   /**
-   * Sets a key in the Hadoop configuration only if it is not already present. Write options
-   * are merged into the conf upstream via `newHadoopConfWithOptions`, so a non-null value
-   * means the user explicitly set a per-write option which should take precedence over the
-   * session-level SQLConf default.
+   * Merges write options into a Hadoop configuration. Keys "path" and "paths" are excluded.
+   * This ensures per-write options are present in the conf even if they were added to the
+   * options map after the Hadoop conf was originally created.
+   */
+  def mergeWriteOptionsIntoHadoopConf(
+      options: Map[String, String], conf: Configuration): Unit = {
+    // CaseInsensitiveMap.iterator yields lowercased keys, but Hadoop Configuration is
+    // case-sensitive. Use the original map to preserve the user's key casing.
+    val rawOptions = options match {
+      case ci: CaseInsensitiveMap[String @unchecked] => ci.originalMap
+      case other => other
+    }
+    rawOptions.foreach { case (k, v) =>
+      if ((v ne null) && k != "path" && k != "paths") {
+        conf.set(k, v)
+      }
+    }
+  }
+
+  /**
+   * Sets a key in the Hadoop configuration only if it is not already present. Per-write
+   * options should be merged into the conf first (via [[mergeWriteOptionsIntoHadoopConf]]),
+   * so a non-null value means the user explicitly set a per-write option which should take
+   * precedence over the session-level SQLConf default.
    */
   def setConfIfAbsent(conf: Configuration, key: String, value: => String): Unit = {
     if (conf.get(key) == null) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -22,6 +22,7 @@ import java.util.Locale
 
 import scala.jdk.CollectionConverters._
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.json4s.{Formats, NoTypeHints}
 import org.json4s.jackson.Serialization
@@ -42,6 +43,19 @@ import org.apache.spark.util.Utils
 
 
 object DataSourceUtils extends PredicateHelper {
+
+  /**
+   * Sets a key in the Hadoop configuration only if it is not already present. Write options
+   * are merged into the conf upstream via `newHadoopConfWithOptions`, so a non-null value
+   * means the user explicitly set a per-write option which should take precedence over the
+   * session-level SQLConf default.
+   */
+  def setConfIfAbsent(conf: Configuration, key: String, value: => String): Unit = {
+    if (conf.get(key) == null) {
+      conf.set(key, value)
+    }
+  }
+
   /**
    * The key to use for storing partitionBy columns as options.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -102,6 +102,10 @@ object FileFormatWriter extends Logging {
     job.setOutputValueClass(classOf[InternalRow])
     FileOutputFormat.setOutputPath(job, new Path(outputSpec.outputPath))
 
+    // Merge write options into the job's configuration so that per-write options
+    // take precedence over session-level defaults set later in prepareWrite.
+    DataSourceUtils.mergeWriteOptionsIntoHadoopConf(options, job.getConfiguration)
+
     val partitionSet = AttributeSet(partitionColumns)
     // cleanup the internal metadata information of
     // the file source metadata attribute if any before write out

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.catalyst.expressions.JoinedRow
 import org.apache.spark.sql.catalyst.expressions.variant.VariantExpressionEvalUtils
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 import org.apache.spark.sql.connector.expressions.aggregate.{Aggregation, Count, CountStar, Max, Min}
-import org.apache.spark.sql.execution.datasources.{AggregatePushDownUtils, OutputWriter, OutputWriterFactory}
+import org.apache.spark.sql.execution.datasources.{AggregatePushDownUtils, DataSourceUtils, OutputWriter, OutputWriterFactory}
 import org.apache.spark.sql.execution.datasources.v2.V2ColumnUtils
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.internal.SQLConf.PARQUET_AGGREGATE_PUSHDOWN_ENABLED
@@ -507,23 +507,18 @@ object ParquetUtils extends Logging {
 
     // Sets flags for `ParquetWriteSupport`, which converts Catalyst schema to Parquet
     // schema and writes actual rows to Parquet files.
-    conf.set(
-      SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key,
-      sqlConf.writeLegacyParquetFormat.toString)
-
-    conf.set(
-      SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key,
-      sqlConf.parquetOutputTimestampType.toString)
-
-    conf.set(
-      SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED.key,
-      sqlConf.parquetFieldIdWriteEnabled.toString)
-
-    conf.set(
-      SQLConf.LEGACY_PARQUET_NANOS_AS_LONG.key,
-      sqlConf.legacyParquetNanosAsLong.toString)
-
-    conf.set(
+    // For each key, only set from SQLConf if not already present in the conf. Write options
+    // are already merged into the conf upstream via `newHadoopConfWithOptions`, so a non-null
+    // value means the user explicitly set a per-write option which should take precedence.
+    DataSourceUtils.setConfIfAbsent(conf,
+      SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key, sqlConf.writeLegacyParquetFormat.toString)
+    DataSourceUtils.setConfIfAbsent(conf,
+      SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key, sqlConf.parquetOutputTimestampType.toString)
+    DataSourceUtils.setConfIfAbsent(conf,
+      SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED.key, sqlConf.parquetFieldIdWriteEnabled.toString)
+    DataSourceUtils.setConfIfAbsent(conf,
+      SQLConf.LEGACY_PARQUET_NANOS_AS_LONG.key, sqlConf.legacyParquetNanosAsLong.toString)
+    DataSourceUtils.setConfIfAbsent(conf,
       SQLConf.PARQUET_ANNOTATE_VARIANT_LOGICAL_TYPE.key,
       sqlConf.parquetAnnotateVariantLogicalType.toString)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
@@ -507,9 +507,6 @@ object ParquetUtils extends Logging {
 
     // Sets flags for `ParquetWriteSupport`, which converts Catalyst schema to Parquet
     // schema and writes actual rows to Parquet files.
-    // For each key, only set from SQLConf if not already present in the conf. Write options
-    // are already merged into the conf upstream via `newHadoopConfWithOptions`, so a non-null
-    // value means the user explicitly set a per-write option which should take precedence.
     DataSourceUtils.setConfIfAbsent(conf,
       SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key, sqlConf.writeLegacyParquetFormat.toString)
     DataSourceUtils.setConfIfAbsent(conf,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetEncodingSuite.scala
@@ -240,9 +240,9 @@ class ParquetEncodingSuite extends ParquetCompatibilityTest with SharedSparkSess
 
   test("per-write options take precedence over session config") {
     val hadoopConf = spark.sessionState.newHadoopConf()
-    // Test outputTimestampType: session sets INT96, write option overrides to TIMESTAMP_MICROS.
     withTempPath { dir =>
       val path = s"${dir.getCanonicalPath}/test.parquet"
+      // Session sets INT96, but the per-write option overrides to TIMESTAMP_MICROS.
       withSQLConf(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> "INT96") {
         spark.sql("SELECT TIMESTAMP '2024-01-01 12:00:00' AS ts")
           .write
@@ -257,24 +257,6 @@ class ParquetEncodingSuite extends ParquetCompatibilityTest with SharedSparkSess
           .asPrimitiveType()
         // TIMESTAMP_MICROS is stored as INT64, not INT96
         assert(tsField.getPrimitiveTypeName === PrimitiveTypeName.INT64)
-      }
-    }
-
-    // Test writerVersion: write option sets PARQUET_2_0 which uses delta encoding.
-    withTempPath { dir =>
-      val path = s"${dir.getCanonicalPath}/test.parquet"
-      spark.range(1, 100).toDF("id")
-        .write
-        .option(ParquetOutputFormat.WRITER_VERSION,
-          ParquetProperties.WriterVersion.PARQUET_2_0.toString)
-        .mode("overwrite")
-        .parquet(path)
-
-      for (footer <- readAllFootersWithoutSummaryFiles(new Path(path), hadoopConf)) {
-        for (blockMetadata <- footer.getParquetMetadata.getBlocks.asScala) {
-          val columnChunkMetadata = blockMetadata.getColumns.asScala.head
-          assert(columnChunkMetadata.getEncodings.contains(Encoding.DELTA_BINARY_PACKED))
-        }
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetEncodingSuite.scala
@@ -25,6 +25,7 @@ import scala.jdk.CollectionConverters._
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.column.{Encoding, ParquetProperties}
 import org.apache.parquet.hadoop.ParquetOutputFormat
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 
 import org.apache.spark.TestUtils
 import org.apache.spark.memory.MemoryMode
@@ -233,6 +234,47 @@ class ParquetEncodingSuite extends ParquetCompatibilityTest with SharedSparkSess
         assert(actual.map(_.getBoolean(1)).forall(_ == false))
         val excepted = (1 to size).map { i => i % 2 == 1 }
         assert(actual.map(_.getBoolean(2)).sameElements(excepted))
+      }
+    }
+  }
+
+  test("per-write options take precedence over session config") {
+    val hadoopConf = spark.sessionState.newHadoopConf()
+    // Test outputTimestampType: session sets INT96, write option overrides to TIMESTAMP_MICROS.
+    withTempPath { dir =>
+      val path = s"${dir.getCanonicalPath}/test.parquet"
+      withSQLConf(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> "INT96") {
+        spark.sql("SELECT TIMESTAMP '2024-01-01 12:00:00' AS ts")
+          .write
+          .option(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key, "TIMESTAMP_MICROS")
+          .mode("overwrite")
+          .parquet(path)
+      }
+
+      for (footer <- readAllFootersWithoutSummaryFiles(new Path(path), hadoopConf)) {
+        val schema = footer.getParquetMetadata.getFileMetaData.getSchema
+        val tsField = schema.getFields.asScala.find(_.getName == "ts").get
+          .asPrimitiveType()
+        // TIMESTAMP_MICROS is stored as INT64, not INT96
+        assert(tsField.getPrimitiveTypeName === PrimitiveTypeName.INT64)
+      }
+    }
+
+    // Test writerVersion: write option sets PARQUET_2_0 which uses delta encoding.
+    withTempPath { dir =>
+      val path = s"${dir.getCanonicalPath}/test.parquet"
+      spark.range(1, 100).toDF("id")
+        .write
+        .option(ParquetOutputFormat.WRITER_VERSION,
+          ParquetProperties.WriterVersion.PARQUET_2_0.toString)
+        .mode("overwrite")
+        .parquet(path)
+
+      for (footer <- readAllFootersWithoutSummaryFiles(new Path(path), hadoopConf)) {
+        for (blockMetadata <- footer.getParquetMetadata.getBlocks.asScala) {
+          val columnChunkMetadata = blockMetadata.getColumns.asScala.head
+          assert(columnChunkMetadata.getEncodings.contains(Encoding.DELTA_BINARY_PACKED))
+        }
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala
@@ -697,6 +697,44 @@ abstract class FileStreamSinkSuite extends StreamTest {
     }
   }
 
+  test("SPARK-56414: per-write options take precedence over session config in streaming sink") {
+    val inputData = MemoryStream[java.sql.Timestamp]
+
+    val outputDir = Utils.createTempDir(namePrefix = "stream.output").getCanonicalPath
+    val checkpointDir = Utils.createTempDir(namePrefix = "stream.checkpoint").getCanonicalPath
+
+    // Session sets INT96, but the per-write option overrides to TIMESTAMP_MICROS.
+    withSQLConf(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> "INT96") {
+      var query: StreamingQuery = null
+      try {
+        query = inputData.toDF()
+          .toDF("ts")
+          .writeStream
+          .option("checkpointLocation", checkpointDir)
+          .option(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key, "TIMESTAMP_MICROS")
+          .format("parquet")
+          .start(outputDir)
+        inputData.addData(java.sql.Timestamp.valueOf("2024-01-01 12:00:00"))
+        query.processAllAvailable()
+      } finally {
+        if (query != null) query.stop()
+      }
+    }
+
+    // Read back and verify the timestamp column is INT64 (TIMESTAMP_MICROS), not INT96.
+    import org.apache.parquet.hadoop.ParquetFileReader
+    import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
+    val hadoopConf = spark.sessionState.newHadoopConf()
+    val parquetFiles = new java.io.File(outputDir).listFiles()
+      .filter(_.getName.endsWith(".parquet"))
+    assert(parquetFiles.nonEmpty, "Expected at least one parquet file")
+    val footer = ParquetFileReader.readFooter(hadoopConf,
+      new Path(parquetFiles.head.getAbsolutePath))
+    val tsField = footer.getFileMetaData.getSchema.getFields.asScala
+      .find(_.getName == "ts").get.asPrimitiveType()
+    assert(tsField.getPrimitiveTypeName === PrimitiveTypeName.INT64)
+  }
+
   test("SPARK-50854: Make path fully qualified before passing it to FileStreamSink") {
     val fileFormat = new ParquetFileFormat() // any valid FileFormat
     val partitionColumnNames = Seq.empty[String]


### PR DESCRIPTION
### What changes were proposed in this pull request?

In Parquet and Avro `prepareWrite`, several Hadoop configuration keys are unconditionally set from session-level `SQLConf`, silently overwriting any per-write options the user provided. Additionally, some write paths (`FileStreamSink`, `InsertIntoHiveTable`) create the Hadoop conf via `newHadoopConf()` without merging write options at all, so per-write options never reach the conf.

This PR fixes both issues:

1. **`FileFormatWriter.write`**: Merges write options into the Job's Hadoop conf before calling `prepareWrite`. This is the central fix that ensures per-write options are in the conf regardless of how the caller created it. Handles `CaseInsensitiveMap` key lowercasing by using the original map keys.

2. **`ParquetUtils.prepareWrite`**: Uses `DataSourceUtils.setConfIfAbsent` so that SQLConf defaults are only applied when the key is not already present in the conf (i.e., no per-write option was provided). Affected keys:
   - `spark.sql.parquet.writeLegacyFormat`
   - `spark.sql.parquet.outputTimestampType`
   - `spark.sql.parquet.fieldId.write.enabled`
   - `spark.sql.legacy.parquet.nanosAsLong`
   - `spark.sql.parquet.annotateVariantLogicalType`

3. **`AvroUtils.prepareWrite`**: Same treatment for Avro compression settings:
   - Zstandard buffer pool (`avro.output.codec.zstd.bufferpool`)
   - Compression levels (`avro.mapred.<codec>.level`)

### Why are the changes needed?

Per-write options (passed via `DataFrameWriter.option()` or `DataStreamWriter.option()`) should take precedence over session-level SQLConf defaults. This is already the case for compression codecs in both Parquet and Avro, but other write configuration keys had their per-write values silently overwritten. For example, setting `spark.sql.parquet.outputTimestampType` as a write option in a streaming sink had no effect because (a) `FileStreamSink` doesn't merge options into the Hadoop conf, and (b) `prepareWrite` always replaced the value with the session config.

### Does this PR introduce _any_ user-facing change?

Yes. Per-write options for the listed keys now take effect instead of being silently ignored. Previously, only the session-level SQLConf value was used regardless of what was passed as a write option.

### How was this patch tested?

- `ParquetEncodingSuite`: test verifying per-write `outputTimestampType` overrides session config for batch writes.
- `FileStreamSinkV1Suite`: test verifying per-write `outputTimestampType` overrides session config for streaming writes (exercises the `FileStreamSink` path that uses `newHadoopConf()` without options).

Both tests fail on master and pass with this PR.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)