### PR TITLE
[SPARK-56426][SQL] Fix SQL failure when LATERAL VIEW column alias contains dot in name

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3358,7 +3358,11 @@ class Analyzer(
         g.copy(generatorOutput =
           GeneratorResolution.makeGeneratorOutput(
             g.generator, g.generatorOutput.map {
-              case ua: UnresolvedAttribute => ua.nameParts.head
+              case ua: UnresolvedAttribute =>
+                // LATERAL VIEW parser always emits single-part names via
+                // UnresolvedAttribute.quoted; assert to fail loudly if that ever changes.
+                assert(ua.nameParts.length == 1, s"unexpected multi-part name: ${ua.nameParts}")
+                ua.nameParts.head
               case a => a.name
             }))
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3356,7 +3356,11 @@ class Analyzer(
           throw QueryCompilationErrors.nestedGeneratorError(g.generator)
         }
         g.copy(generatorOutput =
-          GeneratorResolution.makeGeneratorOutput(g.generator, g.generatorOutput.map(_.name)))
+          GeneratorResolution.makeGeneratorOutput(
+            g.generator, g.generatorOutput.map {
+              case ua: UnresolvedAttribute => ua.nameParts.head
+              case a => a.name
+            }))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
@@ -796,6 +796,28 @@ class GeneratorFunctionSuite extends SharedSparkSession {
       .elementType.asInstanceOf[StructType].fieldNames.toSeq
     assert(fields2 === Seq("value", "key"))
   }
+
+  test("SPARK-56426: LATERAL VIEW column alias with dot in name should resolve correctly") {
+    // Single-alias: explode with a dotted alias
+    checkAnswer(
+      sql(
+        """
+          |SELECT id, `skill.inst`
+          |FROM VALUES (1, array('a', 'b')) AS t(id, skills)
+          |LATERAL VIEW explode(skills) skills_table AS `skill.inst`
+        """.stripMargin),
+      Row(1, "a") :: Row(1, "b") :: Nil)
+
+    // Multi-alias: inline with multiple dotted aliases
+    checkAnswer(
+      sql(
+        """
+          |SELECT `a.b`, `c.d`
+          |FROM (SELECT 1) t
+          |LATERAL VIEW inline(array(named_struct('f1', 10, 'f2', 'hello'))) gen AS `a.b`, `c.d`
+        """.stripMargin),
+      Row(10, "hello") :: Nil)
+  }
 }
 
 case class EmptyGenerator() extends Generator with LeafLike[Expression] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3440,6 +3440,17 @@ class SQLQuerySuite extends SharedSparkSession with AdaptiveSparkPlanHelper
     checkAnswer(df2, Row(1) :: Nil)
   }
 
+  test("SPARK-56426: LATERAL VIEW column alias with dot in name should resolve correctly") {
+    checkAnswer(
+      sql(
+        """
+          |SELECT id, `skill.inst`
+          |FROM VALUES (1, array('a', 'b')) AS t(id, skills)
+          |LATERAL VIEW explode(skills) skills_table AS `skill.inst`
+        """.stripMargin),
+      Row(1, "a") :: Row(1, "b") :: Nil)
+  }
+
   test("SPARK-30279 Support 32 or more grouping attributes for GROUPING_ID()") {
     withTempView("t") {
       sql("CREATE TEMPORARY VIEW t AS SELECT * FROM " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3440,17 +3440,6 @@ class SQLQuerySuite extends SharedSparkSession with AdaptiveSparkPlanHelper
     checkAnswer(df2, Row(1) :: Nil)
   }
 
-  test("SPARK-56426: LATERAL VIEW column alias with dot in name should resolve correctly") {
-    checkAnswer(
-      sql(
-        """
-          |SELECT id, `skill.inst`
-          |FROM VALUES (1, array('a', 'b')) AS t(id, skills)
-          |LATERAL VIEW explode(skills) skills_table AS `skill.inst`
-        """.stripMargin),
-      Row(1, "a") :: Row(1, "b") :: Nil)
-  }
-
   test("SPARK-30279 Support 32 or more grouping attributes for GROUPING_ID()") {
     withTempView("t") {
       sql("CREATE TEMPORARY VIEW t AS SELECT * FROM " +


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `ResolveGenerate`, generator output column names were extracted via `UnresolvedAttribute.name`, which wraps any name containing a dot in backtick characters (e.g. `"skill.inst"` → `` "`skill.inst`" ``). This string was then passed directly to `makeGeneratorOutput` as the resolved attribute name, embedding literal backtick characters into the column name.

The fix uses `nameParts.head` instead, which returns the raw identifier text without display-formatting.

### Why are the changes needed?

Using a backtick-quoted identifier with a dot as a `LATERAL VIEW` column alias causes an `UNRESOLVED_COLUMN` error at analysis time:

```sql
SELECT id, `skill.inst`
FROM VALUES (1, array('a', 'b')) AS t(id, skills)
LATERAL VIEW explode(skills) skills_table AS `skill.inst`
-- ERROR: [UNRESOLVED_COLUMN] `skill.inst` cannot be resolved.
-- Did you mean: `skills_table`.```skill.inst```
```

The triple-backtick suggestion reveals that the resolved attribute name contains literal backtick characters, caused by `UnresolvedAttribute.name` being misused as a raw identifier extractor rather than for display only.

**This worked in previous versions, e.g., Spark 3.1.x.**

### Does this PR introduce _any_ user-facing change?

Yes. Queries using a backtick-quoted `LATERAL VIEW` column alias containing a dot (e.g. `` `a.b` ``) now execute correctly instead of failing with `UNRESOLVED_COLUMN`.

### How was this patch tested?

Added a test case in `SQLQuerySuite` covering `LATERAL VIEW` with a dot-containing column alias.

### Was this patch authored or co-authored using generative AI tooling?

No.
